### PR TITLE
feat: Add lineage definition file to SILO import config

### DIFF
--- a/docs/src/content/docs/reference/helm-chart-config.mdx
+++ b/docs/src/content/docs/reference/helm-chart-config.mdx
@@ -871,7 +871,7 @@ Each organism object has the following fields:
                 Use this on string fields that contain lineages.
                 The value needs to be a lineage system that is defined under the `lineageSystemDefinitions` key.
             </td>
-        <tr>
+        </tr>
     </tbody>
 </table>
 

--- a/docs/src/content/docs/reference/helm-chart-config.mdx
+++ b/docs/src/content/docs/reference/helm-chart-config.mdx
@@ -451,10 +451,10 @@ Here's an example of a `lineageDefinitions` section:
 ```yaml
 lineageSystemDefinitions:
   pangoLineage:  # Lineage name to use in metadata fields
-    "1": https://example.org/lineage_defintions_v1.yaml  # Definition per pipeline version
-    "2": https://example.org/lineage_defintions_v2.yaml
+    1: https://example.org/lineage_defintions_v1.yaml  # Definition per pipeline version
+    2: https://example.org/lineage_defintions_v2.yaml
   myLineage:
-    "1": ...
+    1: ...
 ```
 
 <table>

--- a/docs/src/content/docs/reference/helm-chart-config.mdx
+++ b/docs/src/content/docs/reference/helm-chart-config.mdx
@@ -868,7 +868,7 @@ Each organism object has the following fields:
             <td>String</td>
             <td></td>
             <td>
-                Use this on string fields that contain lineages.
+                Use this on string fields that contain lineages, if you want to enable searches that can include sublineages.
                 The value needs to be a lineage system that is defined under the `lineageSystemDefinitions` key.
             </td>
         </tr>

