### PR TITLE
feat(ci, ingest, prepro): Allow custom nextclade datasets

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -27,6 +27,20 @@ FILTER_FASTA_HEADERS = config.get("filter_fasta_headers", None)
 APPROVE_TIMEOUT_MIN = config.get("approve_timeout_min")  # time in minutes
 CHECK_ENA_DEPOSITION = config.get("check_ena_deposition", False)
 
+dataset_server_map = {}
+dataset_name_map = {}
+
+if SEGMENTED:
+    for segment in config["nucleotide_sequences"]:
+        if config.get("nextclade_dataset_server_map") and segment in config["nextclade_dataset_server_map"]:
+            dataset_server_map[segment] = config["nextclade_dataset_server_map"][segment]
+        else:
+            dataset_server_map[segment] = config.get("nextclade_dataset_server")
+        if config.get("nextclade_dataset_name_map") and segment in config["nextclade_dataset_name_map"]:
+            dataset_name_map[segment] = config["nextclade_dataset_name_map"][segment]
+        else:
+            dataset_name_map[segment] = config.get("nextclade_dataset_name") + "/" + segment
+
 if os.uname().sysname == "Darwin":
     # Don't use conda-forge unzip on macOS
     # Due to https://github.com/conda-forge/unzip-feedstock/issues/16
@@ -197,10 +211,8 @@ rule align:
     output:
         results="results/nextclade_{segment}.tsv",
     params:
