### PR TITLE
fix(website):  fix timestamp field issue for partial dates

### DIFF
--- a/website/src/components/SearchPage/fields/DateField.tsx
+++ b/website/src/components/SearchPage/fields/DateField.tsx
@@ -31,7 +31,14 @@ export const TimestampField: React.FC<
 > = (props) => (
     <CustomizedDatePicker
         {...props}
-        dateToValueConverter={(date) => (date ? String(Math.floor(date.getTime() / 1000)) : '')}
+        dateToValueConverter={(date) => {
+            const initialValue = date ? String(Math.floor(date.getTime() / 1000)) : '';
+            if (initialValue === 'NaN') {
+                return '';
+            } else {
+                return initialValue;
+            }
+        }}
         valueToDateConverter={(value) => {
             const timestamp = Math.max(parseInt(value, 10));
             return isNaN(timestamp) ? undefined : new Date(timestamp * 1000);


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
This resolves a problem that entering a partial date in timestamp fields led to errors from LAPIS, or at minimum much improves it. 

<img width="665" alt="image" src="https://github.com/user-attachments/assets/0f97a3b0-cdb1-49f2-95c1-fdcad5a12d79">

https://fix-timetstamp-field.loculus.org/ebola-sudan/search?visibility_submittedAtTimestamp=true
