### PR TITLE
feat(website): make welcome message configurable

### DIFF
--- a/docs/src/content/docs/reference/helm-chart-config.mdx
+++ b/docs/src/content/docs/reference/helm-chart-config.mdx
@@ -79,6 +79,14 @@ The configuration for the Helm chart is provided as a YAML file. It has the foll
             </td>
         </tr>
         <tr>
+            <td>`welcomeMessageHTML`</td>
+            <td>String</td>
+            <td></td>
+            <td>
+                A custom welcome message to be shown on the landing page
+            </td>
+        </tr>
+        <tr>
             <td>`additionalHeadHTML`</td>
             <td>String</td>
             <td></td>

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -142,6 +142,9 @@ bannerMessage: "Warning: Development or Keycloak main database is enabled. Devel
 {{ if $.Values.gitHubEditLink }}
 gitHubEditLink: {{ quote $.Values.gitHubEditLink }}
 {{ end }}
+{{ if $.Values.welcomeMessageHTML }}
+welcomeMessageHTML: {{ quote $.Values.welcomeMessageHTML }}
+{{end}}
 {{ if $.Values.additionalHeadHTML }}
 additionalHeadHTML: {{ quote $.Values.additionalHeadHTML }}
 {{end}}

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1457,6 +1457,7 @@ auth:
       clientId: "APP-P1P7N7T9YVBHQ4EH"
 insecureCookies: false
 bannerMessage: "This is a demonstration environment. It may contain non-accurate test data and should not be used for real-world applications. Data will be deleted regularly."
+welcomeMessageHTML: null
 additionalHeadHTML: ""
 images:
   lapisSilo: "ghcr.io/genspectrum/lapis-silo:0.3.2"

--- a/website/src/components/IndexPage/WelcomeMessage.astro
+++ b/website/src/components/IndexPage/WelcomeMessage.astro
@@ -1,9 +1,20 @@
 ---
-const websiteName = Astro.props.websiteName;
+interface Props {
+    websiteName: string;
+    welcomeMessageHTML: string | null | undefined;
+}
+
+const { websiteName, welcomeMessageHTML } = Astro.props;
 ---
 
-<p class='my-4'>
-    Welcome to {websiteName}, a system for sharing pathogen genome data.
-</p>
+{
+    welcomeMessageHTML !== null && welcomeMessageHTML !== undefined ? (
+        <Fragment set:html={welcomeMessageHTML} />
+    ) : (
+        <>
+            <p class='my-4'>Welcome to {websiteName}, a system for sharing pathogen genome data.</p>
 
-<h2 class='font-semibold my-3 text-lg'>Explore {websiteName} data!</h2>
+            <h2 class='font-semibold my-3 text-lg'>Explore {websiteName} data!</h2>
+        </>
+    )
+}

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -6,7 +6,7 @@ import { getOrganismStatisticsMap } from '../components/IndexPage/getOrganismSta
 import { getConfiguredOrganisms, getWebsiteConfig } from '../config';
 import BaseLayout from '../layouts/BaseLayout.astro';
 const websiteConfig = getWebsiteConfig();
-const { name: websiteName } = websiteConfig;
+const { name: websiteName, welcomeMessageHTML } = websiteConfig;
 import '../styles/mdcontainer.scss';
 
 const numberDaysAgoStatistics = 30;
@@ -18,7 +18,7 @@ const organismStatisticsMap = await getOrganismStatisticsMap(
 
 <BaseLayout title='Home'>
     <div class='max-w-6xl mx-auto'>
-        <WelcomeMessage websiteName={websiteName} />
+        <WelcomeMessage websiteName={websiteName} welcomeMessageHTML={welcomeMessageHTML} />
 
         <div class='flex flex-wrap'>
             {

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -115,6 +115,7 @@ export const websiteConfig = z.object({
     name: z.string(),
     logo: logoConfig,
     bannerMessage: z.string().optional(),
+    welcomeMessageHTML: z.string().optional().nullable(),
     additionalHeadHTML: z.string().optional(),
     gitHubEditLink: z.string().optional(),
     gitHubMainUrl: z.string().optional(),


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #3161

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://welcome-message.loculus.org

### Summary

This adds an optional `welcomeMessageHTML` config to allow an admin to configure the welcome message.

### Screenshot

See #3217

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- ~~[ ] The implemented feature is covered by an appropriate test.~~
