### PR TITLE
fix(backend): reset etag for data_use_terms_table updates

### DIFF
--- a/backend/docs/db/schema.sql
+++ b/backend/docs/db/schema.sql
@@ -739,6 +739,13 @@ CREATE TRIGGER update_tracker_trigger AFTER INSERT OR DELETE OR UPDATE OR TRUNCA
 
 
 --
+-- Name: data_use_terms_table update_tracker_trigger; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER update_tracker_trigger AFTER INSERT OR DELETE OR UPDATE OR TRUNCATE ON public.data_use_terms_table FOR EACH STATEMENT EXECUTE FUNCTION public.update_table_tracker();
+
+
+--
 -- Name: external_metadata update_tracker_trigger; Type: TRIGGER; Schema: public; Owner: postgres
 --
 

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -12,6 +12,7 @@ import org.loculus.backend.api.Organism
 import org.loculus.backend.api.ProcessedData
 import org.loculus.backend.api.VersionStatus
 import org.loculus.backend.config.BackendConfig
+import org.loculus.backend.service.datauseterms.DATA_USE_TERMS_TABLE_NAME
 import org.loculus.backend.service.groupmanagement.GROUPS_TABLE_NAME
 import org.loculus.backend.service.submission.CURRENT_PROCESSING_PIPELINE_TABLE_NAME
 import org.loculus.backend.service.submission.EXTERNAL_METADATA_TABLE_NAME
@@ -41,6 +42,7 @@ val RELEASED_DATA_RELATED_TABLES: List<String> =
         SEQUENCE_ENTRIES_TABLE_NAME,
         SEQUENCE_ENTRIES_PREPROCESSED_DATA_TABLE_NAME,
         SEQUENCE_UPLOAD_AUX_TABLE_NAME,
+        DATA_USE_TERMS_TABLE_NAME,
     )
 
 @Service

--- a/backend/src/main/resources/db/migration/V1.7__add_table_update_trigger_for_data_use_terms.sql
+++ b/backend/src/main/resources/db/migration/V1.7__add_table_update_trigger_for_data_use_terms.sql
@@ -1,0 +1,1 @@
+SELECT create_update_trigger_for_table('data_use_terms_table');


### PR DESCRIPTION
fixes #3354

preview URL: https://fix-etag.loculus.org

### Summary
I had forgotten to include `data_use_terms_table` updates in the list of tables whose update should reset the etagg
