### PR TITLE
fix(website): Change submitting group ID displayName 

### DIFF
--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -39,21 +39,21 @@ fields:
     generateIndex: true
     autocomplete: true
     header: Submission details
-  - name: groupId
-    displayName: Group ID
-    type: int
-    autocomplete: true
-    header: Submission details
-    displayName: Submitting group
-    customDisplay:
-      type: submittingGroup
-      displayGroup: group
   - name: groupName
     type: string
     generateIndex: true
     autocomplete: true
     header: Submission details
     displayName: Submitting group
+    customDisplay:
+      type: submittingGroup
+      displayGroup: group
+  - name: groupId
+    displayName: Group ID
+    type: int
+    autocomplete: true
+    header: Submission details
+    displayName: Submitting group (numeric ID)
     customDisplay:
       type: submittingGroup
       displayGroup: group


### PR DESCRIPTION
Resolves #2633, resolves https://github.com/loculus-project/loculus/issues/2675

Preview: https://groupchange.loculus.org/

<img width="526" alt="image" src="https://github.com/user-attachments/assets/00cda55e-ba9d-4fd5-bb8d-8e6e5d674e32">

There are some technical constraints here: the first listed name is the one that will appear in the combined field on the sequence page, which is why I've gone for this exact solution. Happy for a fuller change in the future.

<img width="559" alt="image" src="https://github.com/user-attachments/assets/55e40735-819e-4745-bf1e-2b558288f6c1">
