### PR TITLE
Remove '-' from list of allowed symbols in unaligned sequences.

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequenceEntryValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequenceEntryValidator.kt
@@ -55,7 +55,7 @@ enum class AminoAcidSymbols(override val symbol: Char) : Symbol {
     STOP('*'),
 }
 
-enum class NucleotideSymbols(override val symbol: Char) : Symbol {
+enum class AlignedNucleotideSymbols(override val symbol: Char) : Symbol {
     A('A'),
     C('C'),
     G('G'),
@@ -72,6 +72,24 @@ enum class NucleotideSymbols(override val symbol: Char) : Symbol {
     B('B'),
     N('N'),
     GAP('-'),
+}
+
+enum class NucleotideSymbols(override val symbol: Char) : Symbol {
+    A('A'),
+    C('C'),
+    G('G'),
+    T('T'),
+    M('M'),
+    R('R'),
+    W('W'),
+    S('S'),
+    Y('Y'),
+    K('K'),
+    V('V'),
+    H('H'),
+    D('D'),
+    B('B'),
+    N('N'),
 }
 
 private fun <T> validateNoUnknownInMetaData(data: Map<String, T>, known: List<String>) {
@@ -248,7 +266,7 @@ class ProcessedSequenceEntryValidator(private val schema: Schema, private val re
             "nucleotideInsertions",
         )
 
-        validateNoUnknownNucleotideSymbol(
+        validateNoUnknownAlignedNucleotideSymbol(
             processedData.alignedNucleotideSequences,
             "alignedNucleotideSequences",
         )
@@ -305,6 +323,24 @@ class ProcessedSequenceEntryValidator(private val schema: Schema, private val re
             if (invalidSymbols.isNotEmpty()) {
                 throw ProcessingValidationException(
                     "The sequence of segment '$segmentName' in '$sequenceGrouping' " +
+                        "contains invalid symbols: ${invalidSymbols.displayFirstCoupleSymbols()}.",
+                )
+            }
+        }
+    }
+
+    private fun validateNoUnknownAlignedNucleotideSymbol(
+        dataToValidate: Map<String, GeneticSequence?>,
+        sequenceGrouping: String,
+    ) {
+        for ((segmentName, sequence) in dataToValidate) {
+            if (sequence == null) {
+                continue
+            }
+            val invalidSymbols = sequence.getInvalidSymbols<NucleotideSymbols>()
+            if (invalidSymbols.isNotEmpty()) {
+                throw ProcessingValidationException(
+                    "The aligned sequence of segment '$segmentName' in '$sequenceGrouping' " +
                         "contains invalid symbols: ${invalidSymbols.displayFirstCoupleSymbols()}.",
                 )
             }

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequenceEntryValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequenceEntryValidator.kt
@@ -337,7 +337,7 @@ class ProcessedSequenceEntryValidator(private val schema: Schema, private val re
             if (sequence == null) {
                 continue
             }
-            val invalidSymbols = sequence.getInvalidSymbols<NucleotideSymbols>()
+            val invalidSymbols = sequence.getInvalidSymbols<AlignedNucleotideSymbols>()
             if (invalidSymbols.isNotEmpty()) {
                 throw ProcessingValidationException(
                     "The aligned sequence of segment '$segmentName' in '$sequenceGrouping' " +
@@ -362,11 +362,11 @@ class ProcessedSequenceEntryValidator(private val schema: Schema, private val re
     }
 
     private inline fun <reified ValidSymbols> String.getInvalidSymbols()
-        where ValidSymbols : Enum<ValidSymbols>, ValidSymbols : Symbol =
+            where ValidSymbols : Enum<ValidSymbols>, ValidSymbols : Symbol =
         this.filter { !it.isValidSymbol<ValidSymbols>() }.toList()
 
     private inline fun <reified ValidSymbols> Char.isValidSymbol()
-        where ValidSymbols : Enum<ValidSymbols>, ValidSymbols : Symbol =
+            where ValidSymbols : Enum<ValidSymbols>, ValidSymbols : Symbol =
         enumValues<ValidSymbols>().any { it.symbol == this }
 
     private fun validateAminoAcidSequences(processedData: ProcessedData<GeneticSequence>) {

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequenceEntryValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequenceEntryValidator.kt
@@ -322,7 +322,7 @@ class ProcessedSequenceEntryValidator(private val schema: Schema, private val re
             val invalidSymbols = sequence.getInvalidSymbols<ValidSymbols>()
             if (invalidSymbols.isNotEmpty()) {
                 throw ProcessingValidationException(
-                    "The aligned sequence of segment '$segmentName' in '$sequenceGrouping' " +
+                    "The sequence of segment '$segmentName' in '$sequenceGrouping' " +
                         "contains invalid symbols: ${invalidSymbols.displayFirstCoupleSymbols()}.",
                 )
             }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/PreparedProcessedData.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/PreparedProcessedData.kt
@@ -307,7 +307,7 @@ object PreparedProcessedData {
         segment: SegmentName,
     ): SubmittedProcessedData {
         val unalignedNucleotideSequences = defaultProcessedData.unalignedNucleotideSequences.toMutableMap()
-        unalignedNucleotideSequences[segment] = "ÄÖ" + unalignedNucleotideSequences[segment]!!.substring(2)
+        unalignedNucleotideSequences[segment] = "ÄÖ-" + unalignedNucleotideSequences[segment]!!.substring(2)
 
         return defaultSuccessfulSubmittedData.copy(
             accession = accession,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
@@ -586,8 +586,8 @@ class SubmitProcessedDataEndpointTest(
                         accession = "DoesNotMatter",
                         segment = "main",
                     ),
-                expectedErrorMessage = "The aligned sequence of segment 'main' in 'alignedNucleotideSequences' contains " +
-                    "invalid symbols: [Ä, Ö].",
+                expectedErrorMessage = "The aligned sequence of segment 'main' in 'alignedNucleotideSequences' " +
+                    "contains invalid symbols: [Ä, Ö].",
             ),
             InvalidDataScenario(
                 name = "data with segment in unaligned nucleotide sequences with wrong symbols",

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
@@ -586,7 +586,7 @@ class SubmitProcessedDataEndpointTest(
                         accession = "DoesNotMatter",
                         segment = "main",
                     ),
-                expectedErrorMessage = "The aligned sequence of segment 'main' in 'alignedNucleotideSequences' " +
+                expectedErrorMessage = "The sequence of segment 'main' in 'alignedNucleotideSequences' " +
                     "contains invalid symbols: [Ä, Ö].",
             ),
             InvalidDataScenario(

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
@@ -586,7 +586,7 @@ class SubmitProcessedDataEndpointTest(
                         accession = "DoesNotMatter",
                         segment = "main",
                     ),
-                expectedErrorMessage = "The sequence of segment 'main' in 'alignedNucleotideSequences' contains " +
+                expectedErrorMessage = "The aligned sequence of segment 'main' in 'alignedNucleotideSequences' contains " +
                     "invalid symbols: [Ä, Ö].",
             ),
             InvalidDataScenario(
@@ -597,7 +597,7 @@ class SubmitProcessedDataEndpointTest(
                         segment = "main",
                     ),
                 expectedErrorMessage = "The sequence of segment 'main' in 'unalignedNucleotideSequences' contains " +
-                    "invalid symbols: [Ä, Ö].",
+                    "invalid symbols: [Ä, Ö, -].",
             ),
             InvalidDataScenario(
                 name = "data with segment in nucleotide insertions with wrong symbols",

--- a/preprocessing/nextclade/src/loculus_preprocessing/sequence_checks.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/sequence_checks.py
@@ -22,7 +22,6 @@ NUCLEOTIDE_SYMBOLS = {
     "D",
     "B",
     "N",
-    "-",
 }  # This list should always correspond at minimum to the check defined in the backend
 
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/sequence_checks.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/sequence_checks.py
@@ -6,7 +6,7 @@ from .datatypes import (
     SegmentName,
 )
 
-NUCLEOTIDE_SYMBOLS = {
+UNALIGNED_NUCLEOTIDE_SYMBOLS = {
     "A",
     "C",
     "G",
@@ -31,7 +31,7 @@ def errors_if_non_iupac(
     errors: list[ProcessingAnnotation] = []
     for segment, sequence in unaligned_nucleotide_sequences.items():
         if sequence:
-            non_iupac_symbols = set(sequence.upper()) - NUCLEOTIDE_SYMBOLS
+            non_iupac_symbols = set(sequence.upper()) - UNALIGNED_NUCLEOTIDE_SYMBOLS
             if non_iupac_symbols:
                 errors.append(
                     ProcessingAnnotation(


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://no-gaps-in-unaligned.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
'-' only makes sense in the context of aligned sequences. It is not accepted by ENA and is not included in official IUPAC lists: https://genome.ucsc.edu/goldenPath/help/iupac.html#:~:text=The%20International%20Union%20of%20Pure,for%20either%20G%20or%20A).
