### PR TITLE
fix(website): Handle 503 error from SILO

### DIFF
--- a/website/src/utils/search.ts
+++ b/website/src/utils/search.ts
@@ -7,6 +7,7 @@ import type { ProblemDetail } from '../types/backend.ts';
 import type { MetadataFilter, MutationFilter } from '../types/config.ts';
 import { type LapisBaseRequest, type OrderBy, type OrderByType, orderByType } from '../types/lapis.ts';
 import type { ReferenceGenomesSequenceNames } from '../types/referencesGenomes.ts';
+
 export type SearchResponse = {
     data: TableSequenceData[];
     totalCount: number;
@@ -46,7 +47,9 @@ export const getData = async (
 
     const aggregateResult = await lapisClient.call('aggregated', searchFilters);
 
-    if (aggregateResult.isOk() && aggregateResult.value.data[0].count === 0) {
+    const siloDoesNotHaveDataYet = aggregateResult.isErr() && aggregateResult.error.status === 503;
+    const siloIsEmpty = aggregateResult.isOk() && aggregateResult.value.data[0].count === 0;
+    if (siloDoesNotHaveDataYet || siloIsEmpty) {
         return ok({
             data: [],
             totalCount: 0,

--- a/website/tests/playwrightSetup.ts
+++ b/website/tests/playwrightSetup.ts
@@ -24,7 +24,7 @@ enum LapisStateBeforeTests {
 
 export default async function globalSetupForPlaywright() {
     const secondsToWait = 10;
-    const maxNumberOfRetries = 12;
+    const maxNumberOfRetries = 24;
 
     e2eLogger.info(
         'Setting up E2E tests. In order to test search results, data will be prepared in LAPIS. ' +
@@ -97,6 +97,10 @@ async function checkLapisState(lapisClient: LapisClient): Promise<LapisStateBefo
     const accessionTransformer = new AccessionTransformer(accessionPrefix);
 
     const numberOfSequencesInLapisResult = await lapisClient.call('aggregated', {});
+
+    if (numberOfSequencesInLapisResult.isErr() && numberOfSequencesInLapisResult.error.status === 503) {
+        return LapisStateBeforeTests.NoSequencesInLapis;
+    }
 
     if (numberOfSequencesInLapisResult._unsafeUnwrap().data[0].count === 0) {
         return LapisStateBeforeTests.NoSequencesInLapis;


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://lapis503error.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
See https://github.com/GenSpectrum/LAPIS-SILO/issues/295. SILO throws an error now when it did not load a database yet.

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
