### PR TITLE
feat(website): only display relevant data for revocation entries

### DIFF
--- a/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
@@ -37,7 +37,7 @@ spec:
             {{- if eq $.Values.environment "server" }}
             - "--keycloak-host=https://{{ $keycloakHost}}"
             {{- else }}
-            - "--keycloak-host=http://localhost:8083"
+            - "--keycloak-host=http://loculus-keycloak-service:8083"
             {{- end }}
         {{- end }}
       imagePullSecrets:

--- a/website/src/components/SequenceDetailsPage/DataTable.astro
+++ b/website/src/components/SequenceDetailsPage/DataTable.astro
@@ -1,0 +1,24 @@
+---
+import { type TableDataEntry } from './getTableData';
+
+interface Props {
+    tableData: TableDataEntry[];
+}
+
+const { tableData } = Astro.props;
+---
+
+<div class='mt-6'>
+    <table class='table-auto'>
+        <tbody>
+            {
+                tableData.map(({ label, value }) => (
+                    <tr>
+                        <td class='font-semibold pr-4 align-top w-1/4'>{label}:</td>
+                        <td class='break-normal'>{value}</td>
+                    </tr>
+                ))
+            }
+        </tbody>
+    </table>
+</div>

--- a/website/src/components/SequenceDetailsPage/RevocationEntryDataTable.astro
+++ b/website/src/components/SequenceDetailsPage/RevocationEntryDataTable.astro
@@ -1,0 +1,37 @@
+---
+import DataTable from './DataTable.astro';
+import { type TableDataEntry } from './getTableData';
+import {
+    ACCESSION_VERSION_FIELD,
+    SUBMITTED_AT_FIELD,
+    RELEASED_AT_FIELD,
+    IS_REVOCATION_FIELD,
+    ACCESSION_FIELD,
+    VERSION_STATUS_FIELD,
+    SUBMITTER_FIELD,
+    GROUP_FIELD,
+    VERSION_FIELD,
+} from '../../settings';
+
+interface Props {
+    tableData: TableDataEntry[];
+}
+
+const { tableData } = Astro.props;
+
+const relevantFieldsForRevocationVersions = [
+    ACCESSION_VERSION_FIELD,
+    ACCESSION_FIELD,
+    IS_REVOCATION_FIELD,
+    RELEASED_AT_FIELD,
+    VERSION_STATUS_FIELD,
+    SUBMITTED_AT_FIELD,
+    SUBMITTER_FIELD,
+    VERSION_FIELD,
+    GROUP_FIELD,
+];
+
+const relevantData = tableData.filter((entry) => relevantFieldsForRevocationVersions.includes(entry.name));
+---
+
+<DataTable tableData={relevantData} />

--- a/website/src/components/SequenceDetailsPage/SequencesBanner.astro
+++ b/website/src/components/SequenceDetailsPage/SequencesBanner.astro
@@ -1,29 +1,29 @@
 ---
 import { getLatestAccessionVersion } from './getTableData';
 import { routes } from '../../routes.ts';
-import { type SequenceEntryHistory, type SiloVersionStatus, siloVersionStatuses } from '../../types/lapis';
+import { type SequenceEntryHistory, siloVersionStatuses } from '../../types/lapis';
 import { getAccessionVersionString } from '../../utils/extractAccessionVersion';
 
 interface Props {
     sequenceEntryHistory: SequenceEntryHistory;
-    versionStatus: SiloVersionStatus;
+    accessionVersion: string;
     organism: string;
 }
 
-const { sequenceEntryHistory, versionStatus, organism } = Astro.props;
+const { sequenceEntryHistory, accessionVersion, organism } = Astro.props;
 
-// TODO(#619): Currently there are no revocation entry versions in SILO. When they are introduced, this condition has to be expanded.
-//  If versionStatus === latest version AND it is a revocation entry (isRevocation=== true) => revoked = true
-const revoked = versionStatus === siloVersionStatuses.revoked;
+const ownHistoryEntry = sequenceEntryHistory.find((entry) => entry.accessionVersion === accessionVersion);
 
 const latestAccessionVersion = getLatestAccessionVersion(sequenceEntryHistory);
 
