### PR TITLE
feat(auth): restrict redirect uris

### DIFF
--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -280,8 +280,8 @@ data:
           "publicClient": true,
           "directAccessGrantsEnabled": true,
           "redirectUris": [
-            "https://$.Values.host/*",
-            "http://$.Values.host/*",
+            "https://{{$.Values.host}}/*",
+            "http://{{$.Values.host}}/*",
             "http://localhost:3000/*"
           ]
         },


### PR DESCRIPTION
Restricts valid redirect URIs to improve security

https://redirect-uris.loculus.org/

Tested:
- that login works by default
- that editing the redirect URI to another host in the URL did not work
- that localhost:3000 still worked (for dev)