### PR TITLE
Improve need-to-login and need-group styling

### DIFF
--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -409,7 +409,7 @@ const InnerDataUploadForm = ({
 
     if (noGroup) {
         return (
-            <div className='mt-6 alert max-w-4xl'>
+            <div className='mt-6 message max-w-4xl'>
                 <DashiconsGroups className='w-12 h-12 inline-block mr-2' />
                 <div>
                     <p>

--- a/website/src/components/common/NeedToLogin.astro
+++ b/website/src/components/common/NeedToLogin.astro
@@ -14,11 +14,11 @@ if (message === undefined) {
 }
 ---
 
-<div class='mt-6 alert max-w-4xl mx-auto'>
+<div class='mt-6 message max-w-4xl mx-auto'>
     <IcOutlineLogin className='w-12 h-12 inline-block mr-2' />
     <div>
         <p>{message}</p>
         <a href={loginUrl} class='btn mt-3 bg-white hover:bg-gray-50'>Log in</a>
-        <p class='mt-3'></p>
+        <p class='mt-1'></p>
     </div>
 </div>

--- a/website/src/styles/base.scss
+++ b/website/src/styles/base.scss
@@ -81,3 +81,13 @@ table, tr, td {
   -o-animation: react-confirm-alert-fadeIn 0.5s 0.2s forwards;
   animation: react-confirm-alert-fadeIn 0.5s 0.2s forwards;
 }
+
+.message{
+  background-color: theme('colors.primary.50');
+  padding: 2rem;
+  gap: 1rem;
+  align-content: flex-start;
+
+  border-radius: 1rem;
+  display:flex
+}


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://improve-login-messages.loculus.org/

### Summary
Uses primary colour rather than gray as background for the need to login message.

### Screenshot
<img width="1028" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/b92fcc7c-2ef3-4222-83d8-5d2cf6c89be4">

<img width="961" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/c0cb0988-9060-4455-b8ed-722e5471dfe7">


