### PR TITLE
feat(backend): audit log when someone sets data use terms

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsDatabaseService.kt
@@ -10,6 +10,7 @@ import org.loculus.backend.api.DataUseTermsHistoryEntry
 import org.loculus.backend.api.DataUseTermsType
 import org.loculus.backend.auth.AuthenticatedUser
 import org.loculus.backend.controller.NotFoundException
+import org.loculus.backend.log.AuditLogger
 import org.loculus.backend.service.submission.AccessionPreconditionValidator
 import org.loculus.backend.utils.Accession
 import org.springframework.stereotype.Service
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional
 class DataUseTermsDatabaseService(
     private val accessionPreconditionValidator: AccessionPreconditionValidator,
     private val dataUseTermsPreconditionValidator: DataUseTermsPreconditionValidator,
+    private val auditLogger: AuditLogger,
 ) {
 
     fun setNewDataUseTerms(
@@ -47,6 +49,11 @@ class DataUseTermsDatabaseService(
             }
             this[DataUseTermsTable.userNameColumn] = authenticatedUser.username
         }
+
+        auditLogger.log(
+            username = authenticatedUser.username,
+            description = "Set data use terms to $newDataUseTerms for accessions ${accessions.joinToString()}",
+        )
     }
 
     fun getDataUseTermsHistory(accession: Accession): List<DataUseTermsHistoryEntry> {

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
@@ -189,6 +189,7 @@ class UploadDatabaseService(
         } ?: emptyList()
 
         if (submissionParams is SubmissionParams.OriginalSubmissionParams) {
+            log.debug { "Setting data use terms for submission $uploadId to ${submissionParams.dataUseTerms}" }
             dataUseTermsDatabaseService.setNewDataUseTerms(
                 submissionParams.authenticatedUser,
                 insertionResult.map { it.accession },
@@ -197,8 +198,8 @@ class UploadDatabaseService(
         }
 
         auditLogger.log(
-            submissionParams.authenticatedUser.username,
-            "Submitted or revised ${insertionResult.size} sequences: " +
+            username = submissionParams.authenticatedUser.username,
+            description = "Submitted or revised ${insertionResult.size} sequences: " +
                 insertionResult.joinToString { it.displayAccessionVersion() },
         )
 


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

While implementing #2953 I thought it might be good to log (in the audit log) when someone changes data use terms.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
