### PR TITLE
feat(ingest): Add option to use nextclade sort to identify segments for multi-segmented organisms

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -26,20 +26,24 @@ NCBI_API_KEY = os.getenv("NCBI_API_KEY")
 FILTER_FASTA_HEADERS = config.get("filter_fasta_headers", None)
 APPROVE_TIMEOUT_MIN = config.get("approve_timeout_min")  # time in minutes
 CHECK_ENA_DEPOSITION = config.get("check_ena_deposition", False)
+ALIGN = True
 
 dataset_server_map = {}
 dataset_name_map = {}
 
 if SEGMENTED:
-    for segment in config["nucleotide_sequences"]:
-        if config.get("nextclade_dataset_server_map") and segment in config["nextclade_dataset_server_map"]:
-            dataset_server_map[segment] = config["nextclade_dataset_server_map"][segment]
-        else:
-            dataset_server_map[segment] = config.get("nextclade_dataset_server")
-        if config.get("nextclade_dataset_name_map") and segment in config["nextclade_dataset_name_map"]:
-            dataset_name_map[segment] = config["nextclade_dataset_name_map"][segment]
-        else:
-            dataset_name_map[segment] = config.get("nextclade_dataset_name") + "/" + segment
+    if config.get("minimizer_index") and config.get("minimizer_parser"):
+        ALIGN = False
+    if ALIGN:
+        for segment in config["nucleotide_sequences"]:
+            if config.get("nextclade_dataset_server_map") and segment in config["nextclade_dataset_server_map"]:
+                dataset_server_map[segment] = config["nextclade_dataset_server_map"][segment]
+            else:
+                dataset_server_map[segment] = config.get("nextclade_dataset_server")
+            if config.get("nextclade_dataset_name_map") and segment in config["nextclade_dataset_name_map"]:
+                dataset_name_map[segment] = config["nextclade_dataset_name_map"][segment]
+            else:
+                dataset_name_map[segment] = config.get("nextclade_dataset_name") + "/" + segment
 
 if os.uname().sysname == "Darwin":
     # Don't use conda-forge unzip on macOS
