### PR TITLE
fix(k8s/prepro): reduce mpox batch size to 5, use 1 nextclade job, to not use more than 1GB of memory

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -392,7 +392,7 @@ defaultOrganisms:
           nextclade_dataset_tag: 2024-04-19--07-50-39Z
           genes:
             - OPG001
-          batch_size: 20
+          batch_size: 5
           processing_spec:
             total_snps:
               function: identity

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -109,6 +109,7 @@ def enrich_with_nextclade(
             f"--output-all={result_dir}",
             f"--input-dataset={dataset_dir}",
             f"--output-translations={result_dir}/nextclade.cds_translation.{{cds}}.fasta",
+            "--jobs=1",
             "--",
             f"{input_file}",
         ]


### PR DESCRIPTION
https://update-limits.loculus.org

Use one processing thread for Nextclade to reduce memory consumption

We currently set limits to 1GB of memory for preprocessing. It gets hit by mpox with settings prior to this PR:

```
tmp/tmpryvdeuf4/input.fasta']
Traceback (most recent call last):
  File "/opt/conda/bin/prepro", line 8, in <module>
    sys.exit(cli_entry())
             ^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/loculus_preprocessing/__main__.py", line 16, in cli_entry
    run(config)
  File "/opt/conda/lib/python3.12/site-packages/loculus_preprocessing/prepro.py", line 378, in run
    processed = process_all(unprocessed, dataset_dir, config)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/loculus_preprocessing/prepro.py", line 315, in process_all
    nextclade_results = enrich_with_nextclade(unprocessed, dataset_dir, config)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/loculus_preprocessing/prepro.py", line 121, in enrich_with_nextclade
    raise Exception(msg)
Exception: nextclade failed with exit code -9
```