### PR TITLE
chore(kubernetes): update to LAPIS 0.3.5, SILO 0.2.23

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1451,8 +1451,8 @@ insecureCookies: false
 bannerMessage: "This is a demonstration environment. It may contain non-accurate test data and should not be used for real-world applications. Data will be deleted regularly."
 additionalHeadHTML: '<script defer data-domain="loculus.org" src="https://plausible.io/js/script.js"></script>'
 images:
-  lapisSilo: "ghcr.io/genspectrum/lapis-silo:0.2.22"
-  lapis: "ghcr.io/genspectrum/lapis:0.3.4"
+  lapisSilo: "ghcr.io/genspectrum/lapis-silo:0.2.23"
+  lapis: "ghcr.io/genspectrum/lapis:0.3.5"
 secrets:
   smtp-password:
     type: raw


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://lapis035silo0223.loculus.org/

# Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

Both changes are very unlikely to break something for Loculus: 
* In LAPIS we implemented additional checks on the database config. If something changes for Loculus, then LAPIS will crash on startup.
* In SILO we fixed a bug in a code path of the preprocessing that is not used by Loculus.

## LAPIS [0.3.5](https://github.com/GenSpectrum/LAPIS/compare/v0.3.4...v0.3.5) (2024-10-10)

### Features

* **lapis:** validate that `lapisAllowsRegexSearch`-fields are of type string ([97b3ce9](https://github.com/GenSpectrum/LAPIS/commit/97b3ce912c7b28304aec823fd6c794c9d9a99525))
* **lapis:** validate that metadata fields do not contain the reserved character `.` ([97b3ce9](https://github.com/GenSpectrum/LAPIS/commit/97b3ce912c7b28304aec823fd6c794c9d9a99525)), [#976](https://github.com/GenSpectrum/LAPIS/issues/976)

## SILO [0.2.23](https://github.com/GenSpectrum/LAPIS-SILO/compare/v0.2.22...v0.2.23) (2024-10-10)

### Bug Fixes

* **preprocessing:** enforce exact match on file base stem when pairing sequence and metadata when processing from file ([7c9b23d](https://github.com/GenSpectrum/LAPIS-SILO/commit/7c9b23d618a75c4455ed9c7ac4cd76cf1218251a)), [#607](https://github.com/GenSpectrum/LAPIS-SILO/issues/607)

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
