### PR TITLE
feat(website): Add robots no index

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -33,6 +33,7 @@ const lastTimeBannerWasClosed = Astro.cookies.get('lastTimeBannerWasClosed')?.va
         <link rel='preload' as='image' href='/favicon.svg' />
         <meta name='viewport' content='width=device-width' />
         <meta name='generator' content={Astro.generator} />
+        <meta name='robots' content='noindex' />
         <title>{title}</title>
         <Fragment set:html={additionalHeadHTML} />
     </head>


### PR DESCRIPTION
A bit late, but prevent search engine indexing until launch. I will create an issue to undo this.