### PR TITLE
chore(deploy.py): use one agent for lower resource usage

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -98,7 +98,7 @@ def handle_cluster():
     if cluster_exists(CLUSTER_NAME):
         print(f"Cluster '{CLUSTER_NAME}' already exists.")
     else:
-        run_command(f"k3d cluster create {CLUSTER_NAME} {' '.join(PORTS)} --agents 2",
+        run_command(f"k3d cluster create {CLUSTER_NAME} {' '.join(PORTS)} --agents 1",
                        shell=True)
     install_secret_generator()
     install_reloader()


### PR DESCRIPTION
As we don't use multiple agents in our cluster, there's no need to do so for our dev cluster. This just increases system memory usage for no good reason.