### PR TITLE
ci(website): fix path to playwright report for upload

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -64,7 +64,7 @@ jobs:
         if: always()
         with:
           name: playwright-report
-          path: playwright-report/
+          path: website/playwright-report/
           retention-days: 30
 
   dockerImage:


### PR DESCRIPTION
The playwright report is now correctly uploaded as an artifact: see bottom of https://github.com/pathoplexus/pathoplexus/actions/runs/5512757290?pr=47