### PR TITLE
Update appset to support branches with slashes

### DIFF
--- a/kubernetes/appset.yaml
+++ b/kubernetes/appset.yaml
@@ -24,12 +24,12 @@ spec:
         - path: "config.json"
   template:
     metadata:
-      name: 'pp-{{ (printf "%.25s" .branch) | replace "_" "-" | trimSuffix "-" | lower }}-{{.number}}'
+      name: 'pp-{{ (printf "%.25s" .branch) | replace "_" "-" | replace "/" "-" | trimSuffix "-" | lower }}-{{.number}}'
 
     spec:
       destination:
         server: 'https://kubernetes.default.svc'
-        namespace: 'preview-{{ (printf "%.25s" .branch) | replace "_" "-" | trimSuffix "-" | lower  }}'
+        namespace: 'preview-{{ (printf "%.25s" .branch) | replace "_" "-" | replace "/" "-" | trimSuffix "-" | lower  }}'
       project: default
       source:
         path: 'kubernetes/loculus/'
@@ -38,15 +38,15 @@ spec:
         helm:
           parameters:
             - name: namespace
-              value: 'preview-{{ (printf "%.25s" .branch) | replace "_" "-" | trimSuffix "-" | lower }}'
+              value: 'preview-{{ (printf "%.25s" .branch) | replace "_" "-" | replace "/" "-" | trimSuffix "-" | lower }}'
             - name: shortbranch
-              value: '{{ (printf "%.25s" .branch) | replace "_" "-" | trimSuffix "-" | lower  }}'
+              value: '{{ (printf "%.25s" .branch) | replace "_" "-" | replace "/" "-" | trimSuffix "-" | lower  }}'
             - name: sha
               value: '{{.head_short_sha_7}}'
             - name: branch
               value: '{{.branch}}'
             - name: host
-              value: '{{ (printf "%.25s" .branch) | replace "_" "-" | trimSuffix "-" | lower  }}.preview.k3s.loculus.org'
+              value: '{{ (printf "%.25s" .branch) | replace "_" "-" | replace "/" "-" | trimSuffix "-" | lower  }}.preview.k3s.loculus.org'
       syncPolicy:
         automated:
           selfHeal: true


### PR DESCRIPTION
This update updates appset.yaml to the newly deployed version to support e.g. the UoT branch.

(I know the duplication isn't great, but it's not something I personally have bandwidth to check whether can be refactored atm.)