### PR TITLE
fix(website): don't add 1 to indexes in substitution badges

### DIFF
--- a/website/src/components/SequenceDetailsPage/MutationBadge.tsx
+++ b/website/src/components/SequenceDetailsPage/MutationBadge.tsx
@@ -30,7 +30,7 @@ export const SubBadge: FC<SubProps> = ({ position, mutationTo, mutationFrom, seq
                         </span>
                     </>
                 )}
-                <span className='px-[4px] py-[2px] bg-gray-200'>{position + 1}</span>
+                <span className='px-[4px] py-[2px] bg-gray-200'>{position}</span>
                 <span className='px-[4px] py-[2px] rounded-e-[3px]' style={{ background: getColor(mutationTo) }}>
                     {mutationTo}
                 </span>


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1847

We were adding one to positions in substitution badges but LAPIS already returns 1-indexed results

(Thanks @chaoran-chen !)