-const isNotLatestVersion = versionStatus !== siloVersionStatuses.latestVersion;
+const revoked =
+    ownHistoryEntry?.versionStatus === siloVersionStatuses.revoked && latestAccessionVersion?.isRevocation === true;
+const isLatestVersion = ownHistoryEntry?.versionStatus === siloVersionStatuses.latestVersion;
 ---
 
 <div class='py-3'>
     {
-        isNotLatestVersion && (
+        !isLatestVersion && (
             <div class='bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-3' role='alert'>
                 <p class='font-bold'>This is not the latest version of this sequence entry.</p>
                 {latestAccessionVersion !== undefined && (
@@ -37,6 +37,16 @@ const isNotLatestVersion = versionStatus !== siloVersionStatuses.latestVersion;
                         </a>
                     </p>
                 )}
+            </div>
+        )
+    }
+    {
+        ownHistoryEntry?.isRevocation === true && (
+            <div class='bg-red-100 border-l-4 border-red-500 text-red-700 p-3 ' role='alert'>
+                <p class='font-bold'>
+                    This is a revocation version. It essentially contains no data, it's just a marker that all previous
+                    versions have been revoked.
+                </p>
             </div>
         )
     }

--- a/website/src/components/SequenceDetailsPage/getTableData.spec.ts
+++ b/website/src/components/SequenceDetailsPage/getTableData.spec.ts
@@ -1,12 +1,10 @@
 import { err, ok } from 'neverthrow';
 import { beforeEach, describe, expect, test } from 'vitest';
 
-import { getTableData, getVersionStatus } from './getTableData.ts';
+import { getTableData } from './getTableData.ts';
 import { mockRequest, testConfig } from '../../../vitest.setup.ts';
 import { LapisClient } from '../../services/lapisClient.ts';
-import { VERSION_STATUS_FIELD } from '../../settings.ts';
 import type { Schema } from '../../types/config.ts';
-import { siloVersionStatuses } from '../../types/lapis.ts';
 
 const schema: Schema = {
     instanceName: 'instance name',
@@ -207,32 +205,6 @@ describe('getTableData', () => {
             name: 'timestampField',
             value: '2024-01-25 14:59:21 UTC',
         });
-    });
-});
-
-describe('getVersionStatus', () => {
-    test('should return status for correct status', () => {
-        const versionStatus = getVersionStatus([
-            {
-                label: 'does not matter',
-                name: VERSION_STATUS_FIELD,
-                value: siloVersionStatuses.latestVersion,
-            },
-        ]);
-
-        expect(versionStatus).toStrictEqual(siloVersionStatuses.latestVersion);
-    });
-
-    test('should throw error for unknown status', () => {
-        expect(() =>
-            getVersionStatus([
-                {
-                    label: 'does not matter',
-                    name: VERSION_STATUS_FIELD,
-                    value: 'unknown status',
-                },
-            ]),
-        ).toThrowError(/Invalid version status: "unknown status"/);
     });
 });
 

--- a/website/src/components/SequenceDetailsPage/getTableData.ts
+++ b/website/src/components/SequenceDetailsPage/getTableData.ts
@@ -3,8 +3,7 @@ import { DateTime, FixedOffsetZone } from 'luxon';
 import { err, Result } from 'neverthrow';
 
 import { type LapisClient } from '../../services/lapisClient.ts';
-import { VERSION_STATUS_FIELD } from '../../settings.ts';
-import type { AccessionVersion, ProblemDetail } from '../../types/backend.ts';
+import type { ProblemDetail } from '../../types/backend.ts';
 import type { Metadata, Schema } from '../../types/config.ts';
 import {
     type Details,
@@ -12,8 +11,7 @@ import {
     type InsertionCount,
     type MutationProportionCount,
     type SequenceEntryHistory,
-    type SiloVersionStatus,
-    siloVersionStatusSchema,
+    type SequenceEntryHistoryEntry,
 } from '../../types/lapis.ts';
 
 export type TableDataEntry = { label: string; name: string; value: string | number };
@@ -53,19 +51,13 @@ export async function getTableData(
         );
 }
 
