### PR TITLE
feat(kubernetes): make public runtime config urls of the website configurable

### DIFF
--- a/kubernetes/loculus/templates/_lapis-urls.tpl
+++ b/kubernetes/loculus/templates/_lapis-urls.tpl
@@ -7,9 +7,9 @@
 
 {{/* generates external LAPIS urls from { config, host } */}}
 {{ define "loculus.generateExternalLapisUrls"}}
-{{ $host := .host }}
+{{ $lapisUrlTemplate := .lapisUrlTemplate }}
 {{ range $key, $_ := (.config.organisms | default .config.defaultOrganisms) }}
-"{{ $key -}}": "{{ $host }}/{{ $key }}"
+"{{ $key -}}": "{{ $lapisUrlTemplate | replace "%organism%" $key }}"
 {{ end }}
 {{ end }}
 

--- a/kubernetes/loculus/templates/loculus-website-config.yaml
+++ b/kubernetes/loculus/templates/loculus-website-config.yaml
@@ -1,14 +1,3 @@
-{{- $lapisHost := "" }}
-{{- if .Values.codespaceName }}
-  {{- $lapisHost = printf "https://%s-8080.app.github.dev" .Values.codespaceName }}
-{{- else if eq $.Values.environment "server" }}
-  {{- $lapisHost = printf "https://lapis%s%s" .Values.subdomainSeparator .Values.host }}
-{{- else }}
-  {{- $lapisHost = "http://localhost:8080" }}
-{{- end }}
-{{- $externalLapisUrlConfig := dict "host" $lapisHost "config" $.Values }}
-
-
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -23,7 +12,7 @@ data:
         "insecureCookies": {{ $.Values.insecureCookies }},
         "serverSide": {
             {{- if .Values.usePublicRuntimeConfigAsServerSide }}
-            {{- template "loculus.publicRuntimeConfig" dict "Values" .Values "externalLapisUrlConfig" $externalLapisUrlConfig -}}
+            {{- template "loculus.publicRuntimeConfig" . -}}
             {{- else }}
             {{ if $.Values.disableBackend -}}
             "backendUrl": "http://localhost:8079",
@@ -35,7 +24,7 @@ data:
             {{- end }}
         },
         "public": {
-          {{- template "loculus.publicRuntimeConfig" dict "Values" .Values "externalLapisUrlConfig" $externalLapisUrlConfig -}}
+          {{- template "loculus.publicRuntimeConfig" . -}}
         },
         "backendKeycloakClientSecret" : "[[backendKeycloakClientSecret]]"
     }


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://makewebsitepublicurlsconf.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

For GenSpectrum, we need to be able to set the public URLs of the services that the website accesses. Actually this is a generalized case of the "codespaceName" feature, so my approach was to pull out the `$.Values.codespaceName` parameter from the Helm chart into `deploy.py`. The website URLs can be set in values.yaml via
```
website:
  runtetimeConfig:
    public:
      backendUrl: ...
      # where %organism% is a placeholder for the organisms in the config
      lapisUrlTemplate: https://%organism%.my.lapis.org 
      keycloakUrl: ...
```

This is the first step. In a second I will need to do something similar for Keycloak: #3071.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
