### PR TITLE
feat(website): Add header to metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 !.idea/runConfigurations
 *.iml
 .vscode/*
+.venv
 
 # build output
 dist/

--- a/docs/src/content/docs/guides/getting-started.md
+++ b/docs/src/content/docs/guides/getting-started.md
@@ -5,7 +5,7 @@ description: How to deploy a loculus instance
 
 # Prerequisites
 
-Before you get started with deploying Loculus, there are a few prerequisites you'll need to ensure are in place. 
+Before you get started with deploying Loculus, there are a few prerequisites you'll need to ensure are in place.
 
 ## Kubernetes Cluster with Traefik
 
@@ -41,7 +41,6 @@ To use an external database, you'll need to provide the necessary connection det
 
 Here's an example of how the external database configuration might look in the `values.yaml` file:
 
-
 ```yaml
 externalDatabase:
  urlSealedSecret: "ag..."
@@ -60,10 +59,10 @@ The helm chart for deploying pathoplexus is within the Loculus repo, in the `kub
 [We need to write about how to do this]
 
 ## Organism Configuration
+
 Loculus supports multiple organisms, each with its own configuration. The organisms section in the values.yaml file allows you to define the specific settings for each organism.
 
 Here's an example of how the organism configuration might look:
-
 
 ```yaml
 organisms:
@@ -74,18 +73,22 @@ organisms:
       metadata:
         - name: date
           type: date
+          header: "Collection Data"
         - name: region
           type: string
           generateIndex: true
           autocomplete: true
+          header: "Collection Data"
         - name: country
           type: string
           generateIndex: true
           autocomplete: true
+          header: "Collection Data"
         - name: division
           type: string
           generateIndex: true
           autocomplete: true
+          header: "Collection Data"
         - name: host
           type: string
           autocomplete: true
@@ -93,6 +96,12 @@ organisms:
           type: pango_lineage
           autocomplete: true
           required: true
+        - name: insdc_accession_full
+          type: string
+          displayName: INSDC accession
+          customDisplay:
+            type: link
+            url: "https://www.ncbi.nlm.nih.gov/nuccore/{{value}}"
       website:
         tableColumns:
           - country
@@ -120,9 +129,14 @@ organisms:
 
 In this example, the configuration for the "ebolavirus-sudan" organism is defined. It includes schema settings, website display options, silo configuration, preprocessing details, and reference genome information.
 
+Note the metadata section includes various fields for how the metadata of specific sequences should be displayed. Each metadata item must have a `name` which will also be displayed on the page unless `displayName` is also set. The `type` of the data, as well as if the field is `required` and if `autoComplete` is enabled can also be added. Additionally, links from metadata entries to external websites can be added using the `customDisplay` option. We also allow metadata to be grouped in sections, specified by the `header` field.
+
+Additionally, the `tableColumns` section defines which metadata fields are shown as columns in the search results.
+
 You can add multiple organisms under the organisms section, each with its own unique configuration.
 
 ## Ready to Deploy?
+
 Once you have the prerequisites in place and have configured the `values.yaml` file according to your requirements, you're ready to deploy Loculus using the provided Helm chart.
 
 Run `helm install loculus kubernetes/loculus -f kubernetes/loculus/values.yaml`

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -121,6 +121,9 @@ fields:
       type: {{ quote .customDisplay.type }}
       url: {{ .customDisplay.url }}
     {{- end }}
+    {{- if .header }}
+    header: {{ .header }}
+    {{- end }}
 {{- end}}
 {{- end}}
 

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -45,25 +45,30 @@ defaultOrganisms:
         - name: date
           type: date
           initiallyVisible: true
+          header: "Collection Details"
         - name: region
           type: string
           initiallyVisible: true
           generateIndex: true
           autocomplete: true
+          header: "Collection Details"
         - name: country
           initiallyVisible: true
           type: string
           generateIndex: true
           autocomplete: true
+          header: "Collection Details"
         - name: division
           initiallyVisible: true
           type: string
           generateIndex: true
           autocomplete: true
+          header: "Collection Details"
         - name: host
           initiallyVisible: true
           type: string
           autocomplete: true
+          header: "Collection Details"
         - name: pango_lineage
           initiallyVisible: true
           type: pango_lineage
@@ -77,7 +82,6 @@ defaultOrganisms:
           - pango_lineage
         defaultOrder: descending
         defaultOrderBy: date
-       
       silo:
         dateToSortBy: date
         partitionBy: pango_lineage
@@ -148,6 +152,7 @@ defaultOrganisms:
           autocomplete: true
         - name: ncbi_release_date
           type: date
+          header: "INSDC"
         - name: country
           type: string
           required: true
@@ -165,7 +170,7 @@ defaultOrganisms:
         - name: collection_date
           displayName: Collection Date
         - name: clade
-          displayName: Clade  
+          displayName: Clade
         - name: outbreak
           displayName: Outbreak
         - name: lineage
@@ -316,6 +321,7 @@ defaultOrganisms:
         - name: ncbi_release_date
           displayName: NCBI release date
           type: date
+          header: "INSDC"
         - name: country
           type: string
           required: true
@@ -345,19 +351,23 @@ defaultOrganisms:
           autocomplete: true
         - name: insdc_accession_base
           type: string
+          header: "INSDC"
         - name: insdc_version
           type: int
+          header: "INSDC"
         - name: insdc_accession_full
           type: string
           displayName: INSDC accession
           customDisplay:
             type: link
             url: "https://www.ncbi.nlm.nih.gov/nuccore/{{value}}"
+          header: "INSDC"
         - name: bioprojects
           type: string
           customDisplay:
             type: link
             url: "https://www.ncbi.nlm.nih.gov/bioproject/{{value}}"
+          header: "INSDC"
         - name: biosample_accession
           type: string
           customDisplay:
@@ -367,30 +377,38 @@ defaultOrganisms:
           type: string
           generateIndex: true
           autocomplete: true
+          header: "Alignment states and QC metrics"
         - name: ncbi_host_name
           type: string
           generateIndex: true
           autocomplete: true
+          header: "Host"
         - name: ncbi_host_tax_id
           type: int
           autocomplete: true
           customDisplay:
             type: link
             url: "https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=info&id={{value}}"
+          header: "Host"
         - name: ncbi_is_lab_host
           type: string
           generateIndex: true
           autocomplete: true
+          header: "Host"
         - name: ncbi_length
           type: int
+          header: "INSDC"
         - name: ncbi_protein_count
           type: int
+          header: "INSDC"
         - name: ncbi_update_date
           type: date
+          header: "INSDC"
         - name: ncbi_sourcedb
           type: string
           generateIndex: true
           autocomplete: true
+          header: "INSDC"
         - name: ncbi_virus_name
           type: string
           generateIndex: true
@@ -405,31 +423,43 @@ defaultOrganisms:
           type: string
           generateIndex: true
           autocomplete: true
+          header: "Host"
         - name: sra_accessions
           type: string
           customDisplay:
             type: link
             url: "https://www.ncbi.nlm.nih.gov/sra/?term={{value}}"
+          header: "INSDC"
         - name: total_snps
           type: int
+          header: "Mutations, insertions, deletions"
         - name: total_inserted_nucs
           type: int
+          header: "Mutations, insertions, deletions"
         - name: total_deleted_nucs
           type: int
+          header: "Mutations, insertions, deletions"
         - name: total_ambiguous_nucs
           type: int
+          header: "Alignment states and QC metrics"
         - name: total_unknown_nucs
           type: int
+          header: "Alignment states and QC metrics"
         - name: total_frame_shifts
           type: int
+          header: "Alignment states and QC metrics"
         - name: frame_shifts
           type: string
+          header: "Alignment states and QC metrics"
         - name: completeness
           type: float
+          header: "Alignment states and QC metrics"
         - name: total_stop_codons
           type: int
+          header: "Alignment states and QC metrics"
         - name: stop_codons
           type: string
+          header: "Alignment states and QC metrics"
         - name: metadata_hash
           type: string
       website:
@@ -447,18 +477,18 @@ defaultOrganisms:
         defaultOrder: descending
       silo:
         dateToSortBy: collection_date
-      inputFields: 
+      inputFields:
         - name: collection_date
           displayName: Collection Date
-        - name: ncbi_release_date 
+        - name: ncbi_release_date
           displayName: NCBI Release Date
         - name: country
           displayName: Country
         - name: isolate_name
-          displayName: Isolate Name  
+          displayName: Isolate Name
         - name: author_affiliation
           displayName: Author Affiliation
-        - name: authors 
+        - name: authors
           displayName: Authors
         - name: submitter_country
           displayName: Submitter Country
@@ -467,12 +497,12 @@ defaultOrganisms:
         - name: insdc_accession_base
           displayName: INSDC Accession Base
         - name: insdc_version
-          displayName: INSDC Version 
+          displayName: INSDC Version
         - name: insdc_accession_full
           displayName: INSDC Accession Full
         - name: bioprojects
           displayName: BioProjects
-        - name: biosample_accession 
+        - name: biosample_accession
           displayName: BioSample Accession
         - name: ncbi_completeness
           displayName: NCBI Completeness
@@ -489,7 +519,7 @@ defaultOrganisms:
         - name: ncbi_update_date
           displayName: NCBI Update Date
         - name: ncbi_sourcedb
-          displayName: NCBI Source DB 
+          displayName: NCBI Source DB
         - name: ncbi_virus_name
           displayName: NCBI Virus Name
         - name: ncbi_virus_tax_id
@@ -499,7 +529,7 @@ defaultOrganisms:
         - name: sra_accessions
           displayName: SRA Accessions
         - name: total_snps
-          displayName: Total SNPs 
+          displayName: Total SNPs
         - name: total_inserted_nucs
           displayName: Total Inserted Nucleotides
         - name: total_deleted_nucs
@@ -507,7 +537,7 @@ defaultOrganisms:
         - name: total_ambiguous_nucs
           displayName: Total Ambiguous Nucleotides
         - name: total_unknown_nucs
-          displayName: Total Unknown Nucleotides  
+          displayName: Total Unknown Nucleotides
         - name: total_frame_shifts
           displayName: Total Frame Shifts
         - name: frame_shifts
@@ -851,9 +881,9 @@ defaultOrganisms:
           Virus Pangolin Classification: ncbi_virus_pangolin
           Virus Taxonomic ID: ncbi_virus_tax_id
         group_name: insdc_ingest_group
-        username : insdc_ingest_user
-        password : insdc_ingest_user
-        keycloak_client_id : backend-client
+        username: insdc_ingest_user
+        password: insdc_ingest_user
+        keycloak_client_id: backend-client
     referenceGenomes:
       nucleotideSequences:
         - name: "main"

--- a/website/src/components/SequenceDetailsPage/DataTable.astro
+++ b/website/src/components/SequenceDetailsPage/DataTable.astro
@@ -1,6 +1,6 @@
 ---
 import { DataUseTermsHistoryModal } from './DataUseTermsHistoryModal';
-import { type TableDataEntry } from './getTableData';
+import { toHeaderMap, type TableDataEntry } from './getTableData';
 import { type DataUseTermsHistoryEntry } from '../../types/backend';
 
 interface Props {
@@ -9,45 +9,56 @@ interface Props {
 }
 
 const { tableData, dataUseTermsHistory } = Astro.props;
+const headerMap = toHeaderMap(tableData);
 ---
 
 <div class='mt-2'>
-    <table class='min-w-full'>
-        <tbody class='bg-white'>
-            {
-                tableData.map(({ label, value, customDisplay }) => (
-                    <tr>
-                        <td class='py-1 whitespace-nowrap text-sm font-medium text-gray-900 text-right w-32'>
-                            {label}
-                        </td>
-                        <td class='px-4 py-1 whitespace-normal text-sm text-gray-600'>
-                            <div class='flex items-center gap-3'>
-                                {customDisplay === undefined && value}
-                                {customDisplay !== undefined &&
-                                    customDisplay.type === 'link' &&
-                                    customDisplay.url !== undefined && (
-                                        <a
-                                            href={customDisplay.url.replaceAll('{{value}}', value.toString())}
-                                            target='_blank'
-                                            class='underline'
-                                        >
-                                            {value}
-                                        </a>
-                                    )}
-                                {customDisplay !== undefined && customDisplay.type === 'dataUseTerms' && (
-                                    <>
-                                        {value}{' '}
-                                        <DataUseTermsHistoryModal
-                                            dataUseTermsHistory={dataUseTermsHistory}
-                                            client:only='react'
-                                        />
-                                    </>
-                                )}
-                            </div>
-                        </td>
-                    </tr>
-                ))
-            }
-        </tbody>
-    </table>
+    <div>
+        {
+            Object.entries(headerMap).map(([header, names]) => (
+                <div class='pb-8'>
+                    {header !== '' && <h1 class='py-2 font-medium text-primary-600'>{header}</h1>}
+                    <table class='min-w-full'>
+                        <tbody class='bg-white'>
+                            {names.map(({ label, value, customDisplay }) => (
+                                <tr>
+                                    <td class='py-1 whitespace-nowrap text-sm font-medium text-gray-900 text-right w-32'>
+                                        {label}
+                                    </td>
+                                    <td class='px-4 py-1 whitespace-normal text-sm text-gray-600'>
+                                        <div class='flex items-center gap-3'>
+                                            {customDisplay === undefined && value}
+                                            {customDisplay !== undefined &&
+                                                customDisplay.type === 'link' &&
+                                                customDisplay.url !== undefined && (
+                                                    <a
+                                                        href={customDisplay.url.replaceAll(
+                                                            '{{value}}',
+                                                            value.toString(),
+                                                        )}
+                                                        target='_blank'
+                                                        class='underline'
+                                                    >
+                                                        {value}
+                                                    </a>
+                                                )}
+                                            {customDisplay !== undefined && customDisplay.type === 'dataUseTerms' && (
+                                                <>
+                                                    {value}{' '}
+                                                    <DataUseTermsHistoryModal
+                                                        dataUseTermsHistory={dataUseTermsHistory}
+                                                        client:only='react'
+                                                    />
+                                                </>
+                                            )}
+                                        </div>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            ))
+        }
+    </div>
 </div>

--- a/website/src/components/SequenceDetailsPage/SequencesDataTableTitle.astro
+++ b/website/src/components/SequenceDetailsPage/SequencesDataTableTitle.astro
@@ -17,7 +17,7 @@ const { sequenceEntryHistory, accessionVersion } = Astro.props;
 ---
 
 <div class='flex justify-between flex-wrap'>
-    <div class='flex flex-row pb-2'>
+    <div class='flex flex-row pb-6'>
         <h1 class='title'>{accessionVersion}</h1>
     </div>
 

--- a/website/src/components/SequenceDetailsPage/getTableData.spec.ts
+++ b/website/src/components/SequenceDetailsPage/getTableData.spec.ts
@@ -1,7 +1,7 @@
 import { err, ok } from 'neverthrow';
 import { beforeEach, describe, expect, test } from 'vitest';
 
-import { getTableData } from './getTableData.ts';
+import { type TableDataEntry, getTableData, toHeaderMap } from './getTableData.ts';
 import { mockRequest, testConfig } from '../../../vitest.setup.ts';
 import { LapisClient } from '../../services/lapisClient.ts';
 import type { Schema } from '../../types/config.ts';
@@ -9,7 +9,7 @@ import type { Schema } from '../../types/config.ts';
 const schema: Schema = {
     instanceName: 'instance name',
     metadata: [
-        { name: 'metadataField1', type: 'string' },
+        { name: 'metadataField1', type: 'string', header: 'testHeader1' },
         { name: 'metadataField2', type: 'string' },
         { name: 'timestampField', type: 'timestamp' },
     ],
@@ -70,58 +70,44 @@ describe('getTableData', () => {
     test('should return default values when there is no data', async () => {
         const result = await getTableData(accessionVersion, schema, lapisClient);
 
-        expect(result).toStrictEqual(
-            ok([
-                {
-                    label: 'Metadata field1',
-                    name: 'metadataField1',
-                    value: 'N/A',
-                    customDisplay: undefined,
-                },
-                {
-                    label: 'Metadata field2',
-                    name: 'metadataField2',
-                    value: 'N/A',
-                    customDisplay: undefined,
-                },
-                {
-                    label: 'Timestamp field',
-                    name: 'timestampField',
-                    value: 'N/A',
-                    customDisplay: undefined,
-                },
-                {
-                    label: 'Nucleotide substitutions',
-                    name: 'nucleotideSubstitutions',
-                    value: '',
-                },
-                {
-                    label: 'Nucleotide deletions',
-                    name: 'nucleotideDeletions',
-                    value: '',
-                },
-                {
-                    label: 'Nucleotide insertions',
-                    name: 'nucleotideInsertions',
-                    value: '',
-                },
-                {
-                    label: 'Amino acid substitutions',
-                    name: 'aminoAcidSubstitutions',
-                    value: '',
-                },
-                {
-                    label: 'Amino acid deletions',
-                    name: 'aminoAcidDeletions',
-                    value: '',
-                },
-                {
-                    label: 'Amino acid insertions',
-                    name: 'aminoAcidInsertions',
-                    value: '',
-                },
-            ]),
+        const defaultList: TableDataEntry[] = [
+            {
+                label: 'Metadata field1',
+                name: 'metadataField1',
+                value: 'N/A',
+                customDisplay: undefined,
+                header: 'testHeader1',
+            },
+            {
+                label: 'Metadata field2',
+                name: 'metadataField2',
+                value: 'N/A',
+                customDisplay: undefined,
+                header: '',
+            },
+            {
+                label: 'Timestamp field',
+                name: 'timestampField',
+                value: 'N/A',
+                customDisplay: undefined,
+                header: '',
+            },
+        ];
+
+        expect(result).toStrictEqual(ok(defaultList.concat(defaultMutationsInsertionsDeletionsList)));
+    });
+
+    test('toHeaderMap should return default values when there is no data', async () => {
+        const result = await getTableData(accessionVersion, schema, lapisClient);
+
+        const data = result._unsafeUnwrap();
+        const defaultHeaderMap = toHeaderMap(data);
+
+        expect(defaultHeaderMap['Mutations, insertions, deletions']).toStrictEqual(
+            defaultMutationsInsertionsDeletionsList,
         );
+        expect(defaultHeaderMap['']).toStrictEqual(defaultNoHeaderList);
+        expect(defaultHeaderMap.testHeader1).toStrictEqual(defaultHeader1List);
     });
 
     test('should return details field values', async () => {
@@ -144,11 +130,13 @@ describe('getTableData', () => {
             label: 'Metadata field1',
             name: 'metadataField1',
             value: value1,
+            header: 'testHeader1',
         });
         expect(data).toContainEqual({
             label: 'Metadata field2',
             name: 'metadataField2',
             value: value2,
+            header: '',
         });
     });
 
@@ -163,21 +151,25 @@ describe('getTableData', () => {
             label: 'Nucleotide substitutions',
             name: 'nucleotideSubstitutions',
             value: 'T10A, C30G',
+            header: 'Mutations, insertions, deletions',
         });
         expect(data).toContainEqual({
             label: 'Nucleotide deletions',
             name: 'nucleotideDeletions',
             value: '20, 21, 39-45, 400',
+            header: 'Mutations, insertions, deletions',
         });
         expect(data).toContainEqual({
             label: 'Amino acid substitutions',
             name: 'aminoAcidSubstitutions',
             value: 'gene1:N10Y, gene1:T30N',
+            header: 'Mutations, insertions, deletions',
         });
         expect(data).toContainEqual({
             label: 'Amino acid deletions',
             name: 'aminoAcidDeletions',
             value: 'gene1:20-23, gene1:40',
+            header: 'Mutations, insertions, deletions',
         });
     });
 
@@ -192,11 +184,13 @@ describe('getTableData', () => {
             label: 'Nucleotide insertions',
             name: 'nucleotideInsertions',
             value: 'nucleotideInsertion1, nucleotideInsertion2',
+            header: 'Mutations, insertions, deletions',
         });
         expect(data).toContainEqual({
             label: 'Amino acid insertions',
             name: 'aminoAcidInsertions',
             value: 'aminoAcidInsertion1, aminoAcidInsertion2',
+            header: 'Mutations, insertions, deletions',
         });
     });
 
@@ -210,6 +204,7 @@ describe('getTableData', () => {
             label: 'Timestamp field',
             name: 'timestampField',
             value: '2024-01-25 14:59:21 UTC',
+            header: '',
         });
     });
 });
@@ -245,4 +240,70 @@ const nucleotideInsertions = [
 const aminoAcidInsertions = [
     { count: 0, insertion: 'aminoAcidInsertion1' },
     { count: 0, insertion: 'aminoAcidInsertion2' },
+];
+
+const defaultNoHeaderList: TableDataEntry[] = [
+    {
+        label: 'Metadata field2',
+        name: 'metadataField2',
+        value: 'N/A',
+        customDisplay: undefined,
+        header: '',
+    },
+    {
+        label: 'Timestamp field',
+        name: 'timestampField',
+        value: 'N/A',
+        customDisplay: undefined,
+        header: '',
+    },
+];
+
+const defaultHeader1List: TableDataEntry[] = [
+    {
+        label: 'Metadata field1',
+        name: 'metadataField1',
+        value: 'N/A',
+        customDisplay: undefined,
+        header: 'testHeader1',
+    },
+];
+
+const defaultMutationsInsertionsDeletionsList: TableDataEntry[] = [
+    {
+        label: 'Nucleotide substitutions',
+        name: 'nucleotideSubstitutions',
+        value: '',
+        header: 'Mutations, insertions, deletions',
+    },
+    {
+        label: 'Nucleotide deletions',
+        name: 'nucleotideDeletions',
+        value: '',
+        header: 'Mutations, insertions, deletions',
+    },
+    {
+        label: 'Nucleotide insertions',
+        name: 'nucleotideInsertions',
+        value: '',
+        header: 'Mutations, insertions, deletions',
+    },
+    {
+        label: 'Amino acid substitutions',
+        name: 'aminoAcidSubstitutions',
+        value: '',
+        header: 'Mutations, insertions, deletions',
+    },
+    {
+        label: 'Amino acid deletions',
+        name: 'aminoAcidDeletions',
+        value: '',
+        header: 'Mutations, insertions, deletions',
+    },
+    {
+        label: 'Amino acid insertions',
+        name: 'aminoAcidInsertions',
+        value: '',
+        header: 'Mutations, insertions, deletions',
+    },
 ];

--- a/website/src/components/SequenceDetailsPage/getTableData.ts
+++ b/website/src/components/SequenceDetailsPage/getTableData.ts
@@ -14,7 +14,13 @@ import {
 } from '../../types/lapis.ts';
 import { parseUnixTimestamp } from '../../utils/parseUnixTimestamp.ts';
 
-export type TableDataEntry = { label: string; name: string; value: string | number; customDisplay?: CustomDisplay };
+export type TableDataEntry = {
+    label: string;
+    name: string;
+    value: string | number;
+    header: string;
+    customDisplay?: CustomDisplay;
+};
 
 export async function getTableData(
     accessionVersion: string,
@@ -82,6 +88,17 @@ function validateDetailsAreNotEmpty<T extends [DetailsResponse, ...any[]]>(acces
     };
 }
 
+export function toHeaderMap(listTableDataEntries: TableDataEntry[]): { [key: string]: TableDataEntry[] } {
+    const groupedData = listTableDataEntries.reduce((acc: { [key: string]: TableDataEntry[] }, item) => {
+        if (!(item.header in acc)) {
+            acc[item.header] = [];
+        }
+        acc[item.header].push(item);
+        return acc;
+    }, {});
+    return groupedData;
+}
+
 function toTableData(config: Schema) {
     return ({
         details,
@@ -101,37 +118,44 @@ function toTableData(config: Schema) {
             name: metadata.name,
             customDisplay: metadata.customDisplay,
             value: mapValueToDisplayedValue(details[metadata.name], metadata),
+            header: metadata.header ?? '',
         }));
         data.push(
             {
                 label: 'Nucleotide substitutions',
                 name: 'nucleotideSubstitutions',
                 value: substitutionsToCommaSeparatedString(nucleotideMutations),
+                header: 'Mutations, insertions, deletions',
             },
             {
                 label: 'Nucleotide deletions',
                 name: 'nucleotideDeletions',
                 value: deletionsToCommaSeparatedString(nucleotideMutations),
+                header: 'Mutations, insertions, deletions',
             },
             {
                 label: 'Nucleotide insertions',
                 name: 'nucleotideInsertions',
                 value: insertionsToCommaSeparatedString(nucleotideInsertions),
+                header: 'Mutations, insertions, deletions',
             },
             {
                 label: 'Amino acid substitutions',
                 name: 'aminoAcidSubstitutions',
                 value: substitutionsToCommaSeparatedString(aminoAcidMutations),
+                header: 'Mutations, insertions, deletions',
             },
             {
                 label: 'Amino acid deletions',
                 name: 'aminoAcidDeletions',
                 value: deletionsToCommaSeparatedString(aminoAcidMutations),
+                header: 'Mutations, insertions, deletions',
             },
             {
                 label: 'Amino acid insertions',
                 name: 'aminoAcidInsertions',
                 value: insertionsToCommaSeparatedString(aminoAcidInsertions),
+                header: 'Mutations, insertions, deletions',
             },
         );
 

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -20,6 +20,7 @@ export const metadata = z.object({
     customDisplay: customDisplay.optional(),
     truncateColumnDisplayTo: z.number().optional(),
     initiallyVisible: z.boolean().optional(),
+    header: z.string().optional(),
 });
 
 export const inputField = z.object({


### PR DESCRIPTION
preview URL: https://add-header-to-metadata.loculus.org/

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1615

Instead of having all metadata in one long list we would like to allow users to group metadata into subsections with optional subheading.

### Summary and Screenshot
Instead of modifying the structure of the metadata I add another optional `header:` field to the yaml file. The default value is `undefined` and in this case all metadata fields without a header will be grouped together in one table and shown at the start. Otherwise metadata with the same header will be grouped and shown together under that header, e.g.: 
![image](https://github.com/loculus-project/loculus/assets/50943381/4eb5d20d-ebd5-41be-8742-f4de7bc2641f)

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
