### PR TITLE
feat(auth): an obvious button to register with ORCid

### DIFF
--- a/keycloak/keycloakify/src/login/pages/RegisterUserProfile.tsx
+++ b/keycloak/keycloakify/src/login/pages/RegisterUserProfile.tsx
@@ -51,11 +51,9 @@ export default function RegisterUserProfile(props: PageProps<Extract<KcContext, 
                         </ul>
                     </div>
                 )}
-                {
-                    // add horizontal line with "or fill in the form below" text
-                }
+             
                 <hr />
-                <p>or fill in the form below</p>
+                <p className="text-center">..or fill in the form below</p>
 
                 <UserProfileFormFields
                     kcContext={kcContext}


### PR DESCRIPTION
Resolves #1246


<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://register-orcid.loculus.org/

### Summary
Adds an obvious button to register with ORCID on the register page. (Won't work all the way through on preview due to endpoint issue). Styling could be better but this is a good start.

### Screenshot
<img width="566" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/59dcca62-9565-4942-b7b2-0cc46fee5b3a">


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
