### PR TITLE
feat(backend): store the approver of a sequence

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SequenceEntriesTable.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SequenceEntriesTable.kt
@@ -21,6 +21,7 @@ object SequenceEntriesTable : Table(SEQUENCE_ENTRIES_TABLE_NAME) {
     val organismColumn = varchar("organism", 255)
     val submissionIdColumn = varchar("submission_id", 255)
     val submitterColumn = varchar("submitter", 255)
+    val approverColumn = varchar("approver", 255)
     val groupNameColumn = varchar("group_name", 255)
     val submittedAtColumn = datetime("submitted_at")
     val releasedAtColumn = datetime("released_at").nullable()

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -278,6 +278,7 @@ class SubmissionDatabaseService(
                 },
             ) {
                 it[releasedAtColumn] = now
+                it[approverColumn] = authenticatedUser.username
             }
         }
 

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -18,6 +18,7 @@ create table sequence_entries (
     organism text not null,
     submission_id text not null,
     submitter text not null,
+    approver text,
     group_name text not null,
     submitted_at timestamp not null,
     released_at timestamp,


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1513
preview URL: https://1513-store-approver.loculus.org

### Summary

The username of the approver of a sequence is now stored in the database.

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
