### PR TITLE
feat(website): download compressed files

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx
@@ -84,13 +84,15 @@ describe('DownloadDialog', () => {
 
         await userEvent.click(screen.getByLabelText(/Yes, include older versions/));
         await userEvent.click(screen.getByLabelText(/Raw nucleotide sequences/));
+        await userEvent.click(screen.getByLabelText(/Gzip/));
         expect(getDownloadHref()).toBe(
-            `${defaultLapisUrl}/sample/unalignedNucleotideSequences?downloadAsFile=true&dataUseTerms=OPEN&field1=value1`,
+            `${defaultLapisUrl}/sample/unalignedNucleotideSequences?downloadAsFile=true&dataUseTerms=OPEN&compression=gzip&field1=value1`,
         );
 
         await userEvent.click(screen.getByLabelText(/include restricted data/));
+        await userEvent.click(screen.getByLabelText(/Zstandard/));
         expect(getDownloadHref()).toBe(
-            `${defaultLapisUrl}/sample/unalignedNucleotideSequences?downloadAsFile=true&field1=value1`,
+            `${defaultLapisUrl}/sample/unalignedNucleotideSequences?downloadAsFile=true&compression=zstd&field1=value1`,
         );
     });
 });

--- a/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
@@ -13,6 +13,7 @@ export const DownloadForm: FC<DownloadFormProps> = ({ referenceGenomesSequenceNa
     const [includeRestricted, setIncludeRestricted] = useState(0);
     const [includeOldData, setIncludeOldData] = useState(0);
     const [dataType, setDataType] = useState(0);
+    const [compression, setCompression] = useState(0);
     const [unalignedNucleotideSequence, setUnalignedNucleotideSequence] = useState(0);
     const [alignedNucleotideSequence, setAlignedNucleotideSequence] = useState(0);
     const [alignedAminoAcidSequence, setAlignedAminoAcidSequence] = useState(0);
@@ -50,14 +51,17 @@ export const DownloadForm: FC<DownloadFormProps> = ({ referenceGenomesSequenceNa
             default:
                 throw new Error(`Invalid state error: DownloadForm dataType=${dataType}`);
         }
+        const compressionOptions = [undefined, 'zstd', 'gzip'] as const;
         onChange({
             dataType: downloadDataType,
             includeOldData: includeOldData === 1,
             includeRestricted: includeRestricted === 1,
+            compression: compressionOptions[compression],
         });
     }, [
         includeRestricted,
         includeOldData,
+        compression,
         dataType,
         unalignedNucleotideSequence,
         alignedNucleotideSequence,
@@ -160,6 +164,13 @@ export const DownloadForm: FC<DownloadFormProps> = ({ referenceGenomesSequenceNa
                 ]}
                 selected={dataType}
                 onSelect={setDataType}
+            />
+            <RadioOptionBlock
+                name='compression'
+                title='Compression'
+                options={[{ label: <>None</> }, { label: <>Zstandard</> }, { label: <>Gzip</> }]}
+                selected={compression}
+                onSelect={setCompression}
             />
         </div>
     );

--- a/website/src/components/SearchPage/DownloadDialog/OptionBlock.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/OptionBlock.tsx
@@ -21,7 +21,7 @@ export const RadioOptionBlock: FC<OptionBlockProps> = ({
     disabled = false,
 }) => {
     return (
-        <div className='max-w-80'>
+        <div className='max-w-80 basis-1/3'>
             {title !== undefined && <h4 className='font-bold'>{title}</h4>}
             {options.map((option, index) => (
                 <div key={index}>

--- a/website/src/components/SearchPage/DownloadDialog/generateDownloadUrl.ts
+++ b/website/src/components/SearchPage/DownloadDialog/generateDownloadUrl.ts
@@ -8,10 +8,13 @@ export type DownloadDataType =
     | { type: 'alignedNucleotideSequences'; segment: string | undefined }
     | { type: 'alignedAminoAcidSequences'; gene: string };
 
+export type Compression = 'zstd' | 'gzip' | undefined;
+
 export type DownloadOption = {
     includeOldData: boolean;
     includeRestricted: boolean;
     dataType: DownloadDataType;
+    compression: Compression;
 };
 
 export const generateDownloadUrl = (
@@ -32,6 +35,9 @@ export const generateDownloadUrl = (
     }
     if (option.dataType.type === 'metadata') {
         params.set('dataFormat', metadataDefaultDownloadDataFormat);
+    }
+    if (option.compression !== undefined) {
+        params.set('compression', option.compression);
     }
     for (const { name, filterValue } of metadataFilter) {
         if (filterValue.trim().length > 0) {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #849

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://849-download-compressed-f.loculus.org/

### Summary

Users can now download compressed files from the download panel. The default selection is zstd.

### Screenshot
![image](https://github.com/loculus-project/loculus/assets/18666552/421313b4-4a34-48df-8c79-d353424220ec)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
