### PR TITLE
Cleaner organism menu

### DIFF
--- a/website/src/components/Navigation/OrganismSelector.astro
+++ b/website/src/components/Navigation/OrganismSelector.astro
@@ -13,7 +13,7 @@ const label = organism === undefined ? 'Choose Organism' : organism.displayName;
         {label}
         <span class='text-primary'> <IwwaArrowDown className='inline-block -mt-1 ml-1 h-4 w-4 ' /></span>
     </label>
-    <ul tabindex='0' class='dropdown-content z-[1] menu p-1 shadow bg-base-100 rounded-box absolute top-full left-0'>
+    <ul tabindex='0' class='dropdown-content z-[1] menu p-1 shadow bg-base-100 rounded-btn absolute top-full -left-4'>
         {
             knownOrganisms.map((knownOrganism) => (
                 <li>


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://restyle-org-menu.loculus.org/

### Summary
Make the organism menu a bit cleaner. It's not perfect - it would be nice to have a little more animation of the top with the dropdown but that's not super easy atm.

### Screenshot
![image](https://github.com/loculus-project/loculus/assets/19732295/fd574ed0-5ea9-437d-a5fc-db9a09381aa5)

