### PR TITLE
fix: prevent download button layout shifts

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/DowloadDialogButton.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DowloadDialogButton.tsx
@@ -1,0 +1,36 @@
+import type { FC } from 'react';
+
+import type { DownloadParameters } from './DownloadParameters';
+import { formatNumberWithDefaultLocale } from '../../../utils/formatNumber';
+
+type DownloadDialogButtonProps = {
+    onClick: () => void;
+    downloadParams: DownloadParameters;
+};
+
+/**
+ * The button that is displayed above the table and used to open the dialog.
+ * Also shows the number of selected entries, if a selection is made in the table.
+ */
+export const DownloadDialogButton: FC<DownloadDialogButtonProps> = ({ onClick, downloadParams }) => {
+    let buttonText = '';
+    let buttonWidthClass = ''; // fix the width so we don't get layout shifts with changing number of selected entries
+    switch (downloadParams.type) {
+        case 'filter':
+            buttonText = 'Download all entries';
+            buttonWidthClass = 'w-44';
+            break;
+        case 'select':
+            const sequenceCount = downloadParams.selectedSequences.size;
+            const formattedCount = formatNumberWithDefaultLocale(sequenceCount);
+            const entries = sequenceCount === 1 ? 'entry' : 'entries';
+            buttonText = `Download ${formattedCount} selected ${entries}`;
+            buttonWidthClass = 'w-[15rem]'; // this width is fine for up to two digit numbers
+            break;
+    }
+    return (
+        <button className={buttonWidthClass + ' outlineButton'} onClick={onClick}>
+            {buttonText}
+        </button>
+    );
+};

--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
@@ -2,31 +2,18 @@ import { Dialog, DialogPanel, DialogTitle } from '@headlessui/react';
 import { type FC, useState } from 'react';
 
 import { ActiveDownloadFilters } from './ActiveDownloadFilters.tsx';
+import { DownloadDialogButton } from './DowloadDialogButton.tsx';
 import { DownloadButton } from './DownloadButton.tsx';
 import { DownloadForm } from './DownloadForm.tsx';
 import type { DownloadParameters } from './DownloadParameters.tsx';
 import { type DownloadOption } from './generateDownloadUrl.ts';
 import { routes } from '../../../routes/routes.ts';
 import type { ReferenceGenomesSequenceNames } from '../../../types/referencesGenomes.ts';
-import { formatNumberWithDefaultLocale } from '../../../utils/formatNumber.tsx';
 
 type DownloadDialogProps = {
     downloadParams: DownloadParameters;
     referenceGenomesSequenceNames: ReferenceGenomesSequenceNames;
     lapisUrl: string;
-};
-
-const getDownloadButtonText = (downloadParams: DownloadParameters) => {
-    switch (downloadParams.type) {
-        case 'filter':
-            return 'Download all entries';
-        case 'select': {
-            const sequenceCount = downloadParams.selectedSequences.size;
-            const formattedCount = formatNumberWithDefaultLocale(sequenceCount);
-            const entries = sequenceCount === 1 ? 'entry' : 'entries';
-            return `Download ${formattedCount} selected ${entries}`;
-        }
-    }
 };
 
 export const DownloadDialog: FC<DownloadDialogProps> = ({
@@ -43,9 +30,7 @@ export const DownloadDialog: FC<DownloadDialogProps> = ({
 
     return (
         <>
-            <button className='outlineButton' onClick={openDialog}>
-                {getDownloadButtonText(downloadParams)}
-            </button>
+            <DownloadDialogButton downloadParams={downloadParams} onClick={openDialog} />
             <Dialog open={isOpen} onClose={closeDialog} className='relative z-40'>
                 <div className='fixed inset-0 bg-black bg-opacity-25' />
                 <div className='fixed inset-0 overflow-y-auto'>


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
The download button didn't have a fixed with, and so the width dependent on the amount of width of the characters inside. This PR fixes the width to a fixed value so the layout doesn't change anymore when the number of selected sequences changes.

### Screenshot
n/A

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
