### PR TITLE
fix(website): Fix download-my-sequences bug

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/generateDownloadUrl.ts
+++ b/website/src/components/SearchPage/DownloadDialog/generateDownloadUrl.ts
@@ -51,7 +51,6 @@ export const generateDownloadUrl = (
         if (key === 'accession' || mutationKeys.includes(key)) {
             continue;
         }
-        // convert value to string
         const stringValue = String(value);
         const trimmedValue = stringValue.trim();
         if (trimmedValue.length > 0) {


### PR DESCRIPTION
resolves #2612

Fixes a bug where when users tried to download only their sequences they ended up downloading all sequences

groupId is an integer and so it doesn't have a `.length` property so was getting left out. (Normally our typechecks etc. catch this sort of thing, we should look into it)

I tested it reasonably thoroughly and seems good: https://downlad-my-seqs.loculus.org/
