### PR TITLE
chore(ci): Use 2core 'larger' runner, with 75GB disk space

### DIFF
--- a/.github/workflows/e2e-k3d.yml
+++ b/.github/workflows/e2e-k3d.yml
@@ -34,7 +34,8 @@ jobs:
     env:
       ALL_BROWSERS: ${{ github.ref == 'refs/heads/main' || github.event.inputs.all_browsers && 'true' || 'false' }}
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
-      wait_timeout: ${{ github.ref == 'refs/heads/main' && 900 || 180 }}
+      # Timeout for "wait_for_pods_to_be_ready.py" script
+      wait_timeout: ${{ github.ref == 'refs/heads/main' && 1800 || 600 }}
     steps:
       - name: Shorten sha
         run: echo "sha=${sha::7}" >> $GITHUB_ENV
@@ -75,7 +76,7 @@ jobs:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('website/**/package-lock.json') }}
       - name: Install dependencies
-        run: cd website && npm i
+        run: cd website && npm ci
       - name: Get Installed Playwright Version
         id: playwright-version
         run: cd website && echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV

--- a/.github/workflows/e2e-k3d.yml
+++ b/.github/workflows/e2e-k3d.yml
@@ -29,7 +29,7 @@ jobs:
       contents: read
       checks: read
       actions: read # Required by workflow-telemetry-action
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24-2core-75GB
     timeout-minutes: 45
     env:
       ALL_BROWSERS: ${{ github.ref == 'refs/heads/main' || github.event.inputs.all_browsers && 'true' || 'false' }}


### PR DESCRIPTION
Related to #2752 

Using cheapest "larger" runner that has 2 cores and 75GB storage instead of 14GB storage. This might solve the issue with stalling.
