### PR TITLE
feat(ci): Collect telemetry on CPU/RAM/disk in E2E action

### DIFF
--- a/.github/workflows/e2e-k3d.yml
+++ b/.github/workflows/e2e-k3d.yml
@@ -22,6 +22,7 @@ jobs:
       packages: read
       contents: read
       checks: read
+      actions: read # Required by workflow-telemetry-action
 
     runs-on: ubuntu-latest-m
     timeout-minutes: 30


### PR DESCRIPTION
See https://github.com/catchpoint/workflow-telemetry-action

### Summary

Allow tracking of how much CPU/RAM we use by E2E action

I'm not 100% sure that it tracks everything, including things only visible to sudo, but it does look plausible. Apparently memory is not a big problem, that's good. CPU goes to around 75% at times but that seems ok.

### Screenshot

<img width="990" alt="Brave Browser 2024-05-07 17 47 34" src="https://github.com/loculus-project/loculus/assets/25161793/a9267d10-9895-4511-89fc-bd95fe46baa9">

<img width="991" alt="Brave Browser 2024-05-07 17 47 43" src="https://github.com/loculus-project/loculus/assets/25161793/ddee290f-3436-47a6-9e66-183c9b783634">
