### PR TITLE
feat(deployment): Add compression middleware for the website

### DIFF
--- a/kubernetes/loculus/templates/ingressroute.yaml
+++ b/kubernetes/loculus/templates/ingressroute.yaml
@@ -14,7 +14,7 @@ kind: Ingress
 metadata:
   name: loculus-website-ingress
   annotations:
-    traefik.ingress.kubernetes.io/router.middlewares: "compression-middleware@kubernetescrd"
+    traefik.ingress.kubernetes.io/router.middlewares: "{{ $.Release.Namespace }}-compression-middleware@kubernetescrd"
 spec:
   rules:
     - host: "{{ .Values.host }}"


### PR DESCRIPTION
Adds compression middleware for the website, handled by traefik. This reduces e.g. the submission page from transferring 1.1 MB of resources to transferring 323 kB.

We can reuse this middleware in other parts of the deployment later in cases that do not already handle compression.

https://add-compression-middlewar.loculus.org/