### PR TITLE
fix(backend): prevent flaky dataset rate-limit test from failing

### DIFF
--- a/backend/src/test/kotlin/org/loculus/backend/controller/datasetcitations/DatasetValidationEndpointsTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/datasetcitations/DatasetValidationEndpointsTest.kt
@@ -167,7 +167,6 @@ class DatasetValidationEndpointsTest(
 
         for (i in 1..DatasetCitationsConstants.DOI_WEEKLY_RATE_LIMIT) {
             createDatasetWithDOI(accessionJson)
-                .andExpect(status().isOk)
         }
         createDatasetWithDOI(accessionJson)
             .andExpect(status().isUnprocessableEntity)


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
- The failing test seems to be caused by DOIs being created by other tests, possibly from being run in parallel
- We only need to keep the expect call for the failed call after the rate limit is guaranteed to be exceed to prevent the test from being flaky
- As mentioned in the original PR, mocking the service or the rate limit constant didn't work but i'll look into alternative approaches for the unit test

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
