### PR TITLE
feat(website): enable superusers to edit groups

### DIFF
--- a/website/src/components/SequenceDetailsPage/SequencesDetailsPage.astro
+++ b/website/src/components/SequenceDetailsPage/SequencesDetailsPage.astro
@@ -5,8 +5,8 @@ import { SequencesContainer } from './SequencesContainer';
 import { type TableDataEntry } from './getTableData';
 import { getReferenceGenomes, getRuntimeConfig } from '../../config';
 import { routes } from '../../routes/routes.ts';
-import { GroupManagementClient } from '../../services/groupManagementClient';
 import { type DataUseTermsHistoryEntry } from '../../types/backend';
+import { checkIsMyGroup } from '../../utils/checkIsMyGroup';
 import { getAccessToken } from '../../utils/getAccessToken';
 import { EditDataUseTermsButton } from '../DataUseTerms/EditDataUseTermsButton';
 import ErrorBox from '../common/ErrorBox.astro';
@@ -44,12 +44,7 @@ const clientConfig = getRuntimeConfig().public;
 const session = Astro.locals.session;
 const accessToken = getAccessToken(session);
 
-const isMyGroup =
-    accessToken !== undefined &&
-    (await GroupManagementClient.create().getGroupsOfUser(accessToken)).match(
-        (groups) => groups.some((myGroupItem) => myGroupItem.groupId === groupId),
-        () => false,
-    );
+const isMyGroup = accessToken !== undefined && (await checkIsMyGroup(accessToken, groupId));
 ---
 
 {

--- a/website/src/components/User/GroupPage.tsx
+++ b/website/src/components/User/GroupPage.tsx
@@ -7,7 +7,6 @@ import { type ClientConfig } from '../../types/runtimeConfig.ts';
 import { ConfirmationDialog } from '../DeprecatedConfirmationDialog.tsx';
 import { ErrorFeedback } from '../ErrorFeedback.tsx';
 import { withQueryProvider } from '../common/withQueryProvider.tsx';
-import DeleteIcon from '~icons/ci/user-remove';
 import DashiconsGroups from '~icons/dashicons/groups';
 import DashiconsPlus from '~icons/dashicons/plus';
 import IwwaArrowDown from '~icons/iwwa/arrow-down';
@@ -66,6 +65,7 @@ const InnerGroupPage: FC<GroupPageProps> = ({
     };
 
     const userIsGroupMember = groupDetails.data?.users.some((user) => user.name === username) ?? false;
+    const userHasEditPrivileges = userGroups.some((group) => group.groupId === prefetchedGroupDetails.group.groupId);
 
     return (
         <div className='flex flex-col h-full p-4'>
@@ -84,7 +84,7 @@ const InnerGroupPage: FC<GroupPageProps> = ({
                 <ErrorFeedback message={errorMessage} onClose={() => setErrorMessage(undefined)} />
             )}
 
-            {userIsGroupMember ? (
+            {userHasEditPrivileges ? (
                 <div className='flex items-center'>
                     <h1 className='flex flex-row gap-4 title flex-grow'>
                         <label className='py-1 block title'>Group:</label>
@@ -119,12 +119,14 @@ const InnerGroupPage: FC<GroupPageProps> = ({
                             </ul>
                         </div>
                     </h1>
-                    <button
-                        onClick={() => handleOpenConfirmationDialog(username)}
-                        className='object-right p-2 loculusColor text-white rounded px-4'
-                    >
-                        Leave group
-                    </button>
+                    {userIsGroupMember && (
+                        <button
+                            onClick={() => handleOpenConfirmationDialog(username)}
+                            className='object-right p-2 loculusColor text-white rounded px-4'
+                        >
+                            Leave group
+                        </button>
+                    )}
                 </div>
             ) : (
                 <h1 className='flex flex-row gap-4 title flex-grow'>
@@ -159,7 +161,7 @@ const InnerGroupPage: FC<GroupPageProps> = ({
                 </table>
             </div>
 
-            {userIsGroupMember && (
+            {userHasEditPrivileges && (
                 <>
                     <h2 className='text-lg font-bold py-4'> Users </h2>
                     <form onSubmit={handleAddUser}>
@@ -188,7 +190,7 @@ const InnerGroupPage: FC<GroupPageProps> = ({
                                         title='Remove user from group'
                                         aria-label={`Remove User ${user.name}`}
                                     >
-                                        <DeleteIcon className='w-4 h-4' />
+                                        Remove user
                                     </button>
                                 </li>
                             ))}

--- a/website/src/utils/checkIsMyGroup.ts
+++ b/website/src/utils/checkIsMyGroup.ts
@@ -1,0 +1,8 @@
+import { GroupManagementClient } from '../services/groupManagementClient.ts';
+
+export const checkIsMyGroup = async (accessToken: string, groupId: number): Promise<boolean> => {
+    return (await GroupManagementClient.create().getGroupsOfUser(accessToken)).match(
+        (groups) => groups.some((myGroupItem) => myGroupItem.groupId === groupId),
+        () => false,
+    );
+};


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1497 
preview URL: https://1497-superuser.loculus.org

### Summary

This enables superusers to add and remove users from groups. As far as I can see, that is the only missing feature w.r.t. superusers.

I also changed the button to remove a user from a group. It now just contains the text and not an icon (which I find not very clear).

### screenshots

![image](https://github.com/loculus-project/loculus/assets/18666552/717265c3-1046-46db-85fd-3d4a1648fff1)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
