### PR TITLE
add faq style to CSS

### DIFF
--- a/website/src/styles/mdcontainer.scss
+++ b/website/src/styles/mdcontainer.scss
@@ -91,6 +91,10 @@
     @apply ml-4;
 }
 
+.mdContainer .faq{
+  @apply font-semibold text-main my-0;
+}
+
 .mdContainer .lettered-list ol{
    list-style-type: lower-latin;
 }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
Currently there isn't a way to slightly bold & colour text without also making it larger & other style additions. In this particular instance, was looking for a new style that can be used in-line for the Pathoplexus FAQ section, as things like `###` (headings) do not work.

### Summary
This adds a simple new CSS class which bolds the text slightly and adds the main colour, and works within the FAQ `<details>` `<summary>` tags - or anywhere else where similar style might be desired.

### Screenshot
The first 2 questions are with the new style, as `<span class="faq">`, the remaining are in the 'current style' (just bolded):

![image](https://github.com/user-attachments/assets/a3e800ee-903d-451f-abb7-033a93efa154)

Expanded:
![image](https://github.com/user-attachments/assets/33f306e0-ee35-43e2-91fe-aa26afe26f71)


I think this looks much nicer than the current solution.

Happy for this to be called something else other than `faq`. Happy for it to moved location within the CSS file also, as I have no idea if that's ordered in some way 🤷‍♀️ 
