### PR TITLE
feat(silo-prepro): use hash instead of line count to test for equality

### DIFF
--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -57,7 +57,7 @@ download_data() {
   echo "calling $released_data_endpoint"
   
   set +e
-  curl -o "$current_input_data_dir/unsorted_data.ndjson" --fail-with-body "$released_data_endpoint" -H "Authorization: Bearer $jwt"
+  curl -o "$current_input_data_dir/data.ndjson" --fail-with-body "$released_data_endpoint" -H "Authorization: Bearer $jwt"
   exit_code=$?
   set -e
 
@@ -71,15 +71,6 @@ download_data() {
   echo
 
   echo "Sorting downloaded data.ndjson"
-
-  time sort -s -o "$current_input_data_dir/data.ndjson" "$current_input_data_dir/unsorted_data.ndjson"
-  exit_code=$?
-  if [ $exit_code -ne 0 ]; then
-    echo "Sort command failed, cleaning up input dir and exiting."
-    delete_all_input
-    exit $exit_code
-  fi
-
 
   echo "checking for old input data dir $old_input_data_dir"
   if [[ "$old_input_data_dir" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
Resolves #775

See discussion: https://loculus.slack.com/archives/C05G172HL6L/p1711384380415999

preview URL: https://silo-hash.loculus.org

### Summary
- Use hash instead of line count to test for equality of silo preprocessing input files
- If hashes equal, can just use old data as new data
- If hashes unequal, remove old data, run preprocessing on new data
- Apply shellcheck recommendation, separating dirs from args with `--`
- Add todo #1489 once fixed upstream

Ideally, we would not download everything from the backend, but somehow get some "last modified" timestamp from backend. For small data like pathoplexus this doesn't matter. For SARS-CoV-2 it would avoid having to stream 400GB from backend to silo preprocessing.

### Tests

I tested/developed using this test setup:
https://github.com/loculus-project/loculus/pull/148
