### PR TITLE
Revert "chore(deps): bump gradle/actions from 3 to 321 (#1572)"

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Build Docker Image For Branch
         if: env.CACHE_HIT == 'false'
-        uses: gradle/actions/setup-gradle@v321
+        uses: gradle/actions/setup-gradle@v3
         env:
           USER: ${{ github.actor }}
           TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This reverts #1572.

The checks in #1572 passed (maybe due to caches? I didn't check) but gradle/actions@v321 doesn't actually seem to exist. Sorry for merging!

