### PR TITLE
cherypicked: remove reloader from cronjob on 4de75675b18e737f59f00eaa2469d2b5403df111

### DIFF
--- a/kubernetes/loculus/templates/ingest-deployment.yaml
+++ b/kubernetes/loculus/templates/ingest-deployment.yaml
@@ -70,7 +70,6 @@ spec:
             component: loculus-ingest-cronjob-{{ $key }}
           annotations:
             argocd.argoproj.io/sync-options: Replace=true
-            reloader.stakater.com/auto: "true"
         spec:
           restartPolicy: Never
           containers:


### PR DESCRIPTION
This is to use temporarily for staging and production on pathoplexus