### PR TITLE
wip: bulk edit data use terms

### DIFF
--- a/website/src/components/DataUseTerms/EditDataUseTermsButton.tsx
+++ b/website/src/components/DataUseTerms/EditDataUseTermsButton.tsx
@@ -15,14 +15,14 @@ import { datePickerTheme } from '../Submission/DateChangeModal';
 type EditDataUseTermsButtonProps = {
     accessToken: string;
     clientConfig: ClientConfig;
-    accessionVersion: string[];
+    accessions: string[];
     dataUseTerms: RestrictedDataUseTerms;
 };
 
 const InnerEditDataUseTermsButton: FC<EditDataUseTermsButtonProps> = ({
     accessToken,
     clientConfig,
-    accessionVersion,
+    accessions,
     dataUseTerms,
 }) => {
     const restrictedUntil = DateTime.fromISO(dataUseTerms.restrictedUntil);
@@ -79,7 +79,10 @@ const InnerEditDataUseTermsButton: FC<EditDataUseTermsButtonProps> = ({
                         </div>
                         {dataUseTermsType === restrictedDataUseTermsType && (
                             <>
-                                <div className='text-sm pl-8 text-gray-900 mb-4 py-2'>
+                                <div className='text-sm pl-8 text-gray-900'>
+                                    {accessions.length > 1 && (
+                                        <p>{accessions.length} restricted sequences will be modified.</p>
+                                    )}
                                     Currently restricted until <b>{restrictedUntil.toFormat('yyyy-MM-dd')}</b>.<br />
                                     New restriction will be set to <b>{newRestrictedDate.toFormat('yyyy-MM-dd')}</b>.
                                 </div>
@@ -106,7 +109,7 @@ const InnerEditDataUseTermsButton: FC<EditDataUseTermsButtonProps> = ({
                         onClick={() => {
                             closeDialog();
                             useSetDataUseTerms.mutate({
-                                accessions: accessionVersion,
+                                accessions,
                                 newDataUseTerms: {
                                     type: dataUseTermsType,
                                     restrictedUntil: newRestrictedDate.toFormat('yyyy-MM-dd'),

--- a/website/src/components/SequenceDetailsPage/SequencesDetailsPage.astro
+++ b/website/src/components/SequenceDetailsPage/SequencesDetailsPage.astro
@@ -97,7 +97,7 @@ const isMyGroup =
                 <EditDataUseTermsButton
                     clientConfig={clientConfig}
                     accessToken={accessToken}
-                    accessionVersion={[accessionVersion.split('.')[0]]}
+                    accessions={[accessionVersion.split('.')[0]]}
                     dataUseTerms={currentDataUseTerms}
                     client:load
                 />

--- a/website/src/pages/[organism]/submission/[groupId]/released.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/released.astro
@@ -1,14 +1,19 @@
 ---
+import { EditDataUseTermsButton } from '../../../../components/DataUseTerms/EditDataUseTermsButton';
 import { SearchForm } from '../../../../components/SearchPage/SearchForm';
 import { SearchPagination } from '../../../../components/SearchPage/SearchPagination';
 import { Table } from '../../../../components/SearchPage/Table';
 import SubmissionPageWrapper from '../../../../components/Submission/SubmissionPageWrapper.astro';
 import ErrorBox from '../../../../components/common/ErrorBox.astro';
 import { MY_SEQUENCES } from '../../../../routes/routes';
+import { LapisClient } from '../../../../services/lapisClient.ts';
 import { pageSize } from '../../../../settings';
+import { getAccessToken } from '../../../../utils/getAccessToken';
 import { processParametersAndFetchSearch } from '../../../../utils/processParametersAndFetchSearch';
+import { combineSearchFilters } from '../../../../utils/search';
 import { getGroupsAndCurrentGroup } from '../../../../utils/submissionPages';
 
+const accessToken = getAccessToken(Astro.locals.session);
 const groupsResult = await getGroupsAndCurrentGroup(Astro.params, Astro.locals.session);
 if (groupsResult.isErr()) {
     return new Response(undefined, { status: groupsResult.error.status });
@@ -27,6 +32,30 @@ const {
     clientConfig,
     orderBy,
 } = await processParametersAndFetchSearch(Astro, group.groupId);
+
+const lapisClient = LapisClient.createForOrganism(organism);
+const searchFilters = combineSearchFilters(metadataFilter, mutationFilter, accessionFilter);
+searchFilters.DataUseTerms = 'RESTRICTED';
+const detailsResult = await lapisClient.call('details', {
+    fields: ['accessionVersion', 'dataUseTermsRestrictedUntil'],
+    ...searchFilters,
+});
+let restrictedAccessions: string[] = [];
+let earliestRestrictionDate: string = '9999-01-01';
+detailsResult.match(
+    (sequenceData) => {
+        restrictedAccessions = sequenceData.data.map((seq) => {
+            if (seq.dataUseTermsRestrictedUntil < earliestRestrictionDate) {
+                earliestRestrictionDate = seq.dataUseTermsRestrictedUntil;
+            }
+            return String(seq.accessionVersion).split('.')[0];
+        });
+    },
+    () => {
+        /* access only occurs if data is valid */
+    },
+);
+
 ---
 
 <SubmissionPageWrapper title='Released sequences' groupsResult={groupsResult}>
@@ -48,9 +77,25 @@ const {
             data.match(
                 (data) => (
                     <div class='flex-1'>
-                        <div class='mt-4 mb-1 text-sm text-gray-500'>
-                            Search returned {data.totalCount.toLocaleString()}
-                            sequence{data.totalCount === 1 ? '' : 's'}
+                        <div class='text-sm text-gray-800 mb-6 justify-between flex px-6 items-baseline'>
+                            <div class='mt-auto'>
+                                Search returned {data.totalCount.toLocaleString()}
+                                sequence{data.totalCount === 1 ? '' : 's'}
+                            </div>
+                            {restrictedAccessions.length > 0 && (
+                                <div>
+                                    <EditDataUseTermsButton
+                                        accessToken={accessToken!}
+                                        clientConfig={clientConfig}
+                                        accessions={restrictedAccessions}
+                                        dataUseTerms={{
+                                            type: 'RESTRICTED',
+                                            restrictedUntil: earliestRestrictionDate,
+                                        }}
+                                        client:load
+                                    />
+                                </div>
+                            )}
                         </div>
                         <Table
                             organism={organism}

--- a/website/src/utils/search.ts
+++ b/website/src/utils/search.ts
@@ -19,15 +19,11 @@ export function addHiddenFilters(searchFormFilter: MetadataFilter[], hiddenFilte
     return [...searchFormFilter, ...hiddenFiltersToAdd];
 }
 
-export const getData = async (
-    organism: string,
+export function combineSearchFilters(
     metadataFilter: MetadataFilter[],
-    accessionFilter: AccessionFilter,
     mutationFilter: MutationFilter,
-    offset: number,
-    limit: number,
-    orderBy?: OrderBy,
-): Promise<Result<SearchResponse, ProblemDetail>> => {
+    accessionFilter: AccessionFilter,
+) {
     const metadataSearchFilters = metadataFilter
         .filter((metadata) => metadata.filterValue !== '')
         .reduce((acc: Record<string, string>, metadata) => {
@@ -44,6 +40,19 @@ export const getData = async (
     if (accessionFilter.accession !== undefined && accessionFilter.accession.length > 0) {
         searchFilters.accession = accessionFilter.accession;
     }
+    return searchFilters;
+}
+
+export const getData = async (
+    organism: string,
+    metadataFilter: MetadataFilter[],
+    accessionFilter: AccessionFilter,
+    mutationFilter: MutationFilter,
+    offset: number,
+    limit: number,
+    orderBy?: OrderBy,
+): Promise<Result<SearchResponse, ProblemDetail>> => {
+    const searchFilters = combineSearchFilters(metadataFilter, mutationFilter, accessionFilter);
 
     const config = getSchema(organism);
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #992

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: http://bulk-edit-data-use-terms.loculus.org/

### Summary
Implements a button/pop-up to modify the data use terms of sequences returned by the search on `/[organism]/submission/[group-id]/released`.

![Screenshot 2024-04-25 at 17 43 13](https://github.com/loculus-project/loculus/assets/158496618/3fad5086-2a81-4862-a623-e246be89682a)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
