### PR TITLE
Small tweaks to test-prepro-v2

### DIFF
--- a/.github/workflows/preprocessing-tests.yaml
+++ b/.github/workflows/preprocessing-tests.yaml
@@ -28,6 +28,6 @@ jobs:
       - name: Run tests
         run: |
           pip install -e '.[test]'
-          python3 tests/test.py
+          pytest
         shell: micromamba-shell {0}
         working-directory: preprocessing/nextclade/

--- a/preprocessing/nextclade/.justfile
+++ b/preprocessing/nextclade/.justfile
@@ -1,5 +1,14 @@
 all: ruff_format ruff_check run_mypy
 
+create_env:
+    micromamba create -f environment.yml --rc-file .mambarc
+
+install:
+    pip install -e .
+
+install_test:
+    pip install -e .[test]
+
 r: ruff
 
 ruff: ruff_check ruff_format

--- a/preprocessing/nextclade/README.md
+++ b/preprocessing/nextclade/README.md
@@ -20,7 +20,7 @@ This preprocessing pipeline is still a work in progress. It requests unaligned n
 1. Install `conda`/`mamba`/`micromamba`: see e.g. [micromamba installation docs](https://mamba.readthedocs.io/en/latest/micromamba-installation.html#umamba-install)
 1. Install environment:
 
-   ```bash
+   ```sh
    mamba env create -n loculus-nextclade -f environment.yml
    ```
 
@@ -40,10 +40,10 @@ This preprocessing pipeline is still a work in progress. It requests unaligned n
 
 Tests can be run from the same directory
 
-```bash
+```sh
 mamba activate loculus-nextclade
-pip install -e .
-python3 tests/test.py
+pip install -e '.[test]'
+pytest
 ```
 
 Note that we do not add the tests folder to the docker image. In the CI tests are run using the same mamba environment as the preprocessing docker image but do not use the actual docker image. We chose this approach as it makes the CI tests faster but could potentially lead to the tests using a different program version than used in the docker image.
@@ -68,13 +68,13 @@ docker run -it --platform=linux/amd64 --network host --rm nextclade_processing p
 
 When deployed on kubernetes the preprocessing pipeline reads in config files which are created by `loculus/kubernetes/loculus/templates/loculus-preprocessing-config.yaml`. When run locally the pipeline uses only the default values defined in `preprocessing/nextclade/src/loculus_preprocessing/config.py`. When running the preprocessing pipeline locally it makes sense to create a local config file using the command:
 
-```
+```sh
 ../../generate_local_test_config.sh
 ```
 
 and use this in the pipeline as follows:
 
-```
+```sh
 prepro --config-file=../../temp/preprocessing-config.{organism}.yaml --keep-tmp-dir
 ```
 
@@ -105,7 +105,7 @@ However, the `preprocessing` field can be customized to take an arbitrary number
 
 Using these functions in your `values.yaml` will look like:
 
-```
+```yaml
 - name: sampleCollectionDate
    type: date
    preprocessing:

--- a/preprocessing/nextclade/README.md
+++ b/preprocessing/nextclade/README.md
@@ -15,18 +15,20 @@ This preprocessing pipeline is still a work in progress. It requests unaligned n
 
 ## Setup
 
-### Start directly
+### Installation
 
 1. Install `conda`/`mamba`/`micromamba`: see e.g. [micromamba installation docs](https://mamba.readthedocs.io/en/latest/micromamba-installation.html#umamba-install)
-2. Install environment:
+1. Install environment:
 
    ```bash
    mamba env create -n loculus-nextclade -f environment.yml
    ```
 
-3. Start backend (see [backend README](../backend/README.md)), run ingest script to submit sequences from INSDC. (Alternatively you can run `./deploy.py --enablePreprocessing` to start the backend and preprocessing pods in one command.)
+### Running
 
-4. Run pipeline
+1. Start backend (see [backend README](../backend/README.md)), run ingest script to submit sequences from INSDC. (Alternatively you can run `./deploy.py --enablePreprocessing` to start the backend and preprocessing pods in one command.)
+
+1. Run pipeline
 
    ```bash
    mamba activate loculus-nextclade

--- a/preprocessing/nextclade/pyproject.toml
+++ b/preprocessing/nextclade/pyproject.toml
@@ -15,4 +15,4 @@ build-backend = "hatchling.build"
 packages = ["src/loculus_preprocessing"]
 
 [project.optional-dependencies]
-test = ["pytest"]
+test = ["pytest", "mypy", "types-pytz"]

--- a/preprocessing/nextclade/src/loculus_preprocessing/backend.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/backend.py
@@ -82,8 +82,7 @@ def parse_ndjson(ndjson_data: str) -> Sequence[UnprocessedEntry]:
             unalignedNucleotideSequences=json_object["data"]["unalignedNucleotideSequences"],
         )
         entry = UnprocessedEntry(
-            accessionVersion=f"{json_object['accession']}.{
-                json_object['version']}",
+            accessionVersion=json_object["accession"] + "." + json_object["version"],
             data=unprocessed_data,
         )
         entries.append(entry)
@@ -140,10 +139,9 @@ def submit_processed_sequences(
     if not response.ok:
         Path("failed_submission.json").write_text(ndjson_string, encoding="utf-8")
         msg = (
-            f"Submitting processed data failed. Status code: {
-                response.status_code}\n"
+            f"Submitting processed data failed. Status code: {response.status_code}\n"
             f"Response: {response.text}\n"
-            f"Data sent in request: {ndjson_string[0:1000]}...\n"
+            f"Data sent: {ndjson_string[:1000]}...\n"
         )
         raise RuntimeError(msg)
     logging.info("Processed data submitted successfully")

--- a/preprocessing/nextclade/src/loculus_preprocessing/backend.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/backend.py
@@ -82,7 +82,8 @@ def parse_ndjson(ndjson_data: str) -> Sequence[UnprocessedEntry]:
             unalignedNucleotideSequences=json_object["data"]["unalignedNucleotideSequences"],
         )
         entry = UnprocessedEntry(
-            accessionVersion=json_object["accession"] + "." + json_object["version"],
+            accessionVersion=f"{json_object['accession']}.{
+                json_object['version']}",
             data=unprocessed_data,
         )
         entries.append(entry)

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -18,7 +18,7 @@ CLI_TYPES = [str, int, float, bool]
 @dataclass
 class Config:
     organism: str = "mpox"
-    backend_host: str = ""  # populated in get_config if left empty
+    backend_host: str = ""  # populated in get_config if left empty, so we can use organism
     keycloak_host: str = "http://127.0.0.1:8083"
     keycloak_user: str = "preprocessing_pipeline"
     keycloak_password: str = "preprocessing_pipeline"
@@ -37,8 +37,8 @@ class Config:
     pipeline_version: int = 1
 
 
-def load_config_from_yaml(config_file: str, config: Config) -> Config:
-    config = copy.deepcopy(config)
+def load_config_from_yaml(config_file: str, config: Config = None) -> Config:
+    config = Config() if config is None else copy.deepcopy(config)
     with open(config_file, encoding="utf-8") as file:
         yaml_config = yaml.safe_load(file)
         logging.debug(f"Loaded config from {config_file}: {yaml_config}")
@@ -78,8 +78,14 @@ def generate_argparse_from_dataclass(config_cls: type[Config]) -> argparse.Argum
 
 
 def get_config(config_file: str | None = None) -> Config:
-    # Config precedence: CLI args > ENV variables > config file > default
+    """
+    Config precedence: Direct function args > CLI args > ENV variables > config file > default
 
+    args:
+        config_file: Path to YAML config file - only used by tests
+    """
+
+    # Set just log level this early from env, so we can debug log during config loading
     env_log_level = os.environ.get("PREPROCESSING_LOG_LEVEL")
     if env_log_level:
         logging.basicConfig(level=env_log_level)
@@ -87,16 +93,15 @@ def get_config(config_file: str | None = None) -> Config:
     parser = generate_argparse_from_dataclass(Config)
     args = parser.parse_args()
 
-    # Load default config
     config = Config()
 
-    # Overwrite config with config in config_file
-    if config_file:
-        config = load_config_from_yaml(config_file, config)
-    if args.config_file:
-        config = load_config_from_yaml(args.config_file, config)
-    if not config.backend_host:  # Check if backend_host wasn't set during initialization
-        config.backend_host = f"http://127.0.0.1:8079/{config.organism}"
+    # Use first config file present in order of precedence
+    config_file_path = (
+        config_file or args.config_file or os.environ.get("PREPROCESSING_CONFIG_FILE")
+    )
+
+    # Start with lowest precedence config, then overwrite with higher precedence
+    config = load_config_from_yaml(config_file_path) if config_file_path else Config()
 
     # Use environment variables if available
     for key in config.__dict__:
@@ -108,5 +113,8 @@ def get_config(config_file: str | None = None) -> Config:
     for key, value in args.__dict__.items():
         if value is not None:
             setattr(config, key, value)
+
+    if not config.backend_host:  # Set here so we can use organism
+        config.backend_host = f"http://127.0.0.1:8079/{config.organism}"
 
     return config

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -37,7 +37,7 @@ class Config:
     pipeline_version: int = 1
 
 
-def load_config_from_yaml(config_file: str, config: Config = None) -> Config:
+def load_config_from_yaml(config_file: str, config: Config | None = None) -> Config:
     config = Config() if config is None else copy.deepcopy(config)
     with open(config_file, encoding="utf-8") as file:
         yaml_config = yaml.safe_load(file)

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -29,7 +29,7 @@ class Config:
     config_file: str | None = None
     log_level: str = "DEBUG"
     genes: list[str] = dataclasses.field(default_factory=list)
-    nucleotideSequences: list[str] = dataclasses.field(default_factory=lambda: ["main"])
+    nucleotideSequences: list[str] = dataclasses.field(default_factory=lambda: ["main"])  # noqa: N815
     keep_tmp_dir: bool = False
     reference_length: int = 197209
     batch_size: int = 5

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -93,8 +93,6 @@ def get_config(config_file: str | None = None) -> Config:
     parser = generate_argparse_from_dataclass(Config)
     args = parser.parse_args()
 
-    config = Config()
-
     # Use first config file present in order of precedence
     config_file_path = (
         config_file or args.config_file or os.environ.get("PREPROCESSING_CONFIG_FILE")

--- a/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
@@ -50,12 +50,12 @@ class ProcessingAnnotation:
 class UnprocessedData:
     submitter: str
     metadata: InputMetadata
-    unalignedNucleotideSequences: dict[str, NucleotideSequence]
+    unalignedNucleotideSequences: dict[str, NucleotideSequence]  # noqa: N815
 
 
 @dataclass
 class UnprocessedEntry:
-    accessionVersion: AccessionVersion  # {accession}.{version}
+    accessionVersion: AccessionVersion  # {accession}.{version}  # noqa: N815
     data: UnprocessedData
 
 
@@ -74,25 +74,25 @@ class ProcessingSpec:
 # For single segment, need to generalize for multi segments later
 @dataclass
 class UnprocessedAfterNextclade:
-    inputMetadata: InputMetadata
+    inputMetadata: InputMetadata  # noqa: N815
     # Derived metadata produced by Nextclade
-    nextcladeMetadata: dict[SegmentName, Any] | None
-    unalignedNucleotideSequences: dict[SegmentName, NucleotideSequence | None]
-    alignedNucleotideSequences: dict[SegmentName, NucleotideSequence | None]
-    nucleotideInsertions: dict[SegmentName, list[NucleotideInsertion]]
-    alignedAminoAcidSequences: dict[GeneName, AminoAcidSequence | None]
-    aminoAcidInsertions: dict[GeneName, list[AminoAcidInsertion]]
+    nextcladeMetadata: dict[SegmentName, Any] | None  # noqa: N815
+    unalignedNucleotideSequences: dict[SegmentName, NucleotideSequence | None]  # noqa: N815
+    alignedNucleotideSequences: dict[SegmentName, NucleotideSequence | None]  # noqa: N815
+    nucleotideInsertions: dict[SegmentName, list[NucleotideInsertion]]  # noqa: N815
+    alignedAminoAcidSequences: dict[GeneName, AminoAcidSequence | None]  # noqa: N815
+    aminoAcidInsertions: dict[GeneName, list[AminoAcidInsertion]]  # noqa: N815
     errors: list[ProcessingAnnotation]
 
 
 @dataclass
 class ProcessedData:
     metadata: ProcessedMetadata
-    unalignedNucleotideSequences: dict[str, Any]
-    alignedNucleotideSequences: dict[str, Any]
-    nucleotideInsertions: dict[str, Any]
-    alignedAminoAcidSequences: dict[str, Any]
-    aminoAcidInsertions: dict[str, Any]
+    unalignedNucleotideSequences: dict[str, Any]  # noqa: N815
+    alignedNucleotideSequences: dict[str, Any]  # noqa: N815
+    nucleotideInsertions: dict[str, Any]  # noqa: N815
+    alignedAminoAcidSequences: dict[str, Any]  # noqa: N815
+    aminoAcidInsertions: dict[str, Any]  # noqa: N815
 
 
 @dataclass

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -116,7 +116,7 @@ def parse_nextclade_json(
     return nextclade_metadata
 
 
-def enrich_with_nextclade(
+def enrich_with_nextclade(  # noqa: C901, PLR0912, PLR0914, PLR0915
     unprocessed: Sequence[UnprocessedEntry], dataset_dir: str, config: Config
 ) -> dict[AccessionVersion, UnprocessedAfterNextclade]:
     """
@@ -447,7 +447,7 @@ def add_input_metadata(
     return unprocessed.inputMetadata[input_path]
 
 
-def get_metadata(
+def get_metadata(  # noqa: PLR0913, PLR0917
     id: AccessionVersion,
     spec: ProcessingSpec,
     output_field: str,
@@ -491,7 +491,7 @@ def get_metadata(
     return processing_result
 
 
-def processed_entry_no_alignment(
+def processed_entry_no_alignment(  # noqa: PLR0913, PLR0917
     id: AccessionVersion,
     unprocessed: UnprocessedData,
     config: Config,
@@ -538,7 +538,7 @@ def processed_entry_no_alignment(
     )
 
 
-def process_single(
+def process_single(  # noqa: C901
     id: AccessionVersion, unprocessed: UnprocessedAfterNextclade | UnprocessedData, config: Config
 ) -> ProcessedEntry:
     """Process a single sequence per config"""
@@ -751,7 +751,8 @@ def run(config: Config) -> None:
                 logging.debug("No unprocessed sequences found. Sleeping for 1 second.")
                 time.sleep(1)
                 continue
-            # Don't use etag if we just got data, preprocessing only asks for 100 sequences to process at a time, so there might be more
+            # Don't use etag if we just got data
+            # preprocessing only asks for 100 sequences to process at a time, so there might be more
             etag = None
             try:
                 processed = process_all(unprocessed, dataset_dir, config)

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -94,12 +94,14 @@ def parse_nextclade_tsv(
 
 def parse_nextclade_json(
     result_dir,
-    nextclade_metadata: defaultdict[AccessionVersion, defaultdict[SegmentName, dict[str, Any]]],
+    nextclade_metadata: defaultdict[
+        AccessionVersion, defaultdict[SegmentName, dict[str, Any] | None]
+    ],
     segment: SegmentName,
     unaligned_nucleotide_sequences: dict[
         AccessionVersion, dict[SegmentName, NucleotideSequence | None]
     ],
-) -> defaultdict[AccessionVersion, defaultdict[SegmentName, dict[str, Any]]]:
+) -> defaultdict[AccessionVersion, defaultdict[SegmentName, dict[str, Any] | None]]:
     """
     Update nextclade_metadata object with the results of the nextclade analysis.
     If the segment existed in the input (unaligned_nucleotide_sequences) but did not align
@@ -166,12 +168,14 @@ def enrich_with_nextclade(  # noqa: C901, PLR0912, PLR0914, PLR0915
                 error_dict[id] = error_dict.get(id, [])
                 error_dict[id].append(
                     ProcessingAnnotation(
-                        source=[
-                            AnnotationSource(
-                                name=segment,
-                                type=AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
+                        source=(
+                            (
+                                AnnotationSource(
+                                    name=segment,
+                                    type=AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
+                                ),
                             )
-                        ],
+                        ),
                         message="Found multiple sequences with the same segment name.",
                     )
                 )
@@ -191,12 +195,12 @@ def enrich_with_nextclade(  # noqa: C901, PLR0912, PLR0914, PLR0915
             error_dict[id] = error_dict.get(id, [])
             error_dict[id].append(
                 ProcessingAnnotation(
-                    source=[
+                    source=(
                         AnnotationSource(
                             name="main",
                             type=AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
-                        )
-                    ],
+                        ),
+                    ),
                     message=(
                         "Found unknown segments in the input data - "
                         "check your segments are annotated correctly."
@@ -204,9 +208,9 @@ def enrich_with_nextclade(  # noqa: C901, PLR0912, PLR0914, PLR0915
                 )
             )
 
-    nextclade_metadata: defaultdict[AccessionVersion, defaultdict[SegmentName, dict[str, Any]]] = (
-        defaultdict(lambda: defaultdict(dict))
-    )
+    nextclade_metadata: defaultdict[
+        AccessionVersion, defaultdict[SegmentName, dict[str, Any] | None]
+    ] = defaultdict(lambda: defaultdict(dict))
     nucleotide_insertions: defaultdict[
         AccessionVersion, defaultdict[SegmentName, list[NucleotideInsertion]]
     ] = defaultdict(lambda: defaultdict(list))
@@ -234,11 +238,10 @@ def enrich_with_nextclade(  # noqa: C901, PLR0912, PLR0914, PLR0915
                 "run",
                 f"--output-all={result_dir_seg}",
                 f"--input-dataset={dataset_dir_seg}",
-                f"--output-translations={
-                    result_dir_seg}/nextclade.cds_translation.{{cds}}.fasta",
+                f"--output-translations={result_dir_seg}/nextclade.cds_translation.{{cds}}.fasta",
                 "--jobs=1",
                 "--",
-                f"{input_file}",
+                input_file,
             ]
             logging.debug(f"Running nextclade: {command}")
 
@@ -372,12 +375,12 @@ def add_input_metadata(
     unprocessed: UnprocessedAfterNextclade,
     errors: list[ProcessingAnnotation],
     input_path: str,
-) -> InputMetadata:
+) -> str | None:
     """Returns value of input_path in unprocessed metadata"""
     # If field starts with "nextclade.", take from nextclade metadata
     nextclade_prefix = "nextclade."
     if input_path.startswith(nextclade_prefix):
-        segment = spec.args.get("segment", "main")
+        segment = spec.args["segment"] if spec.args and "segment" in spec.args else "main"
         if not unprocessed.nextcladeMetadata:
             # This field should never be empty
             message = (
@@ -386,12 +389,12 @@ def add_input_metadata(
             )
             errors.append(
                 ProcessingAnnotation(
-                    source=[
+                    source=(
                         AnnotationSource(
                             name="segment",
                             type=AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
-                        )
-                    ],
+                        ),
+                    ),
                     message=message,
                 )
             )
@@ -406,17 +409,17 @@ def add_input_metadata(
                 )
                 errors.append(
                     ProcessingAnnotation(
-                        source=[
+                        source=(
                             AnnotationSource(
                                 name=segment,
                                 type=AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
-                            )
-                        ],
+                            ),
+                        ),
                         message=message,
                     )
                 )
                 return None
-            result = str(
+            result: str | None = str(
                 dpath.get(
                     unprocessed.nextcladeMetadata[segment],
                     sub_path,

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -162,7 +162,7 @@ class ProcessingFunctions:
             )
 
     @staticmethod
-    def parse_and_assert_past_date(
+    def parse_and_assert_past_date(  # noqa: C901
         input_data: InputMetadata,
         output_field,
         args: FunctionArgs = None,  # args is essential - even if Pylance says it's not used
@@ -245,7 +245,10 @@ class ProcessingFunctions:
                                     name=output_field, type=AnnotationSourceType.METADATA
                                 )
                             ],
-                            message=f"Metadata field {output_field}:'{date_str}' is after release date.",
+                            message=(
+                                f"Metadata field {output_field}:'{date_str}'"
+                                "is after release date."
+                            ),
                         )
                     )
 
@@ -399,7 +402,7 @@ class ProcessingFunctions:
             )
 
     @staticmethod
-    def identity(
+    def identity(  # noqa: C901, PLR0912
         input_data: InputMetadata, output_field: str, args: FunctionArgs = None
     ) -> ProcessingResult:
         """Identity function, takes input_data["input"] and returns it as output"""

--- a/preprocessing/nextclade/src/loculus_preprocessing/sequence_checks.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/sequence_checks.py
@@ -40,7 +40,10 @@ def errors_if_non_iupac(
                                 name=segment, type=AnnotationSourceType.NUCLEOTIDE_SEQUENCE
                             )
                         ],
-                        message=f"Found non-IUPAC symbols in the {segment} sequence: {', '.join(non_iupac_symbols)}",
+                        message=(
+                            f"Found non-IUPAC symbols in the {segment} sequence: "
+                            + ", ".join(non_iupac_symbols)
+                        ),
                     )
                 )
     return errors

--- a/preprocessing/nextclade/tests/factory_methods.py
+++ b/preprocessing/nextclade/tests/factory_methods.py
@@ -20,23 +20,14 @@ class ProcessingTestCase:
 
 @dataclass
 class UnprocessedEntryFactory:
-    _counter: int = 0
-
-    @classmethod
-    def reset_counter(cls):
-        cls._counter = 0
 
     @staticmethod
     def create_unprocessed_entry(
         metadata_dict: dict[str, str],
-        accession: str | None = None,
+        accession_id: str,
     ) -> UnprocessedEntry:
-        if not accession:
-            accession = f"LOC_{UnprocessedEntryFactory._counter}.1"
-            UnprocessedEntryFactory._counter += 1
-        UnprocessedEntryFactory._counter += 1
         return UnprocessedEntry(
-            accessionVersion=f"LOC_{accession}.1",
+            accessionVersion=f"LOC_{accession_id}.1",
             data=UnprocessedData(
                 submitter="test_submitter",
                 metadata=metadata_dict,
@@ -56,7 +47,7 @@ class ProcessedEntryFactory:
     def create_processed_entry(
         self,
         metadata_dict: dict[str, str],
-        accession_id: str,
+        accession: str,
         metadata_errors: list[tuple[str, str]] | None = None,
         metadata_warnings: list[tuple[str, str]] | None = None,
     ) -> ProcessedEntry:
@@ -69,7 +60,7 @@ class ProcessedEntryFactory:
         base_metadata_dict.update(metadata_dict)
 
         return ProcessedEntry(
-            accession=accession_id,
+            accession=accession,
             version=1,
             data=ProcessedData(
                 metadata=base_metadata_dict,

--- a/preprocessing/nextclade/tests/test.py
+++ b/preprocessing/nextclade/tests/test.py
@@ -1,3 +1,4 @@
+# ruff: noqa: S101
 from dataclasses import dataclass
 
 import pytest
@@ -144,7 +145,10 @@ test_case_definitions = [
         expected_errors=[
             (
                 "sequenced_timestamp",
-                "Timestamp is  2022-11-01Europe which is not in parseable YYYY-MM-DD. Parsing error: Unknown string format:  2022-11-01Europe",
+                (
+                    "Timestamp is  2022-11-01Europe which is not in parseable YYYY-MM-DD."
+                    "Parsing error: Unknown string format:  2022-11-01Europe"
+                ),
             ),
         ],
     ),
@@ -167,7 +171,10 @@ test_case_definitions = [
         expected_warnings=[
             (
                 "collection_date",
-                "Metadata field collection_date:'2023' - Month and day are missing. Assuming January 1st.",
+                (
+                    "Metadata field collection_date:'2023' - Month and day are missing. "
+                    "Assuming January 1st."
+                ),
             ),
         ],
     ),
@@ -247,7 +254,10 @@ test_case_definitions = [
         expected_errors=[
             (
                 "other_date",
-                "Date is 01-02-2024 which is not in the required format YYYY-MM-DD. Parsing error: time data '01-02-2024' does not match format '%Y-%m-%d'",
+                (
+                    "Date is 01-02-2024 which is not in the required format YYYY-MM-DD. "
+                    "Parsing error: time data '01-02-2024' does not match format '%Y-%m-%d'"
+                ),
             ),
         ],
     ),
@@ -328,9 +338,10 @@ def verify_processed_entry(
     # Check warnings
     processed_warnings = sort_annotations(processed_entry.warnings)
     expected_warnings = sort_annotations(expected_output.warnings)
-    assert (
-        processed_warnings == expected_warnings
-    ), f"{test_name}: processed warnings {processed_warnings} does not match expected output {expected_warnings}."
+    assert processed_warnings == expected_warnings, (
+        f"{test_name}: processed warnings {processed_warnings}"
+        f"does not match expected output {expected_warnings}."
+    )
 
 
 @pytest.mark.parametrize("test_case_def", test_case_definitions, ids=lambda tc: tc.name)

--- a/preprocessing/nextclade/tests/test_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_processing_functions.py
@@ -146,7 +146,7 @@ test_case_definitions = [
             (
                 "sequenced_timestamp",
                 (
-                    "Timestamp is  2022-11-01Europe which is not in parseable YYYY-MM-DD."
+                    "Timestamp is  2022-11-01Europe which is not in parseable YYYY-MM-DD. "
                     "Parsing error: Unknown string format:  2022-11-01Europe"
                 ),
             ),

--- a/preprocessing/nextclade/tests/test_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_processing_functions.py
@@ -350,43 +350,45 @@ def test_preprocessing(test_case_def: Case, config: Config, factory_custom: Proc
     processed_entry = process_single_entry(test_case, config)
     verify_processed_entry(processed_entry, test_case.expected_output, test_case.name)
 
-    def test_format_frameshift(self):
-        # Test case 1: Empty input
-        self.assertEqual(format_frameshift("[]"), "")
 
-        # Test case 2: Single frameshift
-        input_single = '[{"cdsName": "GPC", "nucRel": {"begin": 5, "end": 20}, "nucAbs": [{"begin": 97, "end": 112}], "codon": {"begin": 2, "end": 7}, "gapsLeading": {"begin": 1, "end": 2}, "gapsTrailing": {"begin": 7, "end": 8}}]'
-        expected_single = "GPC:3-7(nt:98-112)"
-        self.assertEqual(format_frameshift(input_single), expected_single)
+def test_format_frameshift():
+    # Test case 1: Empty input
+    assert not format_frameshift("[]")
 
-        # Test case 3: Multiple frameshifts
-        input_multiple = '[{"cdsName": "GPC", "nucRel": {"begin": 5, "end": 20}, "nucAbs": [{"begin": 97, "end": 112}], "codon": {"begin": 2, "end": 7}, "gapsLeading": {"begin": 1, "end": 2}, "gapsTrailing": {"begin": 7, "end": 8}}, {"cdsName": "NP", "nucRel": {"begin": 10, "end": 15}, "nucAbs": [{"begin": 200, "end": 205}], "codon": {"begin": 3, "end": 5}, "gapsLeading": {"begin": 2, "end": 3}, "gapsTrailing": {"begin": 5, "end": 6}}]'
-        expected_multiple = "GPC:3-7(nt:98-112),NP:4-5(nt:201-205)"
-        self.assertEqual(format_frameshift(input_multiple), expected_multiple)
+    # Test case 2: Single frameshift
+    input_single = '[{"cdsName": "GPC", "nucRel": {"begin": 5, "end": 20}, "nucAbs": [{"begin": 97, "end": 112}], "codon": {"begin": 2, "end": 7}, "gapsLeading": {"begin": 1, "end": 2}, "gapsTrailing": {"begin": 7, "end": 8}}]'  # noqa: E501
+    expected_single = "GPC:3-7(nt:98-112)"
+    assert format_frameshift(input_single) == expected_single
 
-        # Test case 4: Single nucleotide frameshift
-        input_single_nuc = '[{"cdsName": "L", "nucRel": {"begin": 30, "end": 31}, "nucAbs": [{"begin": 500, "end": 501}], "codon": {"begin": 10, "end": 11}, "gapsLeading": {"begin": 9, "end": 10}, "gapsTrailing": {"begin": 11, "end": 12}}]'
-        expected_single_nuc = "L:11(nt:501)"
-        self.assertEqual(format_frameshift(input_single_nuc), expected_single_nuc)
+    # Test case 3: Multiple frameshifts
+    input_multiple = '[{"cdsName": "GPC", "nucRel": {"begin": 5, "end": 20}, "nucAbs": [{"begin": 97, "end": 112}], "codon": {"begin": 2, "end": 7}, "gapsLeading": {"begin": 1, "end": 2}, "gapsTrailing": {"begin": 7, "end": 8}}, {"cdsName": "NP", "nucRel": {"begin": 10, "end": 15}, "nucAbs": [{"begin": 200, "end": 205}], "codon": {"begin": 3, "end": 5}, "gapsLeading": {"begin": 2, "end": 3}, "gapsTrailing": {"begin": 5, "end": 6}}]'  # noqa: E501
+    expected_multiple = "GPC:3-7(nt:98-112),NP:4-5(nt:201-205)"
+    assert format_frameshift(input_multiple) == expected_multiple
 
-    def test_format_stop_codon(self):
-        # Test case 1: Empty input
-        self.assertEqual(format_stop_codon("[]"), "")
+    # Test case 4: Single nucleotide frameshift
+    input_single_nuc = '[{"cdsName": "L", "nucRel": {"begin": 30, "end": 31}, "nucAbs": [{"begin": 500, "end": 501}], "codon": {"begin": 10, "end": 11}, "gapsLeading": {"begin": 9, "end": 10}, "gapsTrailing": {"begin": 11, "end": 12}}]'  # noqa: E501
+    expected_single_nuc = "L:11(nt:501)"
+    assert format_frameshift(input_single_nuc) == expected_single_nuc
 
-        # Test case 2: Single stop codon
-        input_single = '[{"cdsName": "GPC", "codon": 123}]'
-        expected_single = "GPC:124"
-        self.assertEqual(format_stop_codon(input_single), expected_single)
 
-        # Test case 3: Multiple stop codons
-        input_multiple = '[{"cdsName": "GPC", "codon": 123}, {"cdsName": "NP", "codon": 456}]'
-        expected_multiple = "GPC:124,NP:457"
-        self.assertEqual(format_stop_codon(input_multiple), expected_multiple)
+def test_format_stop_codon():
+    # Test case 1: Empty input
+    assert not format_stop_codon("[]")
 
-        # Test case 4: Stop codon at position 0
-        input_zero = '[{"cdsName": "L", "codon": 0}]'
-        expected_zero = "L:1"
-        self.assertEqual(format_stop_codon(input_zero), expected_zero)
+    # Test case 2: Single stop codon
+    input_single = '[{"cdsName": "GPC", "codon": 123}]'
+    expected_single = "GPC:124"
+    assert format_stop_codon(input_single) == expected_single
+
+    # Test case 3: Multiple stop codons
+    input_multiple = '[{"cdsName": "GPC", "codon": 123}, {"cdsName": "NP", "codon": 456}]'
+    expected_multiple = "GPC:124,NP:457"
+    assert format_stop_codon(input_multiple) == expected_multiple
+
+    # Test case 4: Stop codon at position 0
+    input_zero = '[{"cdsName": "L", "codon": 0}]'
+    expected_zero = "L:1"
+    assert format_stop_codon(input_zero) == expected_zero
 
 
 if __name__ == "__main__":

--- a/preprocessing/nextclade/tests/test_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_processing_functions.py
@@ -20,16 +20,16 @@ class Case:
     expected_metadata: dict[str, str]
     expected_errors: list[tuple[str, str]]
     expected_warnings: list[tuple[str, str]] = None
-    accession: str = "000999"
+    accession_id: str = "000999"
 
     def create_test_case(self, factory_custom: ProcessedEntryFactory) -> ProcessingTestCase:
         unprocessed_entry = UnprocessedEntryFactory.create_unprocessed_entry(
             metadata_dict=self.metadata,
-            accession=self.accession,
+            accession_id=self.accession_id,
         )
         expected_output = factory_custom.create_processed_entry(
             metadata_dict=self.expected_metadata,
-            accession_id=unprocessed_entry.accessionVersion.split(".")[0],
+            accession=unprocessed_entry.accessionVersion.split(".")[0],
             metadata_errors=self.expected_errors,
             metadata_warnings=self.expected_warnings or [],
         )
@@ -42,7 +42,7 @@ test_case_definitions = [
     Case(
         name="missing_required_fields",
         metadata={"submissionId": "missing_required_fields"},
-        accession="0",
+        accession_id="0",
         expected_metadata={"concatenated_string": "LOC_0.1"},
         expected_errors=[
             ("name_required", "Metadata field name_required is required."),
@@ -55,7 +55,7 @@ test_case_definitions = [
     Case(
         name="missing_one_required_field",
         metadata={"submissionId": "missing_one_required_field", "name_required": "name"},
-        accession="1",
+        accession_id="1",
         expected_metadata={"name_required": "name", "concatenated_string": "LOC_1.1"},
         expected_errors=[
             (
@@ -72,7 +72,7 @@ test_case_definitions = [
             "name_required": "name",
             "required_collection_date": "2022-11-01",
         },
-        accession="2",
+        accession_id="2",
         expected_metadata={
             "name_required": "name",
             "required_collection_date": "2022-11-01",
@@ -93,7 +93,7 @@ test_case_definitions = [
             "name_required": "name",
             "required_collection_date": "2022-11-01",
         },
-        accession="3",
+        accession_id="3",
         expected_metadata={
             "collection_date": "2088-12-01",
             "name_required": "name",
@@ -115,7 +115,7 @@ test_case_definitions = [
             "name_required": "name",
             "required_collection_date": "2022-11-01",
         },
-        accession="4",
+        accession_id="4",
         expected_metadata={
             "name_required": "name",
             "required_collection_date": "2022-11-01",
@@ -136,7 +136,7 @@ test_case_definitions = [
             "name_required": "name",
             "required_collection_date": "2022-11-01",
         },
-        accession="5",
+        accession_id="5",
         expected_metadata={
             "name_required": "name",
             "required_collection_date": "2022-11-01",
@@ -160,7 +160,7 @@ test_case_definitions = [
             "name_required": "name",
             "required_collection_date": "2022-11-01",
         },
-        accession="6",
+        accession_id="6",
         expected_metadata={
             "collection_date": "2023-01-01",
             "name_required": "name",
@@ -186,7 +186,7 @@ test_case_definitions = [
             "name_required": "name",
             "required_collection_date": "2022-11-01",
         },
-        accession="7",
+        accession_id="7",
         expected_metadata={
             "collection_date": "2023-12-01",
             "name_required": "name",
@@ -209,7 +209,7 @@ test_case_definitions = [
             "name_required": "name",
             "required_collection_date": "2022-11-01",
         },
-        accession="8",
+        accession_id="8",
         expected_metadata={
             "name_required": "name",
             "required_collection_date": "2022-11-01",
@@ -227,7 +227,7 @@ test_case_definitions = [
             "name_required": "name",
             "required_collection_date": "2022-11-01",
         },
-        accession="9",
+        accession_id="9",
         expected_metadata={
             "name_required": "name",
             "required_collection_date": "2022-11-01",
@@ -245,7 +245,7 @@ test_case_definitions = [
             "other_date": "01-02-2024",
             "required_collection_date": "2022-11-01",
         },
-        accession="10",
+        accession_id="10",
         expected_metadata={
             "name_required": "name",
             "required_collection_date": "2022-11-01",
@@ -269,7 +269,7 @@ test_case_definitions = [
             "is_lab_host_bool": "maybe",
             "required_collection_date": "2022-11-01",
         },
-        accession="11",
+        accession_id="11",
         expected_metadata={
             "name_required": "name",
             "required_collection_date": "2022-11-01",
@@ -290,12 +290,6 @@ def config():
 @pytest.fixture(scope="module")
 def factory_custom(config):
     return ProcessedEntryFactory(all_metadata_fields=list(config.processing_spec.keys()))
-
-
-@pytest.fixture(autouse=True)
-def reset_counter():
-    UnprocessedEntryFactory.reset_counter()
-    yield
 
 
 def sort_annotations(annotations: list[ProcessingAnnotation]) -> list[ProcessingAnnotation]:


### PR DESCRIPTION
Preview: https://test-prepro-v2-cr.loculus.org/

Use pytest instead of unittest: results in nicer test result view:

<img width="1725" alt="iTerm2 2024-10-08 13 29 12" src="https://github.com/user-attachments/assets/83a1156a-22d3-4bda-b86e-63ac87e9653f">

<img width="1728" alt="iTerm2 2024-10-08 13 29 16" src="https://github.com/user-attachments/assets/2988b193-6900-4060-9e6c-fbd7dabb2966">

Just run via `pytest`