### PR TITLE
feat(deployment): Add version comment to input fields

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -91,25 +91,28 @@ open class ReleasedDataModel(
             NullNode.getInstance()
         }
 
-        var metadata = rawProcessedData.processedData.metadata +
-            mapOf(
-                ("accession" to TextNode(rawProcessedData.accession)),
-                ("version" to LongNode(rawProcessedData.version)),
-                (HEADER_TO_CONNECT_METADATA_AND_SEQUENCES to TextNode(rawProcessedData.submissionId)),
-                ("accessionVersion" to TextNode(rawProcessedData.displayAccessionVersion())),
-                ("isRevocation" to BooleanNode.valueOf(rawProcessedData.isRevocation)),
-                ("submitter" to TextNode(rawProcessedData.submitter)),
-                ("groupId" to IntNode(rawProcessedData.groupId)),
-                ("groupName" to TextNode(rawProcessedData.groupName)),
-                ("submittedDate" to TextNode(rawProcessedData.submittedAtTimestamp.toUtcDateString())),
-                ("submittedAtTimestamp" to LongNode(rawProcessedData.submittedAtTimestamp.toTimestamp())),
-                ("releasedAtTimestamp" to LongNode(rawProcessedData.releasedAtTimestamp.toTimestamp())),
-                ("releasedDate" to TextNode(rawProcessedData.releasedAtTimestamp.toUtcDateString())),
-                ("versionStatus" to TextNode(versionStatus.name)),
-                ("dataUseTerms" to TextNode(currentDataUseTerms.type.name)),
-                ("dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil)) +
-                 (rawProcessedData.versionComment?.let { mapOf("versionComment" to TextNode(it)) } ?: emptyMap())
-            ).let {
+        var metadata = (rawProcessedData.processedData.metadata +
+    mapOf(
+        "accession" to TextNode(rawProcessedData.accession),
+        "version" to LongNode(rawProcessedData.version),
+        HEADER_TO_CONNECT_METADATA_AND_SEQUENCES to TextNode(rawProcessedData.submissionId),
+        "accessionVersion" to TextNode(rawProcessedData.displayAccessionVersion()),
+        "isRevocation" to BooleanNode.valueOf(rawProcessedData.isRevocation),
+        "submitter" to TextNode(rawProcessedData.submitter),
+        "groupId" to IntNode(rawProcessedData.groupId),
+        "groupName" to TextNode(rawProcessedData.groupName),
+        "submittedDate" to TextNode(rawProcessedData.submittedAtTimestamp.toUtcDateString()),
+        "submittedAtTimestamp" to LongNode(rawProcessedData.submittedAtTimestamp.toTimestamp()),
+        "releasedAtTimestamp" to LongNode(rawProcessedData.releasedAtTimestamp.toTimestamp()),
+        "releasedDate" to TextNode(rawProcessedData.releasedAtTimestamp.toUtcDateString()),
+        "versionStatus" to TextNode(versionStatus.name),
+        "dataUseTerms" to TextNode(currentDataUseTerms.type.name),
+        "dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil
+    ) + 
+    (rawProcessedData.versionComment?.let { 
+        mapOf("versionComment" to TextNode(it)) 
+    } ?: emptyMap())
+).let {
                 when (backendConfig.dataUseTermsUrls) {
                     null -> it
                     else -> {

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -108,7 +108,7 @@ open class ReleasedDataModel(
                 ("versionStatus" to TextNode(versionStatus.name)),
                 ("dataUseTerms" to TextNode(currentDataUseTerms.type.name)),
                 ("dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil),
-            ) + if (!rawProcessedData.processedData.metadata.containsKey("versionComment")) {
+            ) + if (rawProcessedData.processedData.metadata["versionComment"] == null) {
                 mapOf("versionComment" to TextNode(rawProcessedData.versionComment))
             } else {
                 emptyMap()

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -108,12 +108,11 @@ open class ReleasedDataModel(
                 ("versionStatus" to TextNode(versionStatus.name)),
                 ("dataUseTerms" to TextNode(currentDataUseTerms.type.name)),
                 ("dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil),
-            ) +
-            (
-                rawProcessedData.versionComment?.let {
-                    mapOf("versionComment" to TextNode(it))
-                } ?: emptyMap()
-                ).let {
+            ) + if (!rawProcessedData.processedData.metadata.containsKey("versionComment")) {
+                mapOf("versionComment" to TextNode(rawProcessedData.versionComment))
+            } else {
+                emptyMap()
+            }.let {
                 when (backendConfig.dataUseTermsUrls) {
                     null -> it
                     else -> {

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -91,42 +91,39 @@ open class ReleasedDataModel(
             NullNode.getInstance()
         }
 
-        var metadata = (
-            rawProcessedData.processedData.metadata +
-                mapOf(
-                    "accession" to TextNode(rawProcessedData.accession),
-                    "version" to LongNode(rawProcessedData.version),
-                    HEADER_TO_CONNECT_METADATA_AND_SEQUENCES to TextNode(rawProcessedData.submissionId),
-                    "accessionVersion" to TextNode(rawProcessedData.displayAccessionVersion()),
-                    "isRevocation" to BooleanNode.valueOf(rawProcessedData.isRevocation),
-                    "submitter" to TextNode(rawProcessedData.submitter),
-                    "groupId" to IntNode(rawProcessedData.groupId),
-                    "groupName" to TextNode(rawProcessedData.groupName),
-                    "submittedDate" to TextNode(rawProcessedData.submittedAtTimestamp.toUtcDateString()),
-                    "submittedAtTimestamp" to LongNode(rawProcessedData.submittedAtTimestamp.toTimestamp()),
-                    "releasedAtTimestamp" to LongNode(rawProcessedData.releasedAtTimestamp.toTimestamp()),
-                    "releasedDate" to TextNode(rawProcessedData.releasedAtTimestamp.toUtcDateString()),
-                    "versionStatus" to TextNode(versionStatus.name),
-                    "dataUseTerms" to TextNode(currentDataUseTerms.type.name),
-                    "dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil,
-                ) +
-                (
-                    rawProcessedData.versionComment?.let {
-                        mapOf("versionComment" to TextNode(it))
-                    } ?: emptyMap()
-                    )
+        var metadata = rawProcessedData.processedData.metadata +
+            mapOf(
+                ("accession" to TextNode(rawProcessedData.accession)),
+                ("version" to LongNode(rawProcessedData.version)),
+                (HEADER_TO_CONNECT_METADATA_AND_SEQUENCES to TextNode(rawProcessedData.submissionId)),
+                ("accessionVersion" to TextNode(rawProcessedData.displayAccessionVersion())),
+                ("isRevocation" to BooleanNode.valueOf(rawProcessedData.isRevocation)),
+                ("submitter" to TextNode(rawProcessedData.submitter)),
+                ("groupId" to IntNode(rawProcessedData.groupId)),
+                ("groupName" to TextNode(rawProcessedData.groupName)),
+                ("submittedDate" to TextNode(rawProcessedData.submittedAtTimestamp.toUtcDateString())),
+                ("submittedAtTimestamp" to LongNode(rawProcessedData.submittedAtTimestamp.toTimestamp())),
+                ("releasedAtTimestamp" to LongNode(rawProcessedData.releasedAtTimestamp.toTimestamp())),
+                ("releasedDate" to TextNode(rawProcessedData.releasedAtTimestamp.toUtcDateString())),
+                ("versionStatus" to TextNode(versionStatus.name)),
+                ("dataUseTerms" to TextNode(currentDataUseTerms.type.name)),
+                ("dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil)
+            ) + 
+            (rawProcessedData.versionComment?.let { 
+                mapOf("versionComment" to TextNode(it)) 
+            } ?: emptyMap()
             ).let {
-            when (backendConfig.dataUseTermsUrls) {
-                null -> it
-                else -> {
-                    val url = when (currentDataUseTerms) {
-                        DataUseTerms.Open -> backendConfig.dataUseTermsUrls.open
-                        is DataUseTerms.Restricted -> backendConfig.dataUseTermsUrls.restricted
+                when (backendConfig.dataUseTermsUrls) {
+                    null -> it
+                    else -> {
+                        val url = when (currentDataUseTerms) {
+                            DataUseTerms.Open -> backendConfig.dataUseTermsUrls.open
+                            is DataUseTerms.Restricted -> backendConfig.dataUseTermsUrls.restricted
+                        }
+                        it + ("dataUseTermsUrl" to TextNode(url))
                     }
-                    it + ("dataUseTermsUrl" to TextNode(url))
                 }
             }
-        }
 
         return ProcessedData(
             metadata = metadata,

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -107,12 +107,13 @@ open class ReleasedDataModel(
                 ("releasedDate" to TextNode(rawProcessedData.releasedAtTimestamp.toUtcDateString())),
                 ("versionStatus" to TextNode(versionStatus.name)),
                 ("dataUseTerms" to TextNode(currentDataUseTerms.type.name)),
-                ("dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil)
-            ) + 
-            (rawProcessedData.versionComment?.let { 
-                mapOf("versionComment" to TextNode(it)) 
-            } ?: emptyMap()
-            ).let {
+                ("dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil),
+            ) +
+            (
+                rawProcessedData.versionComment?.let {
+                    mapOf("versionComment" to TextNode(it))
+                } ?: emptyMap()
+                ).let {
                 when (backendConfig.dataUseTermsUrls) {
                     null -> it
                     else -> {

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -107,8 +107,8 @@ open class ReleasedDataModel(
                 ("releasedDate" to TextNode(rawProcessedData.releasedAtTimestamp.toUtcDateString())),
                 ("versionStatus" to TextNode(versionStatus.name)),
                 ("dataUseTerms" to TextNode(currentDataUseTerms.type.name)),
-                ("dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil),
-                ("versionComment" to TextNode(rawProcessedData.versionComment)),
+                ("dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil)) +
+                 (rawProcessedData.versionComment?.let { mapOf("versionComment" to TextNode(it)) } ?: emptyMap())
             ).let {
                 when (backendConfig.dataUseTermsUrls) {
                     null -> it

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -91,39 +91,42 @@ open class ReleasedDataModel(
             NullNode.getInstance()
         }
 
-        var metadata = (rawProcessedData.processedData.metadata +
-    mapOf(
-        "accession" to TextNode(rawProcessedData.accession),
-        "version" to LongNode(rawProcessedData.version),
-        HEADER_TO_CONNECT_METADATA_AND_SEQUENCES to TextNode(rawProcessedData.submissionId),
-        "accessionVersion" to TextNode(rawProcessedData.displayAccessionVersion()),
-        "isRevocation" to BooleanNode.valueOf(rawProcessedData.isRevocation),
-        "submitter" to TextNode(rawProcessedData.submitter),
-        "groupId" to IntNode(rawProcessedData.groupId),
-        "groupName" to TextNode(rawProcessedData.groupName),
-        "submittedDate" to TextNode(rawProcessedData.submittedAtTimestamp.toUtcDateString()),
-        "submittedAtTimestamp" to LongNode(rawProcessedData.submittedAtTimestamp.toTimestamp()),
-        "releasedAtTimestamp" to LongNode(rawProcessedData.releasedAtTimestamp.toTimestamp()),
-        "releasedDate" to TextNode(rawProcessedData.releasedAtTimestamp.toUtcDateString()),
-        "versionStatus" to TextNode(versionStatus.name),
-        "dataUseTerms" to TextNode(currentDataUseTerms.type.name),
-        "dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil
-    ) + 
-    (rawProcessedData.versionComment?.let { 
-        mapOf("versionComment" to TextNode(it)) 
-    } ?: emptyMap())
-).let {
-                when (backendConfig.dataUseTermsUrls) {
-                    null -> it
-                    else -> {
-                        val url = when (currentDataUseTerms) {
-                            DataUseTerms.Open -> backendConfig.dataUseTermsUrls.open
-                            is DataUseTerms.Restricted -> backendConfig.dataUseTermsUrls.restricted
-                        }
-                        it + ("dataUseTermsUrl" to TextNode(url))
+        var metadata = (
+            rawProcessedData.processedData.metadata +
+                mapOf(
+                    "accession" to TextNode(rawProcessedData.accession),
+                    "version" to LongNode(rawProcessedData.version),
+                    HEADER_TO_CONNECT_METADATA_AND_SEQUENCES to TextNode(rawProcessedData.submissionId),
+                    "accessionVersion" to TextNode(rawProcessedData.displayAccessionVersion()),
+                    "isRevocation" to BooleanNode.valueOf(rawProcessedData.isRevocation),
+                    "submitter" to TextNode(rawProcessedData.submitter),
+                    "groupId" to IntNode(rawProcessedData.groupId),
+                    "groupName" to TextNode(rawProcessedData.groupName),
+                    "submittedDate" to TextNode(rawProcessedData.submittedAtTimestamp.toUtcDateString()),
+                    "submittedAtTimestamp" to LongNode(rawProcessedData.submittedAtTimestamp.toTimestamp()),
+                    "releasedAtTimestamp" to LongNode(rawProcessedData.releasedAtTimestamp.toTimestamp()),
+                    "releasedDate" to TextNode(rawProcessedData.releasedAtTimestamp.toUtcDateString()),
+                    "versionStatus" to TextNode(versionStatus.name),
+                    "dataUseTerms" to TextNode(currentDataUseTerms.type.name),
+                    "dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil,
+                ) +
+                (
+                    rawProcessedData.versionComment?.let {
+                        mapOf("versionComment" to TextNode(it))
+                    } ?: emptyMap()
+                    )
+            ).let {
+            when (backendConfig.dataUseTermsUrls) {
+                null -> it
+                else -> {
+                    val url = when (currentDataUseTerms) {
+                        DataUseTerms.Open -> backendConfig.dataUseTermsUrls.open
+                        is DataUseTerms.Restricted -> backendConfig.dataUseTermsUrls.restricted
                     }
+                    it + ("dataUseTermsUrl" to TextNode(url))
                 }
             }
+        }
 
         return ProcessedData(
             metadata = metadata,

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -156,6 +156,8 @@ organisms:
       {{ end }}
       primaryKey: accessionVersion
       inputFields: {{- include "loculus.inputFields" . | nindent 8 }}
+        - name: versionComment
+          displayName: Version comment
       metadata:
         {{- $args := dict "metadata" (concat $commonMetadata .metadata) "nucleotideSequences" $nucleotideSequences}}
         {{ $metadata := include "loculus.generateWebsiteMetadata" $args | fromYaml }}

--- a/kubernetes/loculus/templates/_inputFieldsFromValues.tpl
+++ b/kubernetes/loculus/templates/_inputFieldsFromValues.tpl
@@ -1,7 +1,6 @@
 {{- define "loculus.inputFields" -}}
 {{- $data := . }}
 {{- $metadata := $data.metadata }}
-{{- $extraFields := append $data.extraInputFields (dict "name" "versionComment" "displayName" "Version comment" "position" "last") }}
 {{- $TO_KEEP := list "name" "displayName" "definition" "guidance" "example" "required" "noEdit"}}
 
 

--- a/kubernetes/loculus/templates/_inputFieldsFromValues.tpl
+++ b/kubernetes/loculus/templates/_inputFieldsFromValues.tpl
@@ -44,6 +44,5 @@
   {{- $inputFields = append $inputFields $toAdd }}
 {{- end }}
 
-{{- $inputFields = append $inputFields "versionComment" }}
 {{- toYaml $inputFields }}
 {{- end -}}

--- a/kubernetes/loculus/templates/_inputFieldsFromValues.tpl
+++ b/kubernetes/loculus/templates/_inputFieldsFromValues.tpl
@@ -1,6 +1,7 @@
 {{- define "loculus.inputFields" -}}
 {{- $data := . }}
 {{- $metadata := $data.metadata }}
+{{- $extraFields := $data.extraInputFields }}
 {{- $TO_KEEP := list "name" "displayName" "definition" "guidance" "example" "required" "noEdit"}}
 
 

--- a/kubernetes/loculus/templates/_inputFieldsFromValues.tpl
+++ b/kubernetes/loculus/templates/_inputFieldsFromValues.tpl
@@ -1,7 +1,7 @@
 {{- define "loculus.inputFields" -}}
 {{- $data := . }}
 {{- $metadata := $data.metadata }}
-{{- $extraFields := $data.extraInputFields }}
+{{- $extraFields := append $data.extraInputFields (dict "name" "versionComment" "displayName" "Version comment" "position" "last") }}
 {{- $TO_KEEP := list "name" "displayName" "definition" "guidance" "example" "required" "noEdit"}}
 
 

--- a/kubernetes/loculus/templates/_inputFieldsFromValues.tpl
+++ b/kubernetes/loculus/templates/_inputFieldsFromValues.tpl
@@ -44,5 +44,6 @@
   {{- $inputFields = append $inputFields $toAdd }}
 {{- end }}
 
+{{- $inputFields = append $inputFields "versionComment" }}
 {{- toYaml $inputFields }}
 {{- end -}}

--- a/website/tests/pages/submission/template.spec.ts
+++ b/website/tests/pages/submission/template.spec.ts
@@ -17,6 +17,7 @@ test.describe('The submit page', () => {
 
         expect(download.suggestedFilename()).toBe('Test_Dummy_Organism_metadata_template.tsv');
         const content = await getDownloadedContent(download);
+
         expect(content).toStrictEqual(
             'submissionId\tcountry\tdate\tdivision\thost\tpangoLineage\tregion\tversionComment\n',
         );

--- a/website/tests/pages/submission/template.spec.ts
+++ b/website/tests/pages/submission/template.spec.ts
@@ -17,7 +17,6 @@ test.describe('The submit page', () => {
 
         expect(download.suggestedFilename()).toBe('Test_Dummy_Organism_metadata_template.tsv');
         const content = await getDownloadedContent(download);
-
         expect(content).toStrictEqual(
             'submissionId\tcountry\tdate\tdivision\thost\tpangoLineage\tregion\tversionComment\n',
         );

--- a/website/tests/pages/submission/template.spec.ts
+++ b/website/tests/pages/submission/template.spec.ts
@@ -17,7 +17,7 @@ test.describe('The submit page', () => {
 
         expect(download.suggestedFilename()).toBe('Test_Dummy_Organism_metadata_template.tsv');
         const content = await getDownloadedContent(download);
-        expect(content).toStrictEqual('submissionId\tcountry\tdate\tdivision\thost\tpangoLineage\tregion\n');
+        expect(content).toStrictEqual('submissionId\tcountry\tdate\tdivision\thost\tpangoLineage\tregion\tversionComment\n');
     });
 
     test('should download the metadata file template for revision', async ({
@@ -35,7 +35,7 @@ test.describe('The submit page', () => {
 
         expect(download.suggestedFilename()).toBe('Test_Dummy_Organism_metadata_revision_template.tsv');
         const content = await getDownloadedContent(download);
-        expect(content).toStrictEqual('accession\tsubmissionId\tcountry\tdate\tdivision\thost\tpangoLineage\tregion\n');
+        expect(content).toStrictEqual('accession\tsubmissionId\tcountry\tdate\tdivision\thost\tpangoLineage\tregion\tversionComment\n');
     });
 
     async function getDownloadedContent(download: Download) {

--- a/website/tests/pages/submission/template.spec.ts
+++ b/website/tests/pages/submission/template.spec.ts
@@ -17,7 +17,9 @@ test.describe('The submit page', () => {
 
         expect(download.suggestedFilename()).toBe('Test_Dummy_Organism_metadata_template.tsv');
         const content = await getDownloadedContent(download);
-        expect(content).toStrictEqual('submissionId\tcountry\tdate\tdivision\thost\tpangoLineage\tregion\tversionComment\n');
+        expect(content).toStrictEqual(
+            'submissionId\tcountry\tdate\tdivision\thost\tpangoLineage\tregion\tversionComment\n',
+        );
     });
 
     test('should download the metadata file template for revision', async ({
@@ -35,7 +37,9 @@ test.describe('The submit page', () => {
 
         expect(download.suggestedFilename()).toBe('Test_Dummy_Organism_metadata_revision_template.tsv');
         const content = await getDownloadedContent(download);
-        expect(content).toStrictEqual('accession\tsubmissionId\tcountry\tdate\tdivision\thost\tpangoLineage\tregion\tversionComment\n');
+        expect(content).toStrictEqual(
+            'accession\tsubmissionId\tcountry\tdate\tdivision\thost\tpangoLineage\tregion\tversionComment\n',
+        );
     });
 
     async function getDownloadedContent(download: Download) {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
Adds version comment to input fields so it appears on revision form:
<img width="1346" alt="image" src="https://github.com/user-attachments/assets/4634ad81-2364-4b5f-a267-d243799cabbb">



There's an argument that it shouldn't necessarily for editing version 1. But:

- I think notes can actually be useful even for version 1
- This lets us quickly make the change and we could always change it later

https://addversioncomment.loculus.org/