### PR TITLE
fix(website): remove trailing `;` akin to #1106

### DIFF
--- a/website/src/pages/[organism]/user/index.astro
+++ b/website/src/pages/[organism]/user/index.astro
@@ -2,4 +2,4 @@
 import UserPage from '../../../components/User/UserPage.astro';
 ---
 
-<UserPage />;
+<UserPage />


### PR DESCRIPTION
Didn't realize there was another page with trailing `;` - copy pasted error