### PR TITLE
Unsticky header

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -21,7 +21,7 @@ const { title } = Astro.props;
     </head>
     <body>
         <div class='w-11/12 mx-auto'>
-            <header class='sticky z-30 top-0 bg-white h-fit'>
+            <header class='z-30 top-0 bg-white h-fit'>
                 <nav class='flex justify-between items-center p-4'>
                     <div class='flex justify-start'>
                         <div class='flex flex-col'>


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #913

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://unsticky-header.loculus.org/

### Summary
Makes the header not stick to the top of the screen

