### PR TITLE
fix(website): fix resizing issue on DocsMenu

### DIFF
--- a/website/src/components/Navigation/DocsMenu.tsx
+++ b/website/src/components/Navigation/DocsMenu.tsx
@@ -143,7 +143,7 @@ const DocsMenu: React.FC<DocsMenuProps> = ({ docsPages, currentPageUrl, title })
 
                     <DisclosurePanel className='sm:hidden'>{menuContent}</DisclosurePanel>
 
-                    <div className='hidden sm:block'>{menuContent}</div>
+                    <div className='hidden sm:block sm:w-64'>{menuContent}</div>
                 </>
             )}
         </Disclosure>


### PR DESCRIPTION
This should resolve #2662 by fixing the width of the menu

I've tried to test it just by editing live CSS and it seemed to work

(Cornelius update): https://fix-resizing-issue.loculus.org
