### PR TITLE
feat(website): show sequences in boxes with tabs on edit page

### DIFF
--- a/website/src/components/Edit/EditPage.spec.tsx
+++ b/website/src/components/Edit/EditPage.spec.tsx
@@ -56,13 +56,6 @@ describe('EditPage', () => {
 
         expect(screen.getByText(/Processed Data/i)).toBeInTheDocument();
         expectTextInSequenceData.processedMetadata(defaultReviewData.processedData.metadata);
-        expectTextInSequenceData.processed(defaultReviewData.processedData.unalignedNucleotideSequences);
-
-        expect(screen.getByText(/^Aligned nucleotide sequences/i)).toBeInTheDocument();
-        expectTextInSequenceData.processed(defaultReviewData.processedData.alignedNucleotideSequences);
-
-        expect(screen.getByText(/Amino acid sequences/i)).toBeInTheDocument();
-        expectTextInSequenceData.processed(defaultReviewData.processedData.alignedAminoAcidSequences);
 
         expect(screen.getByText('processedInsertionSequenceName:')).toBeInTheDocument();
         expect(screen.getByText('nucleotideInsertion1,nucleotideInsertion2')).toBeInTheDocument();
@@ -110,11 +103,6 @@ const expectTextInSequenceData = {
         Object.entries(metadata).forEach(([key, value]) => {
             expect(screen.getByText(sentenceCase(key) + ':')).toBeInTheDocument();
             expect(screen.getByDisplayValue(value)).toBeInTheDocument();
-        }),
-    processed: (metadata: Record<string, string | null>): void =>
-        Object.entries(metadata).forEach(([key, value]) => {
-            expect(screen.getByText(key + ':')).toBeInTheDocument();
-            expect(screen.getByText(value ?? 'null')).toBeInTheDocument();
         }),
     processedMetadata: (metadata: Record<string, MetadataField>): void =>
         Object.entries(metadata).forEach(([key, value]) => {

--- a/website/src/components/SequenceDetailsPage/SequenceViewer.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceViewer.tsx
@@ -1,11 +1,11 @@
 import { noCase } from 'change-case';
-import { type FC, useMemo } from 'react';
+import { type FC } from 'react';
 
 import { getLapisUrl } from '../../config.ts';
 import { lapisClientHooks } from '../../services/serviceHooks.ts';
 import type { ClientConfig } from '../../types/runtimeConfig.ts';
 import { type SequenceType } from '../../utils/sequenceTypeHelpers.ts';
-import { splitString } from '../../utils/splitLines';
+import { FixedLengthTextViewer } from '../common/FixedLengthTextViewer.tsx';
 
 const LINE_LENGTH = 100;
 
@@ -28,8 +28,6 @@ export const SequencesViewer: FC<Props> = ({
         getLapisUrl(clientConfig, organism),
     ).utilityHooks.useGetSequence(accessionVersion, sequenceType, isMultiSegmented);
 
-    const lines = useMemo(() => (data !== undefined ? splitString(data.sequence, LINE_LENGTH) : undefined), [data]);
-
     if (error !== null) {
         return (
             <div className='text-error'>
@@ -38,22 +36,13 @@ export const SequencesViewer: FC<Props> = ({
         );
     }
 
-    if (isLoading || lines === undefined) {
+    if (isLoading || data === undefined) {
         return <span className='loading loading-spinner loading-lg' />;
     }
 
     return (
-        <div className='overflow-x-auto'>
-            {lines.map((line, index) => (
-                <pre
-                    key={index}
-                    className='inline-block before:content-[attr(data-line)] before:inline-block before:w-12
-                    before:mr-2 before:text-right before:text-gray-500'
-                    data-line={index * LINE_LENGTH}
-                >
-                    <code>{line}</code>
-                </pre>
-            ))}
+        <div className='max-h-80 overflow-auto'>
+            <FixedLengthTextViewer text={data.sequence} maxLineLength={LINE_LENGTH} />
         </div>
     );
 };

--- a/website/src/components/SequenceDetailsPage/SequencesContainer.tsx
+++ b/website/src/components/SequenceDetailsPage/SequencesContainer.tsx
@@ -11,6 +11,7 @@ import {
     type SequenceType,
     unalignedSequenceSegment,
 } from '../../utils/sequenceTypeHelpers';
+import { BoxWithTabsTabBar, BoxWithTabsTab, BoxWithTabsBox } from '../common/BoxWithTabs.tsx';
 import { withQueryProvider } from '../common/withQueryProvider.tsx';
 
 type SequenceContainerProps = {
@@ -47,7 +48,7 @@ export const InnerSequencesContainer: FC<SequenceContainerProps> = ({
                 setType={setSequenceType}
                 genes={genes}
             />
-            <div className='border p-4 max-w-[1000px]'>
+            <BoxWithTabsBox>
                 <SequencesViewer
                     organism={organism}
                     accessionVersion={accessionVersion}
@@ -55,7 +56,7 @@ export const InnerSequencesContainer: FC<SequenceContainerProps> = ({
                     sequenceType={sequenceType}
                     isMultiSegmented={isMultiSegmented(nucleotideSegmentNames)}
                 />
-            </div>
+            </BoxWithTabsBox>
         </>
     );
 };
@@ -74,7 +75,7 @@ const SequenceTabs: FC<NucleotideSequenceTabsProps & { genes: string[] }> = ({
     sequenceType,
     setType,
 }) => (
-    <div className='tabs -mb-px tabs-lifted flex flex-wrap'>
+    <BoxWithTabsTabBar>
         <UnalignedNucleotideSequenceTabs
             nucleotideSegmentNames={nucleotideSegmentNames}
             sequenceType={sequenceType}
@@ -86,13 +87,13 @@ const SequenceTabs: FC<NucleotideSequenceTabsProps & { genes: string[] }> = ({
             setType={setType}
         />
         {genes.map((gene) => (
-            <Tab
+            <BoxWithTabsTab
                 isActive={isGeneSequence(gene, sequenceType)}
                 onClick={() => setType(geneSequence(gene))}
                 label={gene}
             />
         ))}
-    </div>
+    </BoxWithTabsTabBar>
 );
 
 const UnalignedNucleotideSequenceTabs: FC<NucleotideSequenceTabsProps> = ({
@@ -103,7 +104,7 @@ const UnalignedNucleotideSequenceTabs: FC<NucleotideSequenceTabsProps> = ({
     if (!isMultiSegmented(nucleotideSegmentNames)) {
         const onlySegment = nucleotideSegmentNames[0];
         return (
-            <Tab
+            <BoxWithTabsTab
                 key={onlySegment}
                 isActive={isUnalignedSequence(sequenceType)}
                 onClick={() => setType(unalignedSequenceSegment(onlySegment))}
@@ -115,7 +116,7 @@ const UnalignedNucleotideSequenceTabs: FC<NucleotideSequenceTabsProps> = ({
     return (
         <>
             {nucleotideSegmentNames.map((segmentName) => (
-                <Tab
+                <BoxWithTabsTab
                     key={segmentName}
                     isActive={isUnalignedSequence(sequenceType)}
                     onClick={() => setType(unalignedSequenceSegment(segmentName))}
@@ -130,7 +131,7 @@ const AlignmentSequenceTabs: FC<NucleotideSequenceTabsProps> = ({ nucleotideSegm
     if (!isMultiSegmented(nucleotideSegmentNames)) {
         const onlySegment = nucleotideSegmentNames[0];
         return (
-            <Tab
+            <BoxWithTabsTab
                 key={onlySegment}
                 isActive={isAlignedSequence(sequenceType)}
                 onClick={() => setType(alignedSequenceSegment(onlySegment))}
@@ -142,7 +143,7 @@ const AlignmentSequenceTabs: FC<NucleotideSequenceTabsProps> = ({ nucleotideSegm
     return (
         <>
             {nucleotideSegmentNames.map((segmentName) => (
-                <Tab
+                <BoxWithTabsTab
                     key={segmentName}
                     isActive={isAlignedSequence(sequenceType)}
                     onClick={() => setType(alignedSequenceSegment(segmentName))}
@@ -152,18 +153,6 @@ const AlignmentSequenceTabs: FC<NucleotideSequenceTabsProps> = ({ nucleotideSegm
         </>
     );
 };
-
-type TabProps = {
-    isActive: boolean;
-    label: string;
-    onClick: () => void;
-};
-
-const Tab: FC<TabProps> = ({ isActive, label, onClick }) => (
-    <button className={`tab ${isActive ? 'tab-active' : ''}`} onClick={onClick}>
-        {label}
-    </button>
-);
 
 function isMultiSegmented(nucleotideSegmentNames: string[]) {
     return nucleotideSegmentNames.length > 1;

--- a/website/src/components/common/BoxWithTabs.tsx
+++ b/website/src/components/common/BoxWithTabs.tsx
@@ -1,0 +1,29 @@
+import type { FC, ReactNode } from 'react';
+
+type BoxWithTabsTabBarProps = {
+    children: ReactNode;
+};
+
+export const BoxWithTabsTabBar: FC<BoxWithTabsTabBarProps> = ({ children }) => (
+    <div className='tabs -mb-px tabs-lifted flex flex-wrap'>{children}</div>
+);
+
+type BoxWithTabsTabProps = {
+    isActive: boolean;
+    label: string;
+    onClick?: () => void;
+};
+
+export const BoxWithTabsTab: FC<BoxWithTabsTabProps> = ({ isActive, label, onClick }) => (
+    <button className={`tab ${isActive ? 'tab-active' : ''}`} onClick={onClick}>
+        {label}
+    </button>
+);
+
+type BoxWithTabsBoxProps = {
+    children: ReactNode;
+};
+
+export const BoxWithTabsBox: FC<BoxWithTabsBoxProps> = ({ children }) => (
+    <div className='border p-4 max-w-[1000px]'>{children}</div>
+);

--- a/website/src/components/common/FixedLengthTextViewer.tsx
+++ b/website/src/components/common/FixedLengthTextViewer.tsx
@@ -1,0 +1,27 @@
+import { type FC, useMemo } from 'react';
+
+import { splitString } from '../../utils/splitLines.ts';
+
+type FixedLengthTextViewerPros = {
+    text: string;
+    maxLineLength: number;
+};
+
+export const FixedLengthTextViewer: FC<FixedLengthTextViewerPros> = ({ text, maxLineLength }) => {
+    const lines = useMemo(() => splitString(text, maxLineLength), [text, maxLineLength]);
+
+    return (
+        <div className='overflow-x-auto'>
+            {lines.map((line, index) => (
+                <pre
+                    key={index}
+                    className='inline-block before:content-[attr(data-line)] before:inline-block before:w-12
+                    before:mr-2 before:text-right before:text-gray-500'
+                    data-line={index * maxLineLength}
+                >
+                    <code>{line}</code>
+                </pre>
+            ))}
+        </div>
+    );
+};


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #406

preview URL: https://406-edit-page-sequences.loculus.org

### Summary

Shows the sequences from the processed data in height-limited tabs.

### Screenshot

![image](https://github.com/loculus-project/loculus/assets/18666552/2b03367f-3019-4361-bda9-3793e3411767)



### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
