### PR TITLE
fix(website): update group page confirmation messages

### DIFF
--- a/website/src/components/User/GroupPage.tsx
+++ b/website/src/components/User/GroupPage.tsx
@@ -157,7 +157,7 @@ const InnerGroupPage: FC<GroupPageProps> = ({
                             </button>
                         </div>
                     </form>
-                    <div className='aflex-1 overflow-y-auto'>
+                    <div className='flex-1 overflow-y-auto'>
                         <ul>
                             {groupDetails.data?.users.map((user) => (
                                 <li key={user.name} className='flex items-center gap-6 bg-gray-100 p-2 mb-2 rounded'>


### PR DESCRIPTION
Resolves #1812

~- Doesn't say "leave group" when you are removing yourself~
- Removes the option to "remove yourself" - only allowing you to "leave' instead, which is more intuitive
- Upgrades from previous use of deprecated confirmation dialog

https://grouppageconfirmation.loculus.org/
