### PR TITLE
Use `quote` for adding (some) Helm values

### DIFF
--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -110,7 +110,7 @@ fields:
     {{- if .customDisplay }}
     customDisplay:
       type: {{ quote .customDisplay.type }}
-      url: {{ quote .customDisplay.url }}
+      url: {{ .customDisplay.url }}
     {{- end }}
 {{- end}}
 {{- end}}


### PR DESCRIPTION
I encountered an issue where entering a `bannerMessage` containing a `:` crashed the deployments! This was because this resulted in the bannerMessage being interepreted as a helm mapping. Using `quote` fixes this, and is a pattern we technically should be using everywhere. This does that in a number of places, though isn't at all exhaustive. `quote` treats a value really as a string only.