### PR TITLE
refactor(website): rename `siloVersionStatus` to `versionStatus`

### DIFF
--- a/website/src/components/IndexPage/getOrganismStatistics.ts
+++ b/website/src/components/IndexPage/getOrganismStatistics.ts
@@ -4,7 +4,6 @@ import { LapisClient } from '../../services/lapisClient.ts';
 import { RELEASED_AT_FIELD, VERSION_STATUS_FIELD, IS_REVOCATION_FIELD } from '../../settings.ts';
 import { versionStatuses } from '../../types/lapis';
 
-// Excluding sequences whose latest version is revoked
 export type OrganismStatistics = {
     totalSequences: number;
     recentSequences: number;
@@ -67,10 +66,16 @@ const getTotalAndLastUpdatedAt = async (
         });
 };
 
+/**
+ * Note: This method undercounts in cases where recently released sequences
+ * are later revoked and then unrevoked (revised), all within the "recency window".
+ * This trade-off allows for a simpler, more efficient query
+ * without needing to fetch individual accession lists.
+ */
 const getRecent = async (organism: string, numberDaysAgo: number): Promise<number> => {
     const recentTimestamp = Math.floor(Date.now() / 1000 - numberDaysAgo * 24 * 60 * 60);
     const client = LapisClient.createForOrganism(organism);
-    const recentTotalIncludingRevoked = (
+    const recentlyReleasedTotal = (
         await client.call('aggregated', {
             [`${RELEASED_AT_FIELD}From`]: recentTimestamp,
             version: 1,
@@ -78,7 +83,7 @@ const getRecent = async (organism: string, numberDaysAgo: number): Promise<numbe
     )
         .map((x) => x.data[0].count)
         .unwrapOr(0);
-    const recentTotalRevoked = (
+    const recentlyReleasedThenRevokedTotal = (
         await client.call('aggregated', {
             [`${RELEASED_AT_FIELD}From`]: recentTimestamp,
             version: 1,
@@ -87,5 +92,5 @@ const getRecent = async (organism: string, numberDaysAgo: number): Promise<numbe
     )
         .map((x) => x.data[0].count)
         .unwrapOr(0);
-    return recentTotalIncludingRevoked - recentTotalRevoked;
+    return recentlyReleasedTotal - recentlyReleasedThenRevokedTotal;
 };

--- a/website/src/components/SearchPage/DownloadDialog/generateDownloadUrl.ts
+++ b/website/src/components/SearchPage/DownloadDialog/generateDownloadUrl.ts
@@ -1,5 +1,5 @@
 import { IS_REVOCATION_FIELD, metadataDefaultDownloadDataFormat, VERSION_STATUS_FIELD } from '../../../settings.ts';
-import { siloVersionStatuses } from '../../../types/lapis.ts';
+import { versionStatuses } from '../../../types/lapis.ts';
 
 export type DownloadDataType =
     | { type: 'metadata' }
@@ -26,7 +26,7 @@ export const generateDownloadUrl = (
 
     params.set('downloadAsFile', 'true');
     if (!option.includeOldData) {
-        params.set(VERSION_STATUS_FIELD, siloVersionStatuses.latestVersion);
+        params.set(VERSION_STATUS_FIELD, versionStatuses.latestVersion);
         params.set(IS_REVOCATION_FIELD, 'false');
     }
     if (!option.includeRestricted) {

--- a/website/src/components/SequenceDetailsPage/SequencesBanner.astro
+++ b/website/src/components/SequenceDetailsPage/SequencesBanner.astro
@@ -1,7 +1,7 @@
 ---
 import { getLatestAccessionVersion } from './getTableData';
 import { routes } from '../../routes/routes.ts';
-import { type SequenceEntryHistory, siloVersionStatuses } from '../../types/lapis';
+import { type SequenceEntryHistory, versionStatuses } from '../../types/lapis';
 import { getAccessionVersionString } from '../../utils/extractAccessionVersion';
 
 interface Props {
@@ -16,8 +16,8 @@ const ownHistoryEntry = sequenceEntryHistory.find((entry) => entry.accessionVers
 const latestAccessionVersion = getLatestAccessionVersion(sequenceEntryHistory);
 
 const revoked =
-    ownHistoryEntry?.versionStatus === siloVersionStatuses.revoked && latestAccessionVersion?.isRevocation === true;
-const isLatestVersion = ownHistoryEntry?.versionStatus === siloVersionStatuses.latestVersion;
+    ownHistoryEntry?.versionStatus === versionStatuses.revoked && latestAccessionVersion?.isRevocation === true;
+const isLatestVersion = ownHistoryEntry?.versionStatus === versionStatuses.latestVersion;
 ---
 
 <div class='py-3'>

--- a/website/src/pages/[organism]/search/index.astro
+++ b/website/src/pages/[organism]/search/index.astro
@@ -4,14 +4,14 @@ import { SearchFullUI } from '../../../components/SearchPage/SearchFullUI';
 import { getRuntimeConfig, getSchema } from '../../../config';
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 import { VERSION_STATUS_FIELD, IS_REVOCATION_FIELD } from '../../../settings';
-import { siloVersionStatuses } from '../../../types/lapis';
+import { versionStatuses } from '../../../types/lapis';
 import { getAccessToken } from '../../../utils/getAccessToken';
 import { getMyGroups } from '../../../utils/getMyGroups';
 import { getReferenceGenomesSequenceNames } from '../../../utils/search';
 import { performLapisSearchQueries } from '../../../utils/serversideSearch';
 
 const hiddenFieldValues = {
-    [VERSION_STATUS_FIELD]: siloVersionStatuses.latestVersion,
+    [VERSION_STATUS_FIELD]: versionStatuses.latestVersion,
     [IS_REVOCATION_FIELD]: 'false',
 };
 

--- a/website/src/pages/[organism]/submission/[groupId]/released.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/released.astro
@@ -4,7 +4,7 @@ import { SearchFullUI } from '../../../../components/SearchPage/SearchFullUI';
 import SubmissionPageWrapper from '../../../../components/Submission/SubmissionPageWrapper.astro';
 import { getRuntimeConfig, getSchema } from '../../../../config';
 import { GROUP_ID_FIELD, VERSION_STATUS_FIELD } from '../../../../settings';
-import { siloVersionStatuses } from '../../../../types/lapis';
+import { versionStatuses } from '../../../../types/lapis';
 import { getAccessToken } from '../../../../utils/getAccessToken';
 import { getReferenceGenomesSequenceNames } from '../../../../utils/search';
 import { performLapisSearchQueries } from '../../../../utils/serversideSearch';
@@ -33,7 +33,7 @@ const accessToken = getAccessToken(Astro.locals.session);
 const referenceGenomeSequenceNames = getReferenceGenomesSequenceNames(cleanedOrganism.key);
 
 const hiddenFieldValues = {
-    [VERSION_STATUS_FIELD]: siloVersionStatuses.latestVersion,
+    [VERSION_STATUS_FIELD]: versionStatuses.latestVersion,
     [GROUP_ID_FIELD]: group.groupId,
 };
 

--- a/website/src/services/lapisClient.ts
+++ b/website/src/services/lapisClient.ts
@@ -19,7 +19,7 @@ import {
     type LapisBaseRequest,
     sequenceEntryHistory,
     type SequenceEntryHistory,
-    siloVersionStatuses,
+    versionStatuses,
 } from '../types/lapis.ts';
 import type { BaseType } from '../utils/sequenceTypeHelpers.ts';
 
@@ -56,7 +56,7 @@ export class LapisClient extends ZodiosWrapperClient<typeof lapisApi> {
     public async getLatestAccessionVersion(accession: string): Promise<Result<AccessionVersion, ProblemDetail>> {
         const result = await this.call('details', {
             accession,
-            versionStatus: siloVersionStatuses.latestVersion,
+            versionStatus: versionStatuses.latestVersion,
             fields: [ACCESSION_FIELD, VERSION_FIELD],
         });
 

--- a/website/src/types/lapis.ts
+++ b/website/src/types/lapis.ts
@@ -74,25 +74,25 @@ export type LapisError = {
     error: ProblemDetail;
 };
 
-export const siloVersionStatuses = {
+export const versionStatuses = {
     revoked: 'REVOKED',
     revised: 'REVISED',
     latestVersion: 'LATEST_VERSION',
 } as const;
 
-export const siloVersionStatusSchema = z.enum([
-    siloVersionStatuses.revoked,
-    siloVersionStatuses.revised,
-    siloVersionStatuses.latestVersion,
+export const versionStatusSchema = z.enum([
+    versionStatuses.revoked,
+    versionStatuses.revised,
+    versionStatuses.latestVersion,
 ]);
 
-export type SiloVersionStatus = z.infer<typeof siloVersionStatusSchema>;
+export type VersionStatus = z.infer<typeof versionStatusSchema>;
 
 export const sequenceEntryHistoryEntry = accessionVersion
     .merge(
         z.object({
             accessionVersion: z.string(),
-            versionStatus: siloVersionStatusSchema,
+            versionStatus: versionStatusSchema,
             isRevocation: z.boolean(),
             submittedAtTimestamp: z.number(),
         }),

--- a/website/src/utils/getVersionStatusColor.ts
+++ b/website/src/utils/getVersionStatusColor.ts
@@ -1,8 +1,8 @@
-import { type SiloVersionStatus, siloVersionStatuses } from '../types/lapis.ts';
+import { type VersionStatus, versionStatuses } from '../types/lapis.ts';
 
-export const getVersionStatusColor = (versionStatus: SiloVersionStatus) => {
+export const getVersionStatusColor = (versionStatus: VersionStatus) => {
     switch (versionStatus) {
-        case siloVersionStatuses.latestVersion:
+        case versionStatuses.latestVersion:
             return 'text-green-500';
         default:
             return 'text-red-500';


### PR DESCRIPTION
Also some slight tweaks to function names in organism statistics, follow up to #2814

Backend rename (not coupled as versionStatus usage is only internal) is done in: #2817 