-        dataset_server=config.get("nextclade_dataset_server"),
-        dataset_name=lambda w: config.get("nextclade_dataset_name", "")
-        + "/"
-        + w.segment,
+        dataset_server=lambda w: dataset_server_map[w.segment],
+        dataset_name=lambda w: dataset_name_map[w.segment],
     shell:
         """
         nextclade run \

--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -13,7 +13,7 @@ for key, value in defaults.items():
 
 config["slack_hook"] = os.getenv("SLACK_HOOK")
 # Infer whether nucleotide sequences are segmented
-config["segmented"] = len(config["nucleotideSequences"]) > 1
+config["segmented"] = len(config["nucleotide_sequences"]) > 1
 
 Path("results").mkdir(parents=True, exist_ok=True)
 with open("results/config.yaml", "w") as f:
@@ -31,7 +31,7 @@ dataset_server_map = {}
 dataset_name_map = {}
 
 if SEGMENTED:
-    for segment in config["nucleotideSequences"]:
+    for segment in config["nucleotide_sequences"]:
         if config.get("nextclade_dataset_server_map") and segment in config["nextclade_dataset_server_map"]:
             dataset_server_map[segment] = config["nextclade_dataset_server_map"][segment]
         else:
@@ -227,7 +227,7 @@ rule process_alignments:
     input:
         results=expand(
             "results/nextclade_{segment}.tsv",
-            segment=config["nucleotideSequences"],
+            segment=config["nucleotide_sequences"],
         ),
     output:
         merged="results/nextclade_merged.tsv",
@@ -238,7 +238,7 @@ rule process_alignments:
         segment_paths=" ".join(
             [
                 f"-f {segment}=results/nextclade_{segment}.tsv"
-                for segment in config["nucleotideSequences"]
+                for segment in config["nucleotide_sequences"]
             ]
         ),
     shell:

--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -13,7 +13,7 @@ for key, value in defaults.items():
 
 config["slack_hook"] = os.getenv("SLACK_HOOK")
 # Infer whether nucleotide sequences are segmented
-config["segmented"] = len(config["nucleotide_sequences"]) > 1
+config["segmented"] = len(config["nucleotideSequences"]) > 1
 
 Path("results").mkdir(parents=True, exist_ok=True)
 with open("results/config.yaml", "w") as f:
@@ -31,7 +31,7 @@ dataset_server_map = {}
 dataset_name_map = {}
 
 if SEGMENTED:
-    for segment in config["nucleotide_sequences"]:
+    for segment in config["nucleotideSequences"]:
         if config.get("nextclade_dataset_server_map") and segment in config["nextclade_dataset_server_map"]:
             dataset_server_map[segment] = config["nextclade_dataset_server_map"][segment]
         else:
@@ -227,7 +227,7 @@ rule process_alignments:
     input:
         results=expand(
             "results/nextclade_{segment}.tsv",
-            segment=config["nucleotide_sequences"],
+            segment=config["nucleotideSequences"],
         ),
     output:
         merged="results/nextclade_merged.tsv",
@@ -238,7 +238,7 @@ rule process_alignments:
         segment_paths=" ".join(
             [
                 f"-f {segment}=results/nextclade_{segment}.tsv"
-                for segment in config["nucleotide_sequences"]
+                for segment in config["nucleotideSequences"]
             ]
         ),
     shell:

--- a/ingest/config/defaults.yaml
+++ b/ingest/config/defaults.yaml
@@ -1,6 +1,6 @@
 # Values here are defaults for the `config` variable in the Snakefile
 # Purpose is to keep the `values.yaml` config file clean
-nucleotideSequences: ["main"]
+nucleotide_sequences: ["main"]
 post_start_sleep: 0
 log_level: DEBUG
 compound_country_field: ncbiGeoLocation

--- a/ingest/config/defaults.yaml
+++ b/ingest/config/defaults.yaml
@@ -1,6 +1,6 @@
 # Values here are defaults for the `config` variable in the Snakefile
 # Purpose is to keep the `values.yaml` config file clean
-nucleotide_sequences: ["main"]
+nucleotideSequences: ["main"]
 post_start_sleep: 0
 log_level: DEBUG
 compound_country_field: ncbiGeoLocation

--- a/kubernetes/loculus/templates/ingest-config.yaml
+++ b/kubernetes/loculus/templates/ingest-config.yaml
@@ -14,7 +14,7 @@ metadata:
 data:
   config.yaml: |
     {{- $values.ingest.configFile | toYaml | nindent 4 }}
-    nucleotideSequences: {{- $nucleotideSequencesList | toYaml | nindent 4 }}
+    nucleotide_sequences: {{- $nucleotideSequencesList | toYaml | nindent 4 }}
     verify_loculus_version_is: {{$dockerTag}}
     check_ena_deposition: {{ not $.Values.disableEnaSubmission }}
     organism: {{ $key }}

--- a/kubernetes/loculus/templates/ingest-config.yaml
+++ b/kubernetes/loculus/templates/ingest-config.yaml
@@ -5,6 +5,7 @@
 {{- range $key, $values := (.Values.organisms | default .Values.defaultOrganisms) }}
 {{- if $values.ingest }}
 {{- $metadata := (include "loculus.patchMetadataSchema" $values.schema | fromYaml).metadata }}
+{{- $nucleotideSequencesList := (include "loculus.patchMetadataSchema" $values.schema | fromYaml).nucleotideSequences | default (list "main")}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -13,6 +14,7 @@ metadata:
 data:
   config.yaml: |
     {{- $values.ingest.configFile | toYaml | nindent 4 }}
+    nucleotideSequences: {{- $nucleotideSequencesList | toYaml | nindent 4 }}
     verify_loculus_version_is: {{$dockerTag}}
     check_ena_deposition: {{ not $.Values.disableEnaSubmission }}
     organism: {{ $key }}

--- a/kubernetes/loculus/templates/loculus-preprocessing-config.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-config.yaml
@@ -1,6 +1,7 @@
 {{- range $organism, $organismConfig := (.Values.organisms | default .Values.defaultOrganisms) }}
 {{- $metadata := ($organismConfig.schema | include "loculus.patchMetadataSchema" | fromYaml).metadata }}
 {{- $nucleotideSequences := (($organismConfig.schema | include "loculus.patchMetadataSchema" | fromYaml).nucleotideSequences | default "" ) }}
+{{- $nucleotideSequencesList := ($organismConfig.schema | include "loculus.patchMetadataSchema" | fromYaml).nucleotideSequences | default (list "main")}}
 {{- range $processingIndex, $processingConfig := $organismConfig.preprocessing }}
 {{- if $processingConfig.configFile }}
 ---
@@ -12,6 +13,7 @@ data:
   preprocessing-config.yaml: |
     organism: {{ $organism }}
     {{- $processingConfig.configFile | toYaml | nindent 4 }}
+    nucleotideSequences: {{- $nucleotideSequencesList | toYaml | nindent 4 }}
     processing_spec:
       {{- $args := dict "metadata" $metadata "nucleotideSequences" $nucleotideSequences }}
       {{- include "loculus.preprocessingSpecs" $args | nindent 6 }}

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1405,17 +1405,12 @@ defaultOrganisms:
           log_level: DEBUG
           nextclade_dataset_name: nextstrain/cchfv/linked
           nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/cornelius-cchfv/data_output
-          nucleotideSequences: [L, M, S]
           genes: [RdRp, GPC, NP]
     ingest:
       <<: *ingest
       configFile:
         <<: *ingestConfigFile
         taxon_id: 3052518
-        nucleotide_sequences:
-          - L
-          - M
-          - S
         nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/cornelius-cchfv/data_output
         nextclade_dataset_name: nextstrain/cchfv/linked
     enaDeposition:

--- a/preprocessing/nextclade/README.md
+++ b/preprocessing/nextclade/README.md
@@ -75,7 +75,7 @@ When deployed on kubernetes the preprocessing pipeline reads in config files whi
 and use this in the pipeline as follows:
 
 ```sh
-prepro --config-file=../../temp/preprocessing-config.{organism}.yaml --keep-tmp-dir
+prepro --config-file=../../website/tests/config/preprocessing-config.{organism}.yaml --keep-tmp-dir
 ```
 
 Additionally, the `--keep-tmp-dir` is useful for debugging issues. The results of nextclade run will be stored in the temp directory, as well as a file called `submission_requests.json` which contains a log of the full submit requests that are sent to the backend.

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -24,8 +24,10 @@ class Config:
     keycloak_password: str = "preprocessing_pipeline"
     keycloak_token_path: str = "realms/loculus/protocol/openid-connect/token"
     nextclade_dataset_name: str | None = None
+    nextclade_dataset_name_map: dict[str, str] | None = None
     nextclade_dataset_tag: str | None = None
     nextclade_dataset_server: str = "https://data.clades.nextstrain.org/v3"
+    nextclade_dataset_server_map: dict[str, str] | None = None
     config_file: str | None = None
     log_level: str = "DEBUG"
     genes: list[str] = dataclasses.field(default_factory=list)

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -710,18 +710,26 @@ def process_all(
 
 def download_nextclade_dataset(dataset_dir: str, config: Config) -> None:
     for segment in config.nucleotideSequences:
-        nextclade_dataset_name = (
-            config.nextclade_dataset_name
-            if segment == "main"
-            else config.nextclade_dataset_name + "/" + segment
-        )
+        if config.nextclade_dataset_name_map and segment in config.nextclade_dataset_name_map:
+            nextclade_dataset_name = config.nextclade_dataset_name_map[segment]
+        else:
+            nextclade_dataset_name = (
+                config.nextclade_dataset_name
+                if segment == "main"
+                else config.nextclade_dataset_name + "/" + segment
+            )
+
+        nextclade_dataset_server = config.nextclade_dataset_server
+        if config.nextclade_dataset_server_map and segment in config.nextclade_dataset_server_map:
+            nextclade_dataset_server = config.nextclade_dataset_server_map[segment]
+
         dataset_dir_seg = dataset_dir if segment == "main" else dataset_dir + "/" + segment
         dataset_download_command = [
             "nextclade3",
             "dataset",
             "get",
             f"--name={nextclade_dataset_name}",
-            f"--server={config.nextclade_dataset_server}",
+            f"--server={nextclade_dataset_server}",
             f"--output-dir={dataset_dir_seg}",
         ]
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://allow-custom-datasets.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
This PR allows multi-segmented pathogens to use nextclade datasets from different servers and of different names in the server.

Currently we assume all datasets of a multi-segmented organism are in the same folder on the same server and that that folder has a sub-folder with the name of that respective pathogen - this might not always be the case.

This PR should have no effect on our current pathogens. 

It also allows us to not have to define nucleotide sequences in the ingest and prepro configs separately. 

I removed the preview to save on space - but it has no averse affect: 
<img width="1128" alt="image" src="https://github.com/user-attachments/assets/36b340ae-be30-4de5-8aa6-efb0d165bd45">

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
