### PR TITLE
fix(website): correct download of multiple segments from the edit page

### DIFF
--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -338,8 +338,12 @@ const extractProcessedSequences = (editedData: SequenceEntryToEdit) => {
     ].flatMap(({ type, sequences }) =>
         Object.entries(sequences).map(([sequenceName, sequence]) => {
             let label = sequenceName;
-            if (label === 'main' && type !== 'gene') {
-                label = type === 'unaligned' ? 'Sequence' : 'Aligned';
+            if (type !== 'gene') {
+                if (label === 'main') {
+                    label = type === 'unaligned' ? 'Sequence' : 'Aligned';
+                } else {
+                    label = type === 'unaligned' ? `${sequenceName} (unaligned)` : `${sequenceName} (aligned)`;
+                }
             }
             return { label, sequence };
         }),


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #2122

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://fix-segmented-edit.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Correct fasta download bug - previously all sequences were joined with a comma as separator - this is an invalid format.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->
Edit view of sequences is good: 
![image](https://github.com/loculus-project/loculus/assets/50943381/62adc58e-cc6c-47e4-947e-ca1fcec2b576)

