### PR TITLE
fix(prepro/dummy): Log instead of print, reduce sleep time to 2s from 10

### DIFF
--- a/preprocessing/dummy/main.py
+++ b/preprocessing/dummy/main.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 
 import requests
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG)
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--backend-host", type=str, default="http://127.0.0.1:8079",


### PR DESCRIPTION
Printing is buffered, so we don't actually see logs until there's an error. Logging is unbuffered.