### PR TITLE
docs: add Plausible analytics

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -15,6 +15,14 @@ export default defineConfig({
                         content: 'https://loculus.org/images/og-image.png',
                     },
                 },
+                {
+                    tag: 'script',
+                    attrs: {
+                        'defer': true,
+                        'data-domain': 'loculus.org',
+                        'src': 'https://plausible.io/js/script.js',
+                    },
+                },
             ],
             editLink: {
                 baseUrl: 'https://github.com/loculus-project/loculus/edit/main/docs/',


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #2952

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://docs-plausible.loculus.org

### Summary

This adds Plausible to the Loculus homepage/docs.
