### PR TITLE
ci: try grouping dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,17 @@ updates:
     directory: website/
     schedule:
       interval: weekly
+    groups:
+      minorAndPatch:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: gradle
     directory: backend/
     schedule:
       interval: weekly
+    groups:
+      minorAndPatch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
resolves #151 

New major versions should still create a separate PR per dependency.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups