### PR TITLE
chore(deps): Bump lapis-silo to 0.2.2 to allow empty input in silo-preprocessing

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1170,7 +1170,7 @@ insecureCookies: false
 bannerMessage: "This is a development environment. Data will not be persisted."
 additionalHeadHTML: '<script defer data-domain="main.loculus.org" src="https://plausible.io/js/script.js"></script>'
 images:
-  lapisSilo: "ghcr.io/genspectrum/lapis-silo:empty-input" # until PR merged (empty)
+  lapisSilo: "ghcr.io/genspectrum/lapis-silo:0.2.2"
   lapis: "ghcr.io/genspectrum/lapis-v2:0.2.2"
 secrets:
   smtp-password:


### PR DESCRIPTION
https://github.com/GenSpectrum/LAPIS-SILO/pull/433

https://empty-input.loculus.org

Works!

<img width="1642" alt="image" src="https://github.com/loculus-project/loculus/assets/25161793/fe4983bb-37cb-4697-8c57-6b819b7d46ac">

Let's get it merged @Taepper soon, congrats!