### PR TITLE
feat(website): Add (some) tags for social media summary cards

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -35,9 +35,9 @@ const lastTimeBannerWasClosed = Astro.cookies.get('lastTimeBannerWasClosed')?.va
         <meta name='generator' content={Astro.generator} />
         <meta name='robots' content='noindex, noarchive' />
         <meta property='og:url' content={Astro.url} />
-        <meta property='og:title' content={websiteName + "| " + title} />
+        <meta property='og:title' content={websiteName + '| ' + title} />
         <meta property='twitter:url' content={Astro.url} />
-        <meta property='twitter:title' content={websiteName + "| " + title} />
+        <meta property='twitter:title' content={websiteName + '| ' + title} />
         <title>{title}</title>
         <Fragment set:html={additionalHeadHTML} />
     </head>


### PR DESCRIPTION
This PR adds a subset of the tags needed for social media summary cards. We only add the cards that need to vary on the different pages of the website - the title and URL. We can add the rest in per-instance configuration using the `additionalHeadHTML` configuration option that we have already created.

https://add-meta-tags.loculus.org/