### PR TITLE
fix(deployment): harmonise field display names in sentence case

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -479,7 +479,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         definition: The date on which the sample was received by the laboratory.
         guidance: Alternative if "sample_collection_date" is not available. Record the date the sample was received by the laboratory. Required granularity includes year, month and day. Before sharing this data, ensure this date is not considered identifiable information. If this date is considered identifiable, it is acceptable to add "jitter" to the received date by adding or subtracting calendar days. Do not change the received date in your original records. Alternatively, collection_date may be used as a substitute in the data you share. The date should be provided in ISO 8601 standard format "YYYY-MM-DD".
         example: '2020-03-20'
-        displayName: Sample Received Date
+        displayName: Sample received date
         type: date
         preprocessing:
           function: process_date
@@ -557,42 +557,42 @@ defaultOrganismConfig: &defaultOrganismConfig
         definition: A material consumed and digested for nutritional value or enjoyment.
         guidance: This field includes animal feed. If applicable, select the standardized term and ontology ID for the anatomical material from the picklist provided. Multiple values can be provided, separated by a semi-colon.
         example: Feather meal [FOODON:00003927]; Bone meal [ENVO:02000054]; Chicken breast [FOODON:00002703]
-        displayName: Food Product
+        displayName: Food product
         header: Sampling
       - name: food_product_properties
         ontology_id: GENEPIO:0100445
         definition: Any characteristic of the food product pertaining to its state, processing, a label claim, or implications for consumers.
         guidance: Provide any characteristics of the food product including whether it has been cooked, processed, preserved, any known information about its state (e.g. raw, ready-to-eat), any known information about its containment (e.g. canned), and any information about a label claim (e.g. organic, fat-free).
         example: Food (chopped) [FOODON:00002777]; Ready-to-eat (RTE) [FOODON:03316636]
-        displayName: Food Product Properties
+        displayName: Food product properties
         header: Sampling
       - name: specimen_processing
         ontology_id: GENEPIO:0100435
         definition: The processing applied to samples post-collection, prior to further testing, characterization, or isolation procedures.
         guidance: Provide the sample processing information by selecting a value from the template pick list. If the information is unknown or cannot be provided, leave blank or provide a null value.
         example: Samples pooled [OBI:0600016]
-        displayName: Specimen Processing
+        displayName: Specimen processing
         header: Specimen processing
       - name: specimen_processing_details
         ontology_id: GENEPIO:0100311
         definition: Detailed information regarding the processing applied to a sample during or after receiving the sample.
         guidance: Provide a free text description of any processing details applied to a sample.
         example: 25 swabs were pooled and further prepared as a single sample during library prep.
-        displayName: Specimen Processing Details
+        displayName: Specimen processing details
         header: Specimen processing
       - name: experimental_specimen_role_type
         ontology_id: GENEPIO:0100921
         definition: The type of role that the sample represents in the experiment.
         guidance: Samples can play different types of roles in experiments. A sample under study in one experiment may act as a control or be a replicate of another sample in another experiment. This field is used to distinguish samples under study from controls, replicates, etc.  If the sample acted as an experimental control or a replicate, select a role type from the picklist. If the sample was not a control, leave blank or select "Not Applicable".
         example: Positive experimental control [GENEPIO:0101018]
-        displayName: Experimental Specimen Role  Type
+        displayName: Experimental specimen role type
         header: Specimen processing
       - name: host_age
         ontology_id: GENEPIO:0001392
         definition: Age of host at the time of sampling.
         guidance: If known, provide age. Age-binning is also acceptable.
         example: "79"
-        displayName: Host Age
+        displayName: Host age
         type: int
         header: Host
         rangeSearch: true
@@ -601,14 +601,14 @@ defaultOrganismConfig: &defaultOrganismConfig
         definition: The age category of the host at the time of sampling.
         guidance: Age bins in 10 year intervals have been provided. If a host's age cannot be specified due to provacy concerns, an age bin can be used as an alternative.
         example: 50 - 59 [GENEPIO:0100054]
-        displayName: Host Age Bin
+        displayName: Host age bin
         header: Host
       - name: host_gender
         ontology_id: GENEPIO:0001395
         definition: The gender of the host at the time of sample collection.
         guidance: If known, select a value from the pick list.
         example: Male [NCIT:C46109]
-        displayName: Host Gender
+        displayName: Host gender
         header: Host
         ingest: ncbi_host_sex
       - name: host_origin_country
@@ -616,7 +616,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         definition: The country of origin of the host.
         guidance: If a sample is from a human or animal host that originated from outside of Canada, provide the the name of the country where the host originated by selecting a value from the template pick list. If the information is unknown or cannot be provided, leave blank or provide a null value.
         example: South Africa [GAZ:00001094]
-        displayName: Host Origin Country
+        displayName: Host origin country
         header: Host
       - name: host_disease
         ontology_id: GENEPIO:0001391
@@ -637,21 +637,21 @@ defaultOrganismConfig: &defaultOrganismConfig
         definition: Health status of the host at the time of sample collection.
         guidance: If known, select a value from the pick list.
         example: Asymptomatic [NCIT:C3833]
-        displayName: Host Health State
+        displayName: Host health state
         header: Host
       - name: host_health_outcome
         ontology_id: GENEPIO:0001390
         definition: Disease outcome in the host.
         guidance: If known, select a value from the pick list.
         example: Recovered [NCIT:C49498]
