### PR TITLE
Revert "chore(kubernetes): update LAPIS and SILO"

### DIFF
--- a/kubernetes/loculus/templates/lapis-silo-database-config.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-database-config.yaml
@@ -23,6 +23,10 @@ data:
           generateIndex: {{ .generateIndex }}
           {{- end }}
       {{- end }}
+        - name: nucleotideInsertions
+          type: insertion
+        - name: aminoAcidInsertions
+          type: aaInsertion
       primaryKey: accessionVersion
       {{- .silo | toYaml | nindent 6 }}
   {{- end }}

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1174,8 +1174,8 @@ insecureCookies: false
 bannerMessage: "This is a development environment. Data will not be persisted."
 additionalHeadHTML: '<script defer data-domain="main.loculus.org" src="https://plausible.io/js/script.js"></script>'
 imageTags:
-  lapisSilo: "0.2.0"
-  lapis: "0.2.1"
+  lapisSilo: "0.1.0"
+  lapis: "0.1.1"
 secrets:
   smtp-password:
     type: raw


### PR DESCRIPTION
This reverts commit 57b2e2a2cd5b104c2a06c6350a4f122ddb3a027f.

Upgrade broke silo preprocessing, see https://loculus.slack.com/archives/C05G172HL6L/p1716836290721219

We should investigate why our E2E tests didn't fail despite silo preprocessing failing in preview (at least on main)