### PR TITLE
deployment: add 1 hour limit for SILO import

### DIFF
--- a/kubernetes/loculus/templates/lapis-silo-import-cronjob.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-import-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             - name: silo-preprocessing
               image: ghcr.io/genspectrum/lapis-silo:latest
               imagePullPolicy: IfNotPresent
-              activeDeadlineSeconds: 3600
+              activeDeadlineSeconds: $.Values.siloImportLimitSeconds
               command:
                 - sh
                 - /silo_import_job.sh

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2,6 +2,7 @@ environment: server
 disableWebsite: false
 disableBackend: false
 disablePreprocessing: false
+siloImportLimitSeconds: 3600
 instances:
   dummy-organism:
     schema:


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1020 (doesn't necessarily necessarily fully resolve it, but mentioning this to ensure the link is made)

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://limit-silo-import.loculus.org/

### Summary
Limits each run of the SILO import pipeline to 1 hour, configurable, in case it stalls for some reason.
