### PR TITLE
Make keycloak configurable

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -406,12 +406,11 @@ def get_codespace_params(codespace_name):
     publicRuntimeConfig = {
         "backendUrl": f"https://{codespace_name}-8079.app.github.dev",
         "lapisUrlTemplate": f"https://{codespace_name}-8080.app.github.dev/%organism%",
+        "keycloakUrl": f"https://{codespace_name}-8083.app.github.dev",
     }
     return [
         "--set-json",
-        f'website.runtimeConfig.public={json.dumps(publicRuntimeConfig)}',
-        "--set",
-        f"codespaceName={codespace_name}",
+        f"website.runtimeConfig.public={json.dumps(publicRuntimeConfig)}",
     ]
 
 

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -355,11 +355,7 @@ fields:
             "backendUrl": "http://localhost:8079",
             {{- end }}
             "lapisUrls": {{- include "loculus.generateExternalLapisUrls" $externalLapisUrlConfig | fromYaml | toJson }},
-            {{- if $publicRuntimeConfig.keycloakUrl }}
-            "keycloakUrl":  "{{ $publicRuntimeConfig.keycloakUrl }}"
-            {{- else }}
-            "keycloakUrl":  "https://{{ (printf "authentication%s%s" $.Values.subdomainSeparator $.Values.host) }}"
-            {{- end }}
+            "keycloakUrl":  "{{ include "loculus.keycloakUrl" . }}"
 {{- end }}
 
 

--- a/kubernetes/loculus/templates/_keyclaok-url.tpl
+++ b/kubernetes/loculus/templates/_keyclaok-url.tpl
@@ -1,0 +1,10 @@
+{{- define "loculus.keycloakUrl" -}}
+{{- $publicRuntimeConfig := (($.Values.website).runtimeConfig).public }}
+  {{- if $publicRuntimeConfig.keycloakUrl }}
+    {{- $publicRuntimeConfig.keycloakUrl -}}
+  {{- else if eq $.Values.environment "server" -}}
+    {{- (printf "https://authentication%s%s" $.Values.subdomainSeparator $.Values.host) -}}
+  {{- else -}}
+    {{- "http://localhost:8083" -}}
+  {{- end -}}
+{{- end -}}

--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -11,6 +11,7 @@ data:
       "enabled": true,
       "verifyEmail": {{$.Values.auth.verifyEmail}},
       "resetPasswordAllowed": {{$.Values.auth.resetPasswordAllowed}},
+      {{- if $.Values.auth.verifyEmail }}
       "smtpServer": {
         "host": "{{$.Values.auth.smtp.host}}",
         "port": "{{$.Values.auth.smtp.port}}",
@@ -25,7 +26,8 @@ data:
         "user": "{{$.Values.auth.smtp.user}}",
         "password": "[[smtpPassword]]"
       },
-      "registrationAllowed": true,
+      {{- end }}
+      "registrationAllowed": {{ $.Values.auth.registrationAllowed }},
       "accessTokenLifespan": 36000,
       "ssoSessionIdleTimeout": 36000,
       "actionTokenGeneratedByUserLifespan": 1800,
@@ -113,7 +115,7 @@ data:
                 "manage-account"
               ]
             }
-          }, 
+          },
         {{ end }}
           {
             "username": "insdc_ingest_user",
@@ -309,14 +311,8 @@ data:
         }
       ],
       "attributes": {
-        {{- if eq $.Values.environment "server" }}
-        "frontendUrl": "https://{{ $keycloakHost }}"
-        {{- else if .Values.codespaceName }}
-        "frontendUrl": "https://{{ .Values.codespaceName }}-8083.app.github.dev"
-        {{- else }}
-        "frontendUrl": "http://localhost:8083"
-        {{- end }}
-         , "userProfileEnabled" : "true"
+        "frontendUrl": "{{ include "loculus.keycloakUrl" . }}",
+        "userProfileEnabled" : "true"
       },
       "components": {
         "org.keycloak.userprofile.UserProfileProvider" : [
@@ -332,6 +328,8 @@ data:
       "loginTheme": "loculus",
       "emailTheme": "loculus",
       "identityProviders" : [
+        {{- range $key, $value := .Values.auth.identityProviders }}
+        {{- if eq $key "orcid" }}
         {
           "alias" : "orcid",
           "providerId" : "orcid",
@@ -345,11 +343,15 @@ data:
           "firstBrokerLoginFlowAlias" : "first broker login",
           "config" : {
             "clientSecret" : "[[orcidSecret]]",
-            "clientId" : "APP-P1P7N7T9YVBHQ4EH"
+            "clientId" : "{{ $value.clientId }}"
           }
         }
+        {{- end }}
+        {{- end }}
       ],
       "identityProviderMappers" : [
+        {{- range $key, $_ := .Values.auth.identityProviders }}
+        {{- if eq $key "orcid" }}
         {
           "name" : "username mapper",
           "identityProviderAlias" : "orcid",
@@ -369,5 +371,7 @@ data:
             "userAttribute" : "orcid.path"
           }
         }
+        {{- end }}
+        {{- end }}
       ]
     }

