### PR TITLE
chore: fix typo in preprocessing user/pwd (was: prerocessing)

### DIFF
--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -63,15 +63,15 @@ data:
           }
         },
         {
-          "username": "dummy_prerocessing_pipeline",
+          "username": "dummy_preprocessing_pipeline",
           "enabled": true,
-          "email": "dummy_prerocessing_pipeline@keycloak.org",
+          "email": "dummy_preprocessing_pipeline@keycloak.org",
           "firstName": "Dummy",
           "lastName": "Preprocessing",
           "credentials": [
             {
               "type": "password",
-              "value": "dummy_prerocessing_pipeline"
+              "value": "dummy_preprocessing_pipeline"
             }
           ],
           "realmRoles": [

--- a/preprocessing/dummy/main.py
+++ b/preprocessing/dummy/main.py
@@ -16,9 +16,9 @@ parser.add_argument("--withErrors", action="store_true", help="Add errors to pro
 parser.add_argument("--withWarnings", action="store_true", help="Add warnings to processed data.")
 parser.add_argument("--maxSequences", type=int, help="Max number of sequence entry versions to process.")
 parser.add_argument("--keycloak-host", type=str, default="http://172.0.0.1:8083", help="Host address of Keycloak")
-parser.add_argument("--keycloak-user", type=str, default="dummy_prerocessing_pipeline",
+parser.add_argument("--keycloak-user", type=str, default="dummy_preprocessing_pipeline",
                     help="Keycloak user to use for authentication")
-parser.add_argument("--keycloak-password", type=str, default="dummy_prerocessing_pipeline",
+parser.add_argument("--keycloak-password", type=str, default="dummy_preprocessing_pipeline",
                     help="Keycloak password to use for authentication")
 parser.add_argument("--keycloak-token-path", type=str, default="/realms/loculusRealm/protocol/openid-connect/token", help="Path to Keycloak token endpoint")
 

--- a/preprocessing/nextclade/main.py
+++ b/preprocessing/nextclade/main.py
@@ -18,9 +18,9 @@ parser.add_argument(
     help="Host address of the Loculus backend",
 )
 parser.add_argument("--keycloak-host", type=str, default="http://172.0.0.1:8083", help="Host address of Keycloak")
-parser.add_argument("--keycloak-user", type=str, default="dummy_prerocessing_pipeline",
+parser.add_argument("--keycloak-user", type=str, default="dummy_preprocessing_pipeline",
                     help="Keycloak user to use for authentication")
-parser.add_argument("--keycloak-password", type=str, default="dummy_prerocessing_pipeline",
+parser.add_argument("--keycloak-password", type=str, default="dummy_preprocessing_pipeline",
                     help="Keycloak password to use for authentication")
 parser.add_argument("--keycloak-token-path", type=str, default="/realms/loculusRealm/protocol/openid-connect/token",
                     help="Path to Keycloak token endpoint")

--- a/website/tests/util/preprocessingPipeline.ts
+++ b/website/tests/util/preprocessingPipeline.ts
@@ -55,8 +55,8 @@ async function submit(preprocessingOptions: PreprocessingOptions[]) {
 }
 
 async function getJwtTokenForPreprocessingPipeline(
-    username: string = 'dummy_prerocessing_pipeline',
-    password: string = 'dummy_prerocessing_pipeline',
+    username: string = 'dummy_preprocessing_pipeline',
+    password: string = 'dummy_preprocessing_pipeline',
 ): Promise<string> {
     const token = await getToken(username, password);
 


### PR DESCRIPTION
Did a find replace to change all instances of `prerocessing` to `preprocessing`

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
