### PR TITLE
feat: transform lower case sequences to upper case

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -75,6 +75,7 @@ import org.springframework.transaction.annotation.Transactional
 import java.io.BufferedReader
 import java.io.InputStream
 import java.io.InputStreamReader
+import java.util.Locale
 import javax.sql.DataSource
 
 private val log = KotlinLogging.logger { }
@@ -318,7 +319,7 @@ class SubmissionDatabaseService(
         val submittedWarnings = submittedProcessedData.warnings.orEmpty()
 
         val (newStatus, processedData) = when {
-            submittedErrors.isEmpty() -> FINISHED to validateProcessedData(
+            submittedErrors.isEmpty() -> FINISHED to postprocessAndValidateProcessedData(
                 submittedProcessedData,
                 organism,
             )
@@ -349,12 +350,34 @@ class SubmissionDatabaseService(
         return newStatus
     }
 
-    private fun validateProcessedData(submittedProcessedData: SubmittedProcessedData, organism: Organism) = try {
+    private fun postprocessAndValidateProcessedData(
+        submittedProcessedData: SubmittedProcessedData,
+        organism: Organism,
+    ) = try {
         throwIfIsSubmissionForWrongOrganism(submittedProcessedData, organism)
-        processedSequenceEntryValidatorFactory.create(organism).validate(submittedProcessedData.data)
+        val processedData = makeSequencesUpperCase(submittedProcessedData.data)
+        processedSequenceEntryValidatorFactory.create(organism).validate(processedData)
     } catch (validationException: ProcessingValidationException) {
         throw validationException
     }
+
+    private fun makeSequencesUpperCase(processedData: ProcessedData<GeneticSequence>) = processedData.copy(
+        unalignedNucleotideSequences = processedData.unalignedNucleotideSequences.mapValues { (_, it) ->
+            it?.uppercase(Locale.US)
+        },
+        alignedNucleotideSequences = processedData.alignedNucleotideSequences.mapValues { (_, it) ->
+            it?.uppercase(Locale.US)
+        },
+        alignedAminoAcidSequences = processedData.alignedAminoAcidSequences.mapValues { (_, it) ->
+            it?.uppercase(Locale.US)
+        },
+        nucleotideInsertions = processedData.nucleotideInsertions.mapValues { (_, it) ->
+            it.map { insertion -> insertion.copy(sequence = insertion.sequence.uppercase(Locale.US)) }
+        },
+        aminoAcidInsertions = processedData.aminoAcidInsertions.mapValues { (_, it) ->
+            it.map { insertion -> insertion.copy(sequence = insertion.sequence.uppercase(Locale.US)) }
+        },
+    )
 
     private fun validateExternalMetadata(
         externalSubmittedData: ExternalSubmittedData,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/PreparedProcessedData.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/PreparedProcessedData.kt
@@ -141,6 +141,30 @@ object PreparedProcessedData {
         ),
     )
 
+    fun withLowercaseSequences(accession: Accession, version: Version) = defaultSuccessfulSubmittedData.copy(
+        accession = accession,
+        version = version,
+        data = defaultProcessedData.copy(
+            unalignedNucleotideSequences = mapOf(
+                MAIN_SEGMENT to "nactg",
+            ),
+            alignedNucleotideSequences = mapOf(
+                MAIN_SEGMENT to "attaaaggtttataccttcccaggtaacaaaccaaccaactttcgatct",
+            ),
+            nucleotideInsertions = mapOf(
+                MAIN_SEGMENT to listOf(Insertion(123, "actg")),
+            ),
+            alignedAminoAcidSequences = mapOf(
+                SOME_LONG_GENE to "acdefghiklmnpqrstvwybzx-*",
+                SOME_SHORT_GENE to "mads",
+            ),
+            aminoAcidInsertions = mapOf(
+                SOME_LONG_GENE to listOf(Insertion(123, "def")),
+                SOME_SHORT_GENE to listOf(Insertion(123, "n")),
+            ),
+        ),
+    )
+
     fun withMissingMetadataFields(
         accession: Accession,
         version: Long = defaultSuccessfulSubmittedData.version,


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://allowlowercasesequences.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Transforming all sequences to upper case in the backend after the preprocessing pipeline submitted them.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
