### PR TITLE
chore(kubernetes): update to LAPIS 0.2.8, SILO 0.2.12

### DIFF
--- a/kubernetes/loculus/silo_import_wrapper.sh
+++ b/kubernetes/loculus/silo_import_wrapper.sh
@@ -2,6 +2,6 @@
 
 while true
 do
-    sh /silo_import_job.sh
+    bash /silo_import_job.sh
     sleep 30
 done

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1446,8 +1446,8 @@ insecureCookies: false
 bannerMessage: "This is a development environment. Data will not be persisted."
 additionalHeadHTML: '<script defer data-domain="main.loculus.org" src="https://plausible.io/js/script.js"></script>'
 images:
-  lapisSilo: "ghcr.io/genspectrum/lapis-silo:0.2.11"
-  lapis: "ghcr.io/genspectrum/lapis:0.2.7"
+  lapisSilo: "ghcr.io/genspectrum/lapis-silo:0.2.12"
+  lapis: "ghcr.io/genspectrum/lapis:0.2.8"
 secrets:
   smtp-password:
     type: raw


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://lapis028silo0212.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
This uses the new Ubuntu images of SILO and thus changes the environment in which the import scripts run. It seems that `sh` points to something by default which doesn't have typical command line tools available, we can use bash directly instead.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
