### PR TITLE
fix(deployment): expand secrets set up to allow website image secret

### DIFF
--- a/kubernetes/loculus/templates/secrets.yaml
+++ b/kubernetes/loculus/templates/secrets.yaml
@@ -35,4 +35,7 @@ data:
   {{ $key }}: {{ $value | b64enc }}
   {{- end }}
 {{- end }}
+{{ if $secret.rawType }}
+type: {{ $secret.rawType }}
+{{ end }}
 {{- end }}


### PR DESCRIPTION
We didn't have a way to pass on the secret `type` and that type is needed for docker credentials secrets