### PR TITLE
Review page tweaks

### DIFF
--- a/website/src/components/ReviewPage/ReviewCard.tsx
+++ b/website/src/components/ReviewPage/ReviewCard.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../types/backend.ts';
 import type { ClientConfig } from '../../types/runtimeConfig.ts';
 import { createAuthorizationHeader } from '../../utils/createAuthorizationHeader.ts';
+import { getAccessionVersionString } from '../../utils/extractAccessionVersion.ts';
 import Edit from '~icons/bxs/edit';
 import Trash from '~icons/bxs/trash';
 import Send from '~icons/fa/send';
@@ -25,7 +26,6 @@ import Locked from '~icons/fluent-emoji-high-contrast/locked';
 import Unlocked from '~icons/fluent-emoji-high-contrast/unlocked';
 import EmptyCircle from '~icons/grommet-icons/empty-circle';
 import TickOutline from '~icons/mdi/tick-outline';
-import { getAccessionVersionString } from '../../utils/extractAccessionVersion.ts';
 
 type ReviewCardProps = {
     sequenceEntryStatus: SequenceEntryStatus;
@@ -292,7 +292,7 @@ const KeyValueComponent: FC<KeyValueComponentProps> = ({
     warnings,
     errors,
 }) => {
-    let { textColor, primaryMessages, secondaryMessages } = getTextColorAndMessages(errors, warnings);
+    const { textColor, primaryMessages, secondaryMessages } = getTextColorAndMessages(errors, warnings);
 
     const textTooltipId = 'text-tooltip-' + keyName + accessionVersion;
     const noteTooltipId = 'note-tooltip-' + keyName + accessionVersion;


### PR DESCRIPTION
https://reviewpage-tweaks.loculus.org/

Some small tweaks to the review page, particular around how it reflows on smaller devices, and also to general design. We now display the text values with error messages in red, instead of putting a note next to them (we use the note for empty fields).We now style all the key value fields consistently.

<img width="1056" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/bd6d258a-ce20-4e1d-90ab-acfa06269b7d">

