### PR TITLE
fix(ci): restrict mittwald to reasonable mem limit

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -245,7 +245,8 @@ def install_secret_generator():
     print("Installing Kubernetes Secret Generator...")
     helm_install_command = [
         'helm', 'upgrade', '--install', 'kubernetes-secret-generator',
-        secret_generator_chart, '--set', 'secretLength=32', '--set', 'watchNamespace=""'
+        secret_generator_chart, '--set', 'secretLength=32', '--set', 'watchNamespace=""',
+        '--set', 'resources.limits.memory=400Mi', '--set', 'resources.requests.memory=200Mi'
     ]
     run_command(helm_install_command)
 


### PR DESCRIPTION
It used locally up to 900 MB, which is ridiculous  for what it does. Probably the Go garbage collector forgot to run.

On the server it usually uses only a couple dozen MB. So this limit should be no problem.