### PR TITLE
fix(website): prevent some elements to appear on top of the menu

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -49,7 +49,7 @@ const lastTimeBannerWasClosed = Astro.cookies.get('lastTimeBannerWasClosed')?.va
         />
         <div class='flex flex-col min-h-screen w-11/12 mx-auto'>
             <ToastContainer client:load />
-            <header class='bg-white h-fit'>
+            <header class='bg-white h-fit z-40'>
                 <nav class='flex justify-between items-center p-4'>
                     <div class='flex justify-start'>
                         <div class='flex flex-col'>


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1846 

preview URL: https://fix-sandwich-menu.loculus.org

Solution found by @theosanderson :)

### Summary / technical explanation

Elements for which we set an opacity were on top of the menu because setting the opacity introduces a new stacking context. For elements that are in the same stacking context, we are able to use z-index to put something on top but this does not work across contexts. And by default, due to the order of the elements, the header was below the main content on the z-axis and, therefore, elements within the main content, if they have a different context, will remain on top. This PR now moves the whole header on top of the main content.

### Screenshot

![image](https://github.com/user-attachments/assets/c9c210fb-38bc-4b84-bc1f-bca3a276ce2c)

