### PR TITLE
Fix(ci): type error for keycloakify

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,7 +39,7 @@ updates:
     schedule:
       interval: monthly
     groups:
-      - allUpdates:
+      allUpdates:
           update-types:
             - "minor"
             - "patch"


### PR DESCRIPTION
Fixes dependabot config error:
<img width="1277" alt="image" src="https://github.com/loculus-project/loculus/assets/25161793/a0ee391b-6262-44fa-825d-be704c486697">

https://github.com/loculus-project/loculus/pull/1182/checks?check_run_id=22130253162

