### PR TITLE
feat!: Add substring search support for more fields

### DIFF
--- a/docs/src/content/docs/reference/helm-chart-config.mdx
+++ b/docs/src/content/docs/reference/helm-chart-config.mdx
@@ -568,6 +568,7 @@ Each organism object has the following fields:
             <td>
                 If true, search results will contain results that contain the given value as a substring.
                 If false (the default), only exact matches will be returned.
+                This only works for string fields, and you cannot also enable `autocomplete`.
             </td>
         </tr>
         <tr>

--- a/docs/src/content/docs/reference/helm-chart-config.mdx
+++ b/docs/src/content/docs/reference/helm-chart-config.mdx
@@ -562,6 +562,15 @@ Each organism object has the following fields:
             </td>
         </tr>
         <tr>
+            <td>`enableSubstringSearch`</td>
+            <td>Boolean</td>
+            <td></td>
+            <td>
+                If true, search results will contain results that contain the given value as a substring.
+                If false (the default), only exact matches will be returned.
+            </td>
+        </tr>
+        <tr>
             <td>`initiallyVisible`</td>
             <td>Boolean</td>
             <td></td>

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -24,7 +24,7 @@ fields:
     displayName: Submission ID
     type: string
     header: Submission details
-    enableRegex: true
+    enableSubstringSearch: true
   - name: isRevocation
     type: boolean
     notSearchable: true
@@ -183,8 +183,8 @@ organisms:
   {{- if .autocomplete }}
   autocomplete: {{ .autocomplete }}
   {{- end }}
-  {{- if .enableRegex }}
-  regexSearch: {{ .enableRegex }}
+  {{- if .enableSubstringSearch }}
+  substringSearch: {{ .enableSubstringSearch }}
   {{- end}}
   {{- if .notSearchable }}
   notSearchable: {{ .notSearchable }}

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -24,6 +24,7 @@ fields:
     displayName: Submission ID
     type: string
     header: Submission details
+    enableRegex: true
   - name: isRevocation
     type: boolean
     notSearchable: true
@@ -182,6 +183,9 @@ organisms:
   {{- if .autocomplete }}
   autocomplete: {{ .autocomplete }}
   {{- end }}
+  {{- if .enableRegex }}
+  regexSearch: {{ .enableRegex }}
+  {{- end}}
   {{- if .notSearchable }}
   notSearchable: {{ .notSearchable }}
   {{- end }}

--- a/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
+++ b/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
@@ -1,10 +1,11 @@
 {{- define "loculus.siloDatabaseShared" -}}
 {{- $type := default "string" .type -}}
+{{- $regexSearchable := list "authors" "authorAffiliations" "submissionId" "specimenCollectorSampleId" -}}
 - type: {{ ($type | eq "timestamp") | ternary "int" (($type | eq "authors") | ternary "string" $type) }}
   {{- if .generateIndex }}
   generateIndex: {{ .generateIndex }}
   {{- end }}
-  {{- if eq .type "authors" }}
+  {{- if (in $regexSearchable .name) }}
   lapisAllowsRegexSearch: true
   {{- end }}
 {{- end }}

--- a/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
+++ b/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
@@ -5,7 +5,7 @@
   {{- if .generateIndex }}
   generateIndex: {{ .generateIndex }}
   {{- end }}
-  {{- if (in $regexSearchable .name) }}
+  {{- if (eq .enableRegex true) }}
   lapisAllowsRegexSearch: true
   {{- end }}
 {{- end }}

--- a/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
+++ b/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
@@ -4,7 +4,7 @@
   {{- if .generateIndex }}
   generateIndex: {{ .generateIndex }}
   {{- end }}
-  {{- if (eq .enableRegex true) }}
+  {{- if .enableRegex }}
   lapisAllowsRegexSearch: true
   {{- end }}
 {{- end }}

--- a/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
+++ b/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
@@ -4,7 +4,7 @@
   {{- if .generateIndex }}
   generateIndex: {{ .generateIndex }}
   {{- end }}
-  {{- if .enableRegex }}
+  {{- if .enableSubstringSearch }}
   lapisAllowsRegexSearch: true
   {{- end }}
 {{- end }}

