### PR TITLE
fix(ena-submission): temporarily do not send gcaAccession to Loculus

### DIFF
--- a/ena-submission/scripts/deposition_dry_run.py
+++ b/ena-submission/scripts/deposition_dry_run.py
@@ -25,18 +25,6 @@ logging.basicConfig(
     datefmt="%H:%M:%S",
 )
 
-with open("config/config.yaml", encoding="utf-8") as f:
-    config = yaml.safe_load(f)
-
-with open("config/defaults.yaml", encoding="utf-8") as f:
-    defaults = yaml.safe_load(f)
-
-# Merge configs, using defaults only as fallback
-# Write to results/config.yaml
-for key, value in defaults.items():
-    if not key in config:
-        config[key] = value
-
 
 @dataclass
 class Config:
@@ -71,7 +59,6 @@ def local_ena_submission_generator(
     center_name,
     mode,
     log_level,
-    config_file,
 ):
     """
     Produce output of submission pipeline locally
@@ -79,10 +66,21 @@ def local_ena_submission_generator(
     logger.setLevel(log_level)
     logging.getLogger("requests").setLevel(logging.INFO)
 
-    with open(config_file, encoding="utf-8") as file:
-        full_config = yaml.safe_load(file)
-        relevant_config = {key: full_config.get(key, []) for key in Config.__annotations__}
-        config = Config(**relevant_config)
+    with open("config/config.yaml", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    with open("config/defaults.yaml", encoding="utf-8") as f:
+        defaults = yaml.safe_load(f)
+
+    # Merge configs, using defaults only as fallback
+    # Write to results/config.yaml
+    for key, value in defaults.items():
+        if not key in config:
+            config[key] = value
+
+    full_config = config
+    relevant_config = {key: full_config.get(key, []) for key in Config.__annotations__}
+    config = Config(**relevant_config)
 
     logger.debug(f"Config: {config}")
 

--- a/ena-submission/scripts/upload_external_metadata_to_loculus.py
+++ b/ena-submission/scripts/upload_external_metadata_to_loculus.py
@@ -82,9 +82,11 @@ def get_external_metadata(db_config: SimpleConnectionPool, entry: dict[str, Any]
         db_config, table_name="assembly_table", conditions=seq_key
     )
     if len(corresponding_assembly) == 1:
-        data["externalMetadata"]["gcaAccession"] = corresponding_assembly[0]["result"][
-            "gca_accession"
-        ]
+        # TODO(https://github.com/loculus-project/loculus/issues/2945):
+        # Add gcaAccession to values.yaml
+        # data["externalMetadata"]["gcaAccession"] = corresponding_assembly[0]["result"][
+        #     "gca_accession"
+        # ]
         insdc_accession_keys = [
             key
             for key in corresponding_assembly[0]["result"]


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
workaround until we figure out #2945 

preview URL: https://tempfixes.loculus.org or https://temp-fixes.loculus.org

### Summary
The ena-submission pipeline is failing to upload external metadata because it is uploading a gcaAccession field which is currently missing from the config.yaml.

Adding new metadata fields currently causes issues (this might be helped by addressing #2793), until these can be resolved we temporarily do not upload the gcaAccession to Loculus.

This PR also fixes an unrelated little bug in the dry-run script.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
