### PR TITLE
feat(preprocessing): parse dates into date ranges to correctly represent incomplete dates

### DIFF
--- a/docs/src/content/docs/for-administrators/existing-preprocessing-pipelines.md
+++ b/docs/src/content/docs/for-administrators/existing-preprocessing-pipelines.md
@@ -34,7 +34,6 @@ In the default configuration the pipeline performs:
 
 The pipeline also formats metadata fields:
 
--   **process date**: Takes a date string and returns a date field in the "%Y-%m-%d" format.
--   **parse timestamp**: Takes a timestamp e.g. 2022-11-01T00:00:00Z and returns that field in the "%Y-%m-%d" format.
+-   **parse timestamp**: Takes an ISO timestamp e.g. `2022-11-01T00:00:00Z` and returns that field in the `%Y-%m-%d` format.
 
 The code is available on [GitHub](https://github.com/loculus-project/loculus/tree/main/preprocessing/nextclade) under the [AGPL-3.0 license](https://github.com/loculus-project/loculus/blob/main/LICENSE).

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -81,7 +81,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         type: date
         initiallyVisible: true
         header: Sample details
-        ingest: ncbiCollectionDate
         preprocessing:
           function: parse_date_into_range
           inputs:
@@ -95,7 +94,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         type: date
         initiallyVisible: true
         header: Sample details
-        ingest: ncbiCollectionDate
         preprocessing:
           function: parse_date_into_range
           inputs:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1119,7 +1119,7 @@ defaultOrganismConfig: &defaultOrganismConfig
       defaultOrderBy: sampleCollectionDate
       defaultOrder: descending
     silo:
-      dateToSortBy: sampleCollectionDateUpper
+      dateToSortBy: sampleCollectionDateRangeUpper
     extraInputFields: []
   preprocessing:
     - &preprocessing
@@ -1136,45 +1136,45 @@ defaultOrganismConfig: &defaultOrganismConfig
   ingest: &ingest
     image: ghcr.io/loculus-project/ingest
     configFile: &ingestConfigFile
-      taxon_id: 3052462
+      taxon_id: 186540
   enaDeposition:
     configFile:
-      taxon_id: 186538
-      scientific_name: "Zaire ebolavirus"
+      taxon_id: 186540
+      scientific_name: "Sudan ebolavirus"
       molecule_type: "genomic RNA"
   referenceGenomes:
     nucleotideSequences:
       - name: "main"
-        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-zaire/reference.fasta]]"
+        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/reference.fasta]]"
         insdcAccessionFull: NC_002549.1
     genes:
       - name: NP
-        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-zaire/NP.fasta]]"
+        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/NP.fasta]]"
       - name: VP35
-        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-zaire/VP35.fasta]]"
+        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/VP35.fasta]]"
       - name: VP40
-        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-zaire/VP40.fasta]]"
+        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/VP40.fasta]]"
       - name: GP
-        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-zaire/GP.fasta]]"
+        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/GP.fasta]]"
       - name: ssGP
-        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-zaire/ssGP.fasta]]"
+        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/ssGP.fasta]]"
       - name: sGP
-        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-zaire/sGP.fasta]]"
+        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/sGP.fasta]]"
       - name: VP30
-        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-zaire/VP30.fasta]]"
+        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/VP30.fasta]]"
       - name: VP24
-        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-zaire/VP24.fasta]]"
+        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/VP24.fasta]]"
       - name: L
-        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-zaire/L.fasta]]"
+        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/L.fasta]]"
 defaultOrganisms:
-  ebola-zaire:
+  ebola-sudan:
     <<: *defaultOrganismConfig
     preprocessing:
       - <<: *preprocessing
         configFile:
           <<: *preprocessingConfigFile
           nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/ebola/data_output
-          nextclade_dataset_name: nextstrain/ebola/zaire
+          nextclade_dataset_name: nextstrain/ebola/sudan
   west-nile:
     <<: *defaultOrganismConfig
     schema:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1119,7 +1119,7 @@ defaultOrganismConfig: &defaultOrganismConfig
       defaultOrderBy: sampleCollectionDate
       defaultOrder: descending
     silo:
