### PR TITLE
Allow workflow dispatch for e2e k3d

### DIFF
--- a/.github/workflows/e2e-k3d.yml
+++ b/.github/workflows/e2e-k3d.yml
@@ -1,6 +1,7 @@
 name: E2E test (on kubernetes)
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - 'website/**'


### PR DESCRIPTION
Workflow dispatch is always useful. I had a rare PR that didn't trigger the test but needed it.