### PR TITLE
feat(website): add missing dataset export functionality

### DIFF
--- a/website/src/components/DatasetCitations/ExportDataset.tsx
+++ b/website/src/components/DatasetCitations/ExportDataset.tsx
@@ -1,9 +1,4 @@
-import Button from '@mui/material/Button';
-import Checkbox from '@mui/material/Checkbox';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import FormLabel from '@mui/material/FormLabel';
 import Snackbar from '@mui/material/Snackbar';
-import TextField from '@mui/material/TextField';
 import { type FC, useState } from 'react';
 
 import type { Dataset, DatasetRecord } from '../../types/datasetCitation';
@@ -16,15 +11,21 @@ type ExportDatasetProps = {
 export const ExportDataset: FC<ExportDatasetProps> = ({ dataset, datasetRecords }) => {
     const [isDownloading, setIsDownloading] = useState(false);
     const [isCopyAlertOpen, setIsCopyAlertOpen] = useState(false);
+    const [selectedDownload, setSelectedDownload] = useState(0);
+    const [selectedCitation, setSelectedCitation] = useState(0);
 
     const formatYear = (date: string) => {
         const dateObj = new Date(date);
         return dateObj.getFullYear();
     };
 
-    const exportDataset = () => {
-        setIsDownloading(true);
+    const getDatasetURL = () => {
+        return dataset.datasetDOI === null || dataset.datasetDOI === undefined
+            ? window.location.href
+            : `https://doi.org/10.62599/${dataset.datasetDOI}`;
+    };
 
+    const downloadJSONDataset = () => {
         const exportData = {
             dataset,
             sequences: datasetRecords,
@@ -34,23 +35,61 @@ export const ExportDataset: FC<ExportDatasetProps> = ({ dataset, datasetRecords 
         hiddenLink.href = dataStr;
         hiddenLink.download = `${dataset.name}.json`;
         hiddenLink.click();
+    };
+
+    const downloadTSVDataset = () => {
+        const headers = [...Object.keys(dataset), 'accessions'];
+        const datasetString = Object.values(dataset).join('\t');
+        const accessionsString = datasetRecords.map((record) => record.accession).join(', ');
+        const tsv = [headers.join('\t'), datasetString + '\t' + accessionsString].join('\r\n');
+        const dataStr = 'data:text/tsv;charset=utf-8,' + encodeURIComponent(tsv);
+        const hiddenLink = document.createElement('a');
+        hiddenLink.href = dataStr;
+        hiddenLink.download = `${dataset.name}.tsv`;
+        hiddenLink.click();
+    };
+
+    const downloadDataset = () => {
+        setIsDownloading(true);
+        if (selectedDownload === 0) {
+            downloadJSONDataset();
+        } else if (selectedDownload === 1) {
+            downloadTSVDataset();
+        }
         setIsDownloading(false);
     };
 
     const getBibtex = () => {
-        return `@online{${dataset.name},
+        return `@online{${dataset.name.replace(/\s/g, '_')},
     author = {${dataset.createdBy}},
     title = {${dataset.name}},
     year = {${formatYear(dataset.createdAt)}},
-    doi = {${dataset.datasetDOI}},
-    url = {https://doi.org/placeholder/${dataset.datasetDOI}},
+    url = {${getDatasetURL()}},${dataset.datasetDOI === null || dataset.datasetDOI === undefined ? '' : `\n\tdoi = {${dataset.datasetDOI}},`}
 }`;
+    };
+
+    const getMLACitation = () => {
+        return `${dataset.createdBy}. ${dataset.name}, ${formatYear(dataset.createdAt)}. ${getDatasetURL()}`;
+    };
+
+    const getAPACitation = () => {
+        return `${dataset.createdBy} (${formatYear(dataset.createdAt)}). ${dataset.name} (${dataset.datasetVersion}). ${getDatasetURL()}`;
+    };
+
+    const getSelectedCitationText = () => {
+        if (selectedCitation === 0) {
+            return getBibtex();
+        }
+        if (selectedCitation === 1) {
+            return getMLACitation();
+        }
+        return getAPACitation();
     };
 
     const copyToClipboard = async () => {
         setIsCopyAlertOpen(true);
-        const bibTex = getBibtex();
-        await navigator.clipboard.writeText(bibTex);
+        const citationText = getSelectedCitationText();
+        await navigator.clipboard.writeText(citationText);
     };
 
     return (
@@ -66,38 +105,111 @@ export const ExportDataset: FC<ExportDatasetProps> = ({ dataset, datasetRecords 
             />
             <div className='flex flex-col justify-around max-w-md w-2/4'>
                 <div>
-                    <FormLabel component='legend'>Dataset</FormLabel>
-                    <h2 className='text-lg font-bold'></h2>
-                    <FormControlLabel control={<Checkbox defaultChecked />} label='JSON' />
-                    <FormControlLabel disabled control={<Checkbox />} label='CSV' />
-                    <FormControlLabel disabled control={<Checkbox />} label='XLSX' />
-                    <div className='pb-8'>
-                        <Button variant='outlined' onClick={exportDataset} disabled={isDownloading}>
+                    <div className='flex'>
+                        <div className='flex items-center me-4'>
+                            <input
+                                id='json-radio'
+                                data-testid='json-radio'
+                                checked={selectedDownload === 0}
+                                type='radio'
+                                className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
+                                onChange={() => setSelectedDownload(0)}
+                            />
+                            <label
+                                htmlFor='json-radio'
+                                className='ms-2 text-sm font-medium text-gray-900 dark:text-gray-300'
+                            >
+                                JSON
+                            </label>
+                        </div>
+                        <div className='flex items-center me-4'>
+                            <input
+                                id='tsv-radio'
+                                data-testid='tsv-radio'
+                                type='radio'
+                                checked={selectedDownload === 1}
+                                className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
+                                onChange={() => setSelectedDownload(1)}
+                            />
+                            <label
+                                htmlFor='tsv-radio'
+                                className='ms-2 text-sm font-medium text-gray-900 dark:text-gray-300'
+                            >
+                                TSV
+                            </label>
+                        </div>
+                    </div>
+                    <div className='pb-8 pt-4'>
+                        <button className='btn' onClick={downloadDataset} disabled={isDownloading}>
                             Download
-                        </Button>
+                        </button>
                     </div>
                 </div>
                 <hr className='mb-8' />
-                <div>
-                    <FormLabel component='legend'>Citation</FormLabel>
-                    <FormControlLabel control={<Checkbox defaultChecked />} label='BibTeX' />
-                    <FormControlLabel disabled control={<Checkbox />} label='MLA' />
-                    <FormControlLabel disabled control={<Checkbox />} label='APA' />
+                <div className='flex'>
+                    <div className='flex items-center me-4'>
+                        <input
+                            id='bibtex-radio'
+                            checked={selectedCitation === 0}
+                            type='radio'
+                            name='inline-radio-group'
+                            className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
+                            onChange={() => setSelectedCitation(0)}
+                        />
+                        <label
+                            htmlFor='bibtex-radio'
+                            className='ms-2 text-sm font-medium text-gray-900 dark:text-gray-300'
+                        >
+                            BibTeX
+                        </label>
+                    </div>
+                    <div className='flex items-center me-4'>
+                        <input
+                            id='mla-radio'
+                            type='radio'
+                            checked={selectedCitation === 1}
+                            name='inline-radio-group'
+                            className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
+                            onChange={() => setSelectedCitation(1)}
+                        />
+                        <label
+                            htmlFor='mla-radio'
+                            className='ms-2 text-sm font-medium text-gray-900 dark:text-gray-300'
+                        >
+                            MLA
+                        </label>
+                    </div>
+                    <div className='flex items-center me-4'>
+                        <input
+                            id='apa-radio'
+                            type='radio'
+                            checked={selectedCitation === 2}
+                            name='inline-radio-group'
+                            className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
+                            onChange={() => setSelectedCitation(2)}
+                        />
+                        <label
+                            htmlFor='apa-radio'
+                            className='ms-2 text-sm font-medium text-gray-900 dark:text-gray-300'
+                        >
+                            APA
+                        </label>
+                    </div>
                 </div>
+
                 <div className='py-4 w-full'>
-                    <TextField
-                        id='outlined-multiline-static'
-                        multiline
-                        rows={4}
-                        fullWidth
-                        value={getBibtex()}
-                        size='small'
+                    <textarea
+                        id='citation-text'
+                        className='block w-full p-4 text-gray-900 border border-gray-300 rounded-lg bg-gray-50 text-base focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500'
+                        rows={5}
+                        cols={40}
+                        value={getSelectedCitationText()}
                     />
                 </div>
                 <div className='pb-8'>
-                    <Button variant='outlined' onClick={copyToClipboard}>
+                    <button className='btn' onClick={copyToClipboard} disabled={isDownloading}>
                         Copy to clipboard
-                    </Button>
+                    </button>
                 </div>
             </div>
         </div>

--- a/website/tests/pages/datasets/[dataset].spec.ts
+++ b/website/tests/pages/datasets/[dataset].spec.ts
@@ -36,18 +36,36 @@ test.describe('The dataset item page', () => {
         await expect(datasetPage.page.getByText('Sequences')).toBeVisible();
     });
 
-    test('export functionality allows downloading file', async ({ datasetPage }) => {
+    test('export functionality allows downloading JSON file', async ({ datasetPage }) => {
         await datasetPage.gotoDetail(testDatasetName);
         await expect(datasetPage.page.getByRole('button', { name: 'Export' })).toBeVisible();
         await datasetPage.page.getByRole('button', { name: 'Export' }).click();
         await datasetPage.waitForLoad();
 
+        await datasetPage.page.getByTestId('json-radio').waitFor();
+        await datasetPage.page.getByTestId('json-radio').click();
         await expect(datasetPage.page.getByRole('button', { name: 'Download' })).toBeVisible();
         const [download] = await Promise.all([
             datasetPage.page.waitForEvent('download'),
             datasetPage.page.getByRole('button', { name: 'Download' }).click(),
         ]);
         expect(download.suggestedFilename()).toBe(`${testDatasetName}.json`);
+    });
+
+    test('export functionality allows downloading TSV file', async ({ datasetPage }) => {
+        await datasetPage.gotoDetail(testDatasetName);
+        await expect(datasetPage.page.getByRole('button', { name: 'Export' })).toBeVisible();
+        await datasetPage.page.getByRole('button', { name: 'Export' }).click();
+        await datasetPage.waitForLoad();
+
+        await datasetPage.page.getByTestId('tsv-radio').waitFor();
+        await datasetPage.page.getByTestId('tsv-radio').click();
+        await expect(datasetPage.page.getByRole('button', { name: 'Download' })).toBeVisible();
+        const [download] = await Promise.all([
+            datasetPage.page.waitForEvent('download'),
+            datasetPage.page.getByRole('button', { name: 'Download' }).click(),
+        ]);
+        expect(download.suggestedFilename()).toBe(`${testDatasetName}.tsv`);
     });
 
     test('delete functionality can be cancelled', async ({ datasetPage }) => {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1258

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: http://datasets-1258-export-ui.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
- replace MUI components (button, textfield, labels) with tailwind 
- remove unimplemented export dataset options
- implement citation generation for MLA and APA styles using [dataset citation recommendations](https://guides.lib.uiowa.edu/c.php?g=132283&p=5272709)
- implement dataset TSV download functionality
- add e2e test for TSV download functionality

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
