### PR TITLE
WIP: Append two empty JSON objects to mark the end of the NDJSON stream

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -434,7 +434,7 @@ class SubmissionController(
             transaction {
                 try {
                     iteratorStreamer.streamAsNdjson(sequenceProvider(), stream)
-                    stream.write("{}\n{}\n".toByteArray())
+                    stream.write("\n\n".toByteArray())
                 } catch (e: Exception) {
                     log.error(e) { "An unexpected error occurred while streaming, aborting the stream: $e" }
                     stream.write(

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -434,6 +434,7 @@ class SubmissionController(
             transaction {
                 try {
                     iteratorStreamer.streamAsNdjson(sequenceProvider(), stream)
+                    stream.write("{}\n{}\n".toByteArray())
                 } catch (e: Exception) {
                     log.error(e) { "An unexpected error occurred while streaming, aborting the stream: $e" }
                     stream.write(

--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -37,9 +37,8 @@ download_data() {
   exit_code=$?
   set -e
 
-  c=`tail -c 2 $new_input_data`
-  if [ "$c" != "" ]; then
-      echo "No 2 newlines at end of $new_input_data, instead $c, stream not completed, cleaning up and exiting"
+  if [ -s "$new_input_data" ] && tail -c2 "$new_input_data" | od -An -t x1 | grep -q "0a 0a"; then
+      echo "No 2 newlines at end of $new_input_data, stream not completed, cleaning up and exiting"
       rm -rf "$new_input_data_dir"
       exit $exit_code
   fi

--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -37,6 +37,13 @@ download_data() {
   exit_code=$?
   set -e
 
+  c=`tail -c 2 $new_input_data`
+  if [ "$c" != "" ]; then
+      echo "No 2 newlines at end of $new_input_data, instead $c, stream not completed, cleaning up and exiting"
+      rm -rf "$new_input_data_dir"
+      exit $exit_code
+  fi
+
   if [ $exit_code -ne 0 ]; then
     echo "Curl command failed with exit code $exit_code, cleaning up and exiting."
     rm -rf "$new_input_data_dir"


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves https://github.com/loculus-project/loculus/issues/2724

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://add-explicit-end-to-strea.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Currently we stream sequences using NDJSON for multiple endpoints, including get-released-data which sends clients all data. However, if the stream breaks off the client will not know that the server did not send all sequences. This lead to not all sequences being shown for west nile when we had high database load because the silo import script was calling get-released-data. 

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
