### PR TITLE
docs: add caveats about some schema models

### DIFF
--- a/docs/src/content/docs/for-administrators/schema-designs.mdx
+++ b/docs/src/content/docs/for-administrators/schema-designs.mdx
@@ -41,7 +41,7 @@ This is a good model if:
 
 ### Multiple references for an organism
 
-<Aside title="Note">
+<Aside>
  This approach has not yet been tested. It would definitely require building your own custom preprocessing pipeline, and currently would result in some confusing UI elements.
 </Aside>
 
@@ -52,7 +52,7 @@ This is a good model if there are multiple reference genomes for an organism.
 
 ### No alignments at all
 
-<Aside title="Note">
+<Aside>
 This approach has not yet been tested. It would currently require building your own custom preprocessing pipeline.
 </Aside>
 


### PR DESCRIPTION
We've been having some discussions in https://github.com/loculus-project/loculus/pull/2409 about descriptions of alternative schemas. I think my main concern isn't that we mention them but that we don't provide enough context to users about how tested they each are and how well they are expected to work. This tries to address that.

<img width="626" alt="image" src="https://github.com/user-attachments/assets/633a3efa-f57d-48c9-8b21-2a25cac01201">
