### PR TITLE
feat(website): simplify link hover effect on Docs pages

### DIFF
--- a/website/src/styles/mdcontainer.scss
+++ b/website/src/styles/mdcontainer.scss
@@ -21,7 +21,7 @@
   }
 
   .mdContainer a{
-    @apply text-main underline hover:text-primary-600;
+    @apply text-main underline text-primary-600 hover:text-primary:500;
   }
 
 .mdContainer ol {

--- a/website/src/styles/mdcontainer.scss
+++ b/website/src/styles/mdcontainer.scss
@@ -21,7 +21,7 @@
   }
 
   .mdContainer a{
-    @apply text-main underline text-primary-600 hover:text-primary:500;
+    @apply text-main underline text-primary-600 hover:text-primary-500;
   }
 
 .mdContainer ol {

--- a/website/src/styles/mdcontainer.scss
+++ b/website/src/styles/mdcontainer.scss
@@ -21,7 +21,7 @@
   }
 
   .mdContainer a{
-    @apply text-main underline text-primary-600 hover:text-primary-500;
+    @apply text-main underline text-primary-600 hover:text-primary-700;
   }
 
 .mdContainer ol {

--- a/website/src/styles/mdcontainer.scss
+++ b/website/src/styles/mdcontainer.scss
@@ -21,7 +21,7 @@
   }
 
   .mdContainer a{
-    @apply text-main underline hover:font-semibold;
+    @apply text-main underline hover:text-primary-600;
   }
 
 .mdContainer ol {


### PR DESCRIPTION
Uses a much subtler effect on hovering over docs links, avoiding the potential for text to reflow when bolding

See e.g. front page FAQ of https://preview-test2.pathoplexus.org/