### PR TITLE
organism selector stays on same page

### DIFF
--- a/website/src/components/Navigation/OrganismSelector.astro
+++ b/website/src/components/Navigation/OrganismSelector.astro
@@ -1,11 +1,15 @@
 ---
 import { cleanOrganism } from './cleanOrganism';
+import { type Organism } from '../../config';
 import { routes } from '../../routes';
 import IwwaArrowDown from '~icons/iwwa/arrow-down';
 
 const { knownOrganisms, organism } = cleanOrganism(Astro.params.organism);
 
 const label = organism === undefined ? 'Organisms' : organism.displayName;
+const firstBitOfUrl = Astro.url.pathname.split('/')[1];
+const isOrganismPage = knownOrganisms.some((knownOrganism: Organism) => knownOrganism.key === firstBitOfUrl);
+const restOfUrl = Astro.url.pathname.split('/').slice(2).join('/');
 ---
 
 <div class='dropdown dropdown-hover hidden sm:flex relative'>
@@ -15,9 +19,17 @@ const label = organism === undefined ? 'Organisms' : organism.displayName;
     </label>
     <ul tabindex='0' class='dropdown-content z-[1] menu p-1 shadow bg-base-100 rounded-btn absolute top-full -left-4'>
         {
-            knownOrganisms.map((knownOrganism) => (
+            knownOrganisms.map((knownOrganism: Organism) => (
                 <li>
-                    <a href={routes.organismStartPage(knownOrganism.key)}>{knownOrganism.displayName}</a>
+                    <a
+                        href={
+                            isOrganismPage
+                                ? `/${knownOrganism.key}/${restOfUrl}`
+                                : routes.organismStartPage(knownOrganism.key)
+                        }
+                    >
+                        {knownOrganism.displayName}
+                    </a>
                 </li>
             ))
         }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1076

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://org-selector-stay.loculus.org/

### Summary
Now if you are on the submit page and you change organism with the dropdown selector you go to the submit page for that organism (and same for all other pages)

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
