### PR TITLE
fix(ingest): remove unnecessary call to /get-sequences

### DIFF
--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -127,10 +127,6 @@ def create_group(config: Config) -> str:
     logger.info(f"Creating group: {group_name}")
     create_group_response = make_request(HTTPMethod.POST, create_group_url, config, json_body=data)
 
-    if not create_group_response.ok:
-        print(f"Error creating group: {create_group_response.json()}")
-        create_group_response.raise_for_status()
-
     group_id = create_group_response.json()["groupId"]
 
     logger.info(f"Group created: {group_id}")
@@ -144,8 +140,6 @@ def get_or_create_group(config: Config, allow_creation: bool = False) -> str:
 
     logger.info(f"Getting groups for user: {config.username}")
     get_groups_response = make_request(HTTPMethod.GET, get_user_groups_url, config)
-    if not get_groups_response.ok:
-        get_groups_response.raise_for_status()
 
     if len(get_groups_response.json()) > 0:
         group_id = get_groups_response.json()[0]["groupId"]
@@ -203,7 +197,6 @@ def submit_or_revise(
         }
         response = make_request(HTTPMethod.POST, url, config, params=params, files=files)
     logger.debug(f"{logging_strings["noun"]} response: {response.json()}")
-    response.raise_for_status()
 
     return response.json()
 
@@ -217,7 +210,6 @@ def approve(config: Config):
     url = f"{organism_url(config)}/approve-processed-data"
 
     response = make_request(HTTPMethod.POST, url, config, json_body=payload)
-    response.raise_for_status()
 
     return response.json()
 
@@ -231,10 +223,6 @@ def get_sequence_status(config: Config):
     }
 
     response = make_request(HTTPMethod.GET, url, config, params=params)
-
-    if not response.ok:
-        logger.error(response.text)
-    response.raise_for_status()
 
     # Turn into dict with {accession: {version: status}}
     result = defaultdict(dict)
@@ -288,9 +276,6 @@ def get_submitted(config: Config):
     logger.info("Getting previously submitted sequences")
 
     response = make_request(HTTPMethod.GET, url, config, params=params)
-    if not response.ok:
-        logger.error(response.json())
-    response.raise_for_status()
 
     entries: list[dict[str, Any]] = []
     try:


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://ingestunnecessarycall.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

Unless I missed some side effects or similar, this call is unnecessary? We don't need to get all sequences if we tell the backend "approve all sequences" anyway.
Probably a leftover from before the possibility to approve everything existed?

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
