### PR TITLE
fix(website): Tweak "not latest version" banner.

### DIFF
--- a/website/src/components/SequenceDetailsPage/SequencesBanner.astro
+++ b/website/src/components/SequenceDetailsPage/SequencesBanner.astro
@@ -27,7 +27,7 @@ const isLatestVersion = ownHistoryEntry?.versionStatus === siloVersionStatuses.l
                 <p class='font-bold'>This is not the latest version of this sequence entry.</p>
                 {latestAccessionVersion !== undefined && (
                     <p>
-                        The latest version is: 
+                        The latest version is:
                         <a href={routes.sequencesDetailsPage(latestAccessionVersion)} class='font-bold underline mx-1'>
                             {getAccessionVersionString(latestAccessionVersion)}
                         </a>


### PR DESCRIPTION
Previously we appeared to be ordering users to visit the latest version. Instead we can just let them know it's there.

Changes "Go to latest version:" to "The latest version is:"

Before:

<img width="1209" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/2eb34251-a533-4af4-800f-ce106a6c4f80">

Sorry, I don't have a preview of after
