### PR TITLE
feat(backend): delete /get-data-to-edit endpoint

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -192,30 +192,6 @@ class SubmissionController(
         return ResponseEntity(streamBody, headers, HttpStatus.OK)
     }
 
-    @Operation(description = GET_DATA_TO_EDIT_DESCRIPTION)
-    @GetMapping("/get-data-to-edit", produces = [MediaType.APPLICATION_NDJSON_VALUE])
-    fun getDataToEdit(
-        @PathVariable @Valid
-        organism: Organism,
-        @UsernameFromJwt username: String,
-        @Parameter(
-            description = GROUP_DESCRIPTION,
-        ) @RequestParam groupName: String,
-        @Max(
-            value = MAX_EXTRACTED_SEQUENCE_ENTRIES,
-            message = "You can extract at max $MAX_EXTRACTED_SEQUENCE_ENTRIES sequence entries at once.",
-        )
-        numberOfSequenceEntries: Int,
-    ): ResponseEntity<StreamingResponseBody> {
-        val headers = HttpHeaders()
-        headers.contentType = MediaType.parseMediaType(MediaType.APPLICATION_NDJSON_VALUE)
-
-        val entries = submissionDatabaseService.streamDataToEdit(username, groupName, numberOfSequenceEntries, organism)
-        val streamBody = stream { entries }
-
-        return ResponseEntity(streamBody, headers, HttpStatus.OK)
-    }
-
     @Operation(description = GET_DATA_TO_EDIT_SEQUENCE_VERSION_DESCRIPTION)
     @GetMapping("/get-data-to-edit/{accession}/{version}", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun getSequenceEntryVersionToEdit(

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionControllerDescriptions.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionControllerDescriptions.kt
@@ -58,11 +58,6 @@ On accession version that cannot be written to the database, e.g. if the accessi
  pipeline submits invalid data. Rolls back the whole transaction.
 """
 
-const val GET_DATA_TO_EDIT_DESCRIPTION = """
-Get processed sequence data with errors to edit as a stream of NDJSON.
-This returns all sequence entries of the user that have the status 'HAS_ERRORS'.
-"""
-
 const val GET_DATA_TO_EDIT_SEQUENCE_VERSION_DESCRIPTION = """
 Get processed sequence data with errors to edit for a single accession version.
 The accession version must be in status 'HAS_ERRORS' or 'AWAITING_APPROVAL'.

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
@@ -114,18 +114,6 @@ class SubmissionControllerClient(private val mockMvc: MockMvc, private val objec
             .param("groupName", groupName),
     )
 
-    fun getNumberOfSequenceEntriesThatHaveErrors(
-        numberOfSequenceEntries: Int,
-        organism: String = DEFAULT_ORGANISM,
-        groupName: String = DEFAULT_GROUP_NAME,
-        jwt: String? = jwtForDefaultUser,
-    ): ResultActions = mockMvc.perform(
-        get(addOrganismToPath("/get-data-to-edit", organism = organism))
-            .withAuth(jwt)
-            .param("groupName", groupName)
-            .param("numberOfSequenceEntries", numberOfSequenceEntries.toString()),
-    )
-
     fun submitEditedSequenceEntryVersion(
         editedData: UnprocessedData,
         organism: String = DEFAULT_ORGANISM,


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #422

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://422-delete-get-data-to-re.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
