### PR TITLE
fix(ci): delay ingest group creation by 5 instead of 2 min

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -100,7 +100,7 @@ rule submit_to_loculus:
         log_level=LOG_LEVEL,
     shell:
         """
-        sleep 120
+        sleep 300
         python scripts/submit_to_loculus.py \
             --mode submit \
             --metadata {input.metadata} \


### PR DESCRIPTION
2min turned out not enough often

this is still a workaround, it'll become unnecessary eventually

