### PR TITLE
fix(deployment): Only try to include SILO-specific config in the LAPIS/SILO configmap if it is actually defined

### DIFF
--- a/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
+++ b/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
@@ -32,5 +32,7 @@ schema:
   {{- end }}
   {{- end }}
   primaryKey: accessionVersion
+{{ if .silo}}
   {{- .silo | toYaml | nindent 2 }}
+{{ endif }}
 {{- end }}

--- a/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
+++ b/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
@@ -34,5 +34,5 @@ schema:
   primaryKey: accessionVersion
 {{ if .silo}}
   {{- .silo | toYaml | nindent 2 }}
-{{ endif }}
+{{ end }}
 {{- end }}


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #2668

Previously failing to set `silo:` resulted in 
<img width="240" alt="image" src="https://github.com/user-attachments/assets/66628632-30b7-48b8-b37c-52c6e28e116d">

which led LAPIS to crash

https://theosanderson-patch-7.loculus.org