### PR TITLE
chore(website): disable dailyUI startup log

### DIFF
--- a/website/tailwind.config.cjs
+++ b/website/tailwind.config.cjs
@@ -12,7 +12,7 @@ module.exports = {
     utils: true, // adds responsive and modifier utility classes
     rtl: false, // rotate style direction from left-to-right to right-to-left. You also need to add dir="rtl" to your html tag and install `tailwindcss-flip` plugin for Tailwind CSS.
     prefix: "", // prefix for daisyUI classnames (components, modifiers and responsive class names. Not colors)
-    logs: true, // Shows info about daisyUI version and used config in the console when building your CSS
+    logs: false, // Shows info about daisyUI version and used config in the console when building your CSS
     themes: [
       {
         customTheme: {


### PR DESCRIPTION
This prevents the following log to be displayed at every server start:

```
🌼 daisyUI 3.2.1 https://daisyui.com
╰╮
 ╰─ ✔︎ [ 1 ] theme is enabled. You can add more themes or make your own theme:
      https://daisyui.com/docs/themes

    ❤︎ Support daisyUI: https://opencollective.com/daisyui
```