### PR TITLE
feat(website): move group selector on view sequences page to title

### DIFF
--- a/website/src/components/MySequencesPage/MySequencesGroupSelector.tsx
+++ b/website/src/components/MySequencesPage/MySequencesGroupSelector.tsx
@@ -1,6 +1,7 @@
 import { type FC } from 'react';
 
 import { routes } from '../../routes/routes';
+import IwwaArrowDown from '~icons/iwwa/arrow-down';
 
 type GroupSelectorProps = {
     groupNames: string[];
@@ -8,20 +9,28 @@ type GroupSelectorProps = {
     organism: string;
 };
 export const MySequencesGroupSelector: FC<GroupSelectorProps> = ({ groupNames, selectedGroupName, organism }) => {
+    if (groupNames.length === 1) {
+        return <span className='text-yellow-600'>{selectedGroupName}</span>;
+    }
+
     return (
-        <select
-            className='mt-4 select select-bordered'
-            onChange={(event) => {
-                const newGroup = event.target.value;
-                const page = routes.mySequencesPage(organism, newGroup);
-                location.href = page;
-            }}
-        >
-            {groupNames.map((groupName: string) => (
-                <option selected={groupName === selectedGroupName} value={groupName} key={groupName}>
-                    {groupName}
-                </option>
-            ))}
-        </select>
+        <div className='dropdown'>
+            <div tabIndex={0} role='button' className='text-yellow-600'>
+                {selectedGroupName} <IwwaArrowDown className='inline-block -mt-1 -ml-1 h-6 w-6' />
+            </div>
+            <ul tabIndex={0} className='dropdown-content z-[1] menu p-2 shadow bg-base-100 w-52 text-gray-700'>
+                {groupNames.map((groupName: string) => (
+                    <li key={groupName}>
+                        <a
+                            onClick={() => {
+                                location.href = routes.mySequencesPage(organism, groupName);
+                            }}
+                        >
+                            {groupName}
+                        </a>
+                    </li>
+                ))}
+            </ul>
+        </div>
     );
 };

--- a/website/src/pages/[organism]/my_sequences/[group].astro
+++ b/website/src/pages/[organism]/my_sequences/[group].astro
@@ -46,20 +46,10 @@ const {
 ---
 
 <BaseLayout title={`${cleanedOrganism.displayName} - My sequences`}>
-    <h1 class='title'>Viewing sequences for group {group}</h1>
-    {
-        groupNames.length > 1 && (
-            <>
-                Choose group:
-                <MySequencesGroupSelector
-                    groupNames={groupNames}
-                    selectedGroupName={group}
-                    organism={organism}
-                    client:load
-                />
-            </>
-        )
-    }
+    <h1 class='title'>
+        Viewing sequences for
+        <MySequencesGroupSelector groupNames={groupNames} selectedGroupName={group} organism={organism} client:load />
+    </h1>
 
     <div class='flex flex-col md:flex-row gap-8 md:gap-4'>
         <div class='md:w-72'>


### PR DESCRIPTION
preview URL: https://group-selector-in-title.loculus.org

### Summary

This moves the group selector on the `/my_sequences` / "Viewing sequences" page into the title. Happy to receive suggestions for a different color.

If you like the look, I'd also add it to the titles of the other submission-related pages.

**Alternative proposal:**  #1520

### Screenshot

If the user is only in one group:

<img src="https://github.com/loculus-project/loculus/assets/18666552/2eaa9bc2-dbd5-4503-aab5-c47cd2b48762" width="450" />

If the user is in multiple groups:

<img src="https://github.com/loculus-project/loculus/assets/18666552/339845e2-8e14-42e3-b302-2d181f23f067" width="450" />

<details><summary>Previous view</summary>

<img src="https://github.com/loculus-project/loculus/assets/18666552/94dab39a-45dc-4c02-bc4f-b4d36d411346" width="450" />
</details>

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
