### PR TITLE
docs: contact information

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -59,3 +59,7 @@ import members from '../../team.json';
     randomize={true}
     small={true}
 />
+
+## Contact
+
+If you found a bug or would like to suggest a feature, you are very welcome to [open an issue on GitHub](https://github.com/loculus-project/loculus/issues). For other inquiries, please reach out to one of the [team members](#team).


### PR DESCRIPTION
Would this be a good approach? Or should we set up a dedicated `@loculus.org` email?