--- a/docs/src/content/docs/reference/helm-chart-config.mdx
+++ b/docs/src/content/docs/reference/helm-chart-config.mdx
@@ -434,6 +434,51 @@ For production environments, these should always be set to false. Instead, exter
             <td></td>
             <td>An object where the keys are the organism IDs and values are an [Organism (type)](#organism-type)</td>
         </tr>
+        <tr>
+            <td>`lineageSystemDefinitions`</td>
+            <td>Object</td>
+            <td></td>
+            <td>An object where the keys are the lineage system names and values are links to lineage system definition files per pipeline version (See [Lineage system defintions](#lineage-type))</td>
+
+        </tr>
+    </tbody>
+</table>
+
+### Lineage system definitions
+
+Here's an example of a `lineageDefinitions` section:
+
+```yaml
+lineageSystemDefinitions:
+  pangoLineage:  # Lineage name to use in metadata fields
+    "1": https://example.org/lineage_defintions_v1.yaml  # Definition per pipeline version
+    "2": https://example.org/lineage_defintions_v2.yaml
+  myLineage:
+    "1": ...
+```
+
+<table>
+    <thead>
+        <tr>
+            <th className='w-48'>Field</th>
+            <th>Type</th>
+            <th>Default</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>`lineageSystemDefinitions.<name>`</td>
+            <td>Object</td>
+            <td></td>
+            <td>A map from pipeline versions to file URLs.</td>
+        </tr>
+        <tr>
+            <td>`lineageSystemDefinitions.<name>.<pipelineVersion>`</td>
+            <td>`String`</td>
+            <td></td>
+            <td>The URL to the lineage defintion file for that lineage system and that pipeline version.</td>
+        </tr>
     </tbody>
 </table>
 
@@ -818,6 +863,15 @@ Each organism object has the following fields:
                 [here](https://github.com/loculus-project/loculus/blob/main/preprocessing/nextclade/README.md#custom-preprocessing-functions).
             </td>
         </tr>
+        <tr>
+            <td>`lineageSystem`</td>
+            <td>String</td>
+            <td></td>
+            <td>
+                Use this on string fields that contain lineages.
+                The value needs to be a lineage system that is defined under the `lineageSystemDefinitions` key.
+            </td>
+        <tr>
     </tbody>
 </table>
 

--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -4,7 +4,7 @@ set -e
 # Default values
 root_dir=""
 last_etag=""
-lineage_definition_file=lineage_definitions.yaml
+lineage_definition_file=input/lineage_definitions.yaml
 preprocessing_config_file=preprocessing_config.yaml
 preprocessing_config_file_merged=preprocessing_config_merged.yaml
 
@@ -187,7 +187,7 @@ prepare_preprocessing_config() {
   fi
 
   cp $preprocessing_config_file $preprocessing_config_file_merged
-  echo -e "\nlineageDefinitionsFilename: \"$lineage_definition_file\"\n" >> $preprocessing_config_file_merged
+  echo -e "lineageDefinitionsFilename: \"$lineage_definition_file\"\n" >> $preprocessing_config_file_merged
 }
 
 preprocessing() {

--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -4,6 +4,8 @@ set -e
 # Default values
 root_dir=""
 last_etag=""
+lineage_definition_file=lineage_definitions.yaml
+preprocessing_config_file=preprocessing_config.yaml
 
 # Parse command-line arguments
 usage() {
@@ -147,9 +149,6 @@ download_data() {
   fi
   echo
 }
-
-lineage_definition_file=lineage_definitions.yaml
-preprocessing_config_file=preprocessing_config.yaml
 
 prepare_preprocessing_config() {
   rm $lineage_definition_file $preprocessing_config_file

--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -4,7 +4,7 @@ set -e
 # Default values
 root_dir=""
 last_etag=""
-lineage_definition_file=input/lineage_definitions.yaml
+lineage_definition_file=/preprocessing/input/lineage_definitions.yaml
 preprocessing_config_file=preprocessing_config.yaml
 preprocessing_config_file_merged=preprocessing_config_merged.yaml
 

--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -154,7 +154,7 @@ download_data() {
 # Generate the preprocessing config file with the lineage file for the current pipeline version.
 # the lineage definition file needs to be downloaded first.
 prepare_preprocessing_config() {
-  rm $lineage_definition_file $preprocessing_config_file_merged
+  rm -f $lineage_definition_file $preprocessing_config_file_merged
 
   if [[ -z "$LINEAGE_DEFINITIONS" ]]; then
     echo "No LINEAGE_DEFINITIONS given, nothing to configure;"

--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -184,7 +184,7 @@ prepare_preprocessing_config() {
     exit 1
   fi
 
-  # TODO $lineage_definition_file is now written, create the $preprocessing_config_file
+  echo -e "lineageDefinitionsFilename: \"$lineage_definition_file\"\n" > preprocessing_config_file
 }
 
 preprocessing() {

--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -115,9 +115,6 @@ download_data() {
   true_record_count=$(zstd -d -c "$new_input_data_path" | jq -n 'reduce inputs as $item (0; . + 1)' | tr -d '[:space:]')
   echo "Response contained a total of : $true_record_count records"
 
-  # print all lines (hopefully)
-  zstd -d -c "$new_input_data_path"
-
   if [ "$true_record_count" -ne "$expected_record_count" ]; then
     echo "Expected and actual number of records are not the same"
     echo "Deleting new input data dir $new_input_data_dir"
@@ -190,6 +187,8 @@ prepare_preprocessing_config() {
     exit 1
   fi
 
+  # the lineage definition filename needs to be set in the config
+  # Once https://github.com/GenSpectrum/LAPIS-SILO/pull/633 is merged, it can be done as a commandline arg
   cp $preprocessing_config_file $preprocessing_config_file_merged
   echo -e "lineageDefinitionsFilename: \"$lineage_definition_file\"\n" >> $preprocessing_config_file_merged
 }

--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -6,6 +6,7 @@ root_dir=""
 last_etag=""
 lineage_definition_file=lineage_definitions.yaml
 preprocessing_config_file=preprocessing_config.yaml
+preprocessing_config_file_merged=preprocessing_config_merged.yaml
 
 # Parse command-line arguments
 usage() {
@@ -153,7 +154,7 @@ download_data() {
 # Generate the preprocessing config file with the lineage file for the current pipeline version.
 # the lineage definition file needs to be downloaded first.
 prepare_preprocessing_config() {
-  rm $lineage_definition_file $preprocessing_config_file
+  rm $lineage_definition_file $preprocessing_config_file_merged
 
   if [[ -z "$LINEAGE_DEFINITIONS" ]]; then
     echo "No LINEAGE_DEFINITIONS given, nothing to configure;"
@@ -185,7 +186,8 @@ prepare_preprocessing_config() {
     exit 1
   fi
 
-  echo -e "lineageDefinitionsFilename: \"$lineage_definition_file\"\n" > preprocessing_config_file
+  cp $preprocessing_config_file $preprocessing_config_file_merged
+  echo -e "\nlineageDefinitionsFilename: \"$lineage_definition_file\"\n" >> $preprocessing_config_file_merged
 }
 
 preprocessing() {
@@ -198,7 +200,7 @@ preprocessing() {
   cp "$new_input_data_path" "$silo_input_data_path"
   
   set +e
-  time /app/siloApi --preprocessing
+  time /app/siloApi --preprocessing --preprocessingConfig=$preprocessing_config_file_merged
   exit_code=$?
   set -e
 

--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -115,6 +115,9 @@ download_data() {
   true_record_count=$(zstd -d -c "$new_input_data_path" | jq -n 'reduce inputs as $item (0; . + 1)' | tr -d '[:space:]')
   echo "Response contained a total of : $true_record_count records"
 
+  # print all lines (hopefully)
+  zstd -d -c "$new_input_data_path"
+
   if [ "$true_record_count" -ne "$expected_record_count" ]; then
     echo "Expected and actual number of records are not the same"
     echo "Deleting new input data dir $new_input_data_dir"

--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -151,6 +151,7 @@ download_data() {
 prepare_preprocessing_config() {
   pipelineVersion=$(zstd -d -c "$new_input_data_path" | jq -r '.metadata.pipelineVersion' | sort -u)
   # TODO check that there is only one version in there and raise an error if there are multiple
+  # TODO the data might be empty
   # TODO look at an env var to find the URL of the lineage file for that pipeline version
   # Download the file
   # prepare the preprocessing_conf.yaml

--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -158,6 +158,7 @@ prepare_preprocessing_config() {
 
   if [[ -z "$LINEAGE_DEFINITIONS" ]]; then
     echo "No LINEAGE_DEFINITIONS given, nothing to configure;"
+    cp $preprocessing_config_file $preprocessing_config_file_merged
     return
   fi
 

--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -148,6 +148,14 @@ download_data() {
   echo
 }
 
+prepare_preprocessing_config() {
+  pipelineVersion=$(zstd -d -c "$new_input_data_path" | jq -r '.metadata.pipelineVersion' | sort -u)
+  # TODO check that there is only one version in there and raise an error if there are multiple
+  # TODO look at an env var to find the URL of the lineage file for that pipeline version
+  # Download the file
+  # prepare the preprocessing_conf.yaml
+}
+
 preprocessing() {
   echo "Starting preprocessing"
 
@@ -229,6 +237,7 @@ main() {
   # cleanup at start in case we fail later
   cleanup_output_data
   download_data
+  prepare_preprocessing_config
   preprocessing
 
   echo "done"

--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -150,6 +150,8 @@ download_data() {
   echo
 }
 
+# Generate the preprocessing config file with the lineage file for the current pipeline version.
+# the lineage definition file needs to be downloaded first.
 prepare_preprocessing_config() {
   rm $lineage_definition_file $preprocessing_config_file
 

--- a/kubernetes/loculus/templates/_lineage-system-for-organism.tpl
+++ b/kubernetes/loculus/templates/_lineage-system-for-organism.tpl
@@ -1,18 +1,3 @@
-{{/*
-This template looks up the lineage system for a specific organism and generates
-its JSON configuration based on the defined lineage systems in `lineageSystemDefinitions`.
-
-Parameters:
-  - $organismName: The name of the organism (e.g., "west-nile").
-  
-Returns:
-  - The JSON representation of the lineage system defined in `lineageSystemDefinitions`
-  - Returns nothing (empty string) if no lineage system is found or if multiple lineage systems are present.
-
-
-Usage Example:
-  {{- .Values.organisms[west-nile] | include "loculus.lineageSystemForOrganism" -}}
-*/}}
 {{- define "loculus.lineageSystemForOrganism" -}}
 {{- $organism := . -}}
 {{- $schema := $organism.schema | include "loculus.patchMetadataSchema" | fromYaml }}

--- a/kubernetes/loculus/templates/_lineage-system-for-organism.tpl
+++ b/kubernetes/loculus/templates/_lineage-system-for-organism.tpl
@@ -1,0 +1,37 @@
+{{/*
+This template looks up the lineage system for a specific organism and generates
+its JSON configuration based on the defined lineage systems in `lineageSystemDefinitions`.
+
+Parameters:
+  - $organismName: The name of the organism (e.g., "west-nile").
+  
+Returns:
+  - The JSON representation of the lineage system defined in `lineageSystemDefinitions`
+  - Returns nothing (empty string) if no lineage system is found or if multiple lineage systems are present.
+
+
+Usage Example:
+  {{- .Values.organisms[west-nile] | include "loculus.lineageSystemForOrganism" -}}
+*/}}
+{{- define "loculus.lineageSystemForOrganism" -}}
+{{- $organism := . -}}
+{{- $schema := $organism.schema | include "loculus.patchMetadataSchema" | fromYaml }}
+{{- $lineageSystems := list }}
+{{- range $entry := $schema.metadata }}
+  {{- if hasKey $entry "lineageSystem" }}
+    {{- $lineageSystems = append $lineageSystems $entry.lineageSystem }}
+  {{- end }}
+{{- end }}
+
+{{- $uniqueLineageSystems := $lineageSystems | uniq }}
+{{- if gt (len $uniqueLineageSystems) 1 }}
+  {{- fail (printf "Multiple lineage systems found: %v" $uniqueLineageSystems) }}
+{{- else if eq (len $uniqueLineageSystems) 0 }}
+  {{- /*no op*/ -}}
+{{- else }}
+  {{- $lineageSystem := index $uniqueLineageSystems 0 }}
+  {{ fail .Values.name }}
+  {{- $lineageData := index .Values.lineageSystemDefinitions $lineageSystem }}
+  {{- toJson $lineageData }}
+{{- end }}
+{{- end }}

--- a/kubernetes/loculus/templates/_lineage-system-for-organism.tpl
+++ b/kubernetes/loculus/templates/_lineage-system-for-organism.tpl
@@ -29,9 +29,6 @@ Usage Example:
 {{- else if eq (len $uniqueLineageSystems) 0 }}
   {{- /*no op*/ -}}
 {{- else }}
-  {{- $lineageSystem := index $uniqueLineageSystems 0 }}
-  {{ fail .Values.name }}
-  {{- $lineageData := index .Values.lineageSystemDefinitions $lineageSystem }}
-  {{- toJson $lineageData }}
+  {{- index $uniqueLineageSystems 0 -}}
 {{- end }}
 {{- end }}

--- a/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
+++ b/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
@@ -7,6 +7,9 @@
   {{- if .enableSubstringSearch }}
   lapisAllowsRegexSearch: true
   {{- end }}
+  {{- if .lineageSystem }}
+  generateLineageIndex: true
+  {{- end }}
 {{- end }}
 
 

--- a/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
+++ b/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
@@ -8,6 +8,7 @@
   lapisAllowsRegexSearch: true
   {{- end }}
   {{- if .lineageSystem }}
+  generateIndex: true
   generateLineageIndex: true
   {{- end }}
 {{- end }}

--- a/kubernetes/loculus/templates/foo.yaml
+++ b/kubernetes/loculus/templates/foo.yaml
@@ -1,1 +1,0 @@
-{{ .Values | toYaml | nindent 2 }}

--- a/kubernetes/loculus/templates/foo.yaml
+++ b/kubernetes/loculus/templates/foo.yaml
@@ -1,0 +1,1 @@
+{{ .Values | toYaml | nindent 2 }}

--- a/kubernetes/loculus/templates/lapis-silo-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-deployment.yaml
@@ -25,7 +25,6 @@ spec:
     spec:
       {{- include "possiblePriorityClassName" $ | nindent 6 }}
       initContainers:
-        # can the config processor just download the lineage files and prepare the import config?
         {{- include "loculus.configProcessor" (dict "name" "lapis-silo-database-config" "dockerTag" $dockerTag) | nindent 8 }}
       containers:
         - name: silo

--- a/kubernetes/loculus/templates/lapis-silo-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-deployment.yaml
@@ -1,10 +1,9 @@
 {{- $dockerTag := include "loculus.dockerTag" $.Values }}
 {{- $keycloakTokenUrl := "http://loculus-keycloak-service:8083/realms/loculus/protocol/openid-connect/token" }}
 
-{{- range $key, $_ := (.Values.organisms | default .Values.defaultOrganisms) }}
-# TODO go through the schema for the organism and gather all the metadata entries that are of lineage type
-# TODO There can be multple fields, but they all need to have the same lineageSystem ... not sure how to handle yet
-# TODO generate the '{1: URL, 2: URL}' type env value for further down
+{{- range $key, $organism := (.Values.organisms | default .Values.defaultOrganisms) }}
+{{ fail .Values.defaultOrganisms }}
+{{- $lineageDefinitions := $organism | include "loculus.lineageSystemForOrganism" }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -88,6 +87,10 @@ spec:
               {{- else }}
               value: "http://loculus-backend-service:8079/{{ $key }}"
               {{- end }}
+            {{- if $lineageDefinitions }}
+            - name: LINEAGE_DEFINITIONS
+              value: {{ $lineageDefinitions }}
+            {{- end }}
             # TODO in here we need to set the env var with the lineage file URLs
           volumeMounts:
             - name: lapis-silo-database-config-processed

--- a/kubernetes/loculus/templates/lapis-silo-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-deployment.yaml
@@ -2,6 +2,9 @@
 {{- $keycloakTokenUrl := "http://loculus-keycloak-service:8083/realms/loculus/protocol/openid-connect/token" }}
 
 {{- range $key, $_ := (.Values.organisms | default .Values.defaultOrganisms) }}
+# TODO go through the schema for the organism and gather all the metadata entries that are of lineage type
+# TODO There can be multple fields, but they all need to have the same lineageSystem ... not sure how to handle yet
+# TODO generate the '{1: URL, 2: URL}' type env value for further down
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -24,6 +27,7 @@ spec:
     spec:
       {{- include "possiblePriorityClassName" $ | nindent 6 }}
       initContainers:
+        # can the config processor just download the lineage files and prepare the import config?
         {{- include "loculus.configProcessor" (dict "name" "lapis-silo-database-config" "dockerTag" $dockerTag) | nindent 8 }}
       containers:
         - name: silo
@@ -84,6 +88,7 @@ spec:
               {{- else }}
               value: "http://loculus-backend-service:8079/{{ $key }}"
               {{- end }}
+            # TODO in here we need to set the env var with the lineage file URLs
           volumeMounts:
             - name: lapis-silo-database-config-processed
               mountPath: /preprocessing/input/reference_genomes.json

--- a/kubernetes/loculus/templates/lapis-silo-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-deployment.yaml
@@ -1,9 +1,8 @@
-{{- $dockerTag := include "loculus.dockerTag" $.Values }}
+{{- $dockerTag := include "loculus.dockerTag" .Values }}
 {{- $keycloakTokenUrl := "http://loculus-keycloak-service:8083/realms/loculus/protocol/openid-connect/token" }}
 
 {{- range $key, $organism := (.Values.organisms | default .Values.defaultOrganisms) }}
-{{ fail .Values.defaultOrganisms }}
-{{- $lineageDefinitions := $organism | include "loculus.lineageSystemForOrganism" }}
+{{- $lineageSystem := $organism | include "loculus.lineageSystemForOrganism" }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -87,11 +86,10 @@ spec:
               {{- else }}
               value: "http://loculus-backend-service:8079/{{ $key }}"
               {{- end }}
-            {{- if $lineageDefinitions }}
+            {{- if $lineageSystem }}
             - name: LINEAGE_DEFINITIONS
-              value: {{ $lineageDefinitions }}
+              value: {{ index $.Values.lineageSystemDefinitions $lineageSystem | toJson | quote }}
             {{- end }}
-            # TODO in here we need to set the env var with the lineage file URLs
           volumeMounts:
             - name: lapis-silo-database-config-processed
               mountPath: /preprocessing/input/reference_genomes.json

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -28,6 +28,13 @@ logo:
   url: "/favicon.svg"
   width: 100
   height: 100
+lineageSystemDefinitions:
+  pangoLineage:
+    "1": http://example.com/lineagedef_v1.yaml
+    "2": http://example.com/lineagedef_v1.yaml
+  myLineage:
+    "1": http://example.com/lineagedef_v1.yaml
+    "2": http://example.com/lineagedef_v1.yaml
 defaultOrganismConfig: &defaultOrganismConfig
   schema: &schema
     loadSequencesAutomatically: true
@@ -1207,6 +1214,7 @@ defaultOrganisms:
       metadataAdd:
         - name: lineage
           header: "Lineage"
+          lineageSystem: myLineage
           noInput: true
           generateIndex: true
           autocomplete: true

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -30,7 +30,7 @@ logo:
   height: 100
 lineageSystemDefinitions:
   pangoLineage:
-    "1": https://raw.githubusercontent.com/loculus-project/loculus/refs/heads/lineage-validation/preprocessing/dummy/lineage.yaml
+    1: https://raw.githubusercontent.com/loculus-project/loculus/refs/heads/lineage-validation/preprocessing/dummy/lineage.yaml
 defaultOrganismConfig: &defaultOrganismConfig
   schema: &schema
     loadSequencesAutomatically: true

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -30,7 +30,7 @@ logo:
   height: 100
 lineageSystemDefinitions:
   pangoLineage:
-    "1": https://raw.githubusercontent.com/loculus-project/loculus/cb5411174c17d8dfedf69a35f5f77b0b12db54f1/preprocessing/dummy/lineage.yaml
+    "1": https://raw.githubusercontent.com/loculus-project/loculus/refs/heads/lineage-validation/preprocessing/dummy/lineage.yaml
 defaultOrganismConfig: &defaultOrganismConfig
   schema: &schema
     loadSequencesAutomatically: true

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -31,10 +31,6 @@ logo:
 lineageSystemDefinitions:
   pangoLineage:
     "1": http://example.com/lineagedef_v1.yaml
-    "2": http://example.com/lineagedef_v1.yaml
-  myLineage:
-    "1": http://example.com/lineagedef_v1.yaml
-    "2": http://example.com/lineagedef_v1.yaml
 defaultOrganismConfig: &defaultOrganismConfig
   schema: &schema
     loadSequencesAutomatically: true
@@ -1329,6 +1325,7 @@ defaultOrganisms:
           autocomplete: true
           required: true
           type: string
+          lineageSystem: pangoLineage
       website:
         tableColumns:
           - country

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1210,7 +1210,6 @@ defaultOrganisms:
       metadataAdd:
         - name: lineage
           header: "Lineage"
-          lineageSystem: myLineage
           noInput: true
           generateIndex: true
           autocomplete: true

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -30,7 +30,7 @@ logo:
   height: 100
 lineageSystemDefinitions:
   pangoLineage:
-    "1": http://example.com/lineagedef_v1.yaml
+    "1": https://raw.githubusercontent.com/loculus-project/loculus/cb5411174c17d8dfedf69a35f5f77b0b12db54f1/preprocessing/dummy/lineage.yaml
 defaultOrganismConfig: &defaultOrganismConfig
   schema: &schema
     loadSequencesAutomatically: true

--- a/preprocessing/dummy/lineage.yaml
+++ b/preprocessing/dummy/lineage.yaml
@@ -1,10 +1,10 @@
-A1:
+A.1:
   aliases: []
   parents: []
 A1.1:
   aliases: []
   parents:
-  - A1
-A2:
+  - A.1
+A.2:
   aliases: []
   parents: []

--- a/preprocessing/dummy/lineage.yaml
+++ b/preprocessing/dummy/lineage.yaml
@@ -1,0 +1,10 @@
+A1:
+  aliases: []
+  parents: []
+A1.1:
+  aliases: []
+  parents:
+  - A1
+A2:
+  aliases: []
+  parents: []

--- a/preprocessing/dummy/lineage.yaml
+++ b/preprocessing/dummy/lineage.yaml
@@ -1,7 +1,7 @@
 A.1:
   aliases: []
   parents: []
-A1.1:
+A.1.1:
   aliases: []
   parents:
   - A.1

--- a/preprocessing/dummy/main.py
+++ b/preprocessing/dummy/main.py
@@ -241,7 +241,7 @@ def main():
         etag, unprocessed = fetch_unprocessed_sequences(etag, sequences_to_fetch)
         if len(unprocessed) == 0:
             if watch_mode:
-                logging.debug(f"Processed {locally_processed} sequences. Sleeping for 10 seconds.")
+                logging.debug(f"Processed {locally_processed} sequences. Sleeping for 2 seconds.")
                 time.sleep(2)
                 locally_processed = 0
                 continue

--- a/website/tests/pages/search/index.spec.ts
+++ b/website/tests/pages/search/index.spec.ts
@@ -36,7 +36,7 @@ test.describe('The search page', () => {
 
         const rowLocator = searchPage.page.locator('tr');
         await expect(rowLocator.getByText('2002-12-15')).toBeVisible();
-        await expect(rowLocator.getByText('B.1.1.7')).toBeVisible();
+        await expect(rowLocator.getByText('A.1.1')).toBeVisible();
 
         await accessionLink.click();
         await expect(searchPage.page.getByText('Amino acid mutations')).toBeVisible({ timeout: 30000 });

--- a/website/tests/util/preprocessingPipeline.ts
+++ b/website/tests/util/preprocessingPipeline.ts
@@ -45,7 +45,7 @@ async function submit(preprocessingOptions: PreprocessingOptions[]) {
                         region: 'Europe',
                         country: 'Switzerland',
                         division: 'Schaffhausen',
-                        pangoLineage: 'B.1.1.7',
+                        pangoLineage: 'A.1.1',
                     },
                     ...sequenceData,
                 },


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
~~resolves~~ part of #3074 

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://lineage-validation.loculus.org

### Summary
- make the lineage definition configurable in the helm chart
- provide the lineage definition file URLs to the silo import job
- configure silo import to use the lineage definition file

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->
n/A

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- ~~The implemented feature is covered by an appropriate test.~~