-        displayName: Host Health Outcome
+        displayName: Host health outcome
         header: Host
       - name: travel_history
         ontology_id: GENEPIO:0001416
         definition: Travel history in last six months.
         guidance: Specify the countries (and more granular locations if known) travelled in the last six months; can include multiple travels. Separate multiple travel events with a semicolon. Provide as free text.
         example: Canada, Vancouver; USA, Seattle; Italy, Milan
-        displayName: Travel History
+        displayName: Travel history
         header: Host
       - name: exposure_event
         ontology_id: GENEPIO:0001417
@@ -698,21 +698,21 @@ defaultOrganismConfig: &defaultOrganismConfig
         definition: The vaccination status of the host (fully vaccinated, partially vaccinated, or not vaccinated).
         guidance: Select the vaccination status of the host from the pick list.
         example: Fully Vaccinated [GENEPIO:0100100]
-        displayName: Host Vaccination Status
+        displayName: Host vaccination status
         header: Host
       - name: purpose_of_sequencing
         ontology_id: GENEPIO:0001445
         definition: The reason that the sample was sequenced.
         guidance: The reason why a sample was originally collected may differ from the reason why it was selected for sequencing. The reason a sample was sequenced may provide information about potential biases in sequencing strategy. Provide the purpose of sequencing from the picklist in the template. The reason for sample collection should be indicated in the "purpose of sampling" field.
         example: Baseline surveillance (random sampling) [GENEPIO:0100005]
-        displayName: Purpose Of Sequencing
+        displayName: Purpose of sequencing
         header: Sequencing
       - name: sequencing_date
         ontology_id: GENEPIO:0001447
         definition: The date the sample was sequenced.
         guidance: Provide the sequencing date in ISO 8601 standard format "YYYY-MM-DD".
         example: "2021-04-26"
-        displayName: Sequencing Date
+        displayName: Sequencing date
         type: date
         preprocessing:
           function: process_date
@@ -731,14 +731,14 @@ defaultOrganismConfig: &defaultOrganismConfig
         definition: The length of the amplicon generated by PCR amplification.
         guidance: Provide the amplicon size, including the units.
         example: 300bp
-        displayName: Amplicon Size
+        displayName: Amplicon size
         header: Sequencing
       - name: sequencing_instrument
         ontology_id: GENEPIO:0001452
         definition: The model of the sequencing instrument used.
         guidance: Select the sequencing instrument from the pick list.
         example: Oxford Nanopore MinION [GENEPIO:0100142]
-        displayName: Sequencing Instrument
+        displayName: Sequencing instrument
         header: Sequencing
       - name: sequencing_protocol
         ontology_id: GENEPIO:0001454
@@ -752,28 +752,28 @@ defaultOrganismConfig: &defaultOrganismConfig
         definition: The overarching sequencing methodology that was used to determine the sequence of a biomaterial.
         guidance: 'Example Guidance: Provide the name of the DNA or RNA sequencing technology used in your study. If unsure refer to the protocol documentation, or provide a null value.'
         example: whole genome sequencing assay [OBI:0002117]
-        displayName: Sequencing Assay Type
+        displayName: Sequencing assay type
         header: Sequencing
       - name: sequenced_by_organization
         ontology_id: GENEPIO:0100416
         definition: The name of the agency, organization or institution responsible for sequencing the isolate's genome.
         guidance: Provide the name of the agency, organization or institution that performed the sequencing in full (avoid abbreviations). If the information is unknown or cannot be provided, leave blank or provide a null value.
         example: Public Health Agency of Canada (PHAC) [GENEPIO:0100551]
-        displayName: Sequenced By
+        displayName: Sequenced by
         header: Sequencing
       - name: sequenced_by_contact_name
         ontology_id: GENEPIO:0100471
         definition: The name or title of the contact responsible for follow-up regarding the sequence.
         guidance: Provide the name of an individual or their job title. As personnel turnover may render the contact's name obsolete, it is more prefereable to provide a job title for ensuring accuracy of information and institutional memory. If the information is unknown or cannot be provided, leave blank or provide a null value.
         example: Enterics Lab Manager
-        displayName: Sequenced By Contact Name
+        displayName: Sequenced by - contact name
         header: Sequencing
       - name: sequenced_by_contact_email
         ontology_id: GENEPIO:0100422
         definition: The email address of the contact responsible for follow-up regarding the sequence.
         guidance: Provide the email associated with the listed contact. As personnel turnover may render an individual's email obsolete, it is more prefereable to provide an address for a position or lab, to ensure accuracy of information and institutional memory. If the information is unknown or cannot be provided, leave blank or provide a null value.
         example: enterics@lab.ca
-        displayName: Sequenced By Contact Email
+        displayName: Sequenced by - contact email
         header: Sequencing
       - name: raw_sequence_data_processing_method
         ontology_id: GENEPIO:0001458
@@ -1008,7 +1008,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         preprocessing:
           inputs: {input: nextclade.coverage}
       - name: versionComment
-        displayName: Version Comment
+        displayName: Version comment
         header: Submission details
     website: &website
       tableColumns:


### PR DESCRIPTION
I noticed we had  inconsistency in our field display names: 
<img width="211" alt="image" src="https://github.com/user-attachments/assets/04ef90f0-4aca-4822-a494-2160fcd2b17e">


This hopefully resolves that