### PR TITLE
feat(docs): Add an image-border

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -11,6 +11,7 @@ This website uses [Astro](https://astro.build/) for static site generation and
 -   Install packages: `npm ci` (`ci` as opposed to `install` makes sure to install the exact versions specified in `package-lock.json`)
 -   Generate config files for local testing (requires Helm installed): `../generate_local_test_config.sh`. If you are not running the backend locally, run `../generate_local_test_config.sh --from-live` to point to the backend from the live server (preview of the `main` branch).
 -   Run `npm run start` to start a local development server with hot reloading.
+-   Run `npm run format-fast` to format the code.
 
 ### Unit Tests
 

--- a/website/src/styles/mdcontainer.scss
+++ b/website/src/styles/mdcontainer.scss
@@ -19,7 +19,6 @@
 }
 
 .mdContainer img {
-    @apply my-3;
     @apply my-3 border border-gray-300 rounded-md;
 }
 

--- a/website/src/styles/mdcontainer.scss
+++ b/website/src/styles/mdcontainer.scss
@@ -135,12 +135,12 @@
 }
 
 .mdContainer .image-outline {
-  border: 2px solid #ccc; /* Light gray border for clarity */
-  border-radius: 4px; /* Optional: rounded corners */
-  padding: 4px; /* Optional: space between image and border */
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* Optional: subtle shadow for depth */
+    border: 2px solid #ccc; /* Light gray border for clarity */
+    border-radius: 4px; /* Optional: rounded corners */
+    padding: 4px; /* Optional: space between image and border */
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* Optional: subtle shadow for depth */
 }
-    
-.astro-code{
+
+.astro-code {
     @apply p-2;
 }

--- a/website/src/styles/mdcontainer.scss
+++ b/website/src/styles/mdcontainer.scss
@@ -135,13 +135,6 @@
     @apply text-lg font-semibold text-main my-3 border-t border-gray-300 mt-7 pt-5 mb-0;
 }
 
-.mdContainer .image-outline {
-    border: 2px solid #ccc; /* Light gray border for clarity */
-    border-radius: 4px; /* Optional: rounded corners */
-    padding: 4px; /* Optional: space between image and border */
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* Optional: subtle shadow for depth */
-}
-
 .astro-code {
     @apply p-2;
 }

--- a/website/src/styles/mdcontainer.scss
+++ b/website/src/styles/mdcontainer.scss
@@ -20,6 +20,7 @@
 
 .mdContainer img {
     @apply my-3;
+    @apply my-3 border border-gray-300 rounded-md;
 }
 
 .mdContainer p {

--- a/website/src/styles/mdcontainer.scss
+++ b/website/src/styles/mdcontainer.scss
@@ -134,6 +134,13 @@
     @apply text-lg font-semibold text-main my-3 border-t border-gray-300 mt-7 pt-5 mb-0;
 }
 
-.astro-code {
+.mdContainer .image-outline {
+  border: 2px solid #ccc; /* Light gray border for clarity */
+  border-radius: 4px; /* Optional: rounded corners */
+  padding: 4px; /* Optional: space between image and border */
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* Optional: subtle shadow for depth */
+}
+    
+.astro-code{
     @apply p-2;
 }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Adds an outline to images in the docs: as any explanatory images of how our website works include text which is in the same color and format as the docs this can be confusing, here I just add a very simple border around images to make it clearer that they are images: 
<img width="938" alt="image" src="https://github.com/user-attachments/assets/f21729d8-ebfb-4b53-977d-e564dd54e4ff">

Previously: 
<img width="938" alt="image" src="https://github.com/user-attachments/assets/41ac6296-9779-4436-bc41-de33cde38314">



### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
