### PR TITLE
feat(ingest): Improve memory usage

### DIFF
--- a/ingest/scripts/filter_out_depositions.py
+++ b/ingest/scripts/filter_out_depositions.py
@@ -1,3 +1,4 @@
+import csv
 import logging
 from dataclasses import dataclass
 
@@ -69,7 +70,7 @@ def filter_out_depositions(
         relevant_config = {key: full_config.get(key, []) for key in Config.__annotations__}
         config = Config(**relevant_config)
     logger.info(f"Config: {config}")
-    df = pd.read_csv(input_metadata_tsv, sep="\t", dtype=str, keep_default_na=False)
+    df = pd.read_csv(input_metadata_tsv, sep="\t", dtype=str, keep_default_na=False, quoting=csv.QUOTE_NONE, escapechar="\\")
     original_count = len(df)
     with open(exclude_insdc_accessions, encoding="utf-8") as f:
         loculus_insdc_accessions: set = {line.strip().split(".")[0] for line in f}  # Remove version
@@ -82,7 +83,7 @@ def filter_out_depositions(
     ]  # Filter out all versions of an accession
     filtered_df = filtered_df[~filtered_df["biosampleAccession"].isin(loculus_biosample_accessions)]
     logger.info(f"Filtered out {(original_count - len(filtered_df))} sequences.")
-    filtered_df.to_csv(output_metadata_tsv, sep="\t", index=False)
+    filtered_df.to_csv(output_metadata_tsv, sep="\t", index=False, quoting=csv.QUOTE_NONE, escapechar="\\")
 
 
 if __name__ == "__main__":

--- a/ingest/scripts/prepare_metadata.py
+++ b/ingest/scripts/prepare_metadata.py
@@ -5,6 +5,7 @@
 # Add transformations that can be applied to certain fields
 # Like separation of country into country and division
 
+import csv
 import hashlib
 import json
 import logging
@@ -62,7 +63,7 @@ def main(
     logger.debug(config)
 
     logger.info(f"Reading metadata from {input}")
-    df = pd.read_csv(input, sep="\t", dtype=str, keep_default_na=False)
+    df = pd.read_csv(input, sep="\t", dtype=str, keep_default_na=False, quoting=csv.QUOTE_NONE, escapechar="\\")
     metadata: list[dict[str, str]] = df.to_dict(orient="records")
 
     sequence_hashes: dict[str, str] = {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://ingest-mem-improvements.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Currently format_ncbi_metadata.py formats each line in a jsonl but then saves each line to a dictionary before writing to a tsv file. Instead we could immedietly write each line to a tsv using csv. 

This is a drastic memory reduction for large datasets, e.g. the peak memory usage for Influenza A is currently 2600M (using htop) with this change we decrease to a constant 14M memory usage. Additionally, we even get a small speed-up (shaving off 0.3sec - seen by adding benchmarking to snakemake rule) as I remove the intermediate pandas df conversion step. 

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
