### PR TITLE
feat(website): make bold in markdown less bold

### DIFF
--- a/website/src/styles/mdcontainer.scss
+++ b/website/src/styles/mdcontainer.scss
@@ -115,3 +115,7 @@
 .mdContainer tbody tr:nth-child(even) {
   @apply bg-gray-50;
 }
+
+.mdContainer strong, m.mdContainer b {
+    	font-weight: 600;
+}


### PR DESCRIPTION
Before:
<img width="449" alt="image" src="https://github.com/user-attachments/assets/def950b9-734e-4ada-9a89-bf5b83af2cf8">

After:
<img width="463" alt="image" src="https://github.com/user-attachments/assets/dc72adae-eb0b-4393-8959-bcd19e543797">


Improvement IMO, but np if others disagree