### PR TITLE
feat(website): add pagination to search result table

### DIFF
--- a/website/src/components/SearchPage/Pagination.tsx
+++ b/website/src/components/SearchPage/Pagination.tsx
@@ -1,0 +1,26 @@
+import { Pagination as MUIPagination } from '@mui/material';
+import type { FC } from 'react';
+
+type Props = {
+    count: number;
+};
+
+export const Pagination: FC<Props> = ({ count }) => {
+    const params = new URLSearchParams(location.search);
+    const pageParam = params.get('page');
+    const page = pageParam !== null ? Number.parseInt(pageParam, 10) : 1;
+
+    return (
+        <MUIPagination
+            count={count}
+            page={page}
+            onChange={(_, newPage) => {
+                params.set('page', newPage.toString());
+                location.href = `search?${params}`;
+            }}
+            color='primary'
+            variant='outlined'
+            shape='rounded'
+        />
+    );
+};

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -58,7 +58,7 @@ export const Table: FC<TableProps> = ({ data, config }) => {
     return (
         <div style={{ height: 'auto', width: '100%' }}>
             {rows.length !== 0 ? (
-                <DataGrid rows={rows} columns={columns} disableColumnMenu />
+                <DataGrid rows={rows} columns={columns} disableColumnMenu hideFooter />
             ) : (
                 <div className='flex justify-center font-bold text-xl mb-5'>No Data</div>
             )}

--- a/website/src/pages/search/index.astro
+++ b/website/src/pages/search/index.astro
@@ -1,6 +1,7 @@
 ---
 import { getData, SearchStatus } from './search';
 import { ErrorFeedback } from '../../components/SearchPage/ErrorFeedback';
+import { Pagination } from '../../components/SearchPage/Pagination';
 import { SearchForm } from '../../components/SearchPage/SearchForm';
 import { Table } from '../../components/SearchPage/Table';
 import { getConfig } from '../../config';
@@ -34,7 +35,12 @@ const metadataSettings: Filter[] = config.schema.metadata.flatMap((metadata) => 
     }
 });
 
-const data = await getData(metadataSettings);
+const pageSize = 100;
+const pageParam = Astro.url.searchParams.get('page');
+const page = pageParam !== null ? Number.parseInt(pageParam, 10) : 1;
+const offset = (page - 1) * pageSize;
+
+const data = await getData(metadataSettings, offset, pageSize);
 ---
 
 <BaseLayout title='Search'>
@@ -59,6 +65,10 @@ const data = await getData(metadataSettings);
                             sequence{data.totalCount === 1 ? '' : 's'}
                         </div>
                         <Table data={data.data} config={config} client:only='react' />
+
+                        <div class='mt-4 flex justify-center'>
+                            <Pagination client:only='react' count={Math.ceil(data.totalCount / pageSize)} />
+                        </div>
                     </>
                 ) : null
             }

--- a/website/src/pages/search/search.ts
+++ b/website/src/pages/search/search.ts
@@ -13,7 +13,7 @@ export type SearchResponse = {
     data: TableSequenceData[];
     totalCount: number;
 };
-export const getData = async (metadataFilter: Filter[]): Promise<SearchResponse> => {
+export const getData = async (metadataFilter: Filter[], offset: number, limit: number): Promise<SearchResponse> => {
     const config = getConfig();
     const searchFilters = metadataFilter
         .filter((metadata) => metadata.filter !== '')
@@ -22,8 +22,8 @@ export const getData = async (metadataFilter: Filter[]): Promise<SearchResponse>
             return acc;
         }, {});
 
-    // TODO: when switching to LAPISv2 limit should be handled differently
-    const detailsQuery = `${config.lapisHost}/details?limit=100`;
+    // TODO: when switching to LAPISv2 limit and offset should be handled differently
+    const detailsQuery = `${config.lapisHost}/details?limit=${limit}&offset=${offset}`;
     const totalCountQuery = `${config.lapisHost}/aggregated`;
 
     const headers = {


### PR DESCRIPTION
While we wait for the deployment of LAPIS v2, I just added quickly a limited version of offset to LAPIS v1 (https://github.com/GenSpectrum/LAPIS/pull/305) allowing us to implement pagination.

Closes #8

<img src="https://github.com/pathoplexus/pathoplexus/assets/18666552/988a2cf8-6cc2-4b27-86ce-8ac6d62ffd95" width="400" />