### PR TITLE
fix(dependabot): specify yarn not npm for keycloakify

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
-  - package-ecosystem: npm
+  - package-ecosystem: yarn
     directory: keycloak/keycloakify
     schedule:
       interval: monthly


### PR DESCRIPTION
Keycloakify uses yarn as package manager not npm

Related to #1227 etc