-export function getVersionStatus(tableData: TableDataEntry[]): SiloVersionStatus {
-    const versionStatus = tableData.find((pred) => pred.name === VERSION_STATUS_FIELD)?.value.toString() ?? undefined;
-
-    const parsedStatus = siloVersionStatusSchema.safeParse(versionStatus);
-
-    if (parsedStatus.success) {
-        return parsedStatus.data;
-    }
-
-    throw new Error('Invalid version status: ' + JSON.stringify(versionStatus) + ': ' + parsedStatus.error.toString());
+export function isRevocationEntry(tableData: TableDataEntry[]): boolean {
+    return tableData.some((entry) => entry.name === 'isRevocation' && entry.value === 'true');
 }
 
-export function getLatestAccessionVersion(sequenceEntryHistory: SequenceEntryHistory): AccessionVersion | undefined {
+export function getLatestAccessionVersion(
+    sequenceEntryHistory: SequenceEntryHistory,
+): SequenceEntryHistoryEntry | undefined {
     if (sequenceEntryHistory.length === 0) {
         return undefined;
     }

--- a/website/src/pages/[organism]/seq/[accessionVersion]/getSequenceDetailsTableData.ts
+++ b/website/src/pages/[organism]/seq/[accessionVersion]/getSequenceDetailsTableData.ts
@@ -1,15 +1,11 @@
 import { Result } from 'neverthrow';
 
-import {
-    getTableData,
-    getVersionStatus,
-    type TableDataEntry,
-} from '../../../../components/SequenceDetailsPage/getTableData.ts';
+import { getTableData, type TableDataEntry } from '../../../../components/SequenceDetailsPage/getTableData.ts';
 import { getSchema } from '../../../../config.ts';
 import { routes } from '../../../../routes.ts';
 import { LapisClient } from '../../../../services/lapisClient.ts';
 import type { ProblemDetail } from '../../../../types/backend.ts';
-import type { SequenceEntryHistory, SiloVersionStatus } from '../../../../types/lapis.ts';
+import type { SequenceEntryHistory } from '../../../../types/lapis.ts';
 import { parseAccessionVersionFromString } from '../../../../utils/extractAccessionVersion.ts';
 
 export enum SequenceDetailsTableResultType {
@@ -21,7 +17,6 @@ type TableData = {
     type: SequenceDetailsTableResultType.TABLE_DATA;
     tableData: TableDataEntry[];
     sequenceEntryHistory: SequenceEntryHistory;
-    versionStatus: SiloVersionStatus;
 };
 
 type Redirect = {
@@ -56,6 +51,5 @@ export const getSequenceDetailsTableData = async (
         type: SequenceDetailsTableResultType.TABLE_DATA as const,
         tableData,
         sequenceEntryHistory,
-        versionStatus: getVersionStatus(tableData),
     }));
 };

--- a/website/src/pages/[organism]/seq/[accessionVersion]/index.astro
+++ b/website/src/pages/[organism]/seq/[accessionVersion]/index.astro
@@ -1,8 +1,10 @@
 ---
 import { getSequenceDetailsTableData, SequenceDetailsTableResultType } from './getSequenceDetailsTableData';
+import RevocationEntryDataTable from '../../../../components/SequenceDetailsPage/RevocationEntryDataTable.astro';
 import SequencesBanner from '../../../../components/SequenceDetailsPage/SequencesBanner.astro';
 import SequencesDataTable from '../../../../components/SequenceDetailsPage/SequencesDataTable.astro';
 import SequencesDataTableTitle from '../../../../components/SequenceDetailsPage/SequencesDataTableTitle.astro';
+import { isRevocationEntry } from '../../../../components/SequenceDetailsPage/getTableData';
 import ErrorBox from '../../../../components/common/ErrorBox.astro';
 import BaseLayout from '../../../../layouts/BaseLayout.astro';
 import { routes } from '../../../../routes';
@@ -27,7 +29,7 @@ if (
                 <div slot='banner'>
                     <SequencesBanner
                         sequenceEntryHistory={sequenceDetailsTableData.value.sequenceEntryHistory}
-                        versionStatus={sequenceDetailsTableData.value.versionStatus}
+                        accessionVersion={accessionVersion}
                         organism={organism}
                     />
                 </div>
@@ -46,27 +48,28 @@ if (
     {
         sequenceDetailsTableData.match(
             (data) =>
-                data.type === SequenceDetailsTableResultType.TABLE_DATA && (
+                data.type === SequenceDetailsTableResultType.TABLE_DATA &&
+                (isRevocationEntry(data.tableData) ? (
+                    <RevocationEntryDataTable tableData={data.tableData} />
+                ) : (
                     <SequencesDataTable
                         tableData={data.tableData}
                         organism={organism}
                         accessionVersion={accessionVersion}
                     />
-                ),
-            () => {
-                return (
-                    <>
-                        <ErrorBox title='Sequence entry not found' message='No data found for accession version' />
-                        <div>
-                            Click
-                            <a class='underline' href={routes.searchPage(organism, [])}>
-                                here
-                            </a>
-                            to search for a different sequence.
-                        </div>
-                    </>
-                );
-            },
+                )),
+            () => (
+                <>
+                    <ErrorBox title='Sequence entry not found' message='No data found for accession version' />
+                    <div>
+                        Click
+                        <a class='underline' href={routes.searchPage(organism, [])}>
+                            here
+                        </a>
+                        to search for a different sequence.
+                    </div>
+                </>
+            ),
         )
     }
 </BaseLayout>

--- a/website/src/services/lapisClient.ts
+++ b/website/src/services/lapisClient.ts
@@ -5,7 +5,13 @@ import { lapisApi } from './lapisApi.ts';
 import { ZodiosWrapperClient } from './zodiosWrapperClient.ts';
 import { getLapisUrl, getRuntimeConfig, getSchema } from '../config.ts';
 import { getInstanceLogger, type InstanceLogger } from '../logger.ts';
-import { ACCESSION_FIELD, VERSION_FIELD, VERSION_STATUS_FIELD } from '../settings.ts';
+import {
+    ACCESSION_FIELD,
+    ACCESSION_VERSION_FIELD,
+    IS_REVOCATION_FIELD,
+    VERSION_FIELD,
+    VERSION_STATUS_FIELD,
+} from '../settings.ts';
 import { accessionVersion, type AccessionVersion, type ProblemDetail } from '../types/backend.ts';
 import type { Schema } from '../types/config.ts';
 import {
@@ -84,7 +90,13 @@ export class LapisClient extends ZodiosWrapperClient<typeof lapisApi> {
         // @ts-expect-error Bug in Zod: https://github.com/colinhacks/zod/issues/3136
         const request: LapisBaseRequest = {
             accession,
-            fields: [ACCESSION_FIELD, VERSION_FIELD, VERSION_STATUS_FIELD],
+            fields: [
+                ACCESSION_VERSION_FIELD,
+                ACCESSION_FIELD,
+                VERSION_FIELD,
+                VERSION_STATUS_FIELD,
+                IS_REVOCATION_FIELD,
+            ],
             orderBy: [{ field: VERSION_FIELD, type: 'ascending' }],
         };
         const result = await this.call('details', request);

--- a/website/src/settings.ts
+++ b/website/src/settings.ts
@@ -2,10 +2,15 @@ import { siloVersionStatuses } from './types/lapis.ts';
 
 export const pageSize = 100;
 
+export const ACCESSION_VERSION_FIELD = 'accessionVersion';
 export const ACCESSION_FIELD = 'accession';
 export const VERSION_FIELD = 'version';
 export const VERSION_STATUS_FIELD = 'versionStatus';
 export const IS_REVOCATION_FIELD = 'isRevocation';
+export const SUBMITTED_AT_FIELD = 'submittedAt';
+export const RELEASED_AT_FIELD = 'releasedAt';
+export const SUBMITTER_FIELD = 'submitter';
+export const GROUP_FIELD = 'group';
 
 export const hiddenDefaultSearchFilters = [
     { name: VERSION_STATUS_FIELD, filterValue: siloVersionStatuses.latestVersion, type: 'string' as const },

--- a/website/src/types/lapis.ts
+++ b/website/src/types/lapis.ts
@@ -75,12 +75,18 @@ export const siloVersionStatusSchema = z.enum([
 
 export type SiloVersionStatus = z.infer<typeof siloVersionStatusSchema>;
 
-export const sequenceEntryHistory = z.array(
-    accessionVersion.merge(
-        z.object({
-            versionStatus: siloVersionStatusSchema,
-        }),
-    ),
+export const siloBooleanWorkaround = z.enum(['true', 'false']).transform((value) => value === 'true');
+
+export const sequenceEntryHistoryEntry = accessionVersion.merge(
+    z.object({
+        accessionVersion: z.string(),
+        versionStatus: siloVersionStatusSchema,
+        isRevocation: siloBooleanWorkaround,
+    }),
 );
+
+export type SequenceEntryHistoryEntry = z.infer<typeof sequenceEntryHistoryEntry>;
+
+export const sequenceEntryHistory = z.array(sequenceEntryHistoryEntry);
 
 export type SequenceEntryHistory = z.infer<typeof sequenceEntryHistory>;

--- a/website/tests/e2e.fixture.ts
+++ b/website/tests/e2e.fixture.ts
@@ -55,6 +55,10 @@ export const revokedSequenceEntry = {
     accession: '11',
     version: 1,
 };
+export const revocationSequenceEntry = {
+    accession: '11',
+    version: 2,
+};
 export const deprecatedSequenceEntry = {
     accession: '21',
     version: 1,

--- a/website/tests/pages/sequences/accession.spec.ts
+++ b/website/tests/pages/sequences/accession.spec.ts
@@ -6,6 +6,7 @@ import {
     dummyOrganism,
     expect,
     revisedSequenceEntry,
+    revocationSequenceEntry,
     revokedSequenceEntry,
     test,
     testSequenceEntry,
@@ -22,25 +23,21 @@ test.describe('The detailed sequence page', () => {
         await expect(sequencePage.page.getByText(testSequenceEntry.orf1a, { exact: false })).toBeVisible();
     });
 
-    // TODO(#619): revoked entries should show a link to the newest version. Since SILO cannot process revocation_entries yet, this is not tested.
     test('check initial sequences and verify that banners are shown when revoked or revised', async ({
         sequencePage,
     }) => {
         await sequencePage.goto(revokedSequenceEntry);
         await expect(sequencePage.page.getByText(`This sequence entry has been revoked!`)).toBeVisible();
-        // await expect(
-        //     sequencePage.page.getByText(`This is not the latest version of this sequence entry.`),
-        // ).toBeVisible();
+        await expect(sequencePage.notLatestVersionBanner).toBeVisible();
+
+        await sequencePage.goto(revocationSequenceEntry);
+        await expect(sequencePage.revocationVersionBanner).toBeVisible();
 
         await sequencePage.goto(deprecatedSequenceEntry);
-        await expect(
-            sequencePage.page.getByText(`This is not the latest version of this sequence entry.`),
-        ).toBeVisible();
+        await expect(sequencePage.notLatestVersionBanner).toBeVisible();
 
         await sequencePage.goto(revisedSequenceEntry);
-        await expect(
-            sequencePage.page.getByText(`This is not the latest version of this sequence entry.`),
-        ).not.toBeVisible();
+        await expect(sequencePage.notLatestVersionBanner).not.toBeVisible();
     });
 
     test('can navigate to the versions page and click the link to the deprecated version', async ({ sequencePage }) => {

--- a/website/tests/pages/sequences/sequences.page.ts
+++ b/website/tests/pages/sequences/sequences.page.ts
@@ -9,6 +9,8 @@ export class SequencePage {
     private readonly loadButton: Locator;
     private readonly allVersions: Locator;
     private readonly orf1aButton: Locator;
+    readonly notLatestVersionBanner: Locator;
+    readonly revocationVersionBanner: Locator;
 
     constructor(public readonly page: Page) {
         this.loadButton = this.page.getByRole('button', { name: 'Load sequences' });
@@ -16,6 +18,8 @@ export class SequencePage {
         this.allVersions = this.page.getByRole('link', {
             name: `All versions`,
         });
+        this.notLatestVersionBanner = this.page.getByText('This is not the latest version of this sequence entry.');
+        this.revocationVersionBanner = this.page.getByText('This is a revocation version.');
     }
 
     public async goto(accessionVersion: AccessionVersion = testSequenceEntry) {
@@ -23,14 +27,6 @@ export class SequencePage {
             waitUntil: 'networkidle',
         });
         await expect(this.page).toHaveTitle(getAccessionVersionString(accessionVersion));
-        await expect(this.loadButton).toBeVisible();
-    }
-
-    public async gotoVersionsPage(accessionVersion: AccessionVersion = testSequenceEntry) {
-        await this.page.goto(`${baseUrl}${routes.sequencesVersionsPage(dummyOrganism.key, accessionVersion)}`, {
-            waitUntil: 'networkidle',
-        });
-        await expect(this.page).toHaveTitle(`Versions`);
     }
 
     public async gotoAllVersions() {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #619

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.

## A Revocation Entry

![image](https://github.com/loculus-project/loculus/assets/92720311/672e973c-b096-4dd2-b28d-aa8d1afb3fb4)

# A Revised Revocation Entry

![image](https://github.com/loculus-project/loculus/assets/92720311/1d77fcc2-a483-4e7e-af35-514c91633168)


