### PR TITLE
CSS: use tailwinds break-words to wrap where needed by default

### DIFF
--- a/website/src/components/SequenceDetailsPage/DataTable.astro
+++ b/website/src/components/SequenceDetailsPage/DataTable.astro
@@ -23,7 +23,6 @@ const { tableData, dataUseTermsHistory } = Astro.props;
                         </td>
                         <td class='px-4 py-1 whitespace-normal text-sm text-gray-600'>
                             <div class='flex items-center gap-3'>
-
                                 {value}{' '}
                                 {name === DATA_USE_TERMS_FIELD && (
                                     <DataUseTermsHistoryModal


### PR DESCRIPTION
preview: https://add-break-words-by-defaul.loculus.org

hopefully this simple approach resolves #1396, resolves #1401 wrapping issues (but it doesn't resolve every single one), and doesn't have negative consequences somewhere else.