### PR TITLE
fix(ci): Login to dockerhub to fix rate limits on aws

### DIFF
--- a/.github/workflows/e2e-k3d.yml
+++ b/.github/workflows/e2e-k3d.yml
@@ -33,6 +33,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN_READ_PUBLIC }}
+
+      # Requests docker.io image, hence login above to avoid rate limiting
       - name: Install k3d
         run: |
           curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash


### PR DESCRIPTION
K3d pulls from docker.io, AWS IPs sporadically exceed rate limits.
See: https://loculus.slack.com/archives/C05G172HL6L/p1714385193804139

Alternative to #1689 

Login worked, we now have 200 E2E runs per 6 hours - don't think we'll exceed that!