### PR TITLE
feat(deposition): submit EMBL flatfile instead of fasta for better nucleotide metadata

### DIFF
--- a/ena-submission/ENA_submission.md
+++ b/ena-submission/ENA_submission.md
@@ -267,6 +267,10 @@ The following could be implement as post-MVP features:
    ACGT
    ```
 
+Potentially a better option is to create flatfiles: https://ena-docs.readthedocs.io/en/latest/submit/fileprep/flat-file-example.html, which can include annotations: https://www.ebi.ac.uk/ena/WebFeat/. As we are submitting as a broker it is important that we add the AUTHORS to the assembly: https://ena-docs.readthedocs.io/en/latest/faq/data_brokering.html#authorship. 
+
+https://github.com/NBISweden/EMBLmyGFF3 will generate an embl file given a gff3 file, however it needs a gff3 file for the specific sequence that is being submitted. NIH has gff3 for each reference sequence, but we need to create one for each sequence.
+
 4. Submit the files using the webin-cli:
 
    ```bash

--- a/ena-submission/Snakefile
+++ b/ena-submission/Snakefile
@@ -28,7 +28,7 @@ if SUBMIT_TO_ENA_DEV:
     print("Submitting to ENA dev environment")
     config["ena_submission_url"] = "https://wwwdev.ebi.ac.uk/ena/submit/drop-box/submit"
     config["github_url"] = (
-        "https://raw.githubusercontent.com/pathoplexus/ena-submission/main/test/approved_ena_submission_list.json"
+        "https://raw.githubusercontent.com/pathoplexus/ena-submission/loculus_test/test/approved_ena_submission_list.json"
     )
     config["ena_reports_service_url"] = "https://wwwdev.ebi.ac.uk/ena/submit/report"
 

--- a/ena-submission/Snakefile
+++ b/ena-submission/Snakefile
@@ -28,7 +28,7 @@ if SUBMIT_TO_ENA_DEV:
     print("Submitting to ENA dev environment")
     config["ena_submission_url"] = "https://wwwdev.ebi.ac.uk/ena/submit/drop-box/submit"
     config["github_url"] = (
-        "https://raw.githubusercontent.com/pathoplexus/ena-submission/loculus_test/test/approved_ena_submission_list.json"
+        "https://raw.githubusercontent.com/pathoplexus/ena-submission/main/test/approved_ena_submission_list.json"
     )
     config["ena_reports_service_url"] = "https://wwwdev.ebi.ac.uk/ena/submit/report"
 

--- a/ena-submission/environment.yml
+++ b/ena-submission/environment.yml
@@ -16,3 +16,4 @@ dependencies:
   - psycopg2
   - slack_sdk
   - xmltodict
+  - biopython

