### PR TITLE
fix(kubernetes): don't expect `$instance.enaDeposition` config when ena submission is disabled

### DIFF
--- a/kubernetes/loculus/templates/ena-submission-config.yaml
+++ b/kubernetes/loculus/templates/ena-submission-config.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.disableEnaSubmission }}
 {{- $testconfig := .Values.testconfig | default false }}
 {{- $backendHost := .Values.environment | eq "server" | ternary (printf "https://backend%s%s" .Values.subdomainSeparator $.Values.host) ($testconfig | ternary "http://localhost:8079" "http://loculus-backend-service:8079") }}
 {{- $keycloakHost := $testconfig | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083" }}
@@ -19,3 +20,4 @@ data:
     backend_url: {{ $backendHost }}
     keycloak_token_url: {{ $keycloakHost -}}/realms/loculus/protocol/openid-connect/token
     {{- include "loculus.generateENASubmissionConfig" . | nindent 4 }}
+{{- end }}


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://dontconfigureenadepositio.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

```
Error: template: loculus/templates/ena-submission-config.yaml:21:8: executing "loculus/templates/ena-submission-config.yaml" at <include "loculus.generateENASubmissionConfig" .>: error calling include: template: loculus/templates/_common-metadata.tpl:373:32: executing "loculus.generateENASubmissionConfig" at <$instance.enaDeposition.configFile>: nil pointer evaluating interface {}.configFile
```
But actually I have `disableEnaSubmission: true` in my config.

The `loculus-ena-submission-config` `ConfigMap` is only used (AFAICS) in the `ena-submission-deployment.yaml`, which also has the condition `{{- if not .Values.disableEnaSubmission }}`.
-> We also don't need the config map in that case.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
