### PR TITLE
fix(ci): Remove explicit platform arg to micromamba as this screws with automatic multi-arch builds

### DIFF
--- a/preprocessing/nextclade/Dockerfile
+++ b/preprocessing/nextclade/Dockerfile
@@ -1,10 +1,10 @@
-FROM mambaorg/micromamba:1.5.6
+FROM mambaorg/micromamba:1.5.7
 
 COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml /tmp/env.yaml
 COPY --chown=$MAMBA_USER:$MAMBA_USER .mambarc /tmp/.mambarc
 
 RUN micromamba config set extract_threads 1 \
-    && micromamba install -y -n base -f /tmp/env.yaml --platform=linux-64 --rc-file /tmp/.mambarc \
+    && micromamba install -y -n base -f /tmp/env.yaml --rc-file /tmp/.mambarc \
     && micromamba clean --all --yes
 
 COPY --chown=$MAMBA_USER:$MAMBA_USER . /package


### PR DESCRIPTION
### Summary
This works as soon as the Nextclade aarch64 bioconda package exists. This should happen soon: https://github.com/bioconda/bioconda-recipes/pull/46185 but in case it doesn't, we can install the binary manually.