### PR TITLE
Add reloader annotations to kubernetes deployments

### DIFF
--- a/kubernetes/loculus/templates/keycloak-database-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-database-deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: loculus-keycloak-database
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   selector:

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -16,6 +16,7 @@ metadata:
   name: loculus-keycloak
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   selector:

--- a/kubernetes/loculus/templates/lapis-silo-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   name: loculus-lapis-silo-{{ $key }}
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   selector:

--- a/kubernetes/loculus/templates/loculus-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: loculus
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   selector:

--- a/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
@@ -16,6 +16,7 @@ metadata:
   name: loculus-preprocessing-{{ $key }}
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
These will ensure that when the configmaps change the deployments are recreated. This isn't an issue in our conventional workflow, but is becoming so for `pathoplexus`  as in that context we push changes to config without changing the sha-hash.