### PR TITLE
Increase time to declare keycloak failed to start

### DIFF
--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -121,8 +121,8 @@ spec:
               path: /health/ready
               port: 8080
             timeoutSeconds: 3
-            failureThreshold: 100
-            periodSeconds: 3
+            failureThreshold: 150
+            periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /health/ready


### PR DESCRIPTION
Keycloak can take a really long time to start especially if there are limited compute resources. Increase the timeout to not confuse people trying to use Loculus.