-      dateToSortBy: sampleCollectionDate
+      dateToSortBy: sampleCollectionDateUpper
     extraInputFields: []
   preprocessing:
     - &preprocessing

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -110,7 +110,7 @@ defaultOrganismConfig: &defaultOrganismConfig
             sampleCollectionDate: sampleCollectionDate
           args:
             order: [geoLocCountry, accession_version, sampleCollectionDate]
-            type: [string, string, date]
+            type: [string, string, string]
         noInput: true
       - name: ncbiReleaseDate
         displayName: NCBI release date

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -89,6 +89,7 @@ defaultOrganismConfig: &defaultOrganismConfig
             releaseDate: ncbiReleaseDate
           args:
             fieldType: dateRangeLower
+        noInput: true
       - name: sampleCollectionDateRangeUpper
         displayName: Collection date (upper bound)
         type: date
@@ -102,6 +103,7 @@ defaultOrganismConfig: &defaultOrganismConfig
             releaseDate: ncbiReleaseDate
           args:
             fieldType: dateRangeUpper
+        noInput: true
       - name: displayName
         preprocessing:
           function: concatenate

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -31,7 +31,7 @@ logo:
 defaultOrganismConfig: &defaultOrganismConfig
   schema: &schema
     loadSequencesAutomatically: true
-    organismName: "Ebola Zaire"
+    organismName: "Ebola Sudan"
     image: "/images/organisms/ebolazaire_small.jpg"
     ### Field list
     ## General fields
@@ -1128,7 +1128,7 @@ defaultOrganismConfig: &defaultOrganismConfig
       replicas: 2
       configFile: &preprocessingConfigFile
         log_level: DEBUG
-        nextclade_dataset_name: nextstrain/ebola/zaire
+        nextclade_dataset_name: nextstrain/ebola/sudan
         genes: [NP, VP35, VP40, GP, sGP, ssGP, VP30, VP24, L]
         batch_size: 100
   ingest: &ingest

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -32,7 +32,7 @@ defaultOrganismConfig: &defaultOrganismConfig
   schema: &schema
     loadSequencesAutomatically: true
     organismName: "Ebola Sudan"
-    image: "/images/organisms/ebolazaire_small.jpg"
+    image: "/images/organisms/ebolasudan_small.jpg"
     ### Field list
     ## General fields
     # name: Key used across app to refer to this field (required)

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -64,15 +64,44 @@ defaultOrganismConfig: &defaultOrganismConfig
     metadata:
       - name: sampleCollectionDate
         displayName: Collection date
+        initiallyVisible: true
+        header: Sample details
+        ingest: ncbiCollectionDate
+        preprocessing:
+          function: parse_date_into_range
+          inputs:
+            date: sampleCollectionDate
+            releaseDate: ncbiReleaseDate
+          args:
+            fieldType: dateRangeString
+        required: true
+        enableSubstringSearch: true
+      - name: sampleCollectionDateRangeLower
+        displayName: Collection date (lower bound)
         type: date
         initiallyVisible: true
         header: Sample details
         ingest: ncbiCollectionDate
         preprocessing:
-          function: parse_and_assert_past_date
+          function: parse_date_into_range
           inputs:
             date: sampleCollectionDate
-        required: true
+            releaseDate: ncbiReleaseDate
+          args:
+            fieldType: dateRangeLower
+      - name: sampleCollectionDateRangeUpper
+        displayName: Collection date (upper bound)
+        type: date
+        initiallyVisible: true
+        header: Sample details
+        ingest: ncbiCollectionDate
+        preprocessing:
+          function: parse_date_into_range
+          inputs:
+            date: sampleCollectionDate
+            releaseDate: ncbiReleaseDate
+          args:
+            fieldType: dateRangeUpper
       - name: displayName
         preprocessing:
           function: concatenate

--- a/preprocessing/nextclade/environment.yml
+++ b/preprocessing/nextclade/environment.yml
@@ -5,12 +5,12 @@ channels:
   - nodefaults
 dependencies:
   - python=3.12
