### PR TITLE
feat(website): adjust header for edit page

### DIFF
--- a/website/src/pages/[organism]/submission/edit/[accession]/[version].astro
+++ b/website/src/pages/[organism]/submission/edit/[accession]/[version].astro
@@ -20,7 +20,7 @@ const dataToEdit = await BackendClient.create().getDataToEdit(organism, accessTo
 <BaseLayout title={`Edit ${accession}.${version}`}>
     <div class='flex items-center mb-4'>
         <h1 class='title'>
-            Edit Id: {accession}.{version}
+            Edit {accession}.{version}
         </h1>
     </div>
     {


### PR DESCRIPTION
I found this header odd, as you're not editing the ID: 

<img width="380" alt="image" src="https://github.com/user-attachments/assets/54f15f48-bb27-4da3-aec1-2db4504a5504">

it now just reads "Edit [accession]"