### PR TITLE
Remove namespace from ingress class as it is unused

### DIFF
--- a/kubernetes/preview/templates/lapis-ingress.yaml
+++ b/kubernetes/preview/templates/lapis-ingress.yaml
@@ -30,6 +30,5 @@ apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   name: lapis-ingress-class
-  namespace: {{ .Values.namespace}}
 spec:
   controller: k8s.io/ingress-nginx


### PR DESCRIPTION
This removes the namespace annotation from the IngressClass as my understanding is that `IngressClass` is inherently cluster-wide and not namespaceable, so this reflects the reality. We should consider whether we should incorporate the branch name into the ingress class name so that we get one class per instance. TBH I don't understand the classes enough to know if we need to do that.