### PR TITLE
give group and submitter information to the preprocessing pipeline

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -213,10 +213,24 @@ data class SequenceEntryStatus(
     val dataUseTerms: DataUseTerms,
 ) : AccessionVersionInterface
 
-data class UnprocessedData(
-    @Schema(example = "123") override val accession: Accession,
+data class EditedSequenceEntryData(
+    @Schema(example = "LOC_000S01D") override val accession: Accession,
     @Schema(example = "1") override val version: Version,
     val data: OriginalData<GeneticSequence>,
+) : AccessionVersionInterface
+
+data class UnprocessedData(
+    @Schema(example = "LOC_000S01D") override val accession: Accession,
+    @Schema(example = "1") override val version: Version,
+    val data: OriginalData<GeneticSequence>,
+    @Schema(description = "The submission id that was used in the upload to link metadata and sequences")
+    val submissionId: String,
+    @Schema(description = "The username of the submitter")
+    val submitter: String,
+    @Schema(example = "42", description = "The id of the group that this sequence entry was submitted by")
+    val groupId: Int,
+    @Schema(example = "1720304713", description = "Unix timestamp in seconds")
+    val submittedAt: Long,
 ) : AccessionVersionInterface
 
 data class OriginalData<SequenceType>(

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -19,6 +19,7 @@ import org.loculus.backend.api.Accessions
 import org.loculus.backend.api.CompressionFormat
 import org.loculus.backend.api.DataUseTerms
 import org.loculus.backend.api.DataUseTermsType
+import org.loculus.backend.api.EditedSequenceEntryData
 import org.loculus.backend.api.ExternalSubmittedData
 import org.loculus.backend.api.GetSequenceResponse
 import org.loculus.backend.api.Organism
@@ -284,8 +285,8 @@ class SubmissionController(
         @PathVariable @Valid
         organism: Organism,
         @HiddenParam authenticatedUser: AuthenticatedUser,
-        @RequestBody accessionVersion: UnprocessedData,
-    ) = submissionDatabaseService.submitEditedData(authenticatedUser, accessionVersion, organism)
+        @RequestBody editedSequenceEntryData: EditedSequenceEntryData,
+    ) = submissionDatabaseService.submitEditedData(authenticatedUser, editedSequenceEntryData, organism)
 
     @Operation(description = GET_SEQUENCES_DESCRIPTION)
     @GetMapping("/get-sequences", produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -6,9 +6,7 @@ import com.fasterxml.jackson.databind.node.LongNode
 import com.fasterxml.jackson.databind.node.NullNode
 import com.fasterxml.jackson.databind.node.TextNode
 import kotlinx.datetime.Clock
-import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
 import mu.KotlinLogging
 import org.loculus.backend.api.DataUseTerms
@@ -21,6 +19,7 @@ import org.loculus.backend.service.submission.RawProcessedData
 import org.loculus.backend.service.submission.SubmissionDatabaseService
 import org.loculus.backend.utils.Accession
 import org.loculus.backend.utils.Version
+import org.loculus.backend.utils.toTimestamp
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -118,5 +117,3 @@ class ReleasedDataModel(
         return SiloVersionStatus.REVISED
     }
 }
-
-private fun LocalDateTime.toTimestamp() = this.toInstant(TimeZone.UTC).epochSeconds

--- a/backend/src/main/kotlin/org/loculus/backend/utils/LocalDateTimeExtensions.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/LocalDateTimeExtensions.kt
@@ -1,0 +1,13 @@
+package org.loculus.backend.utils
+
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+
+fun LocalDateTime.toTimestamp() = this.toInstant(TimeZone.UTC).epochSeconds
+
+fun LocalDateTime.toUtcDateString(): String = this.toInstant(TimeZone.currentSystemDefault())
+    .toLocalDateTime(TimeZone.UTC)
+    .date
+    .toString()

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ReviseEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ReviseEndpointTest.kt
@@ -3,6 +3,8 @@ package org.loculus.backend.controller.submission
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.hasItem
 import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.hasProperty
 import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.`is`
 import org.junit.jupiter.api.Test
@@ -102,10 +104,9 @@ class ReviseEndpointTest(
         assertThat(
             responseBody,
             hasItem(
-                UnprocessedData(
-                    accession = accessions.first(),
-                    version = 2,
-                    data = defaultOriginalData,
+                allOf(
+                    hasProperty<UnprocessedData>("accession", `is`(accessions.first())),
+                    hasProperty("version", `is`(2L)),
                 ),
             ),
         )

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
@@ -6,10 +6,10 @@ import org.loculus.backend.api.AccessionVersionInterface
 import org.loculus.backend.api.ApproveDataScope
 import org.loculus.backend.api.DataUseTerms
 import org.loculus.backend.api.DeleteSequenceScope
+import org.loculus.backend.api.EditedSequenceEntryData
 import org.loculus.backend.api.ExternalSubmittedData
 import org.loculus.backend.api.Status
 import org.loculus.backend.api.SubmittedProcessedData
-import org.loculus.backend.api.UnprocessedData
 import org.loculus.backend.api.WarningsFilter
 import org.loculus.backend.controller.DEFAULT_EXTERNAL_METADATA_UPDATER
 import org.loculus.backend.controller.DEFAULT_GROUP_NAME
@@ -147,7 +147,7 @@ class SubmissionControllerClient(private val mockMvc: MockMvc, private val objec
     )
 
     fun submitEditedSequenceEntryVersion(
-        editedData: UnprocessedData,
+        editedData: EditedSequenceEntryData,
         organism: String = DEFAULT_ORGANISM,
         jwt: String? = jwtForDefaultUser,
     ): ResultActions = mockMvc.perform(

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
@@ -9,6 +9,7 @@ import org.loculus.backend.api.AccessionVersionInterface
 import org.loculus.backend.api.AccessionVersionOriginalMetadata
 import org.loculus.backend.api.ApproveDataScope
 import org.loculus.backend.api.DataUseTerms
+import org.loculus.backend.api.EditedSequenceEntryData
 import org.loculus.backend.api.GeneticSequence
 import org.loculus.backend.api.GetSequenceResponse
 import org.loculus.backend.api.Organism
@@ -284,7 +285,7 @@ class SubmissionConvenienceClient(
     fun submitDefaultEditedData(accessions: List<Accession>, userName: String = DEFAULT_USER_NAME) {
         accessions.forEach { accession ->
             client.submitEditedSequenceEntryVersion(
-                UnprocessedData(accession, 1L, defaultOriginalData),
+                EditedSequenceEntryData(accession, 1L, defaultOriginalData),
                 jwt = generateJwtFor(userName),
             )
         }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEditedSequenceEntryVersionEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEditedSequenceEntryVersionEndpointTest.kt
@@ -6,8 +6,8 @@ import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.not
 import org.junit.jupiter.api.Test
+import org.loculus.backend.api.EditedSequenceEntryData
 import org.loculus.backend.api.Status
-import org.loculus.backend.api.UnprocessedData
 import org.loculus.backend.controller.DEFAULT_USER_NAME
 import org.loculus.backend.controller.EndpointTest
 import org.loculus.backend.controller.OTHER_ORGANISM
@@ -29,7 +29,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
     fun `GIVEN invalid authorization token THEN returns 401 Unauthorized`() {
         expectUnauthorizedResponse(isModifyingRequest = true) {
             client.submitEditedSequenceEntryVersion(
-                generateUnprocessedData("1"),
+                generateEditedData("1"),
                 jwt = it,
             )
         }
@@ -42,7 +42,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
         convenienceClient.getSequenceEntry(accession = accessions.first(), version = 1)
             .assertStatusIs(Status.HAS_ERRORS)
 
-        val editedData = generateUnprocessedData(accessions.first())
+        val editedData = generateEditedData(accessions.first())
         client.submitEditedSequenceEntryVersion(editedData)
             .andExpect(status().isNoContent)
 
@@ -57,7 +57,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
         convenienceClient.getSequenceEntry(accession = accessions.first(), version = 1)
             .assertStatusIs(Status.AWAITING_APPROVAL)
 
-        val editedData = generateUnprocessedData(accessions.first())
+        val editedData = generateEditedData(accessions.first())
 
         client.submitEditedSequenceEntryVersion(editedData)
             .andExpect(status().isNoContent)
@@ -76,7 +76,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
             .find { it.accession == firstAccession && it.version == 1L }!!
         assertThat(entryBeforeEdit.originalMetadata, `is`(not(anEmptyMap())))
 
-        val editedData = generateUnprocessedData(firstAccession)
+        val editedData = generateEditedData(firstAccession)
 
         client.submitEditedSequenceEntryVersion(editedData)
             .andExpect(status().isNoContent)
@@ -93,7 +93,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
         convenienceClient.getSequenceEntry(accession = accessions.first(), version = 1)
             .assertStatusIs(Status.HAS_ERRORS)
 
-        val editedDataWithNonExistingVersion = generateUnprocessedData(accessions.first(), version = 2)
+        val editedDataWithNonExistingVersion = generateEditedData(accessions.first(), version = 2)
         val sequenceString = editedDataWithNonExistingVersion.displayAccessionVersion()
 
         client.submitEditedSequenceEntryVersion(editedDataWithNonExistingVersion)
@@ -113,7 +113,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
 
         val nonExistingAccession = "nonExistingAccession"
 
-        val editedDataWithNonExistingAccession = generateUnprocessedData(nonExistingAccession)
+        val editedDataWithNonExistingAccession = generateEditedData(nonExistingAccession)
 
         client.submitEditedSequenceEntryVersion(editedDataWithNonExistingAccession)
             .andExpect(status().isUnprocessableEntity)
@@ -134,7 +134,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
         convenienceClient.getSequenceEntry(accession = accessions.first(), version = 1)
             .assertStatusIs(Status.HAS_ERRORS)
 
-        val editedData = generateUnprocessedData(accessions.first())
+        val editedData = generateEditedData(accessions.first())
 
         client.submitEditedSequenceEntryVersion(editedData, organism = OTHER_ORGANISM)
             .andExpect(status().isUnprocessableEntity)
@@ -156,7 +156,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
         convenienceClient.getSequenceEntry(accession = accessions.first(), version = 1)
             .assertStatusIs(Status.HAS_ERRORS)
 
-        val editedDataFromWrongSubmitter = generateUnprocessedData(accessions.first())
+        val editedDataFromWrongSubmitter = generateEditedData(accessions.first())
         val nonExistingUser = "whoseNameMayNotBeMentioned"
 
         client.submitEditedSequenceEntryVersion(editedDataFromWrongSubmitter, jwt = generateJwtFor(nonExistingUser))
@@ -175,7 +175,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
             .prepareDataTo(Status.HAS_ERRORS, username = DEFAULT_USER_NAME)
             .first()
 
-        val editedData = generateUnprocessedData(accessionVersion.accession, accessionVersion.version)
+        val editedData = generateEditedData(accessionVersion.accession, accessionVersion.version)
         client.submitEditedSequenceEntryVersion(editedData, jwt = jwtForSuperUser)
             .andExpect(status().isNoContent)
 
@@ -183,7 +183,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
             .assertStatusIs(Status.RECEIVED)
     }
 
-    private fun generateUnprocessedData(accession: String, version: Long = 1) = UnprocessedData(
+    private fun generateEditedData(accession: String, version: Long = 1) = EditedSequenceEntryData(
         accession = accession,
         version = version,
         data = emptyOriginalData,

--- a/website/src/services/backendApi.ts
+++ b/website/src/services/backendApi.ts
@@ -9,6 +9,7 @@ import {
     accessionVersionsFilterWithDeletionScope,
     dataUseTerms,
     dataUseTermsHistoryEntry,
+    editedSequenceEntryData,
     getSequencesResponse,
     info,
     problemDetail,
@@ -97,7 +98,7 @@ const submitReviewedSequenceEndpoint = makeEndpoint({
         {
             name: 'data',
             type: 'Body',
-            schema: unprocessedData,
+            schema: editedSequenceEntryData,
         },
     ],
     response: z.never(),

--- a/website/src/types/backend.ts
+++ b/website/src/types/backend.ts
@@ -146,12 +146,26 @@ export const submissionIdMapping = accessionVersion.merge(
 );
 export type SubmissionIdMapping = z.infer<typeof submissionIdMapping>;
 
+export const editedSequenceEntryData = accessionVersion.merge(
+    z.object({
+        data: z.object({
+            metadata: unprocessedMetadataRecord,
+            unalignedNucleotideSequences: z.record(z.string()),
+        }),
+    }),
+);
+export type EditedSequenceEntryData = z.infer<typeof unprocessedData>;
+
 export const unprocessedData = accessionVersion.merge(
     z.object({
         data: z.object({
             metadata: unprocessedMetadataRecord,
             unalignedNucleotideSequences: z.record(z.string()),
         }),
+        submissionId: z.string(),
+        submitter: z.string(),
+        groupId: z.number(),
+        submittedAt: z.number(),
     }),
 );
 export type UnprocessedData = z.infer<typeof unprocessedData>;


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #2263

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://2263-give-group-and-submi.loculus.org/

### Summary
Added 4 fields to the data that is sent to the preprocessing pipeline (`/extract-unprocessed-data`):
* submissionId (String)
* submitter (String)
* groupId (Int)
* submittedAt  (Long, as timestamp)

Other fields, such as `approver` and `released_at` are not set yet.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
