### PR TITLE
Fix generate_local_test_config.sh to run from anywhere

### DIFF
--- a/generate_local_test_config.sh
+++ b/generate_local_test_config.sh
@@ -4,4 +4,5 @@ set -e
 
 root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-"$root/deploy.py" config
+cd "$root"
+"./deploy.py" config


### PR DESCRIPTION
We had a clever trick to always act relative to the script directory but we weren't actually using it (my fault).