### PR TITLE
fix(ena-submission): Parse get analysis process response better for single segment case, return partial results and submit projects with holdUntilDate

### DIFF
--- a/ena-submission/Snakefile
+++ b/ena-submission/Snakefile
@@ -28,7 +28,7 @@ if SUBMIT_TO_ENA_DEV:
     print("Submitting to ENA dev environment")
     config["ena_submission_url"] = "https://wwwdev.ebi.ac.uk/ena/submit/drop-box/submit"
     config["github_url"] = (
-        "https://raw.githubusercontent.com/pathoplexus/ena-submission/main/test/approved_ena_submission_list.json"
+        "https://raw.githubusercontent.com/pathoplexus/ena-submission/loculus_test/test/approved_ena_submission_list.json"
     )
     config["ena_reports_service_url"] = "https://wwwdev.ebi.ac.uk/ena/submit/report"
 

--- a/ena-submission/Snakefile
+++ b/ena-submission/Snakefile
@@ -28,7 +28,7 @@ if SUBMIT_TO_ENA_DEV:
     print("Submitting to ENA dev environment")
     config["ena_submission_url"] = "https://wwwdev.ebi.ac.uk/ena/submit/drop-box/submit"
     config["github_url"] = (
-        "https://raw.githubusercontent.com/pathoplexus/ena-submission/loculus_test/test/approved_ena_submission_list.json"
+        "https://raw.githubusercontent.com/pathoplexus/ena-submission/main/test/approved_ena_submission_list.json"
     )
     config["ena_reports_service_url"] = "https://wwwdev.ebi.ac.uk/ena/submit/report"
 

--- a/ena-submission/scripts/create_assembly.py
+++ b/ena-submission/scripts/create_assembly.py
@@ -556,7 +556,10 @@ def assembly_table_handle_errors(
             f" status WAITING for over {time_threshold_waiting}h"
         )
         send_slack_notification(
-            config, error_msg, time=datetime.now(tz=pytz.utc), time_threshold=slack_time_threshold
+            error_msg,
+            slack_config,
+            time=datetime.now(tz=pytz.utc),
+            time_threshold=slack_time_threshold,
         )
 
 

--- a/ena-submission/scripts/create_assembly.py
+++ b/ena-submission/scripts/create_assembly.py
@@ -464,7 +464,7 @@ def assembly_table_update(
             )
 
             if not (results_contain_gca_accession and results_contain_insdc_accession):
