### PR TITLE
feat(website): Column order for search table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ node_modules/
 temp/
 
 .aider*
+.env

--- a/docs/src/content/docs/reference/helm-chart-config.mdx
+++ b/docs/src/content/docs/reference/helm-chart-config.mdx
@@ -650,6 +650,12 @@ Each organism object has the following fields:
             <td>The minimum column width for this field on the search table.</td>
         </tr>
         <tr>
+            <td>`order`</td>
+            <td>Number</td>
+            <td></td>
+            <td>Order for the column in the search table, lower first</td>
+        </tr>
+        <tr>
             <td>`autocomplete`</td>
             <td>Boolean</td>
             <td></td>

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -216,6 +216,9 @@ organisms:
   {{- if .columnWidth }}
   columnWidth: {{ .columnWidth }}
   {{- end }}
+  {{- if .order }}
+  order: {{ .order }}
+  {{- end }}
   {{- if .customDisplay }}
   customDisplay:
     type: {{ quote .customDisplay.type }}

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -66,6 +66,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Collection date
         header: Sample details
         ingest: ncbiCollectionDate
+        order: 10
         preprocessing:
           function: parse_date_into_range
           inputs:
@@ -158,6 +159,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         autocomplete: true
         initiallyVisible: true
         header: Sample details
+        order: 20
         ingest: country
         required: true
         preprocessing:
@@ -475,6 +477,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         autocomplete: true
         initiallyVisible: true
         header: Sample details
+        order: 30
         ingest: division
       - name: geoLocAdmin2
         displayName: Collection subdivision level 2
@@ -503,6 +506,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         type: authors
         header: Authors
         enableSubstringSearch: true
+        order: 40
         truncateColumnDisplayTo: 25
         ingest: ncbiSubmitterNames
         preprocessing:

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -61,13 +61,19 @@ export const Table: FC<TableProps> = ({
 
     const maxLengths = Object.fromEntries(schema.metadata.map((m) => [m.name, m.truncateColumnDisplayTo ?? 100]));
 
-    const columns = columnsToShow.map((field) => ({
-        field,
-        headerName: schema.metadata.find((m) => m.name === field)?.displayName ?? capitalCase(field),
-        maxLength: maxLengths[field],
-        type: schema.metadata.find((m) => m.name === field)?.type ?? 'string',
-        columnWidth: schema.metadata.find((m) => m.name === field)?.columnWidth,
-    }));
+    const columns = columnsToShow
+        .map((field) => {
+            const metadata = schema.metadata.find((m) => m.name === field);
+            return {
+                field,
+                headerName: metadata?.displayName ?? capitalCase(field),
+                maxLength: maxLengths[field],
+                type: metadata?.type ?? 'string',
+                columnWidth: metadata?.columnWidth,
+                order: metadata?.order ?? Number.MAX_SAFE_INTEGER,
+            };
+        })
+        .sort((a, b) => a.order - b.order);
 
     const handleSort = (field: string) => {
         if (orderBy.field === field) {

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -55,6 +55,7 @@ export const metadata = z.object({
     rangeOverlapSearch: rangeOverlapSearch.optional(),
     substringSearch: z.boolean().optional(),
     columnWidth: z.number().optional(),
+    order: z.number().optional(),
 });
 
 export const inputField = z.object({


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #3378

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://column-order.loculus.org/

### Summary
Adds an optional index to metadata items that determines their order. Currently this applies only to the search page table columns. We could expand this to e.g. the search fields but this would be a bit more complex, so is considered out of scope for now. The order of fields is `accession, [lower order index], [higher order index], [higher still..], [fields without order index specified]`

### Screenshot
![image](https://github.com/user-attachments/assets/56f9c635-2f09-472b-9e2a-20d55ec5be25)

