### PR TITLE
chore: add tailwind and astro config to eslintignore

### DIFF
--- a/website/.eslintrc.cjs
+++ b/website/.eslintrc.cjs
@@ -24,7 +24,7 @@ module.exports = {
             version: 'detect', // React version. "detect" automatically picks the version you have installed.
         },
     },
-    ignorePatterns: ['dist', '.eslintrc.cjs'],
+    ignorePatterns: ['dist', '.eslintrc.cjs', 'tailwind.config.cjs', 'astro.config.mjs'],
     overrides: [
         {
             // Define the configuration for `.astro` file.


### PR DESCRIPTION
Eslint reported these errors in VS Code, this PR fixes them by adding the two config files to eslint ignore.

Error message:

```
Parsing error: ESLint was configured to run on `<tsconfigRootDir>/astro.config.mjs` using `parserOptions.project`: /users/corneliusromer/code/loculus-bun/website/tsconfig.eslint.json
However, that TSConfig does not include this file. Either:
- Change ESLint's list of included files to not include this file
- Change that TSConfig to include this file
- Create a new TSConfig that includes this file and include it in your parserOptions.project
See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-fileeslint
```