### PR TITLE
Move argoCD sync options to the right place in ingest, and add reloader

### DIFF
--- a/kubernetes/loculus/templates/ingest-deployment.yaml
+++ b/kubernetes/loculus/templates/ingest-deployment.yaml
@@ -7,6 +7,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: loculus-ingest-deployment-{{ $key }}
+  annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   strategy:
@@ -20,8 +23,6 @@ spec:
       labels:
         app: loculus
         component: loculus-ingest-deployment-{{ $key }}
-      annotations:
-        argocd.argoproj.io/sync-options: Force=true,Replace=true
     spec:
       {{- include "possiblePriorityClassName" $ | nindent 6 }}
       containers:
@@ -56,6 +57,9 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: loculus-revoke-and-regroup-cronjob-{{ $key }}
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
+    reloader.stakater.com/auto: "true"
 spec:
   schedule: "0 0 31 2 *" # Never runs without manual trigger
   startingDeadlineSeconds: 60
@@ -68,9 +72,6 @@ spec:
           labels:
             app: loculus
             component: loculus-ingest-cronjob-{{ $key }}
-          annotations:
-            argocd.argoproj.io/sync-options: Replace=true
-            reloader.stakater.com/auto: "true"
         spec:
           restartPolicy: Never
           containers:


### PR DESCRIPTION
ArgoCD sync options were tagged in the wrong place, ~likely allowing concurrency~ (edit: but we were using `strategy: Recreate`). Also we were not using reloader.

https://argocd-move.loculus.org/