### PR TITLE
chore(ci): login to dockerhub for backend

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -20,6 +20,11 @@ jobs:
     runs-on: codebuild-loculus-ci-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 15
     steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN_READ_PUBLIC }}
       - uses: actions/checkout@v4
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/e2e-k3d.yml
+++ b/.github/workflows/e2e-k3d.yml
@@ -33,13 +33,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN_READ_PUBLIC }}
-
-      # Requests docker.io image, hence login above to avoid rate limiting
       - name: Install k3d
         run: |
           curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash


### PR DESCRIPTION
Annoying docker rate limit, also hit for backend tests, I've now subscribed to Pro ($7) - gives us 5k pulls per day.