-  - biopython=1.83
-  - dpath=2.1
-  - nextclade=3.8
-  - pip=24.0
+  - biopython=1.84
+  - dpath=2.2
+  - nextclade=3.9
+  - pip=24.3
   - PyYAML=6.0
-  - pyjwt=2.8
+  - pyjwt=2.10
   - python-dateutil=2.9
-  - pytz=2024.1
+  - pytz=2024.2
   - requests=2.32

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -206,7 +206,7 @@ class ProcessingFunctions:
         output_field: str,
         args: FunctionArgs = None,  # args is essential - even if Pylance says it's not used
     ) -> ProcessingResult:
-        """Parse date string formatted as one of YYYY | YYYY-MM | YYYY-MM-DD into a range
+        """Parse date string (`input.date`) formatted as one of YYYY | YYYY-MM | YYYY-MM-DD into a range using upper bound (`input.releaseDate`)
         Return value determined FunctionArgs:
         fieldType: "dateRangeString" | "dateRangeLower" | "dateRangeUpper"
         Default fieldType is "dateRangeString"

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -326,8 +326,10 @@ class ProcessingFunctions:
                     return_value = datum.date_range_string
                 case "dateRangeLower":
                     return_value = datum.date_range_lower.strftime("%Y-%m-%d")
+                    warnings = errors = []
                 case "dateRangeUpper":
                     return_value = datum.date_range_upper.strftime("%Y-%m-%d")
+                    warnings = errors = []
                 case _:
                     msg = f"Config error: Unknown fieldType: {args['fieldType']}"
                     raise ValueError(msg)

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -232,8 +232,6 @@ class ProcessingFunctions:
                 errors=[],
             )
 
-        logger.debug(f"release_date: {release_date}")
-
         formats_to_messages = {
             "%Y-%m-%d": None,
             "%Y-%m": "Day is missing. Assuming date is some time in the month.",
@@ -276,12 +274,6 @@ class ProcessingFunctions:
                         date_range_string=parsed_date.strftime("%Y"),
                         date_range_lower=parsed_date.replace(month=1, day=1),
                         date_range_upper=parsed_date.replace(month=12, day=31),
-                    )
-                case "_":
-                    datum = DateRange(
-                        date_range_string=None,
-                        date_range_lower=None,
-                        date_range_upper=max_upper_limit,
                     )
 
             logger.debug(f"parsed_date: {datum}")

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -220,7 +220,8 @@ class ProcessingFunctions:
         except Exception:
             release_date = None
 
