### PR TITLE
chore(helm): move earliestReleaseDate to _common-metadata.tpl

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
@@ -78,4 +78,4 @@ data class ExternalMetadata(
     override val required: Boolean = false,
 ) : BaseMetadata()
 
-data class EarliestReleaseDate(val enabled: Boolean = false, val externalFields: List<String>)
+data class EarliestReleaseDate(val externalFields: List<String>)

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -60,11 +60,7 @@ open class ReleasedDataModel(
         val latestRevocationVersions = submissionDatabaseService.getLatestRevocationVersions(organism)
 
         val earliestReleaseDateConfig = backendConfig.getInstanceConfig(organism).schema.earliestReleaseDate
-        val finder = if (earliestReleaseDateConfig.enabled) {
-            EarliestReleaseDateFinder(earliestReleaseDateConfig.externalFields)
-        } else {
-            null
-        }
+        val earliestReleaseDateFinder = EarliestReleaseDateFinder(earliestReleaseDateConfig.externalFields)
 
         return submissionDatabaseService.streamReleasedSubmissions(organism)
             .map {
@@ -72,7 +68,7 @@ open class ReleasedDataModel(
                     it,
                     latestVersions,
                     latestRevocationVersions,
-                    finder,
+                    earliestReleaseDateFinder,
                 )
             }
     }

--- a/docs/src/content/docs/reference/helm-chart-config.mdx
+++ b/docs/src/content/docs/reference/helm-chart-config.mdx
@@ -550,12 +550,6 @@ Each organism object has the following fields:
             </td>
         </tr>
         <tr>
-            <td>`earliestReleaseDate.enabled`</td>
-            <td>boolean</td>
-            <td></td>
-            <td>Whether to enable the `earliestReleaseDate` metadata field.</td>
-        </tr>
-        <tr>
             <td>`earliestReleaseDate.externalFields`</td>
             <td>Array of strings</td>
             <td></td>

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -58,10 +58,8 @@ fields:
     displayName: Date submitted
     header: Submission details
   - name: submittedDate
-    type: string
+    type: date
     hideOnSequenceDetailsPage: true
-    generateIndex: true
-    autocomplete: true
     displayName: Date submitted (exact)
   - name: releasedAtTimestamp
     type: timestamp
@@ -69,12 +67,17 @@ fields:
     header: Submission details
     columnWidth: 100
   - name: releasedDate
-    type: string
+    type: date
     hideOnSequenceDetailsPage: true
-    generateIndex: true
-    autocomplete: true
     displayName: Date released (exact)
     columnWidth: 100
+  - name: earliestReleaseDate
+    type: date
+    displayName: Earliest release date
+    header: Sample details
+    noInput: true
+    columnWidth: 100
+    order: 15
   - name: dataUseTerms
     type: string
     generateIndex: true
@@ -289,7 +292,6 @@ organisms:
       {{- if .earliestReleaseDate }}
         {{ .earliestReleaseDate | toYaml | nindent 8 }}
       {{- else }}
-        enabled: false
         externalFields: []
       {{- end }}
       {{- end }}

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -34,7 +34,6 @@ defaultOrganismConfig: &defaultOrganismConfig
     organismName: "Ebola Sudan"
     image: "/images/organisms/ebolasudan_small.jpg"
     earliestReleaseDate:
-      enabled: true
       externalFields:
         - ncbiReleaseDate
     ### Field list
@@ -135,12 +134,6 @@ defaultOrganismConfig: &defaultOrganismConfig
             timestamp: ncbiReleaseDate
         noInput: true
         columnWidth: 100
-      - name: earliestReleaseDate
-        displayName: Earliest release date
-        header: Sample details
-        type: date
-        rangeSearch: true
-        noInput: true
       - name: ncbiUpdateDate
         type: date
         displayName: NCBI update date
@@ -1133,7 +1126,7 @@ defaultOrganismConfig: &defaultOrganismConfig
     website: &website
       tableColumns:
         - sampleCollectionDate
-        - ncbiReleaseDate
+        - earliestReleaseDate
         - authors
         - authorAffiliations
         - geoLocCountry
@@ -1228,7 +1221,7 @@ defaultOrganisms:
         <<: *website
         tableColumns:
           - sampleCollectionDate
-          - ncbiReleaseDate
+          - earliestReleaseDate
           - authors
           - authorAffiliations
           - geoLocCountry
@@ -1458,7 +1451,7 @@ defaultOrganisms:
           - geoLocAdmin1
           - authors
           - authorAffiliations
-          - ncbiReleaseDate
+          - earliestReleaseDate
           - hostNameScientific
           - length_M
           - length_S


### PR DESCRIPTION
Followup to #3380

Hard coded metadata fields are configured in _common-metadata.tpl as they are not something to be configured per instance via values.yaml

Disabling per organism isn't easy for common-metadata fields, so let's remove the ability to disable, earliest release is something that can always be calculated so no need to disable it. Let's only make configurable what truly needs to be configurable.

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
