### PR TITLE
[don't merge without prior discussion] fix: don't sort author lists, except for segment grouping purposes

### DIFF
--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -483,7 +483,7 @@ def submit_to_loculus(
     if mode == "get-submitted":
         logger.info("Getting submitted sequences")
         response = get_submitted(config)
-        Path(output).write_text(json.dumps(response), encoding="utf-8")
+        Path(output).write_text(json.dumps(response, indent=4, sort_keys=True), encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/ingest/scripts/group_segments.py
+++ b/ingest/scripts/group_segments.py
@@ -109,11 +109,11 @@ def main(
     # These are the fields that are expected to be identical across all segments for a given isolate
 
     # Dynamically determine the fields that are present in the metadata
-    some_row = next(iter(segment_metadata.values()))
-    if not some_row:
+    first_row = next(iter(segment_metadata.values()))
+    if not first_row:
         msg = "No data found in metadata file"
         raise ValueError(msg)
-    all_fields = sorted(some_row.keys())
+    all_fields = sorted(first_row.keys())
     logger.debug(f"All metadata fields: {all_fields}")
 
     # Metadata fields can vary between segments w/o indicating being from different assemblies
@@ -134,7 +134,7 @@ def main(
 
     equivalence_classes: EquivalenceClasses = defaultdict(lambda: defaultdict(list))
     for accession, values in segment_metadata.items():
-        # Author order sometimes among segments from same isolate
+        # Author order sometimes varies among segments from same isolate
         # Example: JX999734.1 (L) and JX999735.1 (M)
         modified_values = values_with_sorted_authors(values)
         group_key = str(

--- a/ingest/scripts/group_segments.py
+++ b/ingest/scripts/group_segments.py
@@ -134,7 +134,7 @@ def main(
 
     equivalence_classes: EquivalenceClasses = defaultdict(lambda: defaultdict(list))
     for accession, values in segment_metadata.items():
-        # Author order sometimes varies despite segment apparently the same assembly
+        # Author order sometimes among segments from same isolate
         # Example: JX999734.1 (L) and JX999735.1 (M)
         modified_values = values_with_sorted_authors(values)
         group_key = str(

--- a/ingest/scripts/group_segments.py
+++ b/ingest/scripts/group_segments.py
@@ -30,6 +30,19 @@ import click
 import orjsonl
 import yaml
 
+
+def sort_authors(authors: str) -> str:
+    """Sort authors alphabetically"""
+    return ", ".join(sorted(authors.split(", ")))
+
+
+def values_with_sorted_authors(values: dict[str, str]) -> dict[str, str]:
+    """Sort authors values and return modified values"""
+    values_copy = values.copy()
+    values_copy["authors"] = sort_authors(values_copy["authors"])
+    return values_copy
+
+
 logger = logging.getLogger(__name__)
 logging.basicConfig(
     encoding="utf-8",
@@ -48,6 +61,7 @@ class Config:
     segmented: bool
 
 
+# TODO: Better name needed, what is special about these fields?
 SPECIAL_FIELDS: Final = {"segment", "submissionId"}
 
 
@@ -94,16 +108,21 @@ def main(
     # Group segments according to isolate, collection date and isolate specific values
     # These are the fields that are expected to be identical across all segments for a given isolate
 
+    # Dynamically determine the fields that are present in the metadata
     first_row = next(iter(segment_metadata.values()))
     if not first_row:
         msg = "No data found in metadata file"
         raise ValueError(msg)
-    all_fields = first_row.keys()
+    all_fields = sorted(first_row.keys())
+    logger.debug(f"All metadata fields: {all_fields}")
 
+    # Metadata fields can vary between segments w/o indicating being from different assemblies
     insdc_segment_specific_fields = set(config.insdc_segment_specific_fields)
     insdc_segment_specific_fields.add("hash")
 
-    shared_fields = set(all_fields) - insdc_segment_specific_fields - SPECIAL_FIELDS
+    # Fields that in principle should be identical for all segments of the same assembly
+    shared_fields = sorted(set(all_fields) - insdc_segment_specific_fields - SPECIAL_FIELDS)
+    logger.debug(f"Shared metadata fields: {shared_fields}")
 
     # Build equivalence classes based on shared fields
     # Use shared fields as the key to group the data
@@ -111,10 +130,14 @@ def main(
     type Accession = str
     type EquivalenceClasses = dict[tuple[str, str], dict[SegmentName, list[Accession]]]
 
-    # Creating the nested defaultdict with type hints
     equivalence_classes: EquivalenceClasses = defaultdict(lambda: defaultdict(list))
     for accession, values in segment_metadata.items():
-        group_key = tuple((field, values[field]) for field in shared_fields if values[field])
+        # Author order sometimes varies despite segment apparently the same assembly
+        # Example: JX999734.1 (L) and JX999735.1 (M)
+        modified_values = values_with_sorted_authors(values)
+        group_key = str(
+            tuple((field, value) for field in shared_fields if (value := modified_values[field]))
+        )
         segment = values["segment"]
         equivalence_classes[group_key][segment].append(accession)
 
@@ -189,11 +212,17 @@ def main(
 
         for field in shared_fields:
             values = {segment: segment_metadata[group[segment]][field] for segment in group}
-            deduplicated_values = set(values.values())
-            if len(deduplicated_values) != 1:
-                msg = f"Assertion failed: values for group must be identical: {values}"
-                raise ValueError(msg)
-            row[field] = deduplicated_values.pop()
+            deduplicated_values = sorted(set(values.values()))
+            if len(deduplicated_values) > 1:
+                if field == "authors":
+                    # For authors, we accept different orders
+                    logger.info(
+                        f"Author orders differ for group {joint_key}: {values}"
+                    )
+                else:
+                    msg = f"Assertion failed: values for group must be identical: {values}"
+                    raise ValueError(msg)
+            row[field] = deduplicated_values[0]
 
         for field in insdc_segment_specific_fields:
             for segment in config.nucleotide_sequences:
@@ -209,7 +238,9 @@ def main(
 
         metadata[joint_key] = row
 
-    Path(output_metadata).write_text(json.dumps(metadata, indent=4), encoding="utf-8")
+    Path(output_metadata).write_text(
+        json.dumps(metadata, indent=4, sort_keys=True), encoding="utf-8"
+    )
     logging.info(f"Wrote grouped metadata for {len(metadata)} sequences")
 
     count = 0

--- a/ingest/scripts/prepare_metadata.py
+++ b/ingest/scripts/prepare_metadata.py
@@ -47,7 +47,7 @@ def split_authors(authors: str) -> str:
         else:
             result.append(single_split[i].strip())
 
-    return ", ".join(sorted(result))
+    return ", ".join(result)
 
 
 @click.command()
@@ -145,7 +145,7 @@ def main(
 
     meta_dict = {rec[fasta_id_field]: rec for rec in metadata}
 
-    Path(output).write_text(json.dumps(meta_dict, indent=4), encoding="utf-8")
+    Path(output).write_text(json.dumps(meta_dict, indent=4, sort_keys=True), encoding="utf-8")
 
     logging.info(f"Saved metadata for {len(metadata)} sequences")
 


### PR DESCRIPTION
resolves #2650

preview URL: https://author-order.loculus.org

### Summary

We started sorting author lists when it turned out that different segments of the same isolate could have different author orders. We should have done the sorting only for grouping purposes and not when submitting to Loculus.

This PR fixes that by only sorting for grouping purposes.

Note: this will cause ingest to submit revisions for existing deployments as the ingest hash changes.

### Screenshot

