### PR TITLE
Maybe fix dev test macOS

### DIFF
--- a/.github/workflows/node_dev.yml
+++ b/.github/workflows/node_dev.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install yaml package
-        run: pip install PyYAML requests
+        run: pip3 install PyYAML requests
 
       - name: Generate local test config
         run: ./generate_local_test_config.sh


### PR DESCRIPTION
The MacOS dev server test is currently failing. My theory is that this is because `pip` is (now) pointing to `pip2` and the script uses `python3`, if so this might fix.