### PR TITLE
docs: Fix link to demo instance in Loculus docs

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -12,7 +12,7 @@ hero:
           icon: right-arrow
           variant: primary
         - text: View a demo instance
-          link: https://TODOTODOTODO.todo
+          link: https://main.loculus.org
           icon: external
 ---
 


### PR DESCRIPTION
Use main.loculus.org for now

