### PR TITLE
chore(website): Log at debug level

### DIFF
--- a/website/.env.docker
+++ b/website/.env.docker
@@ -1,2 +1,3 @@
 CONFIG_DIR=/config
 LOG_DIR=/log
+LOG_LEVEL=debug


### PR DESCRIPTION
preview URL: https://log-debug.loculus.org

### Summary
Some interesting things are logged only at debug level right now, I don't see why we shouldn't log at debug

Could help with #1087 etc

### Screenshot

Now getting a few debug logs as well (seems like too many are info and should actually be debug by the way)

<img width="1896" alt="image" src="https://github.com/loculus-project/loculus/assets/25161793/4f462e00-d104-435d-a25d-cdde3d3acd50">
