### PR TITLE
feat(website): improve page linking to api docs

### DIFF
--- a/website/src/pages/api_documentation/index.astro
+++ b/website/src/pages/api_documentation/index.astro
@@ -1,24 +1,44 @@
 ---
-import { getRuntimeConfig } from '../../config';
+import { getRuntimeConfig, getWebsiteConfig } from '../../config';
 import BaseLayout from '../../layouts/BaseLayout.astro';
-
 const clientConfig = getRuntimeConfig().public;
+
+const websiteConfig = getWebsiteConfig();
+
+const organismKeys = Object.keys(websiteConfig.organisms);
+
+const organismToDisplayName = Object.fromEntries(
+    organismKeys.map((organism) => {
+        return [organism, websiteConfig.organisms[organism].schema.instanceName];
+    }),
+);
+
+const BUTTON_CLASS =
+    'inline-block px-6 py-3 bg-primary-400 text-white font-semibold rounded-lg shadow-md hover:bg-primary-500  mr-2 hover:no-underline';
 ---
 
-<BaseLayout title='Api Docs'>
-    <h1 class='title'>Api Documentation</h1>
-    <a class='mt-8' href={clientConfig.backendUrl + '/swagger-ui/index.html'}>
-        Click here for the API documentation of the backend server.
-    </a>
-    <br />
-    {
-        Object.entries(clientConfig.lapisUrls).map(([organism, url]) => (
-            <>
-                <a class='mt-8' href={url + '/swagger-ui/index.html'}>
-                    Click here for the API documentation of the query engine LAPIS for the organism {organism}.
-                </a>
-                <br />
-            </>
-        ))
-    }
+<BaseLayout title='API Documentation'>
+    <div class='container mx-auto p-8'>
+        <h1 class='title'>API Documentation</h1>
+
+        <div class='mb-8 mt-6'>
+            <h2 class='text-xl font-semibold text-primary-400 mb-4'>Backend Server</h2>
+            <a class={BUTTON_CLASS} href={clientConfig.backendUrl + '/swagger-ui/index.html'}>
+                View Backend API Documentation
+            </a>
+        </div>
+
+        <div>
+            <h2 class='text-xl font-semibold text-primary-400 mb-4'>LAPIS Query Engines</h2>
+            <div class='space-y-4'>
+                {
+                    Object.entries(clientConfig.lapisUrls).map(([organism, url]) => (
+                        <a class={BUTTON_CLASS} href={url + '/swagger-ui/index.html'}>
+                            {organismToDisplayName[organism]} LAPIS API Documentation
+                        </a>
+                    ))
+                }
+            </div>
+        </div>
+    </div>
 </BaseLayout>

--- a/website/src/styles/base.scss
+++ b/website/src/styles/base.scss
@@ -29,7 +29,6 @@ a {
 .title{
 
   color: theme('colors.main');
-  margin-left: 15px;
   font-size: 24px;
   font-weight: 600;
   word-break: break-all;


### PR DESCRIPTION
Prettifies API docs linking page:
https://apidocs.loculus.org/api_documentation


<img width="1234" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/7b546ca2-39ae-48db-83bc-c709738a7ef0">

Previously:

<img width="879" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/59daddd9-afbf-4549-b20b-2156e4a9e6e7">


Generally removes left padding from `title`s which didn't make sense
