### PR TITLE
fix: change python to python3 in deploy.py

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -188,7 +188,7 @@ def generate_configs():
     runtime_config_path =  TEMP_DIR / 'runtime_config.json'
     generate_config(helm_chart, 'templates/loculus-website-config.yaml', runtime_config_path, codespace_name)
 
-    run_command(['python', 'kubernetes/config-processor/config-processor.py', TEMP_DIR, output_dir], check=True)
+    run_command(['python3', 'kubernetes/config-processor/config-processor.py', TEMP_DIR, output_dir], check=True)
 
 def generate_config(helm_chart, template, output_path, codespace_name=None):
     helm_template_cmd = ['helm', 'template', 'name-does-not-matter', helm_chart, '--show-only', template]


### PR DESCRIPTION
On my freshly installed Ubuntu, there was no `python` but only `python3` and I learned here that `python` should point to Python 2: https://askubuntu.com/a/475815

Further, the first line of the script also refers to `python3`:

```
#!/usr/bin/env python3
```

