### PR TITLE
Remove flaky sort test

### DIFF
--- a/website/tests/pages/search/index.spec.ts
+++ b/website/tests/pages/search/index.spec.ts
@@ -54,5 +54,4 @@ test.describe('The search page', () => {
 
         await expect(searchPage.getEmptyAccessionVersionField()).toHaveValue('');
     });
-
 });


### PR DESCRIPTION
This functionality isn't super important, and the flaky test makes it hard to figure out if our unrelated PRs are good or not