### PR TITLE
feat(website): download files from download panel

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx
@@ -79,12 +79,14 @@ describe('DownloadDialog', () => {
         await checkAgreement();
 
         expect(getDownloadHref()).toBe(
-            `${defaultLapisUrl}/sample/details?versionStatus=LATEST_VERSION&isRevocation=false&dataFormat=tsv&field1=value1`,
+            `${defaultLapisUrl}/sample/details?downloadAsFile=true&versionStatus=LATEST_VERSION&isRevocation=false&dataFormat=tsv&field1=value1`,
         );
 
         await userEvent.click(screen.getByLabelText(/Yes, include older versions/));
         await userEvent.click(screen.getByLabelText(/Raw nucleotide sequences/));
-        expect(getDownloadHref()).toBe(`${defaultLapisUrl}/sample/unalignedNucleotideSequences?field1=value1`);
+        expect(getDownloadHref()).toBe(
+            `${defaultLapisUrl}/sample/unalignedNucleotideSequences?downloadAsFile=true&field1=value1`,
+        );
     });
 });
 

--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
@@ -84,7 +84,6 @@ export const DownloadDialog: FC<DownloadDialogProps> = ({
                     <a
                         className={`btn loculusGreen ${!agreedToDataUseTerms ? 'btn-disabled' : ''}`}
                         href={downloadUrl}
-                        target='_blank'
                         onClick={closeDialog}
                     >
                         Download

--- a/website/src/components/SearchPage/DownloadDialog/generateDownloadUrl.ts
+++ b/website/src/components/SearchPage/DownloadDialog/generateDownloadUrl.ts
@@ -22,8 +22,7 @@ export const generateDownloadUrl = (
 ) => {
     const baseUrl = `${lapisUrl}${getEndpoint(option.dataType)}`;
     const params = new URLSearchParams();
-    // TODO(#848)
-    // params.set('downloadAsFile', 'true');
+    params.set('downloadAsFile', 'true');
     if (!option.includeOldData) {
         params.set(VERSION_STATUS_FIELD, siloVersionStatuses.latestVersion);
         params.set(IS_REVOCATION_FIELD, 'false');


### PR DESCRIPTION
This PR makes the sequence download dialog download a file instead of opening a new browser tab with the data as cleartext.

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #848

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
