### PR TITLE
fix(backend): allow requests to last 10hr, instead of just 30s

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 server.port=8079
 server.max-http-request-header-size=20KB
+server.mvc.async.request-timeout=36000000 # Allow requests up to 10hr
 
 springdoc.default-produces-media-type=application/json
 springdoc.default-consumes-media-type=application/json
@@ -8,7 +9,6 @@ springdoc.swagger-ui.operationsSorter=alpha
 server.forward-headers-strategy=framework
 spring.servlet.multipart.max-file-size=5000MB
 spring.servlet.multipart.max-request-size=5000MB
-
 
 server.compression.enabled=true
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 server.port=8079
 server.max-http-request-header-size=20KB
-server.mvc.async.request-timeout=36000000 # Allow requests up to 10hr
+server.mvc.async.request-timeout=36000000
 
 springdoc.default-produces-media-type=application/json
 springdoc.default-consumes-media-type=application/json


### PR DESCRIPTION
see https://loculus.slack.com/archives/C05G172HL6L/p1729529276846749

https://fix-timeout.loculus.org

Fixes #3033
