### PR TITLE
Fix display of numbered lists in some contexts in markdown

### DIFF
--- a/website/src/styles/mdcontainer.scss
+++ b/website/src/styles/mdcontainer.scss
@@ -1,18 +1,18 @@
 
 .mdContainer{
-    @apply max-w-3xl mx-auto;
+    @apply max-w-3xl mx-auto break-normal;
   }
   
   .mdContainer h1{
-    @apply text-2xl font-semibold text-main break-all my-3;
+    @apply text-2xl font-semibold text-main my-3;
   }
   
   .mdContainer h2{
-    @apply text-xl font-semibold text-main break-all my-3;
+    @apply text-xl font-semibold text-main my-3;
   }
   
   .mdContainer h3{
-    @apply text-lg font-semibold text-main break-all my-3;
+    @apply text-lg font-semibold text-main my-3;
 
   }
   


### PR DESCRIPTION
Should fix this:

<img width="168" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/89e288bd-bbfc-4dcb-b20c-a3c554b215a3">

and word breaking in headings
