### PR TITLE
feat(website, backend, prepro)!: Update error schema with input and output metadata field names

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -199,7 +199,8 @@ class InsertionDeserializer : JsonDeserializer<Insertion>() {
 }
 
 data class PreprocessingAnnotation(
-    val source: List<PreprocessingAnnotationSource>,
+    val unprocessedFields: List<PreprocessingAnnotationSource>,
+    val processedFields: List<PreprocessingAnnotationSource>,
     @Schema(description = "A descriptive message that helps the submitter to fix the issue") val message: String,
 )
 

--- a/backend/src/main/resources/db/migration/V1.8__update_error_schema.sql
+++ b/backend/src/main/resources/db/migration/V1.8__update_error_schema.sql
@@ -1,0 +1,67 @@
+update sequence_entries_preprocessed_data
+set warnings = (
+  select jsonb_agg(
+    jsonb_build_object(
+      'unprocessedFields', (
+        select jsonb_agg(
+          jsonb_build_object(
+            'name', source->>'name',
+            'type', source->>'type'
+          )
+        )
+        from jsonb_array_elements(warning->'source') as source
+      ),
+      'processedFields', (
+        select jsonb_agg(
+          jsonb_build_object(
+            'name', source->>'name',
+            'type', source->>'type'
+          )
+        )
+        from jsonb_array_elements(warning->'source') as source
+      ),
+      'message', warning->>'message'
+    )
+  )
+  from jsonb_array_elements(warnings) as warning
+)
+where warnings is not null
+  and exists (
+    select 1
+    from jsonb_array_elements(warnings) as warning
+    where warning->'source' is not null
+  );
+
+update sequence_entries_preprocessed_data
+set errors = (
+  select jsonb_agg(
+    jsonb_build_object(
+      'unprocessedFields', (
+        select jsonb_agg(
+          jsonb_build_object(
+            'name', source->>'name',
+            'type', source->>'type'
+          )
+        )
+        from jsonb_array_elements(error->'source') as source
+      ),
+      'processedFields', (
+        select jsonb_agg(
+          jsonb_build_object(
+            'name', source->>'name',
+            'type', source->>'type'
+          )
+        )
+        from jsonb_array_elements(error->'source') as source
+      ),
+      'message', error->>'message'
+    )
+  )
+  from jsonb_array_elements(errors) as error
+)
+where errors is not null
+and exists (
+    select 1
+    from jsonb_array_elements(errors) as error
+    where error->'source' is not null
+  );

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/PreparedProcessedData.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/PreparedProcessedData.kt
@@ -396,7 +396,13 @@ object PreparedProcessedData {
         accession = accession,
         errors = listOf(
             PreprocessingAnnotation(
-                source = listOf(
+                unprocessedFields = listOf(
+                    PreprocessingAnnotationSource(
+                        PreprocessingAnnotationSourceType.Metadata,
+                        "host",
+                    ),
+                ),
+                processedFields = listOf(
                     PreprocessingAnnotationSource(
                         PreprocessingAnnotationSourceType.Metadata,
                         "host",
@@ -405,7 +411,13 @@ object PreparedProcessedData {
                 "Not this kind of host",
             ),
             PreprocessingAnnotation(
-                source = listOf(
+                unprocessedFields = listOf(
+                    PreprocessingAnnotationSource(
+                        PreprocessingAnnotationSourceType.NucleotideSequence,
+                        MAIN_SEGMENT,
+                    ),
+                ),
+                processedFields = listOf(
                     PreprocessingAnnotationSource(
                         PreprocessingAnnotationSourceType.NucleotideSequence,
                         MAIN_SEGMENT,
@@ -420,7 +432,13 @@ object PreparedProcessedData {
         accession = accession,
         warnings = listOf(
             PreprocessingAnnotation(
-                source = listOf(
+                unprocessedFields = listOf(
+                    PreprocessingAnnotationSource(
+                        PreprocessingAnnotationSourceType.Metadata,
+                        "host",
+                    ),
+                ),
+                processedFields = listOf(
                     PreprocessingAnnotationSource(
                         PreprocessingAnnotationSourceType.Metadata,
                         "host",
@@ -429,7 +447,13 @@ object PreparedProcessedData {
                 "Not this kind of host",
             ),
             PreprocessingAnnotation(
-                source = listOf(
+                unprocessedFields = listOf(
+                    PreprocessingAnnotationSource(
+                        PreprocessingAnnotationSourceType.NucleotideSequence,
+                        MAIN_SEGMENT,
+                    ),
+                ),
+                processedFields = listOf(
                     PreprocessingAnnotationSource(
                         PreprocessingAnnotationSourceType.NucleotideSequence,
                         MAIN_SEGMENT,

--- a/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
@@ -36,14 +36,16 @@ class AnnotationSource:
 
 @dataclass(frozen=True)
 class ProcessingAnnotation:
-    source: tuple[AnnotationSource, ...]
+    unprocessedFields: tuple[AnnotationSource, ...]  # noqa: N815
+    processedFields: tuple[AnnotationSource, ...]  # noqa: N815
     message: str
 
     def __post_init__(self):
-        object.__setattr__(self, "source", tuple(self.source))
+        object.__setattr__(self, "unprocessedFields", tuple(self.unprocessedFields))
+        object.__setattr__(self, "processedFields", tuple(self.processedFields))
 
     def __hash__(self):
-        return hash((self.source, self.message))
+        return hash((self.unprocessedFields, self.processedFields, self.message))
 
 
 @dataclass

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -502,7 +502,6 @@ def get_metadata(  # noqa: PLR0913, PLR0917
         for arg_name, input_path in spec.inputs.items():
             input_data[arg_name] = add_input_metadata(spec, unprocessed, errors, input_path)
             input_fields.append(input_path)
-        logging.info(f"Input fields: {input_fields}")
         args = spec.args
         args["submitter"] = unprocessed.inputMetadata["submitter"]
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/sequence_checks.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/sequence_checks.py
@@ -35,7 +35,12 @@ def errors_if_non_iupac(
             if non_iupac_symbols:
                 errors.append(
                     ProcessingAnnotation(
-                        source=[
+                        unprocessedFields=[
+                            AnnotationSource(
+                                name=segment, type=AnnotationSourceType.NUCLEOTIDE_SEQUENCE
+                            )
+                        ],
+                        processedFields=[
                             AnnotationSource(
                                 name=segment, type=AnnotationSourceType.NUCLEOTIDE_SEQUENCE
                             )

--- a/preprocessing/nextclade/tests/factory_methods.py
+++ b/preprocessing/nextclade/tests/factory_methods.py
@@ -19,8 +19,14 @@ class ProcessingTestCase:
 
 
 @dataclass
-class UnprocessedEntryFactory:
+class ProcessingAnnotationTestCase:
+    unprocessedFieldsName: list[str]  # noqa: N815
+    processedFieldsName: list[str]  # noqa: N815
+    message: str
 
+
+@dataclass
+class UnprocessedEntryFactory:
     @staticmethod
     def create_unprocessed_entry(
         metadata_dict: dict[str, str],
@@ -48,8 +54,8 @@ class ProcessedEntryFactory:
         self,
         metadata_dict: dict[str, str],
         accession: str,
-        metadata_errors: list[tuple[str, str]] | None = None,
-        metadata_warnings: list[tuple[str, str]] | None = None,
+        metadata_errors: list[ProcessingAnnotationTestCase] | None = None,
+        metadata_warnings: list[ProcessingAnnotationTestCase] | None = None,
     ) -> ProcessedEntry:
         if metadata_errors is None:
             metadata_errors = []
@@ -72,15 +78,33 @@ class ProcessedEntryFactory:
             ),
             errors=[
                 ProcessingAnnotation(
-                    source=[AnnotationSource(name=error[0], type=AnnotationSourceType.METADATA)],
-                    message=error[1],
+                    unprocessedFields=[
+                        AnnotationSource(
+                            name=field,
+                            type=AnnotationSourceType.METADATA,
+                        ) for field in error.unprocessedFieldsName
+                    ],
+                    processedFields=[
+                        AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
+                        for field in error.processedFieldsName
+                    ],
+                    message=error.message,
                 )
                 for error in metadata_errors
             ],
             warnings=[
                 ProcessingAnnotation(
-                    source=[AnnotationSource(name=warning[0], type=AnnotationSourceType.METADATA)],
-                    message=warning[1],
+                    unprocessedFields=[
+                        AnnotationSource(
+                            name=field,
+                            type=AnnotationSourceType.METADATA,
+                        ) for field in warning.unprocessedFieldsName
+                    ],
+                    processedFields=[
+                        AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
+                        for field in warning.processedFieldsName
+                    ],
+                    message=warning.message,
                 )
                 for warning in metadata_warnings
             ],

--- a/preprocessing/nextclade/tests/test_config.yaml
+++ b/preprocessing/nextclade/tests/test_config.yaml
@@ -64,7 +64,7 @@ processing_spec:
       type: date
     function: parse_and_assert_past_date
     inputs:
-      date: required_collection_date
+      date: ncbi_required_collection_date
     required: true
   concatenated_string:
     function: concatenate
@@ -73,7 +73,7 @@ processing_spec:
       type: [string, string, date]
     inputs:
       continent: continent
-      required_collection_date: required_collection_date
+      required_collection_date: ncbi_required_collection_date
   authors:
     function: check_authors
     inputs:

--- a/preprocessing/specification.md
+++ b/preprocessing/specification.md
@@ -97,7 +97,11 @@ The `errors` and `warnings` fields contain an array of objects of the following 
 
 ```js
 {
-    source: {
+    unprocessedFields: [{
+        type: "Metadata" | "NucleotideSequence",
+        name: string
+    }[],
+    processedFields: {
         type: "Metadata" | "NucleotideSequence",
         name: string
     }[],
@@ -105,9 +109,11 @@ The `errors` and `warnings` fields contain an array of objects of the following 
 }
 ```
 
-The `source` field specifies the source of the error. It can be empty if the error is very general or if it is not possible to pinpoint a specific source. If the error is caused by the value in a metadata field, the `name` field should contain the name of a metadata field. If a nucleotide sequence caused the error, the `name` field should contain the (segment) name of the nucleotide sequence.
+The `source` field(s) specifies the source of the error. It can be empty if the error is very general or if it is not possible to pinpoint a specific source. If the error is caused by the value in a metadata field, the `name` field should contain the name of a metadata field. If a nucleotide sequence caused the error, the `name` field should contain the (segment) name of the nucleotide sequence.
 
-The `message` should contain a human-readable message describing the error.
+The `affected` field(s) work similarly but specify which fields in the processed output are affected by the error or warning.
+
+The `message` should contain a human-readable message describing the error. It may be useful to include the user input in this message.
 
 #### Metadata
 

--- a/preprocessing/specification.md
+++ b/preprocessing/specification.md
@@ -109,9 +109,9 @@ The `errors` and `warnings` fields contain an array of objects of the following 
 }
 ```
 
-The `source` field(s) specifies the source of the error. It can be empty if the error is very general or if it is not possible to pinpoint a specific source. If the error is caused by the value in a metadata field, the `name` field should contain the name of a metadata field. If a nucleotide sequence caused the error, the `name` field should contain the (segment) name of the nucleotide sequence.
+The `unprocessedFields` field(s) specifies the source of the error. It can be empty if the error is very general or if it is not possible to pinpoint a specific unprocessed metadata source. If the error is caused by the value in a metadata field, the `name` field should contain the name of a metadata field. If a nucleotide sequence caused the error, the `name` field should contain the (segment) name of the nucleotide sequence.
 
-The `affected` field(s) work similarly but specify which fields in the processed output are affected by the error or warning.
+The `processedFields` field(s) work similarly but specify which fields in the processed output are affected by the error or warning.
 
 The `message` should contain a human-readable message describing the error. It may be useful to include the user input in this message.
 

--- a/website/src/components/Edit/DataRow.tsx
+++ b/website/src/components/Edit/DataRow.tsx
@@ -1,4 +1,5 @@
 import { type FC } from 'react';
+import { Tooltip } from 'react-tooltip';
 
 import { InputField, type KeyValuePair, type Row } from './InputField.tsx';
 import WarningAmberIcon from '~icons/ic/baseline-warning-amber';
@@ -6,20 +7,33 @@ import DangerousTwoToneIcon from '~icons/ic/twotone-dangerous';
 
 type EditableRowProps = {
     label?: string;
+    inputField: string;
     row: Row;
     onChange: (editedRow: Row) => void;
 };
 
-export const EditableDataRow: FC<EditableRowProps> = ({ label, row, onChange }) => {
+export const EditableDataRow: FC<EditableRowProps> = ({ label, inputField, row, onChange }) => {
     const colorClassName = row.errors.length > 0 ? 'text-red-600' : row.warnings.length > 0 ? 'text-yellow-600' : '';
 
+    const content = `input metadata name: ${inputField}`;
+
     return (
-        <tr>
-            <td className={`w-1/4  ${colorClassName}`}>{label ?? row.key}:</td>
+        <tr className='table-fixed w-full'>
+            <div>
+                <td className={`w-1/4 relative ${colorClassName}`} data-tooltip-id={'field-tooltip' + row.key}>
+                    {label ?? row.key}:
+                </td>
+                <Tooltip
+                    id={'field-tooltip' + row.key}
+                    place='bottom-start'
+                    content={content}
+                    className='absolute z-50 top-full left-0 mt-1'
+                />
+            </div>
             <td className='pr-3 text-right '>
                 <ErrorAndWarningIcons row={row} />
             </td>
-            <td className='w-full'>
+            <td className='w-3/4'>
                 <InputField row={row} onChange={onChange} colorClassName={colorClassName} />
             </td>
         </tr>

--- a/website/src/components/Edit/EditPage.spec.tsx
+++ b/website/src/components/Edit/EditPage.spec.tsx
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, test } from 'vitest';
 
 import { EditPage } from './EditPage.tsx';
 import { defaultReviewData, editableEntry, metadataKey, testAccessToken, testOrganism } from '../../../vitest.setup.ts';
-import type { MetadataField, SequenceEntryToEdit, UnprocessedMetadataRecord } from '../../types/backend.ts';
+import type { SequenceEntryToEdit, UnprocessedMetadataRecord } from '../../types/backend.ts';
 import type { ClientConfig } from '../../types/runtimeConfig.ts';
 
 const queryClient = new QueryClient();
@@ -60,9 +60,6 @@ describe('EditPage', () => {
         expect(screen.getAllByText(/Unaligned nucleotide sequences/i)[0]).toBeInTheDocument();
         expectTextInSequenceData.original(defaultReviewData.originalData.unalignedNucleotideSequences);
 
-        expect(screen.getByText(/Processed Data/i)).toBeInTheDocument();
-        expectTextInSequenceData.processedMetadata(defaultReviewData.processedData.metadata);
-
         expect(screen.getByText('processedInsertionSequenceName:')).toBeInTheDocument();
         expect(screen.getByText('nucleotideInsertion1,nucleotideInsertion2')).toBeInTheDocument();
 
@@ -109,10 +106,5 @@ const expectTextInSequenceData = {
         Object.entries(metadata).forEach(([key, value]) => {
             expect(screen.getByText(sentenceCase(key) + ':')).toBeInTheDocument();
             expect(screen.getByDisplayValue(value)).toBeInTheDocument();
-        }),
-    processedMetadata: (metadata: Record<string, MetadataField>): void =>
-        Object.entries(metadata).forEach(([key, value]) => {
-            expect(screen.getByText(sentenceCase(key) + ':')).toBeInTheDocument();
-            expect(screen.getByText((value ?? 'null').toString())).toBeInTheDocument();
         }),
 };

--- a/website/src/components/ReviewPage/ReviewCard.tsx
+++ b/website/src/components/ReviewPage/ReviewCard.tsx
@@ -218,15 +218,13 @@ const Errors: FC<ErrorsProps> = ({ errors, accession, metadataDisplayNames }) =>
                     const processedFieldName = error.processedFields
                         .map((field) => metadataDisplayNames.get(field.name) ?? field.name)
                         .join(', ');
-                    const unprocessedFieldName = error.unprocessedFields.map((field) => field.name).join(', ');
                     return (
                         <div key={uniqueKey} className='flex flex-shrink-0'>
                             <p
                                 className='text-red-600'
                                 data-tooltip-id={'error-tooltip-' + accession + '-' + uniqueKey}
                             >
-                                {processedFieldName} (produced from input fields: {unprocessedFieldName}):{' '}
-                                {error.message}
+                                {processedFieldName}: {error.message}
                             </p>
                             <CustomTooltip
                                 id={'error-tooltip-' + accession + '-' + uniqueKey}
@@ -251,13 +249,12 @@ const Warnings: FC<WarningsProps> = ({ warnings, accession }) => {
             <div className='flex flex-col m-2 '>
                 {warnings.map((warning) => {
                     const processedFieldName = warning.processedFields.map((field) => field.name).join(', ');
-                    const unprocessedFieldName = warning.unprocessedFields.map((field) => field.name).join(', ');
                     return (
                         <p
                             key={warning.processedFields.map((field) => field.type + field.name).join('.') + accession}
                             className='text-yellow-500'
                         >
-                            {processedFieldName} (produced from input fields: {unprocessedFieldName}): {warning.message}
+                            {processedFieldName}: {warning.message}
                         </p>
                     );
                 })}

--- a/website/src/types/backend.ts
+++ b/website/src/types/backend.ts
@@ -28,7 +28,13 @@ const processingAnnotationSourceType = z.union([z.literal('Metadata'), z.literal
 export type ProcessingAnnotationSourceType = z.infer<typeof processingAnnotationSourceType>;
 
 const processingAnnotation = z.object({
-    source: z.array(
+    unprocessedFields: z.array(
+        z.object({
+            name: z.string(),
+            type: processingAnnotationSourceType,
+        }),
+    ),
+    processedFields: z.array(
         z.object({
             name: z.string(),
             type: processingAnnotationSourceType,

--- a/website/tests/util/preprocessingPipeline.ts
+++ b/website/tests/util/preprocessingPipeline.ts
@@ -23,9 +23,21 @@ async function submit(preprocessingOptions: PreprocessingOptions[]) {
                 accession,
                 version,
                 errors: error
-                    ? [{ source: [{ name: 'host', type: 'Metadata' }], message: 'Not this kind of host' }]
+                    ? [
+                          {
+                              unprocessedFields: [{ name: 'host', type: 'Metadata' }],
+                              processedFields: [{ name: 'host', type: 'Metadata' }],
+                              message: 'Not this kind of host',
+                          },
+                      ]
                     : [],
-                warnings: [{ source: [{ name: 'date', type: 'Metadata' }], message: '"There is no warning"-warning' }],
+                warnings: [
+                    {
+                        unprocessedFields: [{ name: 'date', type: 'Metadata' }],
+                        processedFields: [{ name: 'date', type: 'Metadata' }],
+                        message: '"There is no warning"-warning',
+                    },
+                ],
                 data: {
                     metadata: {
                         date: '2002-12-15',

--- a/website/vitest.setup.ts
+++ b/website/vitest.setup.ts
@@ -52,7 +52,13 @@ export const defaultReviewData: SequenceEntryToEdit = {
     groupId: 1,
     errors: [
         {
-            source: [
+            unprocessedFields: [
+                {
+                    name: metadataKey,
+                    type: 'Metadata',
+                },
+            ],
+            processedFields: [
                 {
                     name: metadataKey,
                     type: 'Metadata',
@@ -63,7 +69,13 @@ export const defaultReviewData: SequenceEntryToEdit = {
     ],
     warnings: [
         {
-            source: [
+            unprocessedFields: [
+                {
+                    name: metadataKey,
+                    type: 'Metadata',
+                },
+            ],
+            processedFields: [
                 {
                     name: metadataKey,
                     type: 'Metadata',


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://update-error-schema-anya.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

Follow up of https://github.com/loculus-project/loculus/pull/932
![image](https://github.com/user-attachments/assets/6b1d6967-4e14-4579-ac13-509cc833f9ae)

This PR:
1. Adds both unprocessed and processed metadata field names to the error annotations, updating the types and tests in preprocessing, website and backend.
2. Use the unprocessed and processed (mapped to displayName) metadata field names for errors and warnings in the edit form.
3. Removed the duplicated uneditable processed metadata section from the edit page and move the edit button to the bottom of the edit page.
4. Add a tooltip with information on the name of the input metadata field (currently we just show the display Name which is confusing for users): 
![image](https://github.com/user-attachments/assets/8834e773-ad48-45b9-aad9-8e15168f939a)


## Info

This change isn't "breaking per-se as we include a flyway migration that updates the schema into the new format - however the results of the error schema won't be fully accurate until the preprocessing pipeline reprocesses all data and adds both unprocesssed and processed metadata field names to the error and warning output. 

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] The structure of the errrors and warnings column in the DB will now change - this needs to be handled correctly: DB migration, prepro pipeline update etc. -> fully tested in https://github.com/loculus-project/loculus/pull/3393, when migrations occur users are logged out of their accounts and when they log back in again the changes have occurred. The schema changes have been added in a flyway migration that can be rerun after the schema is corrected without overwriting values. 
