### PR TITLE
Let the insdc_ingest_user submit data with missing required fields.

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
@@ -49,6 +49,7 @@ class ProcessingAnnotation:
 
 @dataclass
 class UnprocessedData:
+    submitter: str
     metadata: InputMetadata
     unalignedNucleotideSequences: dict[str, NucleotideSequence]
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves https://github.com/loculus-project/loculus/issues/2249

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://insdc-ingest-user-allow-e.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Now that https://github.com/loculus-project/loculus/pull/2268 is merged we can add a check if the submitter is 'insdc_ingest_user' and not throw a required metadata field missing error if data from INSDC is missing required fields.

### Screenshot and Tests
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->
1. First test - check if the CCHF reference sequence is now in the database: NC_005301.3
![image](https://github.com/loculus-project/loculus/assets/50943381/9ca855be-5718-4d67-94aa-df60f72ae2b7)

2. Check that the number of sequences seen is comparable to the state of loculus prior to enforcement of field requirement, can be seen in the screenshot I took for this PR: https://github.com/loculus-project/loculus/pull/2243. We have 2 more sequences on CCHF and indeed there were 2 new releases on 2024-07-06. Also 18 new Mpox seqences from the 2024-07-09 and 1 new on the 2024-07-07. So the numbers match. 
