### PR TITLE
feat(deployment): Make numbers of backend and website replica pods configurable

### DIFF
--- a/kubernetes/loculus/templates/loculus-backend.yaml
+++ b/kubernetes/loculus/templates/loculus-backend.yaml
@@ -9,7 +9,7 @@ metadata:
     argocd.argoproj.io/sync-options: Replace=true
     reloader.stakater.com/auto: "true"
 spec:
-  replicas: 1
+  replicas: {{$.Values.replicas.backend}}
   selector:
     matchLabels:
       app: loculus

--- a/kubernetes/loculus/templates/loculus-website.yaml
+++ b/kubernetes/loculus/templates/loculus-website.yaml
@@ -9,7 +9,7 @@ metadata:
     argocd.argoproj.io/sync-options: Replace=true
     reloader.stakater.com/auto: "true"
 spec:
-  replicas: 1
+  replicas: {{$.Values.replicas.website}}
   selector:
     matchLabels:
       app: loculus

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1456,3 +1456,6 @@ registrationTermsMessage: >
   You must agree to the <a href="http://main.loculus.org/terms">terms of use</a>.
 
 subdomainSeparator: "-"
+replicas:
+  website: 1
+  backend: 1


### PR DESCRIPTION
Allows scaling our number of pods for the backend and website in different instances