### PR TITLE
Tweak title style and search form min width

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -3443,11 +3443,6 @@
                 "@types/react": "*"
             }
         },
-        "node_modules/@types/scheduler": {
-            "version": "0.16.4",
-            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.4.tgz",
-            "integrity": "sha512-2L9ifAGl7wmXwP4v3pN4p2FLhD0O1qsJpvKmNin5VA8+UvNVb447UDaAEV6UdrkA+m/Xs58U1RFps44x6TFsVQ=="
-        },
         "node_modules/@types/semver": {
             "version": "7.5.3",
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.3.tgz",

--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -157,7 +157,7 @@ export const SearchForm: FC<SearchFormProps> = ({
                 className={`${
                     isMobileOpen ? 'translate-y-0' : 'translate-y-full'
                 } fixed bottom-0 left-0 w-full bg-white h-4/5 rounded-t-lg overflow-auto offCanvasTransform
-                      md:translate-y-0 md:static md:h-auto md:overflow-visible`}
+                      md:translate-y-0 md:static md:h-auto md:overflow-visible md:min-w-72`}
             >
                 <div className='shadow-xl rounded-r-lg px-4 pt-4'>
                     <div className='flex'>

--- a/website/src/styles/base.scss
+++ b/website/src/styles/base.scss
@@ -29,7 +29,7 @@ a {
 .title{
 
   color: theme('colors.main');
-
+  margin-left: 15px;
   font-size: 24px;
   font-weight: 600;
   word-break: break-all;


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1509, resolves #1441

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://further-search-tweaks.loculus.org/ebola-zaire/search

### Summary
Gives search form a min width so it doesn't get squished and ensure title lines up with the header. Package lock update is I guess a result of dependabot.

![image](https://github.com/loculus-project/loculus/assets/19732295/3493d3b8-8a13-42d7-bf0d-b237eb1454ce)
