### PR TITLE
fix(website): fix data use terms not updating when edited

### DIFF
--- a/website/src/components/DataUseTerms/EditDataUseTermsButton.tsx
+++ b/website/src/components/DataUseTerms/EditDataUseTermsButton.tsx
@@ -52,11 +52,7 @@ const InnerEditDataUseTermsButton: FC<EditDataUseTermsButtonProps> = ({
                     position: 'top-center',
                     autoClose: false,
                 }),
-            onSuccess: () =>
-                toast.success('The use terms for this sequence will be updated within a few minutes.', {
-                    position: 'top-center',
-                    autoClose: false,
-                }),
+            onSuccess: () => location.reload(),
         },
     );
 

--- a/website/src/components/SequenceDetailsPage/SequencesDetailsPage.astro
+++ b/website/src/components/SequenceDetailsPage/SequencesDetailsPage.astro
@@ -26,6 +26,11 @@ const groupId = tableData.find((entry) => entry.name === 'groupId')!.value as nu
 dataUseTermsHistory.sort((a, b) => (a.changeDate > b.changeDate ? -1 : 1));
 const currentDataUseTerms = dataUseTermsHistory[0].dataUseTerms;
 
+const dataUseTermsIndex = tableData.findIndex((entry) => entry.name === 'dataUseTerms');
+if (dataUseTermsIndex !== -1) {
+    tableData[dataUseTermsIndex].value = currentDataUseTerms.type;
+}
+
 const isRestricted = currentDataUseTerms.type === 'RESTRICTED';
 
 const runtimeConfig = getRuntimeConfig();


### PR DESCRIPTION
resolves #1604

Inserts the up-to-date _data use terms_ status into the sequence details fetched from silo.

Preview: http://instant-update-data-use-t.loculus.org/