### PR TITLE
WIP: add back versionComment field

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -108,8 +108,11 @@ open class ReleasedDataModel(
                 ("versionStatus" to TextNode(versionStatus.name)),
                 ("dataUseTerms" to TextNode(currentDataUseTerms.type.name)),
                 ("dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil),
-                ("versionComment" to TextNode(rawProcessedData.versionComment)),
-            ).let {
+            ) + if (!rawProcessedData.processedData.metadata.containsKey("versionComment")) {
+                mapOf("versionComment" to TextNode(rawProcessedData.versionComment))
+            } else {
+                emptyMap()
+            }.let {
                 when (backendConfig.dataUseTermsUrls) {
                     null -> it
                     else -> {

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -109,9 +109,7 @@ open class ReleasedDataModel(
                 ("dataUseTerms" to TextNode(currentDataUseTerms.type.name)),
                 ("dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil),
             ) +
-            if (!rawProcessedData.processedData.metadata.containsKey("versionComment") ||
-                (rawProcessedData.processedData.metadata["versionComment"] == null)
-            ) {
+            if (rawProcessedData.isRevocation) {
                 mapOf("versionComment" to TextNode(rawProcessedData.versionComment))
             } else {
                 emptyMap()

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -108,7 +108,10 @@ open class ReleasedDataModel(
                 ("versionStatus" to TextNode(versionStatus.name)),
                 ("dataUseTerms" to TextNode(currentDataUseTerms.type.name)),
                 ("dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil),
-            ) + if (!rawProcessedData.processedData.metadata.containsKey("versionComment")) {
+            ) +
+            if (!rawProcessedData.processedData.metadata.containsKey("versionComment") ||
+                (rawProcessedData.processedData.metadata["versionComment"] == null)
+            ) {
                 mapOf("versionComment" to TextNode(rawProcessedData.versionComment))
             } else {
                 emptyMap()

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
@@ -149,7 +149,6 @@ class GetReleasedDataEndpointTest(
                 "releasedDate" to TextNode(currentDate),
                 "submittedDate" to TextNode(currentDate),
                 "dataUseTermsRestrictedUntil" to NullNode.getInstance(),
-                "versionComment" to NullNode.getInstance(),
                 "booleanColumn" to BooleanNode.TRUE,
             )
 

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -92,10 +92,6 @@ fields:
     type: string
     notSearchable: true
     hideOnSequenceDetailsPage: true
-  - name: versionComment
-    type: string
-    displayName: Version comment
-    header: Submission details
 {{- end}}
 
 {{/* Patches schema by adding to it and overwriting overlapping fields by the value in metadataAdd*/}}

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1063,6 +1063,10 @@ defaultOrganismConfig: &defaultOrganismConfig
           type: percentage
         preprocessing:
           inputs: {input: nextclade.coverage}
+      - name: versionComment
+        type: string
+        displayName: Version comment
+        header: Submission details
     website: &website
       tableColumns:
         - sampleCollectionDate
@@ -1251,10 +1255,6 @@ defaultOrganisms:
           autocomplete: true
           required: true
           type: string
-        - name: versionComment
-          type: string
-          displayName: Version comment
-          header: Submission details
       website:
         tableColumns:
           - country

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1251,6 +1251,10 @@ defaultOrganisms:
           autocomplete: true
           required: true
           type: string
+        - name: versionComment
+          type: string
+          displayName: Version comment
+          header: Submission details
       website:
         tableColumns:
           - country


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://add-back-versioncomment.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
https://github.com/loculus-project/loculus/pull/2352 added the option to set a versionComment field for revisions and revocations. However, as revocations do not have original metadata fields I had to add a new column just for the versionComment for revocations. The versionComment in revisions should just be treated as a normal metadata field. However, the field in the column and in the metadata need to be merged in get-released-data and here the contents of the versionComment column were overwriting the contents of the contents of the metadata field - this PR fixes the merge problem.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->
Revisions work again - can be made via page and show up: 
<img width="686" alt="image" src="https://github.com/user-attachments/assets/d2789116-0a22-462e-bdf9-334976cc84e5">
Revocations also still work:
<img width="686" alt="image" src="https://github.com/user-attachments/assets/cce4c17b-5d5c-4766-90e8-46293ba3db2e">

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
