### PR TITLE
feat(deployment): use compression middleware for keycloak

### DIFF
--- a/kubernetes/loculus/templates/ingressroute.yaml
+++ b/kubernetes/loculus/templates/ingressroute.yaml
@@ -56,6 +56,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: loculus-keycloak-ingress
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: "{{ $.Release.Namespace }}-compression-middleware@kubernetescrd"
 spec:
   rules:
     - host: "{{ $keycloakHost }}"


### PR DESCRIPTION
It seemed like keycloak wasn't consistently using compression (though sometimes it was for some content)

https://keycloakcompress.loculus.org/