### PR TITLE
feat(website): style markdown tables nicely

### DIFF
--- a/website/src/styles/mdcontainer.scss
+++ b/website/src/styles/mdcontainer.scss
@@ -94,3 +94,19 @@
    list-style-type: lower-roman;
 }
 
+.mdContainer table {
+  @apply w-full table-auto border-collapse mt-6 mb-6;
+}
+
+.mdContainer th,
+.mdContainer td {
+  @apply border border-gray-300 px-4 py-2 text-left border-solid;
+}
+
+.mdContainer th {
+  @apply bg-gray-100 font-semibold;
+}
+
+.mdContainer tbody tr:nth-child(even) {
+  @apply bg-gray-50;
+}


### PR DESCRIPTION
Styles tables like this:
<img width="1084" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/5ef8e93f-b96e-451c-9f65-1cc4c14549f0">
