### PR TITLE
fix(auth): Prevent root path for KC ingress

### DIFF
--- a/kubernetes/loculus/templates/ingressroute.yaml
+++ b/kubernetes/loculus/templates/ingressroute.yaml
@@ -52,7 +52,7 @@ spec:
     - host: "{{ $keycloakHost }}"
       http:
         paths:
-          - path: /
+          - path: /{+}
             pathType: Prefix
             backend:
               service:


### PR DESCRIPTION
Resolves #975

Prevents accessing the keycloak "welcome" page, which would gives a the appearance of security concerns and unprofessionalism

Preview: https://authentication-prevent-route-for-kc-ingr.loculus.org/ (404 is the desired behaviour!)