### PR TITLE
feat(backend): don't require authentication for /get-released-data

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+.kotlin/
 
 ### STS ###
 .apt_generated

--- a/backend/README.md
+++ b/backend/README.md
@@ -120,7 +120,3 @@ Since the API has endpoints that deal with NDJSON, the documentation of those en
 "the provided schema is a valid JSON schema for each line of the NDJSON file".
 
 The Swagger UI and OpenAPI specification is generated via the [Springdoc plugin](https://springdoc.org/).
-
-```
-
-```

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -77,6 +77,7 @@ tasks.named('test') {
         exceptionFormat TestExceptionFormat.FULL
         showExceptions true
     }
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 }
 
 tasks.named('bootBuildImage') {

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.parallel=true

--- a/backend/src/main/kotlin/org/loculus/backend/auth/AuthenticatedUser.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/auth/AuthenticatedUser.kt
@@ -15,7 +15,6 @@ import org.springframework.web.method.support.ModelAndViewContainer
 object Roles {
     const val SUPER_USER = "super_user"
     const val PREPROCESSING_PIPELINE = "preprocessing_pipeline"
-    const val GET_RELEASED_DATA = "get_released_data"
     const val EXTERNAL_METADATA_UPDATER = "external_metadata_updater"
 }
 

--- a/backend/src/main/kotlin/org/loculus/backend/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/SecurityConfig.kt
@@ -4,7 +4,6 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import mu.KotlinLogging
 import org.loculus.backend.auth.Roles.EXTERNAL_METADATA_UPDATER
-import org.loculus.backend.auth.Roles.GET_RELEASED_DATA
 import org.loculus.backend.auth.Roles.PREPROCESSING_PIPELINE
 import org.loculus.backend.auth.Roles.SUPER_USER
 import org.springframework.beans.factory.InitializingBean
@@ -41,10 +40,6 @@ class SecurityConfig {
     private val defaultAccessDeniedHandler = DelegatingAccessDeniedHandler(
         linkedMapOf(CsrfException::class.java to AccessDeniedHandlerImpl()),
         BearerTokenAccessDeniedHandler(),
-    )
-
-    private val endpointsForGettingReleasedData = arrayOf(
-        "/*/get-released-data",
     )
 
     private val endpointsForPreprocessingPipeline = arrayOf(
@@ -89,7 +84,6 @@ class SecurityConfig {
             auth.requestMatchers(
                 *endpointsForExternalMetadataUpdater,
             ).hasAuthority(EXTERNAL_METADATA_UPDATER)
-            auth.requestMatchers(*endpointsForGettingReleasedData).hasAuthority(GET_RELEASED_DATA)
             auth.requestMatchers(*debugEndpoints).hasAuthority(SUPER_USER)
             auth.anyRequest().authenticated()
         }

--- a/backend/src/main/kotlin/org/loculus/backend/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/SecurityConfig.kt
@@ -57,6 +57,7 @@ class SecurityConfig {
         "/get-seqset-records",
         "/get-seqset-cited-by-publication",
         "/get-author",
+        "/*/get-released-data",
     )
 
     private val debugEndpoints = arrayOf(

--- a/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
@@ -183,7 +183,10 @@ class SubmitModel(
             maybeFileToDelete.file = tempFile
 
             file.transferTo(tempFile)
-            val zipFile = ZipFile(tempFile)
+            val zipFile = ZipFile.builder()
+                .setFile(tempFile)
+                .setUseUnicodeExtraFields(true)
+                .get()
             BufferedInputStream(zipFile.getInputStream(zipFile.entries.nextElement()))
         }
 

--- a/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
@@ -117,9 +117,7 @@ class SubmitModel(
             )
         } else if (submissionParams is SubmissionParams.OriginalSubmissionParams) {
             log.info { "Generating new accessions for uploaded sequence data with uploadId $uploadId" }
-            uploadDatabaseService.generateNewAccessionsForOriginalUpload(
-                uploadId
-            )
+            uploadDatabaseService.generateNewAccessionsForOriginalUpload(uploadId)
         }
 
         log.debug { "Persisting submission with uploadId $uploadId" }

--- a/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
@@ -118,8 +118,7 @@ class SubmitModel(
         } else if (submissionParams is SubmissionParams.OriginalSubmissionParams) {
             log.info { "Generating new accessions for uploaded sequence data with uploadId $uploadId" }
             uploadDatabaseService.generateNewAccessionsForOriginalUpload(
-                uploadId,
-                submissionParams.organism,
+                uploadId
             )
         }
 

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
@@ -252,7 +252,7 @@ class UploadDatabaseService(
         }
     }
 
-    fun generateNewAccessionsForOriginalUpload(uploadId: String, organism: Organism) {
+    fun generateNewAccessionsForOriginalUpload(uploadId: String) {
         val submissionIds =
             MetadataUploadAuxTable
                 .select(submissionIdColumn)

--- a/backend/src/test/kotlin/org/loculus/backend/controller/RequestAuthorization.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/RequestAuthorization.kt
@@ -2,7 +2,6 @@ package org.loculus.backend.controller
 
 import io.jsonwebtoken.Jwts
 import org.loculus.backend.auth.Roles.EXTERNAL_METADATA_UPDATER
-import org.loculus.backend.auth.Roles.GET_RELEASED_DATA
 import org.loculus.backend.auth.Roles.PREPROCESSING_PIPELINE
 import org.loculus.backend.auth.Roles.SUPER_USER
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
@@ -15,9 +14,8 @@ val keyPair: KeyPair = Jwts.SIG.RS256.keyPair().build()
 
 val jwtForDefaultUser = generateJwtFor(DEFAULT_USER_NAME)
 val jwtForProcessingPipeline = generateJwtFor("preprocessing_pipeline", listOf(PREPROCESSING_PIPELINE))
-val jwtForGetReleasedData = generateJwtFor("silo_import_job", listOf(GET_RELEASED_DATA))
 val jwtForExternalMetadataUpdatePipeline =
-    generateJwtFor("external_metadata_updater", listOf(EXTERNAL_METADATA_UPDATER, GET_RELEASED_DATA))
+    generateJwtFor("external_metadata_updater", listOf(EXTERNAL_METADATA_UPDATER))
 val jwtForSuperUser = generateJwtFor(SUPER_USER_NAME, listOf(SUPER_USER))
 
 fun generateJwtFor(username: String, roles: List<String> = emptyList()): String = Jwts.builder()

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
@@ -25,11 +25,8 @@ import org.loculus.backend.api.Status
 import org.loculus.backend.controller.DEFAULT_GROUP_NAME
 import org.loculus.backend.controller.DEFAULT_USER_NAME
 import org.loculus.backend.controller.EndpointTest
-import org.loculus.backend.controller.expectForbiddenResponse
 import org.loculus.backend.controller.expectNdjsonAndGetContent
-import org.loculus.backend.controller.expectUnauthorizedResponse
 import org.loculus.backend.controller.jacksonObjectMapper
-import org.loculus.backend.controller.jwtForDefaultUser
 import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles.NUMBER_OF_SEQUENCES
 import org.loculus.backend.utils.Accession
 import org.loculus.backend.utils.Version
@@ -54,22 +51,6 @@ class GetReleasedDataEndpointTest(
     @Autowired val submissionControllerClient: SubmissionControllerClient,
 ) {
     val currentYear = Clock.System.now().toLocalDateTime(TimeZone.UTC).year
-
-    @Test
-    fun `GIVEN invalid authorization token THEN returns 401 Unauthorized`() {
-        expectUnauthorizedResponse {
-            submissionControllerClient.getReleasedData(jwt = it)
-        }
-    }
-
-    @Test
-    fun `GIVEN authorization token with THEN returns 403 Forbidden`() {
-        expectForbiddenResponse {
-            submissionControllerClient.getReleasedData(
-                jwt = jwtForDefaultUser,
-            )
-        }
-    }
 
     @Test
     fun `GIVEN no sequence entries in database THEN returns empty response`() {

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
@@ -18,7 +18,6 @@ import org.loculus.backend.controller.DEFAULT_PIPELINE_VERSION
 import org.loculus.backend.controller.addOrganismToPath
 import org.loculus.backend.controller.jwtForDefaultUser
 import org.loculus.backend.controller.jwtForExternalMetadataUpdatePipeline
-import org.loculus.backend.controller.jwtForGetReleasedData
 import org.loculus.backend.controller.jwtForProcessingPipeline
 import org.loculus.backend.controller.withAuth
 import org.loculus.backend.utils.Accession
@@ -192,20 +191,16 @@ class SubmissionControllerClient(private val mockMvc: MockMvc, private val objec
             .withAuth(jwt),
     )
 
-    fun getReleasedData(
-        organism: String = DEFAULT_ORGANISM,
-        jwt: String? = jwtForGetReleasedData,
-        compression: String? = null,
-    ): ResultActions = mockMvc.perform(
-        get(addOrganismToPath("/get-released-data", organism = organism))
-            .also {
-                when (compression) {
-                    null -> it
-                    else -> it.param("compression", compression)
-                }
-            }
-            .withAuth(jwt),
-    )
+    fun getReleasedData(organism: String = DEFAULT_ORGANISM, compression: String? = null): ResultActions =
+        mockMvc.perform(
+            get(addOrganismToPath("/get-released-data", organism = organism))
+                .also {
+                    when (compression) {
+                        null -> it
+                        else -> it.param("compression", compression)
+                    }
+                },
+        )
 
     fun deleteSequenceEntries(
         scope: DeleteSequenceScope,

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1567,9 +1567,9 @@
             ]
         },
         "node_modules/@pagefind/default-ui": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@pagefind/default-ui/-/default-ui-1.0.4.tgz",
-            "integrity": "sha512-edkcaPSKq67C49Vehjo+LQCpT615v4d7JRhfGzFPccePvdklaL+VXrfghN/uIfsdoG+HoLI1PcYy2iFcB9CTkw=="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@pagefind/default-ui/-/default-ui-1.1.1.tgz",
+            "integrity": "sha512-ZM0zDatWDnac/VGHhQCiM7UgA4ca8jpjA+VfuTJyHJBaxGqZMQnm4WoTz9E0KFcue1Bh9kxpu7uWFZfwpZZk0A=="
         },
         "node_modules/@pagefind/linux-arm64": {
             "version": "1.1.1",
@@ -9027,9 +9027,9 @@
             "optional": true
         },
         "@pagefind/default-ui": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@pagefind/default-ui/-/default-ui-1.0.4.tgz",
-            "integrity": "sha512-edkcaPSKq67C49Vehjo+LQCpT615v4d7JRhfGzFPccePvdklaL+VXrfghN/uIfsdoG+HoLI1PcYy2iFcB9CTkw=="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@pagefind/default-ui/-/default-ui-1.1.1.tgz",
+            "integrity": "sha512-ZM0zDatWDnac/VGHhQCiM7UgA4ca8jpjA+VfuTJyHJBaxGqZMQnm4WoTz9E0KFcue1Bh9kxpu7uWFZfwpZZk0A=="
         },
         "@pagefind/linux-arm64": {
             "version": "1.1.1",

--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -15,39 +15,6 @@ new_input_touchfile="$new_input_data_dir/processing"
 old_input_touchfile="$old_input_data_dir/processing"
 silo_input_data="$input_data_dir/data.ndjson.zst"
 
-get_token() {
-  if [ -z "$KEYCLOAK_TOKEN_URL" ]; then
-    echo "KEYCLOAK_TOKEN_URL is not set"
-    exit 1
-  fi
-
-  if [ -z "$IMPORT_JOB_USER" ]; then
-    echo "IMPORT_JOB_USER is not set"
-    exit 1
-  fi
-
-  if [ -z "$IMPORT_JOB_USER_PASSWORD" ]; then
-    echo "IMPORT_JOB_USER_PASSWORD is not set"
-    exit 1
-  fi
-
-  if [ -z "$KEYCLOAK_CLIENT_ID" ]; then
-    echo "KEYCLOAK_CLIENT_ID is not set"
-    exit 1
-  fi
-
-  echo "Retrieving JWT from $KEYCLOAK_TOKEN_URL"
-  jwt_keycloak=$(curl -X POST "$KEYCLOAK_TOKEN_URL" --fail-with-body -H 'Content-Type: application/x-www-form-urlencoded' -d "username=$IMPORT_JOB_USER&password=$IMPORT_JOB_USER_PASSWORD&grant_type=password&client_id=$KEYCLOAK_CLIENT_ID")
-  jwt=$(echo "$jwt_keycloak" | jq -r '.access_token')
-
-  if [ -z "$jwt" ]; then
-    echo "Failed to retrieve JWT"
-    exit 1
-  fi
-  echo "JWT retrieved successfully"
-  echo
-}
-
 delete_all_input () {
   echo "Deleting all input data"
   rm -f "$silo_input_data"
@@ -66,7 +33,7 @@ download_data() {
   echo "calling $released_data_endpoint"
   
   set +e
-  curl -o "$new_input_data" --fail-with-body "$released_data_endpoint" -H "Authorization: Bearer $jwt"
+  curl -o "$new_input_data" --fail-with-body "$released_data_endpoint"
   exit_code=$?
   set -e
 
@@ -175,7 +142,6 @@ main() {
 
   # cleanup at start in case we fail later
   cleanup_output_data
-  get_token
   download_data
   preprocessing
 

--- a/kubernetes/loculus/templates/_config-processor.tpl
+++ b/kubernetes/loculus/templates/_config-processor.tpl
@@ -37,11 +37,6 @@
         secretKeyRef:
           name: service-accounts
           key: externalMetadataUpdaterPassword
-    - name: LOCULUSSUB_siloImportJobPassword
-      valueFrom:
-        secretKeyRef:
-          name: service-accounts
-          key: siloImportJobPassword
     - name: LOCULUSSUB_backendUserPassword
       valueFrom:
         secretKeyRef:

--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -195,32 +195,6 @@ data:
             }
           },
         {
-          "username": "silo_import_job",
-          "enabled": true,
-          "email": "silo_import_job@void.o",
-          "emailVerified": true,
-          "firstName": "SILO",
-          "lastName": "ImportJob",
-          "credentials": [
-            {
-              "type": "password",
-              "value": "[[siloImportJobPassword]]"
-            }
-          ],
-          "realmRoles": [
-            "get_released_data",
-            "offline_access"
-          ],
-          "attributes": {
-            "university": "University of Test"
-          },
-          "clientRoles": {
-            "account": [
-              "manage-account"
-            ]
-          }
-        },
-        {
           "username": "backend",
           "enabled": true,
           "email": "nothing@void.o",

--- a/kubernetes/loculus/templates/lapis-silo-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-deployment.yaml
@@ -96,17 +96,6 @@ spec:
               {{- else }}
               value: "http://loculus-backend-service:8079/{{ $key }}"
               {{- end }}
-            - name: KEYCLOAK_TOKEN_URL
-              value: "{{ $keycloakTokenUrl }}"
-            - name: KEYCLOAK_CLIENT_ID
-              value: "backend-client"
-            - name: IMPORT_JOB_USER
-              value: "silo_import_job"
-            - name: IMPORT_JOB_USER_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: service-accounts
-                  key: siloImportJobPassword
           volumeMounts:
             - name: lapis-silo-database-config-processed
               mountPath: /preprocessing/input/reference_genomes.json

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1443,7 +1443,6 @@ secrets:
       insdcIngestUserPassword: ""
       preprocessingPipelinePassword: ""
       externalMetadataUpdaterPassword: ""
-      siloImportJobPassword: ""
       backendUserPassword: ""
   keycloak-admin:
     type: raw

--- a/kubernetes/loculus/values_e2e_and_dev.yaml
+++ b/kubernetes/loculus/values_e2e_and_dev.yaml
@@ -5,7 +5,6 @@ secrets:
       insdcIngestUserPassword: "insdc_ingest_user"
       preprocessingPipelinePassword: "preprocessing_pipeline"
       externalMetadataUpdaterPassword: "external_metadata_updater"
-      siloImportJobPassword: "silo_import_job"
       backendUserPassword: "backend"
 createTestAccounts: true
 backendExtraArgs:


### PR DESCRIPTION
resolves #1913
resolves #1625

preview URL: https://get-no-auth.loculus.org

### Summary

- Don't require authn/authz for `get-released-data` endpoint
- Fix lints
- Run backend tests in paralell