### PR TITLE
Remove more outdated "-n loculus"

### DIFF
--- a/.github/workflows/e2e-k3d.yml
+++ b/.github/workflows/e2e-k3d.yml
@@ -116,10 +116,10 @@ jobs:
         run: kubectl get pods --all-namespaces
       - name: Describe pods
         if: ${{ !cancelled() }}
-        run: kubectl describe pods -l app=loculus -n loculus
+        run: kubectl describe pods -l app=loculus
       - name: Show events
         if: ${{ !cancelled() }}
-        run: kubectl get events -n loculus
+        run: kubectl get events
 
       - name: Save logs from all containers to file
         if: ${{ !cancelled() }}

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -74,13 +74,13 @@ Check the README of the backend and the website for more information on how to d
 Check whether the services are already deployed (it might take some time to start, especially for the first time):
 
 ```shell
-kubectl get pods -n loculus
+kubectl get pods
 ```
 
 If something goes wrong,
 
 ```shell
-kubectl get events -n loculus
+kubectl get events
 ```
 
 might help to see the reason.


### PR DESCRIPTION
I removed the default namespace being "loculus" a while back but forgot to remove these (also #1136)