### PR TITLE
feat(website): add mutation filter to the search

### DIFF
--- a/website/src/components/SearchPage/SearchForm.spec.tsx
+++ b/website/src/components/SearchPage/SearchForm.spec.tsx
@@ -6,7 +6,8 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { SearchForm } from './SearchForm';
 import { testConfig, testOrganism } from '../../../vitest.setup.ts';
 import { routes } from '../../routes.ts';
-import type { Filter } from '../../types/config.ts';
+import type { MetadataFilter } from '../../types/config.ts';
+import type { ReferenceGenomesSequenceNames } from '../../types/referencesGenomes.ts';
 import type { ClientConfig } from '../../types/runtimeConfig.ts';
 
 vi.mock('../../config', () => ({
@@ -22,13 +23,25 @@ const defaultSearchFormFilters = [
     { name: 'field3', type: 'pango_lineage' as const, label: 'Field 3', autocomplete: true, filterValue: '' },
 ];
 
+const defaultReferenceGenomesSequenceNames = {
+    nucleotideSequences: ['main'],
+    genes: ['gene1', 'gene2'],
+};
+
 function renderSearchForm(
-    searchFormFilters: Filter[] = [...defaultSearchFormFilters],
+    searchFormFilters: MetadataFilter[] = [...defaultSearchFormFilters],
     clientConfig: ClientConfig = testConfig.public,
+    referenceGenomesSequenceNames: ReferenceGenomesSequenceNames = defaultReferenceGenomesSequenceNames,
 ) {
     render(
         <QueryClientProvider client={queryClient}>
-            <SearchForm organism={testOrganism} filters={searchFormFilters} clientConfig={clientConfig} />
+            <SearchForm
+                organism={testOrganism}
+                filters={searchFormFilters}
+                initialMutationFilter={{}}
+                clientConfig={clientConfig}
+                referenceGenomesSequenceNames={referenceGenomesSequenceNames}
+            />
         </QueryClientProvider>,
     );
 }

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -2,7 +2,7 @@ import { capitalCase } from 'change-case';
 import type { FC, ReactElement } from 'react';
 
 import { routes } from '../../routes.ts';
-import type { Filter, Schema } from '../../types/config.ts';
+import type { MetadataFilter, MutationFilter, Schema } from '../../types/config.ts';
 import type { OrderBy } from '../../types/lapis.ts';
 import MdiTriangle from '~icons/mdi/triangle';
 import MdiTriangleDown from '~icons/mdi/triangle-down';
@@ -15,12 +15,13 @@ type TableProps = {
     organism: string;
     schema: Schema;
     data: TableSequenceData[];
-    filters: Filter[];
+    metadataFilter: MetadataFilter[];
+    mutationFilter: MutationFilter;
     page: number;
     orderBy?: OrderBy;
 };
 
-export const Table: FC<TableProps> = ({ organism, data, schema, filters, page, orderBy }) => {
+export const Table: FC<TableProps> = ({ organism, data, schema, metadataFilter, mutationFilter, page, orderBy }) => {
     const primaryKey = schema.primaryKey;
 
     const columns = schema.tableColumns.map((field) => ({
@@ -31,12 +32,18 @@ export const Table: FC<TableProps> = ({ organism, data, schema, filters, page, o
     const handleSort = (field: string) => {
         if (orderBy?.field === field) {
             if (orderBy.type === 'ascending') {
-                location.href = routes.searchPage(organism, filters, page, { field, type: 'descending' });
+                location.href = routes.searchPage(organism, metadataFilter, mutationFilter, page, {
+                    field,
+                    type: 'descending',
+                });
             } else {
-                location.href = routes.searchPage(organism, filters);
+                location.href = routes.searchPage(organism, metadataFilter, mutationFilter);
             }
         } else {
-            location.href = routes.searchPage(organism, filters, page, { field, type: 'ascending' });
+            location.href = routes.searchPage(organism, metadataFilter, mutationFilter, page, {
+                field,
+                type: 'ascending',
+            });
         }
     };
 

--- a/website/src/components/SearchPage/fields/AutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/AutoCompleteField.tsx
@@ -4,7 +4,7 @@ import { type FC, useEffect, useMemo, useState } from 'react';
 import type { FieldProps } from './FieldProps';
 import { getClientLogger } from '../../../clientLogger.ts';
 import { lapisClientHooks } from '../../../services/serviceHooks.ts';
-import type { Filter } from '../../../types/config.ts';
+import type { MetadataFilter } from '../../../types/config.ts';
 
 const logger = getClientLogger('AutoCompleteField');
 
@@ -74,7 +74,7 @@ export const AutoCompleteField: FC<FieldProps> = ({ field, allFields, handleFiel
     );
 };
 
-function getOtherFieldsFilter(allFields: Filter[], field: Filter) {
+function getOtherFieldsFilter(allFields: MetadataFilter[], field: MetadataFilter) {
     return allFields
         .filter((f) => f.name !== field.name && f.filterValue !== '')
         .reduce((acc, f) => ({ ...acc, [f.name]: f.filterValue }), {});

--- a/website/src/components/SearchPage/fields/FieldProps.tsx
+++ b/website/src/components/SearchPage/fields/FieldProps.tsx
@@ -1,8 +1,8 @@
-import type { Filter } from '../../../types/config.ts';
+import type { MetadataFilter } from '../../../types/config.ts';
 
 export type FieldProps = {
-    field: Filter;
-    allFields: Filter[];
+    field: MetadataFilter;
+    allFields: MetadataFilter[];
     handleFieldChange: (metadataName: string, filter: string) => void;
     isLoading: boolean;
     lapisUrl: string;

--- a/website/src/components/SearchPage/fields/MutationField.spec.tsx
+++ b/website/src/components/SearchPage/fields/MutationField.spec.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+
+import { MutationField } from './MutationField.tsx';
+import type { MutationFilter } from '../../../types/config.ts';
+import type { ReferenceGenomesSequenceNames } from '../../../types/referencesGenomes.ts';
+
+const singleSegmentedReferenceGenome: ReferenceGenomesSequenceNames = {
+    nucleotideSequences: ['main'],
+    genes: ['gene1', 'gene2'],
+};
+
+const multiSegmentedReferenceGenome: ReferenceGenomesSequenceNames = {
+    nucleotideSequences: ['seg1', 'seg2'],
+    genes: ['gene1', 'gene2'],
+};
+
+function renderField(
+    value: MutationFilter,
+    onChange: (mutationFilter: MutationFilter) => void,
+    referenceGenome: ReferenceGenomesSequenceNames,
+) {
+    render(<MutationField value={value} onChange={onChange} referenceGenomes={referenceGenome} />);
+}
+
+describe('MutationField', () => {
+    test('should render provided value', async () => {
+        const handleChange = vi.fn();
+        renderField(
+            {
+                aminoAcidMutationQueries: ['gene1:10Y'],
+                nucleotideMutationQueries: ['A20T'],
+                nucleotideInsertionQueries: ['ins_30:G?G'],
+            },
+            handleChange,
+            singleSegmentedReferenceGenome,
+        );
+        expect(screen.queryByText('gene1:10Y')).toBeInTheDocument();
+        expect(screen.queryByText('A20T')).toBeInTheDocument();
+        expect(screen.queryByText('ins_30:G?G')).toBeInTheDocument();
+    });
+
+    test('should accept input and dispatch events (single-segmented)', async () => {
+        const handleChange = vi.fn();
+        renderField({}, handleChange, singleSegmentedReferenceGenome);
+
+        await userEvent.type(screen.getByLabelText('Mutations'), 'G100A{enter}');
+        expect(handleChange).toHaveBeenCalledWith({
+            nucleotideMutationQueries: ['G100A'],
+            aminoAcidMutationQueries: [],
+            nucleotideInsertionQueries: [],
+            aminoAcidInsertionQueries: [],
+        });
+    });
+
+    test('should accept input and dispatch events (multi-segmented)', async () => {
+        const handleChange = vi.fn();
+        renderField({}, handleChange, multiSegmentedReferenceGenome);
+
+        await userEvent.type(screen.getByLabelText('Mutations'), 'seg1:G100A{enter}');
+        expect(handleChange).toHaveBeenCalledWith({
+            nucleotideMutationQueries: ['seg1:G100A'],
+            aminoAcidMutationQueries: [],
+            nucleotideInsertionQueries: [],
+            aminoAcidInsertionQueries: [],
+        });
+    });
+
+    test('should reject invalid input', async () => {
+        const handleChange = vi.fn();
+        renderField({}, handleChange, singleSegmentedReferenceGenome);
+
+        await userEvent.type(screen.getByLabelText('Mutations'), 'main:G200A{enter}');
+        expect(handleChange).toHaveBeenCalledTimes(0);
+    });
+});

--- a/website/src/components/SearchPage/fields/MutationField.tsx
+++ b/website/src/components/SearchPage/fields/MutationField.tsx
@@ -1,0 +1,191 @@
+import { Autocomplete, Box, Chip, TextField } from '@mui/material';
+import { type FC, useMemo, useState } from 'react';
+import * as React from 'react';
+
+import type { MutationFilter } from '../../../types/config.ts';
+import type { ReferenceGenomesSequenceNames } from '../../../types/referencesGenomes.ts';
+import type { BaseType } from '../../../utils/sequenceTypeHelpers.ts';
+
+interface MutationFieldProps {
+    referenceGenomes: ReferenceGenomesSequenceNames;
+    value: MutationFilter;
+    onChange: (mutationFilter: MutationFilter) => void;
+}
+
+export const MutationField: FC<MutationFieldProps> = ({ referenceGenomes, value, onChange }) => {
+    const [options, setOptions] = useState<MutationQuery[]>([]);
+
+    const selectedOptions: MutationQuery[] = useMemo(() => {
+        const mappers = [
+            { from: value.nucleotideMutationQueries, baseType: 'nucleotide', mutationType: 'substitutionOrDeletion' },
+            { from: value.aminoAcidMutationQueries, baseType: 'aminoAcid', mutationType: 'substitutionOrDeletion' },
+            { from: value.nucleotideInsertionQueries, baseType: 'nucleotide', mutationType: 'insertion' },
+            { from: value.aminoAcidInsertionQueries, baseType: 'aminoAcid', mutationType: 'insertion' },
+        ] as const;
+        return mappers
+            .map(({ from, baseType, mutationType }) => from?.map((text) => ({ baseType, mutationType, text })) ?? [])
+            .flat();
+    }, [value]);
+
+    const handleInputChange = (_: React.SyntheticEvent, newValue: string) => {
+        const newOptions: MutationQuery[] = [];
+        const tests = [
+            { baseType: 'nucleotide', mutationType: 'substitutionOrDeletion', test: isValidNucleotideMutationQuery },
+            { baseType: 'aminoAcid', mutationType: 'substitutionOrDeletion', test: isValidAminoAcidMutationQuery },
+            { baseType: 'nucleotide', mutationType: 'insertion', test: isValidNucleotideInsertionQuery },
+            { baseType: 'aminoAcid', mutationType: 'insertion', test: isValidAminoAcidInsertionQuery },
+        ] as const;
+        tests.forEach(({ baseType, mutationType, test }) => {
+            if (test(newValue, referenceGenomes)) {
+                newOptions.push({ baseType, mutationType, text: newValue });
+            }
+        });
+        setOptions(newOptions);
+    };
+
+    const handleChange = (_: React.SyntheticEvent, newValue: MutationQuery[]) => {
+        const mutationFilter: Required<MutationFilter> = {
+            nucleotideMutationQueries: [],
+            aminoAcidMutationQueries: [],
+            nucleotideInsertionQueries: [],
+            aminoAcidInsertionQueries: [],
+        };
+        const mappers = [
+            {
+                to: mutationFilter.nucleotideMutationQueries,
+                baseType: 'nucleotide',
+                mutationType: 'substitutionOrDeletion',
+            },
+            {
+                to: mutationFilter.aminoAcidMutationQueries,
+                baseType: 'aminoAcid',
+                mutationType: 'substitutionOrDeletion',
+            },
+            { to: mutationFilter.nucleotideInsertionQueries, baseType: 'nucleotide', mutationType: 'insertion' },
+            { to: mutationFilter.aminoAcidInsertionQueries, baseType: 'aminoAcid', mutationType: 'insertion' },
+        ] as const;
+        for (const { baseType, mutationType, text } of newValue) {
+            mappers.forEach((mapper) => {
+                if (baseType === mapper.baseType && mutationType === mapper.mutationType) {
+                    mapper.to.push(text);
+                }
+            });
+        }
+        onChange(mutationFilter);
+    };
+
+    return (
+        <Autocomplete
+            multiple
+            value={selectedOptions}
+            renderInput={(params) => (
+                <TextField {...params} label='Mutations' margin='dense' size='small' className='w-60' />
+            )}
+            options={options}
+            onChange={handleChange}
+            onInputChange={handleInputChange}
+            renderOption={(props, option) => (
+                <Box component='li' {...props}>
+                    {option.text}
+                </Box>
+            )}
+            renderTags={(values, getTagProps) => {
+                return values.map((option, index) => (
+                    <Chip
+                        {...getTagProps({ index })}
+                        label={option.text}
+                        variant='outlined'
+                        color={option.baseType === 'nucleotide' ? 'primary' : 'success'}
+                    />
+                ));
+            }}
+            getOptionLabel={(option) => option.text}
+            filterOptions={(x) => x}
+            autoHighlight
+        />
+    );
+};
+
+type MutationQuery = {
+    baseType: BaseType;
+    mutationType: 'substitutionOrDeletion' | 'insertion';
+    text: string;
+};
+
+const isValidNucleotideMutationQuery = (text: string, referenceGenomes: ReferenceGenomesSequenceNames): boolean => {
+    try {
+        const isMultiSegmented = referenceGenomes.nucleotideSequences.length > 1;
+        const textUpper = text.toUpperCase();
+        let mutation = textUpper;
+        if (isMultiSegmented) {
+            const [segment, _mutation] = textUpper.split(':');
+            const existingSegments = new Set(referenceGenomes.nucleotideSequences.map((n) => n.toUpperCase()));
+            if (!existingSegments.has(segment)) {
+                return false;
+            }
+            mutation = _mutation;
+        }
+        return /^[A-Z]?[0-9]+[A-Z-\\.]?$/.test(mutation);
+    } catch (_) {
+        return false;
+    }
+};
+
+const isValidAminoAcidMutationQuery = (text: string, referenceGenomes: ReferenceGenomesSequenceNames): boolean => {
+    try {
+        const textUpper = text.toUpperCase();
+        const [gene, mutation] = textUpper.split(':');
+        const existingGenes = new Set(referenceGenomes.genes.map((g) => g.toUpperCase()));
+        if (!existingGenes.has(gene)) {
+            return false;
+        }
+        return /^[A-Z*]?[0-9]+[A-Z-*\\.]?$/.test(mutation);
+    } catch (_) {
+        return false;
+    }
+};
+
+const isValidNucleotideInsertionQuery = (text: string, referenceGenomes: ReferenceGenomesSequenceNames): boolean => {
+    try {
+        const isMultiSegmented = referenceGenomes.nucleotideSequences.length > 1;
+        const textUpper = text.toUpperCase();
+        if (!textUpper.startsWith('INS_')) {
+            return false;
+        }
+        const query = textUpper.slice(4);
+        const split = query.split(':');
+        const [segment, position, insertion] = isMultiSegmented
+            ? split
+            : ([undefined, ...split] as [undefined | string, string, string]);
+        if (segment !== undefined) {
+            const existingSegments = new Set(referenceGenomes.nucleotideSequences.map((n) => n.toUpperCase()));
+            if (!existingSegments.has(segment)) {
+                return false;
+            }
+        }
+        if (!Number.isInteger(Number(position))) {
+            return false;
+        }
+        return /^[A-Z*?]+$/.test(insertion);
+    } catch (_) {
+        return false;
+    }
+};
+
+const isValidAminoAcidInsertionQuery = (text: string, referenceGenomes: ReferenceGenomesSequenceNames): boolean => {
+    try {
+        const textUpper = text.toUpperCase();
+        if (!textUpper.startsWith('INS_')) {
+            return false;
+        }
+        const query = textUpper.slice(4);
+        const [gene, position, insertion] = query.split(':');
+        const existingGenes = new Set(referenceGenomes.genes.map((g) => g.toUpperCase()));
+        if (!existingGenes.has(gene) || !Number.isInteger(Number(position))) {
+            return false;
+        }
+        return /^[A-Z*?]+$/.test(insertion);
+    } catch (_) {
+        return false;
+    }
+};

--- a/website/src/pages/[organism]/search/index.astro
+++ b/website/src/pages/[organism]/search/index.astro
@@ -1,5 +1,5 @@
 ---
-import { getData, getOrderBy, getSearchFormFilters } from './search';
+import { getData, getReferenceGenomesSequenceNames, getMetadataFilters, getMutationFilter, getOrderBy } from './search';
 import { cleanOrganism } from '../../../components/Navigation/cleanOrganism';
 import { Pagination } from '../../../components/SearchPage/Pagination';
 import { SearchForm } from '../../../components/SearchPage/SearchForm';
@@ -17,14 +17,17 @@ const getSearchParams = (field: string): string => {
     return Astro.url.searchParams.get(field) ?? '';
 };
 
-const searchFormFilter = getSearchFormFilters(getSearchParams, organism);
+const metadataFilter = getMetadataFilters(getSearchParams, organism);
+const mutationFilter = getMutationFilter(Astro.url.searchParams);
 
 const pageParam = Astro.url.searchParams.get('page');
 const page = pageParam !== null ? Number.parseInt(pageParam, 10) : 1;
 const offset = (page - 1) * pageSize;
 const orderBy = getOrderBy(Astro.url.searchParams);
 
-const data = await getData(organism, searchFormFilter, offset, pageSize, orderBy);
+const referenceGenomesSequenceNames = getReferenceGenomesSequenceNames(organism);
+
+const data = await getData(organism, metadataFilter, mutationFilter, offset, pageSize, orderBy);
 ---
 
 <BaseLayout title={`${cleanedOrganism!.displayName} - Browse`}>
@@ -33,8 +36,10 @@ const data = await getData(organism, searchFormFilter, offset, pageSize, orderBy
         <div class='md:w-72'>
             <SearchForm
                 organism={organism}
-                filters={searchFormFilter}
+                filters={metadataFilter}
+                initialMutationFilter={mutationFilter}
                 clientConfig={clientConfig}
+                referenceGenomesSequenceNames={referenceGenomesSequenceNames}
                 client:only='react'
             />
         </div>
@@ -50,7 +55,8 @@ const data = await getData(organism, searchFormFilter, offset, pageSize, orderBy
                             organism={organism}
                             data={data.data}
                             schema={schema}
-                            filters={searchFormFilter}
+                            metadataFilter={metadataFilter}
+                            mutationFilter={mutationFilter}
                             page={page}
                             orderBy={orderBy}
                             client:load

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -10,12 +10,19 @@ export const metadata = z.object({
 });
 export type Metadata = z.infer<typeof metadata>;
 
-export type Filter = Metadata & {
+export type MetadataFilter = Metadata & {
     filterValue: string;
     label?: string;
 };
 
-export type FilterValue = Pick<Filter, 'name' | 'filterValue'>;
+export type FilterValue = Pick<MetadataFilter, 'name' | 'filterValue'>;
+
+export type MutationFilter = {
+    aminoAcidMutationQueries?: string[];
+    nucleotideMutationQueries?: string[];
+    aminoAcidInsertionQueries?: string[];
+    nucleotideInsertionQueries?: string[];
+};
 
 const schema = z.object({
     instanceName: z.string(),

--- a/website/src/types/referencesGenomes.ts
+++ b/website/src/types/referencesGenomes.ts
@@ -12,3 +12,8 @@ export const referenceGenomes = z.object({
     genes: z.array(namedSequence),
 });
 export type ReferenceGenomes = z.infer<typeof referenceGenomes>;
+
+export type ReferenceGenomesSequenceNames = {
+    nucleotideSequences: string[];
+    genes: string[];
+};


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #70

This adds a mutation search field similar to the one in CoV-Spectrum. It supports filtering of nucleotide and amino acid substitutions, deletions, and insertions:

![image](https://github.com/loculus-project/loculus/assets/18666552/58697819-a280-4e09-b96c-4e0470c7edbe)

## Future work:

- #816
- #817


## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] ~~All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
  - I wrote a few unit tests.
  - Because we miss suitable data in the e2e tests (I believe we have the same sequence for all entries), it seems difficult to write a proper e2e test.

