### PR TITLE
fix(backend): get rid of logger config deprecation warnings in the log

### DIFF
--- a/backend/src/main/resources/logback.xml
+++ b/backend/src/main/resources/logback.xml
@@ -3,9 +3,9 @@
     <property name="PATTERN" value="%date %level [%thread] [%X{organism}] - %class: %message%n"/>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <layout class="ch.qos.logback.classic.PatternLayout">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <Pattern>${PATTERN}</Pattern>
-        </layout>
+        </encoder>
     </appender>
 
     <root level="info">

--- a/backend/src/test/resources/logback-test.xml
+++ b/backend/src/test/resources/logback-test.xml
@@ -1,8 +1,8 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <layout class="ch.qos.logback.classic.PatternLayout">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <Pattern>%date %level [%thread] [%X{organism}] - %class: %message%n</Pattern>
-        </layout>
+        </encoder>
     </appender>
 
     <root level="info">


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

See https://github.com/GenSpectrum/LAPIS/pull/996
We had the same issue here
https://logback.qos.ch/codes.html#layoutInsteadOfEncoder

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
