### PR TITLE
fix: Exclude change-case and @mui/material from dependabot minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,13 +13,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    ignore:
-      - dependency-name: change-case
-        update-types:
-          - version-update:semver-minor
-      - dependency-name: "@mui/material"
-        update-types:
-          - version-update:semver-minor
+        exclude-patterns:
+          - "@mui/material"
+          - change-case
   - package-ecosystem: npm
     directory: docs/
     schedule:


### PR DESCRIPTION
These packages don't seem to work if bumped at minor level

See https://github.com/loculus-project/loculus/pull/1028/commits/a107358c299f211b0d61d5f2a60dcbfc33edc22b and https://github.com/loculus-project/loculus/pull/1028/commits/c6df0a8360072ac28515e4c1db54f3386a708497