### PR TITLE
fix(website): make mobile menu scrollable

### DIFF
--- a/website/src/components/Navigation/SandwichMenu.tsx
+++ b/website/src/components/Navigation/SandwichMenu.tsx
@@ -35,7 +35,7 @@ export const SandwichMenu: FC<SandwichMenuProps> = ({ top, right, organism, know
                     isOpen ? 'translate-x-0' : 'translate-x-full'
                 }`}
             >
-                <div className='font-bold m-5 flex flex-col justify-between min-h-screen flex-grow'>
+                <div className='font-bold p-5 flex flex-col justify-between min-h-screen max-h-screen overflow-y-auto'>
                     <div>
                         <div className='h-10'>
                             <a href='/'>Loculus</a>


### PR DESCRIPTION
Resolves #1119

preview URL: https://fix-mobile-menu.loculus.org

### Summary
Make mobile menu scroll if it overflows, replace margin with padding to make scrollbar be flush to right hand side.

### Screenshot
<img width="2556" alt="image" src="https://github.com/loculus-project/loculus/assets/25161793/da3b5220-605e-473f-a429-d14213f2e9a7">