### PR TITLE
fix(website): don't allow search page to expand beyond window width - instead make the table scroll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ node_modules/
 temp/
 
 .aider*
+.env

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -374,10 +374,9 @@ export const InnerSearchFullUI = ({
                         </div>
                     </div>
 
-                    <div className='overflow-x-auto'>
-                        <Table
-                            schema={schema}
-                            data={
+                    <Table
+                        schema={schema}
+                        data={
                             detailsHook.data?.data !== undefined
                                 ? (detailsHook.data.data as TableSequenceData[])
                                 : (oldData ?? initialData)
@@ -396,7 +395,6 @@ export const InnerSearchFullUI = ({
                         setOrderDirection={setOrderDirection}
                         columnsToShow={columnsToShow}
                     />
-                    </div>
 
                     <div className='mt-4 flex justify-center'>
                         {totalSequences !== undefined && (

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -374,9 +374,10 @@ export const InnerSearchFullUI = ({
                         </div>
                     </div>
 
-                    <Table
-                        schema={schema}
-                        data={
+                    <div className='overflow-x-auto'>
+                        <Table
+                            schema={schema}
+                            data={
                             detailsHook.data?.data !== undefined
                                 ? (detailsHook.data.data as TableSequenceData[])
                                 : (oldData ?? initialData)
@@ -395,6 +396,7 @@ export const InnerSearchFullUI = ({
                         setOrderDirection={setOrderDirection}
                         columnsToShow={columnsToShow}
                     />
+                    </div>
 
                     <div className='mt-4 flex justify-center'>
                         {totalSequences !== undefined && (

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -270,7 +270,7 @@ export const InnerSearchFullUI = ({
                 setIsHalfScreen={setPreviewHalfScreen}
                 setPreviewedSeqId={setPreviewedSeqId}
             />
-            <div className='md:w-72'>
+            <div className='md:w-[18rem]'>
                 <SearchForm
                     organism={organism}
                     clientConfig={clientConfig}
@@ -284,7 +284,7 @@ export const InnerSearchFullUI = ({
                     lapisSearchParameters={lapisSearchParameters}
                 />
             </div>
-            <div className='flex-1'>
+            <div className='md:w-[calc(100%-18.1rem)]'>
                 <RecentSequencesBanner organism={organism} />
 
                 {(detailsHook.isError || aggregatedHook.isError) &&

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -127,10 +127,10 @@ export const Table: FC<TableProps> = ({
         );
 
     return (
-        <div className='w-full overflow-x-visible text-sm' aria-label='Search Results Table'>
+        <div className='w-full overflow-x-auto text-sm' aria-label='Search Results Table'>
             <Tooltip id='table-tip' />
             {data.length !== 0 ? (
-                <table className='w-full text-left border-collapse'>
+                <table className='min-w-full text-left border-collapse'>
                     <thead>
                         <tr>
                             <th className='px-2 py-3 md:pl-6 text-xs text-gray-500 cursor-pointer text-left'>

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -127,7 +127,7 @@ export const Table: FC<TableProps> = ({
         );
 
     return (
-        <div className='w-full overflow-x-auto text-sm' aria-label='Search Results Table'>
+        <div className='w-full overflow-x-visible text-sm' aria-label='Search Results Table'>
             <Tooltip id='table-tip' />
             {data.length !== 0 ? (
                 <table className='min-w-full text-left border-collapse'>

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -127,7 +127,7 @@ export const Table: FC<TableProps> = ({
         );
 
     return (
-        <div className='w-full overflow-x-auto text-sm' aria-label='Search Results Table'>
+        <div className='w-full overflow-x-visible text-sm' aria-label='Search Results Table'>
             <Tooltip id='table-tip' />
             {data.length !== 0 ? (
                 <table className='w-full text-left border-collapse'>

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -127,7 +127,7 @@ export const Table: FC<TableProps> = ({
         );
 
     return (
-        <div className='w-full overflow-x-visible text-sm' aria-label='Search Results Table'>
+        <div className='w-full overflow-x-auto text-sm' aria-label='Search Results Table'>
             <Tooltip id='table-tip' />
             {data.length !== 0 ? (
                 <table className='min-w-full text-left border-collapse'>


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves https://github.com/loculus-project/loculus/issues/3382

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://search-table-2.loculus.org/ebola-sudan/search?

### Summary
Ensures that the download button always stays on the page even when the table is wider than the screen, which doesn't happen at the moment
