### PR TITLE
feat(backend): send restricted until date to LAPIS

### DIFF
--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
@@ -103,6 +103,7 @@ class GetReleasedDataEndpointTest(
                 "groupName" to TextNode(DEFAULT_GROUP_NAME),
                 "versionStatus" to TextNode("LATEST_VERSION"),
                 "dataUseTerms" to TextNode("OPEN"),
+                "dataUseTermsRestrictedUntil" to NullNode.getInstance(),
             )
 
             assertThat(

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -40,6 +40,9 @@ fields:
     initiallyVisible: true
     customDisplay:
       type: dataUseTerms
+  - name: dataUseTermsRestrictedUntil
+    type: date
+    displayName: Data use terms restricted until
   - name: versionStatus
     type: string
     notSearchable: true


### PR DESCRIPTION
preview URL: https://lapis-restricted-until.loculus.org

### Summary

This adds the "restricted until" date to LAPIS to enable #992.

### Screenshots

![image](https://github.com/loculus-project/loculus/assets/18666552/97b18fe9-9616-4dd4-9015-6f62f78aa8da)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
