### PR TITLE
chore(kubernetes): upgrade to LAPIS 0.3.10

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1509,7 +1509,7 @@ welcomeMessageHTML: null
 additionalHeadHTML: ""
 images:
   lapisSilo: "ghcr.io/genspectrum/lapis-silo:0.3.2"
-  lapis: "ghcr.io/genspectrum/lapis:0.3.8"
+  lapis: "ghcr.io/genspectrum/lapis:0.3.10"
 secrets:
   smtp-password:
     type: raw


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://lapis0310.loculus.org/

# Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

Those are two uncritical LAPIS version updates: One just affects the docs (which Loculus doesn't use), the other introduces a feature such that LAPIS can tell its version:

https://lapis-lapis0310.loculus.org/cchf/sample/aggregated
```
{
    "data": [
        {
            "count": 0
        }
    ],
    "info": {
        ...
        "lapisVersion": "0.3.10"
    }
}
``` 

## [0.3.10](https://github.com/GenSpectrum/LAPIS/compare/v0.3.9...v0.3.10) (2024-12-03)

### Features

* **lapis:** add LAPIS version to info response ([#1019](https://github.com/GenSpectrum/LAPIS/issues/1019)) ([7d8d713](https://github.com/GenSpectrum/LAPIS/commit/7d8d7132150896b85244dbd240b15005b2aa47ec))

## [0.3.9](https://github.com/GenSpectrum/LAPIS/compare/v0.3.8...v0.3.9) (2024-11-14)

### Features

* **lapis-docs:** mark sections of the docs that are generated from the config ([b2009eb](https://github.com/GenSpectrum/LAPIS/commit/b2009eb4674fe1f9d790a5f64e80d4c7f0bb2808)), closes [#928](https://github.com/GenSpectrum/LAPIS/issues/928)


### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
