### PR TITLE
chore(ci): split gradle dependabot updates into patch and minor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,10 +35,17 @@ updates:
     schedule:
       interval: weekly
     groups:
-      minorAndPatch:
+  - package-ecosystem: gradle
+    directory: backend/
+    schedule:
+      interval: weekly
+    groups:
+      minor:
         update-types:
           - "minor"
-          - "patch"
+      patch:
+        update-types:
+          - "patch"      
   - package-ecosystem: npm
     directory: keycloak/keycloakify
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,11 +35,6 @@ updates:
     schedule:
       interval: weekly
     groups:
-  - package-ecosystem: gradle
-    directory: backend/
-    schedule:
-      interval: weekly
-    groups:
       minor:
         update-types:
           - "minor"


### PR DESCRIPTION
Since we now sometimes get CI failure, easier to have things less grouped
