### PR TITLE
fix(ci): delete silo cache properly

### DIFF
--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -157,11 +157,13 @@ main() {
   echo "----------------------------------------"
   echo "Script started at: $(date)"
 
-  # cleanup at start in case we fail later
-
-  ls -l /preprocessing/input
+  echo "Current content of input data dir: $input_data_dir"
+  ls -l $input_data_dir
+  echo "Current content of output data dir: /preprocessing/output"
   ls -l /preprocessing/output
+  echo
 
+  # cleanup at start in case we fail later
   cleanup_output_data
   get_token
   download_data


### PR DESCRIPTION

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://fix-cache.loculus.org

### Summary
- Further refactoring of variable names
- Deleting /input and /output cache now at the start of the script, so it happens even in case of repeated failure to prevent accumulation of caches

### Screenshot
![image](https://github.com/loculus-project/loculus/assets/25161793/f41d8504-445f-417d-98ea-9ae7506b9fbe)
