### PR TITLE
refactor getSequences usage in SeqSetCitationsController

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/SeqSetCitationsController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SeqSetCitationsController.kt
@@ -93,7 +93,7 @@ class SeqSetCitationsController(
     @GetMapping("/get-user-cited-by-seqset")
     fun getUserCitedBySeqSet(@HiddenParam authenticatedUser: AuthenticatedUser): CitedBy =
         seqSetCitationsService.getUserCitedBySeqSet(
-            submissionDatabaseService.getApprovedAccessionVersions(authenticatedUser),
+            submissionDatabaseService.getApprovedUserAccessionVersions(authenticatedUser),
         )
 
     @Operation(description = "Get count of SeqSet cited by publications")

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SeqSetCitationsController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SeqSetCitationsController.kt
@@ -7,7 +7,6 @@ import org.loculus.backend.api.CitedBy
 import org.loculus.backend.api.ResponseSeqSet
 import org.loculus.backend.api.SeqSet
 import org.loculus.backend.api.SeqSetRecord
-import org.loculus.backend.api.Status.APPROVED_FOR_RELEASE
 import org.loculus.backend.api.SubmittedSeqSet
 import org.loculus.backend.api.SubmittedSeqSetRecord
 import org.loculus.backend.api.SubmittedSeqSetUpdate
@@ -92,11 +91,10 @@ class SeqSetCitationsController(
 
     @Operation(description = "Get count of user sequences cited by SeqSets")
     @GetMapping("/get-user-cited-by-seqset")
-    fun getUserCitedBySeqSet(@HiddenParam authenticatedUser: AuthenticatedUser): CitedBy {
-        val statusFilter = listOf(APPROVED_FOR_RELEASE)
-        val userSequences = submissionDatabaseService.getSequences(authenticatedUser, null, null, statusFilter)
-        return seqSetCitationsService.getUserCitedBySeqSet(userSequences.sequenceEntries)
-    }
+    fun getUserCitedBySeqSet(@HiddenParam authenticatedUser: AuthenticatedUser): CitedBy =
+        seqSetCitationsService.getUserCitedBySeqSet(
+            submissionDatabaseService.getApprovedAccessionVersions(authenticatedUser),
+        )
 
     @Operation(description = "Get count of SeqSet cited by publications")
     @GetMapping("/get-seqset-cited-by-publication")

--- a/backend/src/main/kotlin/org/loculus/backend/service/seqsetcitations/SeqSetCitationsDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/seqsetcitations/SeqSetCitationsDatabaseService.kt
@@ -33,7 +33,6 @@ import org.loculus.backend.controller.UnprocessableEntityException
 import org.loculus.backend.service.crossref.CrossRefService
 import org.loculus.backend.service.crossref.DoiEntry
 import org.loculus.backend.service.submission.AccessionPreconditionValidator
-import org.loculus.backend.service.submission.SubmissionDatabaseService
 import org.loculus.backend.utils.DateProvider
 import org.loculus.backend.utils.getNextSequenceNumber
 import org.springframework.stereotype.Service
@@ -48,7 +47,6 @@ private val log = KotlinLogging.logger { }
 @Transactional
 class SeqSetCitationsDatabaseService(
     private val accessionPreconditionValidator: AccessionPreconditionValidator,
-    private val submissionDatabaseService: SubmissionDatabaseService,
     private val backendConfig: BackendConfig,
     private val crossRefService: CrossRefService,
     private val dateProvider: DateProvider,

--- a/backend/src/main/kotlin/org/loculus/backend/service/seqsetcitations/SeqSetCitationsDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/seqsetcitations/SeqSetCitationsDatabaseService.kt
@@ -377,7 +377,7 @@ class SeqSetCitationsDatabaseService(
         )
 
         val userAccessionStrings = accessionVersions
-            .flatMap { listOf(it.accession, "${it.accession}.${it.version}") }
+            .flatMap { listOf(it.accession, it.displayAccessionVersion()) }
             .toSet()
 
         val maxSeqSetVersion = SeqSetsTable.seqSetVersion.max().alias("max_version")

--- a/backend/src/main/kotlin/org/loculus/backend/service/seqsetcitations/SeqSetCitationsDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/seqsetcitations/SeqSetCitationsDatabaseService.kt
@@ -369,18 +369,16 @@ class SeqSetCitationsDatabaseService(
     fun getUserCitedBySeqSet(accessionVersions: List<AccessionVersion>): CitedBy {
         log.info { "Get user cited by seqSet" }
 
-        val userAccessionStrings = (
-            accessionVersions.map { it.accession } +
-                accessionVersions.map { "${it.accession}.${it.version}" }
-            )
-            .toSet()
-
         data class SeqSetWithAccession(
             val accession: String,
             val seqSetId: String,
             val seqSetVersion: Long,
             val createdAt: Timestamp,
         )
+
+        val userAccessionStrings = accessionVersions
+            .flatMap { listOf(it.accession, "${it.accession}.${it.version}") }
+            .toSet()
 
         val maxSeqSetVersion = SeqSetsTable.seqSetVersion.max().alias("max_version")
         val maxVersionPerSeqSet = SeqSetsTable

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -948,7 +948,11 @@ open class SubmissionDatabaseService(
         )
     }
 
-    fun getApprovedAccessionVersions(authenticatedUser: AuthenticatedUser): List<AccessionVersion> =
+    /**
+     * Returns AccessionVersions submitted by groups that the given user is part of
+     * and that are approved for release.
+     */
+    fun getApprovedUserAccessionVersions(authenticatedUser: AuthenticatedUser): List<AccessionVersion> =
         SequenceEntriesView.select(
             SequenceEntriesView.accessionColumn,
             SequenceEntriesView.versionColumn,

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -52,6 +52,7 @@ import org.loculus.backend.api.ProcessedData
 import org.loculus.backend.api.SequenceEntryStatus
 import org.loculus.backend.api.SequenceEntryVersionToEdit
 import org.loculus.backend.api.Status
+import org.loculus.backend.api.Status.APPROVED_FOR_RELEASE
 import org.loculus.backend.api.SubmissionIdMapping
 import org.loculus.backend.api.SubmittedProcessedData
 import org.loculus.backend.api.UnprocessedData
@@ -623,7 +624,7 @@ open class SubmissionDatabaseService(
 
     fun getSequences(
         authenticatedUser: AuthenticatedUser,
-        organism: Organism?,
+        organism: Organism,
         groupIdsFilter: List<Int>?,
         statusesFilter: List<Status>?,
         warningsFilter: WarningsFilter? = null,
@@ -663,11 +664,8 @@ open class SubmissionDatabaseService(
                 DataUseTermsTable.restrictedUntilColumn,
             )
             .where { groupCondition }
+            .andWhere { SequenceEntriesView.organismIs(organism) }
             .orderBy(SequenceEntriesView.accessionColumn)
-
-        if (organism != null) {
-            baseQuery.andWhere { SequenceEntriesView.organismIs(organism) }
-        }
 
         val statusCounts: Map<Status, Int> = Status.entries.associateWith { status ->
             baseQuery.count { it[SequenceEntriesView.statusColumn] == status.name }
@@ -949,6 +947,20 @@ open class SubmissionDatabaseService(
             submissionId = selectedSequenceEntry[SequenceEntriesView.submissionIdColumn],
         )
     }
+
+    fun getApprovedAccessionVersions(authenticatedUser: AuthenticatedUser): List<AccessionVersion> =
+        SequenceEntriesView.select(
+            SequenceEntriesView.accessionColumn,
+            SequenceEntriesView.versionColumn,
+        )
+            .where(SequenceEntriesView.statusIs(APPROVED_FOR_RELEASE))
+            .groupBy(getGroupCondition(null, authenticatedUser))
+            .map {
+                AccessionVersion(
+                    it[SequenceEntriesView.accessionColumn],
+                    it[SequenceEntriesView.versionColumn],
+                )
+            }
 
     private fun originalMetadataFilter(
         authenticatedUser: AuthenticatedUser,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/CitationEndpointsTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/CitationEndpointsTest.kt
@@ -43,7 +43,7 @@ class CitationEndpointsTest(@Autowired private val client: SeqSetCitationsContro
     @Test
     fun `WHEN calling get user cited by seqSet of non-existing user THEN returns empty results`() {
         every {
-            submissionDatabaseService.getApprovedAccessionVersions(any())
+            submissionDatabaseService.getApprovedUserAccessionVersions(any())
         } returns listOf()
 
         client.getUserCitedBySeqSet()
@@ -69,7 +69,7 @@ class CitationEndpointsTest(@Autowired private val client: SeqSetCitationsContro
     @Test
     fun `WHEN calling get seqSet cited by publication of existing seqSet THEN returns results`() {
         every {
-            submissionDatabaseService.getApprovedAccessionVersions(any())
+            submissionDatabaseService.getApprovedUserAccessionVersions(any())
         } returns listOf(AccessionVersion("mock-sequence-accession", 1L))
 
         val seqSetResult = client.createSeqSet()

--- a/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/CitationEndpointsTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/CitationEndpointsTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import org.loculus.backend.api.AccessionVersion
 import org.loculus.backend.api.DataUseTerms
 import org.loculus.backend.api.GetSequenceResponse
 import org.loculus.backend.api.SequenceEntryStatus
@@ -46,8 +47,8 @@ class CitationEndpointsTest(@Autowired private val client: SeqSetCitationsContro
     @Test
     fun `WHEN calling get user cited by seqSet of non-existing user THEN returns empty results`() {
         every {
-            submissionDatabaseService.getSequences(any(), any(), any(), any())
-        } returns GetSequenceResponse(sequenceEntries = emptyList(), statusCounts = emptyMap())
+            submissionDatabaseService.getApprovedAccessionVersions(any())
+        } returns listOf()
 
         client.getUserCitedBySeqSet()
             .andExpect(status().isOk)
@@ -72,22 +73,8 @@ class CitationEndpointsTest(@Autowired private val client: SeqSetCitationsContro
     @Test
     fun `WHEN calling get seqSet cited by publication of existing seqSet THEN returns results`() {
         every {
-            submissionDatabaseService.getSequences(any(), any(), any(), any())
-        } returns GetSequenceResponse(
-            sequenceEntries = listOf(
-                SequenceEntryStatus(
-                    accession = "mock-sequence-accession",
-                    version = 1L,
-                    status = Status.APPROVED_FOR_RELEASE,
-                    groupId = 123,
-                    submitter = "mock-submitter",
-                    isRevocation = false,
-                    submissionId = "mock-submission-id",
-                    dataUseTerms = DataUseTerms.Open,
-                ),
-            ),
-            statusCounts = mapOf(Status.APPROVED_FOR_RELEASE to 1),
-        )
+            submissionDatabaseService.getApprovedAccessionVersions(any())
+        } returns listOf(AccessionVersion("mock-sequence-accession", 1L))
 
         val seqSetResult = client.createSeqSet()
             .andExpect(status().isOk)

--- a/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/CitationEndpointsTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/CitationEndpointsTest.kt
@@ -8,10 +8,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.loculus.backend.api.AccessionVersion
-import org.loculus.backend.api.DataUseTerms
-import org.loculus.backend.api.GetSequenceResponse
-import org.loculus.backend.api.SequenceEntryStatus
-import org.loculus.backend.api.Status
 import org.loculus.backend.controller.EndpointTest
 import org.loculus.backend.controller.expectUnauthorizedResponse
 import org.loculus.backend.service.submission.AccessionPreconditionValidator


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
In preparation for this: https://github.com/loculus-project/loculus/issues/1000 where I want to return metadata which requires the `organism` to be known in getSequences, I decided it would make sense to split the usage of the `getSequences` function that _doesn't_ use the `organism` out into its own function.

I added a new function that does exactly what is needed for the usage in seq set citations, which - I think - makes that code path easier to understand and also makes the `getSequences` function (and the changes to come) easier.

### Screenshot
n/a

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
