### PR TITLE
fix(backend): Fix submitter of revoked sequences to be the revoker

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -772,7 +772,7 @@ class SubmissionDatabaseService(
                     else -> stringParam(versionComment)
                 },
                 SequenceEntriesTable.submissionIdColumn,
-                SequenceEntriesTable.submitterColumn,
+                stringParam(authenticatedUser.username),
                 SequenceEntriesTable.groupIdColumn,
                 dateTimeParam(dateProvider.getCurrentDateTime()),
                 booleanParam(true), SequenceEntriesTable.organismColumn,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/TestHelpers.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/TestHelpers.kt
@@ -96,7 +96,6 @@ fun SequenceEntryStatus.assertIsRevocationIs(revoked: Boolean): SequenceEntrySta
     return this
 }
 
-
 fun expectUnauthorizedResponse(isModifyingRequest: Boolean = false, apiCall: (jwt: String?) -> ResultActions) {
     val response = apiCall(null)
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/TestHelpers.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/TestHelpers.kt
@@ -82,6 +82,21 @@ fun SequenceEntryStatus.assertSubmitterIs(submitter: String): SequenceEntryStatu
     return this
 }
 
+fun SequenceEntryStatus.assertGroupIdIs(groupId: Int): SequenceEntryStatus {
+    assertThat(this.groupId, `is`(groupId))
+    return this
+}
+
+fun SequenceEntryStatus.assertIsRevocationIs(revoked: Boolean): SequenceEntryStatus {
+    if (revoked) {
+        assertThat(this.isRevocation, `is`(true))
+    } else {
+        assertThat(this.isRevocation, `is`(false))
+    }
+    return this
+}
+
+
 fun expectUnauthorizedResponse(isModifyingRequest: Boolean = false, apiCall: (jwt: String?) -> ResultActions) {
     val response = apiCall(null)
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/TestHelpers.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/TestHelpers.kt
@@ -77,6 +77,11 @@ fun SequenceEntryStatus.assertHasError(error: Boolean): SequenceEntryStatus {
     return this
 }
 
+fun SequenceEntryStatus.assertSubmitterIs(submitter: String): SequenceEntryStatus {
+    assertThat(this.submitter, `is`(submitter))
+    return this
+}
+
 fun expectUnauthorizedResponse(isModifyingRequest: Boolean = false, apiCall: (jwt: String?) -> ResultActions) {
     val response = apiCall(null)
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/RevokeEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/RevokeEndpointTest.kt
@@ -8,7 +8,9 @@ import org.loculus.backend.controller.DEFAULT_ORGANISM
 import org.loculus.backend.controller.DEFAULT_USER_NAME
 import org.loculus.backend.controller.EndpointTest
 import org.loculus.backend.controller.OTHER_ORGANISM
+import org.loculus.backend.controller.SUPER_USER_NAME
 import org.loculus.backend.controller.assertStatusIs
+import org.loculus.backend.controller.assertSubmitterIs
 import org.loculus.backend.controller.expectUnauthorizedResponse
 import org.loculus.backend.controller.generateJwtFor
 import org.loculus.backend.controller.jwtForSuperUser
@@ -36,7 +38,7 @@ class RevokeEndpointTest(
     }
 
     @Test
-    fun `GIVEN entries with 'APPROVED_FOR_RELEASE' THEN returns revocation version in status AWAITING_APPROVAL`() {
+    fun `GIVEN entries with 'APPROVED_FOR_RELEASE' THEN returns revocation version in status PROCESSED`() {
         val accessions = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease().map { it.accession }
 
         client.revokeSequenceEntries(accessions)
@@ -48,6 +50,7 @@ class RevokeEndpointTest(
 
         convenienceClient.getSequenceEntry(accession = accessions.first(), version = 2)
             .assertStatusIs(PROCESSED)
+            .assertSubmitterIs(DEFAULT_USER_NAME)
     }
 
     @Test
@@ -94,7 +97,7 @@ class RevokeEndpointTest(
     }
 
     @Test
-    fun `WHEN superuser revokes entries of other group THEN revocation version is created`() {
+    fun `WHEN superuser revokes entries of other group THEN superuser is submitter of revocation entry`() {
         val accessions = convenienceClient
             .prepareDefaultSequenceEntriesToApprovedForRelease(username = DEFAULT_USER_NAME)
             .map { it.accession }
@@ -108,6 +111,7 @@ class RevokeEndpointTest(
 
         convenienceClient.getSequenceEntry(accession = accessions.first(), version = 2)
             .assertStatusIs(PROCESSED)
+            .assertSubmitterIs(SUPER_USER_NAME)
     }
 
     @Test

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/RevokeEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/RevokeEndpointTest.kt
@@ -9,14 +9,11 @@ import org.loculus.backend.controller.DEFAULT_USER_NAME
 import org.loculus.backend.controller.EndpointTest
 import org.loculus.backend.controller.OTHER_ORGANISM
 import org.loculus.backend.controller.SUPER_USER_NAME
-import org.loculus.backend.controller.asserThat
-import org.loculus.backend.controller.assertGroupId
 import org.loculus.backend.controller.assertGroupIdIs
 import org.loculus.backend.controller.assertHasError
 import org.loculus.backend.controller.assertIsRevocationIs
 import org.loculus.backend.controller.assertStatusIs
 import org.loculus.backend.controller.assertSubmitterIs
-import org.loculus.backend.controller.assertThat
 import org.loculus.backend.controller.expectUnauthorizedResponse
 import org.loculus.backend.controller.generateJwtFor
 import org.loculus.backend.controller.jwtForSuperUser
@@ -120,9 +117,13 @@ class RevokeEndpointTest(
             .andExpect(jsonPath("\$[0].accession").value(accessions.first()))
             .andExpect(jsonPath("\$[0].version").value(2))
 
+        val originalEntry = convenienceClient.getSequenceEntry(accession = accessions.first(), version = 1)
+
         convenienceClient.getSequenceEntry(accession = accessions.first(), version = 2)
             .assertStatusIs(PROCESSED)
             .assertHasError(false)
+            .assertGroupIdIs(originalEntry.groupId)
+            .assertIsRevocationIs(true)
             .assertSubmitterIs(SUPER_USER_NAME)
     }
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/RevokeEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/RevokeEndpointTest.kt
@@ -9,8 +9,14 @@ import org.loculus.backend.controller.DEFAULT_USER_NAME
 import org.loculus.backend.controller.EndpointTest
 import org.loculus.backend.controller.OTHER_ORGANISM
 import org.loculus.backend.controller.SUPER_USER_NAME
+import org.loculus.backend.controller.asserThat
+import org.loculus.backend.controller.assertGroupId
+import org.loculus.backend.controller.assertGroupIdIs
+import org.loculus.backend.controller.assertHasError
+import org.loculus.backend.controller.assertIsRevocationIs
 import org.loculus.backend.controller.assertStatusIs
 import org.loculus.backend.controller.assertSubmitterIs
+import org.loculus.backend.controller.assertThat
 import org.loculus.backend.controller.expectUnauthorizedResponse
 import org.loculus.backend.controller.generateJwtFor
 import org.loculus.backend.controller.jwtForSuperUser
@@ -48,8 +54,13 @@ class RevokeEndpointTest(
             .andExpect(jsonPath("\$[0].accession").value(accessions.first()))
             .andExpect(jsonPath("\$[0].version").value(2))
 
+        val originalEntry = convenienceClient.getSequenceEntry(accession = accessions.first(), version = 1)
+
         convenienceClient.getSequenceEntry(accession = accessions.first(), version = 2)
             .assertStatusIs(PROCESSED)
+            .assertHasError(false)
+            .assertGroupIdIs(originalEntry.groupId)
+            .assertIsRevocationIs(true)
             .assertSubmitterIs(DEFAULT_USER_NAME)
     }
 
@@ -111,6 +122,7 @@ class RevokeEndpointTest(
 
         convenienceClient.getSequenceEntry(accession = accessions.first(), version = 2)
             .assertStatusIs(PROCESSED)
+            .assertHasError(false)
             .assertSubmitterIs(SUPER_USER_NAME)
     }
 


### PR DESCRIPTION
Fixes #3244

https://theosanderson-fix-revoked.loculus.org/

Update the submitter of a revoked sequence to the revoker

* Modify `backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt` to set the `submitterColumn` to the revoker's account during the revocation process
* Change the `revoke` function to use the revoker's username for the `submitterColumn` instead of cloning the old submitter information

Tested that autoapprove no longer happens:

<img width="1315" alt="image" src="https://github.com/user-attachments/assets/0fe5a710-13b0-4caf-86e0-2c57d4462e35">



---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/loculus-project/loculus/pull/3246?shareId=b9d63876-b575-4564-b2fb-3c100518daf2).