### PR TITLE
style: Trying out a new active-filter style

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx
@@ -49,7 +49,7 @@ describe('DownloadDialog', () => {
     });
 
     test('should generate the right download link from filters', async () => {
-        await renderDialog(new FieldFilter({ accession: ['accession1', 'accession2'], field1: 'value1' }, {}));
+        await renderDialog(new FieldFilter({ accession: ['accession1', 'accession2'], field1: 'value1' }, {}, []));
         await checkAgreement();
 
         let [path, query] = getDownloadHref()?.split('?') ?? [];

--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
@@ -39,7 +39,7 @@ export const DownloadDialog: FC<DownloadDialogProps> = ({
                         referenceGenomesSequenceNames={referenceGenomesSequenceNames}
                         onChange={setDownloadOption}
                     />
-                    <div className='mb-4 py-5'>
+                    <div className='mb-4 py-4'>
                         <label className='flex items-center'>
                             <input
                                 type='checkbox'

--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
@@ -44,7 +44,7 @@ export const DownloadDialog: FC<DownloadDialogProps> = ({
                             <input
                                 type='checkbox'
                                 name='data-use-terms-agreement'
-                                className='mr-3 ml-1 h-5 w-5 rounded border-gray-300 text-black focus:ring-black'
+                                className='mr-3 ml-1 h-5 w-5 rounded border-gray-300 text-primary-600 focus:ring-primary-600'
                                 checked={agreedToDataUseTerms}
                                 onChange={() => setAgreedToDataUseTerms(!agreedToDataUseTerms)}
                             />

--- a/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
@@ -75,7 +75,7 @@ export const DownloadForm: FC<DownloadFormProps> = ({ referenceGenomesSequenceNa
     ]);
 
     return (
-        <div className='flex flex-row flex-wrap mb-4 justify-between'>
+        <div className='flex flex-row flex-wrap mb-4 gap-y-2 py-4'>
             <RadioOptionBlock
                 name='includeRestricted'
                 title='Include restricted data?'

--- a/website/src/components/SearchPage/DownloadDialog/OptionBlock.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/OptionBlock.tsx
@@ -29,7 +29,7 @@ export const RadioOptionBlock: FC<OptionBlockProps> = ({
                         <input
                             type='radio'
                             name={name}
-                            className='radio mr-2'
+                            className='mr-2 text-primary-600 focus:ring-primary-600'
                             checked={index === selected}
                             onChange={() => onSelect(index)}
                             disabled={disabled}

--- a/website/src/components/SearchPage/DownloadDialog/OptionBlock.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/OptionBlock.tsx
@@ -21,15 +21,15 @@ export const RadioOptionBlock: FC<OptionBlockProps> = ({
     disabled = false,
 }) => {
     return (
-        <div className='max-w-80 basis-1/3'>
+        <div className='basis-1/2 justify-start'>
             {title !== undefined && <h4 className='font-bold'>{title}</h4>}
             {options.map((option, index) => (
                 <div key={index}>
-                    <label className='label justify-start'>
+                    <label className='label justify-start py-1 items-baseline'>
                         <input
                             type='radio'
                             name={name}
-                            className='mr-2 text-primary-600 focus:ring-primary-600'
+                            className='mr-4 text-primary-600 focus:ring-primary-600 relative bottom-[-0.2rem]'
                             checked={index === selected}
                             onChange={() => onSelect(index)}
                             disabled={disabled}
@@ -55,7 +55,7 @@ export const DropdownOptionBlock: FC<OptionBlockProps> = ({
         <div className='max-w-80'>
             <select
                 name={name}
-                className='select select-bordered w-full max-w-xs'
+                className='select select-bordered w-full max-w-xs min-h-0 h-auto py-0'
                 disabled={disabled}
                 value={selected}
                 onChange={(event) => onSelect(event.target.selectedIndex)}

--- a/website/src/components/SearchPage/DownloadDialog/SequenceFilters.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/SequenceFilters.tsx
@@ -25,7 +25,7 @@ export interface SequenceFilter {
     /**
      * Return a map of keys to human readable descriptions of the filters to apply.
      */
-    toDisplayStrings(): Map<string, string>;
+    toDisplayStrings(): Map<string, [string, string]>;
 }
 
 /**
@@ -99,7 +99,7 @@ export class FieldFilter implements SequenceFilter {
         return result;
     }
 
-    public toDisplayStrings(): Map<string, string> {
+    public toDisplayStrings(): Map<string, [string, string]> {
         return new Map(
             Object.entries(this.lapisSearchParameters)
                 .filter((vals) => vals[1] !== undefined && vals[1] !== '')
@@ -109,9 +109,12 @@ export class FieldFilter implements SequenceFilter {
                 )
                 .map(([name, filterValue]) => ({ name, filterValue: filterValue !== null ? filterValue : '' }))
                 .filter(({ filterValue }) => filterValue.length > 0)
-                .map(({ name, filterValue }) => [
+                .map(({ name, filterValue }): [string, [string, string]] => [
                     name,
-                    `${this.findSchemaLabel(name)}: ${typeof filterValue === 'object' ? filterValue.join(', ') : filterValue}`,
+                    [
+                        this.findSchemaLabel(name),
+                        typeof filterValue === 'object' ? filterValue.join(', ') : filterValue,
+                    ],
                 ]),
         );
     }
@@ -169,10 +172,9 @@ export class SelectFilter implements SequenceFilter {
         return result;
     }
 
-    public toDisplayStrings(): Map<string, string> {
+    public toDisplayStrings(): Map<string, [string, string]> {
         const count = this.selectedSequences.size;
         if (count === 0) return new Map();
-        const description = `${count.toLocaleString()} sequence${count === 1 ? '' : 's'} selected`;
-        return new Map([['selectedSequences', description]]);
+        return new Map([['selectedSequences', ['sequences selected', count.toLocaleString()]]]);
     }
 }

--- a/website/src/components/SearchPage/DownloadDialog/SequenceFilters.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/SequenceFilters.tsx
@@ -175,6 +175,13 @@ export class SelectFilter implements SequenceFilter {
     public toDisplayStrings(): Map<string, [string, string]> {
         const count = this.selectedSequences.size;
         if (count === 0) return new Map();
+        const seqs = Array.from(this.selectedSequences).sort();
+        if (count === 1) {
+            return new Map([['selectedSequences', ['single sequence', seqs[0]]]]);
+        }
+        if (count === 2) {
+            return new Map([['selectedSequences', ['sequences selected', seqs.join(', ')]]]);
+        }
         return new Map([['selectedSequences', ['sequences selected', count.toLocaleString()]]]);
     }
 }

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -206,7 +206,7 @@ export const InnerSearchFullUI = ({
 
     const sequencesFilter: SequenceFilter = sequencesSelected
         ? new SelectFilter(selectedSeqs)
-        : new FieldFilter(lapisSearchParameters, hiddenFieldValues);
+        : new FieldFilter(lapisSearchParameters, hiddenFieldValues, consolidatedMetadataSchema);
 
     useEffect(() => {
         aggregatedHook.mutate({

--- a/website/src/components/common/ActiveFilters.spec.tsx
+++ b/website/src/components/common/ActiveFilters.spec.tsx
@@ -18,7 +18,8 @@ describe('ActiveDownloadFilters', () => {
                 />,
             );
             expect(screen.queryByText(/Active filters/)).toBeInTheDocument();
-            expect(screen.queryByText('field1: value1')).toBeInTheDocument();
+            expect(screen.queryByText('field1:')).toBeInTheDocument();
+            expect(screen.getByText('value1')).toBeInTheDocument();
             expect(screen.queryByText(/A123T,G234C/)).toBeInTheDocument();
         });
     });
@@ -32,13 +33,15 @@ describe('ActiveDownloadFilters', () => {
         it('renders a single selected sequence correctly', () => {
             render(<ActiveFilters sequenceFilter={new SelectFilter(new Set(['SEQID1']))} />);
             expect(screen.queryByText(/Active filters/)).toBeInTheDocument();
-            expect(screen.getByText('1 sequence selected')).toBeInTheDocument();
+            expect(screen.getByText('sequences selected:')).toBeInTheDocument();
+            expect(screen.getByText('1')).toBeInTheDocument();
         });
 
         it('renders a two selected sequences correctly', () => {
             render(<ActiveFilters sequenceFilter={new SelectFilter(new Set(['SEQID1', 'SEQID2']))} />);
             expect(screen.queryByText(/Active filters/)).toBeInTheDocument();
-            expect(screen.getByText('2 sequences selected')).toBeInTheDocument();
+            expect(screen.getByText('sequences selected:')).toBeInTheDocument();
+            expect(screen.getByText('2')).toBeInTheDocument();
         });
     });
 });

--- a/website/src/components/common/ActiveFilters.spec.tsx
+++ b/website/src/components/common/ActiveFilters.spec.tsx
@@ -7,14 +7,14 @@ import { FieldFilter, SelectFilter } from '../SearchPage/DownloadDialog/Sequence
 describe('ActiveDownloadFilters', () => {
     describe('with LAPIS filters', () => {
         it('renders empty filters as null', () => {
-            const { container } = render(<ActiveFilters sequenceFilter={new FieldFilter({}, {})} />);
+            const { container } = render(<ActiveFilters sequenceFilter={new FieldFilter({}, {}, [])}/>);
             expect(container).toBeEmptyDOMElement();
         });
 
         it('renders filters correctly', () => {
             render(
                 <ActiveFilters
-                    sequenceFilter={new FieldFilter({ field1: 'value1', nucleotideMutations: 'A123T,G234C' }, {})}
+                    sequenceFilter={new FieldFilter({ field1: 'value1', nucleotideMutations: 'A123T,G234C' }, {}, [])}
                 />,
             );
             expect(screen.queryByText(/Active filters/)).toBeInTheDocument();

--- a/website/src/components/common/ActiveFilters.spec.tsx
+++ b/website/src/components/common/ActiveFilters.spec.tsx
@@ -33,15 +33,22 @@ describe('ActiveDownloadFilters', () => {
         it('renders a single selected sequence correctly', () => {
             render(<ActiveFilters sequenceFilter={new SelectFilter(new Set(['SEQID1']))} />);
             expect(screen.queryByText(/Active filters/)).toBeInTheDocument();
-            expect(screen.getByText('sequences selected:')).toBeInTheDocument();
-            expect(screen.getByText('1')).toBeInTheDocument();
+            expect(screen.getByText('single sequence:')).toBeInTheDocument();
+            expect(screen.getByText('SEQID1')).toBeInTheDocument();
         });
 
         it('renders a two selected sequences correctly', () => {
             render(<ActiveFilters sequenceFilter={new SelectFilter(new Set(['SEQID1', 'SEQID2']))} />);
             expect(screen.queryByText(/Active filters/)).toBeInTheDocument();
             expect(screen.getByText('sequences selected:')).toBeInTheDocument();
-            expect(screen.getByText('2')).toBeInTheDocument();
+            expect(screen.getByText('SEQID1, SEQID2')).toBeInTheDocument();
+        });
+
+        it('renders a three selected sequences correctly', () => {
+            render(<ActiveFilters sequenceFilter={new SelectFilter(new Set(['SEQID1', 'SEQID2', 'SEQID3']))} />);
+            expect(screen.queryByText(/Active filters/)).toBeInTheDocument();
+            expect(screen.getByText('sequences selected:')).toBeInTheDocument();
+            expect(screen.getByText('3')).toBeInTheDocument();
         });
     });
 });

--- a/website/src/components/common/ActiveFilters.spec.tsx
+++ b/website/src/components/common/ActiveFilters.spec.tsx
@@ -7,7 +7,7 @@ import { FieldFilter, SelectFilter } from '../SearchPage/DownloadDialog/Sequence
 describe('ActiveDownloadFilters', () => {
     describe('with LAPIS filters', () => {
         it('renders empty filters as null', () => {
-            const { container } = render(<ActiveFilters sequenceFilter={new FieldFilter({}, {}, [])}/>);
+            const { container } = render(<ActiveFilters sequenceFilter={new FieldFilter({}, {}, [])} />);
             expect(container).toBeEmptyDOMElement();
         });
 

--- a/website/src/components/common/ActiveFilters.tsx
+++ b/website/src/components/common/ActiveFilters.tsx
@@ -12,9 +12,9 @@ export const ActiveFilters: FC<ActiveFiltersProps> = ({ sequenceFilter: download
     return (
         <div className='mb-4'>
             <h4 className='font-bold mb-2'>Active filters</h4>
-            <div className='flex flex-row flex-wrap gap-4'>
+            <div className='flex flex-row flex-wrap gap-3'>
                 {[...downloadParameters.toDisplayStrings()].map(([key, desc]) => (
-                    <div key={key} className='border-black border rounded-full px-2 py-1 text-sm'>
+                    <div key={key} className='border-primary-600 rounded-sm border border-l-primary-600 bg-gray-100 text-primary-900 border-l-8 px-3 py-1 text-sm font-semibold'>
                         {desc}
                     </div>
                 ))}

--- a/website/src/components/common/ActiveFilters.tsx
+++ b/website/src/components/common/ActiveFilters.tsx
@@ -13,12 +13,13 @@ export const ActiveFilters: FC<ActiveFiltersProps> = ({ sequenceFilter: download
         <div className='mb-4'>
             <h4 className='font-bold mb-2'>Active filters</h4>
             <div className='flex flex-row flex-wrap gap-3'>
-                {[...downloadParameters.toDisplayStrings()].map(([key, desc]) => (
+                {[...downloadParameters.toDisplayStrings()].map(([key, [label, value]]) => (
                     <div
                         key={key}
-                        className='border-primary-600 rounded-sm border border-l-primary-600 bg-gray-100 text-primary-900 border-l-8 px-3 py-1 text-sm font-semibold'
+                        className='border-primary-600 rounded-sm border border-l-primary-600 bg-gray-100 border-l-8 px-3 py-1 text-sm'
                     >
-                        {desc}
+                        <span className='text-primary-900 font-light pr-1'>{label}:</span>
+                        <span className='text-primary-900 font-semibold'>{value}</span>
                     </div>
                 ))}
             </div>

--- a/website/src/components/common/ActiveFilters.tsx
+++ b/website/src/components/common/ActiveFilters.tsx
@@ -14,7 +14,10 @@ export const ActiveFilters: FC<ActiveFiltersProps> = ({ sequenceFilter: download
             <h4 className='font-bold mb-2'>Active filters</h4>
             <div className='flex flex-row flex-wrap gap-3'>
                 {[...downloadParameters.toDisplayStrings()].map(([key, desc]) => (
-                    <div key={key} className='border-primary-600 rounded-sm border border-l-primary-600 bg-gray-100 text-primary-900 border-l-8 px-3 py-1 text-sm font-semibold'>
+                    <div
+                        key={key}
+                        className='border-primary-600 rounded-sm border border-l-primary-600 bg-gray-100 text-primary-900 border-l-8 px-3 py-1 text-sm font-semibold'
+                    >
                         {desc}
                     </div>
                 ))}

--- a/website/src/utils/search.ts
+++ b/website/src/utils/search.ts
@@ -121,11 +121,13 @@ export const getMetadataSchemaWithExpandedRanges = (metadataSchema: Metadata[]):
                 ...field,
                 ...fieldGroupProps,
                 name: `${field.name}From`,
+                label: 'From',
             });
             result.push({
                 ...field,
                 ...fieldGroupProps,
                 name: `${field.name}To`,
+                label: 'To',
             });
         } else if (field.rangeSearch === true) {
             const fromField = {
@@ -151,11 +153,13 @@ export const getMetadataSchemaWithExpandedRanges = (metadataSchema: Metadata[]):
     return result;
 };
 
+export type ConsolidatedMetadataFilters = (MetadataFilter | GroupedMetadataFilter)[];
+
 /**
  * Take a list of MetadataFilters and return a new list where filters that belong to a group
  * are grouped together into GroupedMetadataFilters.
  */
-export const consolidateGroupedFields = (filters: MetadataFilter[]): (MetadataFilter | GroupedMetadataFilter)[] => {
+export const consolidateGroupedFields = (filters: MetadataFilter[]): ConsolidatedMetadataFilters => {
     const fieldList: (MetadataFilter | GroupedMetadataFilter)[] = [];
     const groupsMap = new Map<string, GroupedMetadataFilter>();
 


### PR DESCRIPTION
https://filterstyle.loculus.org


Idea is to make it less like an input, and maybe also use some color as accents on the modal. Also use _display names_ for the fields instead of the URL params.

I'll see after the weekend if i still like it!

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

<img width="1033" alt="image" src="https://github.com/user-attachments/assets/47ef467d-2c29-477c-bff7-89b26147bb0d">

<details>
<summary>New 'selected sequences' filter</summary>

https://github.com/user-attachments/assets/b0d4be11-d960-443d-b1a9-7939301932bb

</details>
<details>
<summary>before</summary>

<img width="1042" alt="image" src="https://github.com/user-attachments/assets/75704f32-1642-41f7-b44c-9af3a4f791d6">

</details>

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
