### PR TITLE
chore(deps): upgrade ncbi-datasets-cli to 16.21.0

### DIFF
--- a/ingest/environment.yml
+++ b/ingest/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - biopython
   - click
   - jsonlines
-  - ncbi-datasets-cli >=16.18.1
+  - ncbi-datasets-cli >=16.20.0
   - pandas
   - PyYAML
   - requests


### PR DESCRIPTION
preview URL: https://upgrade-datasets.loculus.org
