### PR TITLE
fix(ena-submission): Use db url instead of host for connections, do not hardcode db name

### DIFF
--- a/.github/workflows/build-arm-images.yaml
+++ b/.github/workflows/build-arm-images.yaml
@@ -24,11 +24,11 @@ jobs:
     with:
       build_arm: true
   trigger-ena-submission:
-    uses: ./.github/workflows/ena-submission-image.yml
+    uses: ./.github/workflows/ena-submission-image.yaml
     with:
       build_arm: true
   trigger-ena-submission-flyway:
-    uses: ./.github/workflows/ena-submission-flyway-image.yml
+    uses: ./.github/workflows/ena-submission-flyway-image.yaml
     with:
       build_arm: true
   trigger-keycloakify:

--- a/ena-submission/README.md
+++ b/ena-submission/README.md
@@ -104,7 +104,7 @@ In our kubernetes pod we run flyway in a docker container, however when running 
 You can then create the schema using the following command:
 
 ```sh
-flyway -user=postgres -password=unsecure -url=jdbc:postgresql://127.0.0.1:5432/loculus -schemas=ena-submission -locations=filesystem:./flyway/sql migrate
+flyway -user=postgres -password=unsecure -url=jdbc:postgresql://127.0.0.1:5432/loculus -schemas=ena_deposition_schema -locations=filesystem:./flyway/sql migrate
 ```
 
 If you want to test the docker image locally. It can be built and run using the commands:

--- a/ena-submission/config/config.yaml
+++ b/ena-submission/config/config.yaml
@@ -2,7 +2,7 @@ backend_url: http://localhost:8079/
 keycloak_token_url: http://localhost:8083/realms/loculus/protocol/openid-connect/token
 db_username: postgres
 db_password: unsecure
-db_host: "127.0.0.1"
+db_url: "jdbc:postgresql://127.0.0.1:5432/loculus"
 organisms:
   cchf:
     ingest:

--- a/ena-submission/config/config.yaml
+++ b/ena-submission/config/config.yaml
@@ -2,7 +2,7 @@ backend_url: http://localhost:8079/
 keycloak_token_url: http://localhost:8083/realms/loculus/protocol/openid-connect/token
 db_username: postgres
 db_password: unsecure
-db_url: "jdbc:postgresql://127.0.0.1:5432/loculus?options=-c%20search_path%3Dschema_ena_deposition"
+db_url: "jdbc:postgresql://127.0.0.1:5432/loculus?options=-c%20search_path%3Dena_deposition_schema"
 organisms:
   cchf:
     ingest:

--- a/ena-submission/config/config.yaml
+++ b/ena-submission/config/config.yaml
@@ -2,7 +2,7 @@ backend_url: http://localhost:8079/
 keycloak_token_url: http://localhost:8083/realms/loculus/protocol/openid-connect/token
 db_username: postgres
 db_password: unsecure
-db_url: "jdbc:postgresql://127.0.0.1:5432/loculus?options=-c%20search_path%3Dena-submission"
+db_url: "jdbc:postgresql://127.0.0.1:5432/loculus?options=-c%20search_path%3Dschema_ena_deposition"
 organisms:
   cchf:
     ingest:

--- a/ena-submission/config/config.yaml
+++ b/ena-submission/config/config.yaml
@@ -2,7 +2,7 @@ backend_url: http://localhost:8079/
 keycloak_token_url: http://localhost:8083/realms/loculus/protocol/openid-connect/token
 db_username: postgres
 db_password: unsecure
-db_url: "jdbc:postgresql://127.0.0.1:5432/loculus"
+db_url: "jdbc:postgresql://127.0.0.1:5432/loculus?options=-c%20search_path%3Dena-submission"
 organisms:
   cchf:
     ingest:

--- a/ena-submission/flyway/conf/flyway.conf
+++ b/ena-submission/flyway/conf/flyway.conf
@@ -1,3 +1,3 @@
 flyway.locations=filesystem:/flyway/sql
-flyway.schemas=schema_ena_deposition
+flyway.schemas=ena_deposition_schema
 flyway.baselineOnMigrate=true

--- a/ena-submission/flyway/conf/flyway.conf
+++ b/ena-submission/flyway/conf/flyway.conf
@@ -1,3 +1,3 @@
 flyway.locations=filesystem:/flyway/sql
-flyway.schemas=ena-submission
+flyway.schemas=schema_ena_deposition
 flyway.baselineOnMigrate=true

--- a/ena-submission/scripts/create_assembly.py
+++ b/ena-submission/scripts/create_assembly.py
@@ -57,7 +57,7 @@ class Config:
     password: str
     db_username: str
     db_password: str
-    db_host: str
+    db_url: str
     db_name: str
     unique_project_suffix: str
     ena_submission_url: str
