### PR TITLE
sketch: do not hide metadata processing in sequence compression function

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedDataPostprocessor.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedDataPostprocessor.kt
@@ -1,0 +1,19 @@
+package org.loculus.backend.service.submission
+
+import org.loculus.backend.api.Organism
+import org.loculus.backend.api.ProcessedData
+import org.springframework.stereotype.Service
+
+@Service
+class ProcessedDataPostprocessor(
+    private val compressionService: CompressionService,
+    private val processedMetadataPostprocessor: ProcessedMetadataPostprocessor,
+) {
+    fun prepareForStorage(processedData: ProcessedData<String>, organism: Organism) = processedData
+        .let { compressionService.compressSequencesInProcessedData(it, organism) }
+        .let { processedMetadataPostprocessor.stripNullValuesFromMetadata(it) }
+
+    fun retrieveFromStoredValue(storedValue: ProcessedData<CompressedSequence>, organism: Organism) = storedValue
+        .let { processedMetadataPostprocessor.addMissingMetadataAsNull(it, organism) }
+        .let { compressionService.decompressSequencesInProcessedData(it, organism) }
+}

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedMetadataPostprocessor.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedMetadataPostprocessor.kt
@@ -1,0 +1,27 @@
+package org.loculus.backend.service.submission
+
+import com.fasterxml.jackson.databind.node.NullNode
+import org.loculus.backend.api.Organism
+import org.loculus.backend.api.ProcessedData
+import org.loculus.backend.config.BackendConfig
+import org.springframework.stereotype.Service
+
+@Service
+class ProcessedMetadataPostprocessor(
+    private val backendConfig: BackendConfig,
+) {
+    fun <SequenceType> stripNullValuesFromMetadata(processedData: ProcessedData<SequenceType>) =
+        processedData.copy(metadata = processedData.metadata.filterNot { (_, value) -> value.isNull })
+
+    fun <SequenceType> addMissingMetadataAsNull(processedData: ProcessedData<SequenceType>, organism: Organism) =
+        processedData.copy(
+            metadata = backendConfig
+                .getInstanceConfig(organism)
+                .schema
+                .metadata
+                .map { it.name }
+                .associateWith { fieldName ->
+                    processedData.metadata[fieldName] ?: NullNode.instance
+                },
+        )
+}


### PR DESCRIPTION
### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

https://github.com/loculus-project/loculus/pull/3232#issuecomment-2485795043

It's missing tests and probably some thought over how to embed this into the rest of the code (e.g. the `CompressionService` is still used separately), but this sketches how we could separate the concerns (metadata postprocessing vs. sequence compression). Separation of concerns is also my main motivation for this.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
