### PR TITLE
dev(website): Add `format-fast` npm-run script that doesn't do eslint

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -12,6 +12,7 @@
     "astro": "astro",
     "check-format": "eslint \"src/**/*.{ts,tsx,astro}\" && prettier --ignore-path \"../.gitignore\" --check \"{src,tests}/**/*.{ts,tsx,json,astro}\"",
     "format": "eslint \"src/**/*.{ts,tsx,astro}\" --fix && prettier --ignore-path \"../.gitignore\" --write \"{src,tests}/**/*.{ts,tsx,json,astro}\"",
+    "format-fast": "prettier --ignore-path \"../.gitignore\" --write \"{src,tests}/**/*.{ts,tsx,json,astro}\"",
     "test": "vitest",
     "e2e": "npx playwright test",
     "e2e:headed": "npx playwright test --headed"


### PR DESCRIPTION
### Summary
The `npm run format` script takes about 30 seconds on my M1, 90% of it is `eslint --fix` which in my experience rarely changes anything.

This adds a script to just run prettier in 3 seconds.