### PR TITLE
chore(cI): allow PR autoformatting with a label

### DIFF
--- a/website/src/components/common/Banner.tsx
+++ b/website/src/components/common/Banner.tsx
@@ -5,7 +5,7 @@ interface BannerProps {
 }
 
 export const Banner: React.FC<BannerProps> = ({ message }) => {
-    if (message ===       undefined) {
+    if (message === undefined) {
         return null;
     }
 


### PR DESCRIPTION
Expands our autoformatting workflow (previously just a workflow dispatch) so you can add the `format_me` label to a PR to have it autoformatted. Later we can get the formatting commits to use a PAT, and then they will trigger CI, which they don't atm.