### PR TITLE
Fix cache cleanup script (now tested to work)

### DIFF
--- a/.github/workflows/clean-cache-post-merge.yml
+++ b/.github/workflows/clean-cache-post-merge.yml
@@ -11,7 +11,7 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      actions: write
     steps:
       - name: Cleanup
         run: |


### PR DESCRIPTION
Fixing the cleanup-cache action.

### Background 
Unfortunately the script as shown in Github docs doesn't work

https://github.com/loculus-project/loculus/actions/runs/7873524962/job/21481061540

```
gh extension install actions/gh-actions-cache
  
  echo "Fetching list of cache key"
  cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH -L 100 | cut -f 1 )
  
  ## Setting this to not fail the workflow while deleting cache keys.
  set +e
  echo "Deleting caches..."
  for cacheKey in $cacheKeysForPR
  do
      gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
  done
  echo "Done"
  shell: /usr/bin/bash -e {0}
  env:
    GH_TOKEN: ***
    REPO: loculus-project/loculus
    BRANCH: refs/pull/98[4](https://github.com/loculus-project/loculus/actions/runs/7873524962/job/21481061540#step:2:4)/merge
Fetching list of cache key
Error: Resource not accessible by integration
Deleting caches...
Done
```
### Testing 
Can be tested with:
```
gh workflow run --ref corneliusroemer-patch-1 
```