### PR TITLE
feat: Allow downloading metadata in the sequence detail view

### DIFF
--- a/website/src/components/Navigation/OrganismSelector.astro
+++ b/website/src/components/Navigation/OrganismSelector.astro
@@ -19,7 +19,7 @@ const restOfUrl = Astro.url.pathname.split('/').slice(2).join('/');
 <div class='dropdown dropdown-hover flex relative'>
     <label tabindex='0' class='py-1 block text-primary-1500 cursor-pointer'>
         {label}
-        <span class='text-primary'> <IwwaArrowDown className='inline-block -mt-1 ml-1 h-4 w-4 ' /></span>
+        <span class='text-primary'> <IwwaArrowDown className='inline-block -mt-1 ml-1 h-4 w-4' /></span>
     </label>
     <ul tabindex='0' class='dropdown-content z-20 menu p-1 shadow bg-base-100 rounded-btn absolute top-full -left-4'>
         {
@@ -31,7 +31,7 @@ const restOfUrl = Astro.url.pathname.split('/').slice(2).join('/');
                                 ? `/${knownOrganism.key}/${restOfUrl}`
                                 : routes.organismStartPage(knownOrganism.key)
                         }
-                        class='text-primary-1500 '
+                        class='text-primary-1500'
                     >
                         {knownOrganism.displayName}
                     </a>

