### PR TITLE
chore(dev): add `stakater/reloader` to `deploy.py`

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -101,6 +101,7 @@ def handle_cluster():
         run_command(f"k3d cluster create {CLUSTER_NAME} {' '.join(PORTS)} --agents 2",
                        shell=True)
     install_secret_generator()
+    install_reloader()
     while not is_traefik_running():
         print("Waiting for Traefik to start...")
         time.sleep(5)
@@ -250,6 +251,25 @@ def install_secret_generator():
     ]
     run_command(helm_install_command)
 
+def install_reloader():
+    add_helm_repo_command = [
+        'helm', 'repo', 'add', 'stakater', 'https://stakater.github.io/stakater-charts'
+    ]
+    run_command(add_helm_repo_command)
+    print("Stakater added to repositories.")
+
+    update_helm_repo_command = ['helm', 'repo', 'update']
+    run_command(update_helm_repo_command)
+    print("Helm repositories updated.")
+
+    secret_generator_chart = 'stakater/reloader'
+    print("Installing Reloader...")
+    helm_install_command = [
+        'helm', 'upgrade', '--install', 'reloader', secret_generator_chart,
+        '--set', 'reloader.deployment.resources.limits.memory=200Mi',
+        '--set', 'reloader.deployment.resources.requests.memory=100Mi'
+    ]
+    run_command(helm_install_command)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Without this operator, changes to configmaps don't trigger reloads
we use it in dev server Cluster, so should also do locally.
