### PR TITLE
fix(deployment): Extend initialDelaySeconds of backend to provide time for migration

### DIFF
--- a/kubernetes/loculus/templates/loculus-backend.yaml
+++ b/kubernetes/loculus/templates/loculus-backend.yaml
@@ -36,7 +36,7 @@ spec:
             httpGet:
               path: "/actuator/health/liveness"
               port: 8079
-            initialDelaySeconds: 30
+            initialDelaySeconds: 90
             periodSeconds: 10
           readinessProbe:
             httpGet:


### PR DESCRIPTION
Hitting problems in prod which I think are due to this.