### PR TITLE
Fix e2e test failures when reading fasta file. 

### DIFF
--- a/website/tests/pages/sequences/accession.fa.spec.ts
+++ b/website/tests/pages/sequences/accession.fa.spec.ts
@@ -10,7 +10,7 @@ test.describe('The sequence.fa page', () => {
         const url = `${baseUrl}${routes.sequencesFastaPage(testSequences.testSequenceEntry)}`;
         const response = await fetch(url);
         const content = await response.text();
-        expect(content.replace(/\n+/g, '\n')).toBe(
+        expect(content.replace(/\n\n+/g, '\n')).toBe(
             `>${getAccessionVersionString(testSequences.testSequenceEntry)}\n${testSequenceEntryData.unaligned}\n`,
         );
     });


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1663

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

Since https://github.com/GenSpectrum/LAPIS/pull/745 LAPIS appends an additional `\n` to the fasta output. Modify the e2e tests to also expect this. 

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->
