### PR TITLE
chore: replace deprecated "::set-output"

### DIFF
--- a/.github/workflows/update-argocd-metadata.yml
+++ b/.github/workflows/update-argocd-metadata.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Get SHA - length 7
       id: get_sha
       run: |
-        echo "::set-output name=sha::$(echo ${GITHUB_SHA} | cut -c1-7)"
+        echo "sha=$(echo ${GITHUB_SHA} | cut -c1-7)" >> $GITHUB_OUTPUT
 
     - name: Wait for Backend Docker Image
       uses: lewagon/wait-on-check-action@v1.3.3


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
