### PR TITLE
docs: fix styling through tailwind

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -11,7 +11,7 @@ export default defineConfig({
             editLink: {
                 baseUrl: 'https://github.com/loculus-project/loculus/edit/main/docs/',
             },
-            customCss: ['./src/styles/custom.css'],
+            customCss: ['./src/styles/tailwind.css', './src/styles/custom.css'],
             social: {
                 github: 'https://github.com/loculus-project/loculus',
             },
@@ -39,6 +39,8 @@ export default defineConfig({
                 },
             ],
         }),
-        tailwind(),
+        tailwind({
+            applyBaseStyles: false,
+        }),
     ],
 });

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "@astrojs/check": "^0.9.2",
                 "@astrojs/starlight": "^0.25.4",
+                "@astrojs/starlight-tailwind": "^2.0.3",
                 "@astrojs/tailwind": "^5.1.0",
                 "astro": "^4.13.3",
                 "prettier": "^3.3.3",
@@ -214,6 +215,17 @@
             },
             "peerDependencies": {
                 "astro": "^4.8.6"
+            }
+        },
+        "node_modules/@astrojs/starlight-tailwind": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@astrojs/starlight-tailwind/-/starlight-tailwind-2.0.3.tgz",
+            "integrity": "sha512-ZwbdXS/9rxYlo3tKZoTZoBPUnaaqek02b341dHwOkmMT0lIR2w+8k0mRUGxnRaYtPdMcaL+nYFd8RUa8sjdyRg==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@astrojs/starlight": ">=0.9.0",
+                "@astrojs/tailwind": "^5.0.0",
+                "tailwindcss": "^3.3.3"
             }
         },
         "node_modules/@astrojs/starlight/node_modules/hastscript": {
@@ -8206,6 +8218,12 @@
                     }
                 }
             }
+        },
+        "@astrojs/starlight-tailwind": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@astrojs/starlight-tailwind/-/starlight-tailwind-2.0.3.tgz",
+            "integrity": "sha512-ZwbdXS/9rxYlo3tKZoTZoBPUnaaqek02b341dHwOkmMT0lIR2w+8k0mRUGxnRaYtPdMcaL+nYFd8RUa8sjdyRg==",
+            "requires": {}
         },
         "@astrojs/tailwind": {
             "version": "5.1.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,7 @@
     "dependencies": {
         "@astrojs/check": "^0.9.2",
         "@astrojs/starlight": "^0.25.4",
+        "@astrojs/starlight-tailwind": "^2.0.3",
         "@astrojs/tailwind": "^5.1.0",
         "astro": "^4.13.3",
         "prettier": "^3.3.3",

--- a/docs/src/components/ConditionalLink.astro
+++ b/docs/src/components/ConditionalLink.astro
@@ -10,7 +10,7 @@ const { link } = Astro.props;
     link === undefined ? (
         <slot />
     ) : (
-        <a href={link}>
+        <a href={link} class='text-inherit no-underline'>
             <slot />
         </a>
     )

--- a/docs/src/styles/tailwind.css
+++ b/docs/src/styles/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/docs/tailwind.config.mjs
+++ b/docs/tailwind.config.mjs
@@ -1,8 +1,10 @@
+import starlightPlugin from '@astrojs/starlight-tailwind';
+
 /** @type {import('tailwindcss').Config} */
 export default {
     content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
     theme: {
         extend: {},
     },
-    plugins: [],
+    plugins: [starlightPlugin()],
 };


### PR DESCRIPTION
When introducing tailwind for the docs in #2421, I broke some of the basic styles of Starlight such as the bullet lists. Now, I properly followed the Starlight-specific documentation to include tailwind: https://starlight.astro.build/guides/css-and-tailwind/#tailwind-css

### Screenshots

**Before:**

![image](https://github.com/user-attachments/assets/caf7f9f8-c033-49b2-8725-9a23b3e3045c)

**Now:**

![image](https://github.com/user-attachments/assets/51bf7a8d-d632-4160-bf12-2d1b64f9c907)
