### PR TITLE
[do not merge] Temporary pop up that cross ref is down when user clicks to create DOI

### DIFF
--- a/website/src/components/SeqSetCitations/SeqSetItem.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItem.tsx
@@ -118,10 +118,9 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
             <a
                 className='mr-4 cursor-pointer font-medium text-blue-600 hover:text-blue-800'
                 onClick={() =>
-                    displayConfirmationDialog({
-                        dialogText: `Are you sure you want to create a DOI for this version of your seqSet?`,
-                        onConfirmation: handleCreateDOI,
-                    })
+                    alert(
+                        'Sorry, the CrossRef instance is down from 16 September to 17 September for a planned outage, and so we cannot currently create DOIs - please come back later.',
+                    )
                 }
             >
                 Generate a DOI

--- a/website/src/components/SeqSetCitations/SeqSetItem.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItem.tsx
@@ -8,7 +8,6 @@ import { seqSetCitationClientHooks } from '../../services/serviceHooks';
 import type { ClientConfig } from '../../types/runtimeConfig';
 import { type SeqSetRecord, type SeqSet, type CitedByResult, SeqSetRecordType } from '../../types/seqSetCitation';
 import { createAuthorizationHeader } from '../../utils/createAuthorizationHeader';
-import { displayConfirmationDialog } from '../ConfirmationDialog.tsx';
 import { ManagedErrorFeedback, useErrorFeedbackState } from '../common/ManagedErrorFeedback';
 import { withQueryProvider } from '../common/withQueryProvider.tsx';
 
@@ -81,17 +80,13 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
     const [page, setPage] = useState(1);
     const sequencesPerPage = 10;
 
-    const { mutate: createSeqSetDOI } = useCreateSeqSetDOIAction(
+    const {} = useCreateSeqSetDOIAction(
         clientConfig,
         accessToken,
         seqSet.seqSetId,
         seqSet.seqSetVersion,
         openErrorFeedback,
     );
-
-    const handleCreateDOI = async () => {
-        createSeqSetDOI(undefined);
-    };
 
     const getCrossRefUrl = () => {
         return `https://search.crossref.org/search/works?from_ui=yes&q=${seqSet.seqSetDOI}`;

--- a/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
@@ -49,10 +49,10 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
 
     return (
         <div className='flex flex-col items-left'>
-            <ManagedErrorFeedback message={isErrorOpen ? (
+            <ManagedErrorFeedback message={isErrorOpen ? 
             "Sorry, the CrossRef instance is down from 16 September to 17 September for a planned outage, and so we cannot currently create DOIs - please come back later. "  : ""
 
-            )} open={isErrorOpen} onClose={closeErrorFeedback} />
+            } open={isErrorOpen} onClose={closeErrorFeedback} />
             <div className='flex-row items-center justify-between w-full'>
                 <div className='flex justify-start items-center pt-4 pb-8'>
                     <div className='pr-2'>

--- a/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
@@ -49,7 +49,10 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
 
     return (
         <div className='flex flex-col items-left'>
-            <ManagedErrorFeedback message={errorMessage} open={isErrorOpen} onClose={closeErrorFeedback} />
+            <ManagedErrorFeedback message={isErrorOpen ? (
+            "Sorry, the CrossRef instance is down from 16 September to 17 September for a planned outage. "  : ""
+
+            )} open={isErrorOpen} onClose={closeErrorFeedback} />
             <div className='flex-row items-center justify-between w-full'>
                 <div className='flex justify-start items-center pt-4 pb-8'>
                     <div className='pr-2'>

--- a/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
@@ -50,7 +50,7 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
     return (
         <div className='flex flex-col items-left'>
             <ManagedErrorFeedback message={isErrorOpen ? (
-            "Sorry, the CrossRef instance is down from 16 September to 17 September for a planned outage. "  : ""
+            "Sorry, the CrossRef instance is down from 16 September to 17 September for a planned outage, and so we cannot currently create DOIs - please come back later. "  : ""
 
             )} open={isErrorOpen} onClose={closeErrorFeedback} />
             <div className='flex-row items-center justify-between w-full'>

--- a/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
@@ -49,10 +49,15 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
 
     return (
         <div className='flex flex-col items-left'>
-            <ManagedErrorFeedback message={isErrorOpen ? 
-            "Sorry, the CrossRef instance is down from 16 September to 17 September for a planned outage, and so we cannot currently create DOIs - please come back later. "  : errorMessage
-
-            } open={isErrorOpen} onClose={closeErrorFeedback} />
+            <ManagedErrorFeedback
+                message={
+                    isErrorOpen
+                        ? 'Sorry, the CrossRef instance is down from 16 September to 17 September for a planned outage, and so we cannot currently create DOIs - please come back later. '
+                        : errorMessage
+                }
+                open={isErrorOpen}
+                onClose={closeErrorFeedback}
+            />
             <div className='flex-row items-center justify-between w-full'>
                 <div className='flex justify-start items-center pt-4 pb-8'>
                     <div className='pr-2'>

--- a/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
@@ -50,7 +50,7 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
     return (
         <div className='flex flex-col items-left'>
             <ManagedErrorFeedback message={isErrorOpen ? 
-            "Sorry, the CrossRef instance is down from 16 September to 17 September for a planned outage, and so we cannot currently create DOIs - please come back later. "  : ""
+            "Sorry, the CrossRef instance is down from 16 September to 17 September for a planned outage, and so we cannot currently create DOIs - please come back later. "  : errorMessage
 
             } open={isErrorOpen} onClose={closeErrorFeedback} />
             <div className='flex-row items-center justify-between w-full'>


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Uglier back up option: 
<img width="719" alt="image" src="https://github.com/user-attachments/assets/0f6fcf83-802b-4a70-9504-15dd355050f0">
When user clicks on generate DOI button pop up tells user that crossref is temporarily down

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
