### PR TITLE
fix(prepro): correctly handle empty ndjson response

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/backend.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/backend.py
@@ -70,6 +70,8 @@ def get_jwt(config: Config) -> str:
 
 def parse_ndjson(ndjson_data: str) -> Sequence[UnprocessedEntry]:
     entries = []
+    if len(ndjson_data) == 0:
+        return entries
     for json_str in ndjson_data.split("\n"):
         if len(json_str) == 0:
             continue

--- a/preprocessing/nextclade/src/loculus_preprocessing/backend.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/backend.py
@@ -70,10 +70,8 @@ def get_jwt(config: Config) -> str:
 
 def parse_ndjson(ndjson_data: str) -> Sequence[UnprocessedEntry]:
     entries = []
-    if len(ndjson_data) == 0:
-        return entries
     for json_str in ndjson_data.split("\n"):
-        if len(json_str) == 0:
+        if len(json_str) == 0 or json_str.isspace():
             continue
         # Loculus currently cannot handle non-breaking spaces.
         json_str_processed = json_str.replace("\N{NO-BREAK SPACE}", " ")


### PR DESCRIPTION
Avoids this error when no data available:

```
DEBUG:urllib3.connectionpool:http://loculus-backend-service:8079 "POST /cchf/extract-unprocessed-data HTTP/11" 200 610
DEBUG:charset_normalizer:Encoding detection: ascii is most likely the one.
Traceback (most recent call last):
  File "/opt/conda/bin/prepro", line 8, in <module>
    sys.exit(cli_entry())
             ^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/loculus_preprocessing/__main__.py", line 16, in cli_entry
    run(config)
  File "/opt/conda/lib/python3.12/site-packages/loculus_preprocessing/prepro.py", line 748, in run
    etag, unprocessed = fetch_unprocessed_sequences(etag, config)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/loculus_preprocessing/backend.py", line 110, in fetch_unprocessed_sequences
    return response.headers["ETag"], parse_ndjson(response.text)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/loculus_preprocessing/backend.py", line 78, in parse_ndjson
    json_object = json.loads(json_str_processed)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```