### PR TITLE
fix(website): Align tables in sequence details page

### DIFF
--- a/website/src/components/SequenceDetailsPage/DataTable.astro
+++ b/website/src/components/SequenceDetailsPage/DataTable.astro
@@ -18,13 +18,11 @@ const headerMap = toHeaderMap(tableData);
             Object.entries(headerMap).map(([header, names]) => (
                 <div class='pb-8'>
                     {header !== '' && <h1 class='py-2 font-medium text-primary-600'>{header}</h1>}
-                    <table class='min-w-full'>
+                    <table class='table-auto'>
                         <tbody class='bg-white'>
                             {names.map(({ label, value, customDisplay }) => (
                                 <tr>
-                                    <td class='py-1 whitespace-nowrap text-sm font-medium text-gray-900 text-right w-32'>
-                                        {label}
-                                    </td>
+                                    <td class='py-1 w-44 text-sm font-medium text-gray-900 text-right'>{label}</td>
                                     <td class='px-4 py-1 whitespace-normal text-sm text-gray-600'>
                                         <div class='flex items-center gap-3'>
                                             {customDisplay === undefined && value}


### PR DESCRIPTION
Align the first row of each table by defining the width of the first column.

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://fix-table-format.loculus.org

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->
Currently we define a new table under each subsection, the table adjust it's size based on the width of the contents in the first column. However, this means that each table has different shape - this doesn't look clean: 
![image](https://github.com/loculus-project/loculus/assets/50943381/53de794b-63cd-4727-a6bc-81d867412d2e)
Fixing the width of the first column should resolve this issue. 
![image](https://github.com/loculus-project/loculus/assets/50943381/3177235f-d916-46fd-9600-81355dc1b151)
