### PR TITLE
feat(ci): dump current db schema automatically

### DIFF
--- a/.github/workflows/schema-dump.yml
+++ b/.github/workflows/schema-dump.yml
@@ -79,13 +79,13 @@ jobs:
     - name: Handle schema changes
       if: steps.check-changes.outputs.changed == 'true'
       run: |
-        if [[ "${{ contains(github.event.pull_request.labels.*.name, 'update-schema') }}" == "true" ]]; then
+        if [[ "${{ contains(github.event.pull_request.labels.*.name, 'update_db_schema') }}" == "true" ]]; then
           git config --global user.name 'GitHub Action'
           git config --global user.email 'action@github.com'
           git commit -m "Update schema documentation based on migration changes"
           git push
         else
           echo "::error::Schema changes detected but 'update-schema' label is not present on the PR"
-          echo "Please add the 'update-schema' label if these changes are intentional"
+          echo "Please add the 'update_db_schema' label if these changes are intentional"
           exit 1
         fi

--- a/.github/workflows/schema-dump.yml
+++ b/.github/workflows/schema-dump.yml
@@ -60,7 +60,7 @@ jobs:
           > /github/workspace/backend/docs/db/schema.sql"
 
     - name: Ensure schema file is tracked
-      run: git add -f backend/docs/schema.sql
+      run: git add -f backend/docs/db/schema.sql
 
     - name: Cat schema
       run: cat backend/docs/db/schema.sql

--- a/.github/workflows/schema-dump.yml
+++ b/.github/workflows/schema-dump.yml
@@ -57,18 +57,18 @@ jobs:
           -U postgres 
           -d postgres 
           --schema-only 
-          > /github/workspace/backend/docs/schema.sql"
+          > /github/workspace/backend/docs/db/schema.sql"
 
     - name: Ensure schema file is tracked
       run: git add -f backend/docs/schema.sql
 
     - name: Cat schema
-      run: cat backend/docs/schema.sql
+      run: cat backend/docs/db/schema.sql
       
     - name: Check for schema changes
       id: check-changes
       run: |
-        if git diff --quiet backend/docs/schema.sql; then
+        if git diff --quiet backend/docs/db/schema.sql; then
           echo "Schema is unchanged"
           echo "changed=false" >> $GITHUB_OUTPUT
         else
@@ -83,7 +83,7 @@ jobs:
           # Update schema if label is present
           git config --global user.name 'GitHub Action'
           git config --global user.email 'action@github.com'
-          git add backend/docs/schema.sql
+          git add backend/docs/db/schema.sql
           git commit -m "Update schema documentation based on migration changes"
           git push
         else

--- a/.github/workflows/schema-dump.yml
+++ b/.github/workflows/schema-dump.yml
@@ -19,7 +19,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: postgres:15
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres

--- a/.github/workflows/schema-dump.yml
+++ b/.github/workflows/schema-dump.yml
@@ -1,0 +1,85 @@
+name: Generate and Validate Flyway Schema
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled]
+    paths:
+      - 'backend/schema/**'
+  workflow_dispatch:
+
+jobs:
+  generate-schema:
+    runs-on: ubuntu-latest
+    
+    # Explicitly set permissions needed for committing
+    permissions:
+      contents: write
+      pull-requests: read
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.head_ref }}
+        fetch-depth: 0
+
+    - name: Run Flyway migrations
+      uses: docker://flyway/flyway:10-alpine
+      env:
+        FLYWAY_URL: jdbc:postgresql://localhost:5432/postgres
+        FLYWAY_USER: postgres
+        FLYWAY_PASSWORD: postgres
+      with:
+        args: -locations=filesystem:./backend/schema migrate
+
+    - name: Generate new schema
+      run: |
+        mkdir -p backend/docs
+        PGPASSWORD=postgres pg_dump \
+          -h localhost \
+          -U postgres \
+          -d postgres \
+          --schema-only \
+          > backend/docs/schema.sql
+
+    - name: Check for schema changes
+      id: check-changes
+      run: |
+        if git diff --quiet backend/docs/schema.sql; then
+          echo "Schema is unchanged"
+          echo "changed=false" >> $GITHUB_OUTPUT
+        else
+          echo "Schema has changes"
+          echo "changed=true" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Handle schema changes
+      if: steps.check-changes.outputs.changed == 'true'
+      run: |
+        if [[ "${{ contains(github.event.pull_request.labels.*.name, 'update-schema') }}" == "true" ]]; then
+          # Update schema if label is present
+          git config --global user.name 'GitHub Action'
+          git config --global user.email 'action@github.com'
+          git add backend/docs/schema.sql
+          git commit -m "Update schema documentation based on migration changes"
+          git push
+        else
+          echo "Error: Schema changes detected but 'update-schema' label is not present on the PR"
+          echo "Please add the 'update-schema' label if these changes are intentional"
+          exit 1
+        fi

