### PR TITLE
Red buttons -> primary color on groups page

### DIFF
--- a/website/src/components/User/GroupPage.tsx
+++ b/website/src/components/User/GroupPage.tsx
@@ -122,7 +122,7 @@ const InnerGroupPage: FC<GroupPageProps> = ({
                     </h1>
                     <button
                         onClick={() => handleOpenConfirmationDialog(username)}
-                        className='object-right p-2 loculusColor text-white rounded'
+                        className='object-right p-2 loculusColor text-white rounded px-4'
                     >
                         Leave group
                     </button>


### PR DESCRIPTION
I think these red buttons are too bright, and look less professional.

<img width="1001" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/5312f81e-6027-4324-8643-9341d7271ad7">

We could make them darker (red-600, or red-700). But I think given we prompt for confirmation we can just make them primary colored like the other buttons, which is what this PR does.

<img width="1001" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/518e0271-cb37-45a8-9099-0841f84d3a78">
