### PR TITLE
[BREAKING] Don't include submission id in website `input fields`, add accession to metadata revision template

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1072,14 +1072,7 @@ defaultOrganismConfig: &defaultOrganismConfig
       defaultOrder: descending
     silo:
       dateToSortBy: sampleCollectionDate
-    extraInputFields: &extraInputFields
-      - name: submissionId
-        displayName: Submission ID
-        definition: FASTA ID
-        guidance: Used to match the sequence(s) to the metadata
-        example: GJP123
-        position: first
-        noEdit: true
+    extraInputFields: []
   preprocessing:
     - &preprocessing
       version: 1

--- a/website/README.md
+++ b/website/README.md
@@ -25,7 +25,7 @@ Run `npm run e2e` to execute the end-to-end tests.
 If you run Playwright for the first time, you might need to run `npx playwright install`
 and `npx playwright install-deps` first. Playwright will tell you if that's the case.
 
-(!) Note: The e2e tests require a running LAPIS instance with test data. This will be prepared automatically, when the LAPIS instance is empty and otherwise skipped. Some e2e tests assume, this prepared data was the first data to be released. If you run the e2e tests for the first time on a LAPIS instance with existing data that is _NOT_ the prepared data, tests will fail ,and you need to delete the data first.
+(!) Note: The e2e tests require a running LAPIS instance with test data. This will be prepared automatically, when the LAPIS instance is empty and otherwise skipped. Some e2e tests assume, this prepared data was the first data to be released. If you run the e2e tests for the first time on a LAPIS instance with existing data that is _NOT_ the prepared data, tests will fail, and you need to delete the data first.
 
 (!) Note: The e2e tests mock the preprocessing pipeline. Ingest and preprocessing are not tested by the e2e tests.
 

--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -252,7 +252,7 @@ const EditableOriginalData: FC<EditableOriginalDataProps> = ({ editedMetadata, s
                 };
             }
 
