### PR TITLE
fix(backend): use correct syntax to extend async timeout

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 server.port=8079
 server.max-http-request-header-size=20KB
-server.mvc.async.request-timeout=36000000
 
 springdoc.default-produces-media-type=application/json
 springdoc.default-consumes-media-type=application/json
@@ -9,6 +8,7 @@ springdoc.swagger-ui.operationsSorter=alpha
 server.forward-headers-strategy=framework
 spring.servlet.multipart.max-file-size=5000MB
 spring.servlet.multipart.max-request-size=5000MB
+spring.mvc.async.request-timeout=36000000
 
 server.compression.enabled=true
 


### PR DESCRIPTION
followup to #3032

I used the wrong syntax, `server.` instead of `spring.`

preview URL: https://fix-timeout.loculus.org

see: https://loculus.slack.com/archives/C05G172HL6L/p1733397193081819

Proof that it now actually works, comparing main with this branch:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/a5c2c353-028f-455f-8248-5bd491236905">
