### PR TITLE
Increase server timeout settings [generated by CoPilot workspace, may not work]

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -9,7 +9,6 @@ server.forward-headers-strategy=framework
 spring.servlet.multipart.max-file-size=5000MB
 spring.servlet.multipart.max-request-size=5000MB
 
-
 server.compression.enabled=true
 
 spring.datasource.driverClassName=org.postgresql.Driver
@@ -25,3 +24,7 @@ loculus.cleanup.task.reset-stale-in-processing-after-seconds=60
 loculus.cleanup.task.run-every-seconds=60
 loculus.stream.batch-size=1000
 loculus.debug-mode=false
+
+server.connection-timeout=60s
+server.servlet.session.timeout=60s
+spring.mvc.async.request-timeout=60000

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -25,6 +25,6 @@ loculus.cleanup.task.run-every-seconds=60
 loculus.stream.batch-size=1000
 loculus.debug-mode=false
 
-server.connection-timeout=60s
-server.servlet.session.timeout=60s
-spring.mvc.async.request-timeout=60000
+server.connection-timeout=6000s
+server.servlet.session.timeout=6000s
+spring.mvc.async.request-timeout=6000000


### PR DESCRIPTION
Fixes #3033

Increase server timeout settings in `application.properties` to allow more time for backend processing.

* Add `server.connection-timeout=60s` to set the maximum time the server will wait for a connection to be established.
* Add `server.servlet.session.timeout=60s` to set the maximum time the server will wait for a session to be active.
* Add `spring.mvc.async.request-timeout=60000` to set the maximum time the server will wait for an asynchronous request to complete.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/loculus-project/loculus/issues/3033?shareId=252fd9f6-7fce-4e34-8e29-ed5ad7869bff).