### PR TITLE
Change readme to trigger CI to rebuild keycloakify

### DIFF
--- a/keycloak/keycloakify/README.md
+++ b/keycloak/keycloakify/README.md
@@ -2,7 +2,6 @@
 
 This is a keycloak theme, built with keycloakify, and branched from https://github.com/keycloakify/keycloakify-starter
 
-
 To preview in the storybook:
 ```
 yarn # install dependencies (it's like npm install)


### PR DESCRIPTION
> I just noticed that [ghcr.io/loculus-project/keycloakify:latest](http://ghcr.io/loculus-project/keycloakify:latest) has no ARM image as caching prevented the build from running. Can we trigger it once manually?