### PR TITLE
feat(ci): speed up E2E by helm deploying before installing playwright deps

### DIFF
--- a/.github/workflows/e2e-k3d.yml
+++ b/.github/workflows/e2e-k3d.yml
@@ -52,6 +52,11 @@ jobs:
           name: default-helm-template
           path: defaultTemplate.yaml
 
+      - name: Deploy with helm
+        uses: WyriHaximus/github-action-helm3@v4
+        with:
+          exec: ./deploy.py --verbose helm --branch ${{ github.ref_name }} --sha ${{ github.sha }} --dockerconfigjson ${{ secrets.GHCR_DOCKER_CONFIG }}
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -83,11 +88,6 @@ jobs:
       - name: Install only System Dependencies
         run: cd website && npx playwright install-deps
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-
-      - name: Deploy with helm
-        uses: WyriHaximus/github-action-helm3@v4
-        with:
-          exec: ./deploy.py --verbose helm --branch ${{ github.ref_name }} --sha ${{ github.sha }} --dockerconfigjson ${{ secrets.GHCR_DOCKER_CONFIG }}
 
       # Waits are identical to the update-argocd-metadata.yml file
       # Mirror changes to that file


### PR DESCRIPTION
### Summary
"Wait for pods to be ready" is rate limiting right now, so starting the deployment
as early as possible should save time