### PR TITLE
Reversed the order of the 'Login' and 'Datasets' buttons

### DIFF
--- a/website/src/routes/navigationItems.ts
+++ b/website/src/routes/navigationItems.ts
@@ -16,13 +16,13 @@ function topNavigationItems(organism: string | undefined, isLoggedIn: boolean, l
                 text: 'Submit',
                 path: routes.organismSelectorPage('submit'),
             },
-            ...(isLoggedIn
-                ? [{ text: 'My account', path: routes.userOverviewPage() }]
-                : [{ text: 'Login', path: loginUrl! }]),
             {
                 text: 'Datasets',
                 path: routes.datasetsPage(),
             },
+            ...(isLoggedIn
+                ? [{ text: 'My account', path: routes.userOverviewPage() }]
+                : [{ text: 'Login', path: loginUrl! }]),
         ];
     }
 
@@ -35,12 +35,12 @@ function topNavigationItems(organism: string | undefined, isLoggedIn: boolean, l
             text: 'Submit',
             path: routes.submissionPage(organism),
         },
-        ...(isLoggedIn
-            ? [{ text: 'My account', path: routes.userOverviewPage(organism) }]
-            : [{ text: 'Login', path: loginUrl! }]),
         {
             text: 'Datasets',
             path: routes.datasetsPage(),
         },
+        ...(isLoggedIn
+            ? [{ text: 'My account', path: routes.userOverviewPage(organism) }]
+            : [{ text: 'Login', path: loginUrl! }]),
     ];
 }


### PR DESCRIPTION
IMO login should live on the right

![image](https://github.com/loculus-project/loculus/assets/19732295/da22c801-55d4-45d6-b9ab-ad02105874e3)
