### PR TITLE
feat(argocd): adapt kubernetes ingress and add letsencrypt

### DIFF
--- a/.argocd/preview/templates/ingress.yml
+++ b/.argocd/preview/templates/ingress.yml
@@ -3,8 +3,13 @@ kind: Ingress
 metadata:
   name: website-{{ .Values.shortbranch }}
   namespace: preview
+  annotations:
+    cert-manager.io/issuer: "letsencrypt-prod"
 spec:
-  ingressClassName: nginx
+  tls:
+  - hosts:
+    - {{ .Values.host }}
+    secretName: website-{{ .Values.shortbranch }}-tls
   rules:
     - host: {{ .Values.host }}
       http:

--- a/.argocd/preview/templates/letsencrypt.yml
+++ b/.argocd/preview/templates/letsencrypt.yml
@@ -1,0 +1,19 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt-prod
+  namespace: letsencrypt
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: chaoran.chen@bsse.ethz.ch
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    # Enable the HTTP-01 challenge provider
+    solvers:
+      - http01:
+          ingress:
+            class: traefik


### PR DESCRIPTION
This prepares for the switch to our self-hosted k3s cluster.

By default, k3s uses Traefik as ingress controller and not nginx.