### PR TITLE
feat(ci): wait for all images to be ready in E2E

### DIFF
--- a/.github/workflows/e2e-k3d.yml
+++ b/.github/workflows/e2e-k3d.yml
@@ -86,6 +86,57 @@ jobs:
         with:
           exec: ./deploy.py --verbose helm --branch ${{ github.ref_name }} --sha ${{ github.sha }} --dockerconfigjson ${{ secrets.GHCR_DOCKER_CONFIG }}
 
+      # Waits are identical to the update-argocd-metadata.yml file
+      # Mirror changes to that file
+      - name: Wait for Prepro Dummy Docker Image
+        uses: lewagon/wait-on-check-action@v1.3.3
+        with:
+          ref: ${{ github.sha }}
+          check-name: Preprocessing dummy docker image build
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 2
+
+      - name: Wait for Config Processor Docker Image
+        uses: lewagon/wait-on-check-action@v1.3.3
+        with:
+          ref: ${{ github.sha }}
+          check-name: Build config-processor Docker Image
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 2
+
+      - name: Wait for Backend Docker Image
+        uses: lewagon/wait-on-check-action@v1.3.3
+        with:
+          ref: ${{ github.sha }}
+          check-name: Build Backend Docker Image
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 2
+
+      - name: Wait for Website Docker Image
+        uses: lewagon/wait-on-check-action@v1.3.3
+        with:
+          ref: ${{ github.sha }}
+          check-name: Build Website Docker Image
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 2
+
+      - name: Wait for Prepro Nextclade Docker Image
+        uses: lewagon/wait-on-check-action@v1.3.3
+        with:
+          ref: ${{ github.sha }}
+          check-name: Build preprocessing-nextclade Docker Image
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 2
+
+      - name: Wait for Keycloakify Docker Image
+        uses: lewagon/wait-on-check-action@v1.3.3
+        with:
+          ref: ${{ github.sha }}
+          check-name: Build keycloakify Docker Image
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 2
+      # End of wait block
+
       - name: Wait for the pods to be ready (timeout 480s)
         run: ./.github/scripts/wait_for_pods_to_be_ready.py
       - name: Sleep for 20 secs

--- a/.github/workflows/update-argocd-metadata.yml
+++ b/.github/workflows/update-argocd-metadata.yml
@@ -28,6 +28,8 @@ jobs:
         run: |
           echo "sha=$(echo ${GITHUB_SHA} | cut -c1-7)" >> $GITHUB_OUTPUT
 
+      # Waits are identical to the e2e-k3d.yml workflow file
+      # Mirror changes to that file
       - name: Wait for Prepro Dummy Docker Image
         uses: lewagon/wait-on-check-action@v1.3.3
         with:
@@ -75,6 +77,7 @@ jobs:
           check-name: Build keycloakify Docker Image
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 2
+      # End of wait block
 
       - name: Checkout External Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Copy steps from `update-argocd-metadata.yml`

Reason is that timeout of 480s is sometimes not enough, as here: https://github.com/loculus-project/loculus/actions/runs/8160168762/job/22306170308 where website image build took 6min and pods weren't ready before timeout.

I initially deleted the waits because they weren't exhaustive - now that we have the waits in update-argocd workflow anyways, copy them over here.