### PR TITLE
fix(prepro): Don't mention nullish for required fields

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -549,6 +549,7 @@ def process_single(
                     message="No sequence data found - check segments are annotated correctly",
                 )
             )
+        
         if errors:
             # Break early
             return ProcessedEntry(
@@ -614,8 +615,7 @@ def process_single(
                         )
                     ],
                     message=(
-                        f"Metadata field {output_field} is required but nullish: "
-                        f"{processing_result.datum}."
+                        f"Metadata field {output_field} is required."
                     ),
                 )
             )


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #2557


We shouldn't mention `nullish` which isn't a user-friendly word (I've previously had the same thought as Emma. As I understand it the user will always have not provided a value so I also don't think we need to show the received value ("None" is confusing).