### PR TITLE
feat(deployment): ensure a banner appears if the development databases are running

### DIFF
--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -130,6 +130,8 @@ name: {{ quote $.Values.name }}
 logo: {{ $.Values.logo | toYaml | nindent 6 }}
 {{ if $.Values.bannerMessage }}
 bannerMessage: {{ quote $.Values.bannerMessage }}
+{{ else if or $.Values.runDevelopmentMainDatabase $.Values.runDevelopmentKeycloakDatabase }}
+bannerMessage: "Warning: Development or Keycloak main database is enabled. Development environment only."
 {{ end }}
 {{ if $.Values.additionalHeadHTML }}
 additionalHeadHTML: {{ quote $.Values.additionalHeadHTML }}


### PR DESCRIPTION
One of the most dangerous things that can happen is if due to misconfiguration we are running a local development database when we think we are connecting to a remote database - in which case data loss could occur. To prevent this, ensure some banner message is always displayed if we are running a local development database.