### PR TITLE
Fix case where concatenate inputs are not in input metadata

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -327,7 +327,9 @@ class ProcessingFunctions:
                 errors += processed.errors
                 warnings += processed.warnings
             elif order[i] in input_data:
-                formatted_input_data.append(input_data.get(order[i], ""))
+                formatted_input_data.append(
+                    "" if input_data[order[i]] is None else input_data[order[i]]
+                )
             else:
                 formatted_input_data.append(accession_version)
         logging.debug(f"formatted input data:{formatted_input_data}")
@@ -335,7 +337,8 @@ class ProcessingFunctions:
         try:
             result = "/".join(formatted_input_data)
             # To avoid downstream issues do not let the result start or end in a "/"
-            result = result.strip("/")
+            # Also replace white space with '_'
+            result = result.strip("/").replace(" ", "_")
 
             return ProcessingResult(datum=result, warnings=warnings, errors=errors)
         except ValueError as e:


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #https://github.com/loculus-project/loculus/issues/2339

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://fix-prepro-bug.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Now when using the example data prepro correctly responds with error: required fields missing

![image](https://github.com/user-attachments/assets/638f7aae-4b78-4e23-b365-1a231eaf49f7)


### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
