### PR TITLE
fix(website): remove trailing `;` from user page

### DIFF
--- a/website/src/pages/user.astro
+++ b/website/src/pages/user.astro
@@ -2,4 +2,4 @@
 import UserPage from '../components/User/UserPage.astro';
 ---
 
-<UserPage />;
+<UserPage />


### PR DESCRIPTION
https://fix-groups.loculus.org

### Screenshot

This will be fixed, almost invisible `;` that however causes a scroll bar to appear
<img width="380" alt="image" src="https://github.com/loculus-project/loculus/assets/25161793/50c88f36-1217-48f5-b590-b36e02352be8">

<img width="1327" alt="image" src="https://github.com/loculus-project/loculus/assets/25161793/d49ea7e0-3ff7-42d7-96c8-5a2af7a830b5">
