### PR TITLE
feat(website): Format percentage fields nicely

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1004,6 +1004,8 @@ defaultOrganismConfig: &defaultOrganismConfig
         noInput: true
         perSegment: true
         rangeSearch: true
+        customDisplay:
+          type: percentage
         preprocessing:
           inputs: {input: nextclade.coverage}
       - name: versionComment

--- a/website/src/components/SequenceDetailsPage/DataTableEntryValue.tsx
+++ b/website/src/components/SequenceDetailsPage/DataTableEntryValue.tsx
@@ -17,6 +17,7 @@ const CustomDisplayComponent: React.FC<Props> = ({ data, dataUseTermsHistory }) 
         <div className='whitespace-normal text-gray-600 break-inside-avoid'>
             <div className='break-all whitespace-wrap'>
                 {!customDisplay && (value !== '' ? value : <span className='italic'>None</span>)}
+                {customDisplay?.type === 'percentage' && typeof value === 'number' && `${(100 * value).toFixed(2)}%`}
                 {customDisplay?.type === 'badge' &&
                     (customDisplay.value === undefined ? (
                         <span className='italic'>N/A</span>


### PR DESCRIPTION
Before:
<img width="1020" alt="image" src="https://github.com/user-attachments/assets/4b8903aa-cd08-44b1-9e8c-3848b28ab546">


After:
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/2a4d0597-3eee-44f7-a02d-b5512caf0413">
