### PR TITLE
fix(backend): Update to Java 20 (#247)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 19
+      - name: Set up JDK 20
         uses: actions/setup-java@v3
         with:
-          java-version: '19'
+          java-version: '20'
           distribution: 'adopt'
       - name: Execute Tests
         uses: gradle/gradle-build-action@v2
@@ -40,10 +40,10 @@ jobs:
       checks: read
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 19
+      - name: Set up JDK 20
         uses: actions/setup-java@v3
         with:
-          java-version: '19'
+          java-version: '20'
           distribution: 'adopt'
 
       - name: Login to GitHub Container Registry

--- a/backend/README.md
+++ b/backend/README.md
@@ -3,6 +3,7 @@
 ## Setup
 
 To start the backend, a PostgreSQL database is required. The database connection is configured via Spring properties that need to be passed on startup:
+
 * Via command line argument: `--database.jdbcUrl=jdbc:postgresql://localhost:5432/pathoplexus`
 * Via environment variable: `SPRING_APPLICATION_JSON={"database":{"jdbcUrl":"jdbc:postgresql://localhost:5432/pathoplexus"}}`
 
@@ -44,6 +45,28 @@ docker compose up database
 ### Operating the backend behind a proxy
 
 When running the backend behind a proxy, the proxy needs to set X-Forwarded headers:
+
 * X-Forwarded-For
 * X-Forwarded-Proto
 * X-Forwarded-Prefix
+
+## Development
+
+### Requirements
+
+* Java 20
+
+### Build docker image
+
+In the `backend` directory run:
+
+```bash
+./gradlew bootBuildImage
+```
+
+### Run tests and lints
+
+```bash
+./gradlew test
+./gradlew ktlintCheck
+```

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -14,7 +14,7 @@ group = 'org.pathoplexus'
 version = '0.0.1'
 
 java {
-	sourceCompatibility = '19'
+	sourceCompatibility = '20'
 }
 
 repositories {


### PR DESCRIPTION
resolves #247 

As an alternative approach to #248. Java 19 reached end of maintenance, let's simply use Java 20.

Java 21 will be released soon. As this is the next LTS version, we should switch to that soon.