### PR TITLE
fix: Add `init: true` to docker-compose.yml to pass thru sigint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   website:
     image: ${WEBSITE_IMAGE}
+    init: true
     ports:
       - "3000:3000"
     volumes:


### PR DESCRIPTION
I noticed that the website didn't shut down until timeout when sending `ctrl+c` to `docker compose up`. This fixes the issue.

When running a Node.js application inside a Docker container, the Node.js process doesn't run as PID 1, so it doesn't receive signals like SIGINT directly.

Another option is to use the tini init system directly in your Dockerfile by installing it and setting it as the entry point.