### PR TITLE
Delete ndjson files after silo import errors in batch script

### DIFF
--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -88,7 +88,7 @@ preprocessing() {
     if [ $exit_code -ne 0 ]; then
       echo "SiloApi command failed with exit code $exit_code, cleaning up and exiting."
 
-      rm -f "$data_dir/data.ndjson"
+      rm -rf "$data_dir"
       rm -f "$base_data_dir/data.ndjson"
 
       exit $exit_code


### PR DESCRIPTION
This deletes .ndjson files to avoid caching a failed result from SILO import - otherwise we get into a confusing situation where the script fails but each subsequent run indicates everything is fine as it doesn't raise any errors and says the number of sequences is unchanged