### PR TITLE
fix: add seqset version to row key to make key unique

### DIFF
--- a/website/src/components/SeqSetCitations/SeqSetList.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetList.tsx
@@ -174,7 +174,7 @@ export const SeqSetList: FC<SeqSetListProps> = ({ seqSets }) => {
                                 id={labelId}
                                 className='hover:bg-primary-100 border-gray-100 cursor-pointer'
                                 onClick={(event) => handleClick(event, row.seqSetId, row.seqSetVersion.toString())}
-                                key={row.seqSetId}
+                                key={`${row.seqSetId}.${row.seqSetVersion}`}
                                 data-testid={isClient ? row.name : 'disabled'}
                             >
                                 <td className='px-2 whitespace-nowrap text-primary-900 pl-6'>


### PR DESCRIPTION
### Summary
When creating a seqset and then editing it, the same seqset ID will come up twice in the seqset table. The key property should be unique.

This PR adds the version to the key to make it unique, thus fixing the error.

### Screenshot of error msg
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/15c41800-5373-4213-ae4d-43626e7be1ba">


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
