### PR TITLE
feat(website): Add padding to code blocks in docs

### DIFF
--- a/website/src/styles/mdcontainer.scss
+++ b/website/src/styles/mdcontainer.scss
@@ -128,3 +128,6 @@
   @apply text-lg font-semibold text-main my-3 border-t border-gray-300 mt-7 pt-5 mb-0;
 }
     
+.astro-code{
+    @apply p-2;
+}


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://docs-padding.loculus.org/governance
old:
![image](https://github.com/user-attachments/assets/df4cdef0-d743-4f27-afd6-cbe7aa9e30a3)

new:
![image](https://github.com/user-attachments/assets/74096121-c401-430b-9160-61dd1bce4f1f)