--- a/.github/workflows/schema-dump.yml
+++ b/.github/workflows/schema-dump.yml
@@ -49,14 +49,15 @@ jobs:
         args: -locations=filesystem:./backend/src/main/resources/db/migration/ migrate
 
     - name: Generate new schema
-      run: |
-        mkdir -p backend/docs
-        PGPASSWORD=postgres pg_dump \
-          -h postgres \
-          -U postgres \
-          -d postgres \
-          --schema-only \
-          > backend/docs/schema.sql
+      uses: docker://postgres:16
+      with:
+        args: >
+          bash -c "PGPASSWORD=postgres pg_dump 
+          -h postgres 
+          -U postgres 
+          -d postgres 
+          --schema-only 
+          > /github/workspace/backend/docs/schema.sql"
 
     - name: Check for schema changes
       id: check-changes

--- a/.github/workflows/schema-dump.yml
+++ b/.github/workflows/schema-dump.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, labeled]
     paths:
       - 'backend/schema/**'
+      - '.github/workflows/schema-dump.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/schema-dump.yml
+++ b/.github/workflows/schema-dump.yml
@@ -58,36 +58,34 @@ jobs:
           -d postgres 
           --schema-only 
           > /github/workspace/backend/docs/db/schema.sql"
-
-    - name: Ensure schema file is tracked
-      run: git add -f backend/docs/db/schema.sql
-
     - name: Cat schema
       run: cat backend/docs/db/schema.sql
       
+    - name: Stage schema file
+      run: git add backend/docs/db/schema.sql
+
     - name: Check for schema changes
       id: check-changes
       run: |
-        if git diff --quiet backend/docs/db/schema.sql; then
-          echo "Schema is unchanged"
-          echo "changed=false" >> $GITHUB_OUTPUT
-        else
-          echo "Schema has changes"
+        if ! git diff --cached --quiet backend/docs/db/schema.sql; then
+          echo "Schema changes detected"
           echo "changed=true" >> $GITHUB_OUTPUT
+          git diff --cached backend/docs/db/schema.sql
+        else
+          echo "No schema changes detected"
+          echo "changed=false" >> $GITHUB_OUTPUT
         fi
 
     - name: Handle schema changes
       if: steps.check-changes.outputs.changed == 'true'
       run: |
         if [[ "${{ contains(github.event.pull_request.labels.*.name, 'update-schema') }}" == "true" ]]; then
-          # Update schema if label is present
           git config --global user.name 'GitHub Action'
           git config --global user.email 'action@github.com'
-          git add backend/docs/db/schema.sql
           git commit -m "Update schema documentation based on migration changes"
           git push
         else
-          echo "Error: Schema changes detected but 'update-schema' label is not present on the PR"
+          echo "::error::Schema changes detected but 'update-schema' label is not present on the PR"
           echo "Please add the 'update-schema' label if these changes are intentional"
           exit 1
         fi

--- a/.github/workflows/schema-dump.yml
+++ b/.github/workflows/schema-dump.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Run Flyway migrations
       uses: docker://flyway/flyway:10-alpine
       env:
-        FLYWAY_URL: jdbc:postgresql://localhost:5432/postgres
+        FLYWAY_URL: jdbc:postgresql://postgres:5432/postgres
         FLYWAY_USER: postgres
         FLYWAY_PASSWORD: postgres
       with:
