### PR TITLE
chore(deployment): Remove bannerMessage from appset

### DIFF
--- a/kubernetes/appset.yaml
+++ b/kubernetes/appset.yaml
@@ -40,8 +40,6 @@ spec:
             value: '{{.head_short_sha_7}}'
           - name: branch
             value: '{{.branch}}'
-          - name: bannerMessage
-            value: Dev build, data will not be persisted. SHA {{.head_short_sha_7}}
           - name: host
             value: '{{ (printf "%.25s" .branch) | replace "_" "-" | replace "/" "-"
               | trimSuffix "-" | lower  }}.loculus.org'


### PR DESCRIPTION
We were overriding the bannerMessage in the appset but now this has more cons than pros, so let's stop. (It meant the changes to https://github.com/loculus-project/loculus/pull/2528 didn't take effect). I have already made this change as the deployed appset is outside version control. So this is just to keep things in sync.

