### PR TITLE
feat(website): display number of sequences awaiting review on submission portal

### DIFF
--- a/website/src/pages/[organism]/submission/[groupId]/index.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/index.astro
@@ -17,7 +17,6 @@ const accessToken = getAccessToken(session)!;
 const { organism } = cleanOrganism(Astro.params.organism);
 const groupsResult = await getGroupsAndCurrentGroup(Astro.params, Astro.locals.session);
 
-// Updated function to use backendClient.call
 async function getSequenceCounts(organism: string, groupId: number) {
     const backendClient = BackendClient.create();
     try {
@@ -66,7 +65,7 @@ async function getSequenceCounts(organism: string, groupId: number) {
                     },
                     {
                         title: 'Review',
-                        description: `Review your group's unreleased submissions.`,
+                        description: "Review your group's unreleased submissions.",
                         route: routes.userSequenceReviewPage(organism!.key, group.groupId),
                         icon: GgCheckO,
                         count: othersTotal,


### PR DESCRIPTION
Resolves #1033

https://numunreleased.loculus.org/


We want it to be very clear to the user when they have sequences ready to review, so that for example they don't re-submit the same sequences not knowing where they have gone. This achieves that with a salient display of the number of sequences awaiting review.

<img width="934" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/70ed5db8-6ee2-468d-ae40-f4fc09519cf8">

