### PR TITLE
tests(website): skip download tests in webkit

### DIFF
--- a/website/tests/pages/submission/template.spec.ts
+++ b/website/tests/pages/submission/template.spec.ts
@@ -3,7 +3,13 @@ import type { Download } from '@playwright/test';
 import { expect, test } from '../../e2e.fixture.ts';
 
 test.describe('The submit page', () => {
-    test('should download the metadata file template for submission', async ({ submitPage, loginAsTestUser }) => {
+    test('should download the metadata file template for submission', async ({
+        submitPage,
+        loginAsTestUser,
+        browserName,
+    }) => {
+        skipDownloadTestInWebkit(browserName);
+
         const { groupId } = await loginAsTestUser();
         await submitPage.goto(groupId);
 
@@ -18,7 +24,10 @@ test.describe('The submit page', () => {
         revisePage,
         submitPage,
         loginAsTestUser,
+        browserName,
     }) => {
+        skipDownloadTestInWebkit(browserName);
+
         const { groupId } = await loginAsTestUser();
         await revisePage.goto(groupId);
 
@@ -36,5 +45,13 @@ test.describe('The submit page', () => {
             readable.on('data', (chunk) => (data += chunk));
             readable.on('end', () => resolve(data));
         });
+    }
+
+    function skipDownloadTestInWebkit(browserName: 'chromium' | 'firefox' | 'webkit') {
+        test.skip(
+            browserName === 'webkit',
+            'webkit seems to ignore the content disposition header.\n' +
+                "It doesn't download the file, instead it displays it.",
+        );
     }
 });

--- a/website/tests/pages/submission/template.spec.ts
+++ b/website/tests/pages/submission/template.spec.ts
@@ -50,7 +50,7 @@ test.describe('The submit page', () => {
     function skipDownloadTestInWebkit(browserName: 'chromium' | 'firefox' | 'webkit') {
         test.skip(
             browserName === 'webkit',
-            'webkit seems to ignore the content disposition header.\n' +
+            'Playwright-webkit seems to ignore the content disposition header.\n' +
                 "It doesn't download the file, instead it displays it.",
         );
     }


### PR DESCRIPTION
resolves #2963

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
webkit seems to ignore the content disposition header. It doesn't download the file, instead it displays it.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
