### PR TITLE
fix(deployment): Use recreate strategy for stand in  dbs

### DIFF
--- a/kubernetes/loculus/templates/keycloak-database-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-database-deployment.yaml
@@ -13,6 +13,8 @@ spec:
     matchLabels:
       app: loculus
       component: keycloak-database
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -41,5 +43,4 @@ spec:
               value: "trust"
             - name: LOCULUS_VERSION
               value: {{ $dockerTag }}
-
 {{- end }}

--- a/kubernetes/loculus/templates/loculus-database-standin.yaml
+++ b/kubernetes/loculus/templates/loculus-database-standin.yaml
@@ -12,6 +12,8 @@ spec:
     matchLabels:
       app: loculus
       component: database
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
This prevents the stand-in databases from using rolling migrations to try to avoid race conditions where the backend runs migrations on the old DB then the new DB has no migrations.
preview URL: https://recreate.loculus.org

