### PR TITLE
fix(website): scroll-to-top on search pagination

### DIFF
--- a/website/src/components/SearchPage/SearchPagination.tsx
+++ b/website/src/components/SearchPage/SearchPagination.tsx
@@ -19,7 +19,7 @@ export const SearchPagination: FC<SearchPaginationProps> = ({
             page={page}
             onChange={(_, newPage) => {
                 setPage(newPage);
-                window.scrollTo({ top: 0, behavior: 'smooth' });
+                window.scrollTo({ top: 0 });
             }}
             color='primary'
             variant='outlined'


### PR DESCRIPTION
Makes website scroll to the top when page is changed on search. Otherwise there is confusion and bad UX.
https://pagination.loculus.org