### PR TITLE
docs: remove template code from landing page

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -15,22 +15,3 @@ hero:
       link: https://TODOTODOTODO.todo
       icon: external
 ---
-
-import { Card, CardGrid } from "@astrojs/starlight/components";
-
-## Next steps
-
-<CardGrid stagger>
-  <Card title="Update content" icon="pencil">
-    Edit `src/content/docs/index.mdx` to see this page change.
-  </Card>
-  <Card title="Add new content" icon="add-document">
-    Add Markdown or MDX files to `src/content/docs` to create new pages.
-  </Card>
-  <Card title="Configure your site" icon="setting">
-    Edit your `sidebar` and other config in `astro.config.mjs`.
-  </Card>
-  <Card title="Read the docs" icon="open-book">
-    Learn more in [the Starlight Docs](https://starlight.astro.build/).
-  </Card>
-</CardGrid>


### PR DESCRIPTION
This removes the "Next steps" boxes from the landing page of the docs that came with the Starlight template.