### PR TITLE
feat(website): improve css for markdown pages

### DIFF
--- a/website/src/styles/mdcontainer.scss
+++ b/website/src/styles/mdcontainer.scss
@@ -12,8 +12,16 @@
   }
   
   .mdContainer h3{
-    @apply text-lg font-semibold text-main my-3;
+    @apply text-lg font-semibold text-main my-3 mt-5;
 
+  }
+
+.mdContainer h4{
+    @apply text-base font-semibold text-main my-3 mt-4;
+  }
+
+.mdContainer img{
+    @apply my-3;
   }
   
   .mdContainer p{


### PR DESCRIPTION
- Give h3 proper top margin (and also add h4 just in case)
- Give images some y margin

Relates to https://github.com/pathoplexus/pathoplexus/pull/262

See https://loculus.slack.com/archives/C05GWA22R19/p1730378998996159?thread_ts=1730377039.594559&cid=C05GWA22R19