### PR TITLE
feat(website): Use sandwich menu even at slightly larger screen sizes

### DIFF
--- a/website/src/components/Navigation/Navigation.astro
+++ b/website/src/components/Navigation/Navigation.astro
@@ -19,7 +19,7 @@ const loginUrl = await getAuthUrl(Astro.url.toString());
 ---
 
 <div class='flex justify-end relative'>
-    <div class='subtitle hidden sm:flex sm:z-6 gap-4'>
+    <div class='subtitle hidden md:flex md:z-6 gap-4'>
         {
             navigationItems
                 .top(selectedOrganism?.key, isLoggedIn, loginUrl)
@@ -28,7 +28,7 @@ const loginUrl = await getAuthUrl(Astro.url.toString());
     </div>
 
     <div
-        class='sm:hidden z-0'
+        class='md:hidden z-0'
         style={{
             position: 'absolute',
             right: '1.5rem',


### PR DESCRIPTION
Preview: https://use-sandwich-menu-even-at.loculus.org/

This is required due to the number of pathoplexus menu items. In time we should adapt our nav strategy.

Change from left to right
<img width="1508" alt="image" src="https://github.com/user-attachments/assets/ccc0c49f-12e1-4514-935f-6aa8864e9bb1">
