### PR TITLE
fix: Remove !important from link styling

### DIFF
--- a/website/src/styles/base.scss
+++ b/website/src/styles/base.scss
@@ -5,7 +5,7 @@
 
 a {
   &:hover {
-    @apply underline decoration-emerald-700 scale-105 #{!important};
+    @apply underline decoration-emerald-700 scale-105;
   }
 }
 


### PR DESCRIPTION
As far as I can tell if we have this `!important` set it is very hard for us to have any `<a` tags on the site that don't e.g. hover on underline. That seems undesirable? (I'm sure there's a reason this was implemented, so feel free to let me know :) )