### PR TITLE
fix(dev): prevent astrojs/check from analyzing dist

### DIFF
--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,8 +1,11 @@
 {
     "extends": "astro/tsconfigs/strict",
     "compilerOptions": {
+        "outDir": "dist",
         "jsx": "react-jsx",
         "jsxImportSource": "react",
-        "types": ["unplugin-icons/types/react"]
+        "types": [
+            "unplugin-icons/types/react"
+        ]
     }
 }


### PR DESCRIPTION
### Summary
Otherwise console gets flooded when running `npx astro check`

Fix from https://github.com/withastro/language-tools/issues/643

### Screenshot

#### Before:
pages and pages of this:
<img width="2512" alt="image" src="https://github.com/loculus-project/loculus/assets/25161793/b7925488-8a41-4a98-a721-1205b70dfb7b">

#### After:
peace:
<img width="2501" alt="image" src="https://github.com/loculus-project/loculus/assets/25161793/bf387da6-c0f6-4192-ba72-12e1a30d189f">

Format change for types is due to formatting with `prettier`