### PR TITLE
fix: don't ingest region as geoLocAdmin2 (it's continent)

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -407,7 +407,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         generateIndex: true
         autocomplete: true
         header: Sample details
-        ingest: ncbiGeoRegion
       - name: geoLocCity
         displayName: Collection city
         generateIndex: true


### PR DESCRIPTION
Relates to #2788

Might require pp values.yaml changes - need to check

https://fix-continent.loculus.org
