### PR TITLE
chore(ci): no need to exclude keycloakify from dependabot updates any…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,5 +43,3 @@ updates:
           update-types:
             - "minor"
             - "patch"
-          exclude-patterns:
-            - "keycloakify"


### PR DESCRIPTION
…more

Bug that made this necessary has been fixed.