### PR TITLE
feat(k8s): Validate Python version and imports for deploy.py, useful errors

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -3,10 +3,26 @@
 import argparse
 import os
 import subprocess
+import sys
 import time
 from pathlib import Path
 
-import yaml
+# Minimum version of Python required is 3.9 due to type hint usage
+if sys.version_info < (3, 9):
+    msg = f"Python 3.9 or higher is required to run the ./deploy.py script\nYou are using version {sys.version} from {sys.executable}"
+    raise RuntimeError(msg)
+
+try:
+    import yaml
+except ImportError as e:
+    msg = (
+        f"pyyaml is not installed but required by ./deploy.py\n"
+        "You can install it for example with 'pip install pyyaml' or 'conda install pyyaml' (if using conda)\n"
+        f"You are currently using Python version {sys.version} from {sys.executable}"
+    )
+    raise ImportError(
+        msg
+    ) from e
 
 script_path = Path(__file__).resolve()
 ROOT_DIR = script_path.parent


### PR DESCRIPTION
## What's new: Better error messages

### Python < 3.9

```
$ micromamba run -n py38-test ./deploy.py cluster
Traceback (most recent call last):
  File "/Users/corneliusromer/code/loculus-config/deploy.py", line 13, in <module>
    raise RuntimeError(msg)
RuntimeError: Python 3.9 or higher is required to run the ./deploy.py script
You are using version 3.8.19 | packaged by conda-forge | (default, Mar 20 2024, 12:49:57) 
[Clang 16.0.6 ] from /Users/corneliusromer/micromamba/envs/py38-test/bin/python3
```

### Missing pyyaml package

```
micromamba run -n py39-test ./deploy.py cluster
Traceback (most recent call last):
  File "/Users/corneliusromer/code/loculus-config/deploy.py", line 16, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/corneliusromer/code/loculus-config/deploy.py", line 23, in <module>
    raise Exception(
Exception: pyyaml is not installed but required by ./deploy.py
You can install it for example with 'pip install pyyaml' or 'conda install pyyaml' (if using conda)
You are currently using Python version 3.9.19 | packaged by conda-forge | (main, Mar 20 2024, 12:55:20) 
[Clang 16.0.6 ] from /Users/corneliusromer/micromamba/envs/py39-test/bin/python3
```

Thanks to Xiaoyu Yu for bringing this to my attention