### PR TITLE
feat(ingest): Use NCBI API key, and don't retry, to not exceed request limits

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -38,14 +38,15 @@ rule all:
 
 
 rule fetch_ncbi_dataset_package:
+    # TODO: #1844 Set API key through secret
     output:
         dataset_package="results/ncbi_dataset.zip",
-    retries: 5
     shell:
         """
         datasets download virus genome taxon {TAXON_ID} \
             --no-progressbar \
-            --filename {output.dataset_package}
+            --filename {output.dataset_package} \
+            --api-key 15c4ff96de265753f878bb08d88ca64df909 \
         """
 
 


### PR DESCRIPTION
- Don't retry when NCBI ingest fails, as this causes rate limits to trip
- Use NCBI API Key. In cleartext for now (while we're private that's no problem). It's easy to generate these keys and easy to reset so there's no risk to using it like this right now. For proper encryption see #1844 