### PR TITLE
k8s: Remote dateToSortBy SILO config flag that contributed to bug

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1033,8 +1033,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         - length
       defaultOrderBy: sampleCollectionDate
       defaultOrder: descending
-    silo:
-      dateToSortBy: sampleCollectionDate
     extraInputFields: &extraInputFields
       - name: submissionId
         displayName: Submission ID
@@ -1215,7 +1213,6 @@ defaultOrganisms:
         defaultOrder: descending
         defaultOrderBy: date
       silo:
-        dateToSortBy: date
         partitionBy: pangoLineage
     preprocessing:
       - version: 1
@@ -1298,8 +1295,6 @@ defaultOrganisms:
           - date
         defaultOrder: descending
         defaultOrderBy: date
-      silo:
-        dateToSortBy: date
     preprocessing:
       - version: 1
         image: ghcr.io/loculus-project/preprocessing-nextclade


### PR DESCRIPTION
preview URL: https://try-minimal-silo-config.loculus.org

### Summary

- Remove the config flag that contributed to the SILO bug. By using the default, we're more confident about the test coverage.

### Followup

- [ ] Remove the config flag also from pathoplexus so loculus and pathoplexus are in sync