-                if previous_result == json.dumps(check_results.results):
+                if previous_result == check_results.results:
                     continue
                 update_values = {
                     "status": Status.WAITING,

--- a/ena-submission/scripts/create_assembly.py
+++ b/ena-submission/scripts/create_assembly.py
@@ -100,15 +100,12 @@ def create_chromosome_list_object(
     return AssemblyChromosomeListFile(chromosomes=entries)
 
 
-def get_segment_order(unaligned_sequences) -> list[str]:
+def get_segment_order(unaligned_sequences: dict[str, str]) -> list[str]:
     """Order in which we put the segments in the chromosome list file"""
     segment_order = []
-    if len(unaligned_sequences.keys()) > 1:
-        for segment_name, item in unaligned_sequences.items():
-            if item:  # Only list sequenced segments
-                segment_order.append(segment_name)
-    else:
-        segment_order.append("main")
+    for segment_name, item in unaligned_sequences.items():
+        if item:  # Only list sequenced segments
+            segment_order.append(segment_name)
     return sorted(segment_order)
 
 

--- a/ena-submission/scripts/create_project.py
+++ b/ena-submission/scripts/create_project.py
@@ -8,7 +8,7 @@ import click
 import pytz
 import yaml
 from call_loculus import get_group_info
-from ena_submission_helper import CreationResults, create_ena_project, get_ena_config
+from ena_submission_helper import CreationResult, create_ena_project, get_ena_config
 from ena_types import (
     OrganismType,
     ProjectLink,
@@ -275,11 +275,11 @@ def project_table_create(
         logger.info(
             f"Starting Project creation for group_id {row["group_id"]} organism {row["organism"]}"
         )
-        project_creation_results: CreationResults = create_ena_project(ena_config, project_set)
-        if project_creation_results.results:
+        project_creation_results: CreationResult = create_ena_project(ena_config, project_set)
+        if project_creation_results.result:
             update_values = {
                 "status": Status.SUBMITTED,
-                "result": json.dumps(project_creation_results.results),
+                "result": json.dumps(project_creation_results.result),
                 "finished_at": datetime.now(tz=pytz.utc),
             }
             number_rows_updated = 0

--- a/ena-submission/scripts/create_sample.py
+++ b/ena-submission/scripts/create_sample.py
@@ -8,7 +8,7 @@ from datetime import datetime
 import click
 import pytz
 import yaml
-from ena_submission_helper import CreationResults, create_ena_sample, get_ena_config
+from ena_submission_helper import CreationResult, create_ena_sample, get_ena_config
 from ena_types import (
     ProjectLink,
     SampleAttribute,
@@ -320,11 +320,11 @@ def sample_table_create(
             )
             continue
         logger.info(f"Starting sample creation for accession {row["accession"]}")
-        sample_creation_results: CreationResults = create_ena_sample(ena_config, sample_set)
-        if sample_creation_results.results:
+        sample_creation_results: CreationResult = create_ena_sample(ena_config, sample_set)
+        if sample_creation_results.result:
             update_values = {
                 "status": Status.SUBMITTED,
-                "result": json.dumps(sample_creation_results.results),
+                "result": json.dumps(sample_creation_results.result),
                 "finished_at": datetime.now(tz=pytz.utc),
             }
             number_rows_updated = 0

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -414,12 +414,12 @@ def get_ena_analysis_process(
             acc_list = entry["acc"].split(",")
             acc_dict = {a.split(":")[0]: a.split(":")[-1] for a in acc_list}
             gca_accession = acc_dict.get("genome")
-            if gca_accession:
-                assembly_results.update(
-                    {
-                        "gca_accession": gca_accession,
-                    }
-                )
+            # if gca_accession:
+            #     assembly_results.update(
+            #         {
+            #             "gca_accession": gca_accession,
+            #         }
+            #     )
             insdc_accession_range = acc_dict.get("chromosomes")
             if insdc_accession_range:
                 chromosome_accessions_dict = get_chromsome_accessions(

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -110,7 +110,7 @@ def get_submission_dict(hold_until_date: str | None = None):
         hold_until_date = datetime.datetime.now(tz=pytz.utc).strftime("%Y-%m-%d")
     action_dicts = [
         {"ADD": None},
-        {"HOLD": {"HoldUntilDate": hold_until_date}},
+        {"HOLD": f"HoldUntilDate={hold_until_date}"},
     ]
     submission["SUBMISSION"]["ACTIONS"]["ACTION"] = list(action_dicts)
     return submission

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -417,7 +417,7 @@ def get_ena_analysis_process(
             if gca_accession:
                 assembly_results.update(
                     {
-                        "erz_accession": erz_accession,
+                        "gca_accession": erz_accession,
                     }
                 )
             insdc_accession_range = acc_dict.get("chromosomes")

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -1,3 +1,4 @@
+import datetime
 import gzip
 import json
 import logging
@@ -9,6 +10,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any
 
+import pytz
 import requests
 import xmltodict
 from ena_types import (
@@ -102,9 +104,15 @@ def dataclass_to_xml(dataclass_instance, root_name="root"):
     return xmltodict.unparse({root_name: dataclass_dict}, pretty=True)
 
 
-def get_submission_dict():
+def get_submission_dict(hold_until_date: str | None = None):
     submission = recursive_defaultdict()
-    submission["SUBMISSION"]["ACTIONS"]["ACTION"]["ADD"] = None
+    if not hold_until_date:
+        hold_until_date = datetime.datetime.now(tz=pytz.utc).strftime("%Y-%m-%d")
+    action_dicts = [
+        {"ACTION": {"ADD": None}},
+        {"ACTION": {"HOLD": {"HoldUntilDate": hold_until_date}}},
+    ]
+    submission["SUBMISSION"]["ACTIONS"] = list(action_dicts)
     return submission
 
 

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -109,10 +109,10 @@ def get_submission_dict(hold_until_date: str | None = None):
     if not hold_until_date:
         hold_until_date = datetime.datetime.now(tz=pytz.utc).strftime("%Y-%m-%d")
     action_dicts = [
-        {"ACTION": {"ADD": None}},
-        {"ACTION": {"HOLD": {"HoldUntilDate": hold_until_date}}},
+        {"ADD": None},
+        {"HOLD": {"HoldUntilDate": hold_until_date}},
     ]
-    submission["SUBMISSION"]["ACTIONS"] = list(action_dicts)
+    submission["SUBMISSION"]["ACTIONS"]["ACTION"] = list(action_dicts)
     return submission
 
 

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -71,10 +71,10 @@ def get_ena_config(
 
 
 @dataclass
-class CreationResults:
+class CreationResult:
     errors: list[str]
     warnings: list[str]
-    results: dict[str, str] | None = None
+    result: dict[str, str] | None = None
 
 
 def recursive_defaultdict():
@@ -116,7 +116,7 @@ def get_submission_dict(hold_until_date: str | None = None):
     )
 
 
-def create_ena_project(config: ENAConfig, project_set: ProjectSet) -> CreationResults:
+def create_ena_project(config: ENAConfig, project_set: ProjectSet) -> CreationResult:
     """
     The project creation request should be equivalent to 
     curl -u {params.ena_submission_username}:{params.ena_submission_password} \
@@ -143,7 +143,7 @@ def create_ena_project(config: ENAConfig, project_set: ProjectSet) -> CreationRe
         )
         logger.warning(error_message)
         errors.append(error_message)
-        return CreationResults(results=None, errors=errors, warnings=warnings)
+        return CreationResult(result=None, errors=errors, warnings=warnings)
     try:
         parsed_response = xmltodict.parse(response.text)
         valid = (
@@ -157,15 +157,15 @@ def create_ena_project(config: ENAConfig, project_set: ProjectSet) -> CreationRe
         error_message = f"Response is in unexpected format: {e}. " f"Response: {response.text}."
         logger.warning(error_message)
         errors.append(error_message)
-        return CreationResults(results=None, errors=errors, warnings=warnings)
+        return CreationResult(result=None, errors=errors, warnings=warnings)
     project_results = {
         "bioproject_accession": parsed_response["RECEIPT"]["PROJECT"]["@accession"],
         "ena_submission_accession": parsed_response["RECEIPT"]["SUBMISSION"]["@accession"],
     }
-    return CreationResults(results=project_results, errors=errors, warnings=warnings)
+    return CreationResult(result=project_results, errors=errors, warnings=warnings)
 
 
-def create_ena_sample(config: ENAConfig, sample_set: SampleSetType) -> CreationResults:
+def create_ena_sample(config: ENAConfig, sample_set: SampleSetType) -> CreationResult:
     """
     The sample creation request should be equivalent to 
     curl -u {params.ena_submission_username}:{params.ena_submission_password} \
@@ -194,7 +194,7 @@ def create_ena_sample(config: ENAConfig, sample_set: SampleSetType) -> CreationR
         )
         logger.warning(error_message)
         errors.append(error_message)
-        return CreationResults(results=None, errors=errors, warnings=warnings)
+        return CreationResult(result=None, errors=errors, warnings=warnings)
     try:
         parsed_response = xmltodict.parse(response.text)
         valid = (
@@ -213,13 +213,13 @@ def create_ena_sample(config: ENAConfig, sample_set: SampleSetType) -> CreationR
         )
         logger.warning(error_message)
         errors.append(error_message)
-        return CreationResults(results=None, errors=errors, warnings=warnings)
+        return CreationResult(result=None, errors=errors, warnings=warnings)
     sample_results = {
         "ena_sample_accession": parsed_response["RECEIPT"]["SAMPLE"]["@accession"],
         "biosample_accession": parsed_response["RECEIPT"]["SAMPLE"]["EXT_ID"]["@accession"],
         "ena_submission_accession": parsed_response["RECEIPT"]["SUBMISSION"]["@accession"],
     }
-    return CreationResults(results=sample_results, errors=errors, warnings=warnings)
+    return CreationResult(result=sample_results, errors=errors, warnings=warnings)
 
 
 def post_webin(config: ENAConfig, xml: dict[str, Any]) -> requests.Response:
@@ -328,7 +328,7 @@ def post_webin_cli(
 
 def create_ena_assembly(
     config: ENAConfig, manifest_filename: str, center_name=None, test=True
-) -> CreationResults:
+) -> CreationResult:
     """
     This is equivalent to running:
     webin-cli -username {params.ena_submission_username} -password {params.ena_submission_password}
@@ -346,7 +346,7 @@ def create_ena_assembly(
         )
         logger.warning(error_message)
         errors.append(error_message)
-        return CreationResults(results=None, errors=errors, warnings=warnings)
+        return CreationResult(result=None, errors=errors, warnings=warnings)
 
     lines = response.stdout.splitlines()
     erz_accession = None
@@ -363,16 +363,16 @@ def create_ena_assembly(
         )
         logger.warning(error_message)
         errors.append(error_message)
-        return CreationResults(results=None, errors=errors, warnings=warnings)
+        return CreationResult(result=None, errors=errors, warnings=warnings)
     assembly_results = {
         "erz_accession": erz_accession,
     }
-    return CreationResults(results=assembly_results, errors=errors, warnings=warnings)
+    return CreationResult(result=assembly_results, errors=errors, warnings=warnings)
 
 
 def get_ena_analysis_process(
     config: ENAConfig, erz_accession: str, segment_order: list[str]
-) -> CreationResults:
+) -> CreationResult:
     """
     This is equivalent to running:
     curl -X 'GET' \
@@ -399,12 +399,12 @@ def get_ena_analysis_process(
         )
         logger.warning(error_message)
         errors.append(error_message)
-        return CreationResults(results=None, errors=errors, warnings=warnings)
+        return CreationResult(result=None, errors=errors, warnings=warnings)
     if response.text == "[]":
         # For some minutes the response will be empty, requests to
         # f"{config.ena_reports_service_url}/analysis-files/{erz_accession}?format=json"
         # should still succeed
-        return CreationResults(results=None, errors=errors, warnings=warnings)
+        return CreationResult(result=None, errors=errors, warnings=warnings)
     try:
         parsed_response = json.loads(response.text)
         entry = parsed_response[0]["report"]
@@ -427,7 +427,7 @@ def get_ena_analysis_process(
                 )
                 assembly_results.update(chromosome_accessions_dict)
         else:
-            return CreationResults(results=None, errors=errors, warnings=warnings)
+            return CreationResult(result=None, errors=errors, warnings=warnings)
     except:
         error_message = (
             f"ENA Check returned errors or is in unexpected format. "
@@ -435,8 +435,8 @@ def get_ena_analysis_process(
         )
         logger.warning(error_message)
         errors.append(error_message)
-        return CreationResults(results=None, errors=errors, warnings=warnings)
-    return CreationResults(results=assembly_results, errors=errors, warnings=warnings)
+        return CreationResult(result=None, errors=errors, warnings=warnings)
+    return CreationResult(result=assembly_results, errors=errors, warnings=warnings)
 
 
 def get_chromsome_accessions(insdc_accession_range: str, segment_order: list[str]):

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -414,12 +414,12 @@ def get_ena_analysis_process(
             acc_list = entry["acc"].split(",")
             acc_dict = {a.split(":")[0]: a.split(":")[-1] for a in acc_list}
             gca_accession = acc_dict.get("genome")
-            # if gca_accession:
-            #     assembly_results.update(
-            #         {
-            #             "gca_accession": gca_accession,
-            #         }
-            #     )
+            if gca_accession:
+                assembly_results.update(
+                    {
+                        "gca_accession": gca_accession,
+                    }
+                )
             insdc_accession_range = acc_dict.get("chromosomes")
             if insdc_accession_range:
                 chromosome_accessions_dict = get_chromsome_accessions(

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -417,7 +417,7 @@ def get_ena_analysis_process(
             if gca_accession:
                 assembly_results.update(
                     {
-                        "gca_accession": erz_accession,
+                        "gca_accession": gca_accession,
                     }
                 )
             insdc_accession_range = acc_dict.get("chromosomes")

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -414,7 +414,7 @@ def get_ena_analysis_process(
                 )
             insdc_accession_range = acc_dict.get("chromosomes")
             if insdc_accession_range:
-                chromosome_accessions_dict = get_chromsome_assemblies(
+                chromosome_accessions_dict = get_chromsome_accessions(
                     insdc_accession_range, segment_order
                 )
                 assembly_results.update(chromosome_accessions_dict)
@@ -431,7 +431,7 @@ def get_ena_analysis_process(
     return CreationResults(results=assembly_results, errors=errors, warnings=warnings)
 
 
-def get_chromsome_assemblies(insdc_accession_range: str, segment_order: list[str]):
+def get_chromsome_accessions(insdc_accession_range: str, segment_order: list[str]):
     results = {}
     start_letters = insdc_accession_range.split("-")[0][:2]
     start_digit = 10 ** (

--- a/ena-submission/scripts/ena_types.py
+++ b/ena-submission/scripts/ena_types.py
@@ -245,3 +245,23 @@ class AssemblyChromosomeListFileObject:
 @dataclass
 class AssemblyChromosomeListFile:
     chromosomes: list[AssemblyChromosomeListFileObject]
+
+
+@dataclass
+class Hold:
+    HoldUntilDate: XmlAttribute | None = None
+
+
+@dataclass
+class Action:
+    add: str | None = None
+    hold: Hold | None = None
+
+
+@dataclass
+class Actions:
+    action: list[Action]
+
+@dataclass
+class Submission:
+    actions: Actions

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -141,10 +141,6 @@ class ProjectCreationTests(unittest.TestCase):
             xmltodict.parse(text_project_xml_request),
         )
 
-    def test_construct_submission(self):
-        submission_set = get_submission_dict()
-        print(dataclass_to_xml(submission_set, root_name="SUBMISSION"))
-
 
 class SampleCreationTests(unittest.TestCase):
     @mock.patch("requests.post")

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -291,6 +291,16 @@ class AssemblyCreationTests(unittest.TestCase):
                 "insdc_accession_full": "OZ189935.1",
             },
         )
+        insdc_accession_range = "OZ189935-OZ189935"
+        segment_order = ["seg3"]
+        result_single = get_chromsome_assemblies(insdc_accession_range, segment_order)
+        self.assertEqual(
+            result_single,
+            {
+                "insdc_accession_seg3": "OZ189935",
+                "insdc_accession_full_seg3": "OZ189935.1",
+            },
+        )
         insdc_accession_range = "OZ189935-OZ189936"
         segment_order = ["main"]
         with self.assertRaises(requests.exceptions.RequestException):

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -22,7 +22,7 @@ from ena_submission_helper import (
     create_fasta,
     create_manifest,
     dataclass_to_xml,
-    get_chromsome_assemblies,
+    get_chromsome_accessions,
 )
 from ena_types import default_project_type, default_sample_type
 from requests import exceptions
@@ -268,10 +268,10 @@ class AssemblyCreationTests(unittest.TestCase):
 
         self.assertEqual(data, expected_data)
 
-    def test_get_chromsome_assemblies(self):
+    def test_get_chromsome_accessions(self):
         insdc_accession_range = "OZ189935-OZ189936"
         segment_order = ["seg2", "seg3"]
-        result_multi = get_chromsome_assemblies(insdc_accession_range, segment_order)
+        result_multi = get_chromsome_accessions(insdc_accession_range, segment_order)
         self.assertEqual(
             result_multi,
             {
@@ -283,7 +283,7 @@ class AssemblyCreationTests(unittest.TestCase):
         )
         insdc_accession_range = "OZ189935-OZ189935"
         segment_order = ["main"]
-        result_single = get_chromsome_assemblies(insdc_accession_range, segment_order)
+        result_single = get_chromsome_accessions(insdc_accession_range, segment_order)
         self.assertEqual(
             result_single,
             {
@@ -293,7 +293,7 @@ class AssemblyCreationTests(unittest.TestCase):
         )
         insdc_accession_range = "OZ189935-OZ189935"
         segment_order = ["seg3"]
-        result_single = get_chromsome_assemblies(insdc_accession_range, segment_order)
+        result_single = get_chromsome_accessions(insdc_accession_range, segment_order)
         self.assertEqual(
             result_single,
             {
@@ -304,7 +304,7 @@ class AssemblyCreationTests(unittest.TestCase):
         insdc_accession_range = "OZ189935-OZ189936"
         segment_order = ["main"]
         with self.assertRaises(requests.exceptions.RequestException):
-            get_chromsome_assemblies(insdc_accession_range, segment_order)
+            get_chromsome_accessions(insdc_accession_range, segment_order)
 
 
 if __name__ == "__main__":

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -5,7 +5,6 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-import requests
 import xmltodict
 import yaml
 from create_assembly import (
@@ -284,6 +283,7 @@ class AssemblyCreationTests(unittest.TestCase):
                 "insdc_accession_full_seg3": "OZ189936.1",
             },
         )
+
         insdc_accession_range = "OZ189935-OZ189935"
         segment_order = ["main"]
         result_single = get_chromsome_accessions(insdc_accession_range, segment_order)
@@ -294,6 +294,7 @@ class AssemblyCreationTests(unittest.TestCase):
                 "insdc_accession_full": "OZ189935.1",
             },
         )
+
         insdc_accession_range = "OZ189935-OZ189935"
         segment_order = ["seg3"]
         result_single = get_chromsome_accessions(insdc_accession_range, segment_order)
@@ -304,9 +305,15 @@ class AssemblyCreationTests(unittest.TestCase):
                 "insdc_accession_full_seg3": "OZ189935.1",
             },
         )
+
         insdc_accession_range = "OZ189935-OZ189936"
         segment_order = ["main"]
-        with self.assertRaises(requests.exceptions.RequestException):
+        with self.assertRaises(ValueError):
+            get_chromsome_accessions(insdc_accession_range, segment_order)
+
+        insdc_accession_range = "OZ189935-TK189936"
+        segment_order = ["A", "B"]
+        with self.assertRaises(ValueError):
             get_chromsome_accessions(insdc_accession_range, segment_order)
 
     @mock.patch("requests.get")

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -23,9 +23,9 @@ from ena_submission_helper import (
     create_manifest,
     dataclass_to_xml,
     get_chromsome_accessions,
+    get_submission_dict,
 )
 from ena_types import default_project_type, default_sample_type
-from requests import exceptions
 
 # Default configs
 with open("config/defaults.yaml", encoding="utf-8") as f:
@@ -140,6 +140,10 @@ class ProjectCreationTests(unittest.TestCase):
             xmltodict.parse(dataclass_to_xml(project_set, root_name="PROJECT_SET")),
             xmltodict.parse(text_project_xml_request),
         )
+
+    def test_construct_submission(self):
+        submission_set = get_submission_dict()
+        print(xmltodict.unparse(submission_set, pretty=True))
 
 
 class SampleCreationTests(unittest.TestCase):

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -143,7 +143,7 @@ class ProjectCreationTests(unittest.TestCase):
 
     def test_construct_submission(self):
         submission_set = get_submission_dict()
-        print(xmltodict.unparse(submission_set, pretty=True))
+        print(dataclass_to_xml(submission_set, root_name="SUBMISSION"))
 
 
 class SampleCreationTests(unittest.TestCase):

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -5,6 +5,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+import requests
 import xmltodict
 import yaml
 from create_assembly import (
@@ -21,6 +22,7 @@ from ena_submission_helper import (
     create_fasta,
     create_manifest,
     dataclass_to_xml,
+    get_chromsome_assemblies,
 )
 from ena_types import default_project_type, default_sample_type
 from requests import exceptions
@@ -265,6 +267,34 @@ class AssemblyCreationTests(unittest.TestCase):
         }
 
         self.assertEqual(data, expected_data)
+
+    def test_get_chromsome_assemblies(self):
+        insdc_accession_range = "OZ189935-OZ189936"
+        segment_order = ["seg2", "seg3"]
+        result_multi = get_chromsome_assemblies(insdc_accession_range, segment_order)
+        self.assertEqual(
+            result_multi,
+            {
+                "insdc_accession_seg2": "OZ189935",
+                "insdc_accession_seg3": "OZ189936",
+                "insdc_accession_full_seg2": "OZ189935.1",
+                "insdc_accession_full_seg3": "OZ189936.1",
+            },
+        )
+        insdc_accession_range = "OZ189935-OZ189935"
+        segment_order = ["main"]
+        result_single = get_chromsome_assemblies(insdc_accession_range, segment_order)
+        self.assertEqual(
+            result_single,
+            {
+                "insdc_accession": "OZ189935",
+                "insdc_accession_full": "OZ189935.1",
+            },
+        )
+        insdc_accession_range = "OZ189935-OZ189936"
+        segment_order = ["main"]
+        with self.assertRaises(requests.exceptions.RequestException):
+            get_chromsome_assemblies(insdc_accession_range, segment_order)
 
 
 if __name__ == "__main__":

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -113,7 +113,7 @@ class ProjectCreationTests(unittest.TestCase):
             "bioproject_accession": "PRJEB20767",
             "ena_submission_accession": "ERA912529",
         }
-        self.assertEqual(response.results, desired_response)
+        self.assertEqual(response.result, desired_response)
 
     @mock.patch("requests.post")
     def test_create_project_xml_failure(self, mock_post):
@@ -156,7 +156,7 @@ class SampleCreationTests(unittest.TestCase):
             "biosample_accession": "SAMEA104174130",
             "ena_submission_accession": "ERA979927",
         }
-        self.assertEqual(response.results, desired_response)
+        self.assertEqual(response.result, desired_response)
 
     def test_sample_set_construction(self):
         config = mock_config()
@@ -321,7 +321,7 @@ class AssemblyCreationTests(unittest.TestCase):
             "insdc_accession_full": "OZ189999.1",
             "segment_order": ["main"],
         }
-        self.assertEqual(response.results, desired_response)
+        self.assertEqual(response.result, desired_response)
 
 
 if __name__ == "__main__":

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -23,7 +23,7 @@ from ena_submission_helper import (
     create_manifest,
     dataclass_to_xml,
     get_chromsome_accessions,
-    get_submission_dict,
+    get_ena_analysis_process,
 )
 from ena_types import default_project_type, default_sample_type
 
@@ -64,6 +64,9 @@ test_project_xml_failure_response = """
 
 test_sample_xml_request = Path("test/test_sample_request.xml").read_text(encoding="utf-8")
 test_sample_xml_response = Path("test/test_sample_response.xml").read_text(encoding="utf-8")
+process_response_text = Path("test/get_ena_analysis_process_response.json").read_text(
+    encoding="utf-8"
+)
 
 
 # Test sample
@@ -305,6 +308,20 @@ class AssemblyCreationTests(unittest.TestCase):
         segment_order = ["main"]
         with self.assertRaises(requests.exceptions.RequestException):
             get_chromsome_accessions(insdc_accession_range, segment_order)
+
+    @mock.patch("requests.get")
+    def test_get_ena_analysis_process(self, mock_post):
+        mock_post.return_value = mock_requests_post(200, process_response_text)
+        response = get_ena_analysis_process(
+            test_ena_config, erz_accession="ERZ000001", segment_order=["main"]
+        )
+        desired_response = {
+            "erz_accession": "ERZ000001",
+            "insdc_accession": "OZ189999",
+            "insdc_accession_full": "OZ189999.1",
+            "segment_order": ["main"],
+        }
+        self.assertEqual(response.results, desired_response)
 
 
 if __name__ == "__main__":

--- a/ena-submission/test/get_ena_analysis_process_response.json
+++ b/ena-submission/test/get_ena_analysis_process_response.json
@@ -1,0 +1,1 @@
+[{"report":{"id":"ERZ24879999","analysisType":"SEQUENCE_ASSEMBLY","acc":"chromosomes:OZ189999-OZ189999","processingStatus":"COMPLETED","processingStart":"27-09-2024 06:06:40","processingEnd":"27-09-2024 06:07:06","processingError":null},"links":[]}]


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves https://github.com/loculus-project/loculus/issues/2895

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://patch-create-assembly.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Note that chromosome accessions are the accessions of the nucleotides in each submitted segment, in PP we call this insdcAccession_{segment}.

1. Rename check_ena to get_ena_analysis_process, refactor so that get_chromsome_accessions is a separate sub-function of get_ena_analysis_process, and results are returned when either the gca accession OR the chromosome accessions are returned (in contrast to now only returning results when both are returned)
2. Add tests that get_chromsome_accessions works for single and multi-segmented viruses now that we know the expected response format for both. I added a test where I mock the response using a known response text for a 1-segment case and confirm this works,
3. Update assembly_table.results column response results as soon as gca or chromosome accessions are known, but only change from WAITING to SUBMITTED state when both are known. Do not update table when there are no results or results are the same as already in table. 

This PR additionally modifies the project submission request to by default submit projects with a `hold_until_date` parameter which is set to the day of submission (as we anyways only submit data to ENA when it is OPEN we should make the project public). 

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### Testing
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
Tested on preview by
- setting github link to https://github.com/pathoplexus/ena-submission/pull/5
- connecting to the db using portforwarding and altering results to known erz accessions
- for the 2-segment case set to `ERZ24784470`, confirm this leads to state SUBMITTED:
```
17:36:33     INFO (  create_assembly.py: 513) - Assembly submission for accession LOC_000RBTK succeeded and accession returned!
```
- Sadly the erz accessions are private so I could not fully confirm this works for the single segment case
- I additionally test that when only the chromosome accession is returned the table (by editing out code to add in the gca accession) the table stays in state WAITING:
```
17:52:59     INFO (  create_assembly.py: 489) - Partial results of assembly submission for accession LOC_000RBTK returned!
```
