### PR TITLE
fix(ci): Use same max-version 2 for all processing pipelines

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -192,7 +192,7 @@ defaultOrganisms:
       silo:
         dateToSortBy: collection_date
     preprocessing:
-      - version: 1
+      - version: 2
         image: ghcr.io/loculus-project/preprocessing-nextclade
         args:
           - "prepro"
@@ -510,7 +510,7 @@ defaultOrganisms:
         - name: metadata_hash
           displayName: Metadata Hash
     preprocessing:
-      - version: 1
+      - version: 2
         image: ghcr.io/loculus-project/preprocessing-nextclade
         args:
           - "prepro"


### PR DESCRIPTION
Resolves #1727

preview URL: https://use-v2-processing.loculus.org

### Summary

It's not necessary to use version 1 and 2 for all pipelines, just the max version needs to be equal across pipelines, this is ensure now.

### Tests

- [x] Works in test deployment