### PR TITLE
docs: Add some initial links to frontpage in place of current icons

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -16,21 +16,15 @@ hero:
       icon: external
 ---
 
-import { Card, CardGrid } from "@astrojs/starlight/components";
+import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 
-## Next steps
+## Key resources
 
-<CardGrid stagger>
-  <Card title="Update content" icon="pencil">
-    Edit `src/content/docs/index.mdx` to see this page change.
-  </Card>
-  <Card title="Add new content" icon="add-document">
-    Add Markdown or MDX files to `src/content/docs` to create new pages.
-  </Card>
-  <Card title="Configure your site" icon="setting">
-    Edit your `sidebar` and other config in `astro.config.mjs`.
-  </Card>
-  <Card title="Read the docs" icon="open-book">
-    Learn more in [the Starlight Docs](https://starlight.astro.build/).
-  </Card>
+<CardGrid>
+  <LinkCard title="What is Loculus?" href="introduction/what-is-loculus/" description="A basic introduction to what Loculus can help you with" />
+
+  <LinkCard title="System overview" href="introduction/system-overview/" 
+    description="An overview of the different sub-compontents that make up the Loculus system" />
+  
+  
 </CardGrid>


### PR DESCRIPTION
This yields:

<img width="1010" alt="image" src="https://github.com/user-attachments/assets/858832c4-4471-48da-8108-e558687ace4d">

Similar goal to #2410