### PR TITLE
fix: use kubernetes dns to avoid basic auth for internal services

### DIFF
--- a/kubernetes/loculus/templates/ena-submission-config.yaml
+++ b/kubernetes/loculus/templates/ena-submission-config.yaml
@@ -1,6 +1,6 @@
 {{- $testconfig := .Values.testconfig | default false }}
 {{- $backendHost := .Values.environment | eq "server" | ternary (printf "https://backend%s%s" .Values.subdomainSeparator $.Values.host) ($testconfig | ternary "http://localhost:8079" "http://loculus-backend-service:8079") }}
-{{- $keycloakHost := .Values.environment | eq "server" | ternary (printf "https://authentication%s%s" $.Values.subdomainSeparator $.Values.host) ($testconfig | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083") }}
+{{- $keycloakHost := $testconfig | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083" }}
 {{- $submitToEnaProduction := .Values.submitToEnaProduction | default false }}
 {{- $enaDbName := .Values.enaDbName | default false }}
 {{- $enaUniqueSuffix := .Values.enaUniqueSuffix | default false }}

--- a/kubernetes/loculus/templates/ena-submission-config.yaml
+++ b/kubernetes/loculus/templates/ena-submission-config.yaml
@@ -1,6 +1,6 @@
 {{- $testconfig := .Values.testconfig | default false }}
 {{- $backendHost := .Values.environment | eq "server" | ternary (printf "https://backend%s%s" .Values.subdomainSeparator $.Values.host) ($testconfig | ternary "http://localhost:8079" "http://loculus-backend-service:8079") }}
-{{- $keycloakHost := $testconfig | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083" }}
+{{- $keycloakHost := ($testconfig | default false) | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083" }}
 {{- $submitToEnaProduction := .Values.submitToEnaProduction | default false }}
 {{- $enaDbName := .Values.enaDbName | default false }}
 {{- $enaUniqueSuffix := .Values.enaUniqueSuffix | default false }}

--- a/kubernetes/loculus/templates/ena-submission-config.yaml
+++ b/kubernetes/loculus/templates/ena-submission-config.yaml
@@ -1,6 +1,6 @@
 {{- $testconfig := .Values.testconfig | default false }}
 {{- $backendHost := .Values.environment | eq "server" | ternary (printf "https://backend%s%s" .Values.subdomainSeparator $.Values.host) ($testconfig | ternary "http://localhost:8079" "http://loculus-backend-service:8079") }}
-{{- $keycloakHost := ($testconfig | default false) | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083" }}
+{{- $keycloakHost := $testconfig | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083" }}
 {{- $submitToEnaProduction := .Values.submitToEnaProduction | default false }}
 {{- $enaDbName := .Values.enaDbName | default false }}
 {{- $enaUniqueSuffix := .Values.enaUniqueSuffix | default false }}

--- a/kubernetes/loculus/templates/ingest-config.yaml
+++ b/kubernetes/loculus/templates/ingest-config.yaml
@@ -1,7 +1,7 @@
 {{- $dockerTag := include "loculus.dockerTag" .Values }}
 {{- $testconfig := .Values.testconfig | default false }}
 {{- $backendHost := .Values.environment | eq "server" | ternary (printf "https://backend%s%s" .Values.subdomainSeparator $.Values.host) ($testconfig | ternary "http://localhost:8079" "http://loculus-backend-service:8079") }}
-{{- $keycloakHost := .Values.environment | eq "server" | ternary (printf "https://authentication%s%s" $.Values.subdomainSeparator $.Values.host) ($testconfig | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083") }}
+{{- $keycloakHost := $testconfig | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083" }}
 {{- range $key, $values := (.Values.organisms | default .Values.defaultOrganisms) }}
 {{- if $values.ingest }}
 {{- $metadata := (include "loculus.patchMetadataSchema" $values.schema | fromYaml).metadata }}

--- a/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
@@ -3,10 +3,7 @@
     "http://host.k3d.internal:8079"
     "http://loculus-backend-service:8079"
 }}
-{{- $organismcloakHost := $.Values.environment | eq "server" | ternary
-    (printf "https://authentication%s%s" $.Values.subdomainSeparator $.Values.host)
-    "http://loculus-keycloak-service:8083"
-}}
+{{- $keycloakHost := $testconfig | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083" }}
 {{- if not .Values.disablePreprocessing }}
 {{- range $organism, $organismConfig := (.Values.organisms | default .Values.defaultOrganisms) }}
 {{- range $processingIndex, $processingConfig := $organismConfig.preprocessing }}
@@ -47,7 +44,7 @@ spec:
             - "{{ $arg }}"
             {{- end }}
             - "--backend-host={{ $backendHost }}/{{ $organism }}"
-            - "--keycloak-host={{ $organismcloakHost }}"
+            - "--keycloak-host={{ $keycloakHost }}"
             - "--pipeline-version={{ $processingConfig.version }}"
             - "--keycloak-password=$(KEYCLOAK_PASSWORD)"
       {{- if $processingConfig.configFile }}

--- a/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
@@ -3,7 +3,7 @@
     "http://host.k3d.internal:8079"
     "http://loculus-backend-service:8079"
 }}
-{{- $keycloakHost := $testconfig | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083" }}
+{{- $keycloakHost := ($testconfig | default false) | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083" }}
 {{- if not .Values.disablePreprocessing }}
 {{- range $organism, $organismConfig := (.Values.organisms | default .Values.defaultOrganisms) }}
 {{- range $processingIndex, $processingConfig := $organismConfig.preprocessing }}

--- a/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
@@ -3,7 +3,8 @@
     "http://host.k3d.internal:8079"
     "http://loculus-backend-service:8079"
 }}
-{{- $keycloakHost := ($testconfig | default false) | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083" }}
+{{- $testconfig := .Values.testconfig | default false }}
+{{- $keycloakHost := $testconfig | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083" }}
 {{- if not .Values.disablePreprocessing }}
 {{- range $organism, $organismConfig := (.Values.organisms | default .Values.defaultOrganisms) }}
 {{- range $processingIndex, $processingConfig := $organismConfig.preprocessing }}


### PR DESCRIPTION
- **fix: use kubernetes dns to avoid basic auth for internal services**

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://fix-dns.loculus.org

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
