### PR TITLE
feat!(website): add redirects to docs and add search sequences docs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -37,6 +37,7 @@ export default defineConfig({
                     label: 'For users',
                     items: [
                         { label: 'Introduction', link: '/for-users/introduction/' },
+                        { label: 'Search sequences', link: '/for-users/search-sequences/' },
                         { label: 'Edit account', link: '/for-users/edit-account/' },
                         { label: 'Create and manage groups', link: '/for-users/create-manage-groups/' },
                         { label: 'Submit sequences', link: '/for-users/submit-sequences/' },

--- a/docs/src/content/docs/for-users/search-sequences.md
+++ b/docs/src/content/docs/for-users/search-sequences.md
@@ -1,0 +1,33 @@
+---
+title: Search sequences
+---
+
+## Mutations
+
+### Nucleotide mutations and insertions
+
+A nucleotide mutation has the format `<position><base>` or `<base_ref><position><base>`. A `<base>` can be one of the four nucleotides `A`, `T`, `C`, and `G`. It can also be `-` for deletion and `N` for unknown. For example if the reference sequence is `A` at position 23 both: `23T` and `A23T` will yield the same results.
+
+If your organism is multi-segmented you must append the name of the segment to the start of the mutation, e.g. `S:23T` and `S:A23T` for a mutation in segment `S`.
+
+Insertions can be searched for in the same manner, they just need to have `ins_` appended to the start of the mutation. Example `ins_10462:A` or if the organism is multi-segmented `ins_S:10462:A`.
+
+### Amino acid mutations and insertions
+
+An amino acid mutation has the format `<gene>:<position><base>` of `<gene>:<base_ref><position><base>`. A `<base>` can be one of the 20 amino acid codes. It can also be `-` for deletion and `X` for unknown. Example: `E:57Q`.
+
+Insertions can be searched for in the same manner, they just need to have `ins_` appended to the start of the mutation. Example `ins_NS4B:31:N`.
+
+### Insertion wildcards
+
+Loculus supports insertion queries that contain wildcards `?`. For example `ins_S:214:?EP?` will match all cases where segment `S` has an insertion of `EP` between the positions 214 and 215 but also an insertion of other AAs which include the `EP`, e.g. the insertion `EPE` will be matched.
+
+You can also use wildcards to match any insertion at a given position. For example `ins_S:214:?:` will match any (but at least one) insertion between the positions 214 and 215.
+
+### Multiple mutations
+
+Multiple mutation filters can be provided by adding one mutation after the other.
+
+### Any mutation
+
+To filter for any mutation at a given position you can omit the `<base>`.

--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -8,6 +8,7 @@ import { AutoCompleteField } from './fields/AutoCompleteField';
 import { DateField, TimestampField } from './fields/DateField.tsx';
 import { MutationField } from './fields/MutationField.tsx';
 import { NormalTextField } from './fields/NormalTextField';
+import { searchFormHelpDocsUrl } from './searchFormHelpDocsUrl.ts';
 import { useOffCanvas } from '../../hooks/useOffCanvas.ts';
 import type { GroupedMetadataFilter, MetadataFilter, FieldValues, SetAFieldValue } from '../../types/config.ts';
 import { type ReferenceGenomesSequenceNames } from '../../types/referencesGenomes.ts';
@@ -78,7 +79,7 @@ export const SearchForm = ({
                                 >
                                     <MaterialSymbolsResetFocus className='inline-block' /> Reset
                                 </button>
-                                <a href='/docs/how-to/search-sequences-website' target='_blank'>
+                                <a href={searchFormHelpDocsUrl} target='_blank'>
                                     <MaterialSymbolsHelpOutline className='inline-block' /> Help
                                 </a>
                             </div>

--- a/website/src/components/SearchPage/searchFormHelpDocsUrl.ts
+++ b/website/src/components/SearchPage/searchFormHelpDocsUrl.ts
@@ -1,0 +1,2 @@
+// This variable is in a separate file as it is overwritten by Pathoplexus.
+export const searchFormHelpDocsUrl = 'https://loculus.org/for-users/search-sequences/';

--- a/website/src/pages/api-documentation/authenticationApiDocsUrl.ts
+++ b/website/src/pages/api-documentation/authenticationApiDocsUrl.ts
@@ -1,0 +1,2 @@
+// This variable is in a separate file as it is overwritten by Pathoplexus.
+export const authenticationApiDocsUrl = 'https://loculus.org/for-users/authenticate-via-api/';

--- a/website/src/pages/api-documentation/index.astro
+++ b/website/src/pages/api-documentation/index.astro
@@ -1,8 +1,10 @@
 ---
+import { authenticationApiDocsUrl } from './authenticationApiDocsUrl';
 import { getRuntimeConfig, getWebsiteConfig } from '../../config';
 import BaseLayout from '../../layouts/BaseLayout.astro';
-const clientConfig = getRuntimeConfig().public;
 import { routes } from '../../routes/routes.ts';
+
+const clientConfig = getRuntimeConfig().public;
 
 const websiteConfig = getWebsiteConfig();
 
@@ -24,17 +26,17 @@ const BUTTON_CLASS =
 
         <div>
             <p class='mt-4 mb-4'>
-                We offer a
+                There is a
                 <a
                     href='https://swagger.io/tools/swagger-ui/'
                     class='underline text-primary-900 hover:text-primary-800 hover:no-underline'
                 >
                     Swagger UI
                 </a>
-                for documentation and direct interaction with our APIs. For more tips on how to use our API we recommend
-                starting out with our
+                for documentation and direct interaction with the APIs. For more tips on how to use the API, it is recommended
+                to start with the
                 <a
-                    href='docs/how-to/authentication-api'
+                    href={authenticationApiDocsUrl}
                     class='underline text-primary-900 hover:text-primary-800 hover:no-underline'
                 >
                     API Authentication documentation.

--- a/website/src/pages/docs/how-to/search-sequences-website.mdx
+++ b/website/src/pages/docs/how-to/search-sequences-website.mdx
@@ -1,3 +1,0 @@
-# How to Search
-
-Fill this in with tips for your loculus instance.


### PR DESCRIPTION
Resolve #3140 and resolve #3160

preview URL: https://redirect-to-docs.loculus.org

### Summary

~This adds a redirect to the Loculus docs from the two locations where Pathoplexus has actual docs pages but not Loculus. This also copies over the mutation search docs from Pathoplexus to the Loculus docs.~

~It unfortunately doesn't seem to possible to have a server-side redirect in .mdx, so I had to create .astro files instead. This means that we have to delete these files on the Pathoplexus-side again because .astro files preceed .mdx files. @theosanderson, do you think that's a reasonable solution?~

The search form help button and the link to the authentication API docs now point to the Loculus docs. The variables are in separate files so that they can be easily overwritten by Pathoplexus. Here is a PR for Pathoplexus: https://github.com/pathoplexus/pathoplexus/pull/281

This also copies over the mutation search docs from Pathoplexus to the Loculus docs.

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
