### PR TITLE
chore: exclude flowbite-react due to issue

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
         exclude-patterns:
           - "@mui/material"
           - change-case
+          - flowbite-react # Due to https://github.com/themesberg/flowbite-react/issues/1343
   - package-ecosystem: npm
     directory: docs/
     schedule:


### PR DESCRIPTION
Flowbite react >0.7.5 fails for us, so exempt it from dependabot updates

See https://github.com/themesberg/flowbite-react/issues/1343

