### PR TITLE
fix(website): don't show empty mutation lists in download panel

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/ActiveDownloadFilters.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/ActiveDownloadFilters.tsx
@@ -15,7 +15,7 @@ export const ActiveDownloadFilters: FC<ActiveDownloadFiltersProps> = ({ metadata
         { name: 'nucleotideInsertion', value: mutationFilter.nucleotideInsertionQueries },
         { name: 'aminoAcidInsertions', value: mutationFilter.aminoAcidInsertionQueries },
     ].forEach(({ name, value }) => {
-        if (value !== undefined) {
+        if (value !== undefined && value.length > 0) {
             filterValues.push({ name, filterValue: value.join(', ') });
         }
     });


### PR DESCRIPTION
resolves #1420
preview URL: https://1420-empty-mutation-list.loculus.org

### Summary

Don't show empty mutation filter lists in the download panel

### Screenshot

![image](https://github.com/loculus-project/loculus/assets/18666552/c3aeb489-04bf-4071-a65b-9bca9c1145e5)

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
