### PR TITLE
feat(website): Update Lapis client endpoints

### DIFF
--- a/website/src/components/SequenceDetailsPage/getTableData.spec.ts
+++ b/website/src/components/SequenceDetailsPage/getTableData.spec.ts
@@ -218,7 +218,7 @@ const nucleotideMutations: MutationProportionCount[] = [
         mutationFrom: 'T',
         mutationTo: 'A',
         position: 10,
-        sequenceName: undefined,
+        sequenceName: null,
     },
     {
         count: 0,
@@ -227,7 +227,7 @@ const nucleotideMutations: MutationProportionCount[] = [
         mutationFrom: 'A',
         mutationTo: '-',
         position: 20,
-        sequenceName: undefined,
+        sequenceName: null,
     },
     {
         count: 0,
@@ -236,7 +236,7 @@ const nucleotideMutations: MutationProportionCount[] = [
         mutationFrom: 'A',
         mutationTo: '-',
         position: 21,
-        sequenceName: undefined,
+        sequenceName: null,
     },
     {
         count: 0,
@@ -245,7 +245,7 @@ const nucleotideMutations: MutationProportionCount[] = [
         mutationFrom: 'C',
         mutationTo: 'G',
         position: 30,
-        sequenceName: undefined,
+        sequenceName: null,
     },
     {
         count: 0,
@@ -254,7 +254,7 @@ const nucleotideMutations: MutationProportionCount[] = [
         mutationFrom: 'G',
         mutationTo: '-',
         position: 40,
-        sequenceName: undefined,
+        sequenceName: null,
     },
     {
         count: 0,
@@ -263,7 +263,7 @@ const nucleotideMutations: MutationProportionCount[] = [
         mutationFrom: 'C',
         mutationTo: '-',
         position: 41,
-        sequenceName: undefined,
+        sequenceName: null,
     },
     {
         count: 0,
@@ -272,7 +272,7 @@ const nucleotideMutations: MutationProportionCount[] = [
         mutationFrom: 'T',
         mutationTo: '-',
         position: 42,
-        sequenceName: undefined,
+        sequenceName: null,
     },
     {
         count: 0,
@@ -281,7 +281,7 @@ const nucleotideMutations: MutationProportionCount[] = [
         mutationFrom: 'T',
         mutationTo: '-',
         position: 39,
-        sequenceName: undefined,
+        sequenceName: null,
     },
     {
         count: 0,
@@ -290,7 +290,7 @@ const nucleotideMutations: MutationProportionCount[] = [
         mutationFrom: 'T',
         mutationTo: '-',
         position: 43,
-        sequenceName: undefined,
+        sequenceName: null,
     },
     {
         count: 0,
@@ -299,7 +299,7 @@ const nucleotideMutations: MutationProportionCount[] = [
         mutationFrom: 'T',
         mutationTo: '-',
         position: 44,
-        sequenceName: undefined,
+        sequenceName: null,
     },
     {
         count: 0,
@@ -308,7 +308,7 @@ const nucleotideMutations: MutationProportionCount[] = [
         mutationFrom: 'T',
         mutationTo: '-',
         position: 45,
-        sequenceName: undefined,
+        sequenceName: null,
     },
     {
         count: 0,
@@ -317,7 +317,7 @@ const nucleotideMutations: MutationProportionCount[] = [
         mutationFrom: 'T',
         mutationTo: '-',
         position: 400,
-        sequenceName: undefined,
+        sequenceName: null,
     },
 ];
 const aminoAcidMutations: MutationProportionCount[] = [

--- a/website/src/components/SequenceDetailsPage/getTableData.ts
+++ b/website/src/components/SequenceDetailsPage/getTableData.ts
@@ -183,11 +183,11 @@ function substitutionsToCommaSeparatedString(mutationData: MutationProportionCou
 }
 
 function deletionsToCommaSeparatedString(mutationData: MutationProportionCount[]) {
-    const segmentPositions = new Map<string | undefined, number[]>();
+    const segmentPositions = new Map<string | null, number[]>();
     mutationData
         .filter((m) => m.mutationTo === '-')
         .forEach((m) => {
-            const segment: string | undefined = m.sequenceName;
+            const segment: string | null = m.sequenceName;
             const position = m.position;
             if (!segmentPositions.has(segment)) {
                 segmentPositions.set(segment, []);
@@ -228,7 +228,7 @@ function deletionsToCommaSeparatedString(mutationData: MutationProportionCount[]
         }
     });
     return segmentRanges
-        .map(({ segment, ranges }) => ranges.map((range) => `${segment !== undefined ? segment + ':' : ''}${range}`))
+        .map(({ segment, ranges }) => ranges.map((range) => `${segment !== null ? segment + ':' : ''}${range}`))
         .flat()
         .join(', ');
 }

--- a/website/src/types/lapis.ts
+++ b/website/src/types/lapis.ts
@@ -28,10 +28,7 @@ const mutationProportionCount = z.object({
     mutation: z.string(),
     proportion: z.number(),
     count: z.number(),
-    sequenceName: z
-        .string()
-        .nullable()
-        .transform((value) => value ?? undefined),
+    sequenceName: z.string().nullable(),
     mutationFrom: z.string(),
     mutationTo: z.string(),
     position: z.number(),


### PR DESCRIPTION
required step to resolve #1620

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
- This should have no impact on functionality or layout.
- It changes the lapis client to expect processed mutation data from lapis (lapis was modified to return processed data in https://github.com/GenSpectrum/LAPIS/pull/723). This is good for us as it means that the frontend will no longer have to process a large mutation string to display mutations but can use the processed data from lapis.
- The `mutationProportionCount` type is also modified to take further fields which correspond to the output returned by lapis (see function in lapis2/src/main/kotlin/org/genspectrum/lapis/response/LapisResponse.kt): 
```
data class NucleotideMutationResponse(
    val mutation: String,
    val count: Int,
    val proportion: Double,
    val sequenceName: String?,
    val mutationFrom: String,
    val mutationTo: String,
    val position: Int)
``` 

This PR is a requirement for displaying mutations as badges (see #1620 and https://github.com/loculus-project/loculus/pull/1655), as the PR keeps failing e2e tests I want to split up the changes in a more incremental manner.


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] ~All necessary documentation has been adapted.~ Edited code is not covered by documentation. 
- [x] The implemented feature is covered by an appropriate test.
