### PR TITLE
docs: Pad out team members

### DIFF
--- a/docs/src/components/Team.astro
+++ b/docs/src/components/Team.astro
@@ -40,7 +40,7 @@ const titleRight = titleSide === 'right';
             displayMembers.map((member) => (
                 <ConditionalLink link={member.link}>
                     <div
-                        class={`w-38 group !mt-0 flex flex-col items-center text-center ${small ? 'md:w-32' : 'md:w-44'}`}
+                        class={`w-38 group !mt-0 mx-2 flex flex-col items-center text-center ${small ? 'md:w-32' : 'md:w-44'}`}
                     >
                         <img
                             class='rounded-full'


### PR DESCRIPTION
The images felt a bit cramped on my screen (but it's really nice)
<img width="1074" alt="image" src="https://github.com/user-attachments/assets/e09555c8-8dcc-4fc1-ac79-bbe85f5e10f7">
