### PR TITLE
fix(website): fix+improve data use terms history link

### DIFF
--- a/website/src/components/SequenceDetailsPage/DataUseTermsHistoryModal.tsx
+++ b/website/src/components/SequenceDetailsPage/DataUseTermsHistoryModal.tsx
@@ -2,7 +2,6 @@ import { DateTime, FixedOffsetZone } from 'luxon';
 import { type FC, useRef } from 'react';
 
 import { type DataUseTermsHistoryEntry, restrictedDataUseTermsType } from '../../types/backend.ts';
-import DataUseTermsHistoryIcon from '~icons/mdi/clipboard-text-history-outline';
 
 export type DataUseTermsHistoryProps = {
     dataUseTermsHistory: DataUseTermsHistoryEntry[];
@@ -23,11 +22,11 @@ export const DataUseTermsHistoryModal: FC<DataUseTermsHistoryProps> = ({ dataUse
                 <DataUseTermsHistoryDialog dataUseTermsHistory={dataUseTermsHistory} />
             </dialog>
 
-            <div>
-                <button className='icon-button' onClick={handleOpenHistoryDialog}>
-                    <DataUseTermsHistoryIcon />
+            <span>
+                <button className='underline' onClick={handleOpenHistoryDialog}>
+                    (history)
                 </button>
-            </div>
+            </span>
         </>
     );
 };


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1705
preview URL: https://1705-use-terms-icon.loculus.org

### Summary

This replaces the data use terms history icon with a simple text and places it on the same line.

### Screenshot

![image](https://github.com/loculus-project/loculus/assets/18666552/4b0e6270-f8e3-42b8-85c2-7ce8e67dd46d)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
