### PR TITLE
feat(website): make LAPIS errors less loud

### DIFF
--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -275,11 +275,14 @@ export const InnerSearchFullUI = ({
                         </div>
                     ) : (
                         <div className='bg-red-400 p-3 rounded-lg'>
-                            <p>There was an error loading the data.</p>
-                            <p className='text-xs'>{JSON.stringify(detailsHook.error)}</p>
+                            <p>There was an error loading the data</p>
+                            <details>
+                                <summary className='text-xs cursor-pointer py-2'>More details</summary>
+                                <p className='text-xs'>{JSON.stringify(detailsHook.error)}</p>
 
-                            <p>{detailsHook.error?.message}</p>
-                            <p>{aggregatedHook.error?.message}</p>
+                                <p>{detailsHook.error?.message}</p>
+                                <p>{aggregatedHook.error?.message}</p>
+                            </details>
                         </div>
                     ))}
                 {(detailsHook.isPaused || aggregatedHook.isPaused) &&


### PR DESCRIPTION
Don't display long error details by default which are a bit scary

<img width="1105" alt="image" src="https://github.com/user-attachments/assets/f8a13d45-5a02-47b2-b83c-0eb953a7356c">
