### PR TITLE
Use standard runner for E2E tests

### DIFF
--- a/.github/workflows/e2e-k3d.yml
+++ b/.github/workflows/e2e-k3d.yml
@@ -29,7 +29,7 @@ jobs:
       contents: read
       checks: read
       actions: read # Required by workflow-telemetry-action
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
       ALL_BROWSERS: ${{ github.ref == 'refs/heads/main' || github.event.inputs.all_browsers && 'true' || 'false' }}


### PR DESCRIPTION
For public repositories, GitHub runners are larger so should be OK for our E2E tests: https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories