### PR TITLE
feat!: allow disabling of seqsets [CFG]

### DIFF
--- a/.idea/runConfigurations/BackendApplicationKt.run.xml
+++ b/.idea/runConfigurations/BackendApplicationKt.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="BackendApplicationKt" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" nameIsGenerated="true">
     <module name="backend.main" />
-    <option name="PROGRAM_PARAMETERS" value="--spring.datasource.url=jdbc:postgresql://localhost:5432/loculus --spring.datasource.username=postgres --spring.datasource.password=unsecure --keycloak.user=backend --keycloak.password=backend --keycloak.realm=loculus --keycloak.client=backend-client --keycloak.url=http://localhost:8083 --loculus.config.path=website/tests/config/backend_config.json --loculus.debug-mode=true --spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://localhost:8083/realms/loculus/protocol/openid-connect/certs" />
+    <option name="PROGRAM_PARAMETERS" value="--spring.datasource.url=jdbc:postgresql://localhost:5432/loculus --spring.datasource.username=postgres --spring.datasource.password=unsecure --keycloak.user=backend --keycloak.password=backend --keycloak.realm=loculus --keycloak.client=backend-client --keycloak.url=http://localhost:8083 --loculus.config.path=website/tests/config/backend_config.json --loculus.debug-mode=true --spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://localhost:8083/realms/loculus/protocol/openid-connect/certs --loculus.enable-seqset-citations=true" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="org.loculus.backend.BackendApplicationKt" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/backend/src/main/kotlin/org/loculus/backend/config/BackendSpringConfig.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/BackendSpringConfig.kt
@@ -30,9 +30,11 @@ object BackendSpringProperty {
     const val CLEAN_UP_RUN_EVERY_SECONDS = "loculus.cleanup.task.run-every-seconds"
     const val STREAM_BATCH_SIZE = "loculus.stream.batch-size"
     const val DEBUG_MODE = "loculus.debug-mode"
+    const val ENABLE_SEQSETS = "loculus.enable-seqsets"
 }
 
 const val DEBUG_MODE_ON_VALUE = "true"
+const val ENABLE_SEQSETS_TRUE_VALUE = "true"
 
 private val logger = mu.KotlinLogging.logger {}
 

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SeqSetCitationsController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SeqSetCitationsController.kt
@@ -12,9 +12,12 @@ import org.loculus.backend.api.SubmittedSeqSetRecord
 import org.loculus.backend.api.SubmittedSeqSetUpdate
 import org.loculus.backend.auth.AuthenticatedUser
 import org.loculus.backend.auth.HiddenParam
+import org.loculus.backend.config.BackendSpringProperty
+import org.loculus.backend.config.ENABLE_SEQSETS_TRUE_VALUE
 import org.loculus.backend.service.KeycloakAdapter
 import org.loculus.backend.service.seqsetcitations.SeqSetCitationsDatabaseService
 import org.loculus.backend.service.submission.SubmissionDatabaseService
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -27,6 +30,10 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @Validated
 @SecurityRequirement(name = "bearerAuth")
+@ConditionalOnProperty(
+    BackendSpringProperty.ENABLE_SEQSETS,
+    havingValue = ENABLE_SEQSETS_TRUE_VALUE,
+)
 class SeqSetCitationsController(
     private val seqSetCitationsService: SeqSetCitationsDatabaseService,
     private val submissionDatabaseService: SubmissionDatabaseService,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/SeqSetEndpointsDisabledTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/SeqSetEndpointsDisabledTest.kt
@@ -1,0 +1,24 @@
+package org.loculus.backend.controller.seqsetcitations
+
+import org.junit.jupiter.api.Test
+import org.loculus.backend.config.BackendSpringProperty
+import org.loculus.backend.controller.EndpointTest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@EndpointTest(
+    properties = ["${BackendSpringProperty.ENABLE_SEQSETS}=false"],
+)
+class SeqSetEndpointsDisabledTest(@Autowired private val client: SeqSetCitationsControllerClient) {
+    @Test
+    fun `GIVEN seqSets are disabled WHEN I get seqSets THEN returns not found`() {
+        client.getSeqSet(MOCK_SEQSET_ID, MOCK_SEQSET_VERSION)
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `GIVEN seqSets are disabled WHEN I create seqSets THEN returns not found`() {
+        client.createSeqSet()
+            .andExpect(status().isNotFound)
+    }
+}

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,6 +1,7 @@
 spring.config.import=file:src/main/resources/application.properties
 loculus.config.path=src/test/resources/backend_config.json
 
+loculus.enable-seqsets=true
 crossref.endpoint=dummy
 crossref.username=dummy
 crossref.password=dummy

--- a/backend/start_dev.sh
+++ b/backend/start_dev.sh
@@ -6,6 +6,7 @@ args=$(printf "%s " \
   "--spring.datasource.password=unsecure" \
   "--loculus.config.path=../website/tests/config/backend_config.json" \
   "--loculus.debug-mode=true" \
+  "--loculus.enable-seqsets=true" \
   "--spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://localhost:8083/realms/loculus/protocol/openid-connect/certs" \
   "--keycloak.user=backend" \
   "--keycloak.password=backend" \

--- a/docs/src/content/docs/reference/helm-chart-config.mdx
+++ b/docs/src/content/docs/reference/helm-chart-config.mdx
@@ -107,49 +107,49 @@ The configuration for the Helm chart is provided as a YAML file. It has the foll
             <td>If true, adds a noindex header to prevent search engine indexing</td>
         </tr>
         <tr>
-            <td>`enableCrossRefCredentials`</td>
+            <td>`seqSets.enabled`</td>
             <td>Boolean</td>
-            <td>true</td>
-            <td>If true, enables CrossRef integration. This is only relevant when SeqSets are used.</td>
+            <td></td>
+            <td>Enable/disable SeqSets. If false, `seqSets.crossRef` can be omitted.</td>
         </tr>
         <tr>
-            <td>`crossRef`</td>
+            <td>`seqSets.crossRef`</td>
             <td>Object</td>
             <td></td>
-            <td>Configuration for CrossRef integration</td>
+            <td>Configuration for CrossRef integration. Set to `null` to disable CrossRef integration (you can still use SeqSets without CrossRef DOIs).</td>
         </tr>
         <tr>
-            <td>`crossRef.DOIPrefix`</td>
+            <td>`seqSets.crossRef.DOIPrefix`</td>
             <td>String</td>
             <td></td>
             <td>The DOI prefix for SeqSets</td>
         </tr>
         <tr>
-            <td>`crossRef.endpoint`</td>
+            <td>`seqSets.crossRef.endpoint`</td>
             <td>String</td>
             <td></td>
             <td>The API endpoint for CrossRef</td>
         </tr>
         <tr>
-            <td>`crossRef.databaseName`</td>
+            <td>`seqSets.crossRef.databaseName`</td>
             <td>String</td>
             <td></td>
             <td>The database name for CrossRef</td>
         </tr>
         <tr>
-            <td>`crossRef.email`</td>
+            <td>`seqSets.crossRef.email`</td>
             <td>String</td>
             <td></td>
             <td>The email address associated with the CrossRef account</td>
         </tr>
         <tr>
-            <td>`crossRef.organization`</td>
+            <td>`seqSets.crossRef.organization`</td>
             <td>String</td>
             <td></td>
             <td>The organization name for CrossRef</td>
         </tr>
         <tr>
-            <td>`crossRef.hostUrl`</td>
+            <td>`seqSets.crossRef.hostUrl`</td>
             <td>String</td>
             <td></td>
             <td>The host URL for CrossRef callbacks</td>

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -149,6 +149,7 @@ welcomeMessageHTML: {{ quote $.Values.welcomeMessageHTML }}
 additionalHeadHTML: {{ quote $.Values.additionalHeadHTML }}
 {{end}}
 
+enableSeqSets: {{ $.Values.seqSets.enabled }}
 accessionPrefix: {{ quote $.Values.accessionPrefix }}
 {{- $commonMetadata := (include "loculus.commonMetadata" . | fromYaml).fields }}
 organisms:

--- a/kubernetes/loculus/templates/loculus-backend.yaml
+++ b/kubernetes/loculus/templates/loculus-backend.yaml
@@ -41,6 +41,8 @@ spec:
           ports:
             - containerPort: 8079
           args:
+            - "--loculus.enable-seqsets={{ $.Values.seqSets.enabled }}"
+            {{- if $.Values.seqSets.crossRef }}
             - "--crossref.doi-prefix=$(CROSSREF_DOI_PREFIX)"
             - "--crossref.endpoint=$(CROSSREF_ENDPOINT)"
             - "--crossref.username=$(CROSSREF_USERNAME)"
@@ -49,6 +51,7 @@ spec:
             - "--crossref.email=$(CROSSREF_EMAIL)"
             - "--crossref.organization=$(CROSSREF_ORGANIZATION)"
             - "--crossref.host-url=$(CROSSREF_HOST_URL)"
+            {{- end }}
             - "--keycloak.password=$(BACKEND_KEYCLOAK_PASSWORD)"
             - "--keycloak.realm=loculus"
             - "--keycloak.client=backend-client"
@@ -65,7 +68,7 @@ spec:
           env:
             - name: JVM_OPTS
               value: -XX:+UseContainerSupport -XX:+UseG1GC -XX:MaxHeapFreeRatio=5 -XX:MinHeapFreeRatio=2
-          {{- if .Values.enableCrossRefCredentials }}
+          {{- if $.Values.seqSets.crossRef }}
             - name: CROSSREF_USERNAME
               valueFrom:
                secretKeyRef:
@@ -77,17 +80,17 @@ spec:
                  name: crossref
                  key: password
             - name: CROSSREF_DOI_PREFIX
-              value: {{$.Values.crossRef.DOIPrefix | quote }}
+              value: {{$.Values.seqSets.crossRef.DOIPrefix | quote }}
             - name: CROSSREF_ENDPOINT
-              value: {{$.Values.crossRef.endpoint | quote  }}
+              value: {{$.Values.seqSets.crossRef.endpoint | quote  }}
             - name: CROSSREF_DATABASE_NAME
-              value: {{$.Values.crossRef.databaseName | quote }}
+              value: {{$.Values.seqSets.crossRef.databaseName | quote }}
             - name: CROSSREF_EMAIL
-              value: {{$.Values.crossRef.email | quote }}
+              value: {{$.Values.seqSets.crossRef.email | quote }}
             - name: CROSSREF_ORGANIZATION
-              value: {{$.Values.crossRef.organization | quote }}
+              value: {{$.Values.seqSets.crossRef.organization | quote }}
             - name: CROSSREF_HOST_URL
-              value: {{$.Values.crossRef.hostUrl | quote }}
+              value: {{$.Values.seqSets.crossRef.hostUrl | quote }}
            {{- end }}
             - name: BACKEND_KEYCLOAK_PASSWORD
               valueFrom:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1,8 +1,10 @@
 environment: server
 robotsNoindexHeader: false
-crossRef:
-  DOIPrefix: "placeholder"
-  endpoint: "https://test.crossref.org"
+seqSets:
+  enabled: true
+  crossRef:
+    DOIPrefix: "placeholder"
+    endpoint: "https://test.crossref.org"
 disableWebsite: false
 disableBackend: false
 disablePreprocessing: false
@@ -1520,7 +1522,6 @@ secrets:
     data:
       username: "dummy"
       password: "dummy"
-enableCrossRefCredentials: true
 runDevelopmentKeycloakDatabase: true
 runDevelopmentMainDatabase: true
 enforceHTTPS: true

--- a/website/src/components/Navigation/Navigation.astro
+++ b/website/src/components/Navigation/Navigation.astro
@@ -17,15 +17,13 @@ const selectedOrganism =
 const isLoggedIn = Astro.locals.session?.isLoggedIn ?? false;
 
 const loginUrl = await getAuthUrl(Astro.url.toString());
+
+const topNavigationItems = navigationItems.top(selectedOrganism?.key, isLoggedIn, loginUrl);
 ---
 
 <div class='flex justify-end relative'>
     <div class='subtitle hidden md:flex md:z-6 gap-4'>
-        {
-            navigationItems
-                .top(selectedOrganism?.key, isLoggedIn, loginUrl)
-                .map(({ text, path }) => <a href={path}>{text}</a>)
-        }
+        {topNavigationItems.map(({ text, path }) => <a href={path}>{text}</a>)}
     </div>
 
     <div
@@ -36,12 +34,6 @@ const loginUrl = await getAuthUrl(Astro.url.toString());
             top: '-2rem',
         }}
     >
-        <SandwichMenu
-            organism={selectedOrganism}
-            isLoggedIn={isLoggedIn}
-            gitHubMainUrl={gitHubMainUrl}
-            loginUrl={loginUrl}
-            client:load
-        />
+        <SandwichMenu topNavigationItems={topNavigationItems} gitHubMainUrl={gitHubMainUrl} client:load />
     </div>
 </div>

--- a/website/src/components/Navigation/SandwichMenu.tsx
+++ b/website/src/components/Navigation/SandwichMenu.tsx
@@ -1,19 +1,16 @@
 import type { FC } from 'react';
 
-import type { Organism } from '../../config.ts';
 import { useOffCanvas } from '../../hooks/useOffCanvas';
-import { navigationItems } from '../../routes/navigationItems';
+import { navigationItems, type TopNavigationItems } from '../../routes/navigationItems';
 import { OffCanvasOverlay } from '../OffCanvasOverlay';
 import { SandwichIcon } from '../SandwichIcon';
 
 type SandwichMenuProps = {
-    organism: Organism | undefined;
-    isLoggedIn: boolean;
-    loginUrl: string | undefined;
+    topNavigationItems: TopNavigationItems;
     gitHubMainUrl: string | undefined;
 };
 
-export const SandwichMenu: FC<SandwichMenuProps> = ({ organism, isLoggedIn, loginUrl, gitHubMainUrl }) => {
+export const SandwichMenu: FC<SandwichMenuProps> = ({ topNavigationItems, gitHubMainUrl }) => {
     const { isOpen, toggle: toggleMenu, close: closeMenu } = useOffCanvas();
 
     return (
@@ -43,7 +40,7 @@ export const SandwichMenu: FC<SandwichMenuProps> = ({ organism, isLoggedIn, logi
                             <a href='/'>Loculus</a>
                         </div>
                         <div className='flex-grow divide-y-2 divide-gray-300 divide-solid border-t-2 border-b-2 border-gray-300 border-solid '>
-                            {navigationItems.top(organism?.key, isLoggedIn, loginUrl).map(({ text, path }) => (
+                            {topNavigationItems.map(({ text, path }) => (
                                 <OffCanvasNavItem key={path} text={text} level={1} path={path} />
                             ))}
                         </div>

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -73,6 +73,10 @@ export function getReferenceGenomes(organism: string): ReferenceGenomes {
     return getConfig(organism).referenceGenomes;
 }
 
+export function seqSetsAreEnabled() {
+    return getWebsiteConfig().enableSeqSets;
+}
+
 function readTypedConfigFile<T>(fileName: string, schema: z.ZodType<T>) {
     const configFilePath = path.join(getConfigDir(), fileName);
     const json = JSON.parse(fs.readFileSync(configFilePath, 'utf8'));

--- a/website/src/pages/seqsets/[seqSetId].[version].astro
+++ b/website/src/pages/seqsets/[seqSetId].[version].astro
@@ -3,7 +3,7 @@ import { ErrorFeedback } from '../../components/ErrorFeedback';
 import { AuthorDetails } from '../../components/SeqSetCitations/AuthorDetails';
 import { SeqSetItem } from '../../components/SeqSetCitations/SeqSetItem';
 import { SeqSetItemActions } from '../../components/SeqSetCitations/SeqSetItemActions';
-import { getRuntimeConfig } from '../../config';
+import { getRuntimeConfig, seqSetsAreEnabled } from '../../config';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { SeqSetCitationClient } from '../../services/seqSetCitationClient.ts';
 import type { SeqSet } from '../../types/seqSetCitation';
@@ -15,6 +15,10 @@ const accessToken = getAccessToken(session)!;
 const seqSetId = Astro.params.seqSetId!;
 const version = Astro.params.version!;
 const username = session?.user?.username;
+
+if (!seqSetsAreEnabled()) {
+    return Astro.rewrite('/404');
+}
 
 const seqSetClient = SeqSetCitationClient.create();
 

--- a/website/src/pages/seqsets/index.astro
+++ b/website/src/pages/seqsets/index.astro
@@ -5,12 +5,16 @@ import { CitationPlot } from '../../components/SeqSetCitations/CitationPlot';
 import { SeqSetList } from '../../components/SeqSetCitations/SeqSetList';
 import { SeqSetListActions } from '../../components/SeqSetCitations/SeqSetListActions';
 import NeedToLogin from '../../components/common/NeedToLogin.astro';
-import { getRuntimeConfig } from '../../config';
+import { getRuntimeConfig, seqSetsAreEnabled } from '../../config';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { SeqSetCitationClient } from '../../services/seqSetCitationClient.ts';
 import { KeycloakClientManager } from '../../utils/KeycloakClientManager';
 import { getAccessToken } from '../../utils/getAccessToken';
 import { urlForKeycloakAccountPage } from '../../utils/urlForKeycloakAccountPage';
+
+if (!seqSetsAreEnabled()) {
+    return Astro.rewrite('/404');
+}
 
 const session = Astro.locals.session!;
 const accessToken = getAccessToken(session)!;

--- a/website/src/routes/navigationItems.ts
+++ b/website/src/routes/navigationItems.ts
@@ -1,11 +1,14 @@
 import { bottomNavigationItems } from './bottomNavigationItems.ts';
 import { extraTopNavigationItems } from './extraTopNavigationItems.js';
 import { routes } from './routes.ts';
+import { getWebsiteConfig } from '../config.ts';
 
 export const navigationItems = {
     top: topNavigationItems,
     bottom: bottomNavigationItems,
 };
+
+export type TopNavigationItems = ReturnType<(typeof navigationItems)['top']>;
 
 function getSequenceRelatedItems(organism: string | undefined) {
     return [
@@ -20,6 +23,15 @@ function getSequenceRelatedItems(organism: string | undefined) {
                     ? routes.submissionPageWithoutGroup(organism)
                     : routes.organismSelectorPage('submission'),
         },
+    ];
+}
+
+function getSeqSetsItems() {
+    if (!getWebsiteConfig().enableSeqSets) {
+        return [];
+    }
+
+    return [
         {
             text: 'SeqSets',
             path: routes.seqSetsPage(),
@@ -41,7 +53,8 @@ function getAccountItem(isLoggedIn: boolean, loginUrl: string | undefined, organ
 
 function topNavigationItems(organism: string | undefined, isLoggedIn: boolean, loginUrl: string | undefined) {
     const sequenceRelatedItems = getSequenceRelatedItems(organism);
+    const seqSetsItems = getSeqSetsItems();
     const accountItem = getAccountItem(isLoggedIn, loginUrl, organism);
 
-    return [...sequenceRelatedItems, ...extraTopNavigationItems, accountItem];
+    return [...sequenceRelatedItems, ...seqSetsItems, ...extraTopNavigationItems, accountItem];
 }

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -119,6 +119,7 @@ export const websiteConfig = z.object({
     additionalHeadHTML: z.string().optional(),
     gitHubEditLink: z.string().optional(),
     gitHubMainUrl: z.string().optional(),
+    enableSeqSets: z.boolean(),
 });
 export type WebsiteConfig = z.infer<typeof websiteConfig>;
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #3210

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://3210-allow-disabling-of-s.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

I grouped the seqSet config values. The values.yaml section can look like
```
seqSets:
  enabled: false
``` 
or
```
seqSets:
  enabled: false
  crossRef: null
``` 
or
```
seqSets:
  enabled: true
  crossRef:
    DOIPrefix: "placeholder"
    endpoint: "https://test.crossref.org"
``` 

When `seqSets. enabled == false`, 
* the backend endpoint are disabled
* the website SeqSets navigation item is disabled
* the SeqSets pages on the website return 404

BREAKING CONFIG CHANGES:
* `enableCrossRefCredentials` was removed. Use `seqSets.enabled` instead.
* moved `crossRef` to `seqSets.crossRef`

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

![grafik](https://github.com/user-attachments/assets/a509c842-bcb6-405e-aa10-97851ab2aaa7)

![grafik](https://github.com/user-attachments/assets/5fa01f55-31d5-47ea-93c3-a518ba0a2152)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
