### PR TITLE
deployment: support non-lowercase branchnames

### DIFF
--- a/kubernetes/appset.yaml
+++ b/kubernetes/appset.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       destination:
         server: 'https://kubernetes.default.svc'
-        namespace: 'preview-{{ (printf "%.25s" .branch) | replace "_" "-" | trimSuffix "-" }}'
+        namespace: 'preview-{{ (printf "%.25s" .branch) | replace "_" "-" | trimSuffix "-" | lower  }}'
       project: default
       source:
         path: 'kubernetes/preview/'
@@ -38,9 +38,9 @@ spec:
         helm:
           parameters:
             - name: namespace
-              value: 'preview-{{ (printf "%.25s" .branch) | replace "_" "-" | trimSuffix "-" }}'
+              value: 'preview-{{ (printf "%.25s" .branch) | replace "_" "-" | trimSuffix "-" | lower }}'
             - name: shortbranch
-              value: '{{ (printf "%.25s" .branch) | replace "_" "-" | trimSuffix "-" }}'
+              value: '{{ (printf "%.25s" .branch) | replace "_" "-" | trimSuffix "-" | lower  }}'
             - name: sha
               value: '{{.head_short_sha_7}}'
             - name: branch


### PR DESCRIPTION
This is already rolled out. Without it we can't get preview for branch names containing upper case chars.