### PR TITLE
chore(website): add playwright outputs to astro check exclude dir

### DIFF
--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -5,5 +5,6 @@
         "jsx": "react-jsx",
         "jsxImportSource": "react",
         "types": ["unplugin-icons/types/react"]
-    }
+    },
+    "exclude": ["playwright-report", "dist", "node_modules"]
 }


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/2937

`astro check` produces a lot of pointless output, flooding the screen, bad developer experiencer. Seems to happen when there's a playwright report dir present with js files.

Adding playwright dir to excludes fixes it.

Before: 
![2024-10-02 15 43 59](https://github.com/user-attachments/assets/7a927092-4372-427f-8d75-dcf73913c619)

After: 
![2024-10-02 15 59 07](https://github.com/user-attachments/assets/e250a9da-9999-4c1c-bfc6-d788bf01b625)
