### PR TITLE
fix: force push in update-argocd-metadata.yml

### DIFF
--- a/.github/workflows/update-argocd-metadata.yml
+++ b/.github/workflows/update-argocd-metadata.yml
@@ -57,4 +57,4 @@ jobs:
         git config --global user.email 'bot@loculus.org'
         git add config.json
         git commit -m "Update config.json"
-        git push
+        git push --force


### PR DESCRIPTION
Apparently there can be inconsistency causing failure: https://github.com/loculus-project/loculus/actions/runs/7878154967/job/21495790018

We should simply force push to ignore that inconsistency
