### PR TITLE
Clean up after failed curl in silo_import

### DIFF
--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -56,9 +56,7 @@ download_data() {
 
   if [ $exit_code -ne 0 ]; then
     echo "Curl command failed with exit code $exit_code, cleaning up and exiting."
-
     rm -rf "$data_dir"
-
     exit $exit_code
   fi
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1139

### Summary
Previously when we failed to get a response from the backend we could end up in a broken state with an empty directory which confused all downstream silo import runs. This led to test failures. Now we clean this up.

