### PR TITLE
fix(website): don't display data as "restricted" when the last restricted data use terms expired

### DIFF
--- a/website/src/components/SequenceDetailsPage/SequenceDataUI.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceDataUI.tsx
@@ -1,13 +1,16 @@
+import type { FC } from 'react';
+
 import DataTable from './DataTable';
 import { RevokeButton } from './RevokeButton';
 import { SequencesContainer } from './SequencesContainer';
 import { getDataTableData } from './getDataTableData';
 import { type TableDataEntry } from './types';
 import { routes } from '../../routes/routes';
-import { type DataUseTermsHistoryEntry, type Group } from '../../types/backend';
+import { DATA_USE_TERMS_FIELD } from '../../settings.ts';
+import { type DataUseTermsHistoryEntry, type Group, type RestrictedDataUseTerms } from '../../types/backend';
 import { type Schema } from '../../types/config';
 import { type ReferenceGenomesSequenceNames } from '../../types/referencesGenomes';
-import { type RuntimeConfig, type ClientConfig } from '../../types/runtimeConfig';
+import { type ClientConfig, type RuntimeConfig } from '../../types/runtimeConfig';
 import { EditDataUseTermsButton } from '../DataUseTerms/EditDataUseTermsButton';
 import ErrorBox from '../common/ErrorBox';
 import MdiEye from '~icons/mdi/eye';
@@ -25,7 +28,7 @@ interface Props {
     referenceGenomeSequenceNames: ReferenceGenomesSequenceNames;
 }
 
-export const SequenceDataUI: React.FC<Props> = ({
+export const SequenceDataUI: FC<Props> = ({
     tableData,
     organism,
     accessionVersion,
@@ -44,12 +47,8 @@ export const SequenceDataUI: React.FC<Props> = ({
     dataUseTermsHistory.sort((a, b) => (a.changeDate > b.changeDate ? -1 : 1));
     const currentDataUseTerms = dataUseTermsHistory[0].dataUseTerms;
 
-    const dataUseTermsIndex = tableData.findIndex((entry) => entry.name === 'dataUseTerms');
-    if (dataUseTermsIndex !== -1) {
-        tableData[dataUseTermsIndex].value = currentDataUseTerms.type;
-    }
-
-    const isRestricted = currentDataUseTerms.type === 'RESTRICTED';
+    const dataUseTerms = tableData.find((entry) => entry.name === DATA_USE_TERMS_FIELD);
+    const isRestricted = dataUseTerms?.value.toString().toUpperCase() === 'RESTRICTED';
 
     const genes = referenceGenomeSequenceNames.genes;
     const nucleotideSegmentNames = referenceGenomeSequenceNames.nucleotideSequences;
@@ -95,7 +94,7 @@ export const SequenceDataUI: React.FC<Props> = ({
                             clientConfig={clientConfig}
                             accessToken={accessToken}
                             accessionVersion={[accessionVersion.split('.')[0]]}
-                            dataUseTerms={currentDataUseTerms}
+                            dataUseTerms={currentDataUseTerms as RestrictedDataUseTerms}
                         />
                     )}
 


### PR DESCRIPTION
preview URL: http://fixdatausetermsdisplay.loculus.org

### Bug

Website seq details showed restricted even after expiration of restriction.

See https://loculus.slack.com/archives/C05G172HL6L/p1727769592602569

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

Root cause was misunderstanding in website code of what the dataUseTermsHistory contains.

The website code assumed there would be a new entry when something becomes open, but in fact the history is just a log of changes.

The backend only returns the history - which does not include "OPEN" as a last entry when the restricted period expired. LAPIS has the correct values - let's simply rely on that.

This assumes the following as correct:
* The backend just stores the history (not the state) of data use terms. 
* getting the history from the backend for a sequence entry that has expired restricted use terms will still only show "restricted" entries

We now simply take the use terms from LAPIS, that means the calculation is done in a single place for search and display.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
