### PR TITLE
tests: Add keycloak check to e2e test setup

### DIFF
--- a/website/tests/e2e.fixture.ts
+++ b/website/tests/e2e.fixture.ts
@@ -1,5 +1,4 @@
 import { readFileSync } from 'fs';
-import { exit } from 'process';
 
 import { type Page, test as base } from '@playwright/test';
 import axios from 'axios';
@@ -96,26 +95,18 @@ const testUserTokens: Record<string, TokenCookie> = {};
 async function ensureKeycloakIsReachable(issuerUrl: string) {
     try {
         const response = await axios.get(issuerUrl);
-        if (response.status === 200) {
-            e2eLogger.debug(`Server reachable at ${issuerUrl}.`);
-        } else {
-            e2eLogger.warn(`Server responded with status ${response.status} at ${issuerUrl}.`);
+        if (response.status !== 200) {
+            e2eLogger.warn(`Keycloak server responded with status ${response.status} at ${issuerUrl}.`);
         }
     } catch (error) {
-        /* eslint-disable no-console */
-        e2eLogger.error(`Failed to reach server at ${issuerUrl}: ${error}`);
+        e2eLogger.error(`Failed to reach Keycloak server at ${issuerUrl}`);
         if (axios.isAxiosError(error)) {
-            console.error('Axios error message:', error.message);
             if (error.response) {
-                console.error('Server responded with:', error.response.status, error.response.statusText);
+                e2eLogger.error('Server responded with:', error.response.status, error.response.statusText);
             }
-            if (error.stack !== undefined) {
-                console.error(error.stack);
-            }
-        } else {
-            console.error('An unknown error occurred:', error);
         }
-        exit(1);
+        e2eLogger.error('Are you sure that Keycloak is running?');
+        throw error;
     }
 }
 


### PR DESCRIPTION
### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Just a little enhancement to the playwright tests. 
I've added a function that checks if the keycloak server is actually reachable. If it isn't, the setup exits with an error code. Before, it was just silently failing and no error was raised.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~
