### PR TITLE
feat(deployment): ingest version checking

### DIFF
--- a/kubernetes/loculus/templates/ingest-config.yaml
+++ b/kubernetes/loculus/templates/ingest-config.yaml
@@ -1,3 +1,4 @@
+{{- $dockerTag := include "loculus.dockerTag" .Values }}
 {{- $testconfig := .Values.testconfig | default false }}
 {{- $backendHost := .Values.environment | eq "server" | ternary (printf "https://backend%s%s" .Values.subdomainSeparator $.Values.host) ($testconfig | ternary "http://localhost:8079" "http://loculus-backend-service:8079") }}
 {{- $keycloakHost := .Values.environment | eq "server" | ternary (printf "https://authentication%s%s" $.Values.subdomainSeparator $.Values.host) ($testconfig | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083") }}
@@ -12,6 +13,7 @@ metadata:
 data:
   config.yaml: |
     {{- $values.ingest.configFile | toYaml | nindent 4 }}
+    verify_loculus_version_is: {{$dockerTag}}
     organism: {{ $key }}
     backend_url: {{ $backendHost }}
     keycloak_token_url: {{ $keycloakHost -}}/realms/loculus/protocol/openid-connect/token

--- a/kubernetes/loculus/templates/ingest-deployment.yaml
+++ b/kubernetes/loculus/templates/ingest-deployment.yaml
@@ -7,6 +7,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: loculus-ingest-deployment-{{ $key }}
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   strategy:

--- a/kubernetes/loculus/templates/ingest-deployment.yaml
+++ b/kubernetes/loculus/templates/ingest-deployment.yaml
@@ -9,6 +9,7 @@ metadata:
   name: loculus-ingest-deployment-{{ $key }}
   annotations:
     reloader.stakater.com/auto: "true"
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
   replicas: 1
   strategy:
@@ -22,8 +23,6 @@ spec:
       labels:
         app: loculus
         component: loculus-ingest-deployment-{{ $key }}
-      annotations:
-        argocd.argoproj.io/sync-options: Force=true,Replace=true
     spec:
       {{- include "possiblePriorityClassName" $ | nindent 6 }}
       initContainers:
@@ -78,6 +77,9 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: loculus-revoke-and-regroup-cronjob-{{ $key }}
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
+    reloader.stakater.com/auto: "true"
 spec:
   schedule: "0 0 31 2 *" # Never runs without manual trigger
   startingDeadlineSeconds: 60
@@ -90,9 +92,6 @@ spec:
           labels:
             app: loculus
             component: loculus-ingest-cronjob-{{ $key }}
-          annotations:
-            argocd.argoproj.io/sync-options: Replace=true
-            reloader.stakater.com/auto: "true"
         spec:
           restartPolicy: Never
           containers:

--- a/kubernetes/loculus/templates/ingest-deployment.yaml
+++ b/kubernetes/loculus/templates/ingest-deployment.yaml
@@ -24,6 +24,26 @@ spec:
         argocd.argoproj.io/sync-options: Force=true,Replace=true
     spec:
       {{- include "possiblePriorityClassName" $ | nindent 6 }}
+      initContainers:
+        - name: version-check
+          image: busybox
+          {{- include "loculus.resources" (list "ingest-init" $.Values) | nindent 10 }}
+          command: ['sh', '-c', '
+            CONFIG_VERSION=$(grep "verify_loculus_version_is:" /package/config/config.yaml | sed "s/verify_loculus_version_is://; s/^[[:space:]]*//; s/[[:space:]]*$//");
+            DOCKER_TAG="{{ $dockerTag }}";
+            echo "Config version: $CONFIG_VERSION";
+            echo "Docker tag: $DOCKER_TAG";
+            if [ "$CONFIG_VERSION" != "$DOCKER_TAG" ]; then
+              echo "Version mismatch: ConfigMap version $CONFIG_VERSION does not match docker tag $DOCKER_TAG";
+              exit 1;
+            else
+              echo "Version match confirmed";
+            fi
+          ']
+          volumeMounts:
+            - name: loculus-ingest-config-volume-{{ $key }}
+              mountPath: /package/config/config.yaml
+              subPath: config.yaml
       containers:
         - name: ingest-{{ $key }}
           image: {{ $value.ingest.image}}:{{ $dockerTag }}

--- a/kubernetes/loculus/templates/ingest-deployment.yaml
+++ b/kubernetes/loculus/templates/ingest-deployment.yaml
@@ -29,7 +29,7 @@ spec:
           image: busybox
           {{- include "loculus.resources" (list "ingest-init" $.Values) | nindent 10 }}
           command: ['sh', '-c', '
-            CONFIG_VERSION=$(grep "verify_loculus_version_is:" /package/config/config.yaml | sed "s/verify_loculus_version_is://; s/^[[:space:]]*//; s/[[:space:]]*$//");
+            CONFIG_VERSION=$(grep "verify_loculus_version_is:" /package/config/config.yaml | sed "s/verify_loculus_version_is: //;");
             DOCKER_TAG="{{ $dockerTag }}";
             echo "Config version: $CONFIG_VERSION";
             echo "Docker tag: $DOCKER_TAG";


### PR DESCRIPTION
We encountered an issue during a rollout in which the config map was changed and triggered a reload of the pod [edit: actually we didn't have the reloader - so I'm not sure if that is it] before the pod itself was upgraded to the next version, causing double version bumps in staging. This avoids that by making the config map contain the loculus version that it targets and making an initContainer in the deployment that checks that this matches that expected by the deployment.

https://ingest-version-checking.loculus.org/

