### PR TITLE
feat(website): Add target "_blank" to data use terms checkbox

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
@@ -71,7 +71,7 @@ export const DownloadDialog: FC<DownloadDialogProps> = ({
                             />
                             <span className='label-text'>
                                 I agree to the {/* TODO(862) */}
-                                <a href={routes.datauseTermsPage()} className='underline'>
+                                <a href={routes.datauseTermsPage()} className='underline' target='_blank'>
                                     data use terms
                                 </a>
                                 .


### PR DESCRIPTION
Users probably don't want to leave the current page to view the data use terms. This will make the link open in a new window.