### PR TITLE
feat(website): use normal organism selector for small screens

### DIFF
--- a/website/src/components/Navigation/Navigation.astro
+++ b/website/src/components/Navigation/Navigation.astro
@@ -4,7 +4,7 @@ import { cleanOrganism } from './cleanOrganism';
 import { navigationItems } from '../../routes';
 import { getAuthUrl } from '../../utils/getAuthUrl';
 
-const { organism, knownOrganisms } = cleanOrganism(Astro.params.organism);
+const { organism } = cleanOrganism(Astro.params.organism);
 
 const isLoggedIn = Astro.locals.session?.isLoggedIn ?? false;
 
@@ -17,14 +17,6 @@ const loginUrl = await getAuthUrl(Astro.url.toString());
     </div>
 
     <div class='sm:hidden fixed z-0'>
-        <SandwichMenu
-            top={16}
-            right={28}
-            organism={organism}
-            knownOrganisms={knownOrganisms}
-            isLoggedIn={isLoggedIn}
-            loginUrl={loginUrl}
-            client:load
-        />
+        <SandwichMenu top={16} right={28} organism={organism} isLoggedIn={isLoggedIn} loginUrl={loginUrl} client:load />
     </div>
 </div>

--- a/website/src/components/Navigation/OrganismSelector.astro
+++ b/website/src/components/Navigation/OrganismSelector.astro
@@ -16,7 +16,7 @@ const isOrganismSelectorPage = firstBitOfUrl === 'organism-selector';
 const restOfUrl = Astro.url.pathname.split('/').slice(2).join('/');
 ---
 
-<div class='dropdown dropdown-hover hidden sm:flex relative'>
+<div class='dropdown dropdown-hover flex relative'>
     <label tabindex='0' class='py-1 block text-gray-900 cursor-pointer'>
         {label}
         <span class='text-primary'> <IwwaArrowDown className='inline-block -mt-1 ml-1 h-4 w-4 ' /></span>

--- a/website/src/components/Navigation/SandwichMenu.tsx
+++ b/website/src/components/Navigation/SandwichMenu.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react';
 
 import type { Organism } from '../../config.ts';
 import { useOffCanvas } from '../../hooks/useOffCanvas';
-import { navigationItems, routes } from '../../routes.ts';
+import { navigationItems } from '../../routes.ts';
 import { OffCanvasOverlay } from '../OffCanvasOverlay';
 import { SandwichIcon } from '../SandwichIcon';
 
@@ -10,12 +10,11 @@ type SandwichMenuProps = {
     top: number;
     right: number;
     organism: Organism | undefined;
-    knownOrganisms: Organism[];
     isLoggedIn: boolean;
     loginUrl: string | undefined;
 };
 
-export const SandwichMenu: FC<SandwichMenuProps> = ({ top, right, organism, knownOrganisms, isLoggedIn, loginUrl }) => {
+export const SandwichMenu: FC<SandwichMenuProps> = ({ top, right, organism, isLoggedIn, loginUrl }) => {
     const { isOpen, toggle: toggleMenu, close: closeMenu } = useOffCanvas();
 
     return (
@@ -41,15 +40,6 @@ export const SandwichMenu: FC<SandwichMenuProps> = ({ top, right, organism, know
                             <a href='/'>Loculus</a>
                         </div>
                         <div className='flex-grow divide-y-2 divide-gray-300 divide-solid border-t-2 border-b-2 border-gray-300 border-solid '>
-                            <OffCanvasNavItem key='organism-selector' text='Select organism' level={1} path={false} />
-                            {knownOrganisms.map((organism) => (
-                                <OffCanvasNavItem
-                                    key={organism.key}
-                                    text={organism.displayName}
-                                    level={2}
-                                    path={routes.organismStartPage(organism.key)}
-                                />
-                            ))}
                             {navigationItems.top(organism?.key, isLoggedIn, loginUrl).map(({ text, path }) => (
                                 <OffCanvasNavItem key={path} text={text} level={1} path={path} />
                             ))}


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1210

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://1210-mobile-organism-sele.loculus.org/

### Summary

I deleted the organism selection from the sandwich menu and used the same organism selector for small screens that we also use for larger screens.

### Screenshot

<img src="https://github.com/loculus-project/loculus/assets/18666552/dba8294a-18ce-4b60-8123-cd24fe17394d" width="300" />

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
