### PR TITLE
fix(website): Improve label text of the "show errors" checkbox on submission review page

### DIFF
--- a/website/src/components/ReviewPage/ReviewPage.tsx
+++ b/website/src/components/ReviewPage/ReviewPage.tsx
@@ -80,7 +80,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({ clientConfig, organism, accessTo
                     title='Show sequences with errors'
                     onChange={(e) => setShowErrors(e.target.checked)}
                 />
-                Show Errors
+                Also show entries with errors
             </div>
         </div>
     );


### PR DESCRIPTION
preview URL: https://fix-text.loculus.org

### Summary
The checkbox controls whether entries with errors are shown or hidden - not whether errors are shown.

### Screenshot
Before:
<img width="769" alt="image" src="https://github.com/loculus-project/loculus/assets/25161793/2c7bac8a-3b7c-473c-8aa6-c2b86a1dc7ee">

After:
<img width="677" alt="image" src="https://github.com/loculus-project/loculus/assets/25161793/9ed1b9db-a1d1-43c9-b394-cb92ecbe4036">

