### PR TITLE
refactor(backend): rename enum `SiloVersionStatus` to `VersionStatus` and document the enum

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -295,10 +295,10 @@ enum class PreprocessingStatus {
     FINISHED,
 }
 
-enum class SiloVersionStatus {
-    REVOKED,
-    REVISED,
-    LATEST_VERSION,
+enum class VersionStatus {
+    REVOKED, // Not the highest version, and a higher version is a revocation
+    REVISED, // Not the highest, and there is no higher revocation
+    LATEST_VERSION, // Highest version
 }
 
 enum class CompressionFormat(val compressionName: String) {

--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -296,9 +296,9 @@ enum class PreprocessingStatus {
 }
 
 enum class VersionStatus {
-    REVOKED, // Not the highest version, and a higher version is a revocation
-    REVISED, // Not the highest, and there is no higher revocation
-    LATEST_VERSION, // Highest version
+    REVOKED, // This is not the highest version of the sequence entry, and a higher version is a revocation
+    REVISED, // This is not the highest version of the sequence entry, and no higher version is a revocation
+    LATEST_VERSION, // This is the highest version of the sequence entry
 }
 
 enum class CompressionFormat(val compressionName: String) {

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -102,9 +102,9 @@ class ReleasedDataModel(
         DataUseTerms.Open
     }
 
-    // LATEST_VERSION: Highest version
-    // REVOKED: Not highest version, higher version is a revocation
-    // REVISED: Not the highest version, and there's no higher version that is a revocation
+    // LATEST_VERSION: This is the highest version of the sequence entry
+    // REVOKED: This is not the highest version of the sequence entry, and a higher version is a revocation
+    // REVISED: This is not the highest version of the sequence entry, and no higher version is a revocation
     // Note: a revocation entry is only REVOKED when there's a higher version that is a revocation
     private fun computeVersionStatus(
         rawProcessedData: RawProcessedData,

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -47,7 +47,7 @@ class ReleasedDataModel(
         latestVersions: Map<Accession, Version>,
         latestRevocationVersions: Map<Accession, Version>,
     ): ProcessedData<GeneticSequence> {
-        val siloVersionStatus = computeVersionStatus(rawProcessedData, latestVersions, latestRevocationVersions)
+        val versionStatus = computeVersionStatus(rawProcessedData, latestVersions, latestRevocationVersions)
 
         val currentDataUseTerms = computeDataUseTerm(rawProcessedData)
         val restrictedDataUseTermsUntil = if (currentDataUseTerms is DataUseTerms.Restricted) {
@@ -69,7 +69,7 @@ class ReleasedDataModel(
             ("submittedAtTimestamp" to LongNode(rawProcessedData.submittedAtTimestamp.toTimestamp())) +
             ("releasedAtTimestamp" to LongNode(rawProcessedData.releasedAtTimestamp.toTimestamp())) +
             ("releasedDate" to TextNode(rawProcessedData.releasedAtTimestamp.toUtcDateString())) +
-            ("versionStatus" to TextNode(siloVersionStatus.name)) +
+            ("versionStatus" to TextNode(versionStatus.name)) +
             ("dataUseTerms" to TextNode(currentDataUseTerms.type.name)) +
             ("dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil) +
             ("versionComment" to TextNode(rawProcessedData.versionComment))

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
@@ -20,8 +20,8 @@ import org.hamcrest.Matchers.not
 import org.junit.jupiter.api.Test
 import org.loculus.backend.api.GeneticSequence
 import org.loculus.backend.api.ProcessedData
-import org.loculus.backend.api.SiloVersionStatus
 import org.loculus.backend.api.Status
+import org.loculus.backend.api.VersionStatus
 import org.loculus.backend.controller.DEFAULT_GROUP_NAME
 import org.loculus.backend.controller.DEFAULT_USER_NAME
 import org.loculus.backend.controller.EndpointTest
@@ -134,23 +134,23 @@ class GetReleasedDataEndpointTest(
 
         assertThat(
             response.findAccessionVersionStatus(accession, revokedVersion1),
-            `is`(SiloVersionStatus.REVOKED.name),
+            `is`(VersionStatus.REVOKED.name),
         )
         assertThat(
             response.findAccessionVersionStatus(accession, revokedVersion2),
-            `is`(SiloVersionStatus.REVOKED.name),
+            `is`(VersionStatus.REVOKED.name),
         )
         assertThat(
             response.findAccessionVersionStatus(accession, revocationVersion3),
-            `is`(SiloVersionStatus.REVISED.name),
+            `is`(VersionStatus.REVISED.name),
         )
         assertThat(
             response.findAccessionVersionStatus(accession, revisedVersion4),
-            `is`(SiloVersionStatus.REVISED.name),
+            `is`(VersionStatus.REVISED.name),
         )
         assertThat(
             response.findAccessionVersionStatus(accession, latestVersion5),
-            `is`(SiloVersionStatus.LATEST_VERSION.name),
+            `is`(VersionStatus.LATEST_VERSION.name),
         )
     }
 


### PR DESCRIPTION
Spawned by this Slack discussion: https://loculus.slack.com/archives/C05G172HL6L/p1726586424473839
