### PR TITLE
docs(backend): document requirements to run backend tests

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -66,8 +66,15 @@ Check the deployment for how to run the image.
 
 ### Run tests and lints
 
+The tests use Testcontainers to start a PostgreSQL database. This requires Docker or a Docker-API compatible container runtime to be installed, and the user executing the test needs the necessary permissions to use it. See [the documentation of the Testcontainers](https://java.testcontainers.org/supported_docker_environment/) for details.
+
 ```bash
 ./gradlew test
+```
+
+### Run linter
+
+```bash
 ./gradlew ktlintCheck
 ```
 


### PR DESCRIPTION
This PR adds a brief statement regarding the need for Docker to run the backend tests to the readme.