### PR TITLE
Add INSDC accession to results of ena submission and upload to backend.

### DIFF
--- a/ena-submission/README.md
+++ b/ena-submission/README.md
@@ -160,19 +160,57 @@ python3 scripts/test_ena_submission.py
 
 ### Testing submission locally
 
-ENA-submission currently is only triggered after manual approval.
+1. Run loculus locally (need prepro, backend and ena-submission pod), e.g.
 
-The `get_ena_submission_list` runs as a cron-job. It queries Loculus for new sequences to submit to ENA (these are sequences that are in state OPEN, were not submitted by the INSDC_INGEST_USER, do not include ena external_metadata fields and are not yet in the submission_table of the ena-submission schema). If it finds new sequences it sends a notification to slack with all sequences.
+```sh
+../deploy.py cluster --dev
+../deploy.py helm --dev --enablePreprocessing
+../generate_local_test_config.sh
+../backend/start_dev.sh &
+micromamba activate loculus-ena-submission
+flyway -user=postgres -password=unsecure -url=jdbc:postgresql://127.0.0.1:5432/loculus -schemas=ena-submission -locations=filesystem:./flyway/sql migrate
+```
 
-It is then the reviewer's turn to review these sequences. [TODO: define review criteria] If these sequences meet our criteria they should be uploaded to [pathoplexus/ena-submission](https://github.com/pathoplexus/ena-submission/blob/main/approved/approved_ena_submission_list.json) (currently we read data from the [test folder](https://github.com/pathoplexus/ena-submission/blob/main/test/approved_ena_submission_list.json) - but this will be changed to the `approved` folder in production). The `trigger_submission_to_ena` rule is constantly checking this folder for new sequences and adding them to the submission_table if they are not already there. Note we cannot yet handle revisions so these should not be added to the approved list [TODO: do not allow submission of revised sequences in `trigger_submission_to_ena`]- revisions will still have to be performed manually.
+2. Submit data to the backend as test user (create group and submit), e.g. using [example data](https://github.com/pathoplexus/example_data). (To test the full submission cycle with insdc accessions submit cchf example data with only 2 segments.)
 
-If you would like to test `trigger_submission_to_ena` while running locally you can also use the `trigger_submission_to_ena_from_file` rule, this will read in data from `results/approved_ena_submission_list.json` (see the test folder for an example). You can also upload data to the [test folder](https://github.com/pathoplexus/ena-submission/blob/main/test/approved_ena_submission_list.json) - note that if you add fake data with a non-existent group-id the project creation will fail, additionally the `upload_to_loculus` rule will fail if these sequences do not actually exist in your loculus instance.
+```sh
+KEYCLOAK_TOKEN_URL="http://localhost:8083/realms/loculus/protocol/openid-connect/token"
+KEYCLOAK_CLIENT_ID="backend-client"
+usernameAndPassword="testuser"
+jwt_keycloak=$(curl -X POST "$KEYCLOAK_TOKEN_URL" --fail-with-body -H 'Content-Type: application/x-www-form-urlencoded' -d "username=$usernameAndPassword&password=$usernameAndPassword&grant_type=password&client_id=$KEYCLOAK_CLIENT_ID")
+JWT=$(echo "$jwt_keycloak" | jq -r '.access_token')
+curl -X 'POST' 'http://localhost:8079/groups' -H 'Authorization": f"Bearer ${JWT}"'
+curl -X 'POST' 'http://localhost:8079/approve-processed-data -H 'Authorization": f"Bearer ${JWT}"' -d '"scope=ALL"'
+```
 
-All other rules query the `submission_table` for projects/samples and assemblies to submit. Once successful they add accessions to the `results` column in dictionary format. Finally, once the entire process has succeeded the new external metadata will be uploaded to Loculus.
+3. Get list of sequences ready to submit to ENA, locally this will write `results/ena_submission_list.json`.
 
-Note that ENA's dev server does not always finish processing and you might not receive a gcaAccession for your dev submissions. If you would like to test the full submission cycle on the ENA dev instance it makes sense to manually alter the gcaAccession in the database using `ERZ24784470`. You can connect to a preview instance via port forwarding to these changes on local database tool such as pgAdmin:
+```sh
+snakemake get_ena_submission_list
+```
 
-1. Apply the preview `~/.kube/config`
-2. Find the database POD using `kubectl get pods -A | grep database`
-3. Connect via port-forwarding `kubectl port-forward $POD -n $NAMESPACE 5432:5432`
-4. If necessary find password using `kubectl get secret`
+4. Check contents and then rename to `results/approved_ena_submission_list.json`, trigger ena submission by adding entries to the submission table
+
+```sh
+cp results/ena_submission_list.json results/approved_ena_submission_list.json
+snakemake trigger_submission_to_ena_from_file
+```
+
+Alternatively you can upload data to the [test folder](https://github.com/pathoplexus/ena-submission/blob/main/test/approved_ena_submission_list.json) and run `snakemake trigger_submission_to_ena` - note that if you add fake data with a non-existent group-id the project creation will fail, additionally the `upload_to_loculus` rule will fail if these sequences do not actually exist in your loculus instance.
+
+5. Create project, sample and assembly: `snakemake results/project_created results/sample_created results/assembly_created` - you will need the credentials of the ENA test submission account for this.
+
+6. Note that ENA's dev server does not always finish processing and you might not receive a `gcaAccession` for your dev submissions. If you would like to test the full submission cycle on the ENA dev instance it makes sense to manually alter the gcaAccession in the database to `ERZ24784470` (a known test submission with 2 chromosomes/segments - sadly ERZ accessions are private so I do not have other test examples).
+
+If you experience issues you can look at the database locally using pgAdmin. On local instances the password is `unsecure`.
+
+### Testing submission on a preview instance
+
+1. Upload data to the [test folder](https://github.com/pathoplexus/ena-submission/blob/main/test/approved_ena_submission_list.json) - note that if you add fake data with a non-existent group-id the project creation will fail, additionally the `upload_to_loculus` rule will fail if these sequences do not actually exist in your loculus instance.
+
+2. Connect to the database of the preview instance via port forwarding using a database tool such as pgAdmin:
+
+- Apply the preview `~/.kube/config`
+- Find the database POD using `kubectl get pods -A | grep database`
+- Connect via port-forwarding `kubectl port-forward $POD -n $NAMESPACE 5432:5432`
+- If necessary find password using `kubectl get secret`

--- a/ena-submission/README.md
+++ b/ena-submission/README.md
@@ -166,7 +166,9 @@ python3 scripts/test_ena_submission.py
 ../deploy.py cluster --dev
 ../deploy.py helm --dev --enablePreprocessing
 ../generate_local_test_config.sh
-../backend/start_dev.sh &
+cd ../backend
+./start_dev.sh &
+cd ../ena-submission
 micromamba activate loculus-ena-submission
 flyway -user=postgres -password=unsecure -url=jdbc:postgresql://127.0.0.1:5432/loculus -schemas=ena-submission -locations=filesystem:./flyway/sql migrate
 ```
@@ -196,7 +198,7 @@ cp results/ena_submission_list.json results/approved_ena_submission_list.json
 snakemake trigger_submission_to_ena_from_file
 ```
 
-Alternatively you can upload data to the [test folder](https://github.com/pathoplexus/ena-submission/blob/main/test/approved_ena_submission_list.json) and run `snakemake trigger_submission_to_ena` - note that if you add fake data with a non-existent group-id the project creation will fail, additionally the `upload_to_loculus` rule will fail if these sequences do not actually exist in your loculus instance.
+Alternatively you can upload data to the [test folder](https://github.com/pathoplexus/ena-submission/blob/main/test/approved_ena_submission_list.json) and run `snakemake trigger_submission_to_ena`.
 
 5. Create project, sample and assembly: `snakemake results/project_created results/sample_created results/assembly_created` - you will need the credentials of the ENA test submission account for this.
 

--- a/ena-submission/Snakefile
+++ b/ena-submission/Snakefile
@@ -18,6 +18,24 @@ with open("results/config.yaml", "w") as f:
     f.write(yaml.dump(config))
 
 LOG_LEVEL = config.get("log_level", "INFO")
+SUBMIT_TO_ENA_PROD = config.get("submit_to_ena_prod", False)
+SUBMIT_TO_ENA_DEV = not SUBMIT_TO_ENA_PROD
+
+if SUBMIT_TO_ENA_DEV:
+    print("Submitting to ENA dev environment")
+    config["ena_submission_url"] = "https://wwwdev.ebi.ac.uk/ena/submit/drop-box/submit"
+    config["github_url"] = (
+        "https://raw.githubusercontent.com/pathoplexus/ena-submission/main/test/approved_ena_submission_list.json"
+    )
+    config["ena_reports_service_url"] = "https://wwwdev.ebi.ac.uk/ena/submit/report"
+
+if SUBMIT_TO_ENA_PROD:
+    print("WARNING: Submitting to ENA production")
+    config["ena_submission_url"] = "https://www.ebi.ac.uk/ena/submit/drop-box/submit"
+    config["github_url"] = (
+        "https://raw.githubusercontent.com/pathoplexus/ena-submission/main/approved/approved_ena_submission_list.json"
+    )
+    config["ena_reports_service_url"] = "https://www.ebi.ac.uk/ena/submit/report"
 
 
 rule all:
@@ -88,11 +106,13 @@ rule create_project:
         project_created=touch("results/project_created"),
     params:
         log_level=LOG_LEVEL,
+        test_flag="--test" if SUBMIT_TO_ENA_DEV else "",
     shell:
         """
         python {input.script} \
             --config-file {input.config} \
             --log-level {params.log_level} \
+            {params.test_flag}
         """
 
 
@@ -104,11 +124,13 @@ rule create_sample:
         sample_created=touch("results/sample_created"),
     params:
         log_level=LOG_LEVEL,
+        test_flag="--test" if SUBMIT_TO_ENA_DEV else "",
     shell:
         """
         python {input.script} \
             --config-file {input.config} \
             --log-level {params.log_level} \
+            {params.test_flag}
         """
 
 
@@ -120,11 +142,13 @@ rule create_assembly:
         sample_created=touch("results/assembly_created"),
     params:
         log_level=LOG_LEVEL,
+        test_flag="--test" if SUBMIT_TO_ENA_DEV else "",
     shell:
         """
         python {input.script} \
             --config-file {input.config} \
             --log-level {params.log_level} \
+            {params.test_flag}
         """
 
 

--- a/ena-submission/Snakefile
+++ b/ena-submission/Snakefile
@@ -13,10 +13,6 @@ for key, value in defaults.items():
     if not key in config:
         config[key] = value
 
-Path("results").mkdir(parents=True, exist_ok=True)
-with open("results/config.yaml", "w") as f:
-    f.write(yaml.dump(config))
-
 LOG_LEVEL = config.get("log_level", "INFO")
 SUBMIT_TO_ENA_PROD = config.get("submit_to_ena_prod", False)
 SUBMIT_TO_ENA_DEV = not SUBMIT_TO_ENA_PROD
@@ -36,6 +32,11 @@ if SUBMIT_TO_ENA_PROD:
         "https://raw.githubusercontent.com/pathoplexus/ena-submission/main/approved/approved_ena_submission_list.json"
     )
     config["ena_reports_service_url"] = "https://www.ebi.ac.uk/ena/submit/report"
+
+
+Path("results").mkdir(parents=True, exist_ok=True)
+with open("results/config.yaml", "w") as f:
+    f.write(yaml.dump(config))
 
 
 rule all:

--- a/ena-submission/config/defaults.yaml
+++ b/ena-submission/config/defaults.yaml
@@ -6,9 +6,7 @@ db_name: Loculus
 unique_project_suffix: Loculus
 ena_submission_username: fake-user
 ena_submission_password: fake-password
-ena_submission_url: https://wwwdev.ebi.ac.uk/ena/submit/drop-box/submit # TODO(https://github.com/loculus-project/loculus/issues/2425): update in production
-github_url: https://raw.githubusercontent.com/pathoplexus/ena-submission/main/test/approved_ena_submission_list.json # TODO(https://github.com/loculus-project/loculus/issues/2425): update in production
-ena_reports_service_url: https://wwwdev.ebi.ac.uk/ena/submit/report # TODO(https://github.com/loculus-project/loculus/issues/2425): update in production
+submit_to_ena_prod: False # TODO(https://github.com/loculus-project/loculus/issues/2425): update in production
 #ena_checklist: ERC000033 - do not use until all fields are mapped to ENA accepted options
 metadata_mapping:
   'subject exposure':

--- a/ena-submission/scripts/create_assembly.py
+++ b/ena-submission/scripts/create_assembly.py
@@ -108,7 +108,7 @@ def get_segment_order(unaligned_sequences) -> list[str]:
                 segment_order.append(segment_name)
     else:
         segment_order.append("main")
-    return segment_order
+    return sorted(segment_order)
 
 
 def create_manifest_object(

--- a/ena-submission/scripts/create_assembly.py
+++ b/ena-submission/scripts/create_assembly.py
@@ -368,7 +368,9 @@ def assembly_table_create(
             )
             continue
         logger.info(f"Starting assembly creation for accession {row["accession"]}")
-        segment_order = get_segment_order(sample_data_in_submission_table[0]["unaligned_sequences"])
+        segment_order = get_segment_order(
+            sample_data_in_submission_table[0]["unaligned_nucleotide_sequences"]
+        )
         assembly_creation_results: CreationResults = create_ena_assembly(
             ena_config, manifest_file, center_name=center_name, test=test
         )

--- a/ena-submission/scripts/create_project.py
+++ b/ena-submission/scripts/create_project.py
@@ -248,6 +248,7 @@ def project_table_create(
             group_info = get_group_info(config, row["group_id"])[0]["group"]
         except Exception as e:
             logger.error(f"Was unable to get group info for group: {row["group_id"]}, {e}")
+            time.sleep(30)
             continue
 
         project_set = construct_project_set_object(group_info, config, row, test)

--- a/ena-submission/scripts/create_project.py
+++ b/ena-submission/scripts/create_project.py
@@ -83,7 +83,7 @@ def construct_project_set_object(
     if test:
         alias = XmlAttribute(
             f"{entry["group_id"]}:{entry["organism"]}:{config.unique_project_suffix}:{datetime.now(tz=pytz.utc)}"
-        )  # TODO(https://github.com/loculus-project/loculus/issues/2425): remove in production
+        )
     else:
         alias = XmlAttribute(
             f"{entry["group_id"]}:{entry["organism"]}:{config.unique_project_suffix}"
@@ -217,13 +217,18 @@ def submission_table_update(db_config: SimpleConnectionPool):
             raise RuntimeError(error_msg)
 
 
-def project_table_create(db_config: SimpleConnectionPool, config: Config, retry_number: int = 3):
+def project_table_create(
+    db_config: SimpleConnectionPool, config: Config, retry_number: int = 3, test: bool = False
+):
     """
     1. Find all entries in project_table in state READY
     2. Create project_set: get_group_info from loculus, use entry and config for other fields
     3. Update project_table to state SUBMITTING (only proceed if update succeeds)
     4. If (create_ena_project succeeds): update state to SUBMITTED with results
     3. Else update state to HAS_ERRORS with error messages
+
+    If test=True add a timestamp to the alias suffix to allow for multiple submissions of the same
+    project for testing.
     """
     ena_config = get_ena_config(
         config.ena_submission_username,
@@ -245,7 +250,7 @@ def project_table_create(db_config: SimpleConnectionPool, config: Config, retry_
             logger.error(f"Was unable to get group info for group: {row["group_id"]}, {e}")
             continue
 
-        project_set = construct_project_set_object(group_info, config, row, test=True)
+        project_set = construct_project_set_object(group_info, config, row, test)
         update_values = {
             "status": Status.SUBMITTING,
             "started_at": datetime.now(tz=pytz.utc),
@@ -358,7 +363,13 @@ def project_table_handle_errors(
     required=True,
     type=click.Path(exists=True),
 )
-def create_project(log_level, config_file):
+@click.option(
+    "--test",
+    is_flag=True,
+    default=False,
+    help="Allow multiple submissions of the same project for testing",
+)
+def create_project(log_level, config_file, test=False):
     logger.setLevel(log_level)
     logging.getLogger("requests").setLevel(logging.INFO)
 
@@ -379,7 +390,7 @@ def create_project(log_level, config_file):
         submission_table_start(db_config)
         submission_table_update(db_config)
 
-        project_table_create(db_config, config)
+        project_table_create(db_config, config, test=test)
         project_table_handle_errors(db_config, config, slack_config)
         time.sleep(2)
 

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -296,7 +296,7 @@ def create_manifest(manifest: AssemblyManifest) -> str:
 
 
 def post_webin_cli(
-    config: ENAConfig, manifest_filename, center_name=None
+    config: ENAConfig, manifest_filename, center_name=None, test=True
 ) -> subprocess.CompletedProcess:
     subprocess_args = [
         "java",
@@ -311,8 +311,8 @@ def post_webin_cli(
         "-manifest",
         manifest_filename,
         "-submit",
-        "-test",  # TODO(https://github.com/loculus-project/loculus/issues/2425): remove in prod
     ]
+    subprocess_args.append("-test") if test else None
     if center_name:
         subprocess_args.extend(["-centername", center_name])
     return subprocess.run(
@@ -324,16 +324,17 @@ def post_webin_cli(
 
 
 def create_ena_assembly(
-    config: ENAConfig, manifest_filename: str, center_name=None
+    config: ENAConfig, manifest_filename: str, center_name=None, test=True
 ) -> CreationResults:
     """
     This is equivalent to running:
     webin-cli -username {params.ena_submission_username} -password {params.ena_submission_password}
         -context genome -manifest {manifest_file} -submit
+    test=True, adds the `-test` flag which means submissions will use the ENA dev endpoint.
     """
     errors = []
     warnings = []
-    response = post_webin_cli(config, manifest_filename, center_name=center_name)
+    response = post_webin_cli(config, manifest_filename, center_name=center_name, test=test)
     logger.info(response.stdout)
     if response.returncode != 0:
         error_message = (

--- a/ena-submission/scripts/upload_external_metadata_to_loculus.py
+++ b/ena-submission/scripts/upload_external_metadata_to_loculus.py
@@ -85,6 +85,14 @@ def get_external_metadata(db_config: SimpleConnectionPool, entry: dict[str, Any]
         data["externalMetadata"]["gcaAccession"] = corresponding_assembly[0]["result"][
             "gca_accession"
         ]
+        insdc_accession_keys = [
+            key for key in corresponding_assembly[0]["result"] if key.startswith("insdc_accession")
+        ]
+        segments = [key[len("insdc_accession") :] for key in insdc_accession_keys]
+        for segment in segments:
+            data["externalMetadata"]["insdcAccessionBase" + segment] = corresponding_assembly[0][
+                "result"
+            ]["insdc_accession" + segment]
     else:
         raise Exception
     return data

--- a/ena-submission/scripts/upload_external_metadata_to_loculus.py
+++ b/ena-submission/scripts/upload_external_metadata_to_loculus.py
@@ -86,13 +86,18 @@ def get_external_metadata(db_config: SimpleConnectionPool, entry: dict[str, Any]
             "gca_accession"
         ]
         insdc_accession_keys = [
-            key for key in corresponding_assembly[0]["result"] if key.startswith("insdc_accession")
+            key
+            for key in corresponding_assembly[0]["result"]
+            if key.startswith("insdc_accession_full")
         ]
-        segments = [key[len("insdc_accession") :] for key in insdc_accession_keys]
+        segments = [key[len("insdc_accession_full") :] for key in insdc_accession_keys]
         for segment in segments:
             data["externalMetadata"]["insdcAccessionBase" + segment] = corresponding_assembly[0][
                 "result"
             ]["insdc_accession" + segment]
+            data["externalMetadata"]["insdcAccessionFull" + segment] = corresponding_assembly[0][
+                "result"
+            ]["insdc_accession_full" + segment]
     else:
         raise Exception
     return data


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
1. Maps results of successful ENA assembly submission to insdc_accession_base and insdc_accession_full and uploads these results to Loculus - handles the case with a single and also a multi-segment organism: 
<img width="375" alt="image" src="https://github.com/user-attachments/assets/a2a718bd-a49e-4532-9296-5fe90267b67b">

2. Tested locally and updated README with exact commands for local testing and additional warnings.
3. Refactored code to have `--test` flag (determines if ENA dev or prod is used) that is set at config level to make code clearer.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
