### PR TITLE
fix(backend): delete metadata type "double"

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
@@ -39,9 +39,6 @@ enum class MetadataType {
     @JsonProperty("float")
     FLOAT,
 
-    @JsonProperty("double")
-    DOUBLE,
-
     @JsonProperty("number")
     NUMBER,
 

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequenceEntryValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequenceEntryValidator.kt
@@ -168,8 +168,7 @@ class ProcessedSequenceEntryValidator(
         val isOfCorrectPrimitiveType = when (metadata.type) {
             MetadataType.STRING -> fieldValue.isTextual
             MetadataType.INTEGER -> fieldValue.isInt
-            MetadataType.FLOAT -> fieldValue.isFloat
-            MetadataType.DOUBLE -> fieldValue.isDouble
+            MetadataType.FLOAT -> fieldValue.isFloatingPointNumber
             MetadataType.NUMBER -> fieldValue.isNumber
             else -> false
         }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/PreparedProcessedData.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/PreparedProcessedData.kt
@@ -26,7 +26,7 @@ val defaultProcessedData = ProcessedData(
         "region" to TextNode("Europe"),
         "country" to TextNode("Spain"),
         "age" to IntNode(42),
-        "qc" to DoubleNode(0.9),
+        "qc" to DoubleNode(0.987654321),
         "pangoLineage" to TextNode("XBB.1.5"),
         "division" to NullNode.instance,
         "dateSubmitted" to NullNode.instance,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
@@ -1,7 +1,11 @@
 package org.loculus.backend.controller.submission
 
+import com.fasterxml.jackson.databind.node.DoubleNode
+import com.fasterxml.jackson.databind.node.IntNode
+import com.fasterxml.jackson.databind.node.TextNode
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.hasEntry
 import org.hamcrest.Matchers.`is`
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -61,9 +65,14 @@ class SubmitProcessedDataEndpointTest(
         )
             .andExpect(status().isNoContent)
 
-        convenienceClient.getSequenceEntry(accession = accessions.first(), version = 1).assertStatusIs(
-            Status.AWAITING_APPROVAL,
-        )
+        convenienceClient.getSequenceEntry(accession = accessions.first(), version = 1)
+            .assertStatusIs(Status.AWAITING_APPROVAL)
+
+        val sequenceEntryToEdit = convenienceClient.getSequenceEntryToEdit(accession = accessions.first(), version = 1)
+        assertThat(sequenceEntryToEdit.processedData.metadata, hasEntry("qc", DoubleNode(0.987654321)))
+        assertThat(sequenceEntryToEdit.processedData.metadata, hasEntry("age", IntNode(42)))
+        assertThat(sequenceEntryToEdit.processedData.metadata, hasEntry("region", TextNode("Europe")))
+        assertThat(sequenceEntryToEdit.processedData.metadata, hasEntry("pangoLineage", TextNode("XBB.1.5")))
     }
 
     @Test

--- a/backend/src/test/resources/backend_config.json
+++ b/backend/src/test/resources/backend_config.json
@@ -70,7 +70,7 @@
                     },
                     {
                         "name": "qc",
-                        "type": "double"
+                        "type": "float"
                     }
                 ]
             }
@@ -153,7 +153,7 @@
                     },
                     {
                         "name": "qc",
-                        "type": "double"
+                        "type": "float"
                     }
                 ]
             }

--- a/backend/src/test/resources/backend_config_single_segment.json
+++ b/backend/src/test/resources/backend_config_single_segment.json
@@ -70,7 +70,7 @@
                     },
                     {
                         "name": "qc",
-                        "type": "double"
+                        "type": "float"
                     }
                 ]
             }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #934

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://934-non-matching-metadata.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

* I was able to reproduce the issue with a longer float (`0.987654321` instead of `0.9`) in the test data.
* Removing the metadata type `double`
* Making sure that floating point numbers are accepted.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
