### PR TITLE
feat(website): show authors at the top on sequence details page

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
@@ -54,6 +54,9 @@ enum class MetadataType {
     @JsonProperty("boolean")
     BOOLEAN,
 
+    @JsonProperty("authors")
+    AUTHORS,
+
     ;
 
     override fun toString(): String = lowerCase(name)

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequenceEntryValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequenceEntryValidator.kt
@@ -166,7 +166,7 @@ class ProcessedSequenceEntryValidator(
         }
 
         val isOfCorrectPrimitiveType = when (metadata.type) {
-            MetadataType.STRING -> fieldValue.isTextual
+            MetadataType.STRING, MetadataType.AUTHORS -> fieldValue.isTextual
             MetadataType.INTEGER -> fieldValue.isInt
             MetadataType.FLOAT -> fieldValue.isFloatingPointNumber
             MetadataType.NUMBER -> fieldValue.isNumber

--- a/kubernetes/loculus/templates/lapis-silo-database-config.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-database-config.yaml
@@ -16,7 +16,7 @@ data:
       metadata:
       {{- range (concat $commonMetadata .metadata) }}
         - name: {{ .name }}
-          type: {{ (.type | eq "timestamp") | ternary "int" .type }}
+          type: {{ (.type | eq "timestamp") | ternary "int" ((.type | eq "authors") | ternary "string" .type) }}
           {{- if .generateIndex }}
           generateIndex: {{ .generateIndex }}
           {{- end }}

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -287,7 +287,7 @@ defaultOrganisms:
           header: Authors
         - name: authors
           displayName: Authors
-          type: string
+          type: authors
           header: Authors
         - name: submitter_country
           displayName: Submitter country

--- a/website/src/components/SequenceDetailsPage/AuthorList.tsx
+++ b/website/src/components/SequenceDetailsPage/AuthorList.tsx
@@ -1,0 +1,63 @@
+import { type FC, useMemo, useState } from 'react';
+
+type AuthorsListProps = {
+    authors: string[];
+};
+
+const DEFAULT_AT_LEAST_VISIBLE = 25;
+const NUMBER_VISIBLE_LAST_AUTHORS = 1;
+
+export const AuthorList: FC<AuthorsListProps> = ({ authors }) => {
+    const [showMore, setShowMore] = useState(false);
+    const data = useMemo(() => {
+        if (authors.length <= DEFAULT_AT_LEAST_VISIBLE + 3) {
+            return {
+                showMoreNeeded: false,
+            } as const;
+        }
+        return {
+            showMoreNeeded: true,
+            beforeEllipsis: authors.slice(0, DEFAULT_AT_LEAST_VISIBLE - NUMBER_VISIBLE_LAST_AUTHORS),
+            afterEllipsis: authors.slice(authors.length - NUMBER_VISIBLE_LAST_AUTHORS, authors.length),
+        } as const;
+    }, [authors]);
+
+    let authorsElements;
+    if (!data.showMoreNeeded || showMore) {
+        authorsElements = authors.map((author, index) => (
+            <span key={index}>
+                {author}
+                {index !== authors.length - 1 ? ', ' : ''}
+            </span>
+        ));
+    } else {
+        authorsElements = (
+            <>
+                {data.beforeEllipsis.map((author, index) => (
+                    <span key={index}>
+                        {author}
+                        {', '}
+                    </span>
+                ))}
+                <span>..., </span>
+                {data.afterEllipsis.map((author, index) => (
+                    <span key={index}>
+                        {author}
+                        {index !== data.afterEllipsis.length - 1 ? ', ' : ''}
+                    </span>
+                ))}
+            </>
+        );
+    }
+
+    return (
+        <div>
+            {authorsElements}
+            {data.showMoreNeeded && (
+                <button onClick={() => setShowMore(!showMore)} className='ml-2 underline'>
+                    {showMore ? 'Show less' : 'Show more'}
+                </button>
+            )}
+        </div>
+    );
+};

--- a/website/src/components/SequenceDetailsPage/DataTable.astro
+++ b/website/src/components/SequenceDetailsPage/DataTable.astro
@@ -1,7 +1,9 @@
 ---
+import { AuthorList } from './AuthorList';
 import { DataUseTermsHistoryModal } from './DataUseTermsHistoryModal';
 import { SubstitutionsContainer } from './MutationBadge';
-import { toHeaderMap, type TableDataEntry } from './getTableData';
+import { getDataTableData } from './getDataTableData';
+import { type TableDataEntry } from './getTableData';
 import { type DataUseTermsHistoryEntry } from '../../types/backend';
 
 interface Props {
@@ -10,18 +12,25 @@ interface Props {
 }
 
 const { tableData, dataUseTermsHistory } = Astro.props;
-const headerMap = toHeaderMap(tableData);
+const data = getDataTableData(tableData);
 ---
 
-<div class='mt-2'>
+<div>
+    {
+        data.topmatter.authors !== undefined && data.topmatter.authors.length > 0 && (
+            <div class='px-6 mb-4'>
+                <AuthorList authors={data.topmatter.authors} client:load />
+            </div>
+        )
+    }
     <div>
         {
-            Object.entries(headerMap).map(([header, names]) => (
+            data.table.map(({ header, rows }) => (
                 <div class='pb-8'>
                     {header !== '' && <h1 class='py-2 font-medium text-primary-600'>{header}</h1>}
                     <table class='table-auto'>
                         <tbody class='bg-white'>
-                            {names.map(({ label, value, customDisplay }) => (
+                            {rows.map(({ label, value, customDisplay }) => (
                                 <tr>
                                     <td class='py-1 w-44 text-sm font-medium text-gray-900 text-right'>{label}</td>
                                     <td class='px-4 py-1 text-sm text-gray-600'>

--- a/website/src/components/SequenceDetailsPage/getDataTableData.spec.ts
+++ b/website/src/components/SequenceDetailsPage/getDataTableData.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'vitest';
+
+import { getDataTableData } from './getDataTableData.ts';
+import { type TableDataEntry } from './getTableData.ts';
+
+describe('getDataTableData', () => {
+    test('should group entries according to header', () => {
+        const data = getDataTableData(testTableDataEntries);
+        expect(data.table.length).toStrictEqual(2);
+        expect(data.table[0].header).toStrictEqual('Header 1');
+        expect(data.table[0].rows.map((r) => r.name)).toStrictEqual(['metadata_field_1', 'metadata_field_2']);
+        expect(data.table[1].header).toStrictEqual('Header 2');
+        expect(data.table[1].rows.map((r) => r.name)).toStrictEqual(['metadata_field_3']);
+    });
+
+    test('should move authors to topmatter', () => {
+        const data = getDataTableData(testTableDataEntries);
+        expect(data.topmatter.authors).toStrictEqual(['author 1', 'author 2', 'author 3']);
+        expect(
+            data.table
+                .flatMap((x) => x.rows)
+                .find((x) => x.type.kind === 'metadata' && x.type.metadataType === 'authors'),
+        ).toBeUndefined();
+    });
+});
+
+const testTableDataEntries: TableDataEntry[] = [
+    {
+        label: 'Metadata Field 1',
+        name: 'metadata_field_1',
+        value: 'value1',
+        header: 'Header 1',
+        type: { kind: 'metadata', metadataType: 'string' },
+    },
+    {
+        label: 'Metadata Field 2',
+        name: 'metadata_field_2',
+        value: 'value2',
+        header: 'Header 1',
+        type: { kind: 'metadata', metadataType: 'timestamp' },
+    },
+    {
+        label: 'Metadata Field 3',
+        name: 'metadata_field_3',
+        value: 'value3',
+        header: 'Header 2',
+        type: { kind: 'metadata', metadataType: 'int' },
+    },
+    {
+        label: 'Authors',
+        name: 'authors',
+        value: 'author 1, author 2, author 3',
+        header: 'Header 2',
+        type: { kind: 'metadata', metadataType: 'authors' },
+    },
+];

--- a/website/src/components/SequenceDetailsPage/getDataTableData.ts
+++ b/website/src/components/SequenceDetailsPage/getDataTableData.ts
@@ -1,0 +1,46 @@
+import type { TableDataEntry } from './getTableData.ts';
+
+type DataTableData = {
+    topmatter: {
+        authors: string[] | undefined;
+    };
+    table: {
+        header: string;
+        rows: TableDataEntry[];
+    }[];
+};
+
+export function getDataTableData(listTableDataEntries: TableDataEntry[]): DataTableData {
+    const result: DataTableData = {
+        topmatter: {
+            authors: undefined,
+        },
+        table: [],
+    };
+
+    const tableHeaderMap = new Map<string, TableDataEntry[]>();
+    for (const entry of listTableDataEntries) {
+        // Move the first entry with type authors to the topmatter
+        if (
+            result.topmatter.authors === undefined &&
+            entry.type.kind === 'metadata' &&
+            entry.type.metadataType === 'authors'
+        ) {
+            result.topmatter.authors = entry.value
+                .toString()
+                .split(',')
+                .map((x) => x.trim());
+            break;
+        }
+
+        if (!tableHeaderMap.has(entry.header)) {
+            tableHeaderMap.set(entry.header, []);
+        }
+        tableHeaderMap.get(entry.header)!.push(entry);
+    }
+    for (const [header, rows] of tableHeaderMap.entries()) {
+        result.table.push({ header, rows });
+    }
+
+    return result;
+}

--- a/website/src/components/SequenceDetailsPage/getTableData.spec.ts
+++ b/website/src/components/SequenceDetailsPage/getTableData.spec.ts
@@ -1,7 +1,7 @@
 import { err, ok } from 'neverthrow';
 import { beforeEach, describe, expect, test } from 'vitest';
 
-import { type TableDataEntry, getTableData, toHeaderMap } from './getTableData.ts';
+import { type TableDataEntry, getTableData } from './getTableData.ts';
 import { mockRequest, testConfig } from '../../../vitest.setup.ts';
 import { LapisClient } from '../../services/lapisClient.ts';
 import type { Schema } from '../../types/config.ts';
@@ -78,6 +78,7 @@ describe('getTableData', () => {
                 value: 'N/A',
                 customDisplay: undefined,
                 header: 'testHeader1',
+                type: { kind: 'metadata', metadataType: 'string' },
             },
             {
                 label: 'Metadata field2',
@@ -85,6 +86,7 @@ describe('getTableData', () => {
                 value: 'N/A',
                 customDisplay: undefined,
                 header: '',
+                type: { kind: 'metadata', metadataType: 'string' },
             },
             {
                 label: 'Timestamp field',
@@ -92,23 +94,11 @@ describe('getTableData', () => {
                 value: 'N/A',
                 customDisplay: undefined,
                 header: '',
+                type: { kind: 'metadata', metadataType: 'timestamp' },
             },
         ];
 
         expect(result).toStrictEqual(ok(defaultList.concat(defaultMutationsInsertionsDeletionsList)));
-    });
-
-    test('toHeaderMap should return default values when there is no data', async () => {
-        const result = await getTableData(accessionVersion, schema, lapisClient);
-
-        const data = result._unsafeUnwrap();
-        const defaultHeaderMap = toHeaderMap(data);
-
-        expect(defaultHeaderMap['Mutations, insertions, deletions']).toStrictEqual(
-            defaultMutationsInsertionsDeletionsList,
-        );
-        expect(defaultHeaderMap['']).toStrictEqual(defaultNoHeaderList);
-        expect(defaultHeaderMap.testHeader1).toStrictEqual(defaultHeader1List);
     });
 
     test('should return details field values', async () => {
@@ -132,12 +122,14 @@ describe('getTableData', () => {
             name: 'metadataField1',
             value: value1,
             header: 'testHeader1',
+            type: { kind: 'metadata', metadataType: 'string' },
         });
         expect(data).toContainEqual({
             label: 'Metadata field2',
             name: 'metadataField2',
             value: value2,
             header: '',
+            type: { kind: 'metadata', metadataType: 'string' },
         });
     });
 
@@ -176,12 +168,14 @@ describe('getTableData', () => {
                     },
                 ],
             },
+            type: { kind: 'mutation' },
         });
         expect(data).toContainEqual({
             label: 'Nucleotide deletions',
             name: 'nucleotideDeletions',
             value: '20, 21, 39-45, 400',
             header: 'Mutations, insertions, deletions',
+            type: { kind: 'mutation' },
         });
         expect(data).toContainEqual({
             label: 'Amino acid substitutions',
@@ -211,12 +205,14 @@ describe('getTableData', () => {
                     },
                 ],
             },
+            type: { kind: 'mutation' },
         });
         expect(data).toContainEqual({
             label: 'Amino acid deletions',
             name: 'aminoAcidDeletions',
             value: 'gene1:20-23, gene1:40',
             header: 'Mutations, insertions, deletions',
+            type: { kind: 'mutation' },
         });
     });
 
@@ -232,12 +228,14 @@ describe('getTableData', () => {
             name: 'nucleotideInsertions',
             value: 'nucleotideInsertion1, nucleotideInsertion2',
             header: 'Mutations, insertions, deletions',
+            type: { kind: 'mutation' },
         });
         expect(data).toContainEqual({
             label: 'Amino acid insertions',
             name: 'aminoAcidInsertions',
             value: 'aminoAcidInsertion1, aminoAcidInsertion2',
             header: 'Mutations, insertions, deletions',
+            type: { kind: 'mutation' },
         });
     });
 
@@ -252,6 +250,7 @@ describe('getTableData', () => {
             name: 'timestampField',
             value: '2024-01-25 14:59:21 UTC',
             header: '',
+            type: { kind: 'metadata', metadataType: 'timestamp' },
         });
     });
 });
@@ -441,33 +440,6 @@ const aminoAcidInsertions = [
     { count: 0, insertion: 'aminoAcidInsertion2' },
 ];
 
-const defaultNoHeaderList: TableDataEntry[] = [
-    {
-        label: 'Metadata field2',
-        name: 'metadataField2',
-        value: 'N/A',
-        customDisplay: undefined,
-        header: '',
-    },
-    {
-        label: 'Timestamp field',
-        name: 'timestampField',
-        value: 'N/A',
-        customDisplay: undefined,
-        header: '',
-    },
-];
-
-const defaultHeader1List: TableDataEntry[] = [
-    {
-        label: 'Metadata field1',
-        name: 'metadataField1',
-        value: 'N/A',
-        customDisplay: undefined,
-        header: 'testHeader1',
-    },
-];
-
 const defaultMutationsInsertionsDeletionsList: TableDataEntry[] = [
     {
         label: 'Nucleotide substitutions',
@@ -478,18 +450,21 @@ const defaultMutationsInsertionsDeletionsList: TableDataEntry[] = [
             type: 'badge',
             value: [],
         },
+        type: { kind: 'mutation' },
     },
     {
         label: 'Nucleotide deletions',
         name: 'nucleotideDeletions',
         value: '',
         header: 'Mutations, insertions, deletions',
+        type: { kind: 'mutation' },
     },
     {
         label: 'Nucleotide insertions',
         name: 'nucleotideInsertions',
         value: '',
         header: 'Mutations, insertions, deletions',
+        type: { kind: 'mutation' },
     },
     {
         label: 'Amino acid substitutions',
@@ -500,17 +475,20 @@ const defaultMutationsInsertionsDeletionsList: TableDataEntry[] = [
             type: 'badge',
             value: [],
         },
+        type: { kind: 'mutation' },
     },
     {
         label: 'Amino acid deletions',
         name: 'aminoAcidDeletions',
         value: '',
         header: 'Mutations, insertions, deletions',
+        type: { kind: 'mutation' },
     },
     {
         label: 'Amino acid insertions',
         name: 'aminoAcidInsertions',
         value: '',
         header: 'Mutations, insertions, deletions',
+        type: { kind: 'mutation' },
     },
 ];

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -4,7 +4,7 @@ import { mutationProportionCount, orderByType } from './lapis.ts';
 import { referenceGenomes } from './referencesGenomes.ts';
 
 // These metadata types need to be kept in sync with the backend config class `MetadataType` in Config.kt
-export const metadataPossibleTypes = [
+const metadataPossibleTypes = z.enum([
     'string',
     'date',
     'int',
@@ -12,7 +12,8 @@ export const metadataPossibleTypes = [
     'pango_lineage',
     'timestamp',
     'boolean',
-] as const;
+    'authors',
+] as const);
 
 export const customDisplay = z.object({
     type: z.string(),
@@ -23,7 +24,7 @@ export const customDisplay = z.object({
 export const metadata = z.object({
     name: z.string(),
     displayName: z.string().optional(),
-    type: z.enum(metadataPossibleTypes),
+    type: metadataPossibleTypes,
     autocomplete: z.boolean().optional(),
     notSearchable: z.boolean().optional(),
     customDisplay: customDisplay.optional(),
@@ -41,6 +42,7 @@ export const inputField = z.object({
 export type InputField = z.infer<typeof inputField>;
 export type CustomDisplay = z.infer<typeof customDisplay>;
 export type Metadata = z.infer<typeof metadata>;
+export type MetadataType = z.infer<typeof metadataPossibleTypes>;
 
 export type MetadataFilter = Metadata & {
     filterValue: string;


### PR DESCRIPTION
preview URL: https://seq-details-authors.loculus.org

### Summary

This moves the author list (if there is one) to the top of the sequence details page. The list is shortened if there are >= 28 authors.

### Screenshot

![image](https://github.com/loculus-project/loculus/assets/18666552/cb7d6d81-1aba-41bd-ab45-4999b0fd1902)

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
