### PR TITLE
fix(config): Undo cleartext ingest user passwords, erroneously merged in #1640

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -771,12 +771,12 @@ secrets:
       testPassword: "dummy"
       livePassword: "dummy"
   service-accounts:
-    type: raw # Undo before merge
+    type: autogen
     data:
-      insdcIngestUserPassword: "insdc_ingest_user"
-      dummyPreprocessingPipelinePassword: "dummy"
-      siloImportJobPassword: "silo"
-      backendUserPassword: "backend"
+      insdcIngestUserPassword: ""
+      dummyPreprocessingPipelinePassword: ""
+      siloImportJobPassword: ""
+      backendUserPassword: ""
   keycloak-admin:
     type: raw
     data:


### PR DESCRIPTION
I should have removed this commit before merging but it's easy to forget.

This happened because our current values.yaml is not ergonomic for testing, I'd prefer if we had preview deployments use cleartext passwords for these service default, except for `main`. Having to 