### PR TITLE
exclude silo import from pod readiness checks

### DIFF
--- a/.github/scripts/wait_for_pods_to_be_ready.py
+++ b/.github/scripts/wait_for_pods_to_be_ready.py
@@ -34,6 +34,8 @@ def get_pods():
 
 def all_pods_are_ready(pods):
     for pod in pods:
+        if "silo-import-cronjob" in pod['metadata']['name']:
+            continue
         print("Status of:", pod['metadata']['name'], "-", pod['status']['phase'])
         if pod['status']['phase'] == 'Succeeded':
             continue


### PR DESCRIPTION
### Summary
Cronjobs aren't really "ready" at all, at the moment this is causing flakiness