### PR TITLE
deps(backend): bump gradle to 8.8 from 8.5

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -4,6 +4,8 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 plugins {
     id 'org.springframework.boot' version '3.3.3'
     id 'io.spring.dependency-management' version '1.1.6'
+    // If kotlin version bumped, check if gradle version can be bumped as well 
+    // Check here: https://kotlinlang.org/docs/gradle-configure-project.html#apply-the-plugin
     id 'org.jetbrains.kotlin.jvm' version '2.0.20'
     id 'org.jetbrains.kotlin.plugin.spring' version '2.0.20'
     id 'org.jlleitschuh.gradle.ktlint' version '12.1.1'

--- a/backend/gradle/wrapper/gradle-wrapper.properties
+++ b/backend/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Last bump was 9 months ago. We should check this whenever kotlin version is bumped by dependabot.

8.8 is the max version of gradle supported by kotlin 2.0.20
See https://kotlinlang.org/docs/gradle-configure-project.html#apply-the-plugin

preview URL: https://bump-gradle.loculus.org

### Summary
Bump gradle version to 8.8 from 8.5