### PR TITLE
fix(website): only display generate doi button for dataset owners

### DIFF
--- a/website/src/components/DatasetCitations/DatasetItem.tsx
+++ b/website/src/components/DatasetCitations/DatasetItem.tsx
@@ -63,6 +63,7 @@ type DatasetItemProps = {
     dataset: Dataset;
     datasetRecords: DatasetRecord[];
     citedByData: CitedByResult;
+    isAdminView?: boolean;
 };
 
 const DatasetItemInner: FC<DatasetItemProps> = ({
@@ -71,6 +72,7 @@ const DatasetItemInner: FC<DatasetItemProps> = ({
     dataset,
     datasetRecords,
     citedByData,
+    isAdminView = false,
 }) => {
     const { errorMessage, isErrorOpen, openErrorFeedback, closeErrorFeedback } = useErrorFeedbackState();
 
@@ -98,6 +100,32 @@ const DatasetItemInner: FC<DatasetItemProps> = ({
         return dateObj.toLocaleDateString('en-US');
     };
 
+    const renderDOI = () => {
+        if (dataset.datasetDOI !== undefined && dataset.datasetDOI !== null) {
+            return dataset.datasetDOI;
+        }
+
+        if (!isAdminView) {
+            return 'N/A';
+        }
+
+        return (
+            <Link
+                className='mr-4'
+                component='button'
+                underline='none'
+                onClick={() =>
+                    displayConfirmationDialog({
+                        dialogText: `Are you sure you want to create a DOI for this dataset and version?`,
+                        onConfirmation: handleCreateDOI,
+                    })
+                }
+            >
+                Generate a DOI
+            </Link>
+        );
+    };
+
     return (
         <div className='flex flex-col items-left'>
             <ManagedErrorFeedback message={errorMessage} open={isErrorOpen} onClose={closeErrorFeedback} />
@@ -119,23 +147,7 @@ const DatasetItemInner: FC<DatasetItemProps> = ({
                 </div>
                 <div className='flex flex-row py-1.5'>
                     <p className='mr-8 w-[120px] text-gray-500 text-right'>DOI</p>
-                    {dataset.datasetDOI === undefined || dataset.datasetDOI === null ? (
-                        <Link
-                            className='mr-4'
-                            component='button'
-                            underline='none'
-                            onClick={() =>
-                                displayConfirmationDialog({
-                                    dialogText: `Are you sure you want to create a DOI for this dataset and version?`,
-                                    onConfirmation: handleCreateDOI,
-                                })
-                            }
-                        >
-                            Generate a DOI
-                        </Link>
-                    ) : (
-                        dataset.datasetDOI
-                    )}
+                    {renderDOI()}
                 </div>
                 <div className='flex flex-row py-1.5'>
                     <p className='mr-8 w-[120px] text-gray-500 text-right'>Total citations</p>

--- a/website/src/components/DatasetCitations/DatasetItemActions.tsx
+++ b/website/src/components/DatasetCitations/DatasetItemActions.tsx
@@ -1,4 +1,3 @@
-import Button from '@mui/material/Button';
 import { type FC, useState } from 'react';
 
 import { DatasetForm } from './DatasetForm';
@@ -52,60 +51,30 @@ const DatasetItemActionsInner: FC<DatasetItemActionsProps> = ({
             <div className='flex-row items-center justify-between w-full'>
                 <div className='flex justify-start items-center pt-4 pb-8'>
                     <div className='pr-2'>
-                        <Button
-                            sx={{
-                                'backgroundColor': 'whitesmoke',
-                                'color': 'black',
-                                'fontWeight': 'bold',
-                                '&:hover': {
-                                    backgroundColor: 'whitesmoke',
-                                },
-                            }}
-                            onClick={() => setExportModalVisible(true)}
-                            variant='contained'
-                        >
+                        <button className='btn' onClick={() => setExportModalVisible(true)}>
                             Export
-                        </Button>
+                        </button>
                     </div>
                     <div className='px-2'>
                         {isAdminView ? (
-                            <Button
-                                sx={{
-                                    'backgroundColor': 'whitesmoke',
-                                    'color': 'black',
-                                    'fontWeight': 'bold',
-                                    '&:hover': {
-                                        backgroundColor: 'whitesmoke',
-                                    },
-                                }}
-                                onClick={() => setEditModalVisible(true)}
-                                variant='contained'
-                            >
+                            <button className='btn' onClick={() => setEditModalVisible(true)}>
                                 Edit
-                            </Button>
+                            </button>
                         ) : null}
                     </div>
                     <div className='px-2'>
                         {isAdminView ? (
-                            <Button
-                                sx={{
-                                    'backgroundColor': 'whitesmoke',
-                                    'color': 'black',
-                                    'fontWeight': 'bold',
-                                    '&:hover': {
-                                        backgroundColor: 'whitesmoke',
-                                    },
-                                }}
+                            <button
+                                className='btn'
                                 onClick={() =>
                                     displayConfirmationDialog({
                                         dialogText: `Are you sure you want to delete this dataset version?`,
                                         onConfirmation: handleDeleteDataset,
                                     })
                                 }
-                                variant='contained'
                             >
                                 Delete
-                            </Button>
+                            </button>
                         ) : null}
                     </div>
                 </div>

--- a/website/src/pages/datasets/[datasetId].astro
+++ b/website/src/pages/datasets/[datasetId].astro
@@ -77,6 +77,7 @@ const dataset = datasetResponse.value !== undefined ? getDatasetByVersion(datase
                                 dataset={dataset}
                                 datasetRecords={datasetRecordsResponse.value}
                                 citedByData={datasetCitedByResponse.value}
+                                isAdminView={dataset.createdBy === username}
                                 client:load
                             />
                         ) : (


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1352 

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: http://datasets-1352-doi-buttons.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
- check if user is owner before displaying 'Generate a DOI' button
- convert MUI button to tailwind 
 
### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
