### PR TITLE
move iconify to dev dependency

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@astrojs/node": "^6.0.3",
         "@emotion/react": "^11.11.1",
-        "@iconify/json": "^2.2.141",
         "@mui/material": "^5.14.17",
         "@mui/x-date-pickers": "^6.18.1",
         "@svgr/core": "^8.1.0",
@@ -37,6 +36,7 @@
         "@astrojs/react": "^3.0.4",
         "@astrojs/tailwind": "^5.0.2",
         "@emotion/styled": "^11.11.0",
+        "@iconify/json": "^2.2.141",
         "@playwright/test": "^1.39.0",
         "@tanstack/eslint-plugin-query": "^5.8.3",
         "@testing-library/dom": "^9.3.1",
@@ -1257,6 +1257,7 @@
       "version": "2.2.141",
       "resolved": "https://registry.npmjs.org/@iconify/json/-/json-2.2.141.tgz",
       "integrity": "sha512-EmHsjVngGE7K9ykKkkGczXTW5552h/dDp7SicHT3SaQD1Krb/GvIVCff9jRgBDFu9QxhcqVdVk+kDHfbzJXT8Q==",
+      "dev": true,
       "dependencies": {
         "@iconify/types": "*",
         "pathe": "^1.1.0"

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@astrojs/node": "^6.0.3",
     "@emotion/react": "^11.11.1",
-    "@iconify/json": "^2.2.141",
     "@mui/material": "^5.14.17",
     "@mui/x-date-pickers": "^6.18.1",
     "@svgr/core": "^8.1.0",
@@ -46,6 +45,7 @@
     "@astrojs/react": "^3.0.4",
     "@astrojs/tailwind": "^5.0.2",
     "@emotion/styled": "^11.11.0",
+    "@iconify/json": "^2.2.141",
     "@playwright/test": "^1.39.0",
     "@tanstack/eslint-plugin-query": "^5.8.3",
     "@testing-library/dom": "^9.3.1",


### PR DESCRIPTION
I think this should fix the bundle size issue? Sorry this was my mistake originally.