### PR TITLE
fix(deploy): hotfix mistake in my changes to `deploy.py` to handle subdomains appropriately

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -344,7 +344,7 @@ def generate_config(
 ):
     if from_live and live_host:
         number_of_dots = live_host.count(".")
-        if number_of_dots <= 2: # this is an imperfect hack
+        if number_of_dots < 2: # this is an imperfect hack
             raise ValueError("Currently only subdomains are supported as live-hosts")
             # To be able to cope with top level domains we need more logic to use the right subdomain separator - but we should probably avoid this anyway as we shouldn't use production domains
     helm_template_cmd = [


### PR DESCRIPTION
I made a mistake in what was meant to be a helpful feature to avoid confusion. It should allow `main.loculus.org` but not `loculus.org` but I used `<=` not `<` so it currently doesn't allow `main.loculus.org`. Apologies.