### PR TITLE
feat(website): make recent sequences banner green

### DIFF
--- a/website/src/components/SearchPage/RecentSequencesBanner.tsx
+++ b/website/src/components/SearchPage/RecentSequencesBanner.tsx
@@ -28,8 +28,8 @@ export const RecentSequencesBanner: React.FC = () => {
     }
     return (
         <div className='bg-green-100 text-center p-4 text-green-800  rounded border-green-600 border mb-4 opacity-70'>
-            You recently approved new sequences for release. Sequences take time to load into the database and so it may be several
-            minutes before they appear here.
+            You recently approved new sequences for release. Sequences take time to load into the database and so it may
+            be several minutes before they appear here.
         </div>
     );
 };


### PR DESCRIPTION
To show that nothing is wrong

<img width="1036" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/60c1db71-3994-400e-b9b7-a9fe5e3e0535">