### PR TITLE
chore(deps): separate minor and patch updates in npm dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,14 @@ updates:
     schedule:
       interval: weekly
     groups:
-      minorAndPatch:
+      minor:
         update-types:
           - "minor"
+        exclude-patterns:
+          - "@mui/material"
+          - change-case
+      patch:
+        update-types:
           - "patch"
         exclude-patterns:
           - "@mui/material"


### PR DESCRIPTION
It happens fairly frequently that npm dependabot updates fail, separating minor and patch will reduce time spent debugging

Inspired by the latest dependabot PR that wasn't quite trivial (multiple unrelated failures, grouping made it harder to figure out what's wrong)