### PR TITLE
fix(website): improve styling of hints for upload form

### DIFF
--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -321,7 +321,7 @@ const InnerDataUploadForm = ({
                                 </span>
                             )}
                             You can download{' '}
-                            <a href={routes.metadataTemplate(organism)} className='text-primary-700  opacity-80'>
+                            <a href={routes.metadataTemplate(organism)} className='text-primary-700  opacity-90'>
                                 a template
                             </a>{' '}
                             for the TSV metadata file with column headings.
@@ -334,7 +334,7 @@ const InnerDataUploadForm = ({
                         <p className='text-gray-400 text-xs mt-3'>
                             For more information on the format in which data should be uploaded and the required
                             metadata, please refer to our{' '}
-                            <a href='#TODO-MVP' className='text-primary-700 opacity-80'>
+                            <a href='#TODO-MVP' className='text-primary-700 opacity-90'>
                                 help pages
                             </a>
                             .


### PR DESCRIPTION
Makes the links a bit less invisible:

<img width="362" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/8a5b17fc-a721-47e5-a971-173b6ab46868">

https://improve-styling-of-hints.loculus.org/
