### PR TITLE
fix(website): exclude chromium-bidi from vite optimisation

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -18,7 +18,7 @@ export default defineConfig({
     },
     vite: {
         optimizeDeps: {
-            exclude: ['fsevents', 'msw/node', 'msw'],
+            exclude: ['fsevents', 'msw/node', 'msw', 'chromium-bidi'],
         },
         plugins: [Icons({ compiler: 'jsx', jsx: 'react' })],
     },


### PR DESCRIPTION
Resolves a bug when running `npm run dev`: https://github.com/microsoft/playwright/issues/33031