### PR TITLE
fix(website): subtly improve alignment of "Search" title

### DIFF
--- a/website/src/pages/[organism]/search/index.astro
+++ b/website/src/pages/[organism]/search/index.astro
@@ -28,7 +28,7 @@ const referenceGenomeSequenceNames = getReferenceGenomesSequenceNames(cleanedOrg
 ---
 
 <BaseLayout title={`${cleanedOrganism.displayName} - Browse`} noHorizontalPadding>
-    <h1 class='title px-3 py-2'>Search</h1>
+    <h1 class='title px-3 py-2 ml-1'>Search</h1>
 
     <SearchFullUI
         client:load


### PR DESCRIPTION
This was slightly off to the left before, and is now aligned:

<img width="341" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/bbca25c9-74dc-46fd-bcf6-68fbc73ecc8d">
