### PR TITLE
Enable preprocessing in helm for codespaces

### DIFF
--- a/.github/scripts/setup_codespace_env.sh
+++ b/.github/scripts/setup_codespace_env.sh
@@ -11,7 +11,7 @@ done
 echo "Docker is up and running!"
 
 ./deploy.py cluster --dev
-./deploy.py helm --dev
+./deploy.py helm --dev --enablePreprocessing
 
 ./deploy.py config
 


### PR DESCRIPTION
This enables preprocessing in helm for codespaces. When I included this is in a PR before @fengelniederhammer sensibly pointed out it would break the ability to run the e2e tests in codespaces - but I'm the only person using the codespaces atm as far as I know and I personally only run these tests from CI. 

I have tried running `./deploy.py helm uninstall` and then redeploying with processing enabled after startup, but this yields an error message about the groups table already existing or something. In general I think the ability to get data into the DB is more important than the ability to run the E2E tests from the codespace so I think this makes sense as the lesser of two evils. In due course we can make multiple codespace configs.