### PR TITLE
Improve backend readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,3 +19,8 @@ We value clean code, here are some guidelines on what we consider clean code:
 
 Keep in mind that Pathoplexus is designed to be run and maintained by anyone. 
 This means that the code that we develop needs to be suitably general and configurable.
+
+### OpenAPI docs
+
+The backend offers a Swagger UI and an OpenAPI specification.
+Try to keep the OpenAPI specification as correct and as useful as possible.

--- a/backend/README.md
+++ b/backend/README.md
@@ -19,8 +19,13 @@ DOCKER_IMAGE_NAME=doesNotMatterHere docker compose up database
 
 The database connection is configured via Spring properties that need to be passed on startup:
 
-* Via command line argument: `--database.jdbcUrl=jdbc:postgresql://localhost:5432/pathoplexus`
-* Via environment variable: `SPRING_APPLICATION_JSON={"database":{"jdbcUrl":"jdbc:postgresql://localhost:5432/pathoplexus"}}`
+* Via command line argument (also see docker-compose.yml): 
+```
+--database.jdbcUrl=jdbc:postgresql://localhost:5432/pathoplexus
+--database.username=postgres
+--database.password=unsecure
+```
+* Via environment variable: `SPRING_APPLICATION_JSON={"database":{"jdbcUrl":"jdbc:postgresql://localhost:5432/pathoplexus","username":"postgres","password":"unsecure"}}`
 
 We use Flyway, so that the service can provision an empty/existing DB without any manual steps in between. On startup scripts in `src/main/resources/db/migration` are executed in order, i.e. `V1__*.sql` before `V2__*.sql` if they didn't run before, so that the DB is always up-to-date. (For more info on the naming convention, see [this](https://www.red-gate.com/blog/database-devops/flyway-naming-patterns-matter) blog post.)
 
@@ -28,11 +33,11 @@ The service listens, by default, to **port 8079**: <http://localhost:8079/swagge
 
 #### Start from command line: 
 ```bash
-./gradlew bootRun --args='--database.jdbcUrl=jdbc:postgresql://localhost:5432/pathoplexus'
+./gradlew bootRun --args='--database.jdbcUrl=jdbc:postgresql://localhost:5432/pathoplexus --database.username=postgres --database.password=unsecure'
 ```
 or
 ```bash
-SPRING_APPLICATION_JSON='{"database":{"jdbcUrl":"jdbc:postgresql://localhost:5432/pathoplexus"}}' ./gradlew bootRun
+SPRING_APPLICATION_JSON='{"database":{"jdbcUrl":"jdbc:postgresql://localhost:5432/pathoplexus","username":"postgres","password":"unsecure"}}' ./gradlew bootRun
 ```
 
 #### Start from docker-compose
@@ -96,3 +101,15 @@ Details on potential problems are most likely found there.
 In the Docker container, the logs can be found in `/workspace/log/backend.log`.
 
 Once per day, the log file is rotated and compressed. Old log files are stored in `./log/archived/`.
+
+## Swagger UI
+
+The backend provides a Swagger UI at <http://localhost:8079/swagger-ui/index.html>.
+We use Swagger to document the API and to provide a playground for testing the API.
+Especially for manual testing during the development, this is very useful.
+
+OpenAPI does not deal well with NDJSON. 
+Since the API has endpoints that deal with NDJSON, the documentation of those endpoints is to be understood as
+"the provided schema is a valid JSON schema for each line of the NDJSON file".
+
+The Swagger UI and OpenAPI specification is generated via the [Springdoc plugin](https://springdoc.org/).

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -13,7 +13,10 @@ services:
     image: ${DOCKER_IMAGE_NAME}
     depends_on:
       - database
-    command: --database.jdbcUrl=jdbc:postgresql://database:5432/pathoplexus
+    command:
+      --database.jdbcUrl=jdbc:postgresql://database:5432/pathoplexus
+      --database.username=postgres
+      --database.password=unsecure
     volumes:
       - ./log:/workspace/log
     ports:

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,6 +1,4 @@
 server.port=8079
-database.username=postgres
-database.password=unsecure
 
 springdoc.default-produces-media-type=application/json
 springdoc.api-docs.path=/api-docs

--- a/intellijRunConfig/BackendApplicationKt.run.xml
+++ b/intellijRunConfig/BackendApplicationKt.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="BackendApplicationKt" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" nameIsGenerated="true">
+    <envs>
+      <env name="SPRING_APPLICATION_JSON" value="{&quot;database&quot;:{&quot;jdbcUrl&quot;:&quot;jdbc:postgresql://0.0.0.0:5432/pathoplexus&quot;,&quot;username&quot;:&quot;postgres&quot;,&quot;password&quot;:&quot;unsecure&quot;}}" />
+    </envs>
+    <module name="backend.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="org.pathoplexus.backend.BackendApplicationKt" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
* The credentials for the Postgres DB should not be hardcoded in the application properties.
* Restructure the README: Try to provide a "story", that one can follow top to bottom, how to get to run the backend.

Suggestions on improvements are welcome!