### PR TITLE
fix(ci): use arch info when querying docker image cache

### DIFF
--- a/.github/workflows/preprocessing-nextclade.yaml
+++ b/.github/workflows/preprocessing-nextclade.yaml
@@ -6,6 +6,7 @@ on:
 
 env:
   DOCKER_IMAGE_NAME: ghcr.io/loculus-project/preprocessing-nextclade
+  BUILD_ARM: ${{ github.ref == 'refs/heads/main' }} # When to build for arm as well
 
 concurrency:
   group: ci-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}-preprocessing-nextclade
@@ -22,11 +23,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # ARM Hash tagged only when built with arm, only used to query when arm required
       - name: Generate files hash
         id: files-hash
         run: |
           DIR_HASH=$(echo -n ${{ hashFiles('preprocessing/nextclade/**', '.github/workflows/preprocessing-nextclade.yml') }})
           echo "DIR_HASH=$DIR_HASH" >> $GITHUB_ENV
+          echo "ARM_HASH=${DIR_HASH}-arm" >> $GITHUB_ENV
+          echo "QUERY_HASH=${{ env.BUILD_ARM && env.ARM_HASH || env.DIR_HASH }}" >> $GITHUB_ENV
 
       - name: Setup Docker metadata
         id: dockerMetadata
@@ -35,6 +39,7 @@ jobs:
           images: ${{ env.DOCKER_IMAGE_NAME }}
           tags: |
             type=raw,value=${{ env.DIR_HASH }}
+            type=raw,value=${{ env.ARM_HASH }},enable=${{ env.BUILD_ARM }}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=branch
             type=sha,prefix=commit-
@@ -49,7 +54,7 @@ jobs:
       - name: Check if image exists
         id: check-image
         run: |
-          EXISTS=$(docker manifest inspect ${{ env.DOCKER_IMAGE_NAME }}:${{ env.DIR_HASH }} > /dev/null 2>&1 && echo "true" || echo "false")
+          EXISTS=$(docker manifest inspect ${{ env.DOCKER_IMAGE_NAME }}:${{ env.QUERY_HASH }} > /dev/null 2>&1 && echo "true" || echo "false")
           echo "CACHE_HIT=$EXISTS" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
@@ -64,12 +69,12 @@ jobs:
           tags: ${{ steps.dockerMetadata.outputs.tags }}
           cache-from: type=gha,scope=nextclade-${{ github.ref }}
           cache-to: type=gha,mode=max,scope=nextclade-${{ github.ref }}
-          platforms: ${{ github.ref == 'refs/heads/main' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          platforms: ${{ env.BUILD_ARM && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
 
       - name: Retag and push existing image if cache hit
         if: env.CACHE_HIT == 'true'
         run: |
           TAGS=(${{ steps.dockerMetadata.outputs.tags }})
           for TAG in "${TAGS[@]}"; do
-            docker buildx imagetools create --tag $TAG ${{ env.DOCKER_IMAGE_NAME }}:${{ env.DIR_HASH }}
+            docker buildx imagetools create --tag $TAG ${{ env.DOCKER_IMAGE_NAME }}:${{ env.QUERY_HASH }}
           done


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

### Summary
We want to rebuild with arm when there's no such image present yet
x86 can use the dual arch images, so tag images with both when built with arm so as not needing to rebuild when not needed.

Issue first reported by @bh-ethz on [Slack](https://loculus.slack.com/archives/C05G172HL6L/p1709909251014289)

Changes still need to be rolled out to other docker builds if tests successful

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