@@ -565,7 +565,7 @@ def create_assembly(
         config = Config(**relevant_config)
     logger.info(f"Config: {config}")
 
-    db_config = db_init(config.db_password, config.db_username, config.db_host)
+    db_config = db_init(config.db_password, config.db_username, config.db_url)
     slack_config = slack_conn_init(
         slack_hook_default=config.slack_hook,
         slack_token_default=config.slack_token,

--- a/ena-submission/scripts/create_project.py
+++ b/ena-submission/scripts/create_project.py
@@ -51,7 +51,7 @@ class Config:
     password: str
     db_username: str
     db_password: str
-    db_host: str
+    db_url: str
     db_name: str
     unique_project_suffix: str
     ena_submission_url: str
@@ -389,7 +389,7 @@ def create_project(log_level, config_file, test=False, time_between_iterations=1
         config = Config(**relevant_config)
     logger.info(f"Config: {config}")
 
-    db_config = db_init(config.db_password, config.db_username, config.db_host)
+    db_config = db_init(config.db_password, config.db_username, config.db_url)
     slack_config = slack_conn_init(
         slack_hook_default=config.slack_hook,
         slack_token_default=config.slack_token,

--- a/ena-submission/scripts/create_sample.py
+++ b/ena-submission/scripts/create_sample.py
@@ -56,7 +56,7 @@ class Config:
     password: str
     db_username: str
     db_password: str
-    db_host: str
+    db_url: str
     db_name: str
     unique_project_suffix: str
     ena_submission_url: str
@@ -431,7 +431,7 @@ def create_sample(log_level, config_file, test=False, time_between_iterations=10
         config = Config(**relevant_config)
     logger.info(f"Config: {config}")
 
-    db_config = db_init(config.db_password, config.db_username, config.db_host)
+    db_config = db_init(config.db_password, config.db_username, config.db_url)
     slack_config = slack_conn_init(
         slack_hook_default=config.slack_hook,
         slack_token_default=config.slack_token,

--- a/ena-submission/scripts/get_ena_submission_list.py
+++ b/ena-submission/scripts/get_ena_submission_list.py
@@ -33,7 +33,7 @@ class Config:
     ingest_pipeline_submitter: str
     db_username: str
     db_password: str
-    db_host: str
+    db_url: str
     slack_hook: str
     slack_token: str
     slack_channel_id: str
@@ -125,7 +125,7 @@ def get_ena_submission_list(log_level, config_file, output_file):
     db_config = db_init(
         db_password_default=config.db_password,
         db_username_default=config.db_username,
-        db_host_default=config.db_host,
+        db_url_default=config.db_url,
     )
 
     entries_to_submit = {}

--- a/ena-submission/scripts/submission_db_helper.py
+++ b/ena-submission/scripts/submission_db_helper.py
@@ -10,7 +10,7 @@ from psycopg2.pool import SimpleConnectionPool
 
 
 def db_init(
-    db_password_default: str, db_username_default: str, db_host_default: str
+    db_password_default: str, db_username_default: str, db_url_default: str
 ) -> SimpleConnectionPool:
     db_password = os.getenv("DB_PASSWORD")
     if not db_password:
@@ -20,18 +20,17 @@ def db_init(
     if not db_username:
         db_username = db_username_default
 
-    db_host = os.getenv("DB_HOST")
-    if not db_host:
-        db_host = db_host_default
+    db_url = os.getenv("DB_URL")
+    if not db_url:
+        db_url = db_url_default
 
+    db_dsn = f"{db_url}-c search_path=ena-submission"
     return SimpleConnectionPool(
         minconn=1,
         maxconn=2,  # max 7*2 connections to db allowed
-        dbname="loculus",
         user=db_username,
-        host=db_host,
         password=db_password,
-        options="-c search_path=ena-submission",
+        dsn=db_dsn,
     )
 
 

--- a/ena-submission/scripts/submission_db_helper.py
+++ b/ena-submission/scripts/submission_db_helper.py
@@ -41,7 +41,7 @@ def db_init(
     if not db_url:
         db_url = db_url_default
 
-    db_dsn = convert_jdbc_to_psycopg2(db_url) + "?options=-c%20search_path%3Dena-submission"
+    db_dsn = convert_jdbc_to_psycopg2(db_url) + "?options=-c%20search_path%3Dschema_ena_deposition"
     return SimpleConnectionPool(
         minconn=1,
         maxconn=2,  # max 7*2 connections to db allowed

--- a/ena-submission/scripts/submission_db_helper.py
+++ b/ena-submission/scripts/submission_db_helper.py
@@ -1,4 +1,5 @@
 import os
+import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import Enum
@@ -7,6 +8,22 @@ import psycopg2
 import pytz
 from psycopg2.extras import RealDictCursor
 from psycopg2.pool import SimpleConnectionPool
+
+
+def convert_jdbc_to_psycopg2(jdbc_url):
+    jdbc_pattern = r"jdbc:postgresql://(?P<host>[^:/]+)(?::(?P<port>\d+))?/(?P<dbname>[^?]+)"
+
+    match = re.match(jdbc_pattern, jdbc_url)
+
+    if not match:
+        msg = "Invalid JDBC URL format."
+        raise ValueError(msg)
+
+    host = match.group("host")
+    port = match.group("port") or "5432"  # Default to 5432 if no port is provided
+    dbname = match.group("dbname")
+
+    return f"postgresql://{host}:{port}/{dbname}"
 
 
 def db_init(
@@ -24,7 +41,7 @@ def db_init(
     if not db_url:
         db_url = db_url_default
 
-    db_dsn = db_url + "?options=-c%20search_path%3Dena-submission"
+    db_dsn = convert_jdbc_to_psycopg2(db_url) + "?options=-c%20search_path%3Dena-submission"
     return SimpleConnectionPool(
         minconn=1,
         maxconn=2,  # max 7*2 connections to db allowed

--- a/ena-submission/scripts/submission_db_helper.py
+++ b/ena-submission/scripts/submission_db_helper.py
@@ -24,7 +24,7 @@ def db_init(
     if not db_url:
         db_url = db_url_default
 
-    db_dsn = f"{db_url}-c search_path=ena-submission"
+    db_dsn = f"{db_url}?options=-c%20search_path%3Dena-submission"
     return SimpleConnectionPool(
         minconn=1,
         maxconn=2,  # max 7*2 connections to db allowed

--- a/ena-submission/scripts/submission_db_helper.py
+++ b/ena-submission/scripts/submission_db_helper.py
@@ -41,7 +41,7 @@ def db_init(
     if not db_url:
         db_url = db_url_default
 
-    db_dsn = convert_jdbc_to_psycopg2(db_url) + "?options=-c%20search_path%3Dschema_ena_deposition"
+    db_dsn = convert_jdbc_to_psycopg2(db_url) + "?options=-c%20search_path%3Dena_deposition_schema"
     return SimpleConnectionPool(
         minconn=1,
         maxconn=2,  # max 7*2 connections to db allowed

--- a/ena-submission/scripts/submission_db_helper.py
+++ b/ena-submission/scripts/submission_db_helper.py
@@ -24,7 +24,7 @@ def db_init(
     if not db_url:
         db_url = db_url_default
 
-    db_dsn = f"{db_url}?options=-c%20search_path%3Dena-submission"
+    db_dsn = db_url + "?options=-c%20search_path%3Dena-submission"
     return SimpleConnectionPool(
         minconn=1,
         maxconn=2,  # max 7*2 connections to db allowed

--- a/ena-submission/scripts/trigger_submission_to_ena.py
+++ b/ena-submission/scripts/trigger_submission_to_ena.py
@@ -34,7 +34,7 @@ class Config:
     organism: str
     db_username: str
     db_password: str
-    db_host: str
+    db_url: str
     github_url: str
 
 
@@ -94,7 +94,7 @@ def trigger_submission_to_ena(
         config = Config(**relevant_config)
     logger.info(f"Config: {config}")
 
-    db_config = db_init(config.db_password, config.db_username, config.db_host)
+    db_config = db_init(config.db_password, config.db_username, config.db_url)
 
     if input_file:
         # Get sequences to upload from a file

--- a/ena-submission/scripts/trigger_submission_to_ena.py
+++ b/ena-submission/scripts/trigger_submission_to_ena.py
@@ -1,7 +1,6 @@
 # This script adds all approved sequences to the submission_table
 # - this should trigger the submission process.
 
-import base64
 import json
 import logging
 import time

--- a/ena-submission/scripts/upload_external_metadata_to_loculus.py
+++ b/ena-submission/scripts/upload_external_metadata_to_loculus.py
@@ -41,7 +41,7 @@ class Config:
     ena_specific_metadata: list[str]
     db_username: str
     db_password: str
-    db_host: str
+    db_url: str
     slack_hook: str
     slack_token: str
     slack_channel_id: str
@@ -222,7 +222,7 @@ def upload_external_metadata(log_level, config_file, time_between_iterations=10)
         relevant_config = {key: full_config.get(key, []) for key in Config.__annotations__}
         config = Config(**relevant_config)
     logger.info(f"Config: {config}")
-    db_config = db_init(config.db_password, config.db_username, config.db_host)
+    db_config = db_init(config.db_password, config.db_username, config.db_url)
     slack_config = slack_conn_init(
         slack_hook_default=config.slack_hook,
         slack_token_default=config.slack_token,

--- a/kubernetes/loculus/templates/ena-submission-deployment.yaml
+++ b/kubernetes/loculus/templates/ena-submission-deployment.yaml
@@ -59,11 +59,11 @@ spec:
                 secretKeyRef:
                   name: service-accounts
                   key: externalMetadataUpdaterPassword
-            - name: DB_HOST
+            - name: DB_URL
               valueFrom:
                 secretKeyRef:
                   name: database
-                  key: host
+                  key: url
             - name: DB_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -152,11 +152,11 @@ spec:
                     secretKeyRef:
                       name: service-accounts
                       key: externalMetadataUpdaterPassword
-                - name: DB_HOST
+                - name: DB_URL
                   valueFrom:
                     secretKeyRef:
                       name: database
-                      key: host
+                      key: url
                 - name: DB_USERNAME
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://use-urlto-connect-to-db.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
The ena-submission pod does not start on Pathoplexus as the db has a different name. This PR changes from using the host to using the java url.

It additionally renames the ena-submission schema to ena_deposition_schema. 

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
