### PR TITLE
docs: Remove date from "my first loculus" tutorial

### DIFF
--- a/docs/src/content/docs/for-administrators/my-first-loculus.md
+++ b/docs/src/content/docs/for-administrators/my-first-loculus.md
@@ -143,22 +143,15 @@ organisms:
         - name: country
           type: string
           initiallyVisible: true
-        - name: date
-          type: date
+        - name: city
+          type: string
           initiallyVisible: true
-          required: true
-          preprocessing:
-            function: process_date
-            inputs:
-              date: date
       website:
         tableColumns:
           - country
-          - date
+          - city
         defaultOrder: descending
         defaultOrderBy: country
-      silo:
-        dateToSortBy: date
     preprocessing:
       - version: 1
         image: ghcr.io/loculus-project/preprocessing-nextclade

--- a/docs/src/content/docs/for-administrators/my-first-loculus.md
+++ b/docs/src/content/docs/for-administrators/my-first-loculus.md
@@ -207,9 +207,9 @@ GCAGAGAGAGATACGTATATATATA
 Then our metadata file, which we might name `metadata.csv`:
 
 ```tsv
-submissionId	date	country
-sample1	2024-03-28	United Kingdom
-sample2	2024-04-02	France
+submissionId	city	country
+sample1	Paris	France
+sample2	Bogota	Colombia
 ```
 
 :::warning


### PR DESCRIPTION
This tutorial is intended to be the most basic configuration of Loculus possible, without requiring people to think about preprocessing functions, etc. but we previously had to include a date due to the fact that our configuration essentially required it for SILO. We've now fixed that, so we can remove it.