### PR TITLE
fix(ci): trigger e2e on keycloakify changes; don't wait for each image instead use timeout

### DIFF
--- a/.github/workflows/e2e-k3d.yml
+++ b/.github/workflows/e2e-k3d.yml
@@ -81,26 +81,13 @@ jobs:
         run: cd website && npx playwright install-deps
         if: steps.playwright-cache.outputs.cache-hit == 'true'
 
-      - name: Wait for Backend Docker Image
-        uses: lewagon/wait-on-check-action@v1.3.3
-        with:
-          ref: ${{ github.sha }}
-          check-name: Build Backend Docker Image
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Wait for Website Docker Image
-        uses: lewagon/wait-on-check-action@v1.3.3
-        with:
-          ref: ${{ github.sha }}
-          check-name: Build Website Docker Image
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Deploy with helm
         uses: WyriHaximus/github-action-helm3@v4
         with:
           exec: ./deploy.py --verbose helm --branch ${{ github.ref_name }} --sha ${{ github.sha }} --dockerconfigjson ${{ secrets.GHCR_DOCKER_CONFIG }}
 
       - name: Wait for the pods to be ready
+        timeout-minutes: 10
         run: ./.github/scripts/wait_for_pods_to_be_ready.py
       - name: Sleep for 20 secs
         run: sleep 20


### PR DESCRIPTION

### Summary
- [fix(ci): add keycloak to paths that trigger E2E](https://github.com/loculus-project/loculus/pull/1175/commits/d151430ce57ba777aa3034e9966677a1139e3a08)
- No need to wait for particular images, kubernetes will retry pulling images and backoff if not found. Given we build many docker images, we would otherwise wait for each - not just the 2 here. Instead, use timeout to fail if the images never make it.
