### PR TITLE
fix(prepro): log and raise if prepro encounters config error to allow early detection

### DIFF
--- a/.github/workflows/preprocessing-tests.yaml
+++ b/.github/workflows/preprocessing-tests.yaml
@@ -20,17 +20,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up micromamba
         uses: mamba-org/setup-micromamba@v2
-        with: 
-            environment-file: preprocessing/nextclade/environment.yml
-            micromamba-version: 'latest'
-            init-shell: >-
-                bash
-            cache-environment: true
-            post-cleanup: 'all'
+        with:
+          environment-file: preprocessing/nextclade/environment.yml
+          micromamba-version: 'latest'
+          cache-environment: true
+          post-cleanup: 'all'
       - name: Run tests
         run: |
-            micromamba activate loculus-nextclade
-            pip install -e .
-            python3 tests/test.py
+          pip install -e '.[test]'
+          python3 tests/test.py
         shell: micromamba-shell {0}
         working-directory: preprocessing/nextclade/

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -113,6 +113,7 @@ class ProcessingFunctions:
     def check_date(
         input_data: InputMetadata,
         output_field: str,
+        args: FunctionArgs = None,  # args is essential - even if Pylance says it's not used
     ) -> ProcessingResult:
         """Check that date is complete YYYY-MM-DD
         If not according to format return error
@@ -164,7 +165,7 @@ class ProcessingFunctions:
     def parse_and_assert_past_date(
         input_data: InputMetadata,
         output_field,
-        args: FunctionArgs = None,
+        args: FunctionArgs = None,  # args is essential - even if Pylance says it's not used
     ) -> ProcessingResult:
         """Parse date string. If it's incomplete, add 01-01, if no year, return null and error
         input_data:
@@ -270,7 +271,7 @@ class ProcessingFunctions:
     def parse_timestamp(
         input_data: InputMetadata,
         output_field: str,
-        args: FunctionArgs = None,
+        args: FunctionArgs = None, # args is essential - even if Pylance says it's not used
     ) -> ProcessingResult:
         """Parse a timestamp string, e.g. 2022-11-01T00:00:00Z and return a YYYY-MM-DD string"""
         timestamp = input_data["timestamp"]

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -9,7 +9,6 @@ from datetime import datetime
 
 import dateutil.parser as dateutil
 import pytz
-from networkx import number_connected_components
 
 from .datatypes import (
     AnnotationSource,
@@ -575,7 +574,7 @@ def format_frameshift(input: str) -> str:
         nuc_range_list = [range_string(nuc["begin"], nuc["end"]) for nuc in frame_shift["nucAbs"]]
         codon_range = range_string(frame_shift["codon"]["begin"], frame_shift["codon"]["end"])
         frame_shift_strings.append(
-            frame_shift["cdsName"] + f":{codon_range} (nt:" + ";".join(nuc_range_list) + ")"
+            frame_shift["cdsName"] + f":{codon_range}(nt:" + ";".join(nuc_range_list) + ")"
         )
     return ",".join(frame_shift_strings)
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -568,7 +568,7 @@ def format_frameshift(input: str) -> str:
             return f"{start}-{end}"
         return str(start)
 
-    frame_shifts = json.loads(input.replace("'", '"'))  # Why is replace needed?
+    frame_shifts = json.loads(input.replace("'", '"'))  # Required for json.loads to recognize input as json string and convert to dict
     frame_shift_strings = []
     for frame_shift in frame_shifts:
         nuc_range_list = [range_string(nuc["begin"], nuc["end"]) for nuc in frame_shift["nucAbs"]]


### PR DESCRIPTION
preview URL: https://prepro-raise.loculus.org

### Summary
Under certain circumstances, prepro annotates sequences with entries, but doesn't log nor error - which makes it hard to detect that something is wrong for admins.

This PR makes sure we log and/or raise in those situations.

Previously, there would be nothing in the logs when a preprocessing function is misspelled in config.

Related to https://loculus.slack.com/archives/C05G172HL6L/p1728487952627419?thread_ts=1728487780.666019&cid=C05G172HL6L

Also makes a few small changes by using simple string concatenation when that is more concise than f-strings.

### Screenshot

Now it logs errors when there's a config error:

```
ERROR:root:Processing failed for PPD_000QKNP.1 with error: Processing for spec: ProcessingSpec(inputs={'date': 'sampleCollectionDate'}, function='process_date', requir │
│ ed=True, args={'type': 'date', 'submitter': 'insdc_ingest_user'}) with input data: {'date': '1987'} failed with CRITICAL: No processing function matches: process_date. │
│ This is a configuration error.
```