### PR TITLE
fix(website): line up organism cards with other UI elements

### DIFF
--- a/website/src/components/IndexPage/OrganismCard.astro
+++ b/website/src/components/IndexPage/OrganismCard.astro
@@ -16,7 +16,7 @@ const { key, image, displayName, organismStatistics, numberDaysAgoStatistics } =
 
 <a
     href={routes.organismStartPage(key)}
-    class='block rounded border box-border border-gray-300 m-2 w-56 hover:bg-gray-100 mx-auto sm:mx-2'
+    class='block rounded border box-border border-gray-300 m-2 w-56 hover:bg-gray-100 mx-auto sm:mx-0'
 >
     {image !== undefined && <img src={image} class='h-40 w-full object-cover rounded-t-[3px]' alt={displayName} />}
     <div class='my-4 mx-4 h-28 flex flex-col justify-between'>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -20,7 +20,7 @@ const organismStatisticsMap = await getOrganismStatisticsMap(
     <div class='max-w-6xl mx-auto'>
         <WelcomeMessage websiteName={websiteName} welcomeMessageHTML={welcomeMessageHTML} />
 
-        <div class='flex flex-wrap gap-4'>
+        <div class='flex flex-wrap gap-x-4'>
             {
                 getConfiguredOrganisms().map(({ key, displayName, image }) => (
                     <OrganismCard

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -20,7 +20,7 @@ const organismStatisticsMap = await getOrganismStatisticsMap(
     <div class='max-w-6xl mx-auto'>
         <WelcomeMessage websiteName={websiteName} welcomeMessageHTML={welcomeMessageHTML} />
 
-        <div class='flex flex-wrap'>
+        <div class='flex flex-wrap gap-4'>
             {
                 getConfiguredOrganisms().map(({ key, displayName, image }) => (
                     <OrganismCard


### PR DESCRIPTION
Small tweak to line up organism cards with other text on the index page

<img width="532" alt="image" src="https://github.com/user-attachments/assets/883a7bdd-6288-4516-a913-60dd3b626d76">


https://test-tweak-to-organism-ca.loculus.org/