### PR TITLE
fix(website): don't show and apply hidden filters in Download Panel

### DIFF
--- a/website/src/pages/[organism]/search/index.astro
+++ b/website/src/pages/[organism]/search/index.astro
@@ -14,6 +14,7 @@ const {
     data,
     page,
     metadataFilter,
+    metadataFilterWithoutHiddenFilters,
     mutationFilter,
     lapisUrl,
     referenceGenomesSequenceNames,
@@ -42,7 +43,7 @@ const {
                 (data) => (
                     <div class='flex-1'>
                         <DownloadDialog
-                            metadataFilter={metadataFilter}
+                            metadataFilter={metadataFilterWithoutHiddenFilters}
                             mutationFilter={mutationFilter}
                             referenceGenomesSequenceNames={referenceGenomesSequenceNames}
                             lapisUrl={lapisUrl}

--- a/website/src/utils/processParametersAndFetchSearch.ts
+++ b/website/src/utils/processParametersAndFetchSearch.ts
@@ -44,18 +44,16 @@ export async function processParametersAndFetchSearch(astro: AstroGlobal, groupF
         ];
     }
 
-    const metadataFilter = addHiddenFilters(
-        getMetadataFilters(
-            getSearchParams,
-            organism,
-            groupForMySequences !== undefined
-                ? {
-                      exclude: [GROUP_FIELD],
-                  }
-                : {},
-        ),
-        hiddenSearchFeatures,
+    const metadataFilterWithoutHiddenFilters = getMetadataFilters(
+        getSearchParams,
+        organism,
+        groupForMySequences !== undefined
+            ? {
+                  exclude: [GROUP_FIELD],
+              }
+            : {},
     );
+    const metadataFilter = addHiddenFilters(metadataFilterWithoutHiddenFilters, hiddenSearchFeatures);
     const mutationFilter = getMutationFilter(astro.url.searchParams);
 
     const pageParam = getSearchParams('page');
@@ -73,6 +71,7 @@ export async function processParametersAndFetchSearch(astro: AstroGlobal, groupF
         data,
         page,
         metadataFilter,
+        metadataFilterWithoutHiddenFilters,
         mutationFilter,
         lapisUrl,
         referenceGenomesSequenceNames,


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1216

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://1216-fix-download-panel.loculus.org/

### Summary
Don't show and apply hidden default filters in Download Panel

### Screenshot
![image](https://github.com/loculus-project/loculus/assets/18666552/ffeebe68-62cf-4dc4-8e53-bc2cf695867c)

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
