### PR TITLE
fix(ingest): Delay test data upload by 120 seconds so it only happens after new database up

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -100,6 +100,7 @@ rule submit_to_loculus:
         log_level=LOG_LEVEL,
     shell:
         """
+        sleep 120
         python scripts/submit_to_loculus.py \
             --mode submit \
             --metadata {input.metadata} \


### PR DESCRIPTION
### Summary
Slight temporary hack to make sure we always end up submitting data to the _new_ database of the new deployment, not the _old_ one that's still hanging around because ingest is up so fast.

I'll make this more robust later, but for now this ensures we always have data for previews to make everyone's lives easier.

Solves this problem (mostly):

![image](https://github.com/loculus-project/loculus/assets/25161793/38d9f157-0bb8-43b9-a035-d47d68c301a8)

Though we still want to ensure LAPIS is cleared after new deployment, see #1438 
