### PR TITLE
fix(backend,website): calculate status counts efficiently & request only aggregates for submission portal

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -346,7 +346,7 @@ open class SubmissionController(
             description = "Filter by status. If not provided, all statuses are considered.",
         ) @RequestParam(required = false) statusesFilter: List<Status>?,
         @Parameter(
-            description = "Filter by processing result. If not provided, all results are considered. " +
+            description = "Filter by processing result. If not provided, no filtering on processing result is done. " +
                 "This only filters sequences that are actually in the PROCESSED status, and does not affect " +
                 "sequences in any other status.",
         ) @RequestParam(required = false) processingResultFilter: List<ProcessingResult>?,

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -711,7 +711,6 @@ class SubmissionDatabaseService(
         )
     }
 
-    /** Efficiently get the counts of sequences in each status for a given organism and group(s). */
     private fun getStatusCounts(organism: Organism, groupCondition: Op<Boolean>): Map<Status, Int> {
         val statusColumn = SequenceEntriesView.statusColumn
         val countColumn = Count(stringLiteral("*"))

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -623,6 +623,7 @@ class SubmissionDatabaseService(
      * Also returns status counts and processing result counts.
      * Note that counts are totals: _not_ affected by pagination, status or processing result filter;
      * i.e. the counts are for all sequences from that group and organism.
+     * Page and size are 0-indexed!
      */
     fun getSequences(
         authenticatedUser: AuthenticatedUser,

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -643,7 +643,7 @@ class SubmissionDatabaseService(
 
         val groupCondition = getGroupCondition(groupIdsFilter, authenticatedUser)
 
-        log.debug { "Defining base query" }
+        log.info { "Defining base query" }
 
         val baseQuery = SequenceEntriesView
             .join(
@@ -674,10 +674,10 @@ class SubmissionDatabaseService(
             .andWhere { SequenceEntriesView.organismIs(organism) }
             .orderBy(SequenceEntriesView.accessionColumn)
 
-        log.debug { "Getting status counts" }
+        log.info { "Getting status counts" }
 
         val statusCounts: Map<Status, Int> = Status.entries.associateWith { status ->
-            log.debug { "Getting count for status $status" }
+            log.info { "Getting count for status $status" }
             baseQuery.count { it[SequenceEntriesView.statusColumn] == status.name }
         }
 
@@ -698,7 +698,7 @@ class SubmissionDatabaseService(
             filteredQuery
         }
 
-        log.debug { "Getting sequence entries" }
+        log.info { "Getting sequence entries" }
 
         val entries = pagedQuery
             .map { row ->
@@ -722,11 +722,11 @@ class SubmissionDatabaseService(
                 )
             }
 
-        log.debug { "Getting processing result counts" }
+        log.info { "Getting processing result counts" }
 
         val processingResultCounts = getProcessingResultCounts(groupIdsFilter, authenticatedUser, organism)
 
-        log.debug { "Returning response" }
+        log.info { "Returning response" }
 
         return GetSequenceResponse(
             sequenceEntries = entries,

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -621,13 +621,17 @@ class SubmissionDatabaseService(
     /** Efficiently get the counts of sequences in each status for a given organism and group(s). */
     fun getStatusCounts(organism: Organism, groupCondition: Op<Boolean>): Map<Status, Int> {
         // Use group by to calculate counts efficiently
-        return SequenceEntriesView
+        val statusCounts = SequenceEntriesView
             .select(SequenceEntriesView.statusColumn, Count(SequenceEntriesView.statusColumn))
             .where {
                 SequenceEntriesView.organismIs(organism) and groupCondition
             }
             .groupBy(SequenceEntriesView.statusColumn)
-            .associate { Status.fromString(it[SequenceEntriesView.statusColumn]) to it[Count(SequenceEntriesView.statusColumn)].toInt() }
+            .associate {
+                Status.fromString(it[SequenceEntriesView.statusColumn]) to
+                    it[Count(SequenceEntriesView.statusColumn)].toInt()
+            }
+        return Status.entries.associateWith { statusCounts[it] ?: 0 }
     }
 
     /**

--- a/website/src/components/ReviewPage/ReviewPage.tsx
+++ b/website/src/components/ReviewPage/ReviewPage.tsx
@@ -74,7 +74,7 @@ const NumberAndVisibility = ({
 };
 
 const InnerReviewPage: FC<ReviewPageProps> = ({ clientConfig, organism, group, accessToken, metadataDisplayNames }) => {
-    const [pageQuery, setPageQuery] = useState<PageQuery>({ page: 1, size: pageSizeOptions[2] });
+    const [pageQuery, setPageQuery] = useState<PageQuery>({ pageOneIndexed: 1, size: pageSizeOptions[2] });
 
     const hooks = useSubmissionOperations(organism, group, clientConfig, accessToken, toast.error, pageQuery);
 
@@ -112,7 +112,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({ clientConfig, organism, group, a
 
     const handleSizeChange = (event: ChangeEvent<HTMLSelectElement>) => {
         const newSize = parseInt(event.target.value, 10);
-        setPageQuery({ page: 1, size: newSize });
+        setPageQuery({ pageOneIndexed: 1, size: newSize });
     };
 
     let sequencesData = hooks.getSequences.data;
@@ -155,8 +155,8 @@ const InnerReviewPage: FC<ReviewPageProps> = ({ clientConfig, organism, group, a
         (showErrors ? errorCount : 0);
 
     // If we narrowed the selection and the selected page doesn't exist anymore, go to the last existing page instead
-    if ((pageQuery.page - 1) * pageQuery.size > selectedCount) {
-        setPageQuery({ ...pageQuery, page: Math.ceil(selectedCount / pageQuery.size) });
+    if ((pageQuery.pageOneIndexed - 1) * pageQuery.size > selectedCount) {
+        setPageQuery({ ...pageQuery, pageOneIndexed: Math.ceil(selectedCount / pageQuery.size) });
     }
 
     if (total === 0) {
@@ -226,9 +226,9 @@ const InnerReviewPage: FC<ReviewPageProps> = ({ clientConfig, organism, group, a
         <div className='flex justify-end align-center gap-3 py-3'>
             <Pagination
                 count={Math.ceil(selectedCount / pageQuery.size)}
-                page={pageQuery.page}
+                page={pageQuery.pageOneIndexed}
                 onChange={(_, newPage) => {
-                    setPageQuery({ ...pageQuery, page: newPage });
+                    setPageQuery({ ...pageQuery, pageOneIndexed: newPage });
                 }}
                 color='primary'
                 variant='outlined'

--- a/website/src/hooks/useSubmissionOperations.ts
+++ b/website/src/hooks/useSubmissionOperations.ts
@@ -42,7 +42,7 @@ export function useSubmissionOperations(
                 initialStatusesFilter: allRelevantStatuses.join(','),
                 statusesFilter: includedStatuses.join(','),
                 processingResultFilter: includedProcessingResults.join(','),
-                page: pageQuery.page - 1,
+                page: pageQuery.pageOneIndexed - 1,
                 size: pageQuery.size,
             },
         },

--- a/website/src/pages/[organism]/submission/[groupId]/index.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/index.astro
@@ -1,5 +1,4 @@
 ---
-import { cleanOrganism } from '../../../../components/Navigation/cleanOrganism';
 import SubmissionPageWrapper from '../../../../components/Submission/SubmissionPageWrapper.astro';
 import { routes } from '../../../../routes/routes';
 import { BackendClient } from '../../../../services/backendClient';
@@ -12,9 +11,9 @@ import IcOutlineUpload from '~icons/ic/outline-upload';
 import MdiViewListOutline from '~icons/mdi/view-list-outline';
 
 const session = Astro.locals.session!;
+const organism = Astro.params.organism!;
 const accessToken = getAccessToken(session)!;
 
-const { organism } = cleanOrganism(Astro.params.organism);
 const groupsResult = await getGroupsAndCurrentGroup(Astro.params, Astro.locals.session);
 
 async function getSequenceCounts(organism: string, groupId: number) {
@@ -25,6 +24,8 @@ async function getSequenceCounts(organism: string, groupId: number) {
             headers: createAuthorizationHeader(accessToken),
             queries: {
                 groupIdsFilter: groupId.toString(),
+                page: 0,
+                size: 0,
             },
         });
 
@@ -48,25 +49,25 @@ async function getSequenceCounts(organism: string, groupId: number) {
     {
         groupsResult.match(
             async ({ currentGroup: group }) => {
-                const { othersTotal, approvedTotal } = await getSequenceCounts(organism!.key, group.groupId);
+                const { othersTotal, approvedTotal } = await getSequenceCounts(organism, group.groupId);
 
                 const options = [
                     {
                         title: 'Submit',
                         description: 'Upload new sequences.',
-                        route: routes.submitPage(organism!.key, group.groupId),
+                        route: routes.submitPage(organism, group.groupId),
                         icon: IcOutlineUpload,
                     },
                     {
                         title: 'Revise',
                         description: 'Upload revisions for existing sequences.',
-                        route: routes.revisePage(organism!.key, group.groupId),
+                        route: routes.revisePage(organism, group.groupId),
                         icon: F7Arrow2Circlepath,
                     },
                     {
                         title: 'Review',
                         description: "Review your group's unreleased submissions.",
-                        route: routes.userSequenceReviewPage(organism!.key, group.groupId),
+                        route: routes.userSequenceReviewPage(organism, group.groupId),
                         icon: GgCheckO,
                         count: othersTotal,
                         countClass: 'text-primary-600 font-semibold',
@@ -75,7 +76,7 @@ async function getSequenceCounts(organism: string, groupId: number) {
                     {
                         title: 'View',
                         description: "View your group's released sequences.",
-                        route: routes.mySequencesPage(organism!.key, group.groupId),
+                        route: routes.mySequencesPage(organism, group.groupId),
                         icon: MdiViewListOutline,
                         count: approvedTotal,
                         countClass: 'text-gray-500 hidden',

--- a/website/src/pages/[organism]/submission/[groupId]/index.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/index.astro
@@ -24,6 +24,8 @@ async function getSequenceCounts(organism: string, groupId: number) {
             headers: createAuthorizationHeader(accessToken),
             queries: {
                 groupIdsFilter: groupId.toString(),
+                // We only need the counts, so we can set the page and size to 0
+                // to avoid fetching the actual sequences (slow part of the endpoint)
                 page: 0,
                 size: 0,
             },

--- a/website/src/services/backendApi.ts
+++ b/website/src/services/backendApi.ts
@@ -127,7 +127,7 @@ const getSequencesEndpoint = makeEndpoint({
             schema: z.string().optional(),
         },
         {
-            name: 'page',
+            name: 'page', // 0-indexed
             type: 'Query',
             schema: z.number().optional(),
         },

--- a/website/src/types/backend.ts
+++ b/website/src/types/backend.ts
@@ -277,7 +277,7 @@ export const groupDetails = z.object({
 export type GroupDetails = z.infer<typeof groupDetails>;
 
 export const pageQuery = z.object({
-    page: z.number(),
+    pageOneIndexed: z.number(),
     size: z.number(),
 });
 


### PR DESCRIPTION
resolves #3095, resolves #1612, resolves #3269, resolves #2880

helps with #3267

preview URL: https://profile-get-seqs.loculus.org

### Summary

@fhennig correctly identified that the way we calculated status counts in getSequences was the culprit behind the inconsistent total counts. 

We issued 4 independent db queries one after the other. In between statuses changed. What made it worse was that each of the calls was hugely inefficient, using a join on data use terms, ordering by accession column and much more that is totally unnecessary for the counts calculation.

The fluctuation could be fixed by higher transaction isolation but this is much much faster and efficient so should be enough (I've profiled with simple logs and tested).

Also fixes fact that log message misses mention of some filters.

### Future work

There's still lots to be done but this goes some way _and_ fixes the inconsistency bug.

We should not have this single endpoint that calculates much more than necessary. It's behind the review page slowness #3269: we really just want total numbers of sequences to review but the backend needs to send loads of unnecessary information to the website simply because we have no simpler endpoint.

Instead, we should spin up a few simple endpoints that do what the website needs - let's mark them as "non-public" in the backend API docs so that we don't need stability guarantees, they should be used solely by the website.

### Screenshot

Reload the page and look at both screencasts together to see speedup.

This PR:
![2024-11-23 07 49 50](https://github.com/user-attachments/assets/439abfc8-e21e-4f06-8aa7-2cbeaff55b6e)


Before (main):
![2024-11-23 05 39 47](https://github.com/user-attachments/assets/6ac4ee61-0568-4b6f-94d8-9e36183c4b0b)



### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
