### PR TITLE
feat(backend): add URLs to the data use terms to SILO

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
@@ -7,11 +7,17 @@ import org.loculus.backend.api.Organism
 data class BackendConfig(
     val organisms: Map<String, InstanceConfig>,
     val accessionPrefix: String,
+    val dataUseTermsUrls: DataUseTermsUrls?,
 ) {
     fun getInstanceConfig(organism: Organism) = organisms[organism.name] ?: throw IllegalArgumentException(
         "Organism: ${organism.name} not found in backend config. Available organisms: ${organisms.keys}",
     )
 }
+
+data class DataUseTermsUrls(
+    val open: String,
+    val restricted: String,
+)
 
 data class InstanceConfig(
     val schema: Schema,

--- a/backend/src/test/kotlin/org/loculus/backend/service/GenerateAccessionFromNumberServiceTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/GenerateAccessionFromNumberServiceTest.kt
@@ -11,7 +11,7 @@ const val PREFIX = "LOC_"
 
 class GenerateAccessionFromNumberServiceTest {
     private val accessionFromNumberService = GenerateAccessionFromNumberService(
-        BackendConfig(accessionPrefix = PREFIX, organisms = emptyMap()),
+        BackendConfig(accessionPrefix = PREFIX, organisms = emptyMap(), dataUseTermsUrls = null),
     )
 
     @Test

--- a/backend/src/test/kotlin/org/loculus/backend/service/submission/EmptyProcessedDataProviderTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/submission/EmptyProcessedDataProviderTest.kt
@@ -46,6 +46,7 @@ class EmptyProcessedDataProviderTest {
                     ),
                 ),
             ),
+            dataUseTermsUrls = null,
         ),
     )
 

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -32,6 +32,11 @@ fields:
   - name: versionStatus
     type: string
     notSearchable: true
+  {{- if $.Values.dataUseTermsUrls }}
+  - name: dataUseTermsUrl
+    type: string
+    notSearchable: true
+  {{- end}}
 {{- end}}
 
 {{/* Generate website config from passed config object */}}
@@ -97,6 +102,8 @@ fields:
 {{- define "loculus.generateBackendConfig" }}
 accessionPrefix: {{$.Values.accessionPrefix}}
 name: {{ $.Values.name }}
+dataUseTermsUrls:
+  {{$.Values.dataUseTermsUrls | toYaml | nindent 2}}
 organisms:
   {{- range $key, $instance := (.Values.organisms | default .Values.defaultOrganisms) }}
   {{ $key }}:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -15,6 +15,9 @@ disablePreprocessing: false
 disableIngest: false
 siloImportLimitSeconds: 3600
 accessionPrefix: "LOC_"
+dataUseTermsUrls:
+  open: https://#TODO-MVP/open
+  restricted: https://#TODO-MVP/restricted
 name: "Loculus"
 logo:
   url: "/favicon.svg"


### PR DESCRIPTION
resolves #1375

preview URL: https://1375-license-url.loculus.org

### Summary

If values.yaml contains `dataUseTermsUrls`, the URLs will be passed on to SILO and show up in the metadata file.

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