-            if (!(inputField.noEdit !== undefined && inputField.noEdit === true)) {
+            if (!(inputField.noEdit !== undefined && inputField.noEdit)) {
                 return (
                     <EditableDataRow
                         label={inputField.displayName ?? sentenceCase(inputField.name)}

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -1,7 +1,7 @@
 import { isErrorFromAlias } from '@zodios/core';
 import type { AxiosError } from 'axios';
 import { type DateTime } from 'luxon';
-import { type FormEvent, useState, useRef, useEffect, useCallback, type ElementType } from 'react';
+import { type ElementType, type FormEvent, useCallback, useEffect, useRef, useState } from 'react';
 
 import { DateChangeModal } from './DateChangeModal';
 import { getClientLogger } from '../../clientLogger.ts';
@@ -12,9 +12,9 @@ import { backendApi } from '../../services/backendApi.ts';
 import { backendClientHooks } from '../../services/serviceHooks.ts';
 import {
     type DataUseTermsType,
+    type Group,
     openDataUseTermsType,
     restrictedDataUseTermsType,
-    type Group,
 } from '../../types/backend.ts';
 import type { ReferenceGenomesSequenceNames } from '../../types/referencesGenomes';
 import type { ClientConfig } from '../../types/runtimeConfig.ts';
@@ -25,13 +25,14 @@ import { withQueryProvider } from '../common/withQueryProvider.tsx';
 import MaterialSymbolsInfoOutline from '~icons/material-symbols/info-outline';
 import MaterialSymbolsLightDataTableOutline from '~icons/material-symbols-light/data-table-outline';
 import PhDnaLight from '~icons/ph/dna-light';
-type Action = 'submit' | 'revise';
+
+export type UploadAction = 'submit' | 'revise';
 
 type DataUploadFormProps = {
     accessToken: string;
     organism: string;
     clientConfig: ClientConfig;
-    action: Action;
+    action: UploadAction;
     group: Group;
     referenceGenomeSequenceNames: ReferenceGenomesSequenceNames;
     onSuccess: () => void;
@@ -365,7 +366,10 @@ const InnerDataUploadForm = ({
                                 </span>
                             )}
                             You can download{' '}
-                            <a href={routes.metadataTemplate(organism)} className='text-primary-700  opacity-90'>
+                            <a
+                                href={routes.metadataTemplate(organism, action)}
+                                className='text-primary-700  opacity-90'
+                            >
                                 a template
                             </a>{' '}
                             for the TSV metadata file with column headings.
@@ -559,7 +563,7 @@ function useSubmitFiles(
     };
 }
 
-function handleError(onError: (message: string) => void, action: Action) {
+function handleError(onError: (message: string) => void, action: UploadAction) {
     return (error: unknown | AxiosError) => {
         void logger.error(`Received error from backend: ${stringifyMaybeAxiosError(error)}`);
         if (isErrorFromAlias(backendApi, action, error)) {

--- a/website/src/pages/[organism]/submission/template/index.ts
+++ b/website/src/pages/[organism]/submission/template/index.ts
@@ -1,9 +1,11 @@
 import type { APIRoute } from 'astro';
 
 import { cleanOrganism } from '../../../../components/Navigation/cleanOrganism';
+import type { UploadAction } from '../../../../components/Submission/DataUploadForm.tsx';
 import { getSchema } from '../../../../config';
+import { ACCESSION_FIELD, SUBMISSION_ID_FIELD } from '../../../../settings.ts';
 
-export const GET: APIRoute = async ({ params }) => {
+export const GET: APIRoute = async ({ params, request }) => {
     const rawOrganism = params.organism!;
     const { organism } = cleanOrganism(rawOrganism);
     if (organism === undefined) {
@@ -12,16 +14,20 @@ export const GET: APIRoute = async ({ params }) => {
         });
     }
 
+    const action: UploadAction = new URL(request.url).searchParams.get('format') === 'revise' ? 'revise' : 'submit';
+    const extraFields = action === 'submit' ? [SUBMISSION_ID_FIELD] : [ACCESSION_FIELD, SUBMISSION_ID_FIELD];
+
     const { inputFields } = getSchema(organism.key);
 
     const headers: Record<string, string> = {
         'Content-Type': 'text/tsv',
     };
 
-    const filename = `${organism.displayName.replaceAll(' ', '_')}_metadata_template.tsv`;
+    const filename = `${organism.displayName.replaceAll(' ', '_')}_metadata_${action === 'revise' ? 'revision_' : ''}template.tsv`;
     headers['Content-Disposition'] = `attachment; filename="${filename}"`;
 
-    const tsvTemplate = inputFields.map((field) => field.name).join('\t') + '\n';
+    const fieldNames = inputFields.map((field) => field.name);
+    const tsvTemplate = [...extraFields, ...fieldNames].join('\t') + '\n';
 
     return new Response(tsvTemplate, {
         headers,

--- a/website/src/routes/routes.ts
+++ b/website/src/routes/routes.ts
@@ -1,4 +1,5 @@
 import { SubmissionRouteUtils } from './SubmissionRoute.ts';
+import type { UploadAction } from '../components/Submission/DataUploadForm.tsx';
 import type { AccessionVersion } from '../types/backend.ts';
 import { getAccessionVersionString } from '../utils/extractAccessionVersion.ts';
 
@@ -12,7 +13,8 @@ export const routes = {
     statusPage: () => '/status',
     organismStartPage: (organism: string) => `/${organism}`,
     searchPage: (organism: string) => withOrganism(organism, `/search`),
-    metadataTemplate: (organism: string) => withOrganism(organism, `/submission/template`),
+    metadataTemplate: (organism: string, format: UploadAction) =>
+        withOrganism(organism, `/submission/template?format=${format}`),
 
     mySequencesPage: (organism: string, groupId: number) =>
         SubmissionRouteUtils.toUrl({

--- a/website/src/settings.ts
+++ b/website/src/settings.ts
@@ -12,5 +12,6 @@ export const GROUP_NAME_FIELD = 'groupName';
 export const GROUP_ID_FIELD = 'groupId';
 export const DATA_USE_TERMS_FIELD = 'dataUseTerms';
 export const VERSION_COMMENT_FIELD = 'versionComment';
+export const SUBMISSION_ID_FIELD = 'submissionId';
 
 export const metadataDefaultDownloadDataFormat = 'tsv';

--- a/website/tests/pages/submission/submit.page.ts
+++ b/website/tests/pages/submission/submit.page.ts
@@ -36,6 +36,7 @@ export class SubmitPage {
     public async uploadMetadata() {
         await this.page.getByLabel('Metadata file').setInputFiles(metadataTestFile);
     }
+
     public async uploadCompressedMetadata() {
         await this.page.getByLabel('Metadata file').setInputFiles(compressedMetadataTestFile);
     }
@@ -43,6 +44,7 @@ export class SubmitPage {
     public async uploadSequenceData() {
         await this.page.getByLabel('Sequence file').setInputFiles(sequencesTestFile);
     }
+
     public async uploadCompressedSequenceData() {
         await this.page.getByLabel('Sequence file').setInputFiles(compressedSequencesTestFile);
     }
@@ -53,5 +55,11 @@ export class SubmitPage {
         await this.page.waitForSelector(restrictedSelector);
 
         await this.page.click(restrictedSelector);
+    }
+
+    public async downloadMetadataTemplate() {
+        const downloadPromise = this.page.waitForEvent('download');
+        await this.page.getByText('a template', { exact: true }).click();
+        return downloadPromise;
     }
 }

--- a/website/tests/pages/submission/template.spec.ts
+++ b/website/tests/pages/submission/template.spec.ts
@@ -1,0 +1,40 @@
+import type { Download } from '@playwright/test';
+
+import { expect, test } from '../../e2e.fixture.ts';
+
+test.describe('The submit page', () => {
+    test('should download the metadata file template for submission', async ({ submitPage, loginAsTestUser }) => {
+        const { groupId } = await loginAsTestUser();
+        await submitPage.goto(groupId);
+
+        const download = await submitPage.downloadMetadataTemplate();
+
+        expect(download.suggestedFilename()).toBe('Test_Dummy_Organism_metadata_template.tsv');
+        const content = await getDownloadedContent(download);
+        expect(content).toStrictEqual('submissionId\tcountry\tdate\tdivision\thost\tpangoLineage\tregion\n');
+    });
+
+    test('should download the metadata file template for revision', async ({
+        revisePage,
+        submitPage,
+        loginAsTestUser,
+    }) => {
+        const { groupId } = await loginAsTestUser();
+        await revisePage.goto(groupId);
+
+        const download = await submitPage.downloadMetadataTemplate();
+
+        expect(download.suggestedFilename()).toBe('Test_Dummy_Organism_metadata_revision_template.tsv');
+        const content = await getDownloadedContent(download);
+        expect(content).toStrictEqual('accession\tsubmissionId\tcountry\tdate\tdivision\thost\tpangoLineage\tregion\n');
+    });
+
+    async function getDownloadedContent(download: Download) {
+        const readable = await download.createReadStream();
+        return new Promise((resolve) => {
+            let data = '';
+            readable.on('data', (chunk) => (data += chunk));
+            readable.on('end', () => resolve(data));
+        });
+    }
+});


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://submissionidedit.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

* The `submissionId` should not be configurable. It's "hardcoded" in the backend (i.e. required), so we can also hardcode it in the website.
* The edit page has a separate display for the submission id anyway - it doesn't need to be in the input fields there
* The metadata template needs the submission id - let's hardcode it
* Also add `accession` when someone want a template for revisions.
* Test the metadata templates

This is a follow-up to https://loculus.slack.com/archives/C06JCAZLG14/p1727707545650969.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