--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -295,14 +295,15 @@ data:
           "authenticationFlowBindingOverrides" : { },
           "fullScopeAllowed" : false,
           "nodeReRegistrationTimeout" : 0,
-          "protocolMappers" : [ {
-           
-            "name" : "audience resolve",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-audience-resolve-mapper",
-            "consentRequired" : false,
-            "config" : { }
-          } ],
+          "protocolMappers" : [
+            {
+              "name" : "audience resolve",
+              "protocol" : "openid-connect",
+              "protocolMapper" : "oidc-audience-resolve-mapper",
+              "consentRequired" : false,
+              "config" : { }
+            }
+          ],
           "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
           "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
         }
@@ -318,48 +319,55 @@ data:
          , "userProfileEnabled" : "true"
       },
       "components": {
-        "org.keycloak.userprofile.UserProfileProvider" : [ {
-          "providerId" : "declarative-user-profile",
-          "subComponents" : { },
-          "config" : {
-            "kc.user.profile.config" : [ "{\"attributes\":[{\"name\":\"username\",\"displayName\":\"${username}\",\"validations\":{\"length\":{\"min\":3,\"max\":255},\"username-prohibited-characters\":{},\"up-username-not-idn-homograph\":{}},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]}},{\"name\":\"email\",\"displayName\":\"${email}\",\"validations\":{\"email\":{},\"length\":{\"max\":255}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]}},{\"name\":\"firstName\",\"displayName\":\"${firstName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]}},{\"name\":\"lastName\",\"displayName\":\"${lastName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]}},{\"name\":\"university\",\"displayName\":\"University / Organisation\",\"validations\":{},\"annotations\":{},\"required\":{\"roles\":[\"admin\",\"user\"]},\"permissions\":{\"view\":[],\"edit\":[\"admin\",\"user\"]}},{\"name\":\"orcid\",\"displayName\":\"\",\"permissions\":{\"edit\":[\"admin\"],\"view\":[\"admin\",\"user\"]},\"annotations\":{},\"validations\":{}}],\"groups\":[]}" ]
-           }
-        } ]
+        "org.keycloak.userprofile.UserProfileProvider" : [
+          {
+            "providerId" : "declarative-user-profile",
+            "subComponents" : { },
+            "config" : {
+              "kc.user.profile.config" : [ "{\"attributes\":[{\"name\":\"username\",\"displayName\":\"${username}\",\"validations\":{\"length\":{\"min\":3,\"max\":255},\"username-prohibited-characters\":{},\"up-username-not-idn-homograph\":{}},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]}},{\"name\":\"email\",\"displayName\":\"${email}\",\"validations\":{\"email\":{},\"length\":{\"max\":255}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]}},{\"name\":\"firstName\",\"displayName\":\"${firstName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]}},{\"name\":\"lastName\",\"displayName\":\"${lastName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]}},{\"name\":\"university\",\"displayName\":\"University / Organisation\",\"validations\":{},\"annotations\":{},\"required\":{\"roles\":[\"admin\",\"user\"]},\"permissions\":{\"view\":[],\"edit\":[\"admin\",\"user\"]}},{\"name\":\"orcid\",\"displayName\":\"\",\"permissions\":{\"edit\":[\"admin\"],\"view\":[\"admin\",\"user\"]},\"annotations\":{},\"validations\":{}}],\"groups\":[]}" ]
+             }
+          }
+        ]
       },
       "loginTheme": "loculus",
       "emailTheme": "loculus",
