### PR TITLE
feat: autocomplete/index for release/submit dates

### DIFF
--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -63,6 +63,8 @@ fields:
     header: Submission details
   - name: submittedDate
     type: string
+    generateIndex: true
+    autocomplete: true
     displayName: Date submitted
     header: Submission details
   - name: releasedAtTimestamp
@@ -71,6 +73,8 @@ fields:
     header: Submission details
   - name: releasedDate
     type: string
+    generateIndex: true
+    autocomplete: true
     displayName: Date released
     header: Submission details
   - name: dataUseTerms


### PR DESCRIPTION
preview URL: https://suggest-dates.loculus.org

### Summary

Make these fields more useful in search by adding autocomplete and showing counts.

Alternatively, we could treat these as `type: date` instead of `type: string`

Prompted by Richard's message "“Date submitted (timestamp)” seems more useful than “Date submitted” which requires exact match." see https://loculus.slack.com/archives/C05G172HL6L/p1724457474224369

### Screenshot

<img width="920" alt="Brave Browser 2024-08-27 09 49 18" src="https://github.com/user-attachments/assets/0a9a5869-8027-43d7-9105-d36dfe55ef50">
