### PR TITLE
feat(deployment): Create liveness and readiness probes for lapis

### DIFF
--- a/kubernetes/loculus/templates/lapis-silo-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-deployment.yaml
@@ -62,6 +62,20 @@ spec:
             - name: lapis-silo-database-config-processed
               mountPath: /workspace/reference_genomes.json
               subPath: reference_genomes.json
+          readinessProbe:
+            httpGet:
+              path: /sample/info
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /sample/info
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
         - name: silo-preprocessing
           image: {{ $.Values.images.lapisSilo }}
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Adds a kubernetes liveness and readiness probe for LAPIS. This is made possible by the fact that LAPIS can now start with zero seqs.

http://lapis-probe.loculus.org/