### PR TITLE
fix(website): aggregate deletions correctly (numerically instead of alphabetically)

### DIFF
--- a/website/src/components/SequenceDetailsPage/getTableData.spec.ts
+++ b/website/src/components/SequenceDetailsPage/getTableData.spec.ts
@@ -163,7 +163,7 @@ describe('getTableData', () => {
         expect(data).toContainEqual({
             label: 'Nucleotide deletions',
             name: 'nucleotideDeletions',
-            value: '20, 21, 40-42',
+            value: '20, 21, 39-45, 400',
         });
         expect(data).toContainEqual({
             label: 'Amino acid substitutions',
@@ -218,6 +218,11 @@ const nucleotideMutations = [
     { count: 0, proportion: 0, mutation: 'G40-' },
     { count: 0, proportion: 0, mutation: 'C41-' },
     { count: 0, proportion: 0, mutation: 'T42-' },
+    { count: 0, proportion: 0, mutation: 'T39-' },
+    { count: 0, proportion: 0, mutation: 'T43-' },
+    { count: 0, proportion: 0, mutation: 'T44-' },
+    { count: 0, proportion: 0, mutation: 'T45-' },
+    { count: 0, proportion: 0, mutation: 'T400-' },
 ];
 const aminoAcidMutations = [
     { count: 0, proportion: 0, mutation: 'gene1:N10Y' },

--- a/website/src/components/SequenceDetailsPage/getTableData.ts
+++ b/website/src/components/SequenceDetailsPage/getTableData.ts
@@ -171,7 +171,7 @@ function deletionsToCommaSeparatedString(mutationData: MutationProportionCount[]
             segmentPositions.get(segment)!.push(position);
         });
     const segmentRanges = [...segmentPositions.entries()].map(([segment, positions]) => {
-        const sortedPositions = positions.sort();
+        const sortedPositions = positions.sort((a, b) => a - b);
         const ranges = [];
         let rangeStart: number | null = null;
         for (let i = 0; i < sortedPositions.length; i++) {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #906 

https://906-fix-grouping-of-delet.loculus.org/dummy-organism/search

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
