### PR TITLE
Fix ORCID login setting username to "" on 2nd login

### DIFF
--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -269,7 +269,7 @@ data:
     "identityProviderAlias" : "orcid",
     "identityProviderMapper" : "hardcoded-attribute-idp-mapper",
     "config" : {
-      "syncMode" : "INHERIT",
+      "syncMode" : "IMPORT",
       "attribute" : "username"
     }
     },{


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1301 (hopefully)

I tested this by reconfiguring main live in keycloak admin settings, and it seemed to work. It'll be easiest to merge this and then make sure it works.