--- a/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
+++ b/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
@@ -1,6 +1,5 @@
 {{- define "loculus.siloDatabaseShared" -}}
 {{- $type := default "string" .type -}}
-{{- $regexSearchable := list "authors" "authorAffiliations" "submissionId" "specimenCollectorSampleId" -}}
 - type: {{ ($type | eq "timestamp") | ternary "int" (($type | eq "authors") | ternary "string" $type) }}
   {{- if .generateIndex }}
   generateIndex: {{ .generateIndex }}

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -451,12 +451,12 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Isolate name
         header: Sample details
         ingest: ncbiIsolateName
-        enableRegex: true
+        enableSubstringSearch: true
       - name: authors
         displayName: Authors
         type: authors
         header: Authors
-        enableRegex: true
+        enableSubstringSearch: true
         truncateColumnDisplayTo: 15
         ingest: ncbiSubmitterNames
         preprocessing:
@@ -467,7 +467,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Author affiliations
         generateIndex: true
         autocomplete: true
-        enableRegex: true
+        enableSubstringSearch: true
         truncateColumnDisplayTo: 15
         header: Authors
         ingest: ncbiSubmitterAffiliation

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -451,10 +451,12 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Isolate name
         header: Sample details
         ingest: ncbiIsolateName
+        enableRegex: true
       - name: authors
         displayName: Authors
         type: authors
         header: Authors
+        enableRegex: true
         truncateColumnDisplayTo: 15
         ingest: ncbiSubmitterNames
         preprocessing:
@@ -465,6 +467,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Author affiliations
         generateIndex: true
         autocomplete: true
+        enableRegex: true
         truncateColumnDisplayTo: 15
         header: Authors
         ingest: ncbiSubmitterAffiliation

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -465,8 +465,6 @@ defaultOrganismConfig: &defaultOrganismConfig
             authors: authors
       - name: authorAffiliations
         displayName: Author affiliations
-        generateIndex: true
-        autocomplete: true
         enableSubstringSearch: true
         truncateColumnDisplayTo: 15
         header: Authors

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -39,7 +39,7 @@ export const metadata = z.object({
     hideOnSequenceDetailsPage: z.boolean().optional(),
     header: z.string().optional(),
     rangeSearch: z.boolean().optional(),
-    regexSearch: z.boolean().optional(),
+    substringSearch: z.boolean().optional(),
 });
 
 export const inputField = z.object({

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -39,6 +39,7 @@ export const metadata = z.object({
     hideOnSequenceDetailsPage: z.boolean().optional(),
     header: z.string().optional(),
     rangeSearch: z.boolean().optional(),
+    regexSearch: z.boolean().optional(),
 });
 
 export const inputField = z.object({

--- a/website/src/utils/search.ts
+++ b/website/src/utils/search.ts
@@ -162,7 +162,7 @@ export const getLapisSearchParameters = (
         Object.entries(fieldValues).filter(([, value]) => value !== undefined && value !== ''),
     );
     for (const field of expandedSchema) {
-        if (field.type === 'authors' && sequenceFilters[field.name] !== undefined) {
+        if (field.regexSearch === true && sequenceFilters[field.name] !== undefined) {
             sequenceFilters[field.name.concat('.regex')] = makeCaseInsensitiveLiteralSubstringRegex(
                 sequenceFilters[field.name],
             );

--- a/website/src/utils/search.ts
+++ b/website/src/utils/search.ts
@@ -162,7 +162,7 @@ export const getLapisSearchParameters = (
         Object.entries(fieldValues).filter(([, value]) => value !== undefined && value !== ''),
     );
     for (const field of expandedSchema) {
-        if (field.regexSearch === true && sequenceFilters[field.name] !== undefined) {
+        if (field.substringSearch === true && sequenceFilters[field.name] !== undefined) {
             sequenceFilters[field.name.concat('.regex')] = makeCaseInsensitiveLiteralSubstringRegex(
                 sequenceFilters[field.name],
             );


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #2684 

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://feat-2684-substring-searc.loculus.org

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Add support for regex search for more fields, by making regex-searchability configurable in the Helm chart values.yaml.
Support is enabled for submissionId, authors, authorAffiliations, specimenCollectorSampleId

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->
TODO

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
