### PR TITLE
fix(prepro): format "no frameshifts" and "no stop codons" case consistent with other cases

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -521,7 +521,7 @@ def format_frameshift(result):
     (the default in nextclade is exclusive end)
     """
     if result == "[]":
-        return result
+        return ""
     result = result.replace("'", '"')
     frame_shifts = json.loads(result)
     frame_shift_strings = []
@@ -558,7 +558,7 @@ def format_stop_codon(result):
     * Converts stop codon positions from index-0 to index-1 (this aligns with other metrics)
     """
     if result == "[]":
-        return result
+        return ""
     result = result.replace("'", '"')
     stop_codons = json.loads(result)
     stop_codon_strings = []


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #2547

We now don't output frameshifts or stop codons in JSON. But we still do in the empty case. This resolves that.