### PR TITLE
Fix insdcIngestUserPassword to fix ingest pipeline erros 

### DIFF
--- a/kubernetes/loculus/values_e2e_and_dev.yaml
+++ b/kubernetes/loculus/values_e2e_and_dev.yaml
@@ -2,7 +2,7 @@ secrets:
     service-accounts:
       type: raw
       data:
-        insdcIngestUserPassword: "insdc_ingest"
+        insdcIngestUserPassword: "insdc_ingest_user"
         dummyPreprocessingPipelinePassword: "preprocessing_pipeline"
         siloImportJobPassword: "silo_import_job"
         backendUserPassword: "backend"


### PR DESCRIPTION
### Fixes
Currently, I am not able to run the ingest pipeline locally as snakemake gives me an access denied warning:
```
"/Users/aparker/Documents/Github/loculus/ingest/scripts/submit_to_loculus.py", line 51, in get_jwt
    response.raise_for_status()
  File "/Users/aparker/micromamba/envs/loculus-ingest/lib/python3.12/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://authentication-main.loculus.org/realms/loculus/protocol/openid-connect/token
```

Changing the `insdcIngestUserPassword` to "insdc_ingest_user" fixes this issue.
Looking back this file was only added in #1734 - previously the password was set here: 
<img width="520" alt="image" src="https://github.com/loculus-project/loculus/assets/50943381/69b30919-8851-4900-8007-2aa8168db2e8">
And so it seems like it was just incorrectly copied over. 

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Correct the insdcIngestUserPassword