### PR TITLE
fix(backend, silo-preprocessing):  add new header x-total-records to get-released-data to enable streaming result verification

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -43,8 +43,6 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -259,7 +259,6 @@ open class SubmissionController(
         ],
     )
     @GetMapping("/get-released-data", produces = [MediaType.APPLICATION_NDJSON_VALUE])
-    @Transactional(isolation = Isolation.REPEATABLE_READ) // All operations will be performed on the same snapshot
     open fun getReleasedData(
         @PathVariable @Valid organism: Organism,
         @RequestParam compression: CompressionFormat?,

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -257,7 +257,7 @@ open class SubmissionController(
         ],
     )
     @GetMapping("/get-released-data", produces = [MediaType.APPLICATION_NDJSON_VALUE])
-    open fun getReleasedData(
+    fun getReleasedData(
         @PathVariable @Valid organism: Organism,
         @RequestParam compression: CompressionFormat?,
     ): ResponseEntity<StreamingResponseBody> {
@@ -269,6 +269,7 @@ open class SubmissionController(
 
         val totalRecords = submissionDatabaseService.countReleasedSubmissions(organism)
         headers.add("x-total-records", totalRecords.toString())
+        // TODO(https://github.com/loculus-project/loculus/issues/2778)
         // There's a possibility that the totalRecords change between the count and the actual query
         // this is not too bad, if the client ends up with a few more records than expected
         // We just need to make sure the etag used is from before the count

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -2,6 +2,7 @@ package org.loculus.backend.controller
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.headers.Header
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -247,6 +248,13 @@ class SubmissionController(
         content = [
             Content(
                 schema = Schema(implementation = ProcessedData::class),
+            ),
+        ],
+        headers = [
+            Header(
+                name = "x-total-records",
+                description = "The total number of records sent in responseBody",
+                schema = Schema(type = "integer"),
             ),
         ],
     )

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -558,7 +558,7 @@ open class SubmissionDatabaseService(
             organism,
         )
     }.count()
-
+// Make sure to keep in sync with countReleasedSubmissions query
     fun streamReleasedSubmissions(organism: Organism): Sequence<RawProcessedData> = SequenceEntriesView.join(
         DataUseTermsTable,
         JoinType.LEFT,

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -558,6 +558,7 @@ open class SubmissionDatabaseService(
             organism,
         )
     }.count()
+
 // Make sure to keep in sync with countReleasedSubmissions query
     fun streamReleasedSubmissions(organism: Organism): Sequence<RawProcessedData> = SequenceEntriesView.join(
         DataUseTermsTable,

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -550,6 +550,7 @@ open class SubmissionDatabaseService(
             .associate { it[SequenceEntriesView.accessionColumn] to it[maxVersionExpression]!! }
     }
 
+    // Make sure to keep in sync with streamReleasedSubmissions query
     fun countReleasedSubmissions(organism: Organism): Long = SequenceEntriesView.select(
         SequenceEntriesView.accessionColumn,
     ).where {

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -550,6 +550,22 @@ class SubmissionDatabaseService(
             .associate { it[SequenceEntriesView.accessionColumn] to it[maxVersionExpression]!! }
     }
 
+    fun countReleasedSubmissions(organism: Organism): Long = SequenceEntriesView.join(
+        DataUseTermsTable,
+        JoinType.LEFT,
+        additionalConstraint = {
+            (SequenceEntriesView.accessionColumn eq DataUseTermsTable.accessionColumn) and
+                (DataUseTermsTable.isNewestDataUseTerms)
+        },
+    )
+        .select(
+            SequenceEntriesView.accessionColumn,
+        ).where {
+            SequenceEntriesView.statusIs(Status.APPROVED_FOR_RELEASE) and SequenceEntriesView.organismIs(
+                organism,
+            )
+        }.count()
+
     fun streamReleasedSubmissions(organism: Organism): Sequence<RawProcessedData> = SequenceEntriesView.join(
         DataUseTermsTable,
         JoinType.LEFT,

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -82,7 +82,7 @@ private val log = KotlinLogging.logger { }
 
 @Service
 @Transactional
-class SubmissionDatabaseService(
+open class SubmissionDatabaseService(
     private val processedSequenceEntryValidatorFactory: ProcessedSequenceEntryValidatorFactory,
     private val externalMetadataValidatorFactory: ExternalMetadataValidatorFactory,
     private val accessionPreconditionValidator: AccessionPreconditionValidator,
@@ -550,21 +550,13 @@ class SubmissionDatabaseService(
             .associate { it[SequenceEntriesView.accessionColumn] to it[maxVersionExpression]!! }
     }
 
-    fun countReleasedSubmissions(organism: Organism): Long = SequenceEntriesView.join(
-        DataUseTermsTable,
-        JoinType.LEFT,
-        additionalConstraint = {
-            (SequenceEntriesView.accessionColumn eq DataUseTermsTable.accessionColumn) and
-                (DataUseTermsTable.isNewestDataUseTerms)
-        },
-    )
-        .select(
-            SequenceEntriesView.accessionColumn,
-        ).where {
-            SequenceEntriesView.statusIs(Status.APPROVED_FOR_RELEASE) and SequenceEntriesView.organismIs(
-                organism,
-            )
-        }.count()
+    fun countReleasedSubmissions(organism: Organism): Long = SequenceEntriesView.select(
+        SequenceEntriesView.accessionColumn,
+    ).where {
+        SequenceEntriesView.statusIs(Status.APPROVED_FOR_RELEASE) and SequenceEntriesView.organismIs(
+            organism,
+        )
+    }.count()
 
     fun streamReleasedSubmissions(organism: Organism): Sequence<RawProcessedData> = SequenceEntriesView.join(
         DataUseTermsTable,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
@@ -60,11 +60,7 @@ class GetReleasedDataEndpointTest(
         assertThat(responseBody, `is`(emptyList()))
 
         response.andExpect(status().isOk)
-            .andExpect(header().exists("x-total-records"))
-            .andExpect { result ->
-                val totalNumberRecords = result.response.getHeader("x-total-records")
-                assertThat(totalNumberRecords, `is`("0"))
-            }
+            .andExpect(header().string("x-total-records", `is`("0")))
     }
 
     @Test
@@ -77,12 +73,7 @@ class GetReleasedDataEndpointTest(
 
         assertThat(responseBody.size, `is`(NUMBER_OF_SEQUENCES))
 
-        response.andExpect(status().isOk)
-            .andExpect(header().exists("x-total-records"))
-            .andExpect { result ->
-                val totalNumberRecords = result.response.getHeader("x-total-records")
-                assertThat(totalNumberRecords, `is`(NUMBER_OF_SEQUENCES.toString()))
-            }
+        response.andExpect(header().string("x-total-records", NUMBER_OF_SEQUENCES.toString()))
 
         responseBody.forEach {
             val id = it.metadata["accession"]!!.asText()

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
@@ -58,6 +58,13 @@ class GetReleasedDataEndpointTest(
 
         val responseBody = response.expectNdjsonAndGetContent<ProcessedData<GeneticSequence>>()
         assertThat(responseBody, `is`(emptyList()))
+
+        response.andExpect(status().isOk)
+            .andExpect(header().exists("x-total-records"))
+            .andExpect { result ->
+                val totalNumberRecords = result.response.getHeader("x-total-records")
+                assertThat(totalNumberRecords, `is`("0"))
+            }
     }
 
     @Test
@@ -69,6 +76,13 @@ class GetReleasedDataEndpointTest(
         val responseBody = response.expectNdjsonAndGetContent<ProcessedData<GeneticSequence>>()
 
         assertThat(responseBody.size, `is`(NUMBER_OF_SEQUENCES))
+
+        response.andExpect(status().isOk)
+            .andExpect(header().exists("x-total-records"))
+            .andExpect { result ->
+                val totalNumberRecords = result.response.getHeader("x-total-records")
+                assertThat(totalNumberRecords, `is`(NUMBER_OF_SEQUENCES.toString()))
+            }
 
         responseBody.forEach {
             val id = it.metadata["accession"]!!.asText()

--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -7,7 +7,7 @@ input_data_dir="/preprocessing/input"
 current_timestamp=$(date +%s)
 new_input_data_dir="$input_data_dir/$current_timestamp"
 
-old_input_data_dir="$input_data_dir"/$(find -1 "$input_data_dir" | sort -n | grep -E '^[0-9]+$' | tail -n 1)
+old_input_data_dir="$input_data_dir"/$(ls -1 "$input_data_dir" | sort -n | grep -E '^[0-9]+$' | tail -n 1)
 
 new_input_header_path="$new_input_data_dir/header.txt"
 
@@ -52,7 +52,8 @@ download_data() {
   expected_record_count=$(grep -i '^x-total-records:' "$new_input_header_path" | awk '{print $2}' | tr -d '[:space:]')
   echo "Response should contain a total of : $expected_record_count records"
 
-  true_record_count=$(zstd -d -c "$new_input_data_path" | jq -c . | wc -l | tr -d '[:space:]')
+   # jq validates each individual json object, to catch truncated lines
+   true_record_count=$(zstd -d -c "$new_input_data_path" | jq -c . | wc -l | tr -d '[:space:]')
   echo "Response contained a total of : $true_record_count records"
 
   if [ "$true_record_count" -ne "$expected_record_count" ]; then

--- a/kubernetes/loculus/templates/lapis-silo-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-deployment.yaml
@@ -88,7 +88,9 @@ spec:
               memory: "20Mi"
           command:
             - sh
-            - /silo_import_wrapper.sh
+            - -c
+            - |
+              apt-get update && apt-get install -y zstd && sh /silo_import_wrapper.sh
           env:
             - name: BACKEND_BASE_URL
               {{- if $.Values.disableBackend }}

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1406,7 +1406,7 @@ insecureCookies: false
 bannerMessage: "This is a demonstration environment. It may contain non-accurate test data and should not be used for real-world applications. Data will be deleted regularly."
 additionalHeadHTML: '<script defer data-domain="loculus.org" src="https://plausible.io/js/script.js"></script>'
 images:
-  lapisSilo: "ghcr.io/genspectrum/lapis-silo:0.2.17"
+  lapisSilo: "ghcr.io/genspectrum/lapis-silo:commit-f7b38154eb93106f2d9a6b9c97e34492248e1500"
   lapis: "ghcr.io/genspectrum/lapis:0.3.1"
 secrets:
   smtp-password:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1406,7 +1406,7 @@ insecureCookies: false
 bannerMessage: "This is a demonstration environment. It may contain non-accurate test data and should not be used for real-world applications. Data will be deleted regularly."
 additionalHeadHTML: '<script defer data-domain="loculus.org" src="https://plausible.io/js/script.js"></script>'
 images:
-  lapisSilo: "ghcr.io/genspectrum/lapis-silo:commit-f7b38154eb93106f2d9a6b9c97e34492248e1500"
+  lapisSilo: "ghcr.io/genspectrum/lapis-silo:0.2.17"
   lapis: "ghcr.io/genspectrum/lapis:0.3.1"
 secrets:
   smtp-password:


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
partially resolves https://github.com/loculus-project/loculus/issues/2724

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: http://add-count-in-header.loculus.org/

### Summary
As we send data in ndjson format, clients (such as the silo_import_job) have no way of knowing if the data they have received is complete or if the stream was interrupted early.

To fix this, /get-released-data adds header x-rowcount to the response with the total number of expected records in the accompanying stream.

Clients can then compare this number with the responseBody to see if they have received all records and discard/re-request in case the stream was aborted early.

### Small caveat
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->
The actual streaming is executed after `getReleased` is defined. This means the count calculated for the header and the results of the stream are not inside the same database transaction. This means that if the table was updated in between calculating the record and streaming there could be more records in the stream than expected from the header. 

`silo_import_job` will not use the data received from `get-released-data` if `x-total-records` header and the actual record count do not match. Meaning it could take slightly longer for new sequences to appear in the database but this should be negligible. 

This only causes a problem if the stream is cut off after exactly as many records as expected from the header. (e.g. count is 20, add one new sequence, stream should include 21 records, stream is cut off after record 20, client thinks stream completed successfully - but we lost an arbitrary sequence).

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
- [x] Add zstd ~(and probably jq to the silo-preprocessing docker image)~ - jq is already there: https://github.com/GenSpectrum/LAPIS-SILO/pull/574, update: I can install zstd after the container is set up, not very clean but this works
- [x] Break stream locally and check that this still works as intended.
Test locally by adding a Thread.sleep(1000) between stream iterations in `streamAsNdjson` and killing the backend mid-stream, the import script responds as expected:
```
Response should contain a total of : 2141 records
jq: parse error: Invalid numeric literal at line 30, column 3
Response contained a total of : 29 records
Expected and actual number of records are not the same
```
