### PR TITLE
chore(deps): bump the minorandpatch group

### DIFF
--- a/keycloak/keycloakify/package.json
+++ b/keycloak/keycloakify/package.json
@@ -19,7 +19,7 @@
     "keywords": [],
     "dependencies": {
         "evt": "^2.5.7",
-        "keycloakify": "~9.6.1",
+        "keycloakify": "~9.6.3",
         "react": "~18.2.0",
         "react-dom": "~18.2.0"
     },
@@ -34,9 +34,9 @@
         "@storybook/preset-create-react-app": "^4.1.2",
         "@storybook/react": "^6.5.16",
         "@storybook/testing-library": "^0.2.2",
-        "@types/node": "~20.11.25",
-        "@types/react": "^18.2.64",
-        "@types/react-dom": "^18.2.21",
+        "@types/node": "~20.12.2",
+        "@types/react": "^18.2.73",
+        "@types/react-dom": "^18.2.23",
         "react-scripts": "^5.0.1",
         "rimraf": "^5.0.5",
         "typescript": "~5.1.6"

--- a/keycloak/keycloakify/yarn.lock
+++ b/keycloak/keycloakify/yarn.lock
@@ -3467,10 +3467,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@~20.11.25":
-  version "20.11.25"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.25.tgz#0f50d62f274e54dd7a49f7704cc16bfbcccaf49f"
-  integrity sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==
+"@types/node@*", "@types/node@~20.12.2":
+  version "20.12.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.2.tgz#9facdd11102f38b21b4ebedd9d7999663343d72e"
+  integrity sha512-zQ0NYO87hyN6Xrclcqp7f8ZbXNbRfoGWNcMvHTPQp9UUrwI0mI7XBz+cu7/W6/VClYo2g63B0cjull/srU7LgQ==
   dependencies:
     undici-types "~5.26.4"
 
@@ -3531,20 +3531,19 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
-"@types/react-dom@^18.2.21":
-  version "18.2.21"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.21.tgz#b8c81715cebdebb2994378616a8d54ace54f043a"
-  integrity sha512-gnvBA/21SA4xxqNXEwNiVcP0xSGHh/gi1VhWv9Bl46a0ItbTT5nFY+G9VSQpaG/8N/qdJpJ+vftQ4zflTtnjLw==
+"@types/react-dom@^18.2.23":
+  version "18.2.23"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.23.tgz#112338760f622a16d64271b408355f2f27f6302c"
+  integrity sha512-ZQ71wgGOTmDYpnav2knkjr3qXdAFu0vsk8Ci5w3pGAIdj7/kKAyn+VsQDhXsmzzzepAiI9leWMmubXz690AI/A==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.2.64":
-  version "18.2.64"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.64.tgz#3700fbb6b2fa60a6868ec1323ae4cbd446a2197d"
-  integrity sha512-MlmPvHgjj2p3vZaxbQgFUQFvD8QiZwACfGqEdDSWou5yISWxDQ4/74nCAwsUiX7UFLKZz3BbVSPj+YxeoGGCfg==
+"@types/react@*", "@types/react@^18.2.73":
+  version "18.2.73"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.73.tgz#0579548ad122660d99e00499d22e33b81e73ed94"
+  integrity sha512-XcGdod0Jjv84HOC7N5ziY3x+qL0AfmubvKOZ9hJjJ2yd5EE+KYjWhdOjt387e9HPheHkdggF9atTifMRtyAaRA==
   dependencies:
     "@types/prop-types" "*"
-    "@types/scheduler" "*"
     csstype "^3.0.2"
 
 "@types/resolve@1.17.1":
@@ -3558,11 +3557,6 @@
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
-
-"@types/scheduler@*":
-  version "0.16.8"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.8.tgz#ce5ace04cfeabe7ef87c0091e50752e36707deff"
-  integrity sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==
 
 "@types/semver@^7.3.12":
   version "7.5.8"
@@ -9940,10 +9934,10 @@ junk@^3.1.0:
   resolved "https://registry.yarnpkg.com/junk/-/junk-3.1.0.tgz#31499098d902b7e98c5d9b9c80f43457a88abfa1"
   integrity sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==
 
-keycloakify@~9.6.1:
-  version "9.6.1"
-  resolved "https://registry.yarnpkg.com/keycloakify/-/keycloakify-9.6.1.tgz#4ba91a8518410696a40d2889d2d0b5e4de028c96"
-  integrity sha512-9mcWkq5rhm1z4yNMb3cTlmyi8dFhcrM90um3ZIQtNedMgm+Ljp9xlKi1ywkrEALQWnYTK5waZZsbs0HLpR3OnQ==
+keycloakify@~9.6.3:
+  version "9.6.3"
+  resolved "https://registry.yarnpkg.com/keycloakify/-/keycloakify-9.6.3.tgz#0b6b6dda6a41e5c0e2ce84de73d6459e8ddf2d2e"
+  integrity sha512-9mfCfe4UQU3/UuF7J/yjjzvlX/7opcaGacOC3XMLPvHcoGElqLUFavHmQEtgB7zKZBMdhNGkFncH14pWCazb6w==
   dependencies:
     "@babel/generator" "^7.22.9"
     "@babel/parser" "^7.22.7"


### PR DESCRIPTION
Bumps the minorandpatch group in /keycloak/keycloakify with 4 updates: [keycloakify](https://github.com/keycloakify/keycloakify), [@types/node](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/node), [@types/react](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/react) and [@types/react-dom](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/react-dom).


Updates `keycloakify` from 9.6.1 to 9.6.3
- [Release notes](https://github.com/keycloakify/keycloakify/releases)
- [Commits](https://github.com/keycloakify/keycloakify/compare/v9.6.1...v9.6.3)

Updates `@types/node` from 20.11.25 to 20.12.2
- [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)
- [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/node)

Updates `@types/react` from 18.2.64 to 18.2.73
- [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)
- [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/react)

Updates `@types/react-dom` from 18.2.21 to 18.2.23
- [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)
- [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/react-dom)

---
updated-dependencies:
- dependency-name: keycloakify
  dependency-type: direct:production
  update-type: version-update:semver-patch
  dependency-group: minorandpatch
- dependency-name: "@types/node"
  dependency-type: direct:development
  update-type: version-update:semver-minor
  dependency-group: minorandpatch
- dependency-name: "@types/react"
  dependency-type: direct:development
  update-type: version-update:semver-patch
  dependency-group: minorandpatch
- dependency-name: "@types/react-dom"
  dependency-type: direct:development
  update-type: version-update:semver-patch
  dependency-group: minorandpatch
...

Signed-off-by: dependabot[bot] <support@github.com>