### PR TITLE
fix(website): remove redundant DOI prefix from SeqSet export

### DIFF
--- a/website/src/components/SeqSetCitations/ExportSeqSet.tsx
+++ b/website/src/components/SeqSetCitations/ExportSeqSet.tsx
@@ -22,7 +22,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords }) =
     const getSeqSetURL = () => {
         return seqSet.seqSetDOI === null || seqSet.seqSetDOI === undefined
             ? window.location.href
-            : `https://doi.org/10.62599/${seqSet.seqSetDOI}`;
+            : `https://doi.org/${seqSet.seqSetDOI}`;
     };
 
     const downloadJSONSeqSet = () => {


### PR DESCRIPTION
@lukepereira noticed that the DOI prefix was appearing twice in the SeqSet export modal:

![image](https://github.com/user-attachments/assets/4b7d2dcb-cd2f-41f1-b285-fdef431aa976)

This fixes the bug.