### PR TITLE
feat(deploy): verify loculus version for config file before using it for preprocessing

### DIFF
--- a/kubernetes/loculus/templates/loculus-preprocessing-config.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-config.yaml
@@ -1,3 +1,4 @@
+{{- $dockerTag := include "loculus.dockerTag" .Values }}
 {{- range $organism, $organismConfig := (.Values.organisms | default .Values.defaultOrganisms) }}
 {{- $metadata := ($organismConfig.schema | include "loculus.patchMetadataSchema" | fromYaml).metadata }}
 {{- $nucleotideSequences := (($organismConfig.schema | include "loculus.patchMetadataSchema" | fromYaml).nucleotideSequences | default "" ) }}
@@ -15,6 +16,7 @@ data:
     processing_spec:
       {{- $args := dict "metadata" $metadata "nucleotideSequences" $nucleotideSequences }}
       {{- include "loculus.preprocessingSpecs" $args | nindent 6 }}
+    verify_loculus_version_is: {{$dockerTag}}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
@@ -31,6 +31,7 @@ spec:
         component: loculus-preprocessing-{{ $organism }}-v{{ $processingConfig.version }}-{{ $processingIndex }}
     spec:
       {{- include "possiblePriorityClassName" $ | nindent 6 }}
+      {{- if $processingConfig.configFile }}
       initContainers:
         - name: version-check
           image: busybox
@@ -50,6 +51,7 @@ spec:
           volumeMounts:
             - name: preprocessing-config-volume-{{ $organism }}-v{{ $processingConfig.version }}-{{ $processingIndex }}
               mountPath: /etc/config
+      {{- end }}
       containers:
         - name: preprocessing-{{ $organism }}
           image: {{ $processingConfig.image}}:{{ $dockerTag }}

--- a/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
@@ -31,6 +31,19 @@ spec:
         component: loculus-preprocessing-{{ $organism }}-v{{ $processingConfig.version }}-{{ $processingIndex }}
     spec:
       {{- include "possiblePriorityClassName" $ | nindent 6 }}
+      initContainers:
+        - name: version-check
+          image: busybox
+          command: ['sh', '-c', '
+            CONFIG_VERSION=$(grep "verify_loculus_version_is:" /etc/config/preprocessing-config.yaml | awk "{print $2}");
+            if [ "$CONFIG_VERSION" != "{{ $dockerTag }}" ]; then
+              echo "Version mismatch: ConfigMap version $CONFIG_VERSION does not match docker tag {{ $dockerTag }}";
+              exit 1;
+            fi
+          ']
+          volumeMounts:
+            - name: preprocessing-config-volume-{{ $organism }}-v{{ $processingConfig.version }}-{{ $processingIndex }}
+              mountPath: /etc/config
       containers:
         - name: preprocessing-{{ $organism }}
           image: {{ $processingConfig.image}}:{{ $dockerTag }}

--- a/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
@@ -34,6 +34,7 @@ spec:
       initContainers:
         - name: version-check
           image: busybox
+          {{- include "loculus.resources" (list "preprocessing-init" $.Values) | nindent 10 }}
           command: ['sh', '-c', '
             CONFIG_VERSION=$(grep "verify_loculus_version_is:" /etc/config/preprocessing-config.yaml | sed "s/verify_loculus_version_is://; s/^[[:space:]]*//; s/[[:space:]]*$//");
             DOCKER_TAG="{{ $dockerTag }}";

--- a/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
@@ -35,10 +35,15 @@ spec:
         - name: version-check
           image: busybox
           command: ['sh', '-c', '
-            CONFIG_VERSION=$(grep "verify_loculus_version_is:" /etc/config/preprocessing-config.yaml | awk "{print $2}");
-            if [ "$CONFIG_VERSION" != "{{ $dockerTag }}" ]; then
-              echo "Version mismatch: ConfigMap version $CONFIG_VERSION does not match docker tag {{ $dockerTag }}";
+            CONFIG_VERSION=$(grep "verify_loculus_version_is:" /etc/config/preprocessing-config.yaml | sed "s/verify_loculus_version_is://; s/^[[:space:]]*//; s/[[:space:]]*$//");
+            DOCKER_TAG="{{ $dockerTag }}";
+            echo "Config version: $CONFIG_VERSION";
+            echo "Docker tag: $DOCKER_TAG";
+            if [ "$CONFIG_VERSION" != "$DOCKER_TAG" ]; then
+              echo "Version mismatch: ConfigMap version $CONFIG_VERSION does not match docker tag $DOCKER_TAG";
               exit 1;
+            else
+              echo "Version match confirmed";
             fi
           ']
           volumeMounts:


### PR DESCRIPTION
We encountered an issue during a rollout in which the config map was changed and triggered a reload of the pod before the pod itself was upgraded to the next version, causing double version bumps in staging. This avoids that by making the config map contain the loculus version that it targets and making an initContainer in the deployment that checks that this matches that expected by the deployment.

https://verify-loculus-ver.loculus.org/