### PR TITLE
feat(website, backend): rate limit doi creation by user

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/api/DatasetCitations.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/DatasetCitations.kt
@@ -84,4 +84,5 @@ data class AuthorProfile(
 
 object DatasetCitationsConstants {
     const val DOI_PREFIX = "placeholder"
+    const val DOI_WEEKLY_RATE_LIMIT = 7
 }

--- a/backend/src/main/kotlin/org/loculus/backend/service/datasetcitations/DatasetCitationsDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/datasetcitations/DatasetCitationsDatabaseService.kt
@@ -1,6 +1,7 @@
 package org.loculus.backend.service.datasetcitations
 
 import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toJavaLocalDateTime
 import kotlinx.datetime.toLocalDateTime
@@ -258,10 +259,8 @@ class DatasetCitationsDatabaseService(
         }
     }
 
-    fun createDatasetDOI(username: String, datasetId: String, version: Long): ResponseDataset {
-        log.info { "Create DOI for dataset $datasetId, version $version, user $username" }
-
-        val datasetDOI = "${DatasetCitationsConstants.DOI_PREFIX}/$datasetId.$version"
+    fun validateCreateDatasetDOI(username: String, datasetId: String, version: Long) {
+        log.info { "Validate create DOI for dataset $datasetId, version $version, user $username" }
 
         if (DatasetsTable
                 .select {
@@ -273,6 +272,29 @@ class DatasetCitationsDatabaseService(
         ) {
             throw NotFoundException("Dataset $datasetId, version $version does not exist")
         }
+
+        val now = Clock.System.now().toLocalDateTime(TimeZone.UTC).toJavaLocalDateTime()
+        val sevenDaysAgo = LocalDateTime.parse(now.minusDays(7).toString())
+        val count = DatasetsTable
+            .select {
+                (DatasetsTable.createdBy eq username) and
+                    (DatasetsTable.createdAt greaterEq sevenDaysAgo) and
+                    (DatasetsTable.datasetDOI neq "")
+            }
+            .count()
+        if (count >= DatasetCitationsConstants.DOI_WEEKLY_RATE_LIMIT) {
+            throw UnprocessableEntityException(
+                "User exceeded limit of ${DatasetCitationsConstants.DOI_WEEKLY_RATE_LIMIT} DOIs created per week.",
+            )
+        }
+    }
+
+    fun createDatasetDOI(username: String, datasetId: String, version: Long): ResponseDataset {
+        log.info { "Create DOI for dataset $datasetId, version $version, user $username" }
+
+        validateCreateDatasetDOI(username, datasetId, version)
+
+        val datasetDOI = "${DatasetCitationsConstants.DOI_PREFIX}/$datasetId.$version"
 
         DatasetsTable.update(
             {

--- a/website/src/components/DatasetCitations/DatasetItem.tsx
+++ b/website/src/components/DatasetCitations/DatasetItem.tsx
@@ -1,4 +1,4 @@
-import Link from '@mui/material/Link';
+import { AxiosError } from 'axios';
 import { type FC } from 'react';
 
 import { CitationPlot } from './CitationPlot';
@@ -39,14 +39,9 @@ const DatasetRecordsTable: FC<DatasetRecordsTableProps> = ({ datasetRecords }) =
                     return (
                         <tr key={`accessionData-${index}`}>
                             <td className='text-left'>
-                                <Link
-                                    href={accessionOutlink[datasetRecord.type](datasetRecord.accession)}
-                                    target='_blank'
-                                    underline='none'
-                                    sx={{ padding: 0, margin: 0 }}
-                                >
+                                <a href={accessionOutlink[datasetRecord.type](datasetRecord.accession)} target='_blank'>
                                     {datasetRecord.accession}
-                                </Link>
+                                </a>
                             </td>
                             <td className='text-left'>{datasetRecord.type as string}</td>
                         </tr>
@@ -110,10 +105,8 @@ const DatasetItemInner: FC<DatasetItemProps> = ({
         }
 
         return (
-            <Link
-                className='mr-4'
-                component='button'
-                underline='none'
+            <a
+                className='mr-4 cursor-pointer font-medium text-blue-600 dark:text-blue-500 hover:underline'
                 onClick={() =>
                     displayConfirmationDialog({
                         dialogText: `Are you sure you want to create a DOI for this dataset and version?`,
@@ -122,7 +115,7 @@ const DatasetItemInner: FC<DatasetItemProps> = ({
                 }
             >
                 Generate a DOI
-            </Link>
+            </a>
         );
     };
 
@@ -154,9 +147,13 @@ const DatasetItemInner: FC<DatasetItemProps> = ({
                     {dataset.datasetDOI === undefined || dataset.datasetDOI === null ? (
                         <p className='text'>Cited By 0</p>
                     ) : (
-                        <Link href={getCrossRefUrl()} target='_blank' underline='none'>
+                        <a
+                            className='mr-4 cursor-pointer font-medium text-blue-600 dark:text-blue-500 hover:underline'
+                            href={getCrossRefUrl()}
+                            target='_blank'
+                        >
                             Cited By 0
-                        </Link>
+                        </a>
                     )}
                 </div>
                 <div className='flex flex-row'>
@@ -189,9 +186,14 @@ function useCreateDatasetDOIAction(
                 location.reload();
             },
             onError: async (error) => {
-                const message = `Failed to create dataset DOI with error: '${JSON.stringify(error)})}'`;
-                await logger.info(message);
-                onError(message);
+                await logger.info(`Failed to create dataset DOI with error: '${JSON.stringify(error)})}'`);
+                if (error instanceof AxiosError) {
+                    if (error.response?.data !== undefined) {
+                        onError(
+                            `Failed to update dataset. ${error.response.data?.title}. ${error.response.data?.detail}`,
+                        );
+                    }
+                }
             },
         },
     );


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1395 

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: http://datasets-1395-rate-limit.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
- Rate limit DOI generation to 7 times per user per week
- Replace MUI Link with anchor  
- Not sure if this is an ideal way to unit test the rate limit. I tried a few alternatives with mocking the constant or the service but couldn't get it working.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
