### PR TITLE
fix: hotfix for LAPIS segment unaligned bug

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/generateDownloadUrl.ts
+++ b/website/src/components/SearchPage/DownloadDialog/generateDownloadUrl.ts
@@ -26,8 +26,12 @@ export const generateDownloadUrl = (
 
     // Hotfix for LAPIS segment bug
     // https://loculus.slack.com/archives/C05G172HL6L/p1724767046331529
-    if (option.dataType.type === 'unalignedNucleotideSequences' && option.dataType.segment !== undefined) {
-        params.set(`length_${option.dataType.segment}From`, '1');
+    if (
+        option.dataType.type === 'unalignedNucleotideSequences' &&
+        option.dataType.segment !== undefined &&
+        option.dataType.segment !== 'main'
+    ) {
+        params.set(`length_${option.dataType.segment.toUpperCase()}From`, '1');
     }
 
     params.set('downloadAsFile', 'true');


### PR DESCRIPTION
Add length 1 in download URL as workaround

See https://loculus.slack.com/archives/C05G172HL6L/p1724767046331529

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://raw-hotfix.loculus.org

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