--- a/website/src/components/SearchPage/SeqPreviewModal.tsx
+++ b/website/src/components/SearchPage/SeqPreviewModal.tsx
@@ -150,7 +150,7 @@ const DownloadButton: React.FC<DownloadButtonProps> = ({ seqId }: { seqId: strin
                         href={routes.sequencesFastaPage(seqId, true)}
                         className="block px-4 py-2 hover:bg-gray-100"
                     >
-                        Download FASTA
+                        FASTA
                     </a>
                 </li>
                 <li>
@@ -158,7 +158,7 @@ const DownloadButton: React.FC<DownloadButtonProps> = ({ seqId }: { seqId: strin
                         href={routes.sequencesTsvPage(seqId, true)}
                         className="block px-4 py-2 hover:bg-gray-100"
                     >
-                        Download Metadata TSV
+                        Metadata TSV
                     </a>
                 </li>
             </ul>

--- a/website/src/components/SearchPage/SeqPreviewModal.tsx
+++ b/website/src/components/SearchPage/SeqPreviewModal.tsx
@@ -102,7 +102,7 @@ export const SeqPreviewModal: React.FC<SeqPreviewModalProps> = ({
                     )}
                 </button>
                 <DownloadButton seqId={seqId} />
-                <a href={routes.sequencesDetailsPage(seqId)} title='Open in full window' className={BUTTONCLASS}>
+                <a href={routes.sequenceEntryDetailsPage(seqId)} title='Open in full window' className={BUTTONCLASS}>
                     <OouiNewWindowLtr className='w-6 h-6' />
                 </a>
                 <button type='button' className={BUTTONCLASS} onClick={onClose} title='Close'>
@@ -146,12 +146,12 @@ const DownloadButton: React.FC<DownloadButtonProps> = ({ seqId }: { seqId: strin
             </button>
             <ul className='dropdown-content z-20 menu p-1 shadow bg-base-100 rounded-btn absolute top-full -left-4'>
                 <li>
-                    <a href={routes.sequencesFastaPage(seqId, true)} className='block px-4 py-2 hover:bg-gray-100'>
+                    <a href={routes.sequenceEntryFastaPage(seqId, true)} className='block px-4 py-2 hover:bg-gray-100'>
                         FASTA
                     </a>
                 </li>
                 <li>
-                    <a href={routes.sequencesTsvPage(seqId, true)} className='block px-4 py-2 hover:bg-gray-100'>
+                    <a href={routes.sequenceEntryTsvPage(seqId, true)} className='block px-4 py-2 hover:bg-gray-100'>
                         Metadata TSV
                     </a>
                 </li>

--- a/website/src/components/SearchPage/SeqPreviewModal.tsx
+++ b/website/src/components/SearchPage/SeqPreviewModal.tsx
@@ -135,33 +135,27 @@ export const SeqPreviewModal: React.FC<SeqPreviewModalProps> = ({
 };
 
 interface DownloadButtonProps {
-    seqId: string
-};
+    seqId: string;
+}
 
 const DownloadButton: React.FC<DownloadButtonProps> = ({ seqId }: { seqId: string }) => {
     return (
-        <div className="dropdown dropdown-hover relative inline-block">
+        <div className='dropdown dropdown-hover relative inline-block'>
             <button className={BUTTONCLASS}>
-                <IcBaselineDownload className="w-6 h-6" />
+                <IcBaselineDownload className='w-6 h-6' />
             </button>
-            <ul className="dropdown-content z-20 menu p-1 shadow bg-base-100 rounded-btn absolute top-full -left-4">
+            <ul className='dropdown-content z-20 menu p-1 shadow bg-base-100 rounded-btn absolute top-full -left-4'>
                 <li>
-                    <a
-                        href={routes.sequencesFastaPage(seqId, true)}
-                        className="block px-4 py-2 hover:bg-gray-100"
-                    >
+                    <a href={routes.sequencesFastaPage(seqId, true)} className='block px-4 py-2 hover:bg-gray-100'>
                         FASTA
                     </a>
                 </li>
                 <li>
-                    <a
-                        href={routes.sequencesTsvPage(seqId, true)}
-                        className="block px-4 py-2 hover:bg-gray-100"
-                    >
+                    <a href={routes.sequencesTsvPage(seqId, true)} className='block px-4 py-2 hover:bg-gray-100'>
                         Metadata TSV
                     </a>
                 </li>
             </ul>
         </div>
     );
-}
+};

--- a/website/src/components/SearchPage/SeqPreviewModal.tsx
+++ b/website/src/components/SearchPage/SeqPreviewModal.tsx
@@ -101,9 +101,7 @@ export const SeqPreviewModal: React.FC<SeqPreviewModalProps> = ({
                         <MdiDockBottom className='w-6 h-6' />
                     )}
                 </button>
-                <a href={routes.sequencesFastaPage(seqId, true)} className={BUTTONCLASS}>
-                    <IcBaselineDownload className='w-6 h-6' />
-                </a>
+                <DownloadButton seqId={seqId} />
                 <a href={routes.sequencesDetailsPage(seqId)} title='Open in full window' className={BUTTONCLASS}>
                     <OouiNewWindowLtr className='w-6 h-6' />
                 </a>
@@ -135,3 +133,35 @@ export const SeqPreviewModal: React.FC<SeqPreviewModalProps> = ({
         </Transition>
     );
 };
+
+interface DownloadButtonProps {
+    seqId: string
+};
+
+const DownloadButton: React.FC<DownloadButtonProps> = ({ seqId }: { seqId: string }) => {
+    return (
+        <div className="dropdown dropdown-hover relative inline-block">
+            <button className={BUTTONCLASS}>
+                <IcBaselineDownload className="w-6 h-6" />
+            </button>
+            <ul className="dropdown-content z-20 menu p-1 shadow bg-base-100 rounded-btn absolute top-full -left-4">
+                <li>
+                    <a
+                        href={routes.sequencesFastaPage(seqId, true)}
+                        className="block px-4 py-2 hover:bg-gray-100"
+                    >
+                        Download FASTA
+                    </a>
+                </li>
+                <li>
+                    <a
+                        href={routes.sequencesTsvPage(seqId, true)}
+                        className="block px-4 py-2 hover:bg-gray-100"
+                    >
+                        Download Metadata TSV
+                    </a>
+                </li>
+            </ul>
+        </div>
+    );
+}

--- a/website/src/components/SearchPage/SeqPreviewModal.tsx
+++ b/website/src/components/SearchPage/SeqPreviewModal.tsx
@@ -144,15 +144,15 @@ const DownloadButton: React.FC<DownloadButtonProps> = ({ seqId }: { seqId: strin
             <button className={BUTTONCLASS}>
                 <IcBaselineDownload className='w-6 h-6' />
             </button>
-            <ul className='dropdown-content z-20 menu p-1 shadow bg-base-100 rounded-btn absolute top-full -left-4'>
+            <ul className='dropdown-content z-20 menu p-1 shadow bg-base-100 rounded-btn absolute top-full w-52 -left-32'>
                 <li>
                     <a href={routes.sequenceEntryFastaPage(seqId, true)} className='block px-4 py-2 hover:bg-gray-100'>
-                        FASTA
+                        Download FASTA
                     </a>
                 </li>
                 <li>
                     <a href={routes.sequenceEntryTsvPage(seqId, true)} className='block px-4 py-2 hover:bg-gray-100'>
-                        Metadata TSV
+                        Download metadata TSV
                     </a>
                 </li>
             </ul>

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -94,10 +94,10 @@ export const Table: FC<TableProps> = ({
                 e.preventDefault();
                 setPreviewedSeqId(seqId);
             } else {
-                window.open(routes.sequencesDetailsPage(seqId));
+                window.open(routes.sequenceEntryDetailsPage(seqId));
             }
         } else if (e.button === 1) {
-            window.open(routes.sequencesDetailsPage(seqId));
+            window.open(routes.sequenceEntryDetailsPage(seqId));
         }
     };
 
@@ -186,7 +186,7 @@ export const Table: FC<TableProps> = ({
                                     aria-label='SearchResult'
                                 >
                                     <a
-                                        href={routes.sequencesDetailsPage(row[primaryKey] as string)}
+                                        href={routes.sequenceEntryDetailsPage(row[primaryKey] as string)}
                                         className='text-primary-900 hover:text-primary-800 hover:no-underline'
                                         onClick={(e) => e.preventDefault()}
                                         onAuxClick={(e) => e.preventDefault()}

--- a/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.tsx
@@ -34,7 +34,7 @@ export const SequenceEntryHistoryMenu: React.FC<Props> = ({
                     {sequenceEntryHistory.map((version) => (
                         <li key={version.accessionVersion}>
                             <a
-                                href={routes.sequencesDetailsPage(version.accessionVersion)}
+                                href={routes.sequenceEntryDetailsPage(version.accessionVersion)}
                                 onClick={(e) => {
                                     if (setPreviewedSeqId) {
                                         setPreviewedSeqId(version.accessionVersion);

--- a/website/src/components/SequenceDetailsPage/SequencesBanner.astro
+++ b/website/src/components/SequenceDetailsPage/SequencesBanner.astro
@@ -28,7 +28,10 @@ const isLatestVersion = ownHistoryEntry?.versionStatus === versionStatuses.lates
                 {latestAccessionVersion !== undefined && (
                     <p>
                         The latest version is:
-                        <a href={routes.sequencesDetailsPage(latestAccessionVersion)} class='font-bold underline mx-1'>
+                        <a
+                            href={routes.sequenceEntryDetailsPage(latestAccessionVersion)}
+                            class='font-bold underline mx-1'
+                        >
                             {getAccessionVersionString(latestAccessionVersion)}
                         </a>
                     </p>

--- a/website/src/components/SequenceDetailsPage/SequencesDataTableTitle.astro
+++ b/website/src/components/SequenceDetailsPage/SequencesDataTableTitle.astro
@@ -29,6 +29,7 @@ const { sequenceEntryHistory, accessionVersion, showFastaDownload } = Astro.prop
             )
         }
         {
+            // TODO update this button here
             showFastaDownload && (
                 <a
                     class='sm:outlineButton inline-block'

--- a/website/src/components/SequenceDetailsPage/SequencesDataTableTitle.astro
+++ b/website/src/components/SequenceDetailsPage/SequencesDataTableTitle.astro
@@ -8,10 +8,10 @@ interface Props {
     sequenceEntryHistory?: SequenceEntryHistory;
     organism: string;
     accessionVersion: string;
-    showFastaDownload: boolean;
+    showDownload: boolean;
 }
 
-const { sequenceEntryHistory, accessionVersion, showFastaDownload } = Astro.props;
+const { sequenceEntryHistory, accessionVersion, showDownload } = Astro.props;
 ---
 
 <div class='flex justify-between flex-wrap'>
@@ -29,17 +29,33 @@ const { sequenceEntryHistory, accessionVersion, showFastaDownload } = Astro.prop
             )
         }
         {
-            // TODO update this button here
-            showFastaDownload && (
-                <a
-                    class='sm:outlineButton inline-block'
-                    href={routes.sequencesFastaPage(accessionVersion) + '?download'}
-                >
-                    <span class='hidden sm:inline'>Download FASTA</span>
-                    <span class='sm:hidden inline text-xl'>
+            showDownload && (
+                <div class='sm:outlineButton inline-block dropdown dropdown-hover dropdown-end'>
+                    <span tabindex='0' class='hidden sm:inline cursor-pointer'>
+                        Download
+                    </span>
+                    <span tabindex='0' class='sm:hidden inline text-xl cursor-pointer'>
                         <IcBaselineDownload />
                     </span>
-                </a>
+                    <ul class='dropdown-content z-20 menu p-1 shadow bg-base-100 rounded-btn top-full -left-22 w-35'>
+                        <li>
+                            <a
+                                href={routes.sequencesFastaPage(accessionVersion, true)}
+                                class='block px-4 py-2 outlineButtonDropdownItem'
+                            >
+                                FASTA
+                            </a>
+                        </li>
+                        <li>
+                            <a
+                                href={routes.sequencesTsvPage(accessionVersion, true)}
+                                class='block px-4 py-2 outlineButtonDropdownItem'
+                            >
+                                Metadata TSV
+                            </a>
+                        </li>
+                    </ul>
+                </div>
             )
         }
     </div>

--- a/website/src/components/SequenceDetailsPage/SequencesDataTableTitle.astro
+++ b/website/src/components/SequenceDetailsPage/SequencesDataTableTitle.astro
@@ -3,6 +3,7 @@ import { SequenceEntryHistoryMenu } from './SequenceEntryHistoryMenu';
 import { routes } from '../../routes/routes';
 import { type SequenceEntryHistory } from '../../types/lapis';
 import IcBaselineDownload from '~icons/ic/baseline-download';
+import IwwaArrowDown from '~icons/iwwa/arrow-down';
 
 interface Props {
     sequenceEntryHistory?: SequenceEntryHistory;
@@ -30,20 +31,24 @@ const { sequenceEntryHistory, accessionVersion, showDownload } = Astro.props;
         }
         {
             showDownload && (
-                <div class='sm:outlineButton inline-block dropdown dropdown-hover dropdown-end'>
-                    <span tabindex='0' class='hidden sm:inline cursor-pointer'>
+                <div class='inline-block dropdown dropdown-hover dropdown-end'>
+                    <label tabindex='0' class='hidden sm:block py-1 text-primary-700 cursor-pointer'>
                         Download
-                    </span>
+                        <span class='text-primary'>
+                            {' '}
+                            <IwwaArrowDown className='inline-block -mt-1 ml-1 h-4 w-4' />
+                        </span>
+                    </label>
                     <span tabindex='0' class='sm:hidden inline text-xl cursor-pointer'>
                         <IcBaselineDownload />
                     </span>
-                    <ul class='dropdown-content z-20 menu p-1 shadow bg-base-100 rounded-btn top-full -left-22 w-35'>
+                    <ul class='dropdown-content z-20 menu p-1 shadow bg-base-100 rounded-btn top-full -left-44 sm:-left-24 w-52'>
                         <li>
                             <a
                                 href={routes.sequenceEntryFastaPage(accessionVersion, true)}
                                 class='block px-4 py-2 outlineButtonDropdownItem'
                             >
-                                FASTA
+                                Download FASTA
                             </a>
                         </li>
                         <li>
@@ -51,7 +56,7 @@ const { sequenceEntryHistory, accessionVersion, showDownload } = Astro.props;
                                 href={routes.sequenceEntryTsvPage(accessionVersion, true)}
                                 class='block px-4 py-2 outlineButtonDropdownItem'
                             >
-                                Metadata TSV
+                                Download metadata TSV
                             </a>
                         </li>
                     </ul>

--- a/website/src/components/SequenceDetailsPage/SequencesDataTableTitle.astro
+++ b/website/src/components/SequenceDetailsPage/SequencesDataTableTitle.astro
@@ -40,7 +40,7 @@ const { sequenceEntryHistory, accessionVersion, showDownload } = Astro.props;
                     <ul class='dropdown-content z-20 menu p-1 shadow bg-base-100 rounded-btn top-full -left-22 w-35'>
                         <li>
                             <a
-                                href={routes.sequencesFastaPage(accessionVersion, true)}
+                                href={routes.sequenceEntryFastaPage(accessionVersion, true)}
                                 class='block px-4 py-2 outlineButtonDropdownItem'
                             >
                                 FASTA
@@ -48,7 +48,7 @@ const { sequenceEntryHistory, accessionVersion, showDownload } = Astro.props;
                         </li>
                         <li>
                             <a
-                                href={routes.sequencesTsvPage(accessionVersion, true)}
+                                href={routes.sequenceEntryTsvPage(accessionVersion, true)}
                                 class='block px-4 py-2 outlineButtonDropdownItem'
                             >
                                 Metadata TSV

--- a/website/src/pages/seq/[accessionVersion].fa/index.ts
+++ b/website/src/pages/seq/[accessionVersion].fa/index.ts
@@ -3,7 +3,7 @@ import type { APIRoute } from 'astro';
 import { getReferenceGenomes } from '../../../config.ts';
 import { routes } from '../../../routes/routes.ts';
 import { LapisClient } from '../../../services/lapisClient.ts';
-import { createDownloadAPIRoute } from '../sequenceDownload.ts';
+import { createDownloadAPIRoute } from '../../../utils/createDownloadAPIRoute.ts';
 
 export const GET: APIRoute = createDownloadAPIRoute(
     'text/x-fasta',

--- a/website/src/pages/seq/[accessionVersion].fa/index.ts
+++ b/website/src/pages/seq/[accessionVersion].fa/index.ts
@@ -1,124 +1,38 @@
 import type { APIRoute } from 'astro';
-import { err, type Result } from 'neverthrow';
 
-import { getConfiguredOrganisms } from '../../../config';
 import { getReferenceGenomes } from '../../../config.ts';
 import { routes } from '../../../routes/routes.ts';
 import { LapisClient } from '../../../services/lapisClient.ts';
-import { type ProblemDetail } from '../../../types/backend.ts';
-import { parseAccessionVersionFromString } from '../../../utils/extractAccessionVersion.ts';
 import { fastaEntryToString, parseFasta } from '../../../utils/parseFasta.ts';
+import { createDownloadAPIRoute } from '../sequenceDownload.ts';
 
-export const GET: APIRoute = async ({ params, redirect, request }) => {
-    const accessionVersion = params.accessionVersion!;
+export const GET: APIRoute = createDownloadAPIRoute(
+    'text/x-fasta',
+    'fa',
+    routes.sequencesFastaPage,
+    async (accessionVersion: string, organism: string) => {
+        const lapisClient = LapisClient.createForOrganism(organism);
+        const referenceGenomes = getReferenceGenomes(organism);
+        const segmentNames = referenceGenomes.nucleotideSequences.map((s) => s.name);
+        const isMultiSegmented = segmentNames.length > 1;
 
-    const isDownload = new URL(request.url).searchParams.has('download');
-
-    const result = await getSequenceDetailsUnalignedFasta(accessionVersion, isDownload);
-    if (!result.isOk()) {
-        return new Response(undefined, {
-            status: 404,
-        });
-    }
-
-    if (result.value.type === ResultType.REDIRECT) {
-        return redirect(result.value.redirectUrl);
-    }
-
-    const headers: Record<string, string> = {
-        'Content-Type': 'text/x-fasta',
-    };
-    if (isDownload) {
-        const filename = `${accessionVersion}.fa`;
-        headers['Content-Disposition'] = `attachment; filename="${filename}"`;
-    }
-
-    return new Response(result.value.fasta, {
-        headers,
-    });
-};
-
-enum ResultType {
-    DATA = 'data',
-    REDIRECT = 'redirect',
-}
-
-type Data = {
-    type: ResultType.DATA;
-    fasta: string;
-};
-
-type Redirect = {
-    type: ResultType.REDIRECT;
-    redirectUrl: string;
-};
-
-const getSequenceDetailsUnalignedFastaWithOrganism = async (
-    accessionVersion: string,
-    organism: string,
-    isDownload: boolean,
-): Promise<Result<Data | Redirect, ProblemDetail>> => {
-    const { accession, version } = parseAccessionVersionFromString(accessionVersion);
-
-    const lapisClient = LapisClient.createForOrganism(organism);
-
-    if (version === undefined) {
-        const latestVersionResult = await lapisClient.getLatestAccessionVersion(accession);
-        return latestVersionResult.map((latestVersion) => ({
-            type: ResultType.REDIRECT,
-            redirectUrl: routes.sequencesFastaPage(latestVersion, isDownload),
-        }));
-    }
-
-    const referenceGenomes = getReferenceGenomes(organism);
-    const segmentNames = referenceGenomes.nucleotideSequences.map((s) => s.name);
-    const isMultiSegmented = segmentNames.length > 1;
-
-    const fastaResult: Result<string, ProblemDetail> = !isMultiSegmented
-        ? await lapisClient.getUnalignedSequences(accessionVersion)
-        : (await lapisClient.getUnalignedSequencesMultiSegment(accessionVersion, segmentNames)).map((segmentFastas) =>
-              segmentFastas
-                  .map((fasta, i) => {
-                      const parsed = parseFasta(fasta);
-                      if (parsed.length === 0) {
-                          return '';
-                      }
-                      const withSegmentSuffix = {
-                          name: `${parsed[0].name}_${segmentNames[i]}`,
-                          sequence: parsed[0].sequence,
-                      };
-                      return fastaEntryToString([withSegmentSuffix]);
-                  })
-                  .join(''),
-          );
-    if (fastaResult.isOk()) {
-        if (fastaResult.value.trim().length === 0) {
-            return err({
-                type: 'about:blank',
-                title: 'Not Found',
-                status: 0,
-                detail: 'No data found for accession version ' + accessionVersion,
-                instance: '/seq/' + accessionVersion + '.fa',
-            });
-        }
-    }
-
-    return fastaResult.map((fasta) => ({
-        type: ResultType.DATA,
-        fasta,
-    }));
-};
-
-const getSequenceDetailsUnalignedFasta = async (accessionVersion: string, isDownload: boolean) => {
-    const organisms = getConfiguredOrganisms();
-    const results = await Promise.all(
-        organisms.map((organism) =>
-            getSequenceDetailsUnalignedFastaWithOrganism(accessionVersion, organism.key, isDownload),
-        ),
-    );
-    const firstSuccess = results.find((result) => result.isOk());
-    if (firstSuccess) {
-        return firstSuccess;
-    }
-    return results[0];
-};
+        return !isMultiSegmented
+            ? lapisClient.getUnalignedSequences(accessionVersion)
+            : (await lapisClient.getUnalignedSequencesMultiSegment(accessionVersion, segmentNames)).map(
+                  (segmentFastas) =>
+                      segmentFastas
+                          .map((fasta, i) => {
+                              const parsed = parseFasta(fasta);
+                              if (parsed.length === 0) {
+                                  return '';
+                              }
+                              const withSegmentSuffix = {
+                                  name: `${parsed[0].name}_${segmentNames[i]}`,
+                                  sequence: parsed[0].sequence,
+                              };
+                              return fastaEntryToString([withSegmentSuffix]);
+                          })
+                          .join(''),
+              );
+    },
+);

--- a/website/src/pages/seq/[accessionVersion].fa/index.ts
+++ b/website/src/pages/seq/[accessionVersion].fa/index.ts
@@ -3,7 +3,6 @@ import type { APIRoute } from 'astro';
 import { getReferenceGenomes } from '../../../config.ts';
 import { routes } from '../../../routes/routes.ts';
 import { LapisClient } from '../../../services/lapisClient.ts';
-import { fastaEntryToString, parseFasta } from '../../../utils/parseFasta.ts';
 import { createDownloadAPIRoute } from '../sequenceDownload.ts';
 
 export const GET: APIRoute = createDownloadAPIRoute(
@@ -17,22 +16,7 @@ export const GET: APIRoute = createDownloadAPIRoute(
         const isMultiSegmented = segmentNames.length > 1;
 
         return !isMultiSegmented
-            ? lapisClient.getUnalignedSequences(accessionVersion)
-            : (await lapisClient.getUnalignedSequencesMultiSegment(accessionVersion, segmentNames)).map(
-                  (segmentFastas) =>
-                      segmentFastas
-                          .map((fasta, i) => {
-                              const parsed = parseFasta(fasta);
-                              if (parsed.length === 0) {
-                                  return '';
-                              }
-                              const withSegmentSuffix = {
-                                  name: `${parsed[0].name}_${segmentNames[i]}`,
-                                  sequence: parsed[0].sequence,
-                              };
-                              return fastaEntryToString([withSegmentSuffix]);
-                          })
-                          .join(''),
-              );
+            ? lapisClient.getSequenceFasta(accessionVersion)
+            : lapisClient.getMultiSegmentSequenceFasta(accessionVersion, segmentNames);
     },
 );

--- a/website/src/pages/seq/[accessionVersion].fa/index.ts
+++ b/website/src/pages/seq/[accessionVersion].fa/index.ts
@@ -9,7 +9,7 @@ import { createDownloadAPIRoute } from '../sequenceDownload.ts';
 export const GET: APIRoute = createDownloadAPIRoute(
     'text/x-fasta',
     'fa',
-    routes.sequencesFastaPage,
+    routes.sequenceEntryFastaPage,
     async (accessionVersion: string, organism: string) => {
         const lapisClient = LapisClient.createForOrganism(organism);
         const referenceGenomes = getReferenceGenomes(organism);

--- a/website/src/pages/seq/[accessionVersion].tsv/index.ts
+++ b/website/src/pages/seq/[accessionVersion].tsv/index.ts
@@ -1,0 +1,71 @@
+import type { APIRoute } from 'astro';
+import { err, type Result } from 'neverthrow';
+
+import { getConfiguredOrganisms } from '../../../config';
+import type { ProblemDetail } from '../../../types/backend';
+
+export const GET: APIRoute = async ({ params, redirect, request }) => {
+    const accessionVersion = params.accessionVersion!;
+
+    const isDownload = new URL(request.url).searchParams.has('download');
+
+    const result = await getSequenceMetadataTsv(accessionVersion, isDownload);
+    if (!result.isOk()) {
+        return new Response(undefined, {
+            status: 404,
+        });
+    }
+
+    if (result.value.type === ResultType.REDIRECT) {
+        return redirect(result.value.redirectUrl);
+    }
+
+    const headers: Record<string, string> = {
+        'Content-Type': 'text/tab-separated-values',
+    };
+    if (isDownload) {
+        const filename = `${accessionVersion}.tsv`;
+        headers['Content-Disposition'] = `attachment; filename="${filename}"`;
+    }
+
+    return new Response(result.value.tsv, {
+        headers,
+    });
+};
+
+enum ResultType {
+    DATA = 'data',
+    REDIRECT = 'redirect',
+}
+
+type Data = {
+    type: ResultType.DATA;
+    tsv: string;
+};
+
+type Redirect = {
+    type: ResultType.REDIRECT;
+    redirectUrl: string;
+};
+
+const getSequenceMetadataTsvWithOrganism = async (
+    accessionVersion: string,
+    organism: string,
+    isDownload: boolean,
+): Promise<Result<Data | Redirect, ProblemDetail>> => {
+    throw new Error('Not implemented'); // TODO
+}
+
+const getSequenceMetadataTsv = async (accessionVersion: string, isDownload: boolean) => {
+    const organisms = getConfiguredOrganisms();
+    const results = await Promise.all(
+        organisms.map((organism) =>
+            getSequenceMetadataTsvWithOrganism(accessionVersion, organism.key, isDownload),
+        ),
+    );
+    const firstSuccess = results.find((result) => result.isOk());
+    if (firstSuccess) {
+        return firstSuccess;
+    }
+    return results[0];
+}

--- a/website/src/pages/seq/[accessionVersion].tsv/index.ts
+++ b/website/src/pages/seq/[accessionVersion].tsv/index.ts
@@ -1,102 +1,15 @@
 import type { APIRoute } from 'astro';
-import { type Result, err } from 'neverthrow';
 
-import { getConfiguredOrganisms } from '../../../config';
 import { routes } from '../../../routes/routes';
 import { LapisClient } from '../../../services/lapisClient';
-import type { ProblemDetail } from '../../../types/backend';
-import { parseAccessionVersionFromString } from '../../../utils/extractAccessionVersion';
+import { createDownloadAPIRoute } from '../sequenceDownload';
 
-export const GET: APIRoute = async ({ params, redirect, request }) => {
-    const accessionVersion = params.accessionVersion!;
-
-    const isDownload = new URL(request.url).searchParams.has('download');
-
-    const result = await getSequenceMetadataTsv(accessionVersion, isDownload);
-    if (!result.isOk()) {
-        return new Response(undefined, {
-            status: 404,
-        });
-    }
-
-    if (result.value.type === ResultType.REDIRECT) {
-        return redirect(result.value.redirectUrl);
-    }
-
-    const headers: Record<string, string> = {
-        'Content-Type': 'text/tab-separated-values',
-    };
-    if (isDownload) {
-        const filename = `${accessionVersion}.tsv`;
-        headers['Content-Disposition'] = `attachment; filename="${filename}"`;
-    }
-
-    return new Response(result.value.tsv, {
-        headers,
-    });
-};
-
-enum ResultType {
-    DATA = 'data',
-    REDIRECT = 'redirect',
-}
-
-type Data = {
-    type: ResultType.DATA;
-    tsv: string;
-};
-
-type Redirect = {
-    type: ResultType.REDIRECT;
-    redirectUrl: string;
-};
-
-const getSequenceMetadataTsvWithOrganism = async (
-    accessionVersion: string,
-    organism: string,
-    isDownload: boolean,
-): Promise<Result<Data | Redirect, ProblemDetail>> => {
-    const { accession, version } = parseAccessionVersionFromString(accessionVersion);
-
-    const lapisClient = LapisClient.createForOrganism(organism);
-
-    if (version === undefined) {
-        const latestVersionResult = await lapisClient.getLatestAccessionVersion(accession);
-        return latestVersionResult.map((latestVersion) => ({
-            type: ResultType.REDIRECT,
-            redirectUrl: routes.sequencesTsvPage(latestVersion, isDownload),
-        }));
-    }
-
-    const details: Result<string, ProblemDetail> =
-        await lapisClient.getSequenceEntryVersionDetailsTsv(accessionVersion);
-        
-    if (details.isOk()) {
-        if (details.value.trim().length === 0) {
-            return err({
-                type: 'about:blank',
-                title: 'Not Found',
-                status: 0,
-                detail: 'No data found for accession version ' + accessionVersion,
-                instance: '/seq/' + accessionVersion + '.tsv',
-            });
-        }
-    }
-
-    return details.map((tsv) => ({
-        type: ResultType.DATA,
-        tsv,
-    }));
-};
-
-const getSequenceMetadataTsv = async (accessionVersion: string, isDownload: boolean) => {
-    const organisms = getConfiguredOrganisms();
-    const results = await Promise.all(
-        organisms.map((organism) => getSequenceMetadataTsvWithOrganism(accessionVersion, organism.key, isDownload)),
-    );
-    const firstSuccess = results.find((result) => result.isOk());
-    if (firstSuccess) {
-        return firstSuccess;
-    }
-    return results[0];
-};
+export const GET: APIRoute = createDownloadAPIRoute(
+    'text/tab-separated-values',
+    'tsv',
+    routes.sequencesTsvPage,
+    (accessionVersion: string, organism: string) => {
+        const lapisClient = LapisClient.createForOrganism(organism);
+        return lapisClient.getSequenceEntryVersionDetailsTsv(accessionVersion);
+    },
+);

--- a/website/src/pages/seq/[accessionVersion].tsv/index.ts
+++ b/website/src/pages/seq/[accessionVersion].tsv/index.ts
@@ -2,7 +2,7 @@ import type { APIRoute } from 'astro';
 
 import { routes } from '../../../routes/routes';
 import { LapisClient } from '../../../services/lapisClient';
-import { createDownloadAPIRoute } from '../sequenceDownload';
+import { createDownloadAPIRoute } from '../../../utils/createDownloadAPIRoute';
 
 export const GET: APIRoute = createDownloadAPIRoute(
     'text/tab-separated-values',

--- a/website/src/pages/seq/[accessionVersion].tsv/index.ts
+++ b/website/src/pages/seq/[accessionVersion].tsv/index.ts
@@ -7,7 +7,7 @@ import { createDownloadAPIRoute } from '../sequenceDownload';
 export const GET: APIRoute = createDownloadAPIRoute(
     'text/tab-separated-values',
     'tsv',
-    routes.sequencesTsvPage,
+    routes.sequenceEntryTsvPage,
     (accessionVersion: string, organism: string) => {
         const lapisClient = LapisClient.createForOrganism(organism);
         return lapisClient.getSequenceEntryVersionDetailsTsv(accessionVersion);

--- a/website/src/pages/seq/[accessionVersion]/getSequenceDetailsTableData.ts
+++ b/website/src/pages/seq/[accessionVersion]/getSequenceDetailsTableData.ts
@@ -44,7 +44,7 @@ export const getSequenceDetailsTableData = async (
         const latestVersionResult = await lapisClient.getLatestAccessionVersion(accession);
         return latestVersionResult.map((latestVersion) => ({
             type: SequenceDetailsTableResultType.REDIRECT,
-            redirectUrl: routes.sequencesDetailsPage(latestVersion),
+            redirectUrl: routes.sequenceEntryDetailsPage(latestVersion),
         }));
     }
 

--- a/website/src/pages/seq/[accessionVersion]/index.astro
+++ b/website/src/pages/seq/[accessionVersion]/index.astro
@@ -64,9 +64,7 @@ const runtimeConfig = getRuntimeConfig();
                                 ? result.sequenceEntryHistory
                                 : undefined
                         }
-                        showFastaDownload={
-                            result.type === SequenceDetailsTableResultType.TABLE_DATA && !result.isRevocation
-                        }
+                        showDownload={result.type === SequenceDetailsTableResultType.TABLE_DATA && !result.isRevocation}
                     />
                     {result.type === SequenceDetailsTableResultType.TABLE_DATA &&
                         (result.isRevocation ? (

--- a/website/src/pages/seq/[accessionVersion]/versions.astro
+++ b/website/src/pages/seq/[accessionVersion]/versions.astro
@@ -32,7 +32,7 @@ const { organism, versionListResult } = await getVersionsData(accession);
                                 <div class='font-semibold'>{version.submittedAtTimestamp}</div>
                                 <div class='flex flex-row gap-3 justify-start'>
                                     <a
-                                        href={routes.sequencesDetailsPage(
+                                        href={routes.sequenceEntryDetailsPage(
                                             getAccessionVersionString(extractAccessionVersion(version)),
                                         )}
                                         class='underline'

--- a/website/src/pages/seq/sequenceDownload.ts
+++ b/website/src/pages/seq/sequenceDownload.ts
@@ -24,7 +24,7 @@ export type DataDownloader = (accessionVersion: string, organism: string) => Pro
 
 /**
  * Given a data fetcher function and some information about the data, this will create an API route
- * That fetches the data.
+ * that fetches the data.
  * @param contentType The content type to use in the HTTP header
  * @param fileSuffix the file suffix for this data type (i.e. 'fa' or 'tsv')
  * @param undefinedVersionRedirectUrl In case the accessionVersion has no version and it needs to be determined

--- a/website/src/pages/seq/sequenceDownload.ts
+++ b/website/src/pages/seq/sequenceDownload.ts
@@ -1,0 +1,150 @@
+import type { APIRoute } from 'astro';
+import { err, type Result } from 'neverthrow';
+
+import { getConfiguredOrganisms } from '../../config';
+import { LapisClient } from '../../services/lapisClient';
+import { type ProblemDetail } from '../../types/backend';
+import { parseAccessionVersionFromString } from '../../utils/extractAccessionVersion';
+
+export type RedirectRoute = (
+    accessionVersion:
+        | string
+        | {
+              accession: string;
+              version: number;
+          },
+    download?: boolean,
+) => string;
+
+/**
+ * A data downloader function. Receives an accessionVersion and an organism and returns a plain string of data
+ * (in a Promise, in a Result).
+ */
+export type DataDownloader = (accessionVersion: string, organism: string) => Promise<Result<string, ProblemDetail>>;
+
+/**
+ * Given a data fetcher function and some information about the data, this will create an API route
+ * That fetches the data.
+ * @param contentType The content type to use in the HTTP header
+ * @param fileSuffix the file suffix for this data type (i.e. 'fa' or 'tsv')
+ * @param undefinedVersionRedirectUrl In case the accessionVersion has no version and it needs to be determined
+ * where to redirect to.
+ * @param getData The function that does the actual data fetching.
+ * @returns An APIRoute.
+ */
+export function createDownloadAPIRoute(
+    contentType: string,
+    fileSuffix: string,
+    undefinedVersionRedirectUrl: RedirectRoute,
+    getData: DataDownloader,
+): APIRoute {
+    return async ({ params, redirect, request }) => {
+        const accessionVersion = params.accessionVersion!;
+
+        const isDownload = new URL(request.url).searchParams.has('download');
+
+        const result = await getSequenceData(accessionVersion, fileSuffix, undefinedVersionRedirectUrl, getData);
+        if (!result.isOk()) {
+            return new Response(undefined, {
+                status: 404,
+            });
+        }
+
+        if (result.value.type === ResultType.REDIRECT) {
+            return redirect(result.value.redirectUrl);
+        }
+
+        const headers: Record<string, string> = {
+            'Content-Type': contentType,
+        };
+        if (isDownload) {
+            const filename = `${accessionVersion}.${fileSuffix}`;
+            headers['Content-Disposition'] = `attachment; filename="${filename}"`;
+        }
+
+        return new Response(result.value.data, {
+            headers,
+        });
+    };
+}
+
+enum ResultType {
+    DATA = 'data',
+    REDIRECT = 'redirect',
+}
+
+type Data = {
+    type: ResultType.DATA;
+    data: string;
+};
+
+type Redirect = {
+    type: ResultType.REDIRECT;
+    redirectUrl: string;
+};
+
+const getSequenceDataWithOrganism = async (
+    accessionVersion: string,
+    organism: string,
+    fileSuffix: string,
+    undefinedVersionRedirectUrl: RedirectRoute,
+    getter: DataDownloader,
+): Promise<Result<Data | Redirect, ProblemDetail>> => {
+    const { accession, version } = parseAccessionVersionFromString(accessionVersion);
+
+    const lapisClient = LapisClient.createForOrganism(organism);
+
+    if (version === undefined) {
+        const latestVersionResult = await lapisClient.getLatestAccessionVersion(accession);
+        return latestVersionResult.map((latestVersion) => ({
+            type: ResultType.REDIRECT,
+            redirectUrl: undefinedVersionRedirectUrl(latestVersion),
+        }));
+    }
+
+    const dataResult: Result<string, ProblemDetail> = await getter(accessionVersion, organism);
+
+    if (dataResult.isOk()) {
+        if (dataResult.value.trim().length === 0) {
+            return err({
+                type: 'about:blank',
+                title: 'Not Found',
+                status: 0,
+                detail: 'No data found for accession version ' + accessionVersion,
+                instance: '/seq/' + accessionVersion + `.${fileSuffix}`,
+            });
+        }
+    }
+
+    return dataResult.map((data) => ({
+        type: ResultType.DATA,
+        data,
+    }));
+};
+
+const getSequenceData = async (
+    accessionVersion: string,
+    fileSuffix: string,
+    undefinedVersionRedirectUrl: RedirectRoute,
+    getter: DataDownloader,
+) => {
+    // We don't know which organism the accessionVersion belongs to,
+    // so we just try all of them until we get a success.
+    const organisms = getConfiguredOrganisms();
+    const results = await Promise.all(
+        organisms.map((organism) =>
+            getSequenceDataWithOrganism(
+                accessionVersion,
+                organism.key,
+                fileSuffix,
+                undefinedVersionRedirectUrl,
+                getter,
+            ),
+        ),
+    );
+    const firstSuccess = results.find((result) => result.isOk());
+    if (firstSuccess) {
+        return firstSuccess;
+    }
+    return results[0];
+};

--- a/website/src/routes/routes.ts
+++ b/website/src/routes/routes.ts
@@ -24,13 +24,13 @@ export const routes = {
             groupId,
             searchParams: new URLSearchParams({}),
         }),
-    sequencesDetailsPage: (accessionVersion: AccessionVersion | string) =>
+    sequenceEntryDetailsPage: (accessionVersion: AccessionVersion | string) =>
         `/seq/${getAccessionVersionString(accessionVersion)}`,
-    sequencesVersionsPage: (accessionVersion: AccessionVersion | string) =>
+    sequenceEntryVersionsPage: (accessionVersion: AccessionVersion | string) =>
         `/seq/${getAccessionVersionString(accessionVersion)}/versions`,
-    sequencesFastaPage: (accessionVersion: AccessionVersion | string, download = false) =>
+    sequenceEntryFastaPage: (accessionVersion: AccessionVersion | string, download = false) =>
         sequenceEntryDownloadUrl(accessionVersion, FileType.FASTA, download),
-    sequencesTsvPage: (accessionVersion: AccessionVersion | string, download = false) =>
+    sequenceEntryTsvPage: (accessionVersion: AccessionVersion | string, download = false) =>
         sequenceEntryDownloadUrl(accessionVersion, FileType.TSV, download),
     createGroup: () => '/user/createGroup',
     submissionPageWithoutGroup: (organism: string) => withOrganism(organism, '/submission'),
@@ -68,7 +68,7 @@ function withOrganism(organism: string, path: `/${string}`) {
 }
 
 function sequenceEntryDownloadUrl(accessionVersion: AccessionVersion | string, fileType: FileType, download = false) {
-    let url = `${routes.sequencesDetailsPage(accessionVersion)}.${fileType}`;
+    let url = `${routes.sequenceEntryDetailsPage(accessionVersion)}.${fileType}`;
     if (download) {
         url += '?download';
     }

--- a/website/src/routes/routes.ts
+++ b/website/src/routes/routes.ts
@@ -1,6 +1,6 @@
 import { SubmissionRouteUtils } from './SubmissionRoute.ts';
 import type { UploadAction } from '../components/Submission/DataUploadForm.tsx';
-import { accessionVersion, type AccessionVersion } from '../types/backend.ts';
+import { type AccessionVersion } from '../types/backend.ts';
 import { FileType } from '../types/lapis.ts';
 import { getAccessionVersionString } from '../utils/extractAccessionVersion.ts';
 

--- a/website/src/routes/routes.ts
+++ b/website/src/routes/routes.ts
@@ -72,5 +72,5 @@ function sequenceDownloadUrl(accessionVersion: AccessionVersion | string, fileTy
     if (download) {
         url += '?download';
     }
-    return url;  
+    return url;
 }

--- a/website/src/routes/routes.ts
+++ b/website/src/routes/routes.ts
@@ -29,9 +29,9 @@ export const routes = {
     sequencesVersionsPage: (accessionVersion: AccessionVersion | string) =>
         `/seq/${getAccessionVersionString(accessionVersion)}/versions`,
     sequencesFastaPage: (accessionVersion: AccessionVersion | string, download = false) =>
-        sequenceDownloadUrl(accessionVersion, FileType.FASTA, download),
+        sequenceEntryDownloadUrl(accessionVersion, FileType.FASTA, download),
     sequencesTsvPage: (accessionVersion: AccessionVersion | string, download = false) =>
-        sequenceDownloadUrl(accessionVersion, FileType.TSV, download),
+        sequenceEntryDownloadUrl(accessionVersion, FileType.TSV, download),
     createGroup: () => '/user/createGroup',
     submissionPageWithoutGroup: (organism: string) => withOrganism(organism, '/submission'),
     submissionPage: (organism: string, groupId: number) =>
@@ -67,7 +67,7 @@ function withOrganism(organism: string, path: `/${string}`) {
     return `/${organism}${path}`;
 }
 
-function sequenceDownloadUrl(accessionVersion: AccessionVersion | string, fileType: FileType, download = false) {
+function sequenceEntryDownloadUrl(accessionVersion: AccessionVersion | string, fileType: FileType, download = false) {
     let url = `${routes.sequencesDetailsPage(accessionVersion)}.${fileType}`;
     if (download) {
         url += '?download';

--- a/website/src/routes/routes.ts
+++ b/website/src/routes/routes.ts
@@ -1,6 +1,7 @@
 import { SubmissionRouteUtils } from './SubmissionRoute.ts';
 import type { UploadAction } from '../components/Submission/DataUploadForm.tsx';
-import type { AccessionVersion } from '../types/backend.ts';
+import { accessionVersion, type AccessionVersion } from '../types/backend.ts';
+import { FileType } from '../types/lapis.ts';
 import { getAccessionVersionString } from '../utils/extractAccessionVersion.ts';
 
 export const approxMaxAcceptableUrlLength = 1900;
@@ -27,13 +28,10 @@ export const routes = {
         `/seq/${getAccessionVersionString(accessionVersion)}`,
     sequencesVersionsPage: (accessionVersion: AccessionVersion | string) =>
         `/seq/${getAccessionVersionString(accessionVersion)}/versions`,
-    sequencesFastaPage: (accessionVersion: AccessionVersion | string, download = false) => {
-        let url = `${routes.sequencesDetailsPage(accessionVersion)}.fa`;
-        if (download) {
-            url += '?download';
-        }
-        return url;
-    },
+    sequencesFastaPage: (accessionVersion: AccessionVersion | string, download = false) =>
+        sequenceDownloadUrl(accessionVersion, FileType.FASTA, download),
+    sequencesTsvPage: (accessionVersion: AccessionVersion | string, download = false) =>
+        sequenceDownloadUrl(accessionVersion, FileType.TSV, download),
     createGroup: () => '/user/createGroup',
     submissionPageWithoutGroup: (organism: string) => withOrganism(organism, '/submission'),
     submissionPage: (organism: string, groupId: number) =>
@@ -67,4 +65,12 @@ export const routes = {
 
 function withOrganism(organism: string, path: `/${string}`) {
     return `/${organism}${path}`;
+}
+
+function sequenceDownloadUrl(accessionVersion: AccessionVersion | string, fileType: FileType, download = false) {
+    let url = `${routes.sequencesDetailsPage(accessionVersion)}.${fileType}`;
+    if (download) {
+        url += '?download';
+    }
+    return url;  
 }

--- a/website/src/services/lapisClient.ts
+++ b/website/src/services/lapisClient.ts
@@ -53,11 +53,14 @@ export class LapisClient extends ZodiosWrapperClient<typeof lapisApi> {
         });
     }
 
-    public getMetadataTsv(accessionVersion: string) {
+    public getSequenceEntryVersionDetailsTsv(accessionVersion: string) {
         return this.call('details', {
             [this.schema.primaryKey]: accessionVersion,
-            dataFormat: 'tsv'
-        });
+            dataFormat: 'TSV',
+            // This type cast isn't pretty, but if the API would be typed correctly, the union type
+            // of the actual details resonse and the potential 'string' would polute the whole API,
+            // so I decided to just do this cast here. We know that the return value is a TSV string.
+        }).then((result) => result.map((data) => data as unknown as string));
     }
 
     public async getLatestAccessionVersion(accession: string): Promise<Result<AccessionVersion, ProblemDetail>> {

--- a/website/src/services/lapisClient.ts
+++ b/website/src/services/lapisClient.ts
@@ -21,6 +21,7 @@ import {
     type SequenceEntryHistory,
     versionStatuses,
 } from '../types/lapis.ts';
+import { fastaEntryToString, parseFasta } from '../utils/parseFasta.ts';
 import type { BaseType } from '../utils/sequenceTypeHelpers.ts';
 
 export class LapisClient extends ZodiosWrapperClient<typeof lapisApi> {
@@ -53,7 +54,7 @@ export class LapisClient extends ZodiosWrapperClient<typeof lapisApi> {
         });
     }
 
-    public getSequenceEntryVersionDetailsTsv(accessionVersion: string) {
+    public getSequenceEntryVersionDetailsTsv(accessionVersion: string): Promise<Result<string, ProblemDetail>> {
         return this.call('details', {
             [this.schema.primaryKey]: accessionVersion,
             dataFormat: 'TSV',
@@ -164,5 +165,31 @@ export class LapisClient extends ZodiosWrapperClient<typeof lapisApi> {
             ),
         );
         return Result.combine(results);
+    }
+
+    public getSequenceFasta(accessionVersion: string): Promise<Result<string, ProblemDetail>> {
+        return this.getUnalignedSequences(accessionVersion);
+    }
+
+    public async getMultiSegmentSequenceFasta(
+        accessionVersion: string,
+        segmentNames: string[],
+    ): Promise<Result<string, ProblemDetail>> {
+        const segments = await this.getUnalignedSequencesMultiSegment(accessionVersion, segmentNames);
+        return segments.map((segmentFastas) =>
+            segmentFastas
+                .map((fasta, i) => {
+                    const parsed = parseFasta(fasta);
+                    if (parsed.length === 0) {
+                        return '';
+                    }
+                    const withSegmentSuffix = {
+                        name: `${parsed[0].name}_${segmentNames[i]}`,
+                        sequence: parsed[0].sequence,
+                    };
+                    return fastaEntryToString([withSegmentSuffix]);
+                })
+                .join(''),
+        );
     }
 }

--- a/website/src/services/lapisClient.ts
+++ b/website/src/services/lapisClient.ts
@@ -53,6 +53,13 @@ export class LapisClient extends ZodiosWrapperClient<typeof lapisApi> {
         });
     }
 
+    public getMetadataTsv(accessionVersion: string) {
+        return this.call('details', {
+            [this.schema.primaryKey]: accessionVersion,
+            dataFormat: 'tsv'
+        });
+    }
+
     public async getLatestAccessionVersion(accession: string): Promise<Result<AccessionVersion, ProblemDetail>> {
         const result = await this.call('details', {
             accession,

--- a/website/src/styles/base.scss
+++ b/website/src/styles/base.scss
@@ -45,6 +45,10 @@ a {
     @apply normal-case py-2 rounded-md font-semibold px-4 text-sm border-primary-600 border text-primary-600 bg-white
     hover:bg-primary-600 hover:text-white;
   }
+
+  .outlineButtonDropdownItem {
+    @apply text-primary-600 hover:text-primary-600 hover:bg-gray-100;
+  }
 }
 
 .loculusColor{

--- a/website/src/types/lapis.ts
+++ b/website/src/types/lapis.ts
@@ -111,4 +111,4 @@ export type SequenceEntryHistory = z.infer<typeof sequenceEntryHistory>;
 export enum FileType {
     TSV = 'tsv',
     FASTA = 'fa',
-};
+}

--- a/website/src/types/lapis.ts
+++ b/website/src/types/lapis.ts
@@ -107,3 +107,8 @@ export type SequenceEntryHistoryEntry = z.infer<typeof sequenceEntryHistoryEntry
 export const sequenceEntryHistory = z.array(sequenceEntryHistoryEntry);
 
 export type SequenceEntryHistory = z.infer<typeof sequenceEntryHistory>;
+
+export enum FileType {
+    TSV = 'tsv',
+    FASTA = 'fa',
+};

--- a/website/src/utils/createDownloadAPIRoute.ts
+++ b/website/src/utils/createDownloadAPIRoute.ts
@@ -1,10 +1,10 @@
 import type { APIRoute } from 'astro';
 import { err, type Result } from 'neverthrow';
 
-import { getConfiguredOrganisms } from '../../config';
-import { LapisClient } from '../../services/lapisClient';
-import { type ProblemDetail } from '../../types/backend';
-import { parseAccessionVersionFromString } from '../../utils/extractAccessionVersion';
+import { parseAccessionVersionFromString } from './extractAccessionVersion';
+import { getConfiguredOrganisms } from '../config';
+import { LapisClient } from '../services/lapisClient';
+import { type ProblemDetail } from '../types/backend';
 
 export type RedirectRoute = (
     accessionVersion:
@@ -104,6 +104,7 @@ const getSequenceDataWithOrganism = async (
 
     const dataResult: Result<string, ProblemDetail> = await getter(accessionVersion, organism);
 
+    // the result might be 'ok' but empty.
     if (dataResult.isOk()) {
         if (dataResult.value.trim().length === 0) {
             return err({

--- a/website/src/utils/shouldMiddlewareEnforceLogin.spec.ts
+++ b/website/src/utils/shouldMiddlewareEnforceLogin.spec.ts
@@ -25,7 +25,7 @@ describe('shouldMiddlewareEnforceLogin', () => {
         expectNoLogin(`/${testOrganism}/search`);
         expectNoLogin(`/`);
         expectNoLogin(`/${testOrganism}`);
-        expectNoLogin(routes.sequencesDetailsPage('id_002156'));
+        expectNoLogin(routes.sequenceEntryDetailsPage('id_002156'));
     });
 
     function expectForceLogin(path: string) {

--- a/website/tests/pages/sequences/accession.fa.spec.ts
+++ b/website/tests/pages/sequences/accession.fa.spec.ts
@@ -7,7 +7,7 @@ test.describe('The sequence.fa page', () => {
     test('can load and show fasta file', async () => {
         const testSequences = getTestSequences();
 
-        const url = `${baseUrl}${routes.sequencesFastaPage(testSequences.testSequenceEntry)}`;
+        const url = `${baseUrl}${routes.sequenceEntryFastaPage(testSequences.testSequenceEntry)}`;
         const response = await fetch(url);
         const content = await response.text();
         expect(content).toBe(
@@ -18,7 +18,7 @@ test.describe('The sequence.fa page', () => {
     test('can download fasta file', async () => {
         const testSequences = getTestSequences();
 
-        const downloadUrl = `${baseUrl}${routes.sequencesFastaPage(testSequences.testSequenceEntry, true)}`;
+        const downloadUrl = `${baseUrl}${routes.sequenceEntryFastaPage(testSequences.testSequenceEntry, true)}`;
         const response = await fetch(downloadUrl);
         const contentDisposition = response.headers.get('Content-Disposition');
 

--- a/website/tests/pages/sequences/accession.spec.ts
+++ b/website/tests/pages/sequences/accession.spec.ts
@@ -53,6 +53,6 @@ test.describe('The detailed sequence page', () => {
         await expect(linkToDeprecatedVersion).toBeVisible();
         await linkToDeprecatedVersion.click();
 
-        await sequencePage.page.waitForURL(baseUrl + routes.sequencesDetailsPage(deprecatedVersionString));
+        await sequencePage.page.waitForURL(baseUrl + routes.sequenceEntryDetailsPage(deprecatedVersionString));
     });
 });

--- a/website/tests/pages/sequences/sequences.page.ts
+++ b/website/tests/pages/sequences/sequences.page.ts
@@ -28,7 +28,7 @@ export class SequencePage {
     }
 
     public async goto(accessionVersion: AccessionVersion) {
-        await this.page.goto(`${baseUrl}${routes.sequencesDetailsPage(accessionVersion)}`);
+        await this.page.goto(`${baseUrl}${routes.sequenceEntryDetailsPage(accessionVersion)}`);
         await expect(this.page).toHaveTitle(new RegExp(`^${getAccessionVersionString(accessionVersion)}`));
     }
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #2019

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://feat-2019-download-indivi.loculus.org/ [Edited by Theo: fyi this gets truncated so you probably need to look it up in ArgoCD - ping on Slack if you don't have the credentials to access that]

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Turn the download button into a selection dropdown instead, where you can select to either download FASTA or a Metadata TSV.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->
<img width="340" alt="image" src="https://github.com/user-attachments/assets/d0a66892-2ba3-416f-8912-9ceadb101020">


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
