### PR TITLE
Use caching and retagging for keycloakify action

### DIFF
--- a/.github/workflows/keycloakify-build.yml
+++ b/.github/workflows/keycloakify-build.yml
@@ -21,6 +21,12 @@ jobs:
       checks: read
     steps:
       - uses: actions/checkout@v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate files hash
         id: files-hash
         run: |
@@ -43,12 +49,6 @@ jobs:
           echo "CACHE_HIT=$EXISTS" >> $GITHUB_ENV
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push image
         if: env.CACHE_HIT == 'false'
         uses: docker/build-push-action@v5


### PR DESCRIPTION
### Summary
Make keycloakify-build action avoid rebuilding when nothing has changed (which will be almost always). Saves ~3-4min per action run.

Same things that were merged earlier for other actions in #1167 