### PR TITLE
feat(deployment): pin lapis/silo

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -880,7 +880,7 @@ devMode: true # TODO https://github.com/loculus-project/loculus/issues/1568: rem
 bannerMessage: "This is a development environment. Data will not be persisted."
 additionalHeadHTML: '<script defer data-domain="main.loculus.org" src="https://plausible.io/js/script.js"></script>'
 imageTags:
-  lapisSilo: commit-76cfaa4
+  lapisSilo: "0.1.0"
   lapis: "0.1.1"
 secrets:
   smtp-password:


### PR DESCRIPTION
As we move towards release we should treat LAPIS and SILO like any other dependency and pin them then update from time to time after testing to avoid being hit by breaking changes. This does that - using releases.