### PR TITLE
fix(website): submission group selector redirected wrongly

### DIFF
--- a/website/src/components/Submission/SubmissionGroupSelector.tsx
+++ b/website/src/components/Submission/SubmissionGroupSelector.tsx
@@ -1,6 +1,6 @@
 import { type FC } from 'react';
 
-import { routes } from '../../routes/routes';
+import { SubmissionRouteUtils } from '../../routes/SubmissionRoute.ts';
 import type { Group } from '../../types/backend.ts';
 import DashiconsGroups from '~icons/dashicons/groups';
 import IwwaArrowDown from '~icons/iwwa/arrow-down';
@@ -8,10 +8,11 @@ import IwwaArrowDown from '~icons/iwwa/arrow-down';
 type GroupSelectorProps = {
     groups: Group[];
     selectedGroupId: number;
-    organism: string;
+    pathname: string;
+    search: string;
 };
 
-export const SubmissionGroupSelector: FC<GroupSelectorProps> = ({ groups, selectedGroupId, organism }) => {
+export const SubmissionGroupSelector: FC<GroupSelectorProps> = ({ groups, selectedGroupId, pathname, search }) => {
     const selectedGroup = groups.find((group) => group.groupId === selectedGroupId);
 
     if (selectedGroup === undefined) {
@@ -39,9 +40,11 @@ export const SubmissionGroupSelector: FC<GroupSelectorProps> = ({ groups, select
                     {groups.map((group) => (
                         <li key={group.groupId}>
                             <a
-                                onClick={() => {
-                                    location.href = routes.mySequencesPage(organism, group.groupId);
-                                }}
+                                href={(() => {
+                                    const currentRoute = SubmissionRouteUtils.parseToRoute(pathname, search)!;
+                                    const newRoute = { ...currentRoute, groupId: group.groupId };
+                                    return SubmissionRouteUtils.toUrl(newRoute);
+                                })()}
                             >
                                 {group.groupName}
                             </a>

--- a/website/src/components/Submission/SubmissionPageWrapper.astro
+++ b/website/src/components/Submission/SubmissionPageWrapper.astro
@@ -6,11 +6,11 @@ import NeedToLogin from '../common/NeedToLogin.astro';
 
 interface Props {
     title: string;
-    organism: string;
     groupsResult: GetGroupsAndCurrentGroupResult;
 }
 
-const { title, groupsResult, organism } = Astro.props;
+const { title, groupsResult } = Astro.props;
+const { pathname, search } = Astro.url;
 ---
 
 <BaseLayout title={title}>
@@ -21,7 +21,8 @@ const { title, groupsResult, organism } = Astro.props;
                     <SubmissionGroupSelector
                         groups={groupsOfUser}
                         selectedGroupId={group.groupId}
-                        organism={organism}
+                        pathname={pathname}
+                        search={search}
                         client:load
                     />
                     <h1 class='title'>{title}</h1>

--- a/website/src/pages/[organism]/submission/[groupId]/index.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/index.astro
@@ -12,7 +12,7 @@ const { organism } = cleanOrganism(Astro.params.organism);
 const groupsResult = await getGroupsAndCurrentGroup(Astro.params, Astro.locals.session);
 ---
 
-<SubmissionPageWrapper title='Submission portal' organism={organism!.key} groupsResult={groupsResult}>
+<SubmissionPageWrapper title='Submission portal' groupsResult={groupsResult}>
     {
         groupsResult.match(
             ({ currentGroup: group }) => {

--- a/website/src/pages/[organism]/submission/[groupId]/released.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/released.astro
@@ -29,7 +29,7 @@ const {
 } = await processParametersAndFetchSearch(Astro, group.groupId);
 ---
 
-<SubmissionPageWrapper title='Released sequences' organism={organism} groupsResult={groupsResult}>
+<SubmissionPageWrapper title='Released sequences' groupsResult={groupsResult}>
     <div class='flex flex-col md:flex-row gap-8 md:gap-4'>
         <div class='md:w-72'>
             <SearchForm

--- a/website/src/pages/[organism]/submission/[groupId]/review.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/review.astro
@@ -12,7 +12,7 @@ const groupsResult = await getGroupsAndCurrentGroup(Astro.params, Astro.locals.s
 const clientConfig: ClientConfig = getRuntimeConfig().public;
 ---
 
-<SubmissionPageWrapper title='Review current submissions' organism={organism} groupsResult={groupsResult}>
+<SubmissionPageWrapper title='Review current submissions' groupsResult={groupsResult}>
     {
         groupsResult.match(
             ({ currentGroup: group }) => (

--- a/website/src/pages/[organism]/submission/[groupId]/revise.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/revise.astro
@@ -11,7 +11,7 @@ const groupsResult = await getGroupsAndCurrentGroup(Astro.params, Astro.locals.s
 const clientConfig = getRuntimeConfig().public;
 ---
 
-<SubmissionPageWrapper title='Revise sequences' organism={organism} groupsResult={groupsResult}>
+<SubmissionPageWrapper title='Revise sequences' groupsResult={groupsResult}>
     {
         groupsResult.match(
             ({ currentGroup: group }) => (

--- a/website/src/pages/[organism]/submission/[groupId]/submit.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/submit.astro
@@ -17,7 +17,7 @@ Astro.response.headers.append('Pragma', 'no-cache');
 Astro.response.headers.append('Expires', '0');
 ---
 
-<SubmissionPageWrapper title='Submit sequences' organism={organism} groupsResult={groupsResult}>
+<SubmissionPageWrapper title='Submit sequences' groupsResult={groupsResult}>
     {
         groupsResult.match(
             ({ currentGroup: group }) => (

--- a/website/src/routes/SubmissionRoute.ts
+++ b/website/src/routes/SubmissionRoute.ts
@@ -1,0 +1,72 @@
+type BaseSubmissionRoute<Name> = {
+    name: Name;
+    organism: string;
+    groupId: number;
+};
+
+type PortalPageRoute = BaseSubmissionRoute<'portal'>;
+type SubmitPageRoute = BaseSubmissionRoute<'submit'>;
+type RevisePageRoute = BaseSubmissionRoute<'revise'>;
+type ReviewPageRoute = BaseSubmissionRoute<'review'>;
+type ReleasedPageRoute = BaseSubmissionRoute<'released'> & {
+    searchParams: URLSearchParams;
+};
+
+type SubmissionRoute = PortalPageRoute | SubmitPageRoute | RevisePageRoute | ReviewPageRoute | ReleasedPageRoute;
+
+export class SubmissionRouteUtils {
+    /**
+     * @param pathname window.location.pathname
+     * @param search window.location.search
+     */
+    public static parseToRoute(pathname: string, search: string): SubmissionRoute | undefined {
+        /* eslint-disable @typescript-eslint/no-unnecessary-condition */
+        /* Because indexed array access is not typed as potentially undefined because we don't use
+        "noUncheckedIndexedAccess" */
+
+        if (!pathname.startsWith('/')) {
+            return undefined;
+        }
+        const [organism, urlConst, groupIdStr, ...remaining] = pathname.substring(1).split('/');
+        if (organism === undefined || urlConst !== 'submission' || groupIdStr === null || !/^\d+$/.test(groupIdStr)) {
+            return undefined;
+        }
+        const baseRoute = { organism, groupId: parseInt(groupIdStr, 10) };
+
+        const [subpage, ...remaining2] = remaining;
+        if (subpage === undefined) {
+            return { ...baseRoute, name: 'portal' };
+        }
+        if (remaining2.length > 0) {
+            return undefined;
+        }
+        switch (subpage) {
+            case 'submit':
+                return { ...baseRoute, name: 'submit' };
+            case 'revise':
+                return { ...baseRoute, name: 'revise' };
+            case 'review':
+                return { ...baseRoute, name: 'review' };
+            case 'released':
+                const searchParams = new URLSearchParams(search);
+                return { ...baseRoute, name: 'released', searchParams };
+        }
+        return undefined;
+        /* eslint-enable @typescript-eslint/no-unnecessary-condition */
+    }
+
+    public static toUrl(route: SubmissionRoute): string {
+        const baseUrl = `/${route.organism}/submission/${route.groupId}`;
+
+        switch (route.name) {
+            case 'portal':
+                return baseUrl;
+            case 'submit':
+            case 'revise':
+            case 'review':
+                return `${baseUrl}/${route.name}`;
+            case 'released':
+                return `${baseUrl}/released?${route.searchParams}`;
+        }
+    }
+}

--- a/website/src/routes/routes.ts
+++ b/website/src/routes/routes.ts
@@ -1,3 +1,4 @@
+import { SubmissionRouteUtils } from './SubmissionRoute.ts';
 import type { AccessionVersion } from '../types/backend.ts';
 import type { AccessionFilter, FilterValue, MutationFilter } from '../types/config.ts';
 import type { OrderBy } from '../types/lapis.ts';
@@ -35,10 +36,12 @@ export const routes = {
         page: number | undefined = undefined,
         orderBy?: OrderBy,
     ) =>
-        withOrganism(
+        SubmissionRouteUtils.toUrl({
+            name: 'released',
             organism,
-            `/submission/${groupId}/released?${buildSearchParams(metadataFilter, accessionFilter, mutationFilter, page, orderBy).toString()}`,
-        ),
+            groupId,
+            searchParams: buildSearchParams(metadataFilter, accessionFilter, mutationFilter, page, orderBy),
+        }),
     sequencesDetailsPage: (accessionVersion: AccessionVersion | string) =>
         `/seq/${getAccessionVersionString(accessionVersion)}`,
     sequencesVersionsPage: (accessionVersion: AccessionVersion | string) =>
@@ -52,9 +55,12 @@ export const routes = {
     },
     createGroup: () => '/user/createGroup',
     submissionPageWithoutGroup: (organism: string) => withOrganism(organism, '/submission'),
-    submissionPage: (organism: string, groupId: number) => withOrganism(organism, `/submission/${groupId}`),
-    submitPage: (organism: string, groupId: number) => withOrganism(organism, `/submission/${groupId}/submit`),
-    revisePage: (organism: string, groupId: number) => withOrganism(organism, `/submission/${groupId}/revise`),
+    submissionPage: (organism: string, groupId: number) =>
+        SubmissionRouteUtils.toUrl({ name: 'portal', organism, groupId }),
+    submitPage: (organism: string, groupId: number) =>
+        SubmissionRouteUtils.toUrl({ name: 'submit', organism, groupId }),
+    revisePage: (organism: string, groupId: number) =>
+        SubmissionRouteUtils.toUrl({ name: 'revise', organism, groupId }),
     editPage: (organism: string, accessionVersion: AccessionVersion) =>
         withOrganism(organism, `/submission/edit/${accessionVersion.accession}/${accessionVersion.version}`),
     userOverviewPage: (organism?: string | undefined) => {
@@ -63,7 +69,7 @@ export const routes = {
     },
     groupOverviewPage: (groupId: number) => `/group/${groupId}`,
     userSequenceReviewPage: (organism: string, groupId: number) =>
-        withOrganism(organism, `/submission/${groupId}/review`),
+        SubmissionRouteUtils.toUrl({ name: 'review', organism, groupId }),
     versionPage: (accession: string) => `/seq/${accession}/versions`,
     seqSetsPage: (username?: string | undefined) => {
         const seqSetPagePath = `/seqsets`;


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1582
preview URL: https://1582-submission-group-red.loculus.org

### Summary

This fixes the submission group selector which was always redirecting to the page with the released sequences.

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
