### PR TITLE
Configure dependabot for keycloakify

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,13 @@ updates:
         update-types:
           - "minor"
           - "patch"
+  - package-ecosystem: npm
+    directory: keycloak/keycloakify
+    schedule:
+      interval: monthly
+    groups:
+      - allUpdates:
+          update-types:
+            - "minor"
+            - "patch"
+            - "major"


### PR DESCRIPTION
Configure dependabot to rarely check for keycloakify updates and to group them together. Keycloakify produces fixed HTML template documents so security vulnerabilities are unlikely to be relevant.