### PR TITLE
fix(website): Edit page: check there are processed sequences before trying to show them

### DIFF
--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -141,20 +141,20 @@ const InnerEditPage: FC<EditPageProps> = ({
                     <Subtitle title='Sequences' />
                 </tbody>
             </table>
-            <div>
-                <BoxWithTabsTabBar>
-                    {processedSequences.map(({ label }, i) => (
-                        <BoxWithTabsTab
-                            key={label}
-                            isActive={i === processedSequenceTab}
-                            label={label}
-                            onClick={() => setProcessedSequenceTab(i)}
-                        />
-                    ))}
-                </BoxWithTabsTabBar>
-                <BoxWithTabsBox>
-                    {processedSequenceTab in processedSequences &&
-                        processedSequences[processedSequenceTab].sequence !== null && (
+            {processedSequences.length > 0 && (
+                <div>
+                    <BoxWithTabsTabBar>
+                        {processedSequences.map(({ label }, i) => (
+                            <BoxWithTabsTab
+                                key={label}
+                                isActive={i === processedSequenceTab}
+                                label={label}
+                                onClick={() => setProcessedSequenceTab(i)}
+                            />
+                        ))}
+                    </BoxWithTabsTabBar>
+                    <BoxWithTabsBox>
+                        {processedSequences[processedSequenceTab].sequence !== null && (
                             <div className='max-h-80 overflow-auto'>
                                 <FixedLengthTextViewer
                                     text={processedSequences[processedSequenceTab].sequence}
@@ -162,8 +162,9 @@ const InnerEditPage: FC<EditPageProps> = ({
                                 />
                             </div>
                         )}
-                </BoxWithTabsBox>
-            </div>
+                    </BoxWithTabsBox>
+                </div>
+            )}
         </>
     );
 };


### PR DESCRIPTION
Resolves ##2581
https://fix-cant-edit-sequence-fa.loculus.org/

Fix a bug where the page crashed when editing sequences that had sequence errors from preprocessing as they had no processed sequences

Seems to be working:

<img width="1236" alt="image" src="https://github.com/user-attachments/assets/ba11780b-47e8-49fd-aac1-9a6049b8caa2">
