### PR TITLE
feat(website): Center organism cards on small screens

### DIFF
--- a/website/src/components/IndexPage/OrganismCard.astro
+++ b/website/src/components/IndexPage/OrganismCard.astro
@@ -17,7 +17,7 @@ const formatNumber = (num: number) => new Intl.NumberFormat('en-US').format(num)
 
 <a
     href={routes.organismStartPage(key)}
-    class='block rounded border border-gray-300 p-4 m-2 w-64 text-center hover:bg-gray-100'
+    class='block rounded border border-gray-300 p-4 m-2 w-64 text-center hover:bg-gray-100 mx-auto sm:mx-2'
 >
     {image !== undefined && <img src={image} class='h-32 mx-auto mb-4' alt={displayName} />}
     <h3 class='font-semibold'>{displayName}</h3>


### PR DESCRIPTION
Centers organism cards on mobile instead of aligning to the left

<img width="436" alt="image" src="https://github.com/user-attachments/assets/c46fa0f7-c7ec-4401-ad29-8c0cad0e7ffa">
