### PR TITLE
feat(backend): record important activities in audit log table

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/log/AuditLogTable.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/log/AuditLogTable.kt
@@ -1,0 +1,14 @@
+package org.loculus.backend.log
+
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.kotlin.datetime.datetime
+
+const val AUDIT_LOG_TABLE_NAME = "audit_log"
+
+object AuditLogTable : Table(AUDIT_LOG_TABLE_NAME) {
+
+    val idColumn = long("id")
+    val usernameColumn = text("username").nullable()
+    val timestampColumn = datetime("timestamp")
+    val descriptionColumn = text("description")
+}

--- a/backend/src/main/kotlin/org/loculus/backend/log/AuditLogger.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/log/AuditLogger.kt
@@ -1,0 +1,23 @@
+package org.loculus.backend.log
+
+import org.jetbrains.exposed.sql.insert
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class AuditLogger {
+
+    fun log(description: String) {
+        AuditLogTable.insert {
+            it[descriptionColumn] = description
+        }
+    }
+
+    fun log(username: String, description: String) {
+        AuditLogTable.insert {
+            it[usernameColumn] = username
+            it[descriptionColumn] = description
+        }
+    }
+}

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
@@ -16,6 +16,7 @@ import org.loculus.backend.api.Organism
 import org.loculus.backend.api.Status
 import org.loculus.backend.api.SubmissionIdMapping
 import org.loculus.backend.auth.AuthenticatedUser
+import org.loculus.backend.log.AuditLogger
 import org.loculus.backend.model.SubmissionId
 import org.loculus.backend.model.SubmissionParams
 import org.loculus.backend.service.GenerateAccessionFromNumberService
@@ -49,6 +50,7 @@ class UploadDatabaseService(
     private val accessionPreconditionValidator: AccessionPreconditionValidator,
     private val dataUseTermsDatabaseService: DataUseTermsDatabaseService,
     private val generateAccessionFromNumberService: GenerateAccessionFromNumberService,
+    private val auditLogger: AuditLogger,
 ) {
 
     fun batchInsertMetadataInAuxTable(
@@ -185,6 +187,12 @@ class UploadDatabaseService(
                 submissionParams.dataUseTerms,
             )
         }
+
+        auditLogger.log(
+            submissionParams.authenticatedUser.username,
+            "Submitted or revised ${insertionResult.size} sequences: " +
+                insertionResult.joinToString { it.displayAccessionVersion() },
+        )
 
         return@transaction insertionResult
     }

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/UseNewerProcessingPipelineVersionTask.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/UseNewerProcessingPipelineVersionTask.kt
@@ -1,5 +1,6 @@
 package org.loculus.backend.service.submission
 
+import org.loculus.backend.log.AuditLogger
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import java.util.concurrent.TimeUnit
@@ -9,13 +10,16 @@ private val log = mu.KotlinLogging.logger {}
 @Component
 class UseNewerProcessingPipelineVersionTask(
     private val submissionDatabaseService: SubmissionDatabaseService,
+    private val auditLogger: AuditLogger,
 ) {
 
     @Scheduled(fixedDelay = 10, timeUnit = TimeUnit.SECONDS)
     fun task() {
         val newVersion = submissionDatabaseService.useNewerProcessingPipelineIfPossible()
         if (newVersion != null) {
-            log.info { "Started using results from new processing pipeline: version $newVersion" }
+            val logMessage = "Started using results from new processing pipeline: version $newVersion"
+            log.info(logMessage)
+            auditLogger.log(logMessage)
         }
     }
 }

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -147,3 +147,10 @@ create table seqset_to_records (
             references seqsets(seqset_id, seqset_version)
             on delete cascade
 );
+
+create table audit_log (
+    id bigserial primary key,
+    username text,
+    timestamp timestamp not null default now(),
+    description text not null
+);


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1514
preview URL: https://1514-audit-log.loculus.org

### Summary

Submissions, revisions, revocations, editing, and approval of sequences and group-related activities (creation of groups, adding/removal of members) are now recorded in an audit log.

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
