### PR TITLE
fix(website): correctly redirect to browse from /seq

### DIFF
--- a/website/src/components/Navigation/Navigation.astro
+++ b/website/src/components/Navigation/Navigation.astro
@@ -4,7 +4,14 @@ import { cleanOrganism } from './cleanOrganism';
 import { navigationItems } from '../../routes/navigationItems';
 import { getAuthUrl } from '../../utils/getAuthUrl';
 
-const { organism } = cleanOrganism(Astro.params.organism);
+interface Props {
+    implicitOrganism?: string;
+}
+
+const { implicitOrganism } = Astro.props;
+const { organism, knownOrganisms } = cleanOrganism(Astro.params.organism);
+const selectedOrganism =
+    implicitOrganism !== undefined ? knownOrganisms.find((it) => it.key === implicitOrganism) : organism;
 
 const isLoggedIn = Astro.locals.session?.isLoggedIn ?? false;
 
@@ -13,10 +20,21 @@ const loginUrl = await getAuthUrl(Astro.url.toString());
 
 <div class='flex justify-end'>
     <div class='subtitle hidden sm:flex sm:z-6 gap-4'>
-        {navigationItems.top(organism?.key, isLoggedIn, loginUrl).map(({ text, path }) => <a href={path}>{text}</a>)}
+        {
+            navigationItems
+                .top(selectedOrganism?.key, isLoggedIn, loginUrl)
+                .map(({ text, path }) => <a href={path}>{text}</a>)
+        }
     </div>
 
     <div class='sm:hidden fixed z-0'>
-        <SandwichMenu top={16} right={28} organism={organism} isLoggedIn={isLoggedIn} loginUrl={loginUrl} client:load />
+        <SandwichMenu
+            top={16}
+            right={28}
+            organism={selectedOrganism}
+            isLoggedIn={isLoggedIn}
+            loginUrl={loginUrl}
+            client:load
+        />
     </div>
 </div>

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -53,7 +53,7 @@ const { title, implicitOrganism } = Astro.props;
                             <OrganismSelector implicitOrganism={implicitOrganism} />
                         </div>
                     </div>
-                    <Navigation />
+                    <Navigation implicitOrganism={implicitOrganism} />
                 </nav>
                 <hr class='border-t border-gray-1000' />
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1529
preview URL: https://1529-seq-organism-redirect.loculus.org

### Summary

From a sequence's details page, the "Browse" and "Submit" button now correctly point to the organism-specific pages.


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
