### PR TITLE
chore(backend): disable parallel test execution to avoid flaky tests

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -79,7 +79,6 @@ tasks.named('test') {
         exceptionFormat TestExceptionFormat.FULL
         showExceptions true
     }
-    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 }
 
 tasks.named('bootBuildImage') {

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,1 +1,0 @@
-org.gradle.parallel=true


### PR DESCRIPTION
Maybe helps with #2708 (hopefully, let's see)

This reverts the parallel test execution that was introduced in #1914. Some tests expect an empty database, so parallel execution can very likely be a source of flakiness.

I will run backend tests five times: https://github.com/loculus-project/loculus/actions/runs/10716872022/job/29715313279?pr=2710
