### PR TITLE
fix(website): fix data use terms link

### DIFF
--- a/website/src/routes/routes.ts
+++ b/website/src/routes/routes.ts
@@ -60,7 +60,7 @@ export const routes = {
     },
     logout: () => '/logout',
     organismSelectorPage: (redirectTo: string) => `/organism-selector/${redirectTo}`,
-    datauseTermsPage: () => '/governance/data_use_terms',
+    datauseTermsPage: () => '/governance/data-use-terms',
 };
 
 function withOrganism(organism: string, path: `/${string}`) {


### PR DESCRIPTION
We seem to have got in a muddle here with respect to: https://demo.pathoplexus.org/governance/data-use-terms . I think it's my fault!