@@ -52,7 +52,7 @@ jobs:
       run: |
         mkdir -p backend/docs
         PGPASSWORD=postgres pg_dump \
-          -h localhost \
+          -h postgres \
           -U postgres \
           -d postgres \
           --schema-only \

--- a/.github/workflows/schema-dump.yml
+++ b/.github/workflows/schema-dump.yml
@@ -61,6 +61,9 @@ jobs:
 
     - name: Ensure schema file is tracked
       run: git add -f backend/docs/schema.sql
+
+    - name: Cat schema
+      run: cat backend/docs/schema.sql
       
     - name: Check for schema changes
       id: check-changes

--- a/.github/workflows/schema-dump.yml
+++ b/.github/workflows/schema-dump.yml
@@ -59,6 +59,9 @@ jobs:
           --schema-only 
           > /github/workspace/backend/docs/schema.sql"
 
+    - name: Ensure schema file is tracked
+      run: git add -f backend/docs/schema.sql
+      
     - name: Check for schema changes
       id: check-changes
       run: |

--- a/.github/workflows/schema-dump.yml
+++ b/.github/workflows/schema-dump.yml
@@ -46,7 +46,7 @@ jobs:
         FLYWAY_USER: postgres
         FLYWAY_PASSWORD: postgres
       with:
-        args: -locations=filesystem:./backend/schema migrate
+        args: -locations=filesystem:./backend/src/main/resources/db/migration/ migrate
 
     - name: Generate new schema
       run: |

