### PR TITLE
fix(deployment): get keycloak to respect configured db

### DIFF
--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -64,7 +64,7 @@ spec:
                 secretKeyRef:
                   name: keycloak-database
                   key: database
-            - name: KC_DB_USER
+            - name: KC_DB_USERNAME
               valueFrom:
                 secretKeyRef:
                   name: keycloak-database


### PR DESCRIPTION
By default Keycloak uses an internal dev db. It turns out although we've been running a special postgres container for keycloak this db has been entirely unused until now (probably ever since keycloak was added in #488). This is intended to begin using it - and to use any managed database that is pointed to.