### PR TITLE
feat(website): move group selector on view sequences page to title

### DIFF
--- a/website/src/components/MySequencesPage/MySequencesGroupSelector.tsx
+++ b/website/src/components/MySequencesPage/MySequencesGroupSelector.tsx
@@ -1,6 +1,8 @@
 import { type FC } from 'react';
 
 import { routes } from '../../routes/routes';
+import DashiconsGroups from '~icons/dashicons/groups';
+import IwwaArrowDown from '~icons/iwwa/arrow-down';
 
 type GroupSelectorProps = {
     groupNames: string[];
@@ -8,20 +10,37 @@ type GroupSelectorProps = {
     organism: string;
 };
 export const MySequencesGroupSelector: FC<GroupSelectorProps> = ({ groupNames, selectedGroupName, organism }) => {
+    const groupNameElement = (
+        <>
+            <DashiconsGroups className='w-6 h-6 inline-block mr-1 -mt-1' />
+            <span className='text-gray-700'>{selectedGroupName}</span>
+        </>
+    );
+
     return (
-        <select
-            className='mt-4 select select-bordered'
-            onChange={(event) => {
-                const newGroup = event.target.value;
-                const page = routes.mySequencesPage(organism, newGroup);
-                location.href = page;
-            }}
-        >
-            {groupNames.map((groupName: string) => (
-                <option selected={groupName === selectedGroupName} value={groupName} key={groupName}>
-                    {groupName}
-                </option>
-            ))}
-        </select>
+        <div className='mb-1'>
+            {groupNames.length === 1 ? (
+                groupNameElement
+            ) : (
+                <div className='dropdown'>
+                    <div tabIndex={0} role='button' className=''>
+                        {groupNameElement} <IwwaArrowDown className='inline-block -mt-1 h-5 w-5' />
+                    </div>
+                    <ul tabIndex={0} className='dropdown-content z-[1] menu p-2 shadow bg-base-100 w-52 text-gray-700'>
+                        {groupNames.map((groupName: string) => (
+                            <li key={groupName}>
+                                <a
+                                    onClick={() => {
+                                        location.href = routes.mySequencesPage(organism, groupName);
+                                    }}
+                                >
+                                    {groupName}
+                                </a>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </div>
     );
 };

--- a/website/src/pages/[organism]/my_sequences/[group].astro
+++ b/website/src/pages/[organism]/my_sequences/[group].astro
@@ -46,20 +46,8 @@ const {
 ---
 
 <BaseLayout title={`${cleanedOrganism.displayName} - My sequences`}>
-    <h1 class='title'>Viewing sequences for group {group}</h1>
-    {
-        groupNames.length > 1 && (
-            <>
-                Choose group:
-                <MySequencesGroupSelector
-                    groupNames={groupNames}
-                    selectedGroupName={group}
-                    organism={organism}
-                    client:load
-                />
-            </>
-        )
-    }
+    <MySequencesGroupSelector groupNames={groupNames} selectedGroupName={group} organism={organism} client:load />
+    <h1 class='title'>Released sequences</h1>
 
     <div class='flex flex-col md:flex-row gap-8 md:gap-4'>
         <div class='md:w-72'>


### PR DESCRIPTION
preview URL: https://group-selector-in-title2.loculus.org

### Summary

Alternative to #1519

### Screenshot

If the user is only in one group:

<img width="450" src="https://github.com/loculus-project/loculus/assets/18666552/0a08a2dd-0e94-45c6-a4d1-a4c577261989" >

If the user is in multiple groups:

<img width="450" src="https://github.com/loculus-project/loculus/assets/18666552/bef89ac4-22c7-4484-a7a7-b407a2c9dd80">


<details><summary>Previous view</summary>

<img src="https://github.com/loculus-project/loculus/assets/18666552/94dab39a-45dc-4c02-bc4f-b4d36d411346" width="450" />
</details>

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
