### PR TITLE
fix(ingest): remove warnings that metadata is not present

### DIFF
--- a/kubernetes/loculus/templates/_preprocessingFromValues.tpl
+++ b/kubernetes/loculus/templates/_preprocessingFromValues.tpl
@@ -7,9 +7,6 @@
     {{- if .type }}
     type: {{ .type }}
     {{- end }}
-    {{- if .noInput }}
-    no_warn: {{ .noInput }}
-    {{- end }}
   {{- if .preprocessing }}
   {{- if hasKey .preprocessing "function" }}
   function: {{ index .preprocessing "function" }}

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -360,15 +360,6 @@ def get_metadata(
                 input_data[arg_name] = None
             continue
         if input_path not in unprocessed.inputMetadata:
-            if not spec.args.get("no_warn", False):
-                warnings.append(
-                    ProcessingAnnotation(
-                        source=[
-                            AnnotationSource(name=input_path, type=AnnotationSourceType.METADATA)
-                        ],
-                        message=f"Metadata field '{input_path}' not found in input",
-                    )
-                )
             continue
         input_data[arg_name] = unprocessed.inputMetadata[input_path]
     try:


### PR DESCRIPTION
Resolves #2125
https://nowarn.loculus.org/

Removes warnings that metadata is not present:
<img width="1291" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/6b8f198e-3d25-49d0-bad9-8b00216000bf">
vs.
![image](https://github.com/loculus-project/loculus/assets/19732295/ddbd068f-07ab-4df7-8524-85a65350cbb1)