### PR TITLE
Add organism selector for browse and submit pages

### DIFF
--- a/website/src/pages/organism-selector/[redirectTo].astro
+++ b/website/src/pages/organism-selector/[redirectTo].astro
@@ -1,8 +1,8 @@
 ---
-import { getConfiguredOrganisms } from '../config';
-import BaseLayout from '../layouts/BaseLayout.astro';
-import { routes } from '../routes';
-const redirectTo = Astro.url.searchParams.get('redirectTo');
+import { getConfiguredOrganisms } from '../../config';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { routes } from '../../routes';
+const redirectTo = Astro.params.redirectTo;
 
 const purposes: { [key: string]: string } = {
     submit: 'for which you want to submit data',

--- a/website/src/routes.ts
+++ b/website/src/routes.ts
@@ -72,7 +72,7 @@ export const routes = {
     },
     notFoundPage: () => `/404`,
     logout: () => '/logout',
-    organismSelectorPage: (redirectTo: string) => `/organism-selector?redirectTo=${redirectTo}`,
+    organismSelectorPage: (redirectTo: string) => `/organism-selector/${redirectTo}`,
 };
 
 export type ClassOfSearchPageType = 'SEARCH' | 'MY_SEQUENCES';


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1086

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://organism-selector.loculus.org/

### Summary
Adds an organism selector used when submit or browse is clicked without an organism selected. Currently duplicates home page quite a bit, but we may change this later so it doesn't make sense to refactor that out.

<img width="621" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/9afcb436-36d5-48d1-b31d-3e59c6f317d0">
