### PR TITLE
fix(ci): increase website image build timeout

### DIFF
--- a/.github/workflows/website-image.yml
+++ b/.github/workflows/website-image.yml
@@ -30,7 +30,7 @@ jobs:
   website-docker:
     name: Build Website Docker Image # Don't change: Referenced by .github/workflows/update-argocd-metadata.yml
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #2523

I think the issue here actually was just that things were timing out - I saw some failed runs and they stopped after 15 mins which is the limit. I guess this is due to slow builds for other architectures.