### PR TITLE
fix bug #1261: wrong edited data submitted

### DIFF
--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -200,7 +200,7 @@ type EditableOriginalDataProps = {
 const EditableOriginalData: FC<EditableOriginalDataProps> = ({ editedMetadata, setEditedMetadata }) => (
     <>
         <Subtitle title='Metadata' />
-        {editedMetadata.map((field) => {
+        {editedMetadata.map((field) => (
             <EditableDataRow
                 key={'raw_metadata' + field.key}
                 row={field}
@@ -211,8 +211,8 @@ const EditableOriginalData: FC<EditableOriginalDataProps> = ({ editedMetadata, s
                         ),
                     )
                 }
-            />;
-        })}
+            />
+        ))}
     </>
 );
 


### PR DESCRIPTION
Now the submitted data is correct but the metadata doesn't show:

<img width="647" alt="image" src="https://github.com/loculus-project/loculus/assets/25161793/1f9ff405-9d69-4e54-ba1e-06ca51803f93">
