### PR TITLE
fix(keycloakify): remove weird message when wrong password

### DIFF
--- a/keycloak/keycloakify/src/login/i18n.ts
+++ b/keycloak/keycloakify/src/login/i18n.ts
@@ -11,7 +11,7 @@ export const { useI18n } = createUseI18n({
         // Here we overwrite the default english value for the message "doForgotPassword"
         // that is "Forgot Password?" see: https://github.com/InseeFrLab/keycloakify/blob/f0ae5ea908e0aa42391af323b6d5e2fd371af851/src/lib/i18n/generated_messages/18.0.1/login/en.ts#L17
         doForgotPassword: "I forgot my password",
-        invalidUserMessage: "Invalid username or password. (this message was overwrite in the theme)"
+        invalidUserMessage: "Invalid username or password."
     },
     fr: {
         /* spell-checker: disable */


### PR DESCRIPTION
Fixes
<img width="544" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/df5d6170-4a06-4786-8dc6-833665694997">
