### PR TITLE
feat(website): display frameshifts nicely

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1006,6 +1006,8 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Frame shifts
         preprocessing:
           inputs: {input: nextclade.frameShifts}
+        customDisplay:
+          type: frameshifts
       - name: completeness
         type: float
         header: "Alignment states and QC metrics"

--- a/website/src/components/SequenceDetailsPage/DataTableEntryValue.tsx
+++ b/website/src/components/SequenceDetailsPage/DataTableEntryValue.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { DataUseTermsHistoryModal } from './DataUseTermsHistoryModal';
+import FrameshiftDisplay from './FrameshiftDisplay.tsx';
 import { SubstitutionsContainers } from './MutationBadge';
 import { type TableDataEntry } from './types.ts';
 import { type DataUseTermsHistoryEntry } from '../../types/backend.ts';
@@ -36,6 +37,9 @@ const CustomDisplayComponent: React.FC<Props> = ({ data, dataUseTermsHistory }) 
                     <>
                         {value} <DataUseTermsHistoryModal dataUseTermsHistory={dataUseTermsHistory} />
                     </>
+                )}
+                {customDisplay?.type === 'frameshifts' && typeof value === 'string' && (
+                    <FrameshiftDisplay value={value} />
                 )}
             </div>
         </div>

--- a/website/src/components/SequenceDetailsPage/FrameshiftDisplay.tsx
+++ b/website/src/components/SequenceDetailsPage/FrameshiftDisplay.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+interface FrameshiftEntry {
+    cdsName: string;
+    nucRel: { begin: number; end: number };
+    nucAbs: { begin: number; end: number }[];
+    codon: { begin: number; end: number };
+    gapsLeading: { begin: number; end: number };
+    gapsTrailing: { begin: number; end: number };
+}
+
+interface FrameshiftDisplayProps {
+    value: string;
+}
+
+const FrameshiftDisplay: React.FC<FrameshiftDisplayProps> = ({ value }) => {
+    let frameshiftData: FrameshiftEntry[];
+
+    try {
+        frameshiftData = JSON.parse(value.replaceAll("'", '"'));
+    } catch (error) {
+        return <span className='text-red-600 text-xs'>Invalid JSON</span>;
+    }
+    if (frameshiftData.length === 0) {
+        return <span className='italic'>None</span>;
+    }
+
+    return (
+        <div className='flex flex-wrap gap-1'>
+            {frameshiftData.map((entry, index) => (
+                <div
+                    key={index}
+                    className='inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 opacity-100'
+                >
+                    {entry.cdsName}
+                    {entry.codon.begin}-{entry.codon.end}: nt{entry.nucRel.begin}-{entry.nucRel.end}
+                    <span className='ml-1 px-1.5 py-0.5 rounded-full text-xs bg-gray-100'>
+                        {entry.gapsLeading.begin}-{entry.gapsLeading.end} / {entry.gapsTrailing.begin}-
+                        {entry.gapsTrailing.end}
+                    </span>
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export default FrameshiftDisplay;


### PR DESCRIPTION
https://frameshifts.loculus.org/

Previously we displayed frameshifts in this way, which looks weird and intimidating:

<img width="644" alt="image" src="https://github.com/user-attachments/assets/fcc4cee4-8433-4b3d-8ad9-4de1ed4a5fc1">

Example sequence with a frameshift: submissionId: `OR964931.1.L/OR964942.1.M/OR964920.1.S`


This _starts_ to show them in a nicer way:

<img width="530" alt="image" src="https://github.com/user-attachments/assets/fbeda28d-5c12-40ae-9dc0-c4ef8c8971aa">


But I don't actually know the best way to represent them and haven't tried to understand their parameters yet, so it would be great to find a good representation with @corneliusroemer .

