### PR TITLE
fix(deployment): allow backend, and hopefully loculus, to be used with no "genes" specified, only a genome

### DIFF
--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -261,9 +261,13 @@ organisms:
 nucleotideSequences:
   {{ $nucleotideSequences := include "loculus.generateSequences" .nucleotideSequences | fromYaml }}
   {{ $nucleotideSequences.fields | toYaml | nindent 8 }}
+{{ if .genes }}
 genes:
   {{ $genes := include "loculus.generateSequences" .genes | fromYaml }}
   {{ $genes.fields | toYaml | nindent 8 }}
+{{ else }}
+genes: []
+{{ end }}
 {{- end }}
 
 {{- define "loculus.generateSequences" }}


### PR DESCRIPTION
Fixes #787

Allows Loculus to be used with a reference-only, no genes. This was always intended behaviour but we had a bug in the deployment which meant that when no genes were configured in the values file, the backend config JSON ended up with `genes: null` not `genes : []`. That is now fixed. There may be other teething issues to identify downstream (though I'm hopeful there are not) but we can fix those as we find them.

