### PR TITLE
fix(website): Fix bug where downloading from "group released sequences page" would not work

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/generateDownloadUrl.ts
+++ b/website/src/components/SearchPage/DownloadDialog/generateDownloadUrl.ts
@@ -51,7 +51,7 @@ export const generateDownloadUrl = (
         if (key === 'accession' || mutationKeys.includes(key)) {
             continue;
         }
-        const trimmedValue = value.trim();
+        const trimmedValue = typeof value === 'string' ? value.trim() : value;
         if (trimmedValue.length > 0) {
             params.set(key, trimmedValue);
         }


### PR DESCRIPTION
We had a bug due to the fact that the groupId is an integer and we were trying to trim it

Issue to add E2E testing of this page: #2575