### PR TITLE
fix(prepro): Raise warning if not all input segments align

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -383,6 +383,7 @@ def add_input_metadata(
     spec: ProcessingSpec,
     unprocessed: UnprocessedAfterNextclade,
     errors: list[ProcessingAnnotation],
+    warnings: list[ProcessingAnnotation],
     input_path: str,
 ) -> InputMetadata:
     """Returns value of input_path in unprocessed metadata"""
@@ -430,6 +431,18 @@ def add_input_metadata(
                     )
                     result = None
             return result
+        else:
+            warnings.append(
+                ProcessingAnnotation(
+                    source=[
+                        AnnotationSource(
+                            name=segment,
+                            type=AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
+                        )
+                    ],
+                    message=f"Nucleotide sequence for {segment} failed to align",
+                )
+            )
         return None
     if input_path not in unprocessed.inputMetadata:
         return None
@@ -454,7 +467,9 @@ def get_metadata(
         args["submitter"] = unprocessed.submitter
     else:
         for arg_name, input_path in spec.inputs.items():
-            input_data[arg_name] = add_input_metadata(spec, unprocessed, errors, input_path)
+            input_data[arg_name] = add_input_metadata(
+                spec, unprocessed, errors, warnings, input_path
+            )
         args = spec.args
         args["submitter"] = unprocessed.inputMetadata["submitter"]
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -434,6 +434,7 @@ def add_input_metadata(
                         message=f"Nucleotide sequence for {segment} failed to align",
                     )
                 )
+                return None
             if input_path == "nextclade.frameShifts":
                 try:
                     result = format_frameshift(result)

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -431,7 +431,7 @@ def add_input_metadata(
                     )
                     result = None
             return result
-        else if segment != "main":
+        elif segment != "main":
             warnings.append(
                 ProcessingAnnotation(
                     source=[

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -431,7 +431,7 @@ def add_input_metadata(
                     )
                     result = None
             return result
-        else:
+        else if segment != "main":
             warnings.append(
                 ProcessingAnnotation(
                     source=[

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -414,15 +414,7 @@ def add_input_metadata(
             return None
         sub_path = input_path[len(nextclade_prefix) :]
         if segment in unprocessed.nextcladeMetadata:
-            result = str(
-                dpath.get(
-                    unprocessed.nextcladeMetadata[segment],
-                    sub_path,
-                    separator=".",
-                    default=None,
-                )
-            )
-            if not result:
+            if not unprocessed.nextcladeMetadata[segment]:
                 warnings.append(
                     ProcessingAnnotation(
                         source=[
@@ -435,6 +427,14 @@ def add_input_metadata(
                     )
                 )
                 return None
+            result = str(
+                dpath.get(
+                    unprocessed.nextcladeMetadata[segment],
+                    sub_path,
+                    separator=".",
+                    default=None,
+                )
+            )
             if input_path == "nextclade.frameShifts":
                 try:
                     result = format_frameshift(result)

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -125,8 +125,8 @@ def parse_nextclade_json(
     If the segment existed in the input (unaligned_nucleotide_sequences) but did not align
     nextclade_metadata[segment]=None.
     """
-    for id, seg_dict in unaligned_nucleotide_sequences.items():
-        if segment in seg_dict and seg_dict[segment] is not None:
+    for id, segment_sequences in unaligned_nucleotide_sequences.items():
+        if segment in segment_sequences and segment_sequences[segment] is not None:
             nextclade_metadata[id][segment] = None
     nextclade_json_path = Path(result_dir) / "nextclade.json"
     json_data = json.loads(nextclade_json_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #2595 

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://segments-align-anya.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->
1. No warning if 1+ segment is removed but others align: 
<img width="915" alt="image" src="https://github.com/user-attachments/assets/dbc91cf8-6a00-4aca-83f8-cf9b0089ef7a">

2. If segments S and L are flipped causing both to not align we see 
<img width="915" alt="image" src="https://github.com/user-attachments/assets/275df34d-2bfc-4151-8658-90539e622d34">
