### PR TITLE
feat(config, prepro): Add dummy check_authors function so that prepro v1 can still run while prepro v2 is being rolled out

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -452,6 +452,10 @@ defaultOrganismConfig: &defaultOrganismConfig
         header: Authors
         truncateColumnDisplayTo: 15
         ingest: ncbiSubmitterNames
+        preprocessing:
+          function: check_authors
+          inputs:
+            authors: authors
       - name: authorAffiliations
         displayName: Author affiliations
         generateIndex: true

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -54,13 +54,17 @@ class ProcessingFunctions:
         input_data: InputMetadata,
         output_field: str,
     ) -> ProcessingResult:
-        if not hasattr(cls, function_name):
+        func = None
+        if function_name == "check_authors":
+            func = cls.identity
+        if not func and not hasattr(cls, function_name):
             msg = (
                 f"CRITICAL: No processing function matches: {function_name}."
                 "This is a configuration error."
             )
             raise ValueError(msg)
-        func = getattr(cls, function_name)
+        if not func:
+            func = getattr(cls, function_name)
         try:
             result = func(input_data, output_field, args=args)
         except Exception as e:

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -57,6 +57,7 @@ class ProcessingFunctions:
         func = None
         if function_name == "check_authors":
             func = cls.identity
+            input_data["input"] = input_data["authors"]
         if not func and not hasattr(cls, function_name):
             msg = (
                 f"CRITICAL: No processing function matches: {function_name}."


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://adddummycheckauthorsfunc.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
See my comment here: https://github.com/pathoplexus/pathoplexus/pull/251/files#r1814729123

This makes calls to the `check_authors` function default to the identity function - which is our current set up.

While updating from prepro pipeline v1 to v2 if anyone submits sequences they will receive an unexpected error (that the `format_authors` function does not exist), adding this will make the prepro v1 backwards compatible - e.g. we will be able to continue to run it while updating to v2 and if we need to go back to v1 we will be able to rollback without prepro breaking due to an "unknown function" warning. 

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
