### PR TITLE
fix(ci): Adds back branch tags for our docker images

### DIFF
--- a/.github/workflows/backend-image.yml
+++ b/.github/workflows/backend-image.yml
@@ -60,8 +60,8 @@ jobs:
           tags: |
             type=raw,value=${{ env.DIR_HASH }}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=ref,event=branch
             type=raw,value=commit-${{ env.sha }}
+            type=raw,value=${{ env.BRANCH_NAME }}
             type=raw,value=${{ env.BRANCH_NAME }}-arm,enable=${{ env.BUILD_ARM }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
When switching from `on: push` to `on: pull_request` the branch tags for docker no longer worked. This fixes it.