### PR TITLE
fix(backend): delete processed entries as well when deleting unreleased sequence entries

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -891,6 +891,7 @@ class SubmissionDatabaseService(
 
         for (accessionVersionsChunk in sequenceEntriesToDelete.chunked(1000)) {
             SequenceEntriesTable.deleteWhere { accessionVersionIsIn(accessionVersionsChunk) }
+            SequenceEntriesPreprocessedDataTable.deleteWhere { accessionVersionIsIn(accessionVersionsChunk) }
         }
 
         auditLogger.log(


### PR DESCRIPTION
Fixes #3250

We should still add foreign key constraints - all sorts of race conditions are still possible until then, but this is better than nothing.

I've looked into whether we can easily test that rows have disappeared from processed data but I couldn't find good ways of doing this, we don't seem to be doing anything like that so far, or maybe I missed it. @fengelniederhammer any ideas on how to assert that after deletion there are no more corresponding entries in processed data table? I guess foreign key constraints are the best way to ensure, then almost no need to test at all.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/loculus-project/loculus/pull/3251?shareId=62292230-c49a-4c62-afeb-1c0304dfb81d).