### PR TITLE
feat(website): Make "modify search" button styled in line with other components

### DIFF
--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -47,7 +47,7 @@ export const SearchForm = ({
     return (
         <QueryClientProvider client={queryClient}>
             <div className='text-right -mb-10 md:hidden'>
-                <button onClick={toggleMobileOpen} className='btn btn-xs'>
+                <button onClick={toggleMobileOpen} className='btn btn-xs bg-primary-600 text-white'>
                     Modify search query
                 </button>
             </div>


### PR DESCRIPTION
On mobile:

<img width="697" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/5701e566-f806-4525-8448-d659a32d02df">


rather than

<img width="591" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/17b3b72a-940c-4a4c-af12-3c10c0f8ccf7">


We can no doubt do better than this, but it sticks out less