-        "identityProviders" : [ {
-        "alias" : "orcid",
-        "providerId" : "orcid",
-        "enabled" : true,
-        "updateProfileFirstLoginMode" : "on",
-        "trustEmail" : false,
-        "storeToken" : false,
-        "addReadTokenRoleOnCreate" : false,
-        "authenticateByDefault" : false,
-        "linkOnly" : false,
-        "firstBrokerLoginFlowAlias" : "first broker login",
-        "config" : {
-          "clientSecret" : "[[orcidSecret]]",
-          "clientId" : "APP-P1P7N7T9YVBHQ4EH"
+      "identityProviders" : [
+        {
+          "alias" : "orcid",
+          "providerId" : "orcid",
+          "enabled" : true,
+          "updateProfileFirstLoginMode" : "on",
+          "trustEmail" : false,
+          "storeToken" : false,
+          "addReadTokenRoleOnCreate" : false,
+          "authenticateByDefault" : false,
+          "linkOnly" : false,
+          "firstBrokerLoginFlowAlias" : "first broker login",
+          "config" : {
+            "clientSecret" : "[[orcidSecret]]",
+            "clientId" : "APP-P1P7N7T9YVBHQ4EH"
+          }
         }
-      } ],
-    "identityProviderMappers" : [ {
-    "name" : "username mapper",
-    "identityProviderAlias" : "orcid",
-    "identityProviderMapper" : "hardcoded-attribute-idp-mapper",
-    "config" : {
-      "syncMode" : "IMPORT",
-      "attribute" : "username"
-    }
-    },{
-      "name" : "orcid",
-      "identityProviderAlias" : "orcid",
-      "identityProviderMapper" : "orcid-user-attribute-mapper",
-      "config" : {
-        "syncMode" : "INHERIT",
-        "jsonField" : "orcid-identifier",
-        "userAttribute" : "orcid.path"
-      }
-    } ]
+      ],
+      "identityProviderMappers" : [
+        {
+          "name" : "username mapper",
+          "identityProviderAlias" : "orcid",
+          "identityProviderMapper" : "hardcoded-attribute-idp-mapper",
+          "config" : {
+            "syncMode" : "IMPORT",
+            "attribute" : "username"
+          }
+        },
+        {
+          "name" : "orcid",
+          "identityProviderAlias" : "orcid",
+          "identityProviderMapper" : "orcid-user-attribute-mapper",
+          "config" : {
+            "syncMode" : "INHERIT",
+            "jsonField" : "orcid-identifier",
+            "userAttribute" : "orcid.path"
+          }
+        }
+      ]
     }

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -1,14 +1,4 @@
-{{- define "keycloakUrl" -}}
-  {{- if eq $.Values.environment "server" -}}
-    {{- (printf "https://authentication%s%s" $.Values.subdomainSeparator $.Values.host) -}}
-  {{- else if .Values.codespaceName -}}
-    {{- printf "https://%s-8083.app.github.dev" .Values.codespaceName -}}
-  {{- else -}}
-    {{- "http://localhost:8083" -}}
-  {{- end -}}
-{{- end -}}
 ---
-
 {{- $dockerTag := include "loculus.dockerTag" .Values }}
 apiVersion: apps/v1
 kind: Deployment
@@ -93,9 +83,9 @@ spec:
             - name: KC_HEALTH_ENABLED
               value: "true"
             - name: KC_HOSTNAME_URL
-              value: "{{ include "keycloakUrl" . }}"
+              value: "{{ include "loculus.keycloakUrl" . }}"
             - name: KC_HOSTNAME_ADMIN_URL
-              value: "{{ include "keycloakUrl" . }}"
+              value: "{{ include "loculus.keycloakUrl" . }}"
             - name: KC_FEATURES
               value: "declarative-user-profile"
             # see https://github.com/keycloak/keycloak/blob/77b58275ca06d1cbe430c51db74479a7e1b409b5/quarkus/dist/src/main/content/bin/kc.sh#L95-L150

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1451,6 +1451,10 @@ auth:
     envelopeFrom: "noreply@loculus.org"
   verifyEmail: true
   resetPasswordAllowed: true
+  registrationAllowed: true
+  identityProviders:
+    orcid:
+      clientId: "APP-P1P7N7T9YVBHQ4EH"
 insecureCookies: false
 bannerMessage: "This is a demonstration environment. It may contain non-accurate test data and should not be used for real-world applications. Data will be deleted regularly."
 additionalHeadHTML: '<script defer data-domain="loculus.org" src="https://plausible.io/js/script.js"></script>'


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://makekeycloakconfigurable.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

This is a follow up to https://github.com/loculus-project/loculus/pull/3063.
* Fully removes `Values.codespaceName`. Instead, everything is configured in `./deploy.py` (for codespaces).
* We also need to be able to configure the frontend url of Keycloak.
* Also we don't want that anyone can register (or login via 3rd party providers).

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
