### PR TITLE
docs: change accent color

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -10,7 +10,9 @@ export default defineConfig({
       editLink: {
         baseUrl: "https://github.com/loculus-project/loculus/edit/main/docs/",
       },
-
+      customCss: [
+        "./src/styles/custom.css",
+      ],
       social: {
         github: "https://github.com/loculus-project/loculus",
       },

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -1,0 +1,29 @@
+/* Dark mode colors. */
+:root {
+    --sl-color-accent-low: #112734;
+    --sl-color-accent: #0672a1;
+    --sl-color-accent-high: #b3cdde;
+    --sl-color-white: #ffffff;
+    --sl-color-gray-1: #eceef2;
+    --sl-color-gray-2: #c0c2c7;
+    --sl-color-gray-3: #888b96;
+    --sl-color-gray-4: #545861;
+    --sl-color-gray-5: #353841;
+    --sl-color-gray-6: #24272f;
+    --sl-color-black: #17181c;
+}
+/* Light mode colors. */
+:root[data-theme='light'] {
+    --sl-color-accent-low: #c6dae7;
+    --sl-color-accent: #0c74a3;
+    --sl-color-accent-high: #11364b;
+    --sl-color-white: #17181c;
+    --sl-color-gray-1: #24272f;
+    --sl-color-gray-2: #353841;
+    --sl-color-gray-3: #545861;
+    --sl-color-gray-4: #888b96;
+    --sl-color-gray-5: #c0c2c7;
+    --sl-color-gray-6: #eceef2;
+    --sl-color-gray-7: #f5f6f8;
+    --sl-color-black: #ffffff;
+}


### PR DESCRIPTION
I used [Starlight's color theme editor](https://starlight.astro.build/guides/css-and-tailwind/#color-theme-editor) to change the accent color to the color of the Loculus title and logo.


**Before:**

<img width="344" alt="image" src="https://github.com/user-attachments/assets/af846867-7ad9-4845-bd5c-7f068aa72833">


**After:**

<img width="346" alt="image" src="https://github.com/user-attachments/assets/4f8acc9e-c698-4fae-a310-0ffe35822392">


