### PR TITLE
fix(website): word-break: break-word;

### DIFF
--- a/website/src/styles/base.scss
+++ b/website/src/styles/base.scss
@@ -109,6 +109,7 @@ td {
 
 * {
     @apply break-words;
+    word-break: break-word;
 }
 
 .rs-input {


### PR DESCRIPTION

Found by @corneliusroemer. Fixes overflows on seq details page. https://loculus.slack.com/archives/C05G172HL6L/p1733766470652209?thread_ts=1733766069.701169&cid=C05G172HL6L



----
Co-authored-by: Cornelius Roemer <corneliusroemer@users.noreply.github.com> 