### PR TITLE
chore(deps): upgrade keycloak to v25

### DIFF
--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -327,6 +327,8 @@ data:
           }
         ]
       },
+      "loginTheme": "loculus",
+      "emailTheme": "loculus",
       "identityProviders" : [
         {{- range $key, $value := .Values.auth.identityProviders }}
         {{- if eq $key "orcid" }}

--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -327,7 +327,6 @@ data:
           }
         ]
       },
-      "loginTheme": "loculus",
       "emailTheme": "loculus",
       "identityProviders" : [
         {{- range $key, $value := .Values.auth.identityProviders }}

--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -327,8 +327,6 @@ data:
           }
         ]
       },
-      "loginTheme": "loculus",
-      "emailTheme": "loculus",
       "identityProviders" : [
         {{- range $key, $value := .Values.auth.identityProviders }}
         {{- if eq $key "orcid" }}

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
+  strategy:
+    type: Recreate # So we don't get a rolling update
   selector:
     matchLabels:
       app: loculus
@@ -37,7 +39,7 @@ spec:
       containers:
         - name: keycloak
           # TODO #1221
-          image: quay.io/keycloak/keycloak:24.0
+          image: quay.io/keycloak/keycloak:25.0
           {{- include "loculus.resources" (list "keycloak" $.Values) | nindent 10 }}
           env:
             - name: REGISTRATION_TERMS_MESSAGE
@@ -95,9 +97,10 @@ spec:
             - "--import-realm"
             - "--cache=local"
             # - "--hostname-strict=false"
-            # - '--features=hostname:v1'
+            - '--features=hostname:v1' # to use v1 hostname feature in v25
+            - '--legacy-observability-interface=true'
             # - "--features=declarative-user-profile" # for v23 only
-            - "--log-level=DEBUG"
+            # - "--log-level=DEBUG"
           ports:
             - containerPort: 8080
           volumeMounts:

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -94,6 +94,7 @@ spec:
             - "--import-realm"
             - "--cache=local"
             - "--hostname-strict=false"
+            - "--log-level=DEBUG"
           ports:
             - containerPort: 8080
           volumeMounts:

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -98,7 +98,7 @@ spec:
             - "--cache=local"
             # - "--hostname-strict=false"
             - '--features=hostname:v1' # to use v1 hostname feature in v25
-            - '--legacy-observability-interface=true'
+            # - '--legacy-observability-interface=true'
             # - "--features=declarative-user-profile" # for v23 only
             # - "--log-level=DEBUG"
           ports:
@@ -111,14 +111,14 @@ spec:
           startupProbe:
             httpGet:
               path: /health/ready
-              port: 8080
+              port: 9000
             timeoutSeconds: 3
             failureThreshold: 150
             periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /health/ready
-              port: 8080
+              port: 9000
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 2

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -21,11 +21,110 @@ spec:
         app: loculus
         component: keycloak
     spec:
+     {{- include "possiblePriorityClassName" . | nindent 6 }}
+      initContainers:
+{{- include "loculus.configProcessor" (dict "name" "keycloak-config" "dockerTag" $dockerTag) | nindent 8 }}
+        - name: keycloak-theme-prep
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          image: "ghcr.io/loculus-project/keycloakify:{{ $dockerTag }}"
+          volumeMounts:
+            - name: theme-volume
+              mountPath: /destination
       containers:
-      - name: debug-echo
-        image: ealen/echo-server:latest  # or hashicorp/http-echo
-        ports:
-          - containerPort: 8080
-        env:
-          - name: PORT
-            value: "8080"
+        - name: keycloak
+          # TODO #1221
+          image: quay.io/keycloak/keycloak:25.0
+          {{- include "loculus.resources" (list "keycloak" $.Values) | nindent 10 }}
+          env:
+            - name: REGISTRATION_TERMS_MESSAGE
+              value: {{ $.Values.registrationTermsMessage }}
+            - name: KC_DB
+              value: postgres
+            - name: KC_DB_URL_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-database
+                  key: addr
+            - name: KC_DB_URL_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-database
+                  key: port
+            - name: KC_DB_URL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-database
+                  key: database
+            - name: KC_DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-database
+                  key: username
+            - name: KC_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-database
+                  key: password
+            - name: KEYCLOAK_ADMIN
+              value: "admin"
+            - name: KEYCLOAK_ADMIN_PASSWORD
+              value: "admin"
+              # valueFrom:
+              #   secretKeyRef:
+              #     name: keycloak-admin
+              #     key: initialAdminPassword
+            # - name: KC_PROXY
+            #   value: "edge"
+            - name: PROXY_ADDRESS_FORWARDING
+              value: "true"
+            - name: KC_HEALTH_ENABLED
+              value: "true"
+            - name: KC_HOSTNAME # Renamed from KC_HOSTNAME_URL to migrate v1->v2
+              value: "{{ include "loculus.keycloakUrl" . }}"
+            - name: KC_HOSTNAME_ADMIN # Renamed from KC_HOSTNAME_ADMIN_URL to migrate v1->v2
+              value: "{{ include "loculus.keycloakUrl" . }}"
+            # see https://github.com/keycloak/keycloak/blob/77b58275ca06d1cbe430c51db74479a7e1b409b5/quarkus/dist/src/main/content/bin/kc.sh#L95-L150
+            - name: KC_RUN_IN_CONTAINER
+              value: "true"
+          args:
+            - "start-dev"
+            - "--import-realm"
+            - "--cache=local"
+            - "--proxy-headers=xforwarded" # double check xforwarded is correct not forwarded
+            - "--http-enabled=true"
+            # - "--hostname-strict=false"
+            # - '--features=hostname:v1' # to use v1 hostname feature in v25
+            # - '--legacy-observability-interface=true'
+            # - "--features=declarative-user-profile" # for v23 only
+            - "--log-level=DEBUG"
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: keycloak-config-processed
+              mountPath: /opt/keycloak/data/import/
+            - name: theme-volume
+              mountPath: /opt/keycloak/providers/
+          startupProbe:
+            httpGet:
+              path: /health/ready
+              port: 9000
+            timeoutSeconds: 3
+            failureThreshold: 150
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health/ready
+              port: 9000
+            timeoutSeconds: 3
+            periodSeconds: 10
+            failureThreshold: 2
+      volumes:
+{{ include "loculus.configVolume" (dict "name" "keycloak-config") | nindent 8 }}
+        - name: theme-volume
+          emptyDir: {}

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -85,9 +85,9 @@ spec:
               value: "true"
             - name: KC_HEALTH_ENABLED
               value: "true"
-            - name: KC_HOSTNAME_URL
+            - name: KC_HOSTNAME
               value: "{{ include "loculus.keycloakUrl" . }}"
-            - name: KC_HOSTNAME_ADMIN_URL
+            - name: KC_HOSTNAME_ADMIN
               value: "{{ include "loculus.keycloakUrl" . }}"
             # see https://github.com/keycloak/keycloak/blob/77b58275ca06d1cbe430c51db74479a7e1b409b5/quarkus/dist/src/main/content/bin/kc.sh#L95-L150
             - name: KC_RUN_IN_CONTAINER
@@ -97,7 +97,7 @@ spec:
             - "--import-realm"
             - "--cache=local"
             # - "--hostname-strict=false"
-            - '--features=hostname:v1' # to use v1 hostname feature in v25
+            # - '--features=hostname:v1' # to use v1 hostname feature in v25
             # - '--legacy-observability-interface=true'
             # - "--features=declarative-user-profile" # for v23 only
             # - "--log-level=DEBUG"

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -39,7 +39,7 @@ spec:
       containers:
         - name: keycloak
           # TODO #1221
-          image: quay.io/keycloak/keycloak:25.0
+          image: quay.io/keycloak/keycloak:26.0
           {{- include "loculus.resources" (list "keycloak" $.Values) | nindent 10 }}
           env:
             - name: REGISTRATION_TERMS_MESSAGE
@@ -79,30 +79,23 @@ spec:
               #   secretKeyRef:
               #     name: keycloak-admin
               #     key: initialAdminPassword
-            # - name: KC_PROXY
-            #   value: "edge"
             - name: PROXY_ADDRESS_FORWARDING
               value: "true"
             - name: KC_HEALTH_ENABLED
               value: "true"
-            - name: KC_HOSTNAME # Renamed from KC_HOSTNAME_URL to migrate v1->v2
+            - name: KC_HOSTNAME
               value: "{{ include "loculus.keycloakUrl" . }}"
-            - name: KC_HOSTNAME_ADMIN # Renamed from KC_HOSTNAME_ADMIN_URL to migrate v1->v2
+            - name: KC_HOSTNAME_ADMIN
               value: "{{ include "loculus.keycloakUrl" . }}"
             # see https://github.com/keycloak/keycloak/blob/77b58275ca06d1cbe430c51db74479a7e1b409b5/quarkus/dist/src/main/content/bin/kc.sh#L95-L150
             - name: KC_RUN_IN_CONTAINER
               value: "true"
           args:
-            - "start-dev"
+            - "start"
             - "--import-realm"
             - "--cache=local"
-            - "--proxy-headers=xforwarded" # double check xforwarded is correct not forwarded
+            - "--proxy-headers=xforwarded"
             - "--http-enabled=true"
-            # - "--hostname-strict=false"
-            # - '--features=hostname:v1' # to use v1 hostname feature in v25
-            # - '--legacy-observability-interface=true'
-            # - "--features=declarative-user-profile" # for v23 only
-            - "--log-level=DEBUG"
           ports:
             - containerPort: 8080
           volumeMounts:

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
         - name: keycloak
           # TODO #1221
-          image: quay.io/keycloak/keycloak:25.0
+          image: quay.io/keycloak/keycloak:24.0
           {{- include "loculus.resources" (list "keycloak" $.Values) | nindent 10 }}
           env:
             - name: REGISTRATION_TERMS_MESSAGE
@@ -72,10 +72,11 @@ spec:
             - name: KEYCLOAK_ADMIN
               value: "admin"
             - name: KEYCLOAK_ADMIN_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: keycloak-admin
-                  key: initialAdminPassword
+              value: "admin"
+              # valueFrom:
+              #   secretKeyRef:
+              #     name: keycloak-admin
+              #     key: initialAdminPassword
             - name: KC_PROXY
               value: "edge"
             - name: PROXY_ADDRESS_FORWARDING
@@ -90,10 +91,12 @@ spec:
             - name: KC_RUN_IN_CONTAINER
               value: "true"
           args:
-            - "start"
+            - "start-dev"
             - "--import-realm"
             - "--cache=local"
-            - "--hostname-strict=false"
+            # - "--hostname-strict=false"
+            # - '--features=hostname:v1'
+            # - "--features=declarative-user-profile" # for v23 only
             - "--log-level=DEBUG"
           ports:
             - containerPort: 8080

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
         - name: keycloak
           # TODO #1221
-          image: quay.io/keycloak/keycloak:23.0
+          image: quay.io/keycloak/keycloak:26.0
           {{- include "loculus.resources" (list "keycloak" $.Values) | nindent 10 }}
           env:
             - name: REGISTRATION_TERMS_MESSAGE

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -39,7 +39,7 @@ spec:
       containers:
         - name: keycloak
           # TODO #1221
-          image: quay.io/keycloak/keycloak:26.0
+          image: quay.io/keycloak/keycloak:25.0
           {{- include "loculus.resources" (list "keycloak" $.Values) | nindent 10 }}
           env:
             - name: REGISTRATION_TERMS_MESSAGE

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -93,6 +93,7 @@ spec:
             - "start"
             - "--import-realm"
             - "--cache=local"
+            - "--hostname-strict false"
           ports:
             - containerPort: 8080
           volumeMounts:

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -93,7 +93,7 @@ spec:
             - "start"
             - "--import-realm"
             - "--cache=local"
-            - "--hostname-strict false"
+            - "--hostname-strict=false"
           ports:
             - containerPort: 8080
           volumeMounts:

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
         - name: keycloak
           # TODO #1221
-          image: quay.io/keycloak/keycloak:26.0
+          image: quay.io/keycloak/keycloak:25.0
           {{- include "loculus.resources" (list "keycloak" $.Values) | nindent 10 }}
           env:
             - name: REGISTRATION_TERMS_MESSAGE
@@ -53,7 +53,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: keycloak-database
-                  key: port        
+                  key: port
             - name: KC_DB_URL_DATABASE
               valueFrom:
                 secretKeyRef:
@@ -86,8 +86,6 @@ spec:
               value: "{{ include "loculus.keycloakUrl" . }}"
             - name: KC_HOSTNAME_ADMIN_URL
               value: "{{ include "loculus.keycloakUrl" . }}"
-            - name: KC_FEATURES
-              value: "declarative-user-profile"
             # see https://github.com/keycloak/keycloak/blob/77b58275ca06d1cbe430c51db74479a7e1b409b5/quarkus/dist/src/main/content/bin/kc.sh#L95-L150
             - name: KC_RUN_IN_CONTAINER
               value: "true"

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -79,15 +79,15 @@ spec:
               #   secretKeyRef:
               #     name: keycloak-admin
               #     key: initialAdminPassword
-            - name: KC_PROXY
-              value: "edge"
+            # - name: KC_PROXY
+            #   value: "edge"
             - name: PROXY_ADDRESS_FORWARDING
               value: "true"
             - name: KC_HEALTH_ENABLED
               value: "true"
-            - name: KC_HOSTNAME
+            - name: KC_HOSTNAME # Renamed from KC_HOSTNAME_URL to migrate v1->v2
               value: "{{ include "loculus.keycloakUrl" . }}"
-            - name: KC_HOSTNAME_ADMIN
+            - name: KC_HOSTNAME_ADMIN # Renamed from KC_HOSTNAME_ADMIN_URL to migrate v1->v2
               value: "{{ include "loculus.keycloakUrl" . }}"
             # see https://github.com/keycloak/keycloak/blob/77b58275ca06d1cbe430c51db74479a7e1b409b5/quarkus/dist/src/main/content/bin/kc.sh#L95-L150
             - name: KC_RUN_IN_CONTAINER
@@ -96,11 +96,13 @@ spec:
             - "start-dev"
             - "--import-realm"
             - "--cache=local"
+            - "--proxy-headers=xforwarded" # double check xforwarded is correct not forwarded
+            - "--http-enabled=true"
             # - "--hostname-strict=false"
             # - '--features=hostname:v1' # to use v1 hostname feature in v25
             # - '--legacy-observability-interface=true'
             # - "--features=declarative-user-profile" # for v23 only
-            # - "--log-level=DEBUG"
+            - "--log-level=DEBUG"
           ports:
             - containerPort: 8080
           volumeMounts:

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -21,110 +21,11 @@ spec:
         app: loculus
         component: keycloak
     spec:
-     {{- include "possiblePriorityClassName" . | nindent 6 }}
-      initContainers:
-{{- include "loculus.configProcessor" (dict "name" "keycloak-config" "dockerTag" $dockerTag) | nindent 8 }}
-        - name: keycloak-theme-prep
-          resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
-            limits:
-              cpu: 500m
-              memory: 256Mi
-          image: "ghcr.io/loculus-project/keycloakify:{{ $dockerTag }}"
-          volumeMounts:
-            - name: theme-volume
-              mountPath: /destination
       containers:
-        - name: keycloak
-          # TODO #1221
-          image: quay.io/keycloak/keycloak:25.0
-          {{- include "loculus.resources" (list "keycloak" $.Values) | nindent 10 }}
-          env:
-            - name: REGISTRATION_TERMS_MESSAGE
-              value: {{ $.Values.registrationTermsMessage }}
-            - name: KC_DB
-              value: postgres
-            - name: KC_DB_URL_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: keycloak-database
-                  key: addr
-            - name: KC_DB_URL_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: keycloak-database
-                  key: port
-            - name: KC_DB_URL_DATABASE
-              valueFrom:
-                secretKeyRef:
-                  name: keycloak-database
-                  key: database
-            - name: KC_DB_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: keycloak-database
-                  key: username
-            - name: KC_DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: keycloak-database
-                  key: password
-            - name: KEYCLOAK_ADMIN
-              value: "admin"
-            - name: KEYCLOAK_ADMIN_PASSWORD
-              value: "admin"
-              # valueFrom:
-              #   secretKeyRef:
-              #     name: keycloak-admin
-              #     key: initialAdminPassword
-            # - name: KC_PROXY
-            #   value: "edge"
-            - name: PROXY_ADDRESS_FORWARDING
-              value: "true"
-            - name: KC_HEALTH_ENABLED
-              value: "true"
-            - name: KC_HOSTNAME # Renamed from KC_HOSTNAME_URL to migrate v1->v2
-              value: "{{ include "loculus.keycloakUrl" . }}"
-            - name: KC_HOSTNAME_ADMIN # Renamed from KC_HOSTNAME_ADMIN_URL to migrate v1->v2
-              value: "{{ include "loculus.keycloakUrl" . }}"
-            # see https://github.com/keycloak/keycloak/blob/77b58275ca06d1cbe430c51db74479a7e1b409b5/quarkus/dist/src/main/content/bin/kc.sh#L95-L150
-            - name: KC_RUN_IN_CONTAINER
-              value: "true"
-          args:
-            - "start-dev"
-            - "--import-realm"
-            - "--cache=local"
-            - "--proxy-headers=xforwarded" # double check xforwarded is correct not forwarded
-            - "--http-enabled=true"
-            # - "--hostname-strict=false"
-            # - '--features=hostname:v1' # to use v1 hostname feature in v25
-            # - '--legacy-observability-interface=true'
-            # - "--features=declarative-user-profile" # for v23 only
-            - "--log-level=DEBUG"
-          ports:
-            - containerPort: 8080
-          volumeMounts:
-            - name: keycloak-config-processed
-              mountPath: /opt/keycloak/data/import/
-            - name: theme-volume
-              mountPath: /opt/keycloak/providers/
-          startupProbe:
-            httpGet:
-              path: /health/ready
-              port: 9000
-            timeoutSeconds: 3
-            failureThreshold: 150
-            periodSeconds: 5
-          livenessProbe:
-            httpGet:
-              path: /health/ready
-              port: 9000
-            timeoutSeconds: 3
-            periodSeconds: 10
-            failureThreshold: 2
-      volumes:
-{{ include "loculus.configVolume" (dict "name" "keycloak-config") | nindent 8 }}
-        - name: theme-volume
-          emptyDir: {}
+      - name: debug-echo
+        image: ealen/echo-server:latest  # or hashicorp/http-echo
+        ports:
+          - containerPort: 8080
+        env:
+          - name: PORT
+            value: "8080"

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -96,6 +96,7 @@ spec:
             - "--cache=local"
             - "--proxy-headers=xforwarded"
             - "--http-enabled=true"
+            - "--hostname-backchannel-dynamic=true"
           ports:
             - containerPort: 8080
           volumeMounts:


### PR DESCRIPTION
relates to #1221

preview URL: https://test-kc25.loculus.org

### Summary

Keycloak 25 works, expect for our custom terms checkbox which doesn't show with our keycloakify theme anymore so we do need to do the keycloakify work. But this is the keycloak part of the task.

This can be bumped to 26, see #3266 without requiring any changes on the keycloak side

### Screenshot

<img width="1589" alt="image" src="https://github.com/user-attachments/assets/9937a2eb-52a6-41a4-b2a3-a15900233ca3">

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
