### PR TITLE
use argocd image updater

### DIFF
--- a/.argocd/appset.yml
+++ b/.argocd/appset.yml
@@ -3,6 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: pp-preview
+  namespace: argocd
 spec:
   goTemplate: true
   generators:
@@ -19,6 +20,14 @@ spec:
   template:
     metadata:
       name: 'pp-{{ (printf "%.25s" .branch) | replace "_" "-" }}-{{.number}}'
+      annotations:
+        argocd-image-updater.argoproj.io/image-list: 'backend=ghcr.io/pathoplexus/backend:{{.branch}} website=ghcr.io/pathoplexus/website:{{.branch}}'
+        argocd-image-updater.argoproj.io/website.update-strategy: "digest"
+        argocd-image-updater.argoproj.io/backend.update-strategy: "digest"
+        argocd-image-updater.argoproj.io/website.pull-secret: "pullsecret:argocd/ghcr-secret"
+        argocd-image-updater.argoproj.io/backend.pull-secret: "pullsecret:argocd/ghcr-secret"
+
+
     spec:
       destination:
         server: 'https://kubernetes.default.svc'


### PR DESCRIPTION
This should ensure that even when images take a while to build the preview instances eventually update. It will take a while to be sure how well this is working but since it is already deployed I would like to keep the github up to date with the current status (by merging this)