### PR TITLE
Fix Kubernetes preview fails for commits whose hash digest is entirely numeric

### DIFF
--- a/kubernetes/loculus/templates/_loculus-docker-tag.tpl
+++ b/kubernetes/loculus/templates/_loculus-docker-tag.tpl
@@ -1,6 +1,6 @@
 {{- define "loculus.dockerTag" }}
 {{- if .sha }}
-{{- printf "commit-%s" .sha }}
+{{- printf "commit-%v" .sha }}
 {{- else }}
 {{- $dockerTag := (eq (.branch | default "main") "main") | ternary "latest" .branch -}}
 {{- regexReplaceAll "/" $dockerTag "-" }}


### PR DESCRIPTION
Fixes #726 