### PR TITLE
docs: change links on landing page

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -7,8 +7,8 @@ hero:
     image:
         file: ../../assets/db.webp
     actions:
-        - text: Getting started with Loculus
-          link: ./for-administrators/getting-started/
+        - text: Read more
+          link: ./introduction/what-is-loculus/
           icon: right-arrow
           variant: primary
         - text: View a demo instance
@@ -23,10 +23,11 @@ import members from '../../team.json';
 ## Key resources
 
 <CardGrid>
-  <LinkCard title="What is Loculus?" href="introduction/what-is-loculus/" description="A basic introduction to what Loculus can help you with" />
 
-  <LinkCard title="System overview" href="introduction/system-overview/" 
-    description="An overview of the different sub-compontents that make up the Loculus system" />
+    <LinkCard title="System overview" href="introduction/system-overview/"
+              description="An overview of the different sub-compontents that make up the Loculus system" />
+
+  <LinkCard title="Getting started" href="for-administrators/getting-started/" description="Set up a new Loculus instance" />
   
   
 </CardGrid>


### PR DESCRIPTION
At the moment, the landing page shows a big button to the getting started for administrator documentation page. This might make sense if we want to invite people to set up a new instance right away but I think this is not the case as we still miss a lot of important documentation. Instead, I would invite people to just read more about Loculus.