### PR TITLE
Review page: hide "show errors" box

### DIFF
--- a/website/src/components/ReviewPage/ReviewPage.tsx
+++ b/website/src/components/ReviewPage/ReviewPage.tsx
@@ -77,7 +77,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({ clientConfig, organism, accessTo
                 {finishedCount} of {total} sequences processed.
                 {processingCount > 0 && <span className='loading loading-spinner loading-sm ml-3'> </span>}
             </div>
-            <div class={"hidden" /*TODO: unhide after #1161*/ } >
+            <div class={'hidden' /* TODO: unhide after #1161*/}>
                 <input
                     className='mr-3'
                     type='checkbox'


### PR DESCRIPTION
Hides this:
<img width="321" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/5d92fbbc-a506-4d89-93d6-4da13bc53083">


This checkbox isn't in itself a useful feature, it only makes sense as part of #1161.