### PR TITLE
feat(deployment): allow all origins CORS from LAPIS

### DIFF
--- a/kubernetes/loculus/templates/lapis-ingress.yaml
+++ b/kubernetes/loculus/templates/lapis-ingress.yaml
@@ -8,7 +8,7 @@ spec:
     accessControlAllowMethods:
       - "GET"
       - "OPTIONS"
-      - "PUT"
+      - "POST"
       - "HEAD"
     accessControlAllowOriginList: 
       - "*"


### PR DESCRIPTION
Allows access from all origins from CORS for LAPIS. The original motivation was for local dev, but IMO this configuration makes sense generally to enable external tools to access LAPIS in the client.