### PR TITLE
fix(website): show more helpful error when LAPIS returns error when fetching sequences

### DIFF
--- a/website/src/services/serviceHooks.ts
+++ b/website/src/services/serviceHooks.ts
@@ -1,9 +1,11 @@
 import { Zodios } from '@zodios/core';
 import { ZodiosHooks, type ZodiosHooksInstance } from '@zodios/react';
+import { isAxiosError } from 'axios';
 
 import { backendApi } from './backendApi.ts';
 import { lapisApi } from './lapisApi.ts';
 import { seqSetCitationApi } from './seqSetCitationApi.ts';
+import { problemDetail } from '../types/backend.ts';
 import type { LapisBaseRequest } from '../types/lapis.ts';
 import type { ClientConfig } from '../types/runtimeConfig.ts';
 import { fastaEntries } from '../utils/parseFasta.ts';
@@ -27,6 +29,16 @@ export function lapisClientHooks(lapisUrl: string) {
                 );
 
                 if (data === undefined) {
+                    if (isAxiosError(error)) {
+                        const maybeProblemDetail = error.response?.data.error ?? error.response?.data;
+
+                        const problemDetailParseResult = problemDetail.safeParse(maybeProblemDetail);
+
+                        if (problemDetailParseResult.success) {
+                            return { data: null, error: problemDetailParseResult.data, isLoading };
+                        }
+                    }
+
                     return { data, error, isLoading };
                 }
 


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://prettierlapissequenceerro.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

The message before was not helpful and not pretty either. This is at least helpful (to us), but not very pretty for users either.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

After: 
![grafik](https://github.com/user-attachments/assets/b6a54088-ecbb-485d-9ba3-72379797d860)

Before:
![grafik](https://github.com/user-attachments/assets/cac95004-6c5d-4ea8-87c2-ed76ae4537f4)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
