### PR TITLE
When hard refresh fails with an exit code, make SILO exit

### DIFF
--- a/kubernetes/loculus/silo_import_wrapper.sh
+++ b/kubernetes/loculus/silo_import_wrapper.sh
@@ -33,7 +33,8 @@ do
         bash /silo_import_job.sh --last-etag=0 --backend-base-url="$BACKEND_BASE_URL"
         exit_code=$?
         if [ "$exit_code" -ne 0 ]; then
-            echo "Error: Hard refresh failed with exit code $exit_code"
+            echo "Error: Hard refresh failed with exit code $exit_code. Exiting."
+            exit $exit_code
         else
             echo "Hard refresh completed successfully"
             echo "$current_time" > "$last_hard_refresh_time_path"


### PR DESCRIPTION
This is an RFC.

Currently if a Silo hard refresh fails this doesn't trigger the container to exit and so can't be seen, for example, in the argoCD status. This is confusing. At some point we should make this cause the container to exit. However this could lead to downtime of the query API so potentially we could do it only after splitting up preprocessing into different pods than the main SILO. But that only makes sense if we expect the refresh to fail which I'm not sure we do?