### PR TITLE
Reduce ena submission induced db load

### DIFF
--- a/ena-submission/Snakefile
+++ b/ena-submission/Snakefile
@@ -14,6 +14,10 @@ for key, value in defaults.items():
         config[key] = value
 
 LOG_LEVEL = config.get("log_level", "INFO")
+TIME_BETWEEN_ITERATIONS = config.get("time_between_iterations", 10)
+MIN_BETWEEN_GITHUB_REQUESTS = config.get("min_between_github_requests", 2)
+MIN_BETWEEN_ENA_CHECKS = config.get("min_between_ena_checks", 5)
+
 SUBMIT_TO_ENA_PROD = config.get("submit_to_ena_prod", False)
 if config.get("backend_url", "") not in config.get("allowed_submission_hosts", []):
     print("WARNING: backend_url not in allowed_hosts")
@@ -76,11 +80,13 @@ rule trigger_submission_to_ena:
         submitted=touch("results/triggered"),
     params:
         log_level=LOG_LEVEL,
+        min_between_github_requests=MIN_BETWEEN_GITHUB_REQUESTS,
     shell:
         """
         python {input.script} \
                 --config-file {input.config} \
                 --log-level {params.log_level} \
+                --min-between-github-requests {params.min_between_github_requests}
         """
 
 
@@ -111,11 +117,13 @@ rule create_project:
     params:
         log_level=LOG_LEVEL,
         test_flag="--test" if SUBMIT_TO_ENA_DEV else "",
+        time_between_iterations=TIME_BETWEEN_ITERATIONS,
     shell:
         """
         python {input.script} \
             --config-file {input.config} \
             --log-level {params.log_level} \
+            --time-between-iterations {params.time_between_iterations} \
             {params.test_flag}
         """
 
@@ -129,11 +137,13 @@ rule create_sample:
     params:
         log_level=LOG_LEVEL,
         test_flag="--test" if SUBMIT_TO_ENA_DEV else "",
+        time_between_iterations=TIME_BETWEEN_ITERATIONS,
     shell:
         """
         python {input.script} \
             --config-file {input.config} \
             --log-level {params.log_level} \
+            --time-between-iterations {params.time_between_iterations} \
             {params.test_flag}
         """
 
@@ -147,11 +157,15 @@ rule create_assembly:
     params:
         log_level=LOG_LEVEL,
         test_flag="--test" if SUBMIT_TO_ENA_DEV else "",
+        time_between_iterations=TIME_BETWEEN_ITERATIONS,
+        min_between_ena_checks=MIN_BETWEEN_ENA_CHECKS,
     shell:
         """
         python {input.script} \
             --config-file {input.config} \
             --log-level {params.log_level} \
+            --time-between-iterations {params.time_between_iterations} \
+            --min-between-ena-checks {params.min_between_ena_checks} \
             {params.test_flag}
         """
 
@@ -164,9 +178,11 @@ rule upload_to_loculus:
         sample_created=touch("results/uploaded_external_metadata"),
     params:
         log_level=LOG_LEVEL,
+        time_between_iterations=TIME_BETWEEN_ITERATIONS,
     shell:
         """
         python {input.script} \
             --config-file {input.config} \
             --log-level {params.log_level} \
+            --time-between-iterations {params.time_between_iterations} \
         """

--- a/ena-submission/config/defaults.yaml
+++ b/ena-submission/config/defaults.yaml
@@ -9,6 +9,9 @@ ena_submission_password: fake-password
 submit_to_ena_prod: False
 allowed_submission_hosts:
   - https://backend.pathoplexus.org
+time_between_iterations: 10
+min_between_github_requests: 2
+min_between_ena_checks: 5
 #ena_checklist: ERC000033 - do not use until all fields are mapped to ENA accepted options
 metadata_mapping:
   'subject exposure':

--- a/ena-submission/scripts/create_assembly.py
+++ b/ena-submission/scripts/create_assembly.py
@@ -567,7 +567,7 @@ def create_assembly(log_level, config_file, test=False):
         assembly_table_create(db_config, config, retry_number=3, test=test)
         assembly_table_update(db_config, config)
         assembly_table_handle_errors(db_config, config, slack_config)
-        time.sleep(2)
+        time.sleep(10)
 
 
 if __name__ == "__main__":

--- a/ena-submission/scripts/create_assembly.py
+++ b/ena-submission/scripts/create_assembly.py
@@ -548,6 +548,11 @@ def assembly_table_handle_errors(
     default=10,
     type=int,
 )
+@click.option(
+    "--min-between-ena-checks",
+    default=5,
+    type=int,
+)
 def create_assembly(
     log_level, config_file, test=False, time_between_iterations=10, min_between_ena_checks=5
 ):

