### PR TITLE
Slight tweaks to group creation form

### DIFF
--- a/website/src/components/User/GroupCreationForm.tsx
+++ b/website/src/components/User/GroupCreationForm.tsx
@@ -57,7 +57,7 @@ const InnerGroupCreationForm: FC<GroupManagerProps> = ({ clientConfig, accessTok
 
     return (
         <div className='p-4 max-w-6xl mx-auto'>
-            <h2 className='title'>Create a new Group</h2>
+            <h2 className='title'>Create a new group</h2>
 
             {errorMessage !== undefined && (
                 <ErrorFeedback message={errorMessage} onClose={() => setErrorMessage(undefined)} />


### PR DESCRIPTION
Centers the form and uses the primary color to indicate focused form elements.

<img width="1352" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/54bfb86d-c812-434e-a807-8848c80a8a9d">

https://grouptweaks.loculus.org/user/createGroup