### PR TITLE
fix(backend): fix the inability to access revision form due to checking status 

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -949,7 +949,6 @@ class SubmissionDatabaseService(
         accessionPreconditionValidator.validate {
             thatAccessionVersionExists(accessionVersion)
                 .andThatUserIsAllowedToEditSequenceEntries(authenticatedUser)
-                .andThatSequenceEntriesAreInStates(listOf(Status.PROCESSED))
                 .andThatOrganismIs(organism)
         }
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetDataToEditEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetDataToEditEndpointTest.kt
@@ -110,24 +110,6 @@ class GetDataToEditEndpointTest(
     }
 
     @Test
-    fun `WHEN I query a sequence entry that has a wrong state THEN refuses request with unprocessable entity`() {
-        val firstAccession = convenienceClient.prepareDataTo(Status.IN_PROCESSING).first().accession
-
-        client.getSequenceEntryToEdit(
-            accession = firstAccession,
-            version = 1,
-        )
-            .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(
-                jsonPath("\$.detail").value(
-                    "Accession versions are in not in one of the states " +
-                        "[PROCESSED]: $firstAccession.1 - IN_PROCESSING",
-                ),
-            )
-    }
-
-    @Test
     fun `WHEN I try to get data for a sequence entry that I do not own THEN refuses request with forbidden entity`() {
         val firstAccession = convenienceClient.prepareDataTo(Status.PROCESSED, errors = true).first().accession
 


### PR DESCRIPTION
https://fix-unable-to-edit.loculus.org/
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #3224

This line was added in https://github.com/loculus-project/loculus/pull/3125 accidentally

This is another reason to potentially rename this endpoint to avoid confusion as Chaoran suggested once

<img width="1410" alt="image" src="https://github.com/user-attachments/assets/db239137-e464-47d4-878a-25215ff22bd9">