--- a/ena-submission/scripts/create_assembly.py
+++ b/ena-submission/scripts/create_assembly.py
@@ -141,6 +141,11 @@ def create_manifest_object(
     authors = (
         metadata["authors"] if metadata.get("authors") else metadata.get("submitter", "Unknown")
     )
+    collection_date = metadata.get("collectionDate", "Unknown")
+    country = metadata.get("geoLocCountry", "Unknown")
+    admin1 = metadata.get("geoLocAdmin1", "")
+    admin2 = metadata.get("geoLocAdmin2", "")
+    country = f"{country}:{admin1}, {admin2}"
     try:
         moleculetype = MoleculeType(organism_metadata.get("molecule_type"))
     except ValueError as err:
@@ -155,6 +160,8 @@ def create_manifest_object(
     flat_file = create_flatfile(
         unaligned_nucleotide_sequences,
         seq_key["accession"],
+        country=country,
+        collection_date=collection_date,
         description=description,
         authors=authors,
         moleculetype=moleculetype,

--- a/ena-submission/scripts/create_assembly.py
+++ b/ena-submission/scripts/create_assembly.py
@@ -354,7 +354,11 @@ def assembly_table_create(
             group_key,
             test,
         )
-        manifest_file = create_manifest(manifest_object)
+        try:
+            manifest_file = create_manifest(manifest_object)
+        except Exception as e:
+            logger.error(f"Manifest creation failed for accession {row["accession"]} with error {e}")
+            continue
 
         update_values = {"status": Status.SUBMITTING}
         number_rows_updated = update_db_where_conditions(

--- a/ena-submission/scripts/create_assembly.py
+++ b/ena-submission/scripts/create_assembly.py
@@ -84,14 +84,14 @@ def create_chromosome_list_object(
     for segment_name in segment_order:
         if segment_name != "main":
             entry = AssemblyChromosomeListFileObject(
-                object_name=f"{seq_key["accession"]}.{seq_key["version"]}_{segment_name}",
+                object_name=f"{seq_key["accession"]}_{segment_name}",
                 chromosome_name=segment_name,
                 chromosome_type=chromosome_type,
             )
             entries.append(entry)
             continue
         entry = AssemblyChromosomeListFileObject(
-            object_name=f"{seq_key["accession"]}.{seq_key["version"]}",
+            object_name=f"{seq_key["accession"]}",
             chromosome_name="main",
             chromosome_type=chromosome_type,
         )

--- a/ena-submission/scripts/create_assembly.py
+++ b/ena-submission/scripts/create_assembly.py
@@ -345,16 +345,16 @@ def assembly_table_create(
             error_msg = f"Entry {row["accession"]} not found in project_table"
             raise RuntimeError(error_msg)
 
-        manifest_object = create_manifest_object(
-            config,
-            results_in_sample_table[0],
-            results_in_project_table[0],
-            sample_data_in_submission_table[0],
-            seq_key,
-            group_key,
-            test,
-        )
         try:
+            manifest_object = create_manifest_object(
+                config,
+                results_in_sample_table[0],
+                results_in_project_table[0],
+                sample_data_in_submission_table[0],
+                seq_key,
+                group_key,
+                test,
+            )
             manifest_file = create_manifest(manifest_object)
         except Exception as e:
             logger.error(f"Manifest creation failed for accession {row["accession"]} with error {e}")

--- a/ena-submission/scripts/create_assembly.py
+++ b/ena-submission/scripts/create_assembly.py
@@ -357,7 +357,9 @@ def assembly_table_create(
             )
             manifest_file = create_manifest(manifest_object)
         except Exception as e:
-            logger.error(f"Manifest creation failed for accession {row["accession"]} with error {e}")
+            logger.error(
+                f"Manifest creation failed for accession {row["accession"]} with error {e}"
+            )
             continue
 
         update_values = {"status": Status.SUBMITTING}
@@ -379,7 +381,11 @@ def assembly_table_create(
             sample_data_in_submission_table[0]["unaligned_nucleotide_sequences"]
         )
         assembly_creation_results: CreationResult = create_ena_assembly(
-            ena_config, manifest_file, center_name=center_name, test=test
+            ena_config,
+            manifest_file,
+            accession=seq_key["accession"],
+            center_name=center_name,
+            test=test,
         )
         if assembly_creation_results.result:
             assembly_creation_results.result["segment_order"] = segment_order

--- a/ena-submission/scripts/create_assembly.py
+++ b/ena-submission/scripts/create_assembly.py
@@ -146,9 +146,14 @@ def create_manifest_object(
     except ValueError:
         moleculetype = None
     organism = organism_metadata.get("scientific_name", "Unknown")
+    description = (
+        f"Original sequence submitted to {config.db_name} with accession: "
+        f"{seq_key["accession"]}, version: {seq_key["version"]}"
+    )
     flat_file = create_flatfile(
         unaligned_nucleotide_sequences,
         seq_key["accession"],
+        description=description,
         authors=authors,
         moleculetype=moleculetype,
         organism=organism,
@@ -170,10 +175,6 @@ def create_manifest_object(
         )
     except ValueError:
         coverage = 1
-    description = (
-        f"Original sequence submitted to {config.db_name} with accession: "
-        f"{seq_key["accession"]}, version: {seq_key["version"]}"
-    )
     assembly_name = (
         seq_key["accession"]
         + f"{datetime.now(tz=pytz.utc)}".replace(" ", "_").replace("+", "_").replace(":", "_")

--- a/ena-submission/scripts/create_assembly.py
+++ b/ena-submission/scripts/create_assembly.py
@@ -147,6 +147,7 @@ def create_manifest_object(
         metadata["sequencingInstrument"] if metadata.get("sequencingInstrument") else "Unknown"
     )
     platform = metadata["sequencingProtocol"] if metadata.get("sequencingProtocol") else "Unknown"
+    authors = metadata["authors"] if metadata.get("authors") else None
     try:
         coverage = (
             (
@@ -188,6 +189,7 @@ def create_manifest_object(
         platform=platform,
         fasta=fasta_file,
         chromosome_list=chromosome_list_file,
+        authors=authors,
         description=description,
         moleculetype=moleculetype,
     )

--- a/ena-submission/scripts/create_assembly.py
+++ b/ena-submission/scripts/create_assembly.py
@@ -142,9 +142,11 @@ def create_manifest_object(
         metadata["authors"] if metadata.get("authors") else metadata.get("submitter", "Unknown")
     )
     try:
-        moleculetype = MoleculeType(organism_metadata.get("moleculeType", "genomic RNA"))
-    except ValueError:
-        moleculetype = None
+        moleculetype = MoleculeType(organism_metadata.get("molecule_type"))
+    except ValueError as err:
+        msg = f"Invalid molecule type: {organism_metadata.get('molecule_type')}"
+        logger.error(msg)
+        raise ValueError(msg) from err
     organism = organism_metadata.get("scientific_name", "Unknown")
     description = (
         f"Original sequence submitted to {config.db_name} with accession: "

--- a/ena-submission/scripts/create_assembly.py
+++ b/ena-submission/scripts/create_assembly.py
@@ -147,7 +147,9 @@ def create_manifest_object(
         metadata["sequencingInstrument"] if metadata.get("sequencingInstrument") else "Unknown"
     )
     platform = metadata["sequencingProtocol"] if metadata.get("sequencingProtocol") else "Unknown"
-    authors = metadata["authors"] if metadata.get("authors") else None
+    authors = (
+        metadata["authors"] if metadata.get("authors") else metadata.get("submitter", "Unknown")
+    )
     try:
         coverage = (
             (

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -437,25 +437,21 @@ def create_ena_assembly(
             f"Request failed with status:{response.returncode}. "
             f"Stdout: {response.stdout}, Stderr: {response.stderr}"
         )
-        validate_dir = f"../tmp/genome/{accession}*/validate"
-        if not os.path.isdir(validate_dir):
-            logging.error(f"Directory not found: {validate_dir}")
+        validate_log_path = f"../tmp/genome/{accession}*/validate/*.report"
+        matching_files = glob.glob(validate_log_path)
+
+        if not matching_files:
+            logging.error("No .report files found.")
         else:
-            pattern = os.path.join(validate_dir, '*.report')
-            matching_files = glob.glob(pattern)
+            file_path = matching_files[0]
+            print(f"Matching file found: {file_path}")
 
-            if not matching_files:
-                logging.error(f"No .report files found in: {validate_dir}")
-            else:
-                file_path = matching_files[0]
-                print(f"Matching file found: {file_path}")
-
-                try:
-                    with open(file_path, 'r') as file:
-                        contents = file.read()
-                        print(f"Contents of the file:\n{contents}")
-                except Exception as e:
-                    logging.error(f"Error reading file {file_path}: {e}")
+            try:
+                with open(file_path, 'r') as file:
+                    contents = file.read()
+                    print(f"Contents of the file:\n{contents}")
+            except Exception as e:
+                logging.error(f"Error reading file {file_path}: {e}")
         errors.append(error_message)
         return CreationResult(result=None, errors=errors, warnings=warnings)
 

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -282,9 +282,9 @@ def create_flatfile(
 ) -> str:
     if dir:
         os.makedirs(dir, exist_ok=True)
-        filename = os.path.join(dir, "sequence.embl.gz")
+        filename = os.path.join(dir, "sequence.embl")
     else:
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".embl.gz") as temp:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".embl") as temp:
             filename = temp.name
 
     seqIO_moleculetype = {
@@ -314,7 +314,7 @@ def create_flatfile(
             lines.insert(i + 1, reference_authors)
             break
 
-    with gzip.GzipFile(filename, "wb") as gz:
+    with gzip.open(filename + '.gz', "wt", encoding="utf-8") as gz:
         gz.writelines(lines)
 
     return filename

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -282,9 +282,9 @@ def create_flatfile(
 ) -> str:
     if dir:
         os.makedirs(dir, exist_ok=True)
-        filename = os.path.join(dir, "sequence.embl")
+        filename = os.path.join(dir, "sequence.embl.gz")
     else:
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".embl") as temp:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".embl.gz") as temp:
             filename = temp.name
 
     seqIO_moleculetype = {
@@ -313,8 +313,9 @@ def create_flatfile(
         if line.startswith("XX"):  # Insert after XX separator following the description
             lines.insert(i + 1, reference_authors)
             break
-    with open(filename, "w") as file:
-        file.writelines(lines)
+
+    with gzip.GzipFile(filename, "wb") as gz:
+        gz.writelines(lines)
 
     return filename
 

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -317,7 +317,7 @@ def create_flatfile(
     with gzip.open(filename + '.gz', "wt", encoding="utf-8") as gz:
         gz.writelines(lines)
 
-    return filename
+    return (filename + '.gz')
 
 
 def create_fasta(

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -280,6 +280,8 @@ def create_flatfile(
     description: str,
     authors: str,
     moleculetype: MoleculeType,
+    country: str,
+    collection_date: str,
     organism: str,
     dir: str | None = None,
 ) -> str:
@@ -325,6 +327,8 @@ def create_flatfile(
             qualifiers={
                 "molecule_type": str(moleculetype),
                 "organism": organism,
+                "country": country,
+                "collection_date": collection_date,
             },
         )
         sequence.features.append(source_feature)

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -378,8 +378,6 @@ def create_manifest(manifest: AssemblyManifest, dir: str | None = None) -> str:
         f.write(f"CHROMOSOME_LIST\t{manifest.chromosome_list}\n")
         if manifest.description:
             f.write(f"DESCRIPTION\t{manifest.description}\n")
-        if manifest.authors:
-            f.write(f"AUTHORS\t{manifest.authors}\n")
         if manifest.moleculetype:
             f.write(f"MOLECULETYPE\t{manifest.moleculetype!s}\n")
 

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -322,6 +322,8 @@ def create_manifest(manifest: AssemblyManifest, dir: str | None = None) -> str:
         f.write(f"CHROMOSOME_LIST\t{manifest.chromosome_list}\n")
         if manifest.description:
             f.write(f"DESCRIPTION\t{manifest.description}\n")
+        if manifest.authors:
+            f.write(f"AUTHORS\t{manifest.authors}\n")
         if manifest.moleculetype:
             f.write(f"MOLECULETYPE\t{manifest.moleculetype!s}\n")
 

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -341,10 +341,12 @@ def create_flatfile(
 
     final_content = "\n".join(embl_content)
 
-    with gzip.open(filename + ".gz", "wt", encoding="utf-8") as gz:
-        gz.write(final_content)
+    gzip_filename = filename + ".gz"
 
-    return filename + ".gz"
+    with gzip.open(gzip_filename, "wt", encoding="utf-8") as file:
+        file.write(final_content)
+
+    return gzip_filename
 
 
 def create_fasta(

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -299,7 +299,12 @@ def create_flatfile(
     sequence = SeqRecord(
         Seq(unaligned_sequences["main"]),
         id=accession,
-        annotations={"molecule_type": seqIO_moleculetype[moleculetype], "organism": organism, "reference_authors": authors},
+        annotations={
+            "molecule_type": seqIO_moleculetype[moleculetype],
+            "organism": organism,
+            "reference_authors": authors,
+            "topology": "linear",
+        },
     )
 
     SeqIO.write(sequence, filename, "embl")
@@ -314,10 +319,10 @@ def create_flatfile(
             lines.insert(i + 1, reference_authors)
             break
 
-    with gzip.open(filename + '.gz', "wt", encoding="utf-8") as gz:
+    with gzip.open(filename + ".gz", "wt", encoding="utf-8") as gz:
         gz.writelines(lines)
 
-    return (filename + '.gz')
+    return filename + ".gz"
 
 
 def create_fasta(

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -437,19 +437,25 @@ def create_ena_assembly(
             f"Request failed with status:{response.returncode}. "
             f"Stdout: {response.stdout}, Stderr: {response.stderr}"
         )
-        base_path = f"../tmp/genome/{accession}*/validate"
-        matching_files = glob.glob(base_path)
-        if not matching_files:
-            logging.error(f"No validation error log file found in: {base_path}")
+        validate_dir = f"../tmp/genome/{accession}*/validate"
+        if not os.path.isdir(validate_dir):
+            logging.error(f"Directory not found: {validate_dir}")
         else:
-            file_path = matching_files[0]
-            logging.error(f"Validation error log file found: {file_path}")
-            try:
-                with open(file_path, 'r') as file:
-                    contents = file.read()
-                    logger.error(f"Contents of the file:\n{contents}")
-            except Exception as e:
-                logging.error(f"Error reading file {file_path}: {e}")
+            pattern = os.path.join(validate_dir, '*.report')
+            matching_files = glob.glob(pattern)
+
+            if not matching_files:
+                logging.error(f"No .report files found in: {validate_dir}")
+            else:
+                file_path = matching_files[0]
+                print(f"Matching file found: {file_path}")
+
+                try:
+                    with open(file_path, 'r') as file:
+                        contents = file.read()
+                        print(f"Contents of the file:\n{contents}")
+                except Exception as e:
+                    logging.error(f"Error reading file {file_path}: {e}")
         errors.append(error_message)
         return CreationResult(result=None, errors=errors, warnings=warnings)
 

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -303,7 +303,6 @@ def create_flatfile(
         annotations={
             "molecule_type": seqIO_moleculetype[moleculetype],
             "organism": organism,
-            "reference_authors": authors,
             "topology": "linear",
         },
     )

--- a/ena-submission/scripts/ena_submission_helper.py
+++ b/ena-submission/scripts/ena_submission_helper.py
@@ -303,6 +303,8 @@ def create_flatfile(
         multi_segment = False
 
     for seq_name, sequence_str in unaligned_sequences.items():
+        if not sequence_str:
+            continue
         reference = Reference()
         reference.authors = authors
         sequence = SeqRecord(

--- a/ena-submission/scripts/ena_types.py
+++ b/ena-submission/scripts/ena_types.py
@@ -181,8 +181,9 @@ class AssemblyManifest:
     coverage: str
     program: str
     platform: str
-    fasta: str
     chromosome_list: str
+    fasta: str | None = None
+    flatfile: str | None = None
     authors: str | None = None
     mingaplength: int | None = None
     moleculetype: MoleculeType | None = None

--- a/ena-submission/scripts/ena_types.py
+++ b/ena-submission/scripts/ena_types.py
@@ -183,6 +183,7 @@ class AssemblyManifest:
     platform: str
     fasta: str
     chromosome_list: str
+    authors: str | None = None
     mingaplength: int | None = None
     moleculetype: MoleculeType | None = None
     description: str | None = None

--- a/ena-submission/scripts/ena_types.py
+++ b/ena-submission/scripts/ena_types.py
@@ -184,7 +184,6 @@ class AssemblyManifest:
     chromosome_list: str
     fasta: str | None = None
     flatfile: str | None = None
-    authors: str | None = None
     mingaplength: int | None = None
     moleculetype: MoleculeType | None = None
     description: str | None = None

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -191,7 +191,7 @@ class AssemblyCreationTests(unittest.TestCase):
 
         self.assertEqual(
             content,
-            b"test_accession.test_version_seg2\tseg2\tlinear-segmented\ntest_accession.test_version_seg3\tseg3\tlinear-segmented\n",
+            b"test_accession_seg2\tseg2\tlinear-segmented\ntest_accession_seg3\tseg3\tlinear-segmented\n",
         )
 
     def test_create_chromosome_list(self):
@@ -203,7 +203,7 @@ class AssemblyCreationTests(unittest.TestCase):
 
         self.assertEqual(
             content,
-            b"test_accession.test_version\tmain\tlinear-segmented\n",
+            b"test_accession\tmain\tlinear-segmented\n",
         )
 
     def test_create_fasta_multi(self):

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -43,7 +43,11 @@ def mock_config():
     config = mock.Mock()
     config.db_name = "Loculus"
     config.unique_project_suffix = "Test suffix"
-    metadata_dict = {"taxon_id": "Test taxon", "scientific_name": "Test scientific name"}
+    metadata_dict = {
+        "taxon_id": "Test taxon",
+        "scientific_name": "Test scientific name",
+        "molecule_type": "genomic RNA",
+    }
     config.organisms = {"Test organism": {"ingest": metadata_dict}}
     config.metadata_mapping = defaults["metadata_mapping"]
     config.metadata_mapping_mandatory_field_defaults = defaults[
@@ -256,7 +260,6 @@ class AssemblyCreationTests(unittest.TestCase):
                     data[key] = value
         # Temp file names are different
         data.pop("CHROMOSOME_LIST")
-        data.pop("FASTA")
         data.pop("FLATFILE")
         expected_data = {
             "STUDY": study_accession,
@@ -267,6 +270,7 @@ class AssemblyCreationTests(unittest.TestCase):
             "PROGRAM": "Unknown",
             "PLATFORM": "Illumina",
             "DESCRIPTION": "Original sequence submitted to Loculus with accession: test_accession, version: test_version",
+            "MOLECULETYPE": "genomic RNA",
         }
 
         self.assertEqual(data, expected_data)

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -216,7 +216,7 @@ class AssemblyCreationTests(unittest.TestCase):
             content = gz.read()
         self.assertEqual(
             content,
-            b">test_accession.test_version_seg2\nGCGGCACGTCAGTACGTAAGTGTATCTCAAAGAAATACTTAACTTTGAGAGAGTGAATT\n>test_accession.test_version_seg3\nCTTAACTTTGAGAGAGTGAATT\n",
+            b">test_accession_seg2\nGCGGCACGTCAGTACGTAAGTGTATCTCAAAGAAATACTTAACTTTGAGAGAGTGAATT\n>test_accession_seg3\nCTTAACTTTGAGAGAGTGAATT\n",
         )
 
     def test_create_fasta(self):
@@ -227,7 +227,7 @@ class AssemblyCreationTests(unittest.TestCase):
             content = gz.read()
         self.assertEqual(
             content,
-            b">test_accession.test_version\nCTTAACTTTGAGAGAGTGAATT\n",
+            b">test_accession\nCTTAACTTTGAGAGAGTGAATT\n",
         )
 
     def test_create_manifest(self):
@@ -257,6 +257,7 @@ class AssemblyCreationTests(unittest.TestCase):
         # Temp file names are different
         data.pop("CHROMOSOME_LIST")
         data.pop("FASTA")
+        data.pop("FLATFILE")
         expected_data = {
             "STUDY": study_accession,
             "SAMPLE": sample_accession,

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1096,6 +1096,7 @@ defaultOrganismConfig: &defaultOrganismConfig
     configFile: &ingestConfigFile
       taxon_id: 186538
       scientific_name: "Zaire ebolavirus"
+      molecule_type: "genomic RNA"
   referenceGenomes:
     nucleotideSequences:
       - name: "main"
@@ -1180,6 +1181,7 @@ defaultOrganisms:
       configFile:
         taxon_id: 3048448
         scientific_name: "West Nile virus"
+        molecule_type: "genomic RNA"
     referenceGenomes:
       nucleotideSequences:
         - name: main
@@ -1408,6 +1410,7 @@ defaultOrganisms:
         <<: *ingestConfigFile
         taxon_id: 3052518
         scientific_name: "Orthonairovirus haemorrhagiae"
+        molecule_type: "genomic RNA"
         nucleotide_sequences:
           - L
           - M


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://test-adding-authors.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Adding AUTHORS as a field to the manifest file was not successful, from reading the docs it has become clear to us that instead of submitting the sequence as a fasta we should submit a flat file, flat files allow us to set metadata fields and the authors field.

Docs: https://ena-docs.readthedocs.io/en/latest/submit/fileprep/flat-file-example.html
Flat file: annotations: https://www.ebi.ac.uk/ena/WebFeat/. 
As we are submitting as a broker it is important that we add the AUTHORS to the assembly: https://ena-docs.readthedocs.io/en/latest/faq/data_brokering.html#authorship.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
