### PR TITLE
fix(website): allow null sequences on the edit page #1266

### DIFF
--- a/website/src/components/Edit/DataRow.tsx
+++ b/website/src/components/Edit/DataRow.tsx
@@ -57,7 +57,7 @@ export const ProcessedDataRow: FC<ProcessedDataRowProps> = ({ row }) => (
         <td className={`w-1/4 `}>{row.key}:</td>
         <td />
         <td className='w-full'>
-            <div className='px-3'>{row.value}</div>{' '}
+            <div className='px-3'>{row.value}</div>
         </td>
     </tr>
 );

--- a/website/src/components/Edit/EditPage.spec.tsx
+++ b/website/src/components/Edit/EditPage.spec.tsx
@@ -111,10 +111,10 @@ const expectTextInSequenceData = {
             expect(screen.getByText(sentenceCase(key) + ':')).toBeInTheDocument();
             expect(screen.getByDisplayValue(value)).toBeInTheDocument();
         }),
-    processed: (metadata: Record<string, string>): void =>
+    processed: (metadata: Record<string, string | null>): void =>
         Object.entries(metadata).forEach(([key, value]) => {
             expect(screen.getByText(key + ':')).toBeInTheDocument();
-            expect(screen.getByText(value.toString())).toBeInTheDocument();
+            expect(screen.getByText(value ?? 'null')).toBeInTheDocument();
         }),
     processedMetadata: (metadata: Record<string, MetadataField>): void =>
         Object.entries(metadata).forEach(([key, value]) => {

--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -265,7 +265,7 @@ const ProcessedSequences: FC<ProcessedSequencesProps> = ({ processedSequenceRows
     <>
         <Subtitle key={`preprocessing_sequences_${sequenceType}`} title={sentenceCase(sequenceType)} />
         {Object.entries(processedSequenceRows[sequenceType]).map(([key, value]) => (
-            <ProcessedDataRow key={`processed_${sequenceType}_${key}`} row={{ key, value }} />
+            <ProcessedDataRow key={`processed_${sequenceType}_${key}`} row={{ key, value: value ?? 'null' }} />
         ))}
     </>
 );

--- a/website/src/types/backend.ts
+++ b/website/src/types/backend.ts
@@ -167,10 +167,10 @@ export const sequenceEntryToEdit = accessionVersion.merge(
         }),
         processedData: z.object({
             metadata: metadataRecord,
-            unalignedNucleotideSequences: z.record(z.string()),
-            alignedNucleotideSequences: z.record(z.string()),
+            unalignedNucleotideSequences: z.record(z.string().nullable()),
+            alignedNucleotideSequences: z.record(z.string().nullable()),
             nucleotideInsertions: z.record(z.array(z.string())),
-            alignedAminoAcidSequences: z.record(z.string()),
+            alignedAminoAcidSequences: z.record(z.string().nullable()),
             aminoAcidInsertions: z.record(z.array(z.string())),
         }),
     }),

--- a/website/tests/util/preprocessingPipeline.ts
+++ b/website/tests/util/preprocessingPipeline.ts
@@ -122,7 +122,7 @@ const sequenceData = {
         ORF7a: 'K'.repeat(122),
         ORF7b: 'I'.repeat(44),
         ORF8: 'L'.repeat(122),
-        ORF9b: 'P'.repeat(98),
+        ORF9b: null,
         S: 'V'.repeat(1274),
     },
     aminoAcidInsertions: {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1266

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://1266-unknown-error-from-b.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

Allow null in the corresponding type, display "null" on the page itself.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->
![grafik](https://github.com/loculus-project/loculus/assets/92720311/9847c342-58e9-4df5-9138-868c2d9489c9)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
