### PR TITLE
fix(website): move organism selector to the front

### DIFF
--- a/website/src/components/Navigation/OrganismSelector.astro
+++ b/website/src/components/Navigation/OrganismSelector.astro
@@ -21,7 +21,7 @@ const restOfUrl = Astro.url.pathname.split('/').slice(2).join('/');
         {label}
         <span class='text-primary'> <IwwaArrowDown className='inline-block -mt-1 ml-1 h-4 w-4 ' /></span>
     </label>
-    <ul tabindex='0' class='dropdown-content z-[1] menu p-1 shadow bg-base-100 rounded-btn absolute top-full -left-4'>
+    <ul tabindex='0' class='dropdown-content z-20 menu p-1 shadow bg-base-100 rounded-btn absolute top-full -left-4'>
         {
             knownOrganisms.map((knownOrganism: Organism) => (
                 <li>


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1804
preview URL: https://1804-orgselector-clipped.loculus.org

### Summary

The `z-index` of the toolbar on the review page was 10 and higher than the z-index of the organism selector which was 1. I changed the latter to 20.

### Screenshot

![image](https://github.com/loculus-project/loculus/assets/18666552/53efdbdf-1e08-4ac8-a3dc-afbbc73c3b1e)

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
