### PR TITLE
refactor(website): remove more MUI components from seqsets

### DIFF
--- a/website/src/components/SeqSetCitations/ExportSeqSet.tsx
+++ b/website/src/components/SeqSetCitations/ExportSeqSet.tsx
@@ -1,5 +1,5 @@
-import Snackbar from '@mui/material/Snackbar';
 import { type FC, useState } from 'react';
+import { toast } from 'react-toastify';
 
 import type { SeqSet, SeqSetRecord } from '../../types/seqSetCitation';
 
@@ -10,7 +10,6 @@ type ExportSeqSetProps = {
 
 export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords }) => {
     const [isDownloading, setIsDownloading] = useState(false);
-    const [isCopyAlertOpen, setIsCopyAlertOpen] = useState(false);
     const [selectedDownload, setSelectedDownload] = useState(0);
     const [selectedCitation, setSelectedCitation] = useState(0);
 
@@ -87,9 +86,12 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords }) =
     };
 
     const copyToClipboard = async () => {
-        setIsCopyAlertOpen(true);
         const citationText = getSelectedCitationText();
         await navigator.clipboard.writeText(citationText);
+        toast.success('Copied to clipboard', {
+            position: 'bottom-center',
+            autoClose: 2000,
+        });
     };
 
     return (
@@ -97,12 +99,6 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords }) =
             <div className='flex justify-start items-center py-5'>
                 <h1 className='text-xl font-semibold'>Export</h1>
             </div>
-            <Snackbar
-                open={isCopyAlertOpen}
-                onClose={() => setIsCopyAlertOpen(false)}
-                autoHideDuration={2000}
-                message='Copied to clipboard'
-            />
             <div className='flex flex-col justify-around max-w-lg w-2/4'>
                 <div>
                     <div className='flex'>

--- a/website/src/components/SeqSetCitations/SeqSetForm.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetForm.tsx
@@ -1,4 +1,3 @@
-import CircularProgress from '@mui/material/CircularProgress';
 import { AxiosError } from 'axios';
 import { type FC, type FormEvent, useState, useEffect, useCallback } from 'react';
 
@@ -200,7 +199,7 @@ export const SeqSetForm: FC<SeqSetFormProps> = ({ clientConfig, accessToken, edi
                 disabled={isLoading || seqSetRecordValidation !== '' || seqSetNameValidation !== ''}
                 onClick={handleSubmit}
             >
-                {isLoading ? <CircularProgress size={20} color='primary' /> : 'Save'}
+                {isLoading ? <span className='loading loading-spinner loading-sm mr-2 relative top-1' /> : 'Save'}
             </button>
         </div>
     );


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: http://seqset-remove-mui.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
- Remaining MUI components in seqset pages are: `MUIPagination` and `Modal`, which can be removed in a later PR


### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
