### PR TITLE
chore: patch backend.yml gh action to use new environment files

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'adopt'
+          java-version: "21"
+          distribution: "adopt"
       - name: Execute Tests
         uses: gradle/gradle-build-action@v3
         with:
@@ -47,8 +47,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'adopt'
+          java-version: "21"
+          distribution: "adopt"
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -70,10 +70,10 @@ jobs:
         id: extractTag
         run: |
           FIRST_TAG=$(echo "${{ steps.dockerMetadata.outputs.tags }}" | head -n 1)
-          echo "::set-output name=firstTag::$FIRST_TAG"
+          echo "firstTag=$FIRST_TAG" >> $GITHUB_OUTPUT
 
           SECOND_TAG=$(echo "${{ steps.dockerMetadata.outputs.tags }}" | head -n 2 | tail -n 1)
-          echo "::set-output name=secondTag::$SECOND_TAG"
+          echo "secondTag=$SECOND_TAG" >> $GITHUB_OUTPUT
       - name: Build Docker Image For Branch
         uses: gradle/gradle-build-action@v3
         env:


### PR DESCRIPTION
resolves #903
for more context see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
