### PR TITLE
fix(auth): set email login link expiry to 30 mins

### DIFF
--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -28,6 +28,7 @@ data:
       "registrationAllowed": true,
       "accessTokenLifespan": 36000,
       "ssoSessionIdleTimeout": 36000,
+      "actionTokenGeneratedByUserLifespan": 1800,
       "users": [
         {{ if $.Values.createTestAccounts }}
           {{- $browsers := list "firefox" "webkit" "chromium"}}


### PR DESCRIPTION
Resolves [#2057](https://github.com/loculus-project/loculus/issues/2057). Emma also raised this previously, maybe on the PP repo.
Resolves #1955

https://set-email-login-link-expi.loculus.org/

<img width="781" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/f0f272d9-0649-48d9-ba4a-e29eb64f2dab">
