### PR TITLE
Login URLs: replace http with https

### DIFF
--- a/website/src/components/common/NeedToLogin.astro
+++ b/website/src/components/common/NeedToLogin.astro
@@ -2,7 +2,7 @@
 import { getAuthUrl } from '../../middleware/authMiddleware';
 import IcOutlineLogin from '~icons/ic/outline-login';
 
-const loginUrl = await getAuthUrl(Astro.url.toString().replace("http://", "https://"));
+const loginUrl = await getAuthUrl(Astro.url.toString().replace('http://', 'https://'));
 
 interface Props {
     message?: string;


### PR DESCRIPTION
See #1087

Astro.url returns `http` URLs as https is handled by traefik

preview: https://replace-astro-https.loculus.org/