### PR TITLE
exclude fsevents from optimisedeps

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -19,6 +19,5 @@ export default defineConfig({
         optimizeDeps: {
             exclude: ['fsevents'],
         },
-    
     },
 });


### PR DESCRIPTION
Fixes #404 - in which the vite dev server fails on MacOS.