### PR TITLE
fix: link target is /doc/how-to/authentication-api not _api

### DIFF
--- a/website/src/pages/api-documentation/index.astro
+++ b/website/src/pages/api-documentation/index.astro
@@ -34,7 +34,7 @@ const BUTTON_CLASS =
                 for documentation and direct interaction with our APIs. For more tips on how to use our API we recommend
                 starting out with our
                 <a
-                    href='docs/how-to/authentication_api'
+                    href='docs/how-to/authentication-api'
                     class='underline text-primary-900 hover:text-primary-800 hover:no-underline'
                 >
                     API Authentication documentation.


### PR DESCRIPTION
Found this 404 with a simple spider script (ChatGPT mostly):

```py
import requests
from bs4 import BeautifulSoup
from urllib.parse import urljoin, urlparse, urlunparse
import sys
from collections import defaultdict

# Function to extract URLs from a webpage
def extract_urls(url):
    response = requests.get(url)
    soup = BeautifulSoup(response.text, 'html.parser')
    
    urls = []
    for link in soup.find_all('a', href=True):
        href = link['href']
        # Resolve relative URLs
        full_url = urljoin(url, href)
        urls.append(full_url)
    
    return urls

# Function to filter and normalize URLs
def filter_and_normalize_urls(urls, base_domain):
    filtered_urls = set()
    for url in urls:
        if url.startswith(base_domain) and '/seq/' not in url:
            # Normalize by stripping the fragment (anchor)
            parsed_url = urlparse(url)
            normalized_url = urlunparse(parsed_url._replace(fragment=""))
            filtered_urls.add(normalized_url)
    return filtered_urls

# Function to check if URL returns 404
def check_url_status(url):
    try:
        response = requests.head(url, allow_redirects=True)
        return response.status_code != 404
    except requests.RequestException:
        return False

# Example usage
base_url = 'https://pathoplexus.org'
base_domain = urlparse(base_url).scheme + "://" + urlparse(base_url).netloc

# Dictionary to track which pages link to which URLs
link_references = defaultdict(set)

# Extract and filter URLs from the base page
first_level_urls = filter_and_normalize_urls(extract_urls(base_url), base_domain)

# Store all unique URLs found
all_urls = set(first_level_urls)

# Add references for first level URLs
for url in first_level_urls:
    link_references[url].add(base_url)

# Spider one level deep and track references
for url in first_level_urls:
    second_level_urls = filter_and_normalize_urls(extract_urls(url), base_domain)
    all_urls.update(second_level_urls)
    for second_level_url in second_level_urls:
        link_references[second_level_url].add(url)

# Check URLs and write to appropriate outputs
with open('sitemap.txt', 'w') as sitemap_file:
    for url in sorted(all_urls):
        if check_url_status(url):
            sitemap_file.write(url + '\n')
        else:
            print(f"404 Not Found: {url}", file=sys.stderr)
            for referrer in link_references[url]:
                print(f"  Linked from: {referrer}", file=sys.stderr)
```