### PR TITLE
Add latitude and longitude to default metadata values.

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -100,12 +100,12 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Latitude
         header: Sample details
         type: float
-        guidance: Geo-coordinate latitude in decimal degree (WGS84) format, i.e. values in range -90 to 90.
+        guidance: Geo-coordinate latitude in decimal degree (WGS84) format, i.e. values in range -90 to 90, where positive values are north of the Equator.
       - name: geoLocLongitude
         displayName: Longitude
         header: Sample details
         type: float
-        guidance: Geo-coordinate longitude in decimal degree (WGS84) format, i.e. values in range -180 to 180.
+        guidance: Geo-coordinate longitude in decimal degree (WGS84) format, i.e. values in range -180 to 180, where positive values are east of the Prime Meridian.
       - name: geoLocCountry
         displayName: Collection country
         generateIndex: true

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -100,12 +100,12 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Latitude
         header: Sample details
         type: float
-        guidance: Geo-coordinate latitude in decimal degree format, i.e. values in range -90 to 90.
+        guidance: Geo-coordinate latitude in decimal degree (WGS84) format, i.e. values in range -90 to 90.
       - name: geoLocLongitude
         displayName: Longitude
         header: Sample details
         type: float
-        guidance: Geo-coordinate longitude in decimal degree format, i.e. values in range -180 to 180.
+        guidance: Geo-coordinate longitude in decimal degree (WGS84) format, i.e. values in range -180 to 180.
       - name: geoLocCountry
         displayName: Collection country
         generateIndex: true

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -96,6 +96,16 @@ defaultOrganismConfig: &defaultOrganismConfig
         noInput: true
         perSegment: true
         oneHeader: true
+      - name: latitude
+        displayName: Latitude
+        header: Sample details
+        type: float
+        guidance: Decimal degree format of latitude, i.e. values in range -90 to 90.
+      - name: longitude
+        displayName: Longitude
+        header: Sample details
+        type: float
+        guidance: Decimal degree format of longitude, i.e. values in range -90 to 90.
       - name: geoLocCountry
         displayName: Collection country
         generateIndex: true

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -96,16 +96,16 @@ defaultOrganismConfig: &defaultOrganismConfig
         noInput: true
         perSegment: true
         oneHeader: true
-      - name: latitude
+      - name: geoLocLatitude
         displayName: Latitude
         header: Sample details
         type: float
-        guidance: Decimal degree format of latitude, i.e. values in range -90 to 90.
-      - name: longitude
+        guidance: Geo-coordinate latitude in decimal degree format, i.e. values in range -90 to 90.
+      - name: geoLocLongitude
         displayName: Longitude
         header: Sample details
         type: float
-        guidance: Decimal degree format of longitude, i.e. values in range -90 to 90.
+        guidance: Geo-coordinate longitude in decimal degree format, i.e. values in range -180 to 180.
       - name: geoLocCountry
         displayName: Collection country
         generateIndex: true


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://add-lat-long.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->
ENA accepts latitude and longitude values - we do not, as some submitters have these values it would be great to also add this option for compatibility. 

I used the decimal degree format as this is expected by ENA: https://www.ebi.ac.uk/ena/browser/view/ERC000033 
### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] Checked that latitude and longitude turn up in submission templates
