### PR TITLE
chore(kubernetes): update to LAPIS 0.3.1

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1458,7 +1458,7 @@ bannerMessage: "This is a demonstration environment. It may contain non-accurate
 additionalHeadHTML: '<script defer data-domain="main.loculus.org" src="https://plausible.io/js/script.js"></script>'
 images:
   lapisSilo: "ghcr.io/genspectrum/lapis-silo:0.2.15"
-  lapis: "ghcr.io/genspectrum/lapis:0.2.10"
+  lapis: "ghcr.io/genspectrum/lapis:0.3.1"
 secrets:
   smtp-password:
     type: raw

--- a/website/src/components/SequenceDetailsPage/SequenceViewer.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceViewer.tsx
@@ -1,5 +1,5 @@
 import { noCase } from 'change-case';
-import { type FC } from 'react';
+import React, { type FC } from 'react';
 
 import { getLapisUrl } from '../../config.ts';
 import { lapisClientHooks } from '../../services/serviceHooks.ts';
@@ -39,6 +39,11 @@ export const SequencesViewer: FC<Props> = ({
     if (isLoading || data === undefined) {
         return <span className='loading loading-spinner loading-lg' />;
     }
+
+    if (data === null) {
+        return <span className='text-gray-600 italic'>None</span>;
+    }
+
     const header = '>' + data.name + (sequenceType.name === 'main' ? '' : `_${sequenceType.name}`);
 
     return (

--- a/website/src/services/serviceHooks.ts
+++ b/website/src/services/serviceHooks.ts
@@ -34,7 +34,7 @@ export function lapisClientHooks(lapisUrl: string) {
 
                 if (parseResult.success) {
                     return {
-                        data: parseResult.data[0],
+                        data: parseResult.data.length > 0 ? parseResult.data[0] : null,
                         error,
                         isLoading,
                     };

--- a/website/src/utils/search.ts
+++ b/website/src/utils/search.ts
@@ -163,7 +163,7 @@ export const getLapisSearchParameters = (
     );
     for (const field of expandedSchema) {
         if (field.type === 'authors' && sequenceFilters[field.name] !== undefined) {
-            sequenceFilters[field.name.concat('$regex')] = makeCaseInsensitiveLiteralSubstringRegex(
+            sequenceFilters[field.name.concat('.regex')] = makeCaseInsensitiveLiteralSubstringRegex(
                 sequenceFilters[field.name],
             );
             delete sequenceFilters[field.name];


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://lapis031.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Changes:
* Regex syntax is now `field.regex` instead of `field$regex` 
* If the unaligned nucleotide sequence of a segment is missing, LAPIS returns no data instead of `null`

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->
![grafik](https://github.com/user-attachments/assets/2a878f4c-9679-4fe7-965f-ab746524a2bf)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
