### PR TITLE
fix(backend): add back updating of data from edit

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -711,8 +711,8 @@ class SubmissionDatabaseService(
 
         SequenceEntriesTable.update(
             where = {
-                SequenceEntriesTable.accessionColumn eq editedAccessionVersion.accession and
-                    SequenceEntriesTable.versionColumn eq editedAccessionVersion.version
+                (SequenceEntriesTable.accessionColumn eq editedAccessionVersion.accession) and
+                    (SequenceEntriesTable.versionColumn eq editedAccessionVersion.version)
             },
         ) {
             it[originalDataColumn] = compressionService


### PR DESCRIPTION
For the submitEditedData endpoint:

In [e87acdd4bb7459abca94b68983f4ff79cfc43364](https://github.com/loculus-project/loculus/commit/e87acdd4bb7459abca94b68983f4ff79cfc43364) we refactored a line that did two functions: deleting processed data and updating unprocessed data. We successfully refactored it to delete the processed data but lost the updating function. This fixes that.

https://try-to-fix-edit.loculus.org/

Remaining issue for test: #2002