### PR TITLE
feat(website): remove source column from SeqSet page

### DIFF
--- a/website/src/components/SeqSetCitations/SeqSetItem.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItem.tsx
@@ -39,7 +39,6 @@ const SeqSetRecordsTable: FC<SeqSetRecordsTableProps> = ({ seqSetRecords, sortBy
             <thead>
                 <tr>
                     <th className='w-1/3 text-left font-medium'>Accession</th>
-                    <th className='w-1/3 text-left font-medium'>Source</th>
                     <th className='w-1/3 text-left font-medium'>Context</th>
                 </tr>
             </thead>
@@ -52,7 +51,6 @@ const SeqSetRecordsTable: FC<SeqSetRecordsTableProps> = ({ seqSetRecords, sortBy
                                     {seqSetRecord.accession}
                                 </a>
                             </td>
-                            <td className='text-left'>{seqSetRecord.type as string}</td>
                             <td className='text-left'>{seqSetRecord.isFocal === true ? 'Focal' : 'Background'}</td>
                         </tr>
                     );


### PR DESCRIPTION
### Summary

This removes the "Source" column from the SeqSet page which doesn't make much sense as we currently do not support sequences from other sources and it is currently not configurable and always shows "Loculus".

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
