### PR TITLE
fix(prepro): Label a sequence with error if not all input segments align

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -83,7 +83,7 @@ def parse_nextclade_tsv(
     ],
     result_dir: str,
     config: Config,
-    segment: str,
+    segment: SegmentName,
 ) -> tuple[
     defaultdict[AccessionVersion, defaultdict[GeneName, list[AminoAcidInsertion]]],
     defaultdict[AccessionVersion, defaultdict[SegmentName, list[NucleotideInsertion]]],
@@ -116,8 +116,10 @@ def parse_nextclade_tsv(
 def parse_nextclade_json(
     result_dir,
     nextclade_metadata: defaultdict[AccessionVersion, defaultdict[SegmentName, dict[str, Any]]],
-    segment,
-    unaligned_nucleotide_sequences,
+    segment: SegmentName,
+    unaligned_nucleotide_sequences: dict[
+        AccessionVersion, dict[SegmentName, NucleotideSequence | None]
+    ],
 ) -> defaultdict[AccessionVersion, defaultdict[SegmentName, dict[str, Any]]]:
     """
     Update nextclade_metadata object with the results of the nextclade analysis.
@@ -350,7 +352,7 @@ def mask_terminal_gaps(
 
 def load_aligned_nuc_sequences(
     result_dir_seg: str,
-    segment: str,
+    segment: SegmentName,
     aligned_nucleotide_sequences: dict[
         AccessionVersion, dict[SegmentName, NucleotideSequence | None]
     ],

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -7,7 +7,6 @@ import re
 import subprocess  # noqa: S404
 import sys
 import time
-
 from collections import defaultdict
 from collections.abc import Sequence
 from pathlib import Path
@@ -19,7 +18,6 @@ from Bio import SeqIO
 
 from .backend import fetch_unprocessed_sequences, submit_processed_sequences
 from .config import Config
-from .sequence_checks import errors_if_non_iupac
 from .datatypes import (
     AccessionVersion,
     AminoAcidInsertion,
@@ -42,6 +40,7 @@ from .datatypes import (
     UnprocessedEntry,
 )
 from .processing_functions import ProcessingFunctions, format_frameshift, format_stop_codon
+from .sequence_checks import errors_if_non_iupac
 
 # https://stackoverflow.com/questions/15063936
 csv.field_size_limit(sys.maxsize)

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -118,10 +118,16 @@ def parse_nextclade_json(
     result_dir,
     nextclade_metadata: defaultdict[AccessionVersion, defaultdict[SegmentName, dict[str, Any]]],
     segment,
+    unaligned_nucleotide_sequences,
 ) -> defaultdict[AccessionVersion, defaultdict[SegmentName, dict[str, Any]]]:
     """
-    Update nextclade_metadata object with the results of the nextclade analysis
+    Update nextclade_metadata object with the results of the nextclade analysis.
+    If the segment existed in the input (unaligned_nucleotide_sequences) but did not align
+    nextclade_metadata[segment]=None.
     """
+    for id, segment_sequences in unaligned_nucleotide_sequences.items():
+        if segment in segment_sequences and segment_sequences[segment] is not None:
+            nextclade_metadata[id][segment] = None
     nextclade_json_path = Path(result_dir) / "nextclade.json"
     json_data = json.loads(nextclade_json_path.read_text(encoding="utf-8"))
     for result in json_data["results"]:
@@ -288,7 +294,9 @@ def enrich_with_nextclade(
                             translation_path}"
                     )
 
-            nextclade_metadata = parse_nextclade_json(result_dir_seg, nextclade_metadata, segment)
+            nextclade_metadata = parse_nextclade_json(
+                result_dir_seg, nextclade_metadata, segment, unaligned_nucleotide_sequences
+            )
             amino_acid_insertions, nucleotide_insertions = parse_nextclade_tsv(
                 amino_acid_insertions, nucleotide_insertions, result_dir_seg, config, segment
             )
@@ -383,6 +391,7 @@ def add_input_metadata(
     spec: ProcessingSpec,
     unprocessed: UnprocessedAfterNextclade,
     errors: list[ProcessingAnnotation],
+    warnings: list[ProcessingAnnotation],
     input_path: str,
 ) -> InputMetadata:
     """Returns value of input_path in unprocessed metadata"""
@@ -405,6 +414,19 @@ def add_input_metadata(
             return None
         sub_path = input_path[len(nextclade_prefix) :]
         if segment in unprocessed.nextcladeMetadata:
+            if not unprocessed.nextcladeMetadata[segment]:
+                warnings.append(
+                    ProcessingAnnotation(
+                        source=[
+                            AnnotationSource(
+                                name=segment,
+                                type=AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
+                            )
+                        ],
+                        message=f"Nucleotide sequence for {segment} failed to align",
+                    )
+                )
+                return None
             result = str(
                 dpath.get(
                     unprocessed.nextcladeMetadata[segment],
@@ -454,7 +476,9 @@ def get_metadata(
         args["submitter"] = unprocessed.submitter
     else:
         for arg_name, input_path in spec.inputs.items():
-            input_data[arg_name] = add_input_metadata(spec, unprocessed, errors, input_path)
+            input_data[arg_name] = add_input_metadata(
+                spec, unprocessed, errors, warnings, input_path
+            )
         args = spec.args
         args["submitter"] = unprocessed.inputMetadata["submitter"]
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -399,6 +399,19 @@ def add_input_metadata(
     nextclade_prefix = "nextclade."
     if input_path.startswith(nextclade_prefix):
         segment = spec.args.get("segment", "main")
+        if not unprocessed.nextcladeMetadata:
+            errors.append(
+                ProcessingAnnotation(
+                    source=[
+                        AnnotationSource(
+                            name="segment",
+                            type=AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
+                        )
+                    ],
+                    message="Error while aligning sequence, please contact the administrator.",
+                )
+            )
+            return None
         sub_path = input_path[len(nextclade_prefix) :]
         if segment in unprocessed.nextcladeMetadata:
             if not unprocessed.nextcladeMetadata[segment]:

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -400,6 +400,11 @@ def add_input_metadata(
     if input_path.startswith(nextclade_prefix):
         segment = spec.args.get("segment", "main")
         if not unprocessed.nextcladeMetadata:
+            # This field should never be empty
+            message = (
+                "An unknown internal error occurred while aligning sequences, "
+                "please contact the administrator."
+            )
             errors.append(
                 ProcessingAnnotation(
                     source=[
@@ -408,7 +413,7 @@ def add_input_metadata(
                             type=AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
                         )
                     ],
-                    message="Error while aligning sequence, please contact the administrator.",
+                    message=message,
                 )
             )
             return None


### PR DESCRIPTION
Preview: https://revert-2678-revert-2676-s.loculus.org/

Resolves #2595

### Summary

#### Motivation

Currently when a user submits multi-segmented entries where at least one segment aligns, then they will not be warned if other segments of the same entry do not align (Use case: someone submits a proper CCHF L segment, but the M segment isn't the M segment, it's actually S).

For non-segmented viruses, we guarantee, that every sequence that's released actually aligns.

The bug here currently is, that this is not true for segmented viruses.

#### Desired (?)

All segments that are submitted _must_ align, otherwise the user cannot release the entry.

#### Pathoplexus changes by this PR (if any)

There should be no change to pathoplexus production DB state with this PR, as ingest already filters out all sequences that do not align.

It only impacts future user submissions of segmented viruses by blocking submissions of entries with non-aligning segments.

### PR History
In https://github.com/loculus-project/loculus/pull/2676 (reverted quickly before making it to Pathoplexus) I changed the code to label a sequence with a warning if a segment does not align.

This had the unintended side effect that for single-segment organisms, sequences that did not align made it through ingest and onto main (ingest auto approves everything that doesn't error).

It was thus reverted very quickly before it reached pathoplexus prod (in #2678).

In this PR, we now more carefully redo the original intent of the original PR but avoiding the side effect that made us revert by emitting an _error_ in case of non-alignment not merely a warning.

### Screenshots

1. No unaligned sequences on website (check that total number of sequences is the same as on main): 
<img width="319" alt="image" src="https://github.com/user-attachments/assets/ab00f03e-f748-4c58-bbaf-27336132fec2">

2. If 1+ segment is missing (as in not provided by submitter) from input do not throw an error:
<img width="915" alt="image" src="https://github.com/user-attachments/assets/01ba8013-d4f3-4fa5-a844-4569615ff72d">

3. If any submitted segment does not align (including single segment case) throw an error - here I introduced an error by switching the L and S segment:
<img width="915" alt="image" src="https://github.com/user-attachments/assets/65336b54-c523-4159-a3ae-1541195f0c34">