--- a/backend/docs/db/schema.sql
+++ b/backend/docs/db/schema.sql
@@ -1,0 +1,820 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 16.4 (Debian 16.4-1.pgdg120+2)
+-- Dumped by pg_dump version 16.4 (Debian 16.4-1.pgdg120+2)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: create_update_trigger_for_table(text); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.create_update_trigger_for_table(table_name text) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF table_name != 'table_update_tracker' THEN
+        EXECUTE format('
+            CREATE OR REPLACE TRIGGER update_tracker_trigger
+            AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE ON %I
+            FOR EACH STATEMENT
+            EXECUTE FUNCTION update_table_tracker()', table_name);
+    END IF;
+END;
+$$;
+
+
+ALTER FUNCTION public.create_update_trigger_for_table(table_name text) OWNER TO postgres;
+
+--
+-- Name: jsonb_concat(jsonb, jsonb); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.jsonb_concat(a jsonb, b jsonb) RETURNS jsonb
+    LANGUAGE sql IMMUTABLE PARALLEL SAFE
+    AS $_$select $1 || $2$_$;
+
+
+ALTER FUNCTION public.jsonb_concat(a jsonb, b jsonb) OWNER TO postgres;
+
+--
+-- Name: update_table_tracker(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.update_table_tracker() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF TG_TABLE_NAME != 'table_update_tracker' THEN
+        INSERT INTO table_update_tracker (table_name, last_time_updated)
+        VALUES (TG_TABLE_NAME, timezone('UTC', CURRENT_TIMESTAMP))
+        ON CONFLICT (table_name)
+        DO UPDATE SET last_time_updated = timezone('UTC', CURRENT_TIMESTAMP);
+    END IF;
+    RETURN NULL;
+END;
+$$;
+
+
+ALTER FUNCTION public.update_table_tracker() OWNER TO postgres;
+
+--
+-- Name: jsonb_merge_agg(jsonb); Type: AGGREGATE; Schema: public; Owner: postgres
+--
+
+CREATE AGGREGATE public.jsonb_merge_agg(jsonb) (
+    SFUNC = jsonb_concat,
+    STYPE = jsonb,
+    INITCOND = '{}'
+);
+
+
+ALTER AGGREGATE public.jsonb_merge_agg(jsonb) OWNER TO postgres;
+
+--
+-- Name: accession_sequence; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.accession_sequence
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.accession_sequence OWNER TO postgres;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: external_metadata; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.external_metadata (
+    accession text NOT NULL,
+    version bigint NOT NULL,
+    external_metadata_updater text NOT NULL,
+    external_metadata jsonb,
+    updated_metadata_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.external_metadata OWNER TO postgres;
+
+--
+-- Name: all_external_metadata; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.all_external_metadata AS
+ SELECT accession,
+    version,
+    max(updated_metadata_at) AS updated_metadata_at,
+    public.jsonb_merge_agg(external_metadata) AS external_metadata
+   FROM public.external_metadata
+  GROUP BY accession, version;
+
+
+ALTER VIEW public.all_external_metadata OWNER TO postgres;
+
+--
+-- Name: audit_log; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.audit_log (
+    id bigint NOT NULL,
+    username text,
+    "timestamp" timestamp without time zone DEFAULT now() NOT NULL,
+    description text NOT NULL
+);
+
+
+ALTER TABLE public.audit_log OWNER TO postgres;
+
+--
+-- Name: audit_log_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.audit_log_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.audit_log_id_seq OWNER TO postgres;
+
+--
+-- Name: audit_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.audit_log_id_seq OWNED BY public.audit_log.id;
+
+
+--
+-- Name: current_processing_pipeline; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.current_processing_pipeline (
+    version bigint NOT NULL,
+    started_using_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.current_processing_pipeline OWNER TO postgres;
+
+--
+-- Name: data_use_terms_table; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.data_use_terms_table (
+    accession text NOT NULL,
+    change_date timestamp without time zone NOT NULL,
+    data_use_terms_type text NOT NULL,
+    restricted_until timestamp without time zone,
+    user_name text NOT NULL
+);
+
+
+ALTER TABLE public.data_use_terms_table OWNER TO postgres;
+
+--
+-- Name: sequence_entries_preprocessed_data; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sequence_entries_preprocessed_data (
+    accession text NOT NULL,
+    version bigint NOT NULL,
+    pipeline_version bigint NOT NULL,
+    processed_data jsonb,
+    errors jsonb,
+    warnings jsonb,
+    processing_status text NOT NULL,
+    started_processing_at timestamp without time zone NOT NULL,
+    finished_processing_at timestamp without time zone
+);
+
+
+ALTER TABLE public.sequence_entries_preprocessed_data OWNER TO postgres;
+
+--
+-- Name: external_metadata_view; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.external_metadata_view AS
+ SELECT cpd.accession,
+    cpd.version,
+    all_external_metadata.updated_metadata_at,
+        CASE
+            WHEN (all_external_metadata.external_metadata IS NULL) THEN jsonb_build_object('metadata', (cpd.processed_data -> 'metadata'::text))
+            ELSE jsonb_build_object('metadata', ((cpd.processed_data -> 'metadata'::text) || all_external_metadata.external_metadata))
+        END AS joint_metadata
+   FROM (( SELECT sequence_entries_preprocessed_data.accession,
+            sequence_entries_preprocessed_data.version,
+            sequence_entries_preprocessed_data.pipeline_version,
+            sequence_entries_preprocessed_data.processed_data,
+            sequence_entries_preprocessed_data.errors,
+            sequence_entries_preprocessed_data.warnings,
+            sequence_entries_preprocessed_data.processing_status,
+            sequence_entries_preprocessed_data.started_processing_at,
+            sequence_entries_preprocessed_data.finished_processing_at
+           FROM public.sequence_entries_preprocessed_data
+          WHERE (sequence_entries_preprocessed_data.pipeline_version = ( SELECT current_processing_pipeline.version
+                   FROM public.current_processing_pipeline))) cpd
+     LEFT JOIN public.all_external_metadata ON (((all_external_metadata.accession = cpd.accession) AND (all_external_metadata.version = cpd.version))));
+
+
+ALTER VIEW public.external_metadata_view OWNER TO postgres;
+
+--
+-- Name: flyway_schema_history; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.flyway_schema_history (
+    installed_rank integer NOT NULL,
+    version character varying(50),
+    description character varying(200) NOT NULL,
+    type character varying(20) NOT NULL,
+    script character varying(1000) NOT NULL,
+    checksum integer,
+    installed_by character varying(100) NOT NULL,
+    installed_on timestamp without time zone DEFAULT now() NOT NULL,
+    execution_time integer NOT NULL,
+    success boolean NOT NULL
+);
+
+
+ALTER TABLE public.flyway_schema_history OWNER TO postgres;
+
+--
+-- Name: groups_table; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.groups_table (
+    group_id integer NOT NULL,
+    group_name character varying(255),
+    institution character varying(255) NOT NULL,
+    address_line_1 character varying(255) NOT NULL,
+    address_line_2 character varying(255),
+    address_postal_code character varying(255) NOT NULL,
+    address_city character varying(255) NOT NULL,
+    address_state character varying(255),
+    address_country character varying(255) NOT NULL,
+    contact_email character varying(255) NOT NULL
+);
+
+
+ALTER TABLE public.groups_table OWNER TO postgres;
+
+--
+-- Name: groups_table_group_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.groups_table_group_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.groups_table_group_id_seq OWNER TO postgres;
+
+--
+-- Name: groups_table_group_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.groups_table_group_id_seq OWNED BY public.groups_table.group_id;
+
+
+--
+-- Name: metadata_upload_aux_table; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.metadata_upload_aux_table (
+    accession text,
+    version bigint,
+    upload_id text NOT NULL,
+    organism text NOT NULL,
+    submission_id text NOT NULL,
+    submitter text NOT NULL,
+    group_id integer,
+    uploaded_at timestamp without time zone NOT NULL,
+    metadata jsonb NOT NULL
+);
+
+
+ALTER TABLE public.metadata_upload_aux_table OWNER TO postgres;
+
+--
+-- Name: seqset_id_sequence; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.seqset_id_sequence
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.seqset_id_sequence OWNER TO postgres;
+
+--
+-- Name: seqset_records; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.seqset_records (
+    seqset_record_id bigint NOT NULL,
+    accession text NOT NULL,
+    type text NOT NULL,
+    is_focal boolean NOT NULL
+);
+
+
+ALTER TABLE public.seqset_records OWNER TO postgres;
+
+--
+-- Name: seqset_records_seqset_record_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.seqset_records_seqset_record_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.seqset_records_seqset_record_id_seq OWNER TO postgres;
+
+--
+-- Name: seqset_records_seqset_record_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.seqset_records_seqset_record_id_seq OWNED BY public.seqset_records.seqset_record_id;
+
+
+--
+-- Name: seqset_to_records; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.seqset_to_records (
+    seqset_record_id bigint NOT NULL,
+    seqset_id text NOT NULL,
+    seqset_version bigint NOT NULL
+);
+
+
+ALTER TABLE public.seqset_to_records OWNER TO postgres;
+
+--
+-- Name: seqset_to_records_seqset_record_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.seqset_to_records_seqset_record_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.seqset_to_records_seqset_record_id_seq OWNER TO postgres;
+
+--
+-- Name: seqset_to_records_seqset_record_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.seqset_to_records_seqset_record_id_seq OWNED BY public.seqset_to_records.seqset_record_id;
+
+
+--
+-- Name: seqsets; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.seqsets (
+    seqset_id text NOT NULL,
+    seqset_version bigint NOT NULL,
+    name text NOT NULL,
+    description text,
+    seqset_doi text,
+    created_at timestamp without time zone NOT NULL,
+    created_by text NOT NULL
+);
+
+
+ALTER TABLE public.seqsets OWNER TO postgres;
+
+--
+-- Name: sequence_entries; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sequence_entries (
+    accession text NOT NULL,
+    version bigint NOT NULL,
+    organism text NOT NULL,
+    submission_id text NOT NULL,
+    submitter text NOT NULL,
+    approver text,
+    group_id integer NOT NULL,
+    submitted_at timestamp without time zone NOT NULL,
+    released_at timestamp without time zone,
+    is_revocation boolean DEFAULT false NOT NULL,
+    original_data jsonb,
+    version_comment text
+);
+
+
+ALTER TABLE public.sequence_entries OWNER TO postgres;
+
+--
+-- Name: sequence_entries_view; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.sequence_entries_view AS
+ SELECT se.accession,
+    se.version,
+    se.organism,
+    se.submission_id,
+    se.submitter,
+    se.approver,
+    se.group_id,
+    se.submitted_at,
+    se.released_at,
+    se.is_revocation,
+    se.original_data,
+    se.version_comment,
+    sepd.started_processing_at,
+    sepd.finished_processing_at,
+    sepd.processed_data,
+    (sepd.processed_data || em.joint_metadata) AS joint_metadata,
+    sepd.errors,
+    sepd.warnings,
+        CASE
+            WHEN (se.released_at IS NOT NULL) THEN 'APPROVED_FOR_RELEASE'::text
+            WHEN se.is_revocation THEN 'AWAITING_APPROVAL'::text
+            WHEN (sepd.processing_status = 'IN_PROCESSING'::text) THEN 'IN_PROCESSING'::text
+            WHEN (sepd.processing_status = 'HAS_ERRORS'::text) THEN 'HAS_ERRORS'::text
+            WHEN (sepd.processing_status = 'FINISHED'::text) THEN 'AWAITING_APPROVAL'::text
+            ELSE 'RECEIVED'::text
+        END AS status
+   FROM ((public.sequence_entries se
+     LEFT JOIN public.sequence_entries_preprocessed_data sepd ON (((se.accession = sepd.accession) AND (se.version = sepd.version) AND (sepd.pipeline_version = ( SELECT current_processing_pipeline.version
+           FROM public.current_processing_pipeline)))))
+     LEFT JOIN public.external_metadata_view em ON (((se.accession = em.accession) AND (se.version = em.version))));
+
+
+ALTER VIEW public.sequence_entries_view OWNER TO postgres;
+
+--
+-- Name: sequence_upload_aux_table; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sequence_upload_aux_table (
+    upload_id text NOT NULL,
+    submission_id text NOT NULL,
+    segment_name text NOT NULL,
+    compressed_sequence_data text NOT NULL
+);
+
+
+ALTER TABLE public.sequence_upload_aux_table OWNER TO postgres;
+
+--
+-- Name: table_update_tracker; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.table_update_tracker (
+    table_name text NOT NULL,
+    last_time_updated timestamp without time zone DEFAULT timezone('UTC'::text, CURRENT_TIMESTAMP)
+);
+
+
+ALTER TABLE public.table_update_tracker OWNER TO postgres;
+
+--
+-- Name: user_groups_table; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.user_groups_table (
+    id integer NOT NULL,
+    user_name text NOT NULL,
+    group_id integer NOT NULL
+);
+
+
+ALTER TABLE public.user_groups_table OWNER TO postgres;
+
+--
+-- Name: user_groups_table_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.user_groups_table_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.user_groups_table_id_seq OWNER TO postgres;
+
+--
+-- Name: user_groups_table_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.user_groups_table_id_seq OWNED BY public.user_groups_table.id;
+
+
+--
+-- Name: audit_log id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.audit_log ALTER COLUMN id SET DEFAULT nextval('public.audit_log_id_seq'::regclass);
+
+
+--
+-- Name: groups_table group_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.groups_table ALTER COLUMN group_id SET DEFAULT nextval('public.groups_table_group_id_seq'::regclass);
+
+
+--
+-- Name: seqset_records seqset_record_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.seqset_records ALTER COLUMN seqset_record_id SET DEFAULT nextval('public.seqset_records_seqset_record_id_seq'::regclass);
+
+
+--
+-- Name: seqset_to_records seqset_record_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.seqset_to_records ALTER COLUMN seqset_record_id SET DEFAULT nextval('public.seqset_to_records_seqset_record_id_seq'::regclass);
+
+
+--
+-- Name: user_groups_table id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_groups_table ALTER COLUMN id SET DEFAULT nextval('public.user_groups_table_id_seq'::regclass);
+
+
+--
+-- Name: audit_log audit_log_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.audit_log
+    ADD CONSTRAINT audit_log_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: current_processing_pipeline current_processing_pipeline_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.current_processing_pipeline
+    ADD CONSTRAINT current_processing_pipeline_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: external_metadata external_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.external_metadata
+    ADD CONSTRAINT external_metadata_pkey PRIMARY KEY (accession, version, external_metadata_updater);
+
+
+--
+-- Name: flyway_schema_history flyway_schema_history_pk; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.flyway_schema_history
+    ADD CONSTRAINT flyway_schema_history_pk PRIMARY KEY (installed_rank);
+
+
+--
+-- Name: groups_table groups_table_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.groups_table
+    ADD CONSTRAINT groups_table_pkey PRIMARY KEY (group_id);
+
+
+--
+-- Name: metadata_upload_aux_table metadata_upload_aux_table_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.metadata_upload_aux_table
+    ADD CONSTRAINT metadata_upload_aux_table_pkey PRIMARY KEY (upload_id, submission_id);
+
+
+--
+-- Name: seqset_records seqset_records_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.seqset_records
+    ADD CONSTRAINT seqset_records_pkey PRIMARY KEY (seqset_record_id);
+
+
+--
+-- Name: seqset_to_records seqset_to_records_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.seqset_to_records
+    ADD CONSTRAINT seqset_to_records_pkey PRIMARY KEY (seqset_record_id, seqset_id, seqset_version);
+
+
+--
+-- Name: seqsets seqsets_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.seqsets
+    ADD CONSTRAINT seqsets_pkey PRIMARY KEY (seqset_id, seqset_version);
+
+
+--
+-- Name: sequence_entries sequence_entries_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sequence_entries
+    ADD CONSTRAINT sequence_entries_pkey PRIMARY KEY (accession, version);
+
+
+--
+-- Name: sequence_entries_preprocessed_data sequence_entries_preprocessed_data_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sequence_entries_preprocessed_data
+    ADD CONSTRAINT sequence_entries_preprocessed_data_pkey PRIMARY KEY (accession, version, pipeline_version);
+
+
+--
+-- Name: sequence_upload_aux_table sequence_upload_aux_table_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sequence_upload_aux_table
+    ADD CONSTRAINT sequence_upload_aux_table_pkey PRIMARY KEY (upload_id, submission_id, segment_name);
+
+
+--
+-- Name: table_update_tracker table_update_tracker_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.table_update_tracker
+    ADD CONSTRAINT table_update_tracker_pkey PRIMARY KEY (table_name);
+
+
+--
+-- Name: user_groups_table user_groups_table_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_groups_table
+    ADD CONSTRAINT user_groups_table_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: user_groups_table user_groups_table_user_name_group_id_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_groups_table
+    ADD CONSTRAINT user_groups_table_user_name_group_id_key UNIQUE (user_name, group_id);
+
+
+--
+-- Name: data_use_terms_table_accession_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX data_use_terms_table_accession_idx ON public.data_use_terms_table USING btree (accession);
+
+
+--
+-- Name: flyway_schema_history_s_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX flyway_schema_history_s_idx ON public.flyway_schema_history USING btree (success);
+
+
+--
+-- Name: sequence_entries_submitter_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sequence_entries_submitter_idx ON public.sequence_entries USING btree (submitter);
+
+
+--
+-- Name: user_groups_table_user_name_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX user_groups_table_user_name_idx ON public.user_groups_table USING btree (user_name);
+
+
+--
+-- Name: current_processing_pipeline update_tracker_trigger; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER update_tracker_trigger AFTER INSERT OR DELETE OR UPDATE OR TRUNCATE ON public.current_processing_pipeline FOR EACH STATEMENT EXECUTE FUNCTION public.update_table_tracker();
+
+
+--
+-- Name: external_metadata update_tracker_trigger; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER update_tracker_trigger AFTER INSERT OR DELETE OR UPDATE OR TRUNCATE ON public.external_metadata FOR EACH STATEMENT EXECUTE FUNCTION public.update_table_tracker();
+
+
+--
+-- Name: groups_table update_tracker_trigger; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER update_tracker_trigger AFTER INSERT OR DELETE OR UPDATE OR TRUNCATE ON public.groups_table FOR EACH STATEMENT EXECUTE FUNCTION public.update_table_tracker();
+
+
+--
+-- Name: metadata_upload_aux_table update_tracker_trigger; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER update_tracker_trigger AFTER INSERT OR DELETE OR UPDATE OR TRUNCATE ON public.metadata_upload_aux_table FOR EACH STATEMENT EXECUTE FUNCTION public.update_table_tracker();
+
+
+--
+-- Name: sequence_entries update_tracker_trigger; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER update_tracker_trigger AFTER INSERT OR DELETE OR UPDATE OR TRUNCATE ON public.sequence_entries FOR EACH STATEMENT EXECUTE FUNCTION public.update_table_tracker();
+
+
+--
+-- Name: sequence_entries_preprocessed_data update_tracker_trigger; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER update_tracker_trigger AFTER INSERT OR DELETE OR UPDATE OR TRUNCATE ON public.sequence_entries_preprocessed_data FOR EACH STATEMENT EXECUTE FUNCTION public.update_table_tracker();
+
+
+--
+-- Name: sequence_upload_aux_table update_tracker_trigger; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER update_tracker_trigger AFTER INSERT OR DELETE OR UPDATE OR TRUNCATE ON public.sequence_upload_aux_table FOR EACH STATEMENT EXECUTE FUNCTION public.update_table_tracker();
+
+
+--
+-- Name: user_groups_table update_tracker_trigger; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER update_tracker_trigger AFTER INSERT OR DELETE OR UPDATE OR TRUNCATE ON public.user_groups_table FOR EACH STATEMENT EXECUTE FUNCTION public.update_table_tracker();
+
+
+--
+-- Name: seqset_to_records foreign_key_seqset_id; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.seqset_to_records
+    ADD CONSTRAINT foreign_key_seqset_id FOREIGN KEY (seqset_id, seqset_version) REFERENCES public.seqsets(seqset_id, seqset_version) ON DELETE CASCADE;
+
+
+--
+-- Name: seqset_to_records foreign_key_seqset_record_id; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.seqset_to_records
+    ADD CONSTRAINT foreign_key_seqset_record_id FOREIGN KEY (seqset_record_id) REFERENCES public.seqset_records(seqset_record_id) ON DELETE CASCADE;
+
+
+--
+-- Name: sequence_entries sequence_entries_group_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sequence_entries
+    ADD CONSTRAINT sequence_entries_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.groups_table(group_id);
+
+
+--
+-- Name: user_groups_table user_groups_table_group_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_groups_table
+    ADD CONSTRAINT user_groups_table_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.groups_table(group_id);
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/backend/docs/db/schema.sql
+++ b/backend/docs/db/schema.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 16.4 (Debian 16.4-1.pgdg120+2)
+-- Dumped from database version 15.8 (Debian 15.8-1.pgdg120+1)
 -- Dumped by pg_dump version 16.4 (Debian 16.4-1.pgdg120+2)
 
 SET statement_timeout = 0;
@@ -120,12 +120,12 @@ ALTER TABLE public.external_metadata OWNER TO postgres;
 --
 
 CREATE VIEW public.all_external_metadata AS
- SELECT accession,
-    version,
-    max(updated_metadata_at) AS updated_metadata_at,
-    public.jsonb_merge_agg(external_metadata) AS external_metadata
+ SELECT external_metadata.accession,
+    external_metadata.version,
+    max(external_metadata.updated_metadata_at) AS updated_metadata_at,
+    public.jsonb_merge_agg(external_metadata.external_metadata) AS external_metadata
    FROM public.external_metadata
-  GROUP BY accession, version;
+  GROUP BY external_metadata.accession, external_metadata.version;
 
 
 ALTER VIEW public.all_external_metadata OWNER TO postgres;


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #2791 

Adds CI to capture the DB schema after all migrations in `backend/docs/db/schema.sql`. It calculates what this is and if it doesn't match the current captured file the check fails. To make the check pass you can add the `update_db_schema` label which will cause the CI to write over that schema file with the current schema.

Purpose: to make it easy to see diffs in schema, allows seeing the current schema without having to manually add up all migrations in one's head

Limitations:

CI does not re-run after the auto-update. I consider that out of scope for this PR.
I'm not sure if migrations will change order - maybe there is a way to make the order more deterministic?
