### PR TITLE
feat(website): Use headlessUI for download dialog, make download dialog close on click outside, improve checkbox on download dialog

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
@@ -1,5 +1,6 @@
-import { type FC, useState } from 'react';
 import { Dialog, DialogPanel, DialogTitle } from '@headlessui/react';
+import { type FC, useState } from 'react';
+
 import { ActiveDownloadFilters } from './ActiveDownloadFilters.tsx';
 import { DownloadButton } from './DownloadButton.tsx';
 import { DownloadForm } from './DownloadForm.tsx';
@@ -33,27 +34,29 @@ export const DownloadDialog: FC<DownloadDialogProps> = ({
             <button className='outlineButton' onClick={openDialog}>
                 Download
             </button>
-            <Dialog open={isOpen} onClose={closeDialog} className="relative z-10">
-                <div className="fixed inset-0 bg-black bg-opacity-25" />
-                <div className="fixed inset-0 overflow-y-auto">
-                    <div className="flex min-h-full items-center justify-center p-4 text-center">
-                        <DialogPanel className="w-full max-w-5xl transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl">
-                            <DialogTitle
-                                as="h3"
-                                className="text-2xl font-bold leading-6 text-gray-900 mb-4"
-                            >
+            <Dialog open={isOpen} onClose={closeDialog} className='relative z-10'>
+                <div className='fixed inset-0 bg-black bg-opacity-25' />
+                <div className='fixed inset-0 overflow-y-auto'>
+                    <div className='flex min-h-full items-center justify-center p-4 text-center'>
+                        <DialogPanel className='w-full max-w-5xl transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl'>
+                            <DialogTitle as='h3' className='text-2xl font-bold leading-6 text-gray-900 mb-4'>
                                 Download
                             </DialogTitle>
                             <button
-                                className="absolute right-2 top-2 text-gray-400 hover:text-gray-500"
+                                className='absolute right-2 top-2 text-gray-400 hover:text-gray-500'
                                 onClick={closeDialog}
                             >
-                                <span className="sr-only">Close</span>
-                                <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                                <span className='sr-only'>Close</span>
+                                <svg className='h-6 w-6' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
+                                    <path
+                                        strokeLinecap='round'
+                                        strokeLinejoin='round'
+                                        strokeWidth={2}
+                                        d='M6 18L18 6M6 6l12 12'
+                                    />
                                 </svg>
                             </button>
-                            <div className="mt-2">
+                            <div className='mt-2'>
                                 <ActiveDownloadFilters
                                     lapisSearchParameters={lapisSearchParameters}
                                     hiddenFieldValues={hiddenFieldValues}
@@ -73,7 +76,12 @@ export const DownloadDialog: FC<DownloadDialogProps> = ({
                                         />
                                         <span className='text-sm'>
                                             I agree to the {/* TODO(862) */}
-                                            <a href={routes.datauseTermsPage()} className='underline' target='_blank' rel="noopener noreferrer">
+                                            <a
+                                                href={routes.datauseTermsPage()}
+                                                className='underline'
+                                                target='_blank'
+                                                rel='noopener noreferrer'
+                                            >
                                                 data use terms
                                             </a>
                                             .


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #2069, resolves #853, resolves #1271 (dupe)

Some small tweaks to download dialog.

<img width="1087" alt="image" src="https://github.com/loculus-project/loculus/assets/19732295/df47cacb-f72d-4d0b-b841-69a68723481f">

https://download-dialog-headlessu.loculus.org/
