### PR TITLE
wip: push the footer always to bottom if there isn't enough content

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -24,7 +24,7 @@ const { title } = Astro.props;
         <title>{title}</title>
     </head>
     <body>
-        <div class='w-11/12 mx-auto'>
+        <div class='flex flex-col min-h-screen w-11/12 mx-auto'>
             <header class='z-30 top-0 bg-white h-fit'>
                 <nav class='flex justify-between items-center p-4'>
                     <div class='flex justify-start'>
@@ -52,7 +52,7 @@ const { title } = Astro.props;
                 <slot name='banner' />
             </header>
 
-            <div class='mt-3 mb-5'>
+            <div class='flex-grow mt-3 mb-5'>
                 <slot />
             </div>
 


### PR DESCRIPTION


<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1075 

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:  https://push-footer-down.loculus.org

### Summary
Move footer to bottom on pages with little content

I'm not a css person at all, this seems to workish (with help of GPT4) but there's definitely something not ideal with my css edits

### Screenshot
Footer now at very bottom here:
<img width="1908" alt="image" src="https://github.com/loculus-project/loculus/assets/25161793/252fde03-fb8e-47c1-a34e-da932085886a">


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
