### PR TITLE
fix(ingest): add environment secret to ingest cronjob

### DIFF
--- a/kubernetes/loculus/templates/loculus-ingest-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-ingest-deployment.yaml
@@ -73,6 +73,12 @@ spec:
             - name: ingest-{{ $key }}
               image: {{ $value.ingest.image}}:{{ $dockerTag }}
               imagePullPolicy: Always
+              env:
+                - name: KEYCLOAK_INGEST_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: service-accounts
+                      key: insdcIngestUserPassword
               args:
                 - snakemake
                 - results/submitted


### PR DESCRIPTION
All ingest cronjobs currently fail because the secure ingest user password isn't passed to the cronjob

Adding the env variable fixes it.

- [x] https://fix-ingest-pw.loculus.org works, I've verified

Test failure is unrelated (and fixed by #1784)