### PR TITLE
feat(website): replace MUI DataGrid with a server side-renderable table

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -14,7 +14,6 @@
         "@astrojs/tailwind": "^4.0.0",
         "@emotion/styled": "^11.11.0",
         "@mui/material": "^5.14.1",
-        "@mui/x-data-grid": "^6.10.0",
         "@mui/x-date-pickers": "^6.9.1",
         "@tanstack/react-query": "^4.32.0",
         "@types/react": "^18.2.14",
@@ -1594,31 +1593,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
-    },
-    "node_modules/@mui/x-data-grid": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-6.10.0.tgz",
-      "integrity": "sha512-x9h+Z4B2vu+ZKKwClBVs30Y9eZYdhqyV3toHH2E0zat7FIZxwiVfk6qz4Q98V1fV0Fe1nczPj9i0siUmduMEXg==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.5",
-        "@mui/utils": "^5.13.6",
-        "clsx": "^1.2.1",
-        "prop-types": "^15.8.1",
-        "reselect": "^4.1.8"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui"
-      },
-      "peerDependencies": {
-        "@mui/material": "^5.4.1",
-        "@mui/system": "^5.4.1",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
-      }
     },
     "node_modules/@mui/x-date-pickers": {
       "version": "6.9.1",
@@ -8642,11 +8616,6 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
-    "node_modules/reselect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
-      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
-    },
     "node_modules/resolve": {
       "version": "1.22.2",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
@@ -12079,18 +12048,6 @@
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
           "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         }
-      }
-    },
-    "@mui/x-data-grid": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-6.10.0.tgz",
-      "integrity": "sha512-x9h+Z4B2vu+ZKKwClBVs30Y9eZYdhqyV3toHH2E0zat7FIZxwiVfk6qz4Q98V1fV0Fe1nczPj9i0siUmduMEXg==",
-      "requires": {
-        "@babel/runtime": "^7.22.5",
-        "@mui/utils": "^5.13.6",
-        "clsx": "^1.2.1",
-        "prop-types": "^15.8.1",
-        "reselect": "^4.1.8"
       }
     },
     "@mui/x-date-pickers": {
@@ -16888,11 +16845,6 @@
         "retext-smartypants": "^5.1.0",
         "unist-util-visit": "^4.1.0"
       }
-    },
-    "reselect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
-      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
     },
     "resolve": {
       "version": "1.22.2",

--- a/website/package.json
+++ b/website/package.json
@@ -21,7 +21,6 @@
     "@astrojs/tailwind": "^4.0.0",
     "@emotion/styled": "^11.11.0",
     "@mui/material": "^5.14.1",
-    "@mui/x-data-grid": "^6.10.0",
     "@mui/x-date-pickers": "^6.9.1",
     "@tanstack/react-query": "^4.32.0",
     "@types/react": "^18.2.14",

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -1,6 +1,5 @@
-import { DataGrid } from '@mui/x-data-grid';
 import { capitalCase } from 'change-case';
-import React, { useLayoutEffect, useState, type FC, useMemo } from 'react';
+import type { FC } from 'react';
 
 import type { Config } from '../../types';
 
@@ -14,51 +13,48 @@ type TableProps = {
 };
 
 export const Table: FC<TableProps> = ({ data, config }) => {
-    const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
-
-    useLayoutEffect(() => {
-        const handleResize = (): void => {
-            setViewportWidth(window.innerWidth);
-        };
-
-        window.addEventListener('resize', handleResize);
-
-        return () => {
-            window.removeEventListener('resize', handleResize);
-        };
-    }, []);
-
-    // Calculate the number of columns to omit based on the container width
-    const maximumNumberOfColumns = useMemo(() => Math.floor(viewportWidth / 300), [viewportWidth]);
-
     const primaryKey = config.schema.primaryKey;
     const rows = data.map((entry, index) => ({
         id: index,
         ...entry,
         [primaryKey]: { label: entry[primaryKey], url: `/sequences/${entry[primaryKey]}` },
     }));
-    const columns = [
-        {
-            field: primaryKey,
-            headerName: capitalCase(primaryKey),
-            flex: 3,
-            renderCell: (params: any) => (
-                <a href={params.value.url} rel='noopener noreferrer'>
-                    {params.value.label}
-                </a>
-            ),
-        },
-        ...config.schema.tableColumns.slice(0, maximumNumberOfColumns).map((field) => ({
-            field,
-            headerName: capitalCase(field),
-            flex: 2,
-        })),
-    ];
+    const primaryKeyColumn = {
+        field: primaryKey,
+        headerName: capitalCase(primaryKey),
+    };
+    const columns = config.schema.tableColumns.map((field) => ({
+        field,
+        headerName: capitalCase(field),
+    }));
 
     return (
-        <div style={{ height: 'auto', width: '100%' }}>
+        <div className='w-full overflow-x-auto'>
             {rows.length !== 0 ? (
-                <DataGrid rows={rows} columns={columns} disableColumnMenu hideFooter />
+                <table className='table'>
+                    <thead>
+                        <tr>
+                            <th>{primaryKeyColumn.headerName}</th>
+                            {columns.map((c) => (
+                                <th key={c.field}>{c.headerName}</th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {data.map((row, index) => (
+                            <tr key={index}>
+                                <td>
+                                    <a href={`/sequences/${row[primaryKeyColumn.field]}`}>
+                                        {row[primaryKeyColumn.field]}
+                                    </a>
+                                </td>
+                                {columns.map((c) => (
+                                    <td key={`${index}-${c.field}`}>{row[c.field]}</td>
+                                ))}
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
             ) : (
                 <div className='flex justify-center font-bold text-xl mb-5'>No Data</div>
             )}

--- a/website/src/pages/search/index.astro
+++ b/website/src/pages/search/index.astro
@@ -64,7 +64,7 @@ const data = await getData(metadataSettings, offset, pageSize);
                             Search returned {data.totalCount.toLocaleString()}
                             sequence{data.totalCount === 1 ? '' : 's'}
                         </div>
-                        <Table data={data.data} config={config} client:only='react' />
+                        <Table data={data.data} config={config} client:load />
 
                         <div class='mt-4 flex justify-center'>
                             <Pagination client:only='react' count={Math.ceil(data.totalCount / pageSize)} />


### PR DESCRIPTION
So far, we used MUI Data Grid for the search result table. Unfortunately, Astro is not able to properly server-side render it (possibly related to https://github.com/withastro/astro/issues/4432) and we have to render it entirely on the client side. This is slow and has a flickering effect. This PR replaces it with a much simpler table. Below are videos to compare before vs. after.

**Before:**


https://github.com/pathoplexus/pathoplexus/assets/18666552/e9e949f6-0ea0-4315-a5f9-7143b278a364

**After:**

https://github.com/pathoplexus/pathoplexus/assets/18666552/73caf7de-b4ba-4815-87d1-982560d3cedd


