### PR TITLE
Add load example data to no-aligned-organism

### DIFF
--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -398,7 +398,7 @@ const InnerDataUploadForm = ({
                             .
                         </p>
 
-                        {organism.startsWith('dummy-organism') && action === 'submit' && (
+                        {organism.startsWith('no-aligned-organism') && action === 'submit' && (
                             <DevExampleData
                                 setExampleEntries={setExampleEntries}
                                 exampleEntries={exampleEntries}

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -398,15 +398,16 @@ const InnerDataUploadForm = ({
                             .
                         </p>
 
-                        {(organism.startsWith('not-aligned-organism') || organism.startsWith('dummy')) && action === 'submit' && (
-                            <DevExampleData
-                                setExampleEntries={setExampleEntries}
-                                exampleEntries={exampleEntries}
-                                metadataFile={metadataFile}
-                                sequenceFile={sequenceFile}
-                                handleLoadExampleData={handleLoadExampleData}
-                            />
-                        )}
+                        {(organism.startsWith('not-aligned-organism') || organism.startsWith('dummy')) &&
+                            action === 'submit' && (
+                                <DevExampleData
+                                    setExampleEntries={setExampleEntries}
+                                    exampleEntries={exampleEntries}
+                                    metadataFile={metadataFile}
+                                    sequenceFile={sequenceFile}
+                                    handleLoadExampleData={handleLoadExampleData}
+                                />
+                            )}
                     </div>
                     <form className='sm:col-span-2 '>
                         <div className='px-8'>

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -398,7 +398,7 @@ const InnerDataUploadForm = ({
                             .
                         </p>
 
-                        {(organism.startsWith('not-aligned-organism') || organism.startsWith('dummy')) &&
+                        {(organism.startsWith('not-aligned-organism') || organism.startsWith('dummy-organism')) &&
                             action === 'submit' && (
                                 <DevExampleData
                                     setExampleEntries={setExampleEntries}

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -398,7 +398,7 @@ const InnerDataUploadForm = ({
                             .
                         </p>
 
-                        {organism.startsWith('not-aligned-organism') && action === 'submit' && (
+                        {(organism.startsWith('not-aligned-organism') || organism.startsWith('dummy')) && action === 'submit' && (
                             <DevExampleData
                                 setExampleEntries={setExampleEntries}
                                 exampleEntries={exampleEntries}

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -398,7 +398,7 @@ const InnerDataUploadForm = ({
                             .
                         </p>
 
-                        {organism.startsWith('no-aligned-organism') && action === 'submit' && (
+                        {organism.startsWith('not-aligned-organism') && action === 'submit' && (
                             <DevExampleData
                                 setExampleEntries={setExampleEntries}
                                 exampleEntries={exampleEntries}


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://delete-dummy.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Also lets us use load dummy data for the unaligned test organism. 

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->
Adds the load example data to 
<img width="520" alt="image" src="https://github.com/user-attachments/assets/79a78353-c309-420e-888e-066d20a89366">
This works: 
<img width="520" alt="image" src="https://github.com/user-attachments/assets/334e37b1-66ca-459b-9fb4-e5bcff78b2a8"> - now all sequences will be "accurate" and submittable. 

