### PR TITLE
fix(deployment): Raise error on failure to replace a URL in config preprocessing

### DIFF
--- a/kubernetes/config-processor/config-processor.py
+++ b/kubernetes/config-processor/config-processor.py
@@ -23,7 +23,8 @@ def replace_url_with_content(file_content):
         if response.status_code == 200:
             file_content = file_content.replace(f"[[URL:{url}]]", response.text.strip())
         else:
-            raise ValueError(f"Problem downloading {url}")
+            error_details = f"URL: {url}, Status Code: {response.status_code}, Reason: {response.reason}"
+            raise ValueError(f"Problem downloading {error_details}")
     return file_content
 
 def make_substitutions(file_content, substitutions):


### PR DESCRIPTION
Raise an error when URL replacement fails in config preprocessing due to a failure to download from the URL. Previously if a URL gave e.g. a 404 the placeholder would just be passed on intact `[[URL:blabla]]`, leading to confusing behaviour.