### PR TITLE
fix(website): Increase website memory limit to 1024 mb to avoid crashes with very large numbers of deletions

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -24,4 +24,4 @@ EXPOSE 3000
 VOLUME /config
 VOLUME /log
 
-CMD node ./dist/server/entry.mjs
+CMD node --max-old-space-size=1024 ./dist/server/entry.mjs


### PR DESCRIPTION
Increase the memory availability to the website to avoid crashes on sequences with very large numbers of deletions