### PR TITLE
feat(deployment): allow specifying a priorityClassName

### DIFF
--- a/kubernetes/loculus/templates/_possiblePriorityClassName.tpl
+++ b/kubernetes/loculus/templates/_possiblePriorityClassName.tpl
@@ -1,0 +1,5 @@
+{{- define "possiblePriorityClassName" -}}
+{{- if .Values.priorityClassName }}
+  priorityClassName: {{ .Values.priorityClassName }}
+{{- end -}}
+{{- end -}}

--- a/kubernetes/loculus/templates/_possiblePriorityClassName.tpl
+++ b/kubernetes/loculus/templates/_possiblePriorityClassName.tpl
@@ -1,5 +1,5 @@
 {{- define "possiblePriorityClassName" -}}
-{{- if .Values.priorityClassName }}
-priorityClassName: {{ .Values.priorityClassName }}
+{{- if .Values.podPriorityClassName }}
+priorityClassName: {{ .Values.podPriorityClassName }}
 {{- end -}}
 {{- end -}}

--- a/kubernetes/loculus/templates/_possiblePriorityClassName.tpl
+++ b/kubernetes/loculus/templates/_possiblePriorityClassName.tpl
@@ -1,5 +1,5 @@
 {{- define "possiblePriorityClassName" -}}
 {{- if .Values.priorityClassName }}
-  priorityClassName: {{ .Values.priorityClassName }}
+priorityClassName: {{ .Values.priorityClassName }}
 {{- end -}}
 {{- end -}}

--- a/kubernetes/loculus/templates/ena-submission-deployment.yaml
+++ b/kubernetes/loculus/templates/ena-submission-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         app: loculus
         component: loculus-ena-submission
     spec:
+      {{- include "possiblePriorityClassName" . | nindent 6 }}
       initContainers:
         - name: ena-submission-flyway
           image: "ghcr.io/loculus-project/ena-submission-flyway:{{ $dockerTag }}"

--- a/kubernetes/loculus/templates/ingest-deployment.yaml
+++ b/kubernetes/loculus/templates/ingest-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         argocd.argoproj.io/sync-options: Force=true,Replace=true
     spec:
-      {{- include "possiblePriorityClassName" . | nindent 6 }}
+      {{- include "possiblePriorityClassName" $ | nindent 6 }}
       containers:
         - name: ingest-{{ $key }}
           image: {{ $value.ingest.image}}:{{ $dockerTag }}

--- a/kubernetes/loculus/templates/ingest-deployment.yaml
+++ b/kubernetes/loculus/templates/ingest-deployment.yaml
@@ -23,6 +23,7 @@ spec:
       annotations:
         argocd.argoproj.io/sync-options: Force=true,Replace=true
     spec:
+      {{- include "possiblePriorityClassName" . | nindent 6 }}
       containers:
         - name: ingest-{{ $key }}
           image: {{ $value.ingest.image}}:{{ $dockerTag }}

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -29,6 +29,7 @@ spec:
         app: loculus
         component: keycloak
     spec:
+     {{- include "possiblePriorityClassName" . | nindent 6 }}
       initContainers:
 {{- include "loculus.configProcessor" (dict "name" "keycloak-config" "dockerTag" $dockerTag) | nindent 8 }}
         - name: keycloak-theme-prep

--- a/kubernetes/loculus/templates/lapis-silo-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-deployment.yaml
@@ -22,6 +22,7 @@ spec:
         app: loculus
         component: lapis-silo-{{ $key }}
     spec:
+      {{- include "possiblePriorityClassName" . | nindent 6 }}
       initContainers:
         {{- include "loculus.configProcessor" (dict "name" "lapis-silo-database-config" "dockerTag" $dockerTag) | nindent 8 }}
       containers:

--- a/kubernetes/loculus/templates/lapis-silo-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         app: loculus
         component: lapis-silo-{{ $key }}
     spec:
-      {{- include "possiblePriorityClassName" . | nindent 6 }}
+      {{- include "possiblePriorityClassName" $ | nindent 6 }}
       initContainers:
         {{- include "loculus.configProcessor" (dict "name" "lapis-silo-database-config" "dockerTag" $dockerTag) | nindent 8 }}
       containers:

--- a/kubernetes/loculus/templates/loculus-backend.yaml
+++ b/kubernetes/loculus/templates/loculus-backend.yaml
@@ -20,6 +20,7 @@ spec:
         app: loculus
         component: backend
     spec:
+      {{- include "possiblePriorityClassName" . | nindent 6 }}
       initContainers:
 {{- include "loculus.configProcessor" (dict "name" "loculus-backend-config" "dockerTag" $dockerTag) | nindent 8 }}
       containers:

--- a/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
@@ -30,6 +30,7 @@ spec:
         app: loculus
         component: loculus-preprocessing-{{ $organism }}-v{{ $processingConfig.version }}-{{ $processingIndex }}
     spec:
+      {{- include "possiblePriorityClassName" . | nindent 6 }}
       containers:
         - name: preprocessing-{{ $organism }}
           image: {{ $processingConfig.image}}:{{ $dockerTag }}

--- a/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         app: loculus
         component: loculus-preprocessing-{{ $organism }}-v{{ $processingConfig.version }}-{{ $processingIndex }}
     spec:
-      {{- include "possiblePriorityClassName" . | nindent 6 }}
+      {{- include "possiblePriorityClassName" $ | nindent 6 }}
       containers:
         - name: preprocessing-{{ $organism }}
           image: {{ $processingConfig.image}}:{{ $dockerTag }}

--- a/kubernetes/loculus/templates/loculus-website.yaml
+++ b/kubernetes/loculus/templates/loculus-website.yaml
@@ -20,6 +20,7 @@ spec:
         app: loculus
         component: website
     spec:
+      {{- include "possiblePriorityClassName" . | nindent 6 }}
       initContainers:
 {{- include "loculus.configProcessor" (dict "name" "loculus-website-config" "dockerTag" $dockerTag) | nindent 8 }}
       containers:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1479,4 +1479,3 @@ replicas:
   website: 1
   backend: 1
 gitHubEditLink: "https://github.com/loculus-project/loculus/edit/main/monorepo/website/"
-priorityClassName: test

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1479,3 +1479,4 @@ replicas:
   website: 1
   backend: 1
 gitHubEditLink: "https://github.com/loculus-project/loculus/edit/main/monorepo/website/"
+priorityClassName: test


### PR DESCRIPTION
To allow instances to have various levels of priority - e.g. to make production more important than staging in a cluster.

> Pods can have priority. Priority indicates the importance of a Pod relative to other Pods. If a Pod cannot be scheduled, the scheduler tries to preempt (evict) lower priority Pods to make scheduling of the pending Pod possible

https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/