### PR TITLE
feat(website): show API URLs on API documentation page

### DIFF
--- a/website/src/pages/api-documentation/index.astro
+++ b/website/src/pages/api-documentation/index.astro
@@ -3,9 +3,10 @@ import { authenticationApiDocsUrl } from './authenticationApiDocsUrl';
 import { getRuntimeConfig, getWebsiteConfig } from '../../config';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { routes } from '../../routes/routes.ts';
+import { getAuthBaseUrl } from '../../utils/getAuthUrl';
 
 const clientConfig = getRuntimeConfig().public;
-const keycloakUrl = getRuntimeConfig().serverSide.keycloakUrl;
+const keycloakUrl = getAuthBaseUrl();
 
 const websiteConfig = getWebsiteConfig();
 

--- a/website/src/pages/api-documentation/index.astro
+++ b/website/src/pages/api-documentation/index.astro
@@ -5,6 +5,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import { routes } from '../../routes/routes.ts';
 
 const clientConfig = getRuntimeConfig().public;
+const keycloakUrl = getRuntimeConfig().serverSide.keycloakUrl;
 
 const websiteConfig = getWebsiteConfig();
 
@@ -24,7 +25,7 @@ const BUTTON_CLASS =
     <div class='container mx-auto p-8'>
         <h1 class='title'>API Documentation</h1>
 
-        <div>
+        <div class='mb-10'>
             <p class='mt-4 mb-4'>
                 There is a
                 <a
@@ -57,7 +58,7 @@ const BUTTON_CLASS =
             </p>
         </div>
 
-        <div class='mb-8 mt-10'>
+        <div class='mb-10'>
             <h2 class='text-xl font-semibold text-primary-400 mb-4'>Backend Server</h2>
             <div class='mb-4'>
                 Please note that Loculus is under continuous development and the endpoints are subject to change.
@@ -65,9 +66,13 @@ const BUTTON_CLASS =
             <a class={BUTTON_CLASS} href={clientConfig.backendUrl + '/swagger-ui/index.html'}>
                 View Backend API Documentation
             </a>
+            <div class='mt-8'>
+                <span class='font-medium'>Host of Backend Server:</span>
+                <code>{clientConfig.backendUrl}</code>
+            </div>
         </div>
 
-        <div>
+        <div class='mb-10'>
             <h2 class='text-xl font-semibold text-primary-400 mb-4'>LAPIS Query Engines</h2>
             <div class='space-y-4'>
                 {
@@ -77,6 +82,29 @@ const BUTTON_CLASS =
                         </a>
                     ))
                 }
+            </div>
+            <div class='mt-8'>
+                <span class='font-medium'>Host of LAPIS Query Engines:</span>
+                <ul class='list-disc ml-6'>
+                    {
+                        Object.entries(clientConfig.lapisUrls).map(([organism, url]) => (
+                            <li>
+                                {organismToDisplayName[organism]}: <code>{url}</code>
+                            </li>
+                        ))
+                    }
+                </ul>
+            </div>
+        </div>
+
+        <div>
+            <h2 class='text-xl font-semibold text-primary-400 mb-4'>Keycloak Server</h2>
+            <div>
+                We use the open source software <a href='https://www.keycloak.org/'>Keycloak</a> for authentication.
+            </div>
+            <div class='mt-2'>
+                <span class='font-medium'>Host of Keycloak Server:</span>
+                <code>{keycloakUrl}</code>
             </div>
         </div>
     </div>

--- a/website/src/pages/api-documentation/index.astro
+++ b/website/src/pages/api-documentation/index.astro
@@ -68,7 +68,7 @@ const BUTTON_CLASS =
                 View Backend API Documentation
             </a>
             <div class='mt-8'>
-                <span class='font-medium'>Host of Backend Server:</span>
+                <span class='font-medium'>URL of Backend Server:</span>
                 <code>{clientConfig.backendUrl}</code>
             </div>
         </div>
@@ -85,7 +85,7 @@ const BUTTON_CLASS =
                 }
             </div>
             <div class='mt-8'>
-                <span class='font-medium'>Host of LAPIS Query Engines:</span>
+                <span class='font-medium'>URLs of LAPIS Query Engines:</span>
                 <ul class='list-disc ml-6'>
                     {
                         Object.entries(clientConfig.lapisUrls).map(([organism, url]) => (
@@ -104,7 +104,7 @@ const BUTTON_CLASS =
                 We use the open source software <a href='https://www.keycloak.org/'>Keycloak</a> for authentication.
             </div>
             <div class='mt-2'>
-                <span class='font-medium'>Host of Keycloak Server:</span>
+                <span class='font-medium'>URL of Keycloak Server:</span>
                 <code>{keycloakUrl}</code>
             </div>
         </div>

--- a/website/src/utils/getAuthUrl.ts
+++ b/website/src/utils/getAuthUrl.ts
@@ -20,3 +20,12 @@ export const getAuthUrl = async (redirectUrl: string) => {
     });
     /* eslint-enable @typescript-eslint/naming-convention */
 };
+
+export const getAuthBaseUrl = async () => {
+    const authUrl = await getAuthUrl('/');
+    const index = authUrl.indexOf('/realms');
+    if (index === -1) {
+        return null;
+    }
+    return authUrl.substring(0, index);
+};


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #3358

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://api-urls.loculus.org/api-documentation

### Summary

This displays the API URLs directly on the API documentation page.

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
