### PR TITLE
Fix errors when file is changed after selection

### DIFF
--- a/website/src/components/DataUploadForm.tsx
+++ b/website/src/components/DataUploadForm.tsx
@@ -118,6 +118,8 @@ const InnerDataUploadForm = ({
 
     useEffect(() => {
         const interval = setInterval(() => {
+            // Check for files which are no longer readable - which generally indicates the file has been edited since being
+            // selected in the UI - and clear these.
             metadataFile
                 ?.slice(0, 1)
                 .arrayBuffer()


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #950 

If you edited a file after selecting it that used to cause a generic "Network error" to appear, due to how the browser deals with this case. Now we poll regularly to check the file can still be accessed (meaning it has not been edited) and then clear the upload field when it is changed.

https://fix-file-changed.loculus.org/