### PR TITLE
fix(kubernetes): don't create `external_metadata_updater` user when `disableEnaSubmission`

### DIFF
--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -169,6 +169,7 @@ data:
               ]
             }
           },
+          {{- if not .Values.disableEnaSubmission }}
           {
             "username": "external_metadata_updater",
             "enabled": true,
@@ -196,6 +197,7 @@ data:
               ]
             }
           },
+          {{ end }}
         {
           "username": "backend",
           "enabled": true,


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

If `disableEnaSubmission: true`, then I don't want to be forced to configure a `externalMetadataUpdaterPassword`

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
