### PR TITLE
fix(website): Set min width to 130px for columns without defined widths

### DIFF
--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -43,7 +43,7 @@ type TableProps = {
 };
 
 const getColumnWidthStyle = (columnWidth: number | undefined) =>
-    columnWidth !== undefined ? `${columnWidth}px` : undefined;
+    columnWidth !== undefined ? `${columnWidth}px` : `100px`;
 
 export const Table: FC<TableProps> = ({
     data,

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -43,7 +43,7 @@ type TableProps = {
 };
 
 const getColumnWidthStyle = (columnWidth: number | undefined) =>
-    columnWidth !== undefined ? `${columnWidth}px` : `150px`;
+    columnWidth !== undefined ? `${columnWidth}px` : `130px`;
 
 export const Table: FC<TableProps> = ({
     data,

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -43,7 +43,7 @@ type TableProps = {
 };
 
 const getColumnWidthStyle = (columnWidth: number | undefined) =>
-    columnWidth !== undefined ? `${columnWidth}px` : `100px`;
+    columnWidth !== undefined ? `${columnWidth}px` : `150px`;
 
 export const Table: FC<TableProps> = ({
     data,


### PR DESCRIPTION
Now that we have lots of columns with defined min widths on PPX, when you add a new column it is given essentially zero width, and looks absurd.

<img width="174" alt="image" src="https://github.com/user-attachments/assets/31218e4a-95ce-4d9c-808c-e49d3674db9b">

Preview: https://theosanderson-patch-1.loculus.org/

Instead we should give a sensible minimum width, for now I'm going for 130px.

![image](https://github.com/user-attachments/assets/8571dc5c-12a2-4f77-9b20-d035a46ae427)
