### PR TITLE
feat(website): format number of search results as locale string and pluralisation

### DIFF
--- a/website/src/pages/search/index.astro
+++ b/website/src/pages/search/index.astro
@@ -54,7 +54,10 @@ const data = await getData(metadataSettings);
             {
                 data.status === SearchStatus.OK ? (
                     <>
-                        <div class='mb-1'>Search returned {data.totalCount} sequences</div>
+                        <div class='mb-1'>
+                            Search returned {data.totalCount.toLocaleString()}
+                            sequence{data.totalCount === 1 ? '' : 's'}
+                        </div>
                         <Table data={data.data} config={config} client:only='react' />
                     </>
                 ) : null


### PR DESCRIPTION
Just an idea to make the display of the count a bit prettier (and for me to learn about how things work)