### PR TITLE
fix(silo-preprocessing): Fix interpolation syntax error

### DIFF
--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -140,7 +140,7 @@ download_data() {
         exit 0
       else
         echo "Hashes are unequal, deleting old input data dir"
-        rm -rf "$old_input_data_dir:?}"
+        rm -rf "$old_input_data_dir"
       fi
     fi
   else


### PR DESCRIPTION
Accidentally introduced in "feat(silo-prepro): use hash instead of line count to test for equality (#1488)" (b0523ad9) when changing the interpolation.

Thank you to @tsibley for this fix in #2855
