### PR TITLE
feat(deployment): Disable ENA submission by default

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -6,7 +6,7 @@ disableWebsite: false
 disableBackend: false
 disablePreprocessing: false
 disableIngest: false
-disableEnaSubmission: false
+disableEnaSubmission: true
 siloImportLimitSeconds: 3600
 ingestLimitSeconds: 1800
 getSubmissionListLimitSeconds: 600


### PR DESCRIPTION
ENA submission is an advanced feature that not many users will use (and which is not finalised yet) so we should make it default to disabled and be optionally enabled in the Helm chart