### PR TITLE
test(backend): test `/get-original-metadata` locked during new submissions

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -352,7 +352,7 @@ open class SubmissionController(
     )
     @ApiResponse(
         responseCode = "423",
-        description = "Locked. The metadata is currently being processed.",
+        description = "Locked. New sequence entries are currently being uploaded.",
     )
     @GetMapping("/get-original-metadata", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun getOriginalMetadata(
@@ -375,7 +375,7 @@ open class SubmissionController(
             headers.add(HttpHeaders.CONTENT_ENCODING, compression.compressionName)
         }
 
-        val stillProcessing = submissionDatabaseService.checkIfStillProcessingSubmittedData()
+        val stillProcessing = submitModel.checkIfStillProcessingSubmittedData()
         if (stillProcessing) {
             return ResponseEntity.status(HttpStatus.LOCKED).build()
         }

--- a/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
@@ -17,11 +17,14 @@ import org.loculus.backend.controller.UnprocessableEntityException
 import org.loculus.backend.service.datauseterms.DataUseTermsPreconditionValidator
 import org.loculus.backend.service.groupmanagement.GroupManagementPreconditionValidator
 import org.loculus.backend.service.submission.CompressionAlgorithm
+import org.loculus.backend.service.submission.MetadataUploadAuxTable
+import org.loculus.backend.service.submission.SequenceUploadAuxTable
 import org.loculus.backend.service.submission.UploadDatabaseService
 import org.loculus.backend.utils.FastaReader
 import org.loculus.backend.utils.metadataEntryStreamAsSequence
 import org.loculus.backend.utils.revisionEntryStreamAsSequence
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 import java.io.BufferedInputStream
 import java.io.File
@@ -312,5 +315,14 @@ class SubmitModel(
             }
             throw UnprocessableEntityException(metadataNotPresentErrorText + sequenceNotPresentErrorText)
         }
+    }
+
+    @Transactional(readOnly = true)
+    fun checkIfStillProcessingSubmittedData(): Boolean {
+        val metadataInAuxTable: Boolean =
+            MetadataUploadAuxTable.select(MetadataUploadAuxTable.submissionIdColumn).count() > 0
+        val sequencesInAuxTable: Boolean =
+            SequenceUploadAuxTable.select(SequenceUploadAuxTable.sequenceSubmissionIdColumn).count() > 0
+        return metadataInAuxTable || sequencesInAuxTable
     }
 }

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -950,14 +950,6 @@ open class SubmissionDatabaseService(
         )
     }
 
-    fun checkIfStillProcessingSubmittedData(): Boolean {
-        val metadataInAuxTable: Boolean =
-            MetadataUploadAuxTable.select(MetadataUploadAuxTable.submissionIdColumn).count() > 0
-        val sequencesInAuxTable: Boolean =
-            SequenceUploadAuxTable.select(SequenceUploadAuxTable.sequenceSubmissionIdColumn).count() > 0
-        return metadataInAuxTable || sequencesInAuxTable
-    }
-
     fun streamOriginalMetadata(
         authenticatedUser: AuthenticatedUser,
         organism: Organism,

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
@@ -7,7 +7,6 @@ import org.jetbrains.exposed.sql.VarCharColumnType
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.batchInsert
 import org.jetbrains.exposed.sql.deleteWhere
-import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.statements.StatementType
 import org.jetbrains.exposed.sql.transactions.transaction


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://testMtadataLock.loculus.org

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

This is a follow-up to #2846

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
