### PR TITLE
fix(backend): delete processed entries as well when deleting unreleased sequence entries

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SequenceEntriesPreprocessedDataTable.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SequenceEntriesPreprocessedDataTable.kt
@@ -1,6 +1,7 @@
 package org.loculus.backend.service.submission
 
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.inList
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.kotlin.datetime.datetime
@@ -8,6 +9,7 @@ import org.loculus.backend.api.AccessionVersionInterface
 import org.loculus.backend.api.PreprocessingAnnotation
 import org.loculus.backend.api.PreprocessingStatus
 import org.loculus.backend.api.ProcessedData
+import org.loculus.backend.api.toPairs
 import org.loculus.backend.service.jacksonSerializableJsonb
 
 const val SEQUENCE_ENTRIES_PREPROCESSED_DATA_TABLE_NAME = "sequence_entries_preprocessed_data"
@@ -29,6 +31,9 @@ object SequenceEntriesPreprocessedDataTable : Table(SEQUENCE_ENTRIES_PREPROCESSE
     fun accessionVersionEquals(accessionVersion: AccessionVersionInterface) =
         (accessionColumn eq accessionVersion.accession) and
             (versionColumn eq accessionVersion.version)
+
+    fun accessionVersionIsIn(accessionVersions: List<AccessionVersionInterface>) =
+        Pair(accessionColumn, versionColumn) inList accessionVersions.toPairs()
 
     fun statusIs(status: PreprocessingStatus) = processingStatusColumn eq status.name
 }

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -891,6 +891,7 @@ class SubmissionDatabaseService(
 
         for (accessionVersionsChunk in sequenceEntriesToDelete.chunked(1000)) {
             SequenceEntriesTable.deleteWhere { accessionVersionIsIn(accessionVersionsChunk) }
+            SequenceEntriesPreprocessedDataTable.deleteWhere { accessionVersionIsIn(accessionVersionsChunk) }
         }
 
         auditLogger.log(

--- a/backend/src/test/kotlin/org/loculus/backend/controller/debug/DeleteAllSequenceDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/debug/DeleteAllSequenceDataEndpointTest.kt
@@ -13,6 +13,7 @@ import org.hamcrest.Matchers.not
 import org.junit.jupiter.api.Test
 import org.loculus.backend.api.DataUseTerms
 import org.loculus.backend.api.DataUseTermsChangeRequest
+import org.loculus.backend.api.DeleteSequenceScope
 import org.loculus.backend.api.Status
 import org.loculus.backend.config.BackendSpringProperty
 import org.loculus.backend.controller.DEFAULT_USER_NAME
@@ -26,6 +27,7 @@ import org.loculus.backend.controller.submission.SubmissionControllerClient
 import org.loculus.backend.controller.submission.SubmissionConvenienceClient
 import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles.NUMBER_OF_SEQUENCES
 import org.loculus.backend.controller.withAuth
+import org.loculus.backend.service.submission.SubmissionDatabaseService
 import org.loculus.backend.service.submission.UseNewerProcessingPipelineVersionTask
 import org.loculus.backend.utils.DateProvider
 import org.springframework.beans.factory.annotation.Autowired
@@ -40,6 +42,7 @@ class DeleteAllSequenceDataEndpointTest(
     @Autowired private val submissionControllerClient: SubmissionControllerClient,
     @Autowired private val dataUseTermsClient: DataUseTermsControllerClient,
     @Autowired private val useNewerProcessingPipelineVersionTask: UseNewerProcessingPipelineVersionTask,
+    @Autowired val submissionDatabaseService: SubmissionDatabaseService,
     @Autowired private val mockMvc: MockMvc,
 ) {
     @Test
@@ -140,6 +143,27 @@ class DeleteAllSequenceDataEndpointTest(
         submissionConvenienceClient.prepareDataTo(Status.RECEIVED)
         val extractedDataAfterDeletion = submissionConvenienceClient.extractUnprocessedData(pipelineVersion = 1)
         assertThat(extractedDataAfterDeletion, hasSize(NUMBER_OF_SEQUENCES))
+    }
+
+    @Test
+    fun `GIVEN preprocessing pipeline version 1 WHEN some sequences deleted THEN can update pipeline to version 2`() {
+        val accessionVersions = submissionConvenienceClient.prepareDataTo(Status.PROCESSED)
+
+        val accessionFirst = accessionVersions.first()
+
+        submissionControllerClient.deleteSequenceEntries(
+            scope = DeleteSequenceScope.ALL,
+            accessionVersionsFilter = listOf(accessionFirst),
+            jwt = jwtForSuperUser,
+        )
+
+        val extractedDataVersion2 = submissionConvenienceClient.extractUnprocessedData(pipelineVersion = 2)
+        val processedDataVersion2 = extractedDataVersion2
+            .map { PreparedProcessedData.successfullyProcessed(accession = it.accession, version = it.version) }
+        submissionConvenienceClient.submitProcessedData(processedDataVersion2, pipelineVersion = 2)
+
+        val canUpdate = submissionDatabaseService.useNewerProcessingPipelineIfPossible()
+        assertThat("An update to v2 should be possible", canUpdate, `is`(2L))
     }
 
     @Test


### PR DESCRIPTION
Fixes #3250

preview URL: https://delete-processed.loculus.org

Generated partially with help from Copilot, see #3251 

### Summary

When deleting entries from sequence_entries table, we also now delete from sequence_entries_preprocessed_data table.

### Followup

We should still add foreign key constraints - all sorts of race conditions are still possible until then, but this is better than nothing.

### Testing

I've manually tested that if I delete something from sequence_entries it also disappears from sequence_entries_preprocessed_data.

I've looked into whether we can easily test programmatically that rows have disappeared from processed data but I couldn't find good ways of doing this, we don't seem to be doing anything like that so far, or maybe I missed it. @fengelniederhammer any ideas on how to assert that after deletion there are no more corresponding entries in processed data table? I guess foreign key constraints are the best way to ensure, then almost no need to test at all.
### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
