### PR TITLE
Rename dummyPreprocessingPipelinePassword to remove "dummy"

### DIFF
--- a/kubernetes/loculus/templates/_config-processor.tpl
+++ b/kubernetes/loculus/templates/_config-processor.tpl
@@ -27,11 +27,11 @@
         secretKeyRef:
           name: service-accounts
           key: insdcIngestUserPassword
-    - name: LOCULUSSUB_dummyPreprocessingPipelinePassword
+    - name: LOCULUSSUB_preprocessingPipelinePassword
       valueFrom:
         secretKeyRef:
           name: service-accounts
-          key: dummyPreprocessingPipelinePassword
+          key: preprocessingPipelinePassword
     - name: LOCULUSSUB_dummyExternalMetadataUpdaterPassword
       valueFrom:
         secretKeyRef:

--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -151,7 +151,7 @@ data:
             "credentials": [
               {
                 "type": "password",
-                "value": "[[dummyPreprocessingPipelinePassword]]"
+                "value": "[[preprocessingPipelinePassword]]"
               }
             ],
             "realmRoles": [

--- a/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
@@ -45,7 +45,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: service-accounts
-                  key: dummyPreprocessingPipelinePassword
+                  key: preprocessingPipelinePassword
           args:
             {{- range $arg := $processingConfig.args }}
             - "{{ $arg }}"

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1487,7 +1487,7 @@ secrets:
     type: autogen
     data:
       insdcIngestUserPassword: ""
-      dummyPreprocessingPipelinePassword: ""
+      preprocessingPipelinePassword: ""
       dummyExternalMetadataUpdaterPassword: ""
       siloImportJobPassword: ""
       backendUserPassword: ""

--- a/kubernetes/loculus/values_e2e_and_dev.yaml
+++ b/kubernetes/loculus/values_e2e_and_dev.yaml
@@ -3,7 +3,7 @@ secrets:
     type: raw
     data:
       insdcIngestUserPassword: "insdc_ingest_user"
-      dummyPreprocessingPipelinePassword: "preprocessing_pipeline"
+      preprocessingPipelinePassword: "preprocessing_pipeline"
       dummyExternalMetadataUpdaterPassword: "external_metadata_updater"
       siloImportJobPassword: "silo_import_job"
       backendUserPassword: "backend"


### PR DESCRIPTION
As I understand it this is used for the real preprocessing pipeline too, so shouldn't have "dummy" in its name