### PR TITLE
Return groupid

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -105,6 +105,7 @@ data class SequenceEntryVersionToEdit(
     override val accession: Accession,
     override val version: Version,
     val status: Status,
+    val groupId: Int,
     val processedData: ProcessedData<GeneticSequence>,
     val originalData: OriginalData<GeneticSequence>,
     @Schema(description = "The preprocessing will be considered failed if this is not empty")

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -723,6 +723,7 @@ class SubmissionDatabaseService(
         val selectedSequenceEntry = SequenceEntriesView.slice(
             SequenceEntriesView.accessionColumn,
             SequenceEntriesView.versionColumn,
+            SequenceEntriesView.groupIdColumn,
             SequenceEntriesView.statusColumn,
             SequenceEntriesView.processedDataColumn,
             SequenceEntriesView.originalDataColumn,
@@ -747,6 +748,7 @@ class SubmissionDatabaseService(
             accession = selectedSequenceEntry[SequenceEntriesView.accessionColumn],
             version = selectedSequenceEntry[SequenceEntriesView.versionColumn],
             status = Status.fromString(selectedSequenceEntry[SequenceEntriesView.statusColumn]),
+            groupId = selectedSequenceEntry[SequenceEntriesView.groupIdColumn],
             processedData = compressionService.decompressSequencesInProcessedData(
                 selectedSequenceEntry[SequenceEntriesView.processedDataColumn]!!,
                 organism,


### PR DESCRIPTION
preview URL:  https://return-groupid.loculus.org

### Summary

The `/get-data-to-edit` endpoint now also returns the group ID of a sequence. I need this for #1038 because the edit page needs to know the group ID so that one can return to the right review page after submitting edits.

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
