### PR TITLE
deployment: avoid unnecessarily redeclaring helm variables

### DIFF
--- a/kubernetes/preview/templates/lapis-ingress.yaml
+++ b/kubernetes/preview/templates/lapis-ingress.yaml
@@ -1,7 +1,5 @@
 {{- $lapisHost := printf "lapis.%s" .Values.host }}
-{{- $environment := .Values.environment }}
 {{- $configFile := .Files.Get "config.yaml" | fromYaml }}
-{{- $namespace := .Values.namespace }}
 {{- range $key, $_ := $configFile.instances }}
 
 ---
@@ -9,28 +7,28 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   name: lapis-ingressroute-{{ $key }}
-  namespace: {{ $namespace }}
+  namespace: {{ $.Values.namespace }}
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
-{{- if eq $environment "server" }}
+{{- if eq $.Values.environment "server" }}
     link.argocd.argoproj.io/external-link: https://{{ $lapisHost }}
 {{- end }}
 spec:
   entryPoints:
-    {{- if eq $environment "server" }}
+    {{- if eq $.Values.environment "server" }}
     - websecure
     {{- else }}
     - web
     {{- end }}
   routes:
-  - match: Path(`/{{ $key }}`, `/{{ $key }}/{path:.*}`) {{- if eq $environment "server" }} && Host(`{{ $lapisHost }}`){{- end }}
+  - match: Path(`/{{ $key }}`, `/{{ $key }}/{path:.*}`) {{- if eq $.Values.environment "server" }} && Host(`{{ $lapisHost }}`){{- end }}
     kind: Rule
     services:
     - name: {{ template "pathoplexus.lapisServiceName" $key }}
       port: 8080
     middlewares:
     - name: strip-{{ $key }}-prefix
-{{- if eq $environment "server" }}
+{{- if eq $.Values.environment "server" }}
   tls:
     certResolver: myresolver
 {{- end }}
@@ -40,7 +38,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   name: strip-{{ $key }}-prefix
-  namespace: {{ $namespace }}
+  namespace: {{ $.Values.namespace }}
 spec:
   stripPrefix:
     prefixes:

--- a/kubernetes/preview/templates/lapis-service.yaml
+++ b/kubernetes/preview/templates/lapis-service.yaml
@@ -1,5 +1,4 @@
 {{- $configFile := .Files.Get "config.yaml" | fromYaml }}
-{{ $namespace := .Values.namespace }}
 
 {{- range $key, $_ := $configFile.instances }}
 ---
@@ -7,7 +6,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "pathoplexus.lapisServiceName" $key }}
-  namespace: {{ $namespace }}
+  namespace: {{ $.Values.namespace }}
 spec:
   type: ClusterIP
   selector:

--- a/kubernetes/preview/templates/lapis-silo-database-config.yaml
+++ b/kubernetes/preview/templates/lapis-silo-database-config.yaml
@@ -1,6 +1,5 @@
 {{- $configFile := .Files.Get "config.yaml" | fromYaml }}
 {{- $commonMetadata := (include "pathoplexus.commonMetadata" . | fromYaml).fields }}
-{{- $namespace := .Values.namespace }}
 {{- $importScriptLines := .Files.Lines "silo_import_job.sh" }}
 
 {{- range $key, $instance := $configFile.instances }}
@@ -9,7 +8,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: lapis-silo-database-config-{{ $key }}
-  namespace: {{ $namespace }}
+  namespace: {{ $.Values.namespace }}
 data:
   {{- with $instance.schema }}
   database_config.yaml: |

--- a/kubernetes/preview/templates/lapis-silo-deployment.yaml
+++ b/kubernetes/preview/templates/lapis-silo-deployment.yaml
@@ -1,5 +1,4 @@
 {{- $configFile := .Files.Get "config.yaml" | fromYaml }}
-{{ $namespace := .Values.namespace }}
 
 {{- range $key, $_ := $configFile.instances }}
 ---
@@ -7,7 +6,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pathoplexus-lapis-silo-{{ $key }}
-  namespace: {{ $namespace }}
+  namespace: {{ $.Values.namespace }}
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
 spec:

--- a/kubernetes/preview/templates/lapis-silo-import-cronjob.yaml
+++ b/kubernetes/preview/templates/lapis-silo-import-cronjob.yaml
@@ -1,6 +1,4 @@
 {{- $configFile := .Files.Get "config.yaml" | fromYaml }}
-{{- $namespace := .Values.namespace }}
-{{- $disableBackend := .Values.disableBackend }}
 
 {{- $keycloakTokenUrl := "http://pathoplexus-keycloak-service:8083/realms/pathoplexusRealm/protocol/openid-connect/token" }}
 
@@ -11,7 +9,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: lapis-silo-import-cronjob-{{ $key }}
-  namespace: {{ $namespace }}
+  namespace: {{ $.Values.namespace  }}
 spec:
   schedule: "* * * * *"
   concurrencyPolicy: Forbid
@@ -32,7 +30,7 @@ spec:
                 - /silo_import_job.sh
               env:
                 - name: BACKEND_BASE_URL
-                  {{- if $disableBackend }}
+                  {{- if $.Values.disableBackend }}
                   value: "http://host.k3d.internal:8079/{{ $key }}"
                   {{- else }}
                   value: "http://pathoplexus-backend-service:8079/{{ $key }}"

--- a/kubernetes/preview/templates/lapis-silo-shared-data.yaml
+++ b/kubernetes/preview/templates/lapis-silo-shared-data.yaml
@@ -1,5 +1,4 @@
 {{- $configFile := .Files.Get "config.yaml" | fromYaml }}
-{{ $namespace := .Values.namespace }}
 
 {{- range $key, $_ := $configFile.instances }}
 ---
@@ -7,7 +6,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: lapis-silo-shared-data-{{ $key }}
-  namespace: {{ $namespace }}
+  namespace: {{ $.Values.namespace }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/kubernetes/preview/templates/pathoplexus-preprocessing-deployment.yaml
+++ b/kubernetes/preview/templates/pathoplexus-preprocessing-deployment.yaml
@@ -1,6 +1,5 @@
 {{- $dockerTag := include "pathoplexus.dockerTag" .Values }}
 {{ $configFile := .Files.Get "config.yaml" | fromYaml }}
-{{ $namespace := .Values.namespace }}
 {{ $backendHost := .Values.disableBackend | ternary
     "http://host.k3d.internal:8079"
     "http://pathoplexus-backend-service:8079"
@@ -36,7 +35,7 @@ spec:
           args:
             - "--watch"
             - "--backend-host={{ $backendHost }}/{{ $key }}"
-            {{- if eq .Values.environment "server" }}
+            {{- if eq $.Values.environment "server" }}
             - "--keycloak-host=https://{{ $keycloakHost}}"
             {{- else }}
             - "--keycloak-host=http://localhost:8083"


### PR DESCRIPTION
When you enter a helm loop the contents of `.Values` changes so it no longer has the root values. We've previously been dealing with this by assigning the variables we needed outside of the loop, but its a bit verbose. I finally asked ChatGPT and it told me about `$.Values` where the `$` is the root context. Let's use that?