--- a/ena-submission/scripts/create_assembly.py
+++ b/ena-submission/scripts/create_assembly.py
@@ -543,7 +543,12 @@ def assembly_table_handle_errors(
     default=False,
     help="Allow multiple submissions of the same project for testing AND use the webin-cli test endpoint",
 )
-def create_assembly(log_level, config_file, test=False):
+@click.option(
+    "--time-between-iterations",
+    default=10,
+    type=int,
+)
+def create_assembly(log_level, config_file, test=False, time_between_iterations=10):
     logger.setLevel(log_level)
     logging.getLogger("requests").setLevel(logging.INFO)
 
@@ -567,7 +572,7 @@ def create_assembly(log_level, config_file, test=False):
         assembly_table_create(db_config, config, retry_number=3, test=test)
         assembly_table_update(db_config, config)
         assembly_table_handle_errors(db_config, config, slack_config)
-        time.sleep(10)
+        time.sleep(time_between_iterations)
 
 
 if __name__ == "__main__":

--- a/ena-submission/scripts/create_assembly.py
+++ b/ena-submission/scripts/create_assembly.py
@@ -548,7 +548,9 @@ def assembly_table_handle_errors(
     default=10,
     type=int,
 )
-def create_assembly(log_level, config_file, test=False, time_between_iterations=10):
+def create_assembly(
+    log_level, config_file, test=False, time_between_iterations=10, min_between_ena_checks=5
+):
     logger.setLevel(log_level)
     logging.getLogger("requests").setLevel(logging.INFO)
 
@@ -570,7 +572,7 @@ def create_assembly(log_level, config_file, test=False, time_between_iterations=
         submission_table_update(db_config)
 
         assembly_table_create(db_config, config, retry_number=3, test=test)
-        assembly_table_update(db_config, config)
+        assembly_table_update(db_config, config, time_threshold=min_between_ena_checks)
         assembly_table_handle_errors(db_config, config, slack_config)
         time.sleep(time_between_iterations)
 

--- a/ena-submission/scripts/create_project.py
+++ b/ena-submission/scripts/create_project.py
@@ -272,7 +272,9 @@ def project_table_create(
                 )
             )
             continue
