### PR TITLE
fix(website): don't open file picker twice

### DIFF
--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -207,7 +207,14 @@ const UploadComponent = ({
                         <Icon className='mx-auto h-12 w-12 text-gray-300' aria-hidden='true' />
                         <div className='mt-4  text-sm leading-6 text-gray-600'>
                             <label className='inline relative cursor-pointer rounded-md bg-white font-semibold text-primary-600 focus-within:outline-none focus-within:ring-2 focus-within:ring-primary-600 focus-within:ring-offset-2 hover:text-primary-500'>
-                                <span onClick={handleUpload}>Upload a file </span>
+                                <span
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        handleUpload();
+                                    }}
+                                >
+                                    Upload a file
+                                </span>
                                 {isClient && (
                                     <input
                                         id={name}


### PR DESCRIPTION


preview URL: https://fix-picker.loculus.org

### Summary

File picker opened twice since c29b9128c8f01e9d45b4373a80efa37ab0293429

Bug noticed by @theosanderson

I can't figure out how to add a playwright test for this

So we will have to look out for it manually

See: https://loculus.slack.com/archives/C05G172HL6L/p1716246834623479

### Screenshot

Fixes this issue:
![2024-05-21 01 20 56](https://github.com/loculus-project/loculus/assets/25161793/f6588086-e486-44ec-bbe0-7a2c19a3ab04)

