### PR TITLE
feat(website): remove "user" from seqset url

### DIFF
--- a/website/src/components/SeqSetCitations/SeqSetList.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetList.tsx
@@ -79,10 +79,9 @@ const SeqSetListHead = (props: SeqSetListHeadProps) => {
 
 type SeqSetListProps = {
     seqSets: SeqSet[];
-    username: string;
 };
 
-export const SeqSetList: FC<SeqSetListProps> = ({ seqSets, username }) => {
+export const SeqSetList: FC<SeqSetListProps> = ({ seqSets }) => {
     const [order, setOrder] = useState<Order>('desc');
     const [orderBy, setOrderBy] = useState<keyof SeqSet>('createdAt');
     const [page, setPage] = useState(1);
@@ -96,7 +95,7 @@ export const SeqSetList: FC<SeqSetListProps> = ({ seqSets, username }) => {
     };
 
     const handleClick = (_: MouseEvent<unknown>, seqSetId: string, seqSetVersion: string) => {
-        window.location.href = routes.seqSetPage(seqSetId, seqSetVersion, username);
+        window.location.href = routes.seqSetPage(seqSetId, seqSetVersion);
     };
 
     const handleChangePage = (_: unknown, newPage: number) => {

--- a/website/src/pages/seqsets/index.astro
+++ b/website/src/pages/seqsets/index.astro
@@ -80,7 +80,7 @@ const editAccountUrl = (await urlForKeycloakAccountPage(keycloakClient!)) + '/#/
                                 <div>
                                     {seqSetsResponse.match(
                                         (seqSets) => (
-                                            <SeqSetList seqSets={seqSets} username={username} client:load />
+                                            <SeqSetList seqSets={seqSets} client:load />
                                         ),
                                         (error) => (
                                             <ErrorFeedback

--- a/website/src/routes/routes.ts
+++ b/website/src/routes/routes.ts
@@ -54,9 +54,8 @@ export const routes = {
         const seqSetPagePath = `/seqsets`;
         return username === undefined ? seqSetPagePath : seqSetPagePath + `?user=${username}`;
     },
-    seqSetPage: (seqSetId: string, seqSetVersion: string, username?: string | undefined) => {
-        const seqSetPagePath = `/seqsets/${seqSetId}?version=${seqSetVersion}`;
-        return username === undefined ? seqSetPagePath : seqSetPagePath + `&user=${username}`;
+    seqSetPage: (seqSetId: string, seqSetVersion: string) => {
+        return `/seqsets/${seqSetId}?version=${seqSetVersion}`;
     },
     logout: () => '/logout',
     organismSelectorPage: (redirectTo: string) => `/organism-selector/${redirectTo}`,


### PR DESCRIPTION
The seqset URLs looked like `?version=1&user=chaoran-chen`, i.e., included the user, but the user is not used by the page. This PR removes the user.