### PR TITLE
feat(website): amend review card tooltips

### DIFF
--- a/website/src/components/ReviewPage/ReviewCard.tsx
+++ b/website/src/components/ReviewPage/ReviewCard.tsx
@@ -270,8 +270,8 @@ type DataUseTermsIconProps = {
 const DataUseTermsIcon: FC<DataUseTermsIconProps> = ({ dataUseTerms, accession }) => {
     const hintText =
         dataUseTerms.type === restrictedDataUseTermsType
-            ? `Data use restricted until ${dataUseTerms.restrictedUntil}`
-            : `Data open to use`;
+            ? `Under the Restricted Use Terms until ${dataUseTerms.restrictedUntil}`
+            : `To be released as open data`;
 
     return (
         <>


### PR DESCRIPTION
Amends the tooltips re: conditions of use on the review page. Main purpose was to replace `Data open to use` which sounds stilted to me. I'm open to further rewording suggestions -- I don't think mine are great either.

resolves #1683