### PR TITLE
chore(ci): run e2e on aws

### DIFF
--- a/.github/workflows/e2e-k3d.yml
+++ b/.github/workflows/e2e-k3d.yml
@@ -34,6 +34,12 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@v2
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN_READ_PUBLIC }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
potentially helps with #1820 

I have a suspicion that our E2E test's connection errors might be due to Github actions runners being too small.

Trying out runs on aws again, with xlarge runners to make sure we can exclude resource shortage.

And we save ~120-150$ per month which isn't bad!