-        max_upper_limit = min(filter(None, [datetime.now(tz=pytz.utc), release_date]))
+        now = datetime.now(tz=pytz.utc)
+        max_upper_limit = min(now, release_date) if release_date else now
 
         if not date_str:
             return ProcessingResult(

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -239,8 +239,8 @@ class ProcessingFunctions:
         @dataclass
         class DateRange:
             date_range_string: str
-            date_range_lower: datetime.date
-            date_range_upper: datetime.date
+            date_range_lower: datetime
+            date_range_upper: datetime
 
         for format, message in formats_to_messages.items():
             try:

--- a/preprocessing/nextclade/tests/test_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_processing_functions.py
@@ -347,7 +347,7 @@ accepted_authors = {
 not_accepted_authors = [
     ";",
     ",;",
-    " ,;" ",X.;Yu,X.",
+    " ,;", ",X.;Yu,X.",
     ",;Yu,X.",
     "Anna Maria Smith; Jose X. Perez",
     "Anna Maria Smith;",

--- a/preprocessing/nextclade/tests/test_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_processing_functions.py
@@ -7,8 +7,13 @@ from factory_methods import ProcessedEntryFactory, ProcessingTestCase, Unprocess
 from loculus_preprocessing.config import Config, get_config
 from loculus_preprocessing.datatypes import ProcessedEntry, ProcessingAnnotation
 from loculus_preprocessing.prepro import process_all
-from loculus_preprocessing.processing_functions import format_frameshift, format_stop_codon
-from loculus_preprocessing.processing_functions import valid_authors, format_authors
+from loculus_preprocessing.processing_functions import (
+    ProcessingFunctions,
+    format_authors,
+    format_frameshift,
+    format_stop_codon,
+    valid_authors,
+)
 
 # Config file used for testing
 test_config_file = "tests/test_config.yaml"
@@ -342,8 +347,7 @@ accepted_authors = {
 not_accepted_authors = [
     ";",
     ",;",
-    " ,;"
-    ",X.;Yu,X.",
+    " ,;" ",X.;Yu,X.",
     ",;Yu,X.",
     "Anna Maria Smith; Jose X. Perez",
     "Anna Maria Smith;",
@@ -476,6 +480,29 @@ def test_format_authors() -> None:
                 f"as expected: '{formatted_author}'"
             )
             raise AssertionError(msg)
+
+
+def test_parse_date_into_range():
+    assert ProcessingFunctions.parse_date_into_range(
+        {"date": "2021-12"}, "field_name", {"fieldType": "dateRangeString"}
+    ), "2021-12"
+    assert ProcessingFunctions.parse_date_into_range(
+        {"date": "2021-12"}, "field_name", {"fieldType": "dateRangeLower"}
+    ), "2021-12-01"
+    assert ProcessingFunctions.parse_date_into_range(
+        {"date": "2021-12"}, "field_name", {"fieldType": "dateRangeUpper"}
+    ), "2021-12-31"
+    assert ProcessingFunctions.parse_date_into_range(
+        {"date": "2021-02"}, "field_name", {"fieldType": "dateRangeUpper"}
+    ), "2021-02-28"
+    assert ProcessingFunctions.parse_date_into_range(
+        {"date": "2021"}, "field_name", {"fieldType": "dateRangeUpper"}
+    ), "2021-12-31"
+    assert ProcessingFunctions.parse_date_into_range(
+        {"date": "2021-12", "releaseDate": "2021-12-15"},
+        "field_name",
+        {"fieldType": "dateRangeUpper"},
+    ), "2021-12-15"
 
 
 if __name__ == "__main__":

--- a/preprocessing/nextclade/tests/test_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_processing_functions.py
@@ -347,7 +347,8 @@ accepted_authors = {
 not_accepted_authors = [
     ";",
     ",;",
-    " ,;", ",X.;Yu,X.",
+    " ,;",
+    ",X.;Yu,X.",
     ",;Yu,X.",
     "Anna Maria Smith; Jose X. Perez",
     "Anna Maria Smith;",

--- a/preprocessing/nextclade/tests/test_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_processing_functions.py
@@ -483,27 +483,73 @@ def test_format_authors() -> None:
             raise AssertionError(msg)
 
 
-def test_parse_date_into_range():
-    assert ProcessingFunctions.parse_date_into_range(
-        {"date": "2021-12"}, "field_name", {"fieldType": "dateRangeString"}
-    ), "2021-12"
-    assert ProcessingFunctions.parse_date_into_range(
-        {"date": "2021-12"}, "field_name", {"fieldType": "dateRangeLower"}
-    ), "2021-12-01"
-    assert ProcessingFunctions.parse_date_into_range(
-        {"date": "2021-12"}, "field_name", {"fieldType": "dateRangeUpper"}
-    ), "2021-12-31"
-    assert ProcessingFunctions.parse_date_into_range(
-        {"date": "2021-02"}, "field_name", {"fieldType": "dateRangeUpper"}
-    ), "2021-02-28"
-    assert ProcessingFunctions.parse_date_into_range(
-        {"date": "2021"}, "field_name", {"fieldType": "dateRangeUpper"}
-    ), "2021-12-31"
-    assert ProcessingFunctions.parse_date_into_range(
-        {"date": "2021-12", "releaseDate": "2021-12-15"},
-        "field_name",
-        {"fieldType": "dateRangeUpper"},
-    ), "2021-12-15"
+def test_parse_date_into_range() -> None:
+    assert (
+        ProcessingFunctions.parse_date_into_range(
+            {"date": "2021-12"}, "field_name", {"fieldType": "dateRangeString"}
+        ).datum
+        == "2021-12"
+    ), "dateRangeString: 2021-12 should be returned as is."
+    assert (
+        ProcessingFunctions.parse_date_into_range(
+            {"date": "2021-12"}, "field_name", {"fieldType": "dateRangeLower"}
+        ).datum
+        == "2021-12-01"
+    ), "dateRangeLower: 2021-12 should be returned as 2021-12-01."
+    assert (
+        ProcessingFunctions.parse_date_into_range(
+            {"date": "2021-12"}, "field_name", {"fieldType": "dateRangeUpper"}
+        ).datum
+        == "2021-12-31"
+    ), "dateRangeUpper: 2021-12 should be returned as 2021-12-31."
+    assert (
+        ProcessingFunctions.parse_date_into_range(
+            {"date": "2021-02"}, "field_name", {"fieldType": "dateRangeUpper"}
+        ).datum
+        == "2021-02-28"
+    ), "dateRangeUpper: 2021-02 should be returned as 2021-02-28."
+    assert (
+        ProcessingFunctions.parse_date_into_range(
+            {"date": "2021"}, "field_name", {"fieldType": "dateRangeUpper"}
+        ).datum
+        == "2021-12-31"
+    ), "dateRangeUpper: 2021 should be returned as 2021-12-31."
+    assert (
+        ProcessingFunctions.parse_date_into_range(
+            {"date": "2021-12", "releaseDate": "2021-12-15"},
+            "field_name",
+            {"fieldType": "dateRangeUpper"},
+        ).datum
+        == "2021-12-15"
+    ), "dateRangeUpper: 2021-12 with releaseDate 2021-12-15 should be returned as 2021-12-15."
+    assert (
+        ProcessingFunctions.parse_date_into_range(
+            {"date": "", "releaseDate": "2021-12-15"},
+            "field_name",
+            {"fieldType": "dateRangeUpper"},
+        ).datum
+        == "2021-12-15"
+    ), "dateRangeUpper: empty date with releaseDate 2021-12-15 should be returned as 2021-12-15."
+    assert (
+        ProcessingFunctions.parse_date_into_range(
+            {"date": ""}, "field_name", {"fieldType": "dateRangeString"}
+        ).datum
+        is None
+    ), "dateRangeString: empty date should be returned as None."
+    assert (
+        ProcessingFunctions.parse_date_into_range(
+            {"date": "not.date"}, "field_name", {"fieldType": "dateRangeString"}
+        ).datum
+        is None
+    ), "dateRangeString: invalid date should be returned as None."
+    assert (
+        ProcessingFunctions.parse_date_into_range(
+            {"date": "", "releaseDate": "2021-12-15"},
+            "field_name",
+            {"fieldType": "dateRangeLower"},
+        ).datum
+        is None
+    ), "dateRangeLower: empty date should be returned as None."
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Discussed on Slack: https://loculus.slack.com/archives/C05G172HL6L/p1732110859357449

preview URL: https://date-ranges.loculus.org

### Summary
- Replace Ebola Zaire with Ebola Sudan to have a small, fast loading, real organism (Zaire is 3k sequences, Sudan 150, we already have large ones with WNV and CCHF). This speeds up time to useful preview.
- Change processing of dates to make `sampleCollectionDate` be of type string and of form `YYYY` or `YYYY-MM` or `YYYY-MM-DD` (instead of type date with `YYYY-MM-DD` and MM and DD forced to 01 if missing)
- Introduce new processed data fields of type date `sampleCollectionDateRangeLower` and `sampleCollectionDateRangeUpper`
- Upper bound of date range is constrained by submission date (sequences cannot be from samples collected after they were submitted)
- Currently no lower bound is chosen, though doing so might be useful for ranged searches - we might decide to introduce an artificial min date for search purposes only, otherwise this might require a LAPIS/SILO feature, see https://github.com/GenSpectrum/LAPIS/issues/1012 for thoughts

### Screenshot
<img width="1656" alt="Brave Browser 2024-11-25 16 38 29" src="https://github.com/user-attachments/assets/10f9b15b-f56f-471d-a8e6-88ed35b6fe7b">


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
