### PR TITLE
fix(ingest): call len() on response.text not response

### DIFF
--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -288,7 +288,7 @@ def get_submitted(config: Config):
     except jsonlines.Error as err:
         response_summary = response.text
         if len(response_summary) > 100:
-            response_summary = response_summary[:50] + response_summary[-50:]
+            response_summary = response_summary[:50] + "\n[..]\n" + response_summary[-50:]
         logger.error(f"Error decoding JSON from /get-original-metadata: {response_summary}")
         raise ValueError() from err
 


### PR DESCRIPTION
Only touches error path, not super critical but good to not error in an error.