### PR TITLE
fix(backend): Pango lineages are valid without `.`, e.g. XBB

### DIFF
--- a/backend/src/main/kotlin/org/pathoplexus/backend/service/SequenceValidatorService.kt
+++ b/backend/src/main/kotlin/org/pathoplexus/backend/service/SequenceValidatorService.kt
@@ -42,7 +42,7 @@ class SequenceValidatorService
     }
 
     fun isValidPangoLineage(pangoLineageCandidate: String): Boolean {
-        return pangoLineageCandidate.matches(Regex("[a-zA-Z]{1,3}(\\.\\d{1,3}){1,3}"))
+        return pangoLineageCandidate.matches(Regex("[a-zA-Z]{1,3}(\\.\\d{1,3}){0,3}"))
     }
 
     fun validateFieldType(fieldValue: JsonNode, metadata: Metadata): Boolean {


### PR DESCRIPTION
I noticed that recombinants like `XF` were getting rejected.

Turns out the regex required at least one "dot-number" - which is overly strict

Now things like `XF` are accepted.