### PR TITLE
fix: "No known conditions for node specifier in msw"

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config';
+import {defineConfig} from 'astro/config';
 import node from '@astrojs/node';
 import tailwind from '@astrojs/tailwind';
 import Icons from 'unplugin-icons/vite';
@@ -17,8 +17,8 @@ export default defineConfig({
     },
     vite: {
         optimizeDeps: {
-            exclude: ['fsevents'],
+            exclude: ['fsevents', 'msw/node', 'msw'],
         },
-        plugins: [Icons({ compiler: 'jsx', jsx: 'react' })],
+        plugins: [Icons({compiler: 'jsx', jsx: 'react'})],
     },
 });


### PR DESCRIPTION
This fixes the error, when running `npm run dev`
`  ✘ [ERROR] No known conditions for "./node" specifier in "msw" package [plugin vite:dep-scan]

    vitest.setup.ts:6:28:
      6 │ import { setupServer } from 'msw/node';
        ╵                             ~~~~~~~~~~

  This error came from the "onResolve" callback registered here:

    node_modules/vite/node_modules/esbuild/lib/main.js:1292:20:
      1292 │       let promise = setup({
           ╵                     ^

    at setup (file:///home/kellerer/Dokumente/covSpectrum/pathoplexus/website/node_modules/vite/dist/node/chunks/dep-68d1a114.js:44748:19)
    at handlePlugins (/home/kellerer/Dokumente/covSpectrum/pathoplexus/website/node_modules/vite/node_modules/esbuild/lib/main.js:1292:21)
    at buildOrContextImpl (/home/kellerer/Dokumente/covSpectrum/pathoplexus/website/node_modules/vite/node_modules/esbuild/lib/main.js:978:5)
    at Object.buildOrContext (/home/kellerer/Dokumente/covSpectrum/pathoplexus/website/node_modules/vite/node_modules/esbuild/lib/main.js:786:5)
    at /home/kellerer/Dokumente/covSpectrum/pathoplexus/website/node_modules/vite/node_modules/esbuild/lib/main.js:2186:68
    at new Promise (<anonymous>)
    at Object.context (/home/kellerer/Dokumente/covSpectrum/pathoplexus/website/node_modules/vite/node_modules/esbuild/lib/main.js:2186:27)
    at Object.context (/home/kellerer/Dokumente/covSpectrum/pathoplexus/website/node_modules/vite/node_modules/esbuild/lib/main.js:2026:58)
    at prepareEsbuildScanner (file:///home/kellerer/Dokumente/covSpectrum/pathoplexus/website/node_modules/vite/dist/node/chunks/dep-68d1a114.js:44531:26)


    at failureErrorWithLog (/home/kellerer/Dokumente/covSpectrum/pathoplexus/website/node_modules/vite/node_modules/esbuild/lib/main.js:1649:15)
    at /home/kellerer/Dokumente/covSpectrum/pathoplexus/website/node_modules/vite/node_modules/esbuild/lib/main.js:1058:25
    at runOnEndCallbacks (/home/kellerer/Dokumente/covSpectrum/pathoplexus/website/node_modules/vite/node_modules/esbuild/lib/main.js:1484:45)
    at buildResponseToResult (/home/kellerer/Dokumente/covSpectrum/pathoplexus/website/node_modules/vite/node_modules/esbuild/lib/main.js:1056:7)
    at /home/kellerer/Dokumente/covSpectrum/pathoplexus/website/node_modules/vite/node_modules/esbuild/lib/main.js:1068:9
    at new Promise (<anonymous>)
    at requestCallbacks.on-end (/home/kellerer/Dokumente/covSpectrum/pathoplexus/website/node_modules/vite/node_modules/esbuild/lib/main.js:1067:54)
    at handleRequest (/home/kellerer/Dokumente/covSpectrum/pathoplexus/website/node_modules/vite/node_modules/esbuild/lib/main.js:729:19)
    at handleIncomingPacket (/home/kellerer/Dokumente/covSpectrum/pathoplexus/website/node_modules/vite/node_modules/esbuild/lib/main.js:755:7)
    at Socket.readFromStdout (/home/kellerer/Dokumente/covSpectrum/pathoplexus/website/node_modules/vite/node_modules/esbuild/lib/main.js:679:7)
`