### PR TITLE
feat(website): support batch search of accessions

### DIFF
--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -3,6 +3,7 @@
 fields:
   - name: accession
     type: string
+    notSearchable: true
   - name: version
     type: int
     notSearchable: true
@@ -10,6 +11,7 @@ fields:
     type: string
   - name: accessionVersion
     type: string
+    notSearchable: true
   - name: isRevocation
     type: string
     notSearchable: true

--- a/website/src/components/SearchPage/SearchForm.spec.tsx
+++ b/website/src/components/SearchPage/SearchForm.spec.tsx
@@ -38,6 +38,7 @@ function renderSearchForm(
             <SearchForm
                 organism={testOrganism}
                 filters={searchFormFilters}
+                initialAccessionFilter={{}}
                 initialMutationFilter={{}}
                 clientConfig={clientConfig}
                 classOfSearchPage={SEARCH}

--- a/website/src/components/SearchPage/SearchPagination.tsx
+++ b/website/src/components/SearchPage/SearchPagination.tsx
@@ -2,12 +2,13 @@ import { Pagination as MUIPagination } from '@mui/material';
 import type { FC } from 'react';
 
 import { navigateToSearchLikePage, type ClassOfSearchPageType } from '../../routes';
-import type { MetadataFilter, MutationFilter } from '../../types/config.ts';
+import type { AccessionFilter, MetadataFilter, MutationFilter } from '../../types/config.ts';
 import type { OrderBy } from '../../types/lapis.ts';
 
 type SearchPaginationProps = {
     count: number;
     metadataFilter: MetadataFilter[];
+    accessionFilter: AccessionFilter;
     mutationFilter: MutationFilter;
     orderBy: OrderBy;
     organism: string;
@@ -19,6 +20,7 @@ type SearchPaginationProps = {
 export const SearchPagination: FC<SearchPaginationProps> = ({
     count,
     metadataFilter,
+    accessionFilter,
     mutationFilter,
     orderBy,
     organism,
@@ -36,6 +38,7 @@ export const SearchPagination: FC<SearchPaginationProps> = ({
                     classOfSearchPage,
                     group,
                     metadataFilter,
+                    accessionFilter,
                     mutationFilter,
                     newPage,
                     orderBy,

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -2,7 +2,7 @@ import { capitalCase } from 'change-case';
 import type { FC, ReactElement } from 'react';
 
 import { routes, navigateToSearchLikePage, type ClassOfSearchPageType } from '../../routes.ts';
-import type { MetadataFilter, MutationFilter, Schema } from '../../types/config.ts';
+import type { AccessionFilter, MetadataFilter, MutationFilter, Schema } from '../../types/config.ts';
 import type { OrderBy } from '../../types/lapis.ts';
 import MdiTriangle from '~icons/mdi/triangle';
 import MdiTriangleDown from '~icons/mdi/triangle-down';
@@ -15,6 +15,7 @@ type TableProps = {
     schema: Schema;
     data: TableSequenceData[];
     metadataFilter: MetadataFilter[];
+    accessionFilter: AccessionFilter;
     mutationFilter: MutationFilter;
     page: number;
     orderBy: OrderBy;
@@ -27,6 +28,7 @@ export const Table: FC<TableProps> = ({
     data,
     schema,
     metadataFilter,
+    accessionFilter,
     mutationFilter,
     page,
     orderBy,
@@ -43,21 +45,48 @@ export const Table: FC<TableProps> = ({
     const handleSort = (field: string) => {
         if (orderBy.field === field) {
             if (orderBy.type === 'ascending') {
-                navigateToSearchLikePage(organism, classOfSearchPage, group, metadataFilter, mutationFilter, page, {
-                    field,
-                    type: 'descending',
-                });
+                navigateToSearchLikePage(
+                    organism,
+                    classOfSearchPage,
+                    group,
+                    metadataFilter,
+                    accessionFilter,
+                    mutationFilter,
+                    page,
+                    {
+                        field,
+                        type: 'descending',
+                    },
+                );
             } else {
-                navigateToSearchLikePage(organism, classOfSearchPage, group, metadataFilter, mutationFilter, page, {
-                    field,
-                    type: 'ascending',
-                });
+                navigateToSearchLikePage(
+                    organism,
+                    classOfSearchPage,
+                    group,
+                    metadataFilter,
+                    accessionFilter,
+                    mutationFilter,
+                    page,
+                    {
+                        field,
+                        type: 'ascending',
+                    },
+                );
             }
         } else {
-            navigateToSearchLikePage(organism, classOfSearchPage, group, metadataFilter, mutationFilter, page, {
-                field,
-                type: 'ascending',
-            });
+            navigateToSearchLikePage(
+                organism,
+                classOfSearchPage,
+                group,
+                metadataFilter,
+                accessionFilter,
+                mutationFilter,
+                page,
+                {
+                    field,
+                    type: 'ascending',
+                },
+            );
         }
     };
 

--- a/website/src/components/SearchPage/fields/AccessionField.tsx
+++ b/website/src/components/SearchPage/fields/AccessionField.tsx
@@ -1,0 +1,43 @@
+import { type FC, useState } from 'react';
+
+import { NormalTextField } from './NormalTextField.tsx';
+import type { AccessionFilter } from '../../../types/config.ts';
+
+type AccessionFieldProps = {
+    initialValue: AccessionFilter;
+    onChange: (accessionFilter: AccessionFilter) => void;
+};
+
+export const AccessionField: FC<AccessionFieldProps> = ({ initialValue, onChange }) => {
+    const [textValue, setTextValue] = useState((initialValue.accession ?? []).sort().join('\n'));
+
+    return (
+        <NormalTextField
+            field={{
+                type: 'string',
+                label: 'Accession',
+                autocomplete: false,
+                name: 'accession',
+                notSearchable: false,
+                filterValue: textValue,
+            }}
+            handleFieldChange={(_, filter) => {
+                setTextValue(filter);
+                const accessions = filter
+                    .split(/[\t,;\n ]/)
+                    .map((s) => s.trim())
+                    .filter((s) => s !== '')
+                    .map((s) => {
+                        if (s.includes('.')) {
+                            return s.split('.')[0];
+                        }
+                        return s;
+                    });
+                const uniqueAccessions = [...new Set(accessions)];
+                onChange({ accession: uniqueAccessions });
+            }}
+            isLoading={false}
+            multiline
+        />
+    );
+};

--- a/website/src/components/SearchPage/fields/AutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/AutoCompleteField.tsx
@@ -8,7 +8,18 @@ import type { MetadataFilter } from '../../../types/config.ts';
 
 const logger = getClientLogger('AutoCompleteField');
 
-export const AutoCompleteField: FC<FieldProps> = ({ field, allFields, handleFieldChange, isLoading, lapisUrl }) => {
+export type AutoCompleteFieldProps = FieldProps & {
+    allFields: MetadataFilter[];
+    lapisUrl: string;
+};
+
+export const AutoCompleteField: FC<AutoCompleteFieldProps> = ({
+    field,
+    allFields,
+    handleFieldChange,
+    isLoading,
+    lapisUrl,
+}) => {
     const [open, setOpen] = useState(false);
 
     const {

--- a/website/src/components/SearchPage/fields/FieldProps.tsx
+++ b/website/src/components/SearchPage/fields/FieldProps.tsx
@@ -2,8 +2,6 @@ import type { MetadataFilter } from '../../../types/config.ts';
 
 export type FieldProps = {
     field: MetadataFilter;
-    allFields: MetadataFilter[];
     handleFieldChange: (metadataName: string, filter: string) => void;
     isLoading: boolean;
-    lapisUrl: string;
 };

--- a/website/src/components/SearchPage/fields/NormalTextField.tsx
+++ b/website/src/components/SearchPage/fields/NormalTextField.tsx
@@ -3,7 +3,16 @@ import type { FC } from 'react';
 
 import type { FieldProps } from './FieldProps';
 
-export const NormalTextField: FC<FieldProps> = ({ field, handleFieldChange, isLoading }) => (
+type NormalTextFieldProps = FieldProps & {
+    multiline?: boolean;
+};
+
+export const NormalTextField: FC<NormalTextFieldProps> = ({
+    field,
+    handleFieldChange,
+    isLoading,
+    multiline = false,
+}) => (
     <TextField
         variant='outlined'
         margin='dense'
@@ -20,5 +29,7 @@ export const NormalTextField: FC<FieldProps> = ({ field, handleFieldChange, isLo
         inputProps={{
             autoComplete: 'off',
         }}
+        multiline={multiline}
+        rows={3}
     />
 );

--- a/website/src/components/SearchPage/fields/PangoLineageField.tsx
+++ b/website/src/components/SearchPage/fields/PangoLineageField.tsx
@@ -1,11 +1,16 @@
 import { Checkbox, FormControlLabel } from '@mui/material';
 import { type FC, useState } from 'react';
 
-import { AutoCompleteField } from './AutoCompleteField';
-import type { FieldProps } from './FieldProps';
+import { AutoCompleteField, type AutoCompleteFieldProps } from './AutoCompleteField';
 import { NormalTextField } from './NormalTextField';
 
-export const PangoLineageField: FC<FieldProps> = ({ field, allFields, handleFieldChange, isLoading, lapisUrl }) => {
+export const PangoLineageField: FC<AutoCompleteFieldProps> = ({
+    field,
+    allFields,
+    handleFieldChange,
+    isLoading,
+    lapisUrl,
+}) => {
     const filter = field.filterValue;
     const [includeSubLineages, setIncludeSubLineages] = useState(filter.length > 0 ? filter.endsWith('*') : true);
 

--- a/website/src/pages/[organism]/my_sequences/[group].astro
+++ b/website/src/pages/[organism]/my_sequences/[group].astro
@@ -36,6 +36,7 @@ const {
     data,
     page,
     metadataFilter,
+    accessionFilter,
     mutationFilter,
     referenceGenomesSequenceNames,
     schema,
@@ -65,6 +66,7 @@ const {
             <SearchForm
                 organism={organism}
                 filters={metadataFilter}
+                initialAccessionFilter={accessionFilter}
                 initialMutationFilter={mutationFilter}
                 clientConfig={clientConfig}
                 referenceGenomesSequenceNames={referenceGenomesSequenceNames}
@@ -86,6 +88,7 @@ const {
                             data={data.data}
                             schema={schema}
                             metadataFilter={metadataFilter}
+                            accessionFilter={accessionFilter}
                             mutationFilter={mutationFilter}
                             page={page}
                             orderBy={orderBy}
@@ -100,6 +103,7 @@ const {
                                 count={Math.ceil(data.totalCount / pageSize)}
                                 page={page}
                                 metadataFilter={metadataFilter}
+                                accessionFilter={accessionFilter}
                                 mutationFilter={mutationFilter}
                                 orderBy={orderBy}
                                 organism={organism}

--- a/website/src/pages/[organism]/search/index.astro
+++ b/website/src/pages/[organism]/search/index.astro
@@ -15,6 +15,7 @@ const {
     page,
     metadataFilter,
     metadataFilterWithoutHiddenFilters,
+    accessionFilter,
     mutationFilter,
     lapisUrl,
     referenceGenomesSequenceNames,
@@ -31,6 +32,7 @@ const {
             <SearchForm
                 organism={organism}
                 filters={metadataFilter}
+                initialAccessionFilter={accessionFilter}
                 initialMutationFilter={mutationFilter}
                 clientConfig={clientConfig}
                 referenceGenomesSequenceNames={referenceGenomesSequenceNames}
@@ -58,6 +60,7 @@ const {
                             data={data.data}
                             schema={schema}
                             metadataFilter={metadataFilter}
+                            accessionFilter={accessionFilter}
                             mutationFilter={mutationFilter}
                             page={page}
                             orderBy={orderBy}
@@ -71,6 +74,7 @@ const {
                                 count={Math.ceil(data.totalCount / pageSize)}
                                 page={page}
                                 metadataFilter={metadataFilter}
+                                accessionFilter={accessionFilter}
                                 mutationFilter={mutationFilter}
                                 orderBy={orderBy}
                                 organism={organism}

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -18,6 +18,10 @@ export type MetadataFilter = Metadata & {
 
 export type FilterValue = Pick<MetadataFilter, 'name' | 'filterValue'>;
 
+export type AccessionFilter = {
+    accession?: string[];
+};
+
 export type MutationFilter = {
     aminoAcidMutationQueries?: string[];
     nucleotideMutationQueries?: string[];

--- a/website/src/utils/processParametersAndFetchSearch.ts
+++ b/website/src/utils/processParametersAndFetchSearch.ts
@@ -9,6 +9,7 @@ import {
     getMutationFilter,
     getOrderBy,
     addHiddenFilters,
+    getAccessionFilter,
 } from './search';
 import { cleanOrganism } from '../components/Navigation/cleanOrganism';
 import { getSchema, getRuntimeConfig, getLapisUrl } from '../config';
@@ -57,6 +58,7 @@ export async function processParametersAndFetchSearch(astro: AstroGlobal, groupF
             : {},
     );
     const metadataFilter = addHiddenFilters(metadataFilterWithoutHiddenFilters, hiddenSearchFeatures);
+    const accessionFilter = getAccessionFilter(getSearchParams);
     const mutationFilter = getMutationFilter(getSearchParams);
 
     const pageParam = getSearchParams('page');
@@ -66,7 +68,7 @@ export async function processParametersAndFetchSearch(astro: AstroGlobal, groupF
 
     const referenceGenomesSequenceNames = getReferenceGenomesSequenceNames(organism);
 
-    const data = await getData(organism, metadataFilter, mutationFilter, offset, pageSize, orderBy);
+    const data = await getData(organism, metadataFilter, accessionFilter, mutationFilter, offset, pageSize, orderBy);
 
     return {
         organism,
@@ -75,6 +77,7 @@ export async function processParametersAndFetchSearch(astro: AstroGlobal, groupF
         page,
         metadataFilter,
         metadataFilterWithoutHiddenFilters,
+        accessionFilter,
         mutationFilter,
         lapisUrl,
         referenceGenomesSequenceNames,

--- a/website/src/utils/search.ts
+++ b/website/src/utils/search.ts
@@ -4,7 +4,7 @@ import type { TableSequenceData } from '../components/SearchPage/Table.tsx';
 import { getReferenceGenomes, getSchema } from '../config.ts';
 import { LapisClient } from '../services/lapisClient.ts';
 import type { ProblemDetail } from '../types/backend.ts';
-import type { MetadataFilter, MutationFilter } from '../types/config.ts';
+import type { AccessionFilter, MetadataFilter, MutationFilter } from '../types/config.ts';
 import { type LapisBaseRequest, type OrderBy, type OrderByType, orderByType } from '../types/lapis.ts';
 import type { ReferenceGenomesSequenceNames } from '../types/referencesGenomes.ts';
 
@@ -22,6 +22,7 @@ export function addHiddenFilters(searchFormFilter: MetadataFilter[], hiddenFilte
 export const getData = async (
     organism: string,
     metadataFilter: MetadataFilter[],
+    accessionFilter: AccessionFilter,
     mutationFilter: MutationFilter,
     offset: number,
     limit: number,
@@ -33,13 +34,16 @@ export const getData = async (
             acc[metadata.name] = metadata.filterValue;
             return acc;
         }, {});
-    const searchFilters = {
+    const searchFilters: Record<string, string | string[]> = {
         ...metadataSearchFilters,
         nucleotideMutations: mutationFilter.nucleotideMutationQueries ?? [],
         aminoAcidMutations: mutationFilter.aminoAcidMutationQueries ?? [],
         nucleotideInsertions: mutationFilter.nucleotideInsertionQueries ?? [],
         aminoAcidInsertions: mutationFilter.aminoAcidInsertionQueries ?? [],
     };
+    if (accessionFilter.accession !== undefined && accessionFilter.accession.length > 0) {
+        searchFilters.accession = accessionFilter.accession;
+    }
 
     const config = getSchema(organism);
 
@@ -124,6 +128,14 @@ export const getOrderBy = (
     return {
         field: sortByField,
         type: orderByTypeValue,
+    };
+};
+
+export const getAccessionFilter = (getSearchParams: (name: string) => string): AccessionFilter => {
+    return {
+        accession: getSearchParams('accession')
+            .split(',')
+            .filter((s) => s !== ''),
     };
 };
 

--- a/website/tests/pages/search/index.spec.ts
+++ b/website/tests/pages/search/index.spec.ts
@@ -1,8 +1,8 @@
 import { DateTime } from 'luxon';
 
 import { routes } from '../../../src/routes.ts';
-import { baseUrl, dummyOrganism, expect, test } from '../../e2e.fixture';
 import { getAccessionVersionString } from '../../../src/utils/extractAccessionVersion.ts';
+import { baseUrl, dummyOrganism, expect, test } from '../../e2e.fixture';
 import { getTestSequences } from '../../util/testSequenceProvider.ts';
 
 test.describe('The search page', () => {
@@ -13,7 +13,7 @@ test.describe('The search page', () => {
     });
 
     test('should find no data in the future', async ({ searchPage }) => {
-        const tomorrow = DateTime.now().plus({ days: 1 }).toISODate()!;
+        const tomorrow = DateTime.now().plus({ days: 1 }).toISODate();
 
         await searchPage.goto();
         await searchPage.searchFor([{ name: 'dateFrom', filterValue: tomorrow }]);
@@ -21,25 +21,60 @@ test.describe('The search page', () => {
         await expect(searchPage.page.getByText('No data')).toBeVisible();
     });
 
-    test('should search for existing sequence entries', async ({ searchPage }) => {
+    test('should search one existing sequence entry by accession', async ({ searchPage }) => {
         const testAccessionVersion = getAccessionVersionString(getTestSequences().testSequenceEntry);
 
         await searchPage.goto();
-        await searchPage.getEmptyAccessionVersionField().fill(testAccessionVersion);
+        await searchPage.getEmptyAccessionField().fill(testAccessionVersion);
         await searchPage.clickSearchButton();
 
         await searchPage.page.waitForURL(
             `${baseUrl}${routes.searchPage(dummyOrganism.key, [
                 {
-                    name: 'accessionVersion',
+                    name: 'accession',
                     type: 'string',
-                    filterValue: testAccessionVersion,
+                    filterValue: getTestSequences().testSequenceEntry.accession,
                 },
             ])}`,
         );
         await expect(searchPage.page.getByText(testAccessionVersion, { exact: true })).toBeVisible();
         await expect(searchPage.page.getByText('2002-12-15')).toBeVisible();
         await expect(searchPage.page.getByText('B.1.1.7')).toBeVisible();
+    });
+
+    test('should search a few sequence entries by accession', async ({ searchPage }) => {
+        await searchPage.goto();
+        const previousAccessions = (await searchPage.getTableContent()).map((arr) => arr[0]);
+
+        const query = `doesnotexist\n${previousAccessions[0]},${previousAccessions[1]}\t${previousAccessions[2]}`;
+        await searchPage.getEmptyAccessionField().fill(query);
+        await searchPage.clickSearchButton();
+
+        const newAccessions = (await searchPage.getTableContent()).map((arr) => arr[0]);
+
+        expect(newAccessions.length).toBe(3);
+        expect(newAccessions.includes(previousAccessions[0])).toBeTruthy();
+        expect(newAccessions.includes(previousAccessions[1])).toBeTruthy();
+        expect(newAccessions.includes(previousAccessions[2])).toBeTruthy();
+    });
+
+    test('should search many sequence entries by accession', async ({ searchPage }) => {
+        await searchPage.goto();
+        const previousAccessions = (await searchPage.getTableContent()).map((arr) => arr[0]);
+
+        let query = `doesnotexist\n${previousAccessions[0]},${previousAccessions[1]}\t${previousAccessions[2]}`;
+        for (let i = 0; i < 1000; i++) {
+            query += `\ndoesnotexist${i}`;
+        }
+        await searchPage.getEmptyAccessionField().fill(query);
+        await searchPage.clickSearchButton();
+
+        const newAccessions = (await searchPage.getTableContent()).map((arr) => arr[0]);
+
+        expect(newAccessions.length).toBe(3);
+        expect(newAccessions.includes(previousAccessions[0])).toBeTruthy();
+        expect(newAccessions.includes(previousAccessions[1])).toBeTruthy();
+        expect(newAccessions.includes(previousAccessions[2])).toBeTruthy();
     });
 
     test('should search for existing data from one country', async ({ searchPage }) => {
@@ -55,12 +90,12 @@ test.describe('The search page', () => {
         await searchPage.goto();
 
         const testAccessionVersion = getAccessionVersionString(getTestSequences().testSequenceEntry);
-        await searchPage.getEmptyAccessionVersionField().fill(testAccessionVersion);
+        await searchPage.getEmptyAccessionField().fill(testAccessionVersion);
 
-        await expect(searchPage.getFilledAccessionVersionField()).toHaveValue(testAccessionVersion);
+        await expect(searchPage.getFilledAccessionField()).toHaveValue(testAccessionVersion);
 
         await searchPage.clickResetButton();
 
-        await expect(searchPage.getEmptyAccessionVersionField()).toHaveValue('');
+        await expect(searchPage.getEmptyAccessionField()).toHaveValue('');
     });
 });

--- a/website/tests/pages/search/search.page.ts
+++ b/website/tests/pages/search/search.page.ts
@@ -4,7 +4,7 @@ import { baseUrl, dummyOrganism } from '../../e2e.fixture';
 import { routes } from '../../../src/routes.ts';
 import type { FilterValue } from '../../../src/types/config.ts';
 
-export const ACCESSION_VERSION = 'Accession version';
+export const ACCESSION = 'Accession';
 
 export class SearchPage {
     public readonly searchButton: Locator;
@@ -30,12 +30,12 @@ export class SearchPage {
     }
 
     // Note: This only gets a locator when the field is empty
-    public getEmptyAccessionVersionField() {
-        return this.page.getByPlaceholder(ACCESSION_VERSION, { exact: true });
+    public getEmptyAccessionField() {
+        return this.page.getByPlaceholder(ACCESSION, { exact: true });
     }
 
-    public getFilledAccessionVersionField() {
-        return this.page.getByLabel(ACCESSION_VERSION, { exact: true });
+    public getFilledAccessionField() {
+        return this.page.getByLabel(ACCESSION, { exact: true });
     }
 
     public async searchFor(params: FilterValue[]) {
@@ -47,18 +47,12 @@ export class SearchPage {
     }
 
     public async getTableContent() {
-        const tableData: string[][] = [];
-        const rowCount = await this.page.locator('table >> css=tr').count();
-        for (let i = 1; i < rowCount; i++) {
-            const rowCells = this.page.locator(`table >> css=tr:nth-child(${i}) >> css=td`);
-            const cellCount = await rowCells.count();
-            const rowData: string[] = [];
-            for (let j = 0; j < cellCount; j++) {
-                const cellText = await rowCells.nth(j).textContent();
-                rowData.push(cellText ?? '');
-            }
-            tableData.push(rowData);
-        }
-        return tableData;
+        const tableData = await this.page.locator('table >> css=tr').evaluateAll((rows) => {
+            return rows.map((row) => {
+                const cells = Array.from(row.querySelectorAll('td'));
+                return cells.map((cell) => cell.textContent!.trim());
+            });
+        });
+        return tableData.slice(1);
     }
 }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #99, resolves #1291, resolves #1001

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://99-batch-search.loculus.org/

### Summary

The search form that is used by the "Browse" page and the "My released sequences" page now contains a field for searching multiple accessions.

- The accessions can be provided with or without a version: the version will always be ignored.
- Various separators are supported: `\t`, `,`, `;`, `\n`, and ` `.
- The former Accession and Accession Version fields were removed.

### Screenshot

<img src="https://github.com/loculus-project/loculus/assets/18666552/13095dac-5ed3-4577-8b58-8d8ba3bc7daf" width="300" />

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
