### PR TITLE
feat(website, backend): prevent dataset deletion after DOI is created

### DIFF
--- a/website/src/components/DatasetCitations/DatasetItem.tsx
+++ b/website/src/components/DatasetCitations/DatasetItem.tsx
@@ -27,11 +27,11 @@ const DatasetRecordsTable: FC<DatasetRecordsTableProps> = ({ datasetRecords }) =
     };
 
     return (
-        <table className='table-auto w-full'>
+        <table className='table-auto w-full max-w-xl'>
             <thead>
                 <tr>
-                    <th className='w-1/10 text-left font-medium'>Accession</th>
-                    <th className='w-1/10 text-left font-medium'>Source</th>
+                    <th className='w-1/2 text-left font-medium'>Accession</th>
+                    <th className='w-1/2 text-left font-medium'>Source</th>
                 </tr>
             </thead>
             <tbody>
@@ -102,7 +102,7 @@ const DatasetItemInner: FC<DatasetItemProps> = ({
 
     const renderDOI = () => {
         if (dataset.datasetDOI !== undefined && dataset.datasetDOI !== null) {
-            return dataset.datasetDOI;
+            return `https://doi.org/${dataset.datasetDOI}`;
         }
 
         if (!isAdminView) {
@@ -116,7 +116,7 @@ const DatasetItemInner: FC<DatasetItemProps> = ({
                 underline='none'
                 onClick={() =>
                     displayConfirmationDialog({
-                        dialogText: `Are you sure you want to create a DOI for this dataset and version?`,
+                        dialogText: `Are you sure you want to create a DOI for this version of your dataset?`,
                         onConfirmation: handleCreateDOI,
                     })
                 }

--- a/website/src/components/DatasetCitations/DatasetItemActions.tsx
+++ b/website/src/components/DatasetCitations/DatasetItemActions.tsx
@@ -63,7 +63,7 @@ const DatasetItemActionsInner: FC<DatasetItemActionsProps> = ({
                         ) : null}
                     </div>
                     <div className='px-2'>
-                        {isAdminView ? (
+                        {isAdminView && (dataset.datasetDOI === null || dataset.datasetDOI === undefined) ? (
                             <button
                                 className='btn'
                                 onClick={() =>

--- a/website/src/pages/datasets/[datasetId].astro
+++ b/website/src/pages/datasets/[datasetId].astro
@@ -46,11 +46,11 @@ const authorResponse = dataset !== undefined ? await datasetClient.getAuthor(dat
 ---
 
 <BaseLayout title='Datasets' data-testid='datasets-item-container'>
-    <div class='flex flex-col justify-start'>
+    <div class='flex flex-col justify-center max-w-7xl'>
         {
             dataset !== undefined ? (
                 <div class='flex flex-row items-left'>
-                    <div class='w-1/6 flex flex-col justify-start items-center'>
+                    <div class='w-1/5 flex flex-col justify-start items-center'>
                         {authorResponse !== undefined
                             ? authorResponse.match(
                                   (authorProfile) => (
@@ -69,7 +69,7 @@ const authorResponse = dataset !== undefined ? await datasetClient.getAuthor(dat
                               )
                             : null}
                     </div>
-                    <div class='w-5/6 pl-6'>
+                    <div class='w-4/5 pl-6'>
                         {datasetRecordsResponse.value !== undefined ? (
                             <DatasetItemActions
                                 clientConfig={clientConfig}

--- a/website/src/pages/datasets/index.astro
+++ b/website/src/pages/datasets/index.astro
@@ -28,7 +28,7 @@ const editAccountUrl = (await urlForKeycloakAccountPage(keycloakClient!)) + '/#/
 
 <BaseLayout title='Datasets' data-testid='datasets-list-container'>
     <div class='flex flex-col justify-center items-center'>
-        <div class='flex flex-row justify-center w-5/6 divide-x'>
+        <div class='flex flex-row justify-center w-5/6 divide-x max-w-7xl'>
             <div class='w-3/4 flex flex-col justify-start'>
                 {
                     authorResponse.match(


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1253 

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: http://datasets-1253-doi-deletio.loculus.org/
### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
- backend: if the dataset has a DOI associated with it, then throw an error if user tries to delete it
- backend: add test coverage
- website: hide delete button if user is viewing dataset version with DOI already generated
- misc UI updates: 
   - add max width on dataset pages to better display on large screens (similar behaviour to google scholar)
   - render doi as http://doi.org/{doi} on dataset item page

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
