### PR TITLE
feat(website): move FASTA download button and improve sequence viewer

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
@@ -45,15 +45,7 @@ export const DownloadDialog: FC<DownloadDialogProps> = ({
 
     return (
         <>
-            <button
-                className='normal-case 
-                py-2 rounded-md font-semibold px-4 text-sm
-                border-primary-600 border
-                text-primary-600 bg-white
-                w-full
-                hover:bg-primary-600 hover:text-white'
-                onClick={openDialog}
-            >
+            <button className='outlineButton' onClick={openDialog}>
                 Download
             </button>
 

--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -275,19 +275,7 @@ const SearchField: FC<AutoCompleteFieldProps> = (props) => {
 };
 
 const SearchButton: FC<{ isLoading: boolean }> = ({ isLoading }) => (
-    <button
-        className='normal-case 
-     py-2 rounded-md font-semibold px-4 text-sm
-     border-primary-600 border
-     text-primary-600 bg-white
-     w-full
-     hover:bg-primary-600 hover:text-white
-
-    
-    '
-        type='submit'
-        disabled={isLoading}
-    >
+    <button className='outlineButton w-full' type='submit' disabled={isLoading}>
         {isLoading ? <CircularProgress size={20} color='inherit' /> : 'Search sequences'}
     </button>
 );

--- a/website/src/components/SequenceDetailsPage/SequencesDataTableTitle.astro
+++ b/website/src/components/SequenceDetailsPage/SequencesDataTableTitle.astro
@@ -3,17 +3,19 @@ import { sentenceCase } from 'change-case';
 
 import { routes } from '../../routes/routes';
 import { type SequenceEntryHistory } from '../../types/lapis';
-import { getAccessionVersionString } from '../../utils/extractAccessionVersion';
 import { getVersionStatusColor } from '../../utils/getVersionStatusColor';
+import IcBaselineDownload from '~icons/ic/baseline-download';
+import IcBaselineHistory from '~icons/ic/baseline-history';
 import Arrow from '~icons/ic/sharp-keyboard-arrow-down';
 
 interface Props {
     sequenceEntryHistory?: SequenceEntryHistory;
     organism: string;
     accessionVersion: string;
+    showFastaDownload: boolean;
 }
 
-const { sequenceEntryHistory, accessionVersion } = Astro.props;
+const { sequenceEntryHistory, accessionVersion, showFastaDownload } = Astro.props;
 ---
 
 <div class='flex justify-between flex-wrap'>
@@ -21,32 +23,53 @@ const { sequenceEntryHistory, accessionVersion } = Astro.props;
         <h1 class='title'>{accessionVersion}</h1>
     </div>
 
-    {
-        sequenceEntryHistory !== undefined && sequenceEntryHistory.length > 1 && (
-            <div class='dropdown dropdown-hover'>
-                <label tabindex='0' class='btn btn-sm btn-outline py-1'>
-                    <a href={routes.versionPage(accessionVersion)} class='text-sm'>
-                        All versions
-                    </a>
-                    <Arrow />
-                </label>
-                <ul
-                    tabindex='0'
-                    class='dropdown-content z-[1] menu p-1 shadow bg-base-100 rounded-box absolute top-full left-0 text-sm'
-                >
-                    {sequenceEntryHistory.map((version) => (
-                        <li>
-                            <a href={routes.sequencesDetailsPage(getAccessionVersionString({ ...version }))}>
-                                {getAccessionVersionString({ ...version })}
-
-                                <p class={`font-bold ${getVersionStatusColor(version.versionStatus)}`}>
-                                    ({sentenceCase(version.versionStatus)})
-                                </p>
+    <div class='pt-2'>
+        {
+            sequenceEntryHistory !== undefined && sequenceEntryHistory.length > 1 && (
+                <>
+                    <div class='dropdown dropdown-hover hidden sm:inline-block'>
+                        <label tabindex='0' class='btn btn-sm btn-outline py-1'>
+                            <a href={routes.versionPage(accessionVersion)} class='text-sm'>
+                                All versions
                             </a>
-                        </li>
-                    ))}
-                </ul>
-            </div>
-        )
-    }
+                            <Arrow />
+                        </label>
+                        <ul
+                            tabindex='0'
+                            class='dropdown-content z-[1] menu p-1 shadow bg-base-100 rounded-box absolute top-full left-0 text-sm'
+                        >
+                            {sequenceEntryHistory.map((version) => (
+                                <li>
+                                    <a href={routes.sequencesDetailsPage(version.accessionVersion)}>
+                                        {version.accessionVersion}
+                                        <p class={`font-bold ${getVersionStatusColor(version.versionStatus)}`}>
+                                            ({sentenceCase(version.versionStatus)})
+                                        </p>
+                                    </a>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                    <div class='sm:hidden inline-block'>
+                        <a href={routes.versionPage(accessionVersion)} class='text-xl'>
+                            <IcBaselineHistory />
+                        </a>
+                    </div>
+                </>
+            )
+        }
+        {
+            showFastaDownload && (
+                <a
+                    class='sm:outlineButton inline-block'
+                    href={routes.sequencesFastaPage(accessionVersion) + '?download'}
+                >
+                    <span class='hidden sm:inline'>Download FASTA</span>
+                    <span class='sm:hidden inline text-xl'>
+                        <IcBaselineDownload />
+                    </span>
+                </a>
+            )
+        }
+    </div>
 </div>

--- a/website/src/components/SequenceDetailsPage/SequencesDetailsPage.astro
+++ b/website/src/components/SequenceDetailsPage/SequencesDetailsPage.astro
@@ -62,14 +62,6 @@ const loadSequencesAutomatically = getSchema(organism).loadSequencesAutomaticall
     )
 }
 <DataTable tableData={tableData} dataUseTermsHistory={dataUseTermsHistory} />
-<div>
-    <a
-        class='mt-4 inline-block text-primary-700 hover:text-blue-800'
-        href={routes.sequencesFastaPage(accessionVersion) + '?download'}
-    >
-        Download FASTA
-    </a>
-</div>
 <div class='mt-10'>
     <SequencesContainer
         client:load

--- a/website/src/components/common/BoxWithTabs.tsx
+++ b/website/src/components/common/BoxWithTabs.tsx
@@ -15,7 +15,7 @@ type BoxWithTabsTabProps = {
 };
 
 export const BoxWithTabsTab: FC<BoxWithTabsTabProps> = ({ isActive, label, onClick }) => (
-    <button className={`tab ${isActive ? 'tab-active' : ''}`} onClick={onClick}>
+    <button className={`tab ${isActive ? 'tab-active font-semibold' : ''}`} onClick={onClick}>
         {label}
     </button>
 );
@@ -24,6 +24,4 @@ type BoxWithTabsBoxProps = {
     children: ReactNode;
 };
 
-export const BoxWithTabsBox: FC<BoxWithTabsBoxProps> = ({ children }) => (
-    <div className='border p-4 max-w-[1000px]'>{children}</div>
-);
+export const BoxWithTabsBox: FC<BoxWithTabsBoxProps> = ({ children }) => <div className='border p-4'>{children}</div>;

--- a/website/src/pages/seq/[accessionVersion]/index.astro
+++ b/website/src/pages/seq/[accessionVersion]/index.astro
@@ -44,9 +44,13 @@ if (
                         accessionVersion={accessionVersion}
                         organism={organism}
                         sequenceEntryHistory={
-                            sequenceDetailsTableData.isOk() && result.type === SequenceDetailsTableResultType.TABLE_DATA
+                            result.type === SequenceDetailsTableResultType.TABLE_DATA
                                 ? result.sequenceEntryHistory
                                 : undefined
+                        }
+                        showFastaDownload={
+                            result.type === SequenceDetailsTableResultType.TABLE_DATA &&
+                            !isRevocationEntry(result.tableData)
                         }
                     />
                     {result.type === SequenceDetailsTableResultType.TABLE_DATA &&

--- a/website/src/styles/base.scss
+++ b/website/src/styles/base.scss
@@ -41,6 +41,13 @@ a {
   font-weight: 400;
 }
 
+@layer utilities {
+  .outlineButton {
+    @apply normal-case py-2 rounded-md font-semibold px-4 text-sm border-primary-600 border text-primary-600 bg-white
+    hover:bg-primary-600 hover:text-white;
+  }
+}
+
 .loculusColor{
   background: theme('colors.main');
   &:hover {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1768, resolves #1743, resolves #1772

preview URL: https://sequence-viewer.loculus.org

### Summary

This PR moves the FASTA download button on the sequence details page to the top right. The FASTA download button and the version selector button turn into a symbol on small screens.

It also un-restricts the width of the sequence viewer.

### Screenshot

#### Download buttons

Non-small screen:

![image](https://github.com/loculus-project/loculus/assets/18666552/fcc22da5-6b8b-41a5-9371-32caf88564e4)

Small screen:

<img src="https://github.com/loculus-project/loculus/assets/18666552/023f3404-8f67-4316-8794-31d2510feef2" width="300" />

#### Sequence viewer

<img width="1354" alt="image" src="https://github.com/loculus-project/loculus/assets/18666552/31c53b84-46a9-4893-bb15-740442015b6a">


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
