### PR TITLE
feat(website): Hide last updated date

### DIFF
--- a/website/src/components/IndexPage/OrganismCard.astro
+++ b/website/src/components/IndexPage/OrganismCard.astro
@@ -24,6 +24,10 @@ const formatNumber = (num: number) => new Intl.NumberFormat('en-US').format(num)
     <p class='text-sm'>
         {formatNumber(organismStatistics.totalSequences)} sequences<br />
         (+{formatNumber(organismStatistics.recentSequences)} in last {numberDaysAgoStatistics} days)<br />
-        <span class='hidden'>{organismStatistics.lastUpdatedAt && <>Last updated {organismStatistics.lastUpdatedAt.toRelative()}</>}</span>
+        <span class='hidden'
+            >{
+                organismStatistics.lastUpdatedAt && <>Last updated {organismStatistics.lastUpdatedAt.toRelative()}</>
+            }</span
+        >
     </p>
 </a>


### PR DESCRIPTION
I think it's a problem that in our current infra set up we can't restart our servers without resetting the last updated date to "now" for all organisms. (I'm sorry we haven't solved that before launch). I'd suggest hiding this UI element for now. When the first sequences actually arrive we can turn it back on? (Things may have settled down by then)