### PR TITLE
feat(web): keep restOfUrl when switching via org-selector on org-selector-page

### DIFF
--- a/website/src/components/Navigation/OrganismSelector.astro
+++ b/website/src/components/Navigation/OrganismSelector.astro
@@ -9,6 +9,7 @@ const { knownOrganisms, organism } = cleanOrganism(Astro.params.organism);
 const label = organism === undefined ? 'Organisms' : organism.displayName;
 const firstBitOfUrl = Astro.url.pathname.split('/')[1];
 const isOrganismPage = knownOrganisms.some((knownOrganism: Organism) => knownOrganism.key === firstBitOfUrl);
+const isOrganismSelectorPage = firstBitOfUrl === 'organism-selector';
 const restOfUrl = Astro.url.pathname.split('/').slice(2).join('/');
 ---
 
@@ -23,7 +24,7 @@ const restOfUrl = Astro.url.pathname.split('/').slice(2).join('/');
                 <li>
                     <a
                         href={
-                            isOrganismPage
+                            isOrganismPage || isOrganismSelectorPage
                                 ? `/${knownOrganism.key}/${restOfUrl}`
                                 : routes.organismStartPage(knownOrganism.key)
                         }


### PR DESCRIPTION
Follow-up to #1129

preview URL: https://org-sel-nav.loculus.org

### Summary
There's no reason why organism selector dropdown should change the rest of url on org selector page 

### Screenshot