@@ -200,55 +204,97 @@ if FILTER_FASTA_HEADERS:
             --config-file {input.config} \
             """
 
-
-rule align:
-    input:
-        sequences=(
+if ALIGN:
+    rule align:
+        input:
+            sequences=(
             "results/sequences_filtered.fasta"
             if FILTER_FASTA_HEADERS
             else "results/sequences.fasta"
         ),
-    output:
-        results="results/nextclade_{segment}.tsv",
-    params:
-        dataset_server=lambda w: dataset_server_map[w.segment],
-        dataset_name=lambda w: dataset_name_map[w.segment],
-    shell:
-        """
-        nextclade run \
-            {input.sequences} \
-            --output-tsv {output.results} \
-            --server {params.dataset_server} \
-            --dataset-name {params.dataset_name} \
-        """
+        output:
+            results="results/nextclade_{segment}.tsv",
+        params:
+            dataset_server=lambda w: dataset_server_map[w.segment],
+            dataset_name=lambda w: dataset_name_map[w.segment],
+        shell:
+            """
+            nextclade run \
+                {input.sequences} \
+                --output-tsv {output.results} \
+                --server {params.dataset_server} \
+                --dataset-name {params.dataset_name} \
+            """
 
 
-rule process_alignments:
-    input:
-        results=expand(
-            "results/nextclade_{segment}.tsv",
-            segment=config["nucleotide_sequences"],
-        ),
-    output:
-        merged="results/nextclade_merged.tsv",
-    params:
-        # -f segment_name1=segment_path1 - segment_name2=segment_path2
-        # to do source tracking with tsv-append
-        # https://github.com/eBay/tsv-utils/blob/master/docs/tool_reference/tsv-append.md
-        segment_paths=" ".join(
-            [
-                f"-f {segment}=results/nextclade_{segment}.tsv"
-                for segment in config["nucleotide_sequences"]
-            ]
-        ),
-    shell:
-        """
-        tsv-append --header --source-header segment \
-            {params.segment_paths} \
-        | tsv-filter --header --not-empty alignmentScore \
-        | tsv-select --header --fields seqName,segment \
-        > {output.merged}
-        """
+    rule process_alignments:
+        input:
+            results=expand(
+                "results/nextclade_{segment}.tsv",
+                segment=config["nucleotide_sequences"],
+            ),
+        output:
+            merged="results/nextclade_merged.tsv",
+        params:
+            # -f segment_name1=segment_path1 - segment_name2=segment_path2
+            # to do source tracking with tsv-append
+            # https://github.com/eBay/tsv-utils/blob/master/docs/tool_reference/tsv-append.md
+            segment_paths=" ".join(
+                [
+                    f"-f {segment}=results/nextclade_{segment}.tsv"
+                    for segment in config["nucleotide_sequences"]
+                ]
+            ),
+        shell:
+            """
+            tsv-append --header --source-header segment \
+                {params.segment_paths} \
+            | tsv-filter --header --not-empty alignmentScore \
+            | tsv-select --header --fields seqName,segment \
+            > {output.merged}
+            """
+
+if not ALIGN:
+    rule download:
+        output:
+            results="results/minimzer.json",
+        params:
+            minimizer=config.get("minimizer_index")
+        shell:
+            """
+            curl -L -o {output.results} {params.minimizer}
+            """
+
+    rule nextclade_sort:
+        input:
+            sequences= "results/sequences.fasta",
+            minimizer="results/minimzer.json",
+        output:
+            results="results/sort_results.tsv",
+        shell:
+            """
+            nextclade sort -m {input.minimizer} \
+            -r {output.results}  {input.sequences} \
+            --max-score-gap 0.3 --min-score 0.1 --min-hits 2  --all-matches
+            """
+
+    rule parse_sort:
+        input:
+            sorted="results/sort_results.tsv",
+            config="results/config.yaml",
+            script="scripts/parse_nextclade_sort_output.py",
+        output:
+            merged="results/nextclade_merged.tsv",
+        params:
+            log_level=LOG_LEVEL,
+        shell:
+            """
+            python {input.script} \
+            --config-file {input.config} \
+            --sort-results {input.sorted} \
+            --output {output.merged} \
+            --log-level {params.log_level} \
+            """
 
 
 rule prepare_metadata:

--- a/ingest/environment.yml
+++ b/ingest/environment.yml
@@ -21,3 +21,4 @@ dependencies:
   - snakemake
   - tsv-utils
   - unzip
+  - curl

--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -11,9 +11,11 @@ from typing import Any, Literal
 
 import click
 import jsonlines
+import pandas as pd
 import pytz
 import requests
 import yaml
+from Bio import SeqIO
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(
@@ -171,6 +173,65 @@ def get_or_create_group_and_return_group_id(config: Config, allow_creation: bool
     return create_group_and_return_group_id(config)
 
 
+def filter_fasta_by_submission_ids(
+    fasta_dict: dict[str, Any], submission_ids: list[str], config: Config
+):
+    if config.segmented:
+        segmented_submission_ids = [
+            f"{submission_id}_{segment}"
+            for submission_id in submission_ids
+            for segment in config.nucleotide_sequences
+        ]
+        return [
+            fasta_dict[submission_id]
+            for submission_id in segmented_submission_ids
+            if submission_id in fasta_dict
+        ]
+    return [
+        fasta_dict[submission_id] for submission_id in submission_ids if submission_id in fasta_dict
+    ]
+
+
+def post_fasta_batches(
+    url,
+    fasta_file: str,
+    metadata_file: str,
+    config: Config,
+    params: dict[str, str],
+    chunk_size=60000,
+) -> requests.Response:
+    """Chunks metadata files, joins with sequences and submits each chunk via POST."""
+    df = pd.read_csv(metadata_file, sep="\t")
+    logger.info(df.columns)
+    sequences_dict = {record.id: record for record in SeqIO.parse(fasta_file, "fasta")}
+    submission_ids = df["submissionId"].tolist()
+    for batch_num, submission_id_chunk in (
+        (i, submission_ids[i : i + chunk_size]) for i in range(0, len(submission_ids), chunk_size)
+    ):
+        matching_fasta_records = filter_fasta_by_submission_ids(
+            sequences_dict, submission_id_chunk, config
+        )
+
+        sequences_output_file = "results/batch_sequences.fasta"
+        with open(sequences_output_file, "w") as output:
+            SeqIO.write(matching_fasta_records, output, "fasta")
+
+        metadata = df[df["submissionId"].isin(submission_id_chunk)]
+        metadata_output_file = "results/batch_metadata.tsv"
+        metadata.to_csv(metadata_output_file, sep="\t", index=False, float_format="%.0f")
+        with open(metadata_output_file, "rb") as metadata_ , open(sequences_output_file, "rb") as fasta_:
+            files = {
+                "metadataFile": metadata_,
+                "sequenceFile": fasta_,
+            }
+            response = make_request(HTTPMethod.POST, url, config, params=params, files=files)
+            logger.info(f"Batch {batch_num + 1} Response: {response.status_code}")
+            if response.status_code != 200:
+                logger.error(f"Error in batch {batch_num + 1}: {response.text}")
+                return response
+    return response
+
+
 def submit_or_revise(
     metadata, sequences, config: Config, group_id, mode=Literal["submit", "revise"]
 ):
@@ -207,12 +268,10 @@ def submit_or_revise(
     if mode == "submit":
         params["dataUseTermsType"] = "OPEN"
 
-    with open(metadata, "rb") as metadata_file, open(sequences, "rb") as sequences_file:
-        files = {
-            "metadataFile": metadata_file,
-            "sequenceFile": sequences_file,
-        }
-        response = make_request(HTTPMethod.POST, url, config, params=params, files=files)
+    with open(sequences, encoding="utf-8") as sequences_file:
+        response = post_fasta_batches(
+            url, sequences_file, metadata, config, params=params, chunk_size=60000
+        )
     logger.debug(f"{logging_strings["noun"]} response: {response.json()}")
 
     return response.json()

--- a/ingest/scripts/parse_nextclade_sort_output.py
+++ b/ingest/scripts/parse_nextclade_sort_output.py
@@ -73,7 +73,7 @@ def main(config_file: str, sort_results: str, output: str, log_level: str) -> No
         relevant_config = {key: full_config.get(key, []) for key in Config.__annotations__}
         config = Config(**relevant_config)
     logger.info(f"Config: {config}")
-    if not config.minimizer_parser.get("segment"):
+    if "segment" not in config.minimizer_parser:
         error_msg = "minimizer_parser must include 'segment'"
         raise ValueError(error_msg)
     parse_file(config, sort_results, output)

--- a/ingest/scripts/parse_nextclade_sort_output.py
+++ b/ingest/scripts/parse_nextclade_sort_output.py
@@ -1,0 +1,74 @@
+import logging
+from dataclasses import dataclass
+
+import click
+import pandas as pd
+import yaml
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    encoding="utf-8",
+    level=logging.DEBUG,
+    format="%(asctime)s %(levelname)8s (%(filename)20s:%(lineno)4d) - %(message)s ",
+    datefmt="%H:%M:%S",
+)
+
+
+@dataclass
+class Config:
+    minimizer_index: str
+    minimizer_parser: list[str]
+    nucleotide_sequences: list[str]
+
+
+def parse(field: str, index: int) -> str:
+    return field.split("_")[index] if len(field.split("_")) > index else ""
+
+
+def parse_file(config: Config, sort_results: str, output_file: str):
+    df = pd.read_csv(sort_results, sep="\t", dtype={"index": "Int64"})
+
+    no_rows = df.shape[0]
+
+    # Drop rows where 'score' is NaN - i.e. no hits
+    df["score"] = pd.to_numeric(df["score"], errors="coerce")
+    df = df.dropna(subset=["score"])
+
+    logger.info(f"Dropped {no_rows - df.shape[0]} sequences with no hits")
+
+    # Group by 'index', then sort within each group by 'score' and keep the highest score
+    df_sorted = df.sort_values(["index", "score"], ascending=[True, False])
+    df_highest_per_group = df_sorted.drop_duplicates(subset="index", keep="first")
+
+    for i, field in enumerate(config.minimizer_parser):
+        df_highest_per_group[field] = df_highest_per_group.apply(
+            lambda x: parse(x["dataset"], i), axis=1
+        )
+    header = list(config.minimizer_parser)
+    header.append("seqName")
+    df_highest_per_group.to_csv(output_file, columns=header, sep="\t", index=False)
+
+
+@click.command()
+@click.option("--config-file", required=True, type=click.Path(exists=True))
+@click.option("--sort-results", required=True, type=click.Path(exists=True))
+@click.option("--output", required=True, type=click.Path(exists=False))
+@click.option(
+    "--log-level",
+    default="INFO",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
+)
+def main(config_file: str, sort_results: str, output: str, log_level: str) -> None:
+    logger.setLevel(log_level)
+
+    with open(config_file, encoding="utf-8") as file:
+        full_config = yaml.safe_load(file)
+        relevant_config = {key: full_config.get(key, []) for key in Config.__annotations__}
+        config = Config(**relevant_config)
+    logger.info(f"Config: {config}")
+    #TODO: throw an error if minimizer_index does not include segment
+    parse_file(config, sort_results, output)
+
+
+if __name__ == "__main__":
+    main()

--- a/ingest/scripts/parse_nextclade_sort_output.py
+++ b/ingest/scripts/parse_nextclade_sort_output.py
@@ -1,3 +1,10 @@
+"""
+This script parses the results of nextclade sort:
+ - keeps only the highest scoring hit for each sequence
+ - parses the corresponding dataset name according to the minimizer_parser
+ - creates an output tsv with the parsed dataset names and seqName columns
+"""
+
 import logging
 from dataclasses import dataclass
 
@@ -66,7 +73,9 @@ def main(config_file: str, sort_results: str, output: str, log_level: str) -> No
         relevant_config = {key: full_config.get(key, []) for key in Config.__annotations__}
         config = Config(**relevant_config)
     logger.info(f"Config: {config}")
-    #TODO: throw an error if minimizer_index does not include segment
+    if not config.minimizer_parser.get("segment"):
+        error_msg = "minimizer_parser must include 'segment'"
+        raise ValueError(error_msg)
     parse_file(config, sort_results, output)
 
 

--- a/ingest/scripts/prepare_metadata.py
+++ b/ingest/scripts/prepare_metadata.py
@@ -71,15 +71,14 @@ def main(
     }
 
     if config.segmented:
-        # Segments are a tsv file with the first column being the fasta id
-        # and the second being the segment
-        segments_dict: dict[str, str] = {}
-        with open(segments, encoding="utf-8") as file:
-            for line in file:
-                if line.startswith("seqName"):
-                    continue
-                fasta_id, segment = line.strip().split("\t")
-                segments_dict[fasta_id] = segment
+        segments_dict: dict[str, dict[str, str]] = {}
+        segment_df = pd.read_csv(segments, sep="\t")
+        segmented_fields = list(segment_df.columns)
+
+        rows_as_dicts = segment_df.to_dict(orient="records")
+
+        for row in rows_as_dicts:
+            segments_dict[row["seqName"]] = row
 
     for record in metadata:
         # Transform the metadata
@@ -92,7 +91,9 @@ def main(
         record["insdcAccessionBase"] = record[config.fasta_id_field].split(".", 1)[0]
         record["insdcVersion"] = record[config.fasta_id_field].split(".", 1)[1]
         if config.segmented:
-            record["segment"] = segments_dict.get(record[config.fasta_id_field], "")
+            results_dic = segments_dict.get(record[config.fasta_id_field], {})
+            for key in segmented_fields:
+                record[key] = results_dic.get(key, "")
 
     # Get rid of all records without segment
     # TODO: Log the ones that are missing

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -591,7 +591,9 @@ def process_single(  # noqa: C901
         unaligned_nucleotide_sequences = unprocessed.unalignedNucleotideSequences
 
     for segment in config.nucleotideSequences:
-        sequence = unaligned_nucleotide_sequences[segment]
+        sequence = unaligned_nucleotide_sequences.get(segment, None)
+        if not sequence:
+            unprocessed.unalignedNucleotideSequences[segment] = None
         key = "length" if segment == "main" else "length_" + segment
         if key in config.processing_spec:
             output_metadata[key] = len(sequence) if sequence else 0


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://add-fast-segment-identifi.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
1. Add option in Snakefile to either determine segments via [nextclade sort](https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-cli/reference.html#nextclade-sort) or nextclade align. Nextclade sort is extremely fast and when used on influenza data produces highly accurate results. Similar to the nextclade dataset requirement for nextclade align nextclade sort requires a minimzer.json. 
2. Add script to parse nextclade sort output, set dataset with highest score as segment -> allow option to parse `dataset` (identified sorted group's name) into additional metadata fields and add them to the metadata tsv during prepare_metadata. 
3. Fix small bug in prepro.

See this isn action here: https://virus4.loculus.org/ code here: https://github.com/loculus-project/private_deployments/blob/main/deploy/virus4/values.yaml

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] Update config docs?

### Future work
- [ ] Use for CCHF to make ingest faster/ less CPU intensive. 
