### PR TITLE
fix(k8s): allow startup delay of 180 seconds for keycloak

### DIFF
--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -111,8 +111,8 @@ spec:
             httpGet:
               path: /health
               port: 8080
-            initialDelaySeconds: 60
-            periodSeconds: 10
+            initialDelaySeconds: 180
+            periodSeconds: 1
           readinessProbe:
             httpGet:
               path: /health/ready


### PR DESCRIPTION
Resolves #2117

preview URL: https://keycloak-startup.loculus.org

### Summary

Don't restart keycloak if it isn't up within 60s, give it 180s to start