### PR TITLE
chore(deps): install orjsonl from conda-forge, not pip

### DIFF
--- a/ingest/environment.yml
+++ b/ingest/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - jsonlines
   - ncbi-datasets-cli >=16.21.0
   - nextclade >=3.7.0
+  - orjsonl
   - pandas
   - PyYAML
   - requests
@@ -19,5 +20,3 @@ dependencies:
   - snakemake
   - tsv-utils
   - unzip
-  - pip:
-    - orjsonl


### PR DESCRIPTION
Enabled due to https://github.com/conda-forge/orjsonl-feedstock
