### PR TITLE
fix(website): use runtime config for Api docs as well

### DIFF
--- a/website/src/pages/api_documentation/index.astro
+++ b/website/src/pages/api_documentation/index.astro
@@ -1,7 +1,9 @@
 ---
+import { getRuntimeConfig } from '../../config';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 
-const backendurl = import.meta.env.BACKEND_URL;
+const config = getRuntimeConfig().forClient;
+const backendurl = config.backendUrl;
 ---
 
 <BaseLayout title='Api Docs'>


### PR DESCRIPTION
Adjustment necessary due to PR #298. Since that PR, the iframe doesn't work anymore. With this PR here it'll work again.

I'm not sure whether I should use `getRuntimeConfig().forClient` or `getRuntimeConfig().forServer`. I tested both and both worked.

It doesn't work with the netlify preview due to CORS and us not having a backend deployed yet I suppose.