### PR TITLE
fix: stack depth limit exhausted when trying to release 9000 dummy sequences

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/AccessionPreconditionValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/AccessionPreconditionValidator.kt
@@ -16,13 +16,14 @@ import org.loculus.backend.utils.AccessionComparator
 import org.loculus.backend.utils.AccessionVersionComparator
 import org.loculus.backend.utils.Version
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Component
 class AccessionPreconditionValidator(
     private val sequenceEntriesViewProvider: SequenceEntriesViewProvider,
     private val groupManagementPreconditionValidator: GroupManagementPreconditionValidator,
 ) {
-
+    @Transactional(readOnly = true)
     fun validateAccessionVersions(
         authenticatedUser: AuthenticatedUser,
         accessionVersions: List<AccessionVersionInterface>,
@@ -48,6 +49,7 @@ class AccessionPreconditionValidator(
         }
     }
 
+    @Transactional(readOnly = true)
     fun validateAccessionVersions(accessionVersions: List<AccessionVersionInterface>, statuses: List<Status>) {
         sequenceEntriesViewProvider.get(organism = null).let { table ->
             val sequenceEntries = table
@@ -63,6 +65,7 @@ class AccessionPreconditionValidator(
         }
     }
 
+    @Transactional(readOnly = true)
     fun validateAccessions(
         authenticatedUser: AuthenticatedUser,
         accessions: List<Accession>,
@@ -90,6 +93,7 @@ class AccessionPreconditionValidator(
         }
     }
 
+    @Transactional(readOnly = true)
     fun validateAccessions(authenticatedUser: AuthenticatedUser, accessions: List<Accession>) {
         sequenceEntriesViewProvider.get(organism = null).let { table ->
             val sequenceEntries = table
@@ -108,6 +112,7 @@ class AccessionPreconditionValidator(
         }
     }
 
+    @Transactional(readOnly = true)
     fun validateAccessions(accessions: List<Accession>, statuses: List<Status>): List<AccessionVersionGroup> {
         sequenceEntriesViewProvider.get(organism = null).let { table ->
             val sequenceEntries = table

--- a/preprocessing/dummy/main.py
+++ b/preprocessing/dummy/main.py
@@ -165,10 +165,10 @@ def main():
         print("Started in watch mode - waiting 10 seconds before fetching data.")
         time.sleep(10)
 
-    if args.maxSequences and args.maxSequences < 5:
+    if args.maxSequences and args.maxSequences < 100:
         sequences_to_fetch = args.maxSequences
     else:
-        sequences_to_fetch = 5
+        sequences_to_fetch = 100
 
     while True:
         unprocessed = fetch_unprocessed_sequences(sequences_to_fetch)


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #982 

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://982-stack-depth-limit-exh.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
One could also set the max_stack_depth in Postgres, but it's better if we don't rely on how the DB instance is configured.
This is a simple and robust solution.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
