### PR TITLE
perf(silo-prepro): speed up by using more efficient jq command

### DIFF
--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -109,7 +109,7 @@ download_data() {
   echo "Response should contain a total of : $expected_record_count records"
 
   # jq validates each individual json object, to catch truncated lines
-  true_record_count=$(zstd -d -c "$new_input_data_path" | jq -c . | wc -l | tr -d '[:space:]')
+  true_record_count=$(zstd -d -c "$new_input_data_path" | jq -n 'reduce inputs as $item (0; . + 1)' | tr -d '[:space:]')
   echo "Response contained a total of : $true_record_count records"
 
   if [ "$true_record_count" -ne "$expected_record_count" ]; then


### PR DESCRIPTION
It truned out that `jq -c '.'` was rate limiting and causing significant extra processing time.

New command has been tested for correctness and performance, still validates.

see https://loculus.slack.com/archives/C05G172HL6L/p1733500150097089?thread_ts=1733478069.696049&cid=C05G172HL6L

https://speed-up-silo-prepro.loculus.org