### PR TITLE
wip: Keycloak 26 (without keycloakify)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation "org.jetbrains.exposed:exposed-kotlin-datetime:0.56.0"
     implementation "org.jetbrains.kotlinx:kotlinx-datetime:0.6.1"
     implementation "org.hibernate.validator:hibernate-validator:8.0.1.Final"
-    implementation "org.keycloak:keycloak-admin-client:23.0.7"
+    implementation "org.keycloak:keycloak-admin-client:26.0.2"
 
     implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server"
     implementation "org.springframework.boot:spring-boot-starter-security"

--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -327,7 +327,6 @@ data:
           }
         ]
       },
-      "loginTheme": "loculus",
       "emailTheme": "loculus",
       "identityProviders" : [
         {{- range $key, $value := .Values.auth.identityProviders }}

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -96,6 +96,7 @@ spec:
             - "--cache=local"
             - "--proxy-headers=xforwarded"
             - "--http-enabled=true"
+            - "--hostname-backchannel-dynamic=true"
           ports:
             - containerPort: 8080
           volumeMounts:

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
+  strategy:
+    type: Recreate # So we don't get a rolling update
   selector:
     matchLabels:
       app: loculus
@@ -37,7 +39,7 @@ spec:
       containers:
         - name: keycloak
           # TODO #1221
-          image: quay.io/keycloak/keycloak:23.0
+          image: quay.io/keycloak/keycloak:26.0
           {{- include "loculus.resources" (list "keycloak" $.Values) | nindent 10 }}
           env:
             - name: REGISTRATION_TERMS_MESSAGE
@@ -53,7 +55,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: keycloak-database
-                  key: port        
+                  key: port
             - name: KC_DB_URL_DATABASE
               valueFrom:
                 secretKeyRef:
@@ -72,22 +74,19 @@ spec:
             - name: KEYCLOAK_ADMIN
               value: "admin"
             - name: KEYCLOAK_ADMIN_PASSWORD
+              # value: "admin"
               valueFrom:
                 secretKeyRef:
                   name: keycloak-admin
                   key: initialAdminPassword
-            - name: KC_PROXY
-              value: "edge"
             - name: PROXY_ADDRESS_FORWARDING
               value: "true"
             - name: KC_HEALTH_ENABLED
               value: "true"
-            - name: KC_HOSTNAME_URL
+            - name: KC_HOSTNAME
               value: "{{ include "loculus.keycloakUrl" . }}"
-            - name: KC_HOSTNAME_ADMIN_URL
+            - name: KC_HOSTNAME_ADMIN
               value: "{{ include "loculus.keycloakUrl" . }}"
-            - name: KC_FEATURES
-              value: "declarative-user-profile"
             # see https://github.com/keycloak/keycloak/blob/77b58275ca06d1cbe430c51db74479a7e1b409b5/quarkus/dist/src/main/content/bin/kc.sh#L95-L150
             - name: KC_RUN_IN_CONTAINER
               value: "true"
@@ -95,6 +94,8 @@ spec:
             - "start"
             - "--import-realm"
             - "--cache=local"
+            - "--proxy-headers=xforwarded"
+            - "--http-enabled=true"
           ports:
             - containerPort: 8080
           volumeMounts:
@@ -105,14 +106,14 @@ spec:
           startupProbe:
             httpGet:
               path: /health/ready
-              port: 8080
+              port: 9000
             timeoutSeconds: 3
             failureThreshold: 150
             periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /health/ready
-              port: 8080
+              port: 9000
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 2


### PR DESCRIPTION
relates to #1221

preview URL: https://kc26.loculus.org

### Summary
Getting keycloak ready, now just waiting for keycloakify. One can already use as is, keycloakify is just for the looks (and the checkbox). Even registration still works!

### Screenshot
Can already be used, just the login theme is missing. Everything else looks great.

~Weird that E2E tests fail on this but it works in practice.~ That's because we're using the non-26 ready theme here, stupid me.

```
{"level":"error","message":"Failed to reach Keycloak server at http://localhost:8083/realms/loculus","timestamp":"2024-11-21T22:48:13.521Z"}
```

<img width="1109" alt="image" src="https://github.com/user-attachments/assets/d9e8b682-9e55-445a-a587-3e71ef37b6f1">


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
