### PR TITLE
fix(ci/nextclade-prepro): Use separate docker cache for multi-arch builds

### DIFF
--- a/.github/workflows/preprocessing-nextclade.yaml
+++ b/.github/workflows/preprocessing-nextclade.yaml
@@ -5,8 +5,9 @@ on:
   workflow_dispatch:
     inputs:
       build_arm:
-        description: "Build for arm as well"
-        default: ""
+        type: boolean
+        description: "Build for ARM as well"
+        default: false
         required: false
 
 env:


### PR DESCRIPTION
- **fix(ci): use arch info when querying docker image cache**
- **Simplify logic addressing @theosanderson's comment**

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
