### PR TITLE
chore: add node dev test

### DIFF
--- a/.github/workflows/node_dev.yml
+++ b/.github/workflows/node_dev.yml
@@ -21,12 +21,10 @@ jobs:
     - name: Test dev node server
       working-directory: website
       run: |
-        # Start the Node server in the background
         npm run start &
         npx playwright install chromium
    
         
-        # Use Playwright to open localhost
         npx playwright screenshot localhost:3000 test.png
         sleep 5
         npx playwright screenshot localhost:3000 test.png


### PR DESCRIPTION
This adds CI that provides a very basic test for the ability of the dev server to serve a request and then serve a second request (meaning that it has not crashed), across all platforms. It is motivated to catch e.g. #404.

The (added) current failing test is expected, because the dev server currently does not work on macOS (#404).