### PR TITLE
Stop scaling links on mouseover

### DIFF
--- a/website/src/styles/base.scss
+++ b/website/src/styles/base.scss
@@ -5,7 +5,7 @@
 
 a {
   &:hover {
-    @apply underline decoration-emerald-700 scale-105;
+    @apply underline decoration-emerald-700;
   }
 }
 


### PR DESCRIPTION
In some ways I like the current behaviour in which links grow when moused over but it feels unprofessional?


<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://stop-scaling-links.loculus.org/

### Summary
Previously all links jumped a bit bigger when moused over, this removes that