-        logger.info(f"Starting Project creation for group_id {row["group_id"]}")
+        logger.info(
+            f"Starting Project creation for group_id {row["group_id"]} organism {row["organism"]}"
+        )
         project_creation_results: CreationResults = create_ena_project(ena_config, project_set)
         if project_creation_results.results:
             update_values = {
@@ -296,7 +298,9 @@ def project_table_create(
                 )
                 tries += 1
             if number_rows_updated == 1:
-                logger.info(f"Project creation for group_id {row["group_id"]} succeeded!")
+                logger.info(
+                    f"Project creation for group_id {row["group_id"]} organism {row["organism"]} succeeded!"
+                )
         else:
             update_values = {
                 "status": Status.HAS_ERRORS,

--- a/ena-submission/scripts/create_project.py
+++ b/ena-submission/scripts/create_project.py
@@ -370,7 +370,12 @@ def project_table_handle_errors(
     default=False,
     help="Allow multiple submissions of the same project for testing",
 )
-def create_project(log_level, config_file, test=False):
+@click.option(
+    "--time-between-iterations",
+    default=10,
+    type=int,
+)
+def create_project(log_level, config_file, test=False, time_between_iterations=10):
     logger.setLevel(log_level)
     logging.getLogger("requests").setLevel(logging.INFO)
 
@@ -393,7 +398,7 @@ def create_project(log_level, config_file, test=False):
 
         project_table_create(db_config, config, test=test)
         project_table_handle_errors(db_config, config, slack_config)
-        time.sleep(10)
+        time.sleep(time_between_iterations)
 
 
 if __name__ == "__main__":

--- a/ena-submission/scripts/create_project.py
+++ b/ena-submission/scripts/create_project.py
@@ -393,7 +393,7 @@ def create_project(log_level, config_file, test=False):
 
         project_table_create(db_config, config, test=test)
         project_table_handle_errors(db_config, config, slack_config)
-        time.sleep(2)
+        time.sleep(10)
 
 
 if __name__ == "__main__":

--- a/ena-submission/scripts/create_sample.py
+++ b/ena-submission/scripts/create_sample.py
@@ -439,7 +439,7 @@ def create_sample(log_level, config_file, test=False):
 
         sample_table_create(db_config, config, test=test)
         sample_table_handle_errors(db_config, config, slack_config)
-        time.sleep(2)
+        time.sleep(10)
 
 
 if __name__ == "__main__":

--- a/ena-submission/scripts/create_sample.py
+++ b/ena-submission/scripts/create_sample.py
@@ -416,7 +416,12 @@ def sample_table_handle_errors(
     default=False,
     help="Allow multiple submissions of the same project for testing",
 )
-def create_sample(log_level, config_file, test=False):
+@click.option(
+    "--time-between-iterations",
+    default=10,
+    type=int,
+)
+def create_sample(log_level, config_file, test=False, time_between_iterations=10):
     logger.setLevel(log_level)
     logging.getLogger("requests").setLevel(logging.INFO)
 
@@ -439,7 +444,7 @@ def create_sample(log_level, config_file, test=False):
 
         sample_table_create(db_config, config, test=test)
         sample_table_handle_errors(db_config, config, slack_config)
-        time.sleep(10)
+        time.sleep(time_between_iterations)
 
 
 if __name__ == "__main__":

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -384,7 +384,7 @@ def check_ena(config: ENAConfig, erz_accession: str, segment_order: list[str]) -
     response.raise_for_status()
     if not response.ok:
         error_message = (
-            f"Request failed with status:{response.status_code}. "
+            f"ENA check failed with status:{response.status_code}. "
             f"Request: {response.request}, Response: {response.text}"
         )
         logger.warning(error_message)

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -128,13 +128,10 @@ def create_ena_project(config: ENAConfig, project_set: ProjectSet) -> CreationRe
         }
 
     xml = get_project_xml(project_set)
-    try:
-        response = post_webin(config, xml)
-        response.raise_for_status()
-    except requests.exceptions.RequestException as e:
+    response = post_webin(config, xml)
+    if not response.ok:
         error_message = (
-            f"Request failed with status:{response.status_code}. Message: {e}. "
-            f"Response: {response.text}."
+            f"Request failed with status:{response.status_code}. " f"Response: {response.text}."
         )
         logger.warning(error_message)
         errors.append(error_message)
@@ -181,10 +178,8 @@ def create_ena_sample(config: ENAConfig, sample_set: SampleSetType) -> CreationR
         return files
 
     xml = get_sample_xml(sample_set)
-    try:
-        response = post_webin(config, xml)
-        response.raise_for_status()
-    except requests.exceptions.RequestException:
+    response = post_webin(config, xml)
+    if not response.ok:
         error_message = (
             f"Request failed with status:{response.status_code}. "
             f"Request: {response.request}, Response: {response.text}"
@@ -380,16 +375,16 @@ def check_ena(config: ENAConfig, erz_accession: str, segment_order: list[str]) -
     errors = []
     warnings = []
     assembly_results = {"segment_order": segment_order}
-    try:
-        response = requests.get(
-            url,
-            auth=HTTPBasicAuth(config.ena_submission_username, config.ena_submission_password),
-            timeout=10,  # wait a full 10 seconds for a response incase slow
-        )
-        response.raise_for_status()
-    except requests.exceptions.RequestException:
+
+    response = requests.get(
+        url,
+        auth=HTTPBasicAuth(config.ena_submission_username, config.ena_submission_password),
+        timeout=10,  # wait a full 10 seconds for a response incase slow
+    )
+    response.raise_for_status()
+    if not response.ok:
         error_message = (
-            f"ENA check failed with status:{response.status_code}. "
+            f"Request failed with status:{response.status_code}. "
             f"Request: {response.request}, Response: {response.text}"
         )
         logger.warning(error_message)

--- a/ena-submission/scripts/submission_db_helper.py
+++ b/ena-submission/scripts/submission_db_helper.py
@@ -26,7 +26,7 @@ def db_init(
 
     return SimpleConnectionPool(
         minconn=1,
-        maxconn=4,  # max 7*4 connections to db allowed
+        maxconn=2,  # max 7*2 connections to db allowed
         dbname="loculus",
         user=db_username,
         host=db_host,

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -93,6 +93,7 @@ def mock_requests_post(status_code, text):
     mock_response = mock.Mock()
     mock_response.status_code = status_code
     mock_response.text = text
+    mock_response.ok = mock_response.status_code < 400
     return mock_response
 
 
@@ -122,7 +123,6 @@ class ProjectCreationTests(unittest.TestCase):
     def test_create_project_server_failure(self, mock_post):
         # Testing project creation failure
         mock_post.return_value = mock_requests_post(500, "Internal Server Error")
-        mock_post.return_value.raise_for_status.side_effect = exceptions.RequestException()
         project_set = default_project_type()
         response = create_ena_project(test_ena_config, project_set)
         error_message_part = "Request failed with status:500"

--- a/ena-submission/scripts/trigger_submission_to_ena.py
+++ b/ena-submission/scripts/trigger_submission_to_ena.py
@@ -109,7 +109,7 @@ def trigger_submission_to_ena(log_level, config_file, input_file=None):
             error_msg = f"Failed to retrieve file: {response.status_code}"
             logger.error(error_msg)
         upload_sequences(db_config, sequences_to_upload)
-        time.sleep(60)  # Sleep for 1min to not overwhelm github
+        time.sleep(120)  # Sleep for 2min to not overwhelm github
 
 
 if __name__ == "__main__":

--- a/ena-submission/scripts/trigger_submission_to_ena.py
+++ b/ena-submission/scripts/trigger_submission_to_ena.py
@@ -77,7 +77,14 @@ def upload_sequences(db_config: SimpleConnectionPool, sequences_to_upload: dict[
     required=False,
     type=click.Path(),
 )
-def trigger_submission_to_ena(log_level, config_file, input_file=None):
+@click.option(
+    "--min-between-github-requests",
+    default=2,
+    type=int,
+)
+def trigger_submission_to_ena(
+    log_level, config_file, input_file=None, min_between_github_requests=2
+):
     logger.setLevel(log_level)
     logging.getLogger("requests").setLevel(logging.INFO)
 
@@ -109,7 +116,7 @@ def trigger_submission_to_ena(log_level, config_file, input_file=None):
             error_msg = f"Failed to retrieve file: {response.status_code}"
             logger.error(error_msg)
         upload_sequences(db_config, sequences_to_upload)
-        time.sleep(120)  # Sleep for 2min to not overwhelm github
+        time.sleep(min_between_github_requests * 60)  # Sleep for x min to not overwhelm github
 
 
 if __name__ == "__main__":

--- a/ena-submission/scripts/upload_external_metadata_to_loculus.py
+++ b/ena-submission/scripts/upload_external_metadata_to_loculus.py
@@ -231,7 +231,7 @@ def upload_external_metadata(log_level, config_file):
             config,
             slack_config,
         )
-        time.sleep(2)
+        time.sleep(10)
 
 
 if __name__ == "__main__":

--- a/ena-submission/scripts/upload_external_metadata_to_loculus.py
+++ b/ena-submission/scripts/upload_external_metadata_to_loculus.py
@@ -208,7 +208,12 @@ def upload_handle_errors(
     required=True,
     type=click.Path(exists=True),
 )
-def upload_external_metadata(log_level, config_file):
+@click.option(
+    "--time-between-iterations",
+    default=10,
+    type=int,
+)
+def upload_external_metadata(log_level, config_file, time_between_iterations=10):
     logger.setLevel(log_level)
     logging.getLogger("requests").setLevel(logging.INFO)
 
@@ -231,7 +236,7 @@ def upload_external_metadata(log_level, config_file):
             config,
             slack_config,
         )
-        time.sleep(10)
+        time.sleep(time_between_iterations)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://reduce-ena-db-load.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
1. Reduce the size of connection pools (for connections to the postgres db) used by each snakemake rule from max4 to max2. 
2. Increase sleep period after each iteration of snakemake rules from 2 to 10seconds.
3. Increase period between checking github for new data from 1 to 2min.
4. Improve error handling when requests to ENA fail (I had tests for this but they were wrong - errors on main currently due to incorrect error handling). 
```
During handling of the above exception, another exception occurred:
...
File "/package/scripts/ena_submission_helper.py", line 392, in check_ena
    f"ENA check failed with status:{response.status_code}. "
                                    ^^^^^^^^
UnboundLocalError: cannot access local variable 'response' where it is not associated with a value
```

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

```
❯ kubectl top pod --sum --containers --all-namespaces | egrep "backend|database|ena-submission" | grep reduce-ena
prev-reduce-ena-db-load         loculus-backend-77c6678886-l9vlv                                  backend                              11m          442Mi
prev-reduce-ena-db-load         loculus-database-668fd89855-vl6xs                                 database                             8m           296Mi
prev-reduce-ena-db-load         loculus-ena-submission-54dfc85d8f-tdqnh                           ena-submission                       1m           158Mi
prev-reduce-ena-db-load         loculus-keycloak-database-684964cd87-jjhvq                        loculus-keycloak-database            1m           34Mi

❯ kubectl top pod --sum --containers --all-namespaces | egrep "backend|database|ena-submission" | grep prev-main
prev-main                       loculus-backend-699874799b-vmjmj                                  backend                              62m          329Mi
prev-main                       loculus-database-b9f6bbd64-gnh7v                                  database                             9m           307Mi
prev-main                       loculus-ena-submission-b7d796cf7-d24p4                            ena-submission                       2m           240Mi
prev-main                       loculus-keycloak-database-78bdf95fb-9zhw4                         loculus-keycloak-database            1m           35Mi
```

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
