### PR TITLE
chore: add example runtime_config.json to use main for everything but website

### DIFF
--- a/website/tests/config/runtime_config.json.example
+++ b/website/tests/config/runtime_config.json.example
@@ -1,0 +1,20 @@
+{
+    "name": "Loculus",
+    "serverSide": {
+        "backendUrl": "https://backend-main.loculus.org",
+        "lapisUrls": {
+            "dummy-organism": "https://lapis-main.loculus.org/dummy-organism",
+            "ebola-zaire": "https://lapis-main.loculus.org/ebola-zaire",
+            "mpox": "https://lapis-main.loculus.org/mpox"
+        },
+        "keycloakUrl": "https://authentication-main.loculus.org"
+    },
+    "public": {
+        "backendUrl": "https://backend-main.loculus.org",
+        "lapisUrls": {
+            "dummy-organism": "https://lapis-main.loculus.org/dummy-organism",
+            "ebola-zaire": "https://lapis-main.loculus.org/ebola-zaire",
+            "mpox": "https://lapis-main.loculus.org/mpox"
+        }
+    }
+}


### PR DESCRIPTION
The easiest way to do quick local website dev is to point use main (or another branch) for everything but website code.

I've edited the `runtime_config.json` multiple times to do this, so many times that I think it would be good to have an example config to quickly use. Maybe there's a better place for this, let me know.
