### PR TITLE
fix(website): Adjust break all to break word

### DIFF
--- a/website/src/components/SequenceDetailsPage/DataTableEntryValue.tsx
+++ b/website/src/components/SequenceDetailsPage/DataTableEntryValue.tsx
@@ -27,7 +27,7 @@ const CustomDisplayComponent: React.FC<Props> = ({ data, dataUseTermsHistory }) 
 
     return (
         <div className='whitespace-normal text-gray-600 break-inside-avoid'>
-            <div className='break-all whitespace-wrap'>
+            <div className='whitespace-wrap'>
                 {!customDisplay && <PlainValueDisplay value={value} />}
                 {customDisplay?.type === 'percentage' && typeof value === 'number' && `${(100 * value).toFixed(2)}%`}
                 {customDisplay?.type === 'badge' &&

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -257,7 +257,7 @@ const UploadComponent = ({
                         <button
                             onClick={() => setMyFile(null)}
                             data-testid={`discard_${name}`}
-                            className='text-xs break-word text-gray-700 py-1.5 px-4 border border-gray-300 rounded-md hover:bg-gray-50'
+                            className='text-xs break-words text-gray-700 py-1.5 px-4 border border-gray-300 rounded-md hover:bg-gray-50'
                         >
                             Discard file
                         </button>

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -257,7 +257,7 @@ const UploadComponent = ({
                         <button
                             onClick={() => setMyFile(null)}
                             data-testid={`discard_${name}`}
-                            className='text-xs break-words text-gray-700 py-1.5 px-4 border border-gray-300 rounded-md hover:bg-gray-50'
+                            className='text-xs break-word text-gray-700 py-1.5 px-4 border border-gray-300 rounded-md hover:bg-gray-50'
                         >
                             Discard file
                         </button>

--- a/website/src/styles/base.scss
+++ b/website/src/styles/base.scss
@@ -110,7 +110,7 @@ td {
 }
 
 * {
-    @apply break-word;
+    @apply break-words;
 }
 
 .rs-input {

--- a/website/src/styles/base.scss
+++ b/website/src/styles/base.scss
@@ -28,14 +28,12 @@ a {
     text-decoration: red;
     font-size: 24px;
     font-weight: 600;
-   
 }
 
 .title {
     color: theme('colors.main');
     font-size: 24px;
     font-weight: 600;
-   
 }
 
 .subtitle {

--- a/website/src/styles/base.scss
+++ b/website/src/styles/base.scss
@@ -28,14 +28,14 @@ a {
     text-decoration: red;
     font-size: 24px;
     font-weight: 600;
-    word-break: break-all;
+   
 }
 
 .title {
     color: theme('colors.main');
     font-size: 24px;
     font-weight: 600;
-    word-break: break-all;
+   
 }
 
 .subtitle {
@@ -68,7 +68,6 @@ a {
 
 .customTable {
     display: table;
-    word-break: break-all;
     border: none;
 }
 table,
@@ -111,7 +110,7 @@ td {
 }
 
 * {
-    @apply break-words;
+    @apply break-word;
 }
 
 .rs-input {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves https://github.com/loculus-project/loculus/issues/3341 and various other problems

preview URL: https://breakword.loculus.org/

## Screenshot

![image](https://github.com/user-attachments/assets/67782fa2-7b3c-4ab9-b7a2-b8ae06a212b8)
 becomes
![image](https://github.com/user-attachments/assets/3cb3bb13-ac3c-42ff-9801-7b066962ca45)




We were using `break-all` which allows wrapping newlines very arbitrarily.  Now we only use `break-words`
.