### PR TITLE
fix(ci): Explicitly install python in dev server test

### DIFF
--- a/.github/workflows/website-playwright-dev-test.yml
+++ b/.github/workflows/website-playwright-dev-test.yml
@@ -5,7 +5,7 @@ on:
       - "website/**"
       - "deploy.py"
       - generate_local_test_config.sh
-      - .github/workflows/node_dev.yml
+      - .github/workflows/website-playwright-dev-test.yml.yml
   push:
     branches:
       - main

--- a/.github/workflows/website-playwright-dev-test.yml
+++ b/.github/workflows/website-playwright-dev-test.yml
@@ -27,12 +27,12 @@ jobs:
           - os: ${{ github.ref != 'refs/heads/main' && 'macos-latest' }}
     steps:
       - uses: azure/setup-helm@v4
-      - name: Checkout repository
-        uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: 'pip'
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Install yaml package
         run: pip3 install PyYAML requests
       - name: Generate local test config

--- a/.github/workflows/website-playwright-dev-test.yml
+++ b/.github/workflows/website-playwright-dev-test.yml
@@ -29,6 +29,10 @@ jobs:
       - uses: azure/setup-helm@v4
       - name: Checkout repository
         uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
       - name: Install yaml package
         run: pip3 install PyYAML requests
       - name: Generate local test config

--- a/.github/workflows/website-playwright-dev-test.yml
+++ b/.github/workflows/website-playwright-dev-test.yml
@@ -30,7 +30,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          cache: 'pip'
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install yaml package

--- a/.github/workflows/website-playwright-dev-test.yml
+++ b/.github/workflows/website-playwright-dev-test.yml
@@ -5,7 +5,7 @@ on:
       - "website/**"
       - "deploy.py"
       - generate_local_test_config.sh
-      - .github/workflows/website-playwright-dev-test.yml.yml
+      - .github/workflows/website-playwright-dev-test.yml
   push:
     branches:
       - main


### PR DESCRIPTION
We were getting errors in the pip install due to a managed environment (due to some change on the GitHub side)

<img width="641" alt="image" src="https://github.com/user-attachments/assets/1ac2dacd-a317-41a1-a194-2bf65334f428">
