### PR TITLE
[don't merge until ingest grouping changes tested] fix(ingest): also try reverse complement when identifying segment

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -175,6 +175,7 @@ rule align:
             --output-tsv {output.results} \
             --server {params.dataset_server} \
             --dataset-name {params.dataset_name} \
+            --retry-reverse-complement
         """
 
 


### PR DESCRIPTION
preview URL: https://try-reverse-complement.loculus.org

### Summary
As we rely on nextclade to identify segments, switching on `--retry-reverse-complement` allows us to deal with reverse complemented sequences.

For CCHF, there are 25 extra sequences that we can identify with this option enabled.

We need to be **very careful** with this fix as it can change grouping - something that ingest might not be able to deal with in the current state.

### Screenshot


### PR Checklist

- [ ] We've verified that ingest can handle grouping changes (by revoking/revising/submitting appropriately)
