### PR TITLE
feat(kubernetes): activate autocomplete for data use terms field

### DIFF
--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -25,6 +25,8 @@ fields:
     type: timestamp
   - name: dataUseTerms
     type: string
+    generateIndex: true
+    autocomplete: true
   - name: versionStatus
     type: string
     notSearchable: true


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://activate-autocomplete-for.loculus.org/

### Summary

The data use terms field now supports autocompletion. The capital letters don't look very nice but it's better than nothing.

### Screenshot

![image](https://github.com/loculus-project/loculus/assets/18666552/94051db2-fee8-4c28-a164-6d8c2888d152)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
