### PR TITLE
Test database persistency on argocd

### DIFF
--- a/kubernetes/loculus/templates/loculus-database-standin.yaml
+++ b/kubernetes/loculus/templates/loculus-database-standin.yaml
@@ -39,5 +39,5 @@ spec:
         - name: POSTGRES_HOST_AUTH_METHOD
           value: "trust"
         - name: LOCULUS_VERSION
-          value: "commit-e3f268f"
+          value: "commit-20a9eaf"
 {{- end }}

--- a/kubernetes/loculus/templates/loculus-database-standin.yaml
+++ b/kubernetes/loculus/templates/loculus-database-standin.yaml
@@ -39,5 +39,5 @@ spec:
         - name: POSTGRES_HOST_AUTH_METHOD
           value: "trust"
         - name: LOCULUS_VERSION
-          value: {{ $dockerTag }}
+          value: "commit-e3f268f"
 {{- end }}

--- a/kubernetes/loculus/templates/loculus-database-standin.yaml
+++ b/kubernetes/loculus/templates/loculus-database-standin.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: loculus-database
   annotations:
-    argocd.argoproj.io/sync-options: Replace=true
+    argocd.argoproj.io/sync-options: Replace=false
 spec:
   replicas: 1
   selector:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -385,6 +385,16 @@ defaultOrganismConfig: &defaultOrganismConfig
               - Yemen
               - Zambia
               - Zimbabwe
+      - name: geoLocLatitude
+        displayName: Latitude
+        header: Sample details
+        type: float
+        guidance: Geo-coordinate latitude in decimal degree (WGS84) format, i.e. values in range -90 to 90, where positive values are north of the Equator.
+      - name: geoLocLongitude
+        displayName: Longitude
+        header: Sample details
+        type: float
+        guidance: Geo-coordinate longitude in decimal degree (WGS84) format, i.e. values in range -180 to 180, where positive values are east of the Prime Meridian.
       - name: geoLocAdmin1
         displayName: Collection subdivision level 1
         generateIndex: true

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -385,16 +385,6 @@ defaultOrganismConfig: &defaultOrganismConfig
               - Yemen
               - Zambia
               - Zimbabwe
-      - name: geoLocLatitude
-        displayName: Latitude
-        header: Sample details
-        type: float
-        guidance: Geo-coordinate latitude in decimal degree (WGS84) format, i.e. values in range -90 to 90, where positive values are north of the Equator.
-      - name: geoLocLongitude
-        displayName: Longitude
-        header: Sample details
-        type: float
-        guidance: Geo-coordinate longitude in decimal degree (WGS84) format, i.e. values in range -180 to 180, where positive values are east of the Prime Meridian.
       - name: geoLocAdmin1
         displayName: Collection subdivision level 1
         generateIndex: true
@@ -1548,9 +1538,9 @@ resources:
     limits:
       memory: "3Gi"
 defaultResources:
-    requests:
-      memory: "200Mi"
-      cpu: "20m"
-    limits:
-       memory: "1Gi"
-       cpu: "20m"
+  requests:
+    memory: "200Mi"
+    cpu: "20m"
+  limits:
+    memory: "1Gi"
+    cpu: "20m"

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -96,16 +96,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         noInput: true
         perSegment: true
         oneHeader: true
-      - name: geoLocLatitude
-        displayName: Latitude
-        header: Sample details
-        type: float
-        guidance: Geo-coordinate latitude in decimal degree (WGS84) format, i.e. values in range -90 to 90, where positive values are north of the Equator.
-      - name: geoLocLongitude
-        displayName: Longitude
-        header: Sample details
-        type: float
-        guidance: Geo-coordinate longitude in decimal degree (WGS84) format, i.e. values in range -180 to 180, where positive values are east of the Prime Meridian.
       - name: geoLocCountry
         displayName: Collection country
         generateIndex: true

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -385,16 +385,6 @@ defaultOrganismConfig: &defaultOrganismConfig
               - Yemen
               - Zambia
               - Zimbabwe
-      - name: geoLocLatitude
-        displayName: Latitude
-        header: Sample details
-        type: float
-        guidance: Geo-coordinate latitude in decimal degree (WGS84) format, i.e. values in range -90 to 90, where positive values are north of the Equator.
-      - name: geoLocLongitude
-        displayName: Longitude
-        header: Sample details
-        type: float
-        guidance: Geo-coordinate longitude in decimal degree (WGS84) format, i.e. values in range -180 to 180, where positive values are east of the Prime Meridian.
       - name: geoLocAdmin1
         displayName: Collection subdivision level 1
         generateIndex: true

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1055,7 +1055,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         noEdit: true
   preprocessing:
     - &preprocessing
-      version: 1
+      version: 2
       image: ghcr.io/loculus-project/preprocessing-nextclade
       args:
         - "prepro"


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Launch database then try adding more metadata fields to this persistent database, currently running here: https://test-presistent.loculus.org/.
Then:
- [ ] Confirm uploading sequences with the new fields does not crash the database: 
- upload of new cchf sequences with empty lat and long fields is successful: 
<img width="542" alt="image" src="https://github.com/user-attachments/assets/31a151cf-f2e1-4895-b799-118081930a4d">

Hmmm... the page is behaving ok but I see some LAPIS issues when I look at argo (SILO pods are degraded):
```
[2024-09-18 08:33:54.882] [logger] [info] [logging_request_handler.cpp:21] Request Id [c562bba9-db79-40ef-aa8f-cb3dd0579a84] - Responding with status code 503
[2024-09-18 08:33:55.099] [logger] [info] [logging_request_handler.cpp:15] Request Id [ff72065f-bf61-46b8-91f0-bacb9bb41030] - Handling GET /info
[2024-09-18 08:33:55.099] [logger] [info] [error_request_handler.cpp:30] Caught exception: Database not initialized yet
[2024-09-18 08:33:55.099] [logger] [info] [logging_request_handler.cpp:21] Request Id [ff72065f-bf61-46b8-91f0-bacb9bb41030] - Responding with status code 503
[2024-09-18 08:33:55.343] [logger] [info] [database_directory_watcher.cpp:112] No data found in /data/ for ingestion
```
maybe this is just due to LAPIS being restarted? Hmm... search and download is working... interesting so LAPIS for cchf seems to have restarted logs look fine and downloads now include the new metadata fields, however for west nile and ebola where the SILO pods are degraded downloads do not include the new fields

Ok I tried to force the SILO pods to restart by deleting the old ones but they stay in this state. 

So it would seem that until new sequences are uploaded which include all metadata fields the new SILO pods cannot start...

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
