### PR TITLE
feat(backend): add endpoint to get original metadata

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -236,6 +236,12 @@ data class OriginalData<SequenceType>(
     val unalignedNucleotideSequences: Map<SegmentName, SequenceType?>,
 )
 
+data class AccessionVersionOriginalMetadata(
+    override val accession: Accession,
+    override val version: Version,
+    val originalMetadata: Map<String, String?>,
+) : AccessionVersionInterface
+
 enum class Status {
     @JsonProperty("RECEIVED")
     RECEIVED,

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionControllerDescriptions.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionControllerDescriptions.kt
@@ -133,3 +133,8 @@ const val GET_RELEASED_DATA_RESPONSE_DESCRIPTION = """
 Releasable accession versions.
 The schema is to be understood per line of the NDJSON stream.    
 """
+
+const val GET_ORIGINAL_METADATA_RESPONSE_DESCRIPTION = """
+The original metadata of submission sequence versions as NDJSON where each line is a flat JSON object where the values
+are all strings (or null).
+"""

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SequenceEntriesView.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SequenceEntriesView.kt
@@ -9,7 +9,6 @@ import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.json.exists
 import org.jetbrains.exposed.sql.kotlin.datetime.datetime
 import org.jetbrains.exposed.sql.max
-import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.wrapAsExpression
 import org.loculus.backend.api.AccessionVersionInterface
 import org.loculus.backend.api.Organism
@@ -19,7 +18,6 @@ import org.loculus.backend.api.ProcessedData
 import org.loculus.backend.api.Status
 import org.loculus.backend.api.toPairs
 import org.loculus.backend.service.jacksonSerializableJsonb
-import org.loculus.backend.service.submission.SequenceEntriesView.accessionColumn
 
 const val SEQUENCE_ENTRIES_VIEW_NAME = "sequence_entries_view"
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetOriginalMetadataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetOriginalMetadataEndpointTest.kt
@@ -1,0 +1,151 @@
+package org.loculus.backend.controller.submission
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.github.luben.zstd.ZstdInputStream
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.not
+import org.junit.jupiter.api.Test
+import org.loculus.backend.api.AccessionVersionOriginalMetadata
+import org.loculus.backend.api.Status
+import org.loculus.backend.controller.DEFAULT_ORGANISM
+import org.loculus.backend.controller.EndpointTest
+import org.loculus.backend.controller.OTHER_ORGANISM
+import org.loculus.backend.controller.expectNdjsonAndGetContent
+import org.loculus.backend.controller.expectUnauthorizedResponse
+import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
+import org.loculus.backend.controller.groupmanagement.andGetGroupId
+import org.loculus.backend.controller.jacksonObjectMapper
+import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.shaded.org.awaitility.Awaitility.await
+
+typealias MetadataMap = Map<String, String>
+
+@EndpointTest
+class GetOriginalMetadataEndpointTest(
+    @Autowired val convenienceClient: SubmissionConvenienceClient,
+    @Autowired val submissionControllerClient: SubmissionControllerClient,
+    @Autowired val groupManagementClient: GroupManagementControllerClient,
+) {
+    @Test
+    fun `GIVEN invalid authorization token THEN returns 401 Unauthorized`() {
+        expectUnauthorizedResponse {
+            submissionControllerClient.getOriginalMetadata(jwt = it)
+        }
+    }
+
+    @Test
+    fun `GIVEN no sequence entries in database THEN returns empty response`() {
+        val response = submissionControllerClient.getOriginalMetadata()
+
+        val responseBody = response.expectNdjsonAndGetContent<MetadataMap>()
+        assertThat(responseBody, `is`(emptyList()))
+    }
+
+    @Test
+    fun `GIVEN data exists THEN returns correct number of entries`() {
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease()
+        val response = submissionControllerClient.getOriginalMetadata()
+
+        val responseBody = response.expectNdjsonAndGetContent<AccessionVersionOriginalMetadata>()
+        assertThat(responseBody.size, `is`(DefaultFiles.NUMBER_OF_SEQUENCES))
+    }
+
+    @Test
+    fun `GIVEN no specified fields THEN returns all fields`() {
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease()
+        val response = submissionControllerClient.getOriginalMetadata()
+
+        val responseBody = response.expectNdjsonAndGetContent<AccessionVersionOriginalMetadata>()
+        val entry = responseBody[0]
+
+        assertThat(entry.originalMetadata, `is`(defaultOriginalData.metadata))
+    }
+
+    @Test
+    fun `GIVEN specified fields that exist THEN returns only these fields`() {
+        val fields = listOf("region", "country")
+
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease()
+        val response = submissionControllerClient.getOriginalMetadata(fields = fields)
+
+        val responseBody = response.expectNdjsonAndGetContent<AccessionVersionOriginalMetadata>()
+        val entry = responseBody[0]
+
+        assertThat(entry.originalMetadata, `is`(fields.associateWith { defaultOriginalData.metadata[it] }))
+    }
+
+    @Test
+    fun `GIVEN a field that does not exist THEN returns null`() {
+        val field = "doesNotExist"
+
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease()
+        val response = submissionControllerClient.getOriginalMetadata(fields = listOf(field))
+
+        val responseBody = response.expectNdjsonAndGetContent<AccessionVersionOriginalMetadata>()
+        val entry = responseBody[0]
+
+        assertThat(entry.originalMetadata, `is`(mapOf(field to null)))
+    }
+
+    @Test
+    fun `WHEN I request zstd compressed data THEN should return zstd compressed data`() {
+        val entries = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease()
+        val response = submissionControllerClient.getOriginalMetadata(compression = "zstd")
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_NDJSON_VALUE))
+            .andExpect(header().string(HttpHeaders.CONTENT_ENCODING, "zstd"))
+            .andReturn()
+            .response
+        await().until {
+            response.isCommitted
+        }
+        val content = response.contentAsByteArray
+
+        val decompressedContent = ZstdInputStream(content.inputStream())
+            .apply { setContinuous(true) }
+            .readAllBytes()
+            .decodeToString()
+
+        val data = decompressedContent.lines()
+            .filter { it.isNotBlank() }
+            .map { jacksonObjectMapper.readValue<AccessionVersionOriginalMetadata>(it) }
+
+        assertThat(data, hasSize(entries.size))
+        assertThat(data[0].originalMetadata, `is`(not(emptyMap())))
+    }
+
+    @Test
+    fun `WHEN I filter by group, status and organism THEN should return only filtered data`() {
+        val g0 = groupManagementClient.createNewGroup().andGetGroupId()
+        val g1 = groupManagementClient.createNewGroup().andGetGroupId()
+
+        val expected = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+            organism = OTHER_ORGANISM,
+            groupId = g0,
+        )
+        val expectedAccessionVersions = expected.map { it.displayAccessionVersion() }.toSet()
+
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(organism = DEFAULT_ORGANISM, groupId = g0)
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(organism = OTHER_ORGANISM, groupId = g1)
+        convenienceClient.prepareDefaultSequenceEntriesToInProcessing(organism = OTHER_ORGANISM, groupId = g0)
+
+        val response = submissionControllerClient.getOriginalMetadata(
+            organism = OTHER_ORGANISM,
+            groupIdsFilter = listOf(g0),
+            statusesFilter = listOf(Status.APPROVED_FOR_RELEASE),
+        )
+        val responseBody = response.expectNdjsonAndGetContent<AccessionVersionOriginalMetadata>()
+
+        assertThat(responseBody, hasSize(expected.size))
+        val responseAccessionVersions = responseBody.map { it.displayAccessionVersion() }.toSet()
+        assertThat(responseAccessionVersions, `is`(expectedAccessionVersions))
+    }
+}

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
@@ -100,8 +100,8 @@ class SubmissionControllerClient(private val mockMvc: MockMvc, private val objec
         return mockMvc.perform(
             get(addOrganismToPath("/get-sequences", organism = organism))
                 .withAuth(jwt)
-                .param("groupIdsFilter", groupIdsFilter?.joinToString { it.toString() })
-                .param("statusesFilter", statusesFilter?.joinToString { it.name })
+                .param("groupIdsFilter", groupIdsFilter?.joinToString(",") { it.toString() })
+                .param("statusesFilter", statusesFilter?.joinToString(",") { it.name })
                 .param("warningsFilter", warningsFilter?.name)
                 .param("page", page?.toString())
                 .param("size", size?.toString()),
@@ -205,6 +205,27 @@ class SubmissionControllerClient(private val mockMvc: MockMvc, private val objec
             .file(sequencesFile)
             .file(metadataFile)
             .withAuth(jwt),
+    )
+
+    fun getOriginalMetadata(
+        organism: String = DEFAULT_ORGANISM,
+        jwt: String? = jwtForDefaultUser,
+        groupIdsFilter: List<Int>? = null,
+        statusesFilter: List<Status>? = null,
+        fields: List<String>? = null,
+        compression: String? = null,
+    ): ResultActions = mockMvc.perform(
+        get(addOrganismToPath("/get-original-metadata", organism = organism))
+            .withAuth(jwt)
+            .also {
+                when (compression) {
+                    null -> it
+                    else -> it.param("compression", compression)
+                }
+            }
+            .param("groupIdsFilter", groupIdsFilter?.joinToString(",") { it.toString() })
+            .param("statusesFilter", statusesFilter?.joinToString(",") { it.name })
+            .param("fields", fields?.joinToString(",")),
     )
 
     private fun serialize(listOfSequencesToApprove: List<AccessionVersionInterface>? = null): String {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1595 

preview URL: https://get-original-data.loculus.org

### Summary

This adds a new endpoint `/{organism}/get-original-metadata`. It supports filters for group IDs and statuses and has an optional `fields` parameter. If an entry does not have a requested field, the value for that field will be set to `null`.

The result is returned as an NDJSON.

### Screenshot

![image](https://github.com/loculus-project/loculus/assets/18666552/90ad65ec-d092-4699-9420-70ef3bf5d2e0)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
