### PR TITLE
fix(backend): actually stream batches lazily from database

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/config/BackendSpringConfig.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/BackendSpringConfig.kt
@@ -22,6 +22,7 @@ object BackendSpringProperty {
     const val BACKEND_CONFIG_PATH = "loculus.config.path"
     const val STALE_AFTER_SECONDS = "loculus.cleanup.task.reset-stale-in-processing-after-seconds"
     const val CLEAN_UP_RUN_EVERY_SECONDS = "loculus.cleanup.task.run-every-seconds"
+    const val STREAM_BATCH_SIZE = "loculus.stream.batch-size"
 }
 
 private val logger = mu.KotlinLogging.logger {}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -23,4 +23,4 @@ management.health.readinessState.enabled=true
 
 loculus.cleanup.task.reset-stale-in-processing-after-seconds=60
 loculus.cleanup.task.run-every-seconds=60
-
+loculus.stream.batch-size=1000


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #833

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://833-test-streaming-data-f.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Fetch batches from the database and stream every batch individually. The batch size can be configured via `loculus.stream.batch-size`. The default value is 1000.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
