### PR TITLE
feat(config): allow dev standin dbs to be semi-persistent through values.yaml

### DIFF
--- a/kubernetes/loculus/templates/keycloak-database-standin.yaml
+++ b/kubernetes/loculus/templates/keycloak-database-standin.yaml
@@ -41,7 +41,7 @@ spec:
               value: "keycloak"
             - name: POSTGRES_HOST_AUTH_METHOD
               value: "trust"
-            {{ if not .Values.runDevelopmentKeycloakDatabaseWithPersistence }}
+            {{ if not .Values.developmentDatabasePersistence }}
             - name: LOCULUS_VERSION
               value: {{ $dockerTag }}
             {{- end }}

--- a/kubernetes/loculus/templates/keycloak-database-standin.yaml
+++ b/kubernetes/loculus/templates/keycloak-database-standin.yaml
@@ -41,6 +41,8 @@ spec:
               value: "keycloak"
             - name: POSTGRES_HOST_AUTH_METHOD
               value: "trust"
+            {{ if not .Values.runDevelopmentKeycloakDatabaseWithPersistence }}
             - name: LOCULUS_VERSION
               value: {{ $dockerTag }}
+            {{- end }}
 {{- end }}

--- a/kubernetes/loculus/templates/loculus-database-standin.yaml
+++ b/kubernetes/loculus/templates/loculus-database-standin.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: loculus-database
   annotations:
-    argocd.argoproj.io/sync-options: Replace=true
+    argocd.argoproj.io/sync-options: Replace={{ not .Values.runDevelopmentMainDatabaseWithPersistence }}
 spec:
   replicas: 1
   selector:
@@ -40,6 +40,8 @@ spec:
           value: "loculus"
         - name: POSTGRES_HOST_AUTH_METHOD
           value: "trust"
+        {{ if not .Values.runDevelopmentMainDatabaseWithPersistence }}
         - name: LOCULUS_VERSION
           value: {{ $dockerTag }}
+        {{- end }}
 {{- end }}

--- a/kubernetes/loculus/templates/loculus-database-standin.yaml
+++ b/kubernetes/loculus/templates/loculus-database-standin.yaml
@@ -40,7 +40,7 @@ spec:
           value: "loculus"
         - name: POSTGRES_HOST_AUTH_METHOD
           value: "trust"
-        {{ if not .Values.runDevelopmentMainDatabaseWithPersistence }}
+        {{ if not .Values.developmentDatabasePersistence }}
         - name: LOCULUS_VERSION
           value: {{ $dockerTag }}
         {{- end }}

--- a/kubernetes/loculus/templates/loculus-database-standin.yaml
+++ b/kubernetes/loculus/templates/loculus-database-standin.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: loculus-database
   annotations:
-    argocd.argoproj.io/sync-options: Replace={{ not .Values.runDevelopmentMainDatabaseWithPersistence }}
+    argocd.argoproj.io/sync-options: Replace=true
 spec:
   replicas: 1
   selector:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1529,9 +1529,8 @@ secrets:
       username: "dummy"
       password: "dummy"
 runDevelopmentKeycloakDatabase: true
-runDevelopmentKeycloakDatabaseWithPersistence: true
 runDevelopmentMainDatabase: true
-runDevelopmentMainDatabaseWithPersistence: true
+developmentDatabasePersistence: true
 enforceHTTPS: true
 registrationTermsMessage: >
   You must agree to the <a href="http://main.loculus.org/terms">terms of use</a>.

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1530,6 +1530,7 @@ secrets:
       password: "dummy"
 runDevelopmentKeycloakDatabase: true
 runDevelopmentMainDatabase: true
+runDevelopmentMainDatabaseWithPersistence: false
 enforceHTTPS: true
 registrationTermsMessage: >
   You must agree to the <a href="http://main.loculus.org/terms">terms of use</a>.

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1529,6 +1529,7 @@ secrets:
       username: "dummy"
       password: "dummy"
 runDevelopmentKeycloakDatabase: true
+runDevelopmentKeycloakDatabaseWithPersistence: true
 runDevelopmentMainDatabase: true
 runDevelopmentMainDatabaseWithPersistence: true
 enforceHTTPS: true

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1530,7 +1530,7 @@ secrets:
       password: "dummy"
 runDevelopmentKeycloakDatabase: true
 runDevelopmentMainDatabase: true
-developmentDatabasePersistence: true
+developmentDatabasePersistence: false
 enforceHTTPS: true
 registrationTermsMessage: >
   You must agree to the <a href="http://main.loculus.org/terms">terms of use</a>.

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1530,7 +1530,7 @@ secrets:
       password: "dummy"
 runDevelopmentKeycloakDatabase: true
 runDevelopmentMainDatabase: true
-runDevelopmentMainDatabaseWithPersistence: false
+runDevelopmentMainDatabaseWithPersistence: true
 enforceHTTPS: true
 registrationTermsMessage: >
   You must agree to the <a href="http://main.loculus.org/terms">terms of use</a>.


### PR DESCRIPTION
resolves #3254

preview URL: https://persistence.loculus.org

Need to revert from true to false before merging.

### Summary

Allows not reloading the main and keycloak dbs for each commit in preview/dev deployments through values.yaml

Note that the database is 20+ minutes old while backend was replaced recently, that's what we can do now:
<img width="733" alt="image" src="https://github.com/user-attachments/assets/5a8a4838-97db-4d88-8f7b-9b741b4209d4">
