### PR TITLE
feat!: Allow disabling data use terms

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/config/BackendSpringConfig.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/BackendSpringConfig.kt
@@ -1,5 +1,6 @@
 package org.loculus.backend.config
 
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.swagger.v3.oas.models.headers.Header
@@ -146,7 +147,9 @@ internal fun validateEarliestReleaseDateFields(config: BackendConfig): List<Stri
 }
 
 fun readBackendConfig(objectMapper: ObjectMapper, configPath: String): BackendConfig {
-    val config = objectMapper.readValue<BackendConfig>(File(configPath))
+    val config = objectMapper
+        .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+        .readValue<BackendConfig>(File(configPath))
     logger.info { "Loaded backend config from $configPath" }
     logger.info { "Config: $config" }
     val validationErrors = validateEarliestReleaseDateFields(config)

--- a/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
@@ -7,6 +7,7 @@ import org.loculus.backend.api.Organism
 data class BackendConfig(
     val organisms: Map<String, InstanceConfig>,
     val accessionPrefix: String,
+    // TODO changes to be made here: add the flag here. we can put the Urls in a "date use terms" section in the config
     val dataUseTermsUrls: DataUseTermsUrls?,
 ) {
     fun getInstanceConfig(organism: Organism) = organisms[organism.name] ?: throw IllegalArgumentException(

--- a/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
@@ -7,13 +7,14 @@ import org.loculus.backend.api.Organism
 data class BackendConfig(
     val organisms: Map<String, InstanceConfig>,
     val accessionPrefix: String,
-    val dataUseTermsEnabled: Boolean,
-    val dataUseTermsUrls: DataUseTermsUrls?,
+    val dataUseTerms: DataUseTerms,
 ) {
     fun getInstanceConfig(organism: Organism) = organisms[organism.name] ?: throw IllegalArgumentException(
         "Organism: ${organism.name} not found in backend config. Available organisms: ${organisms.keys}",
     )
 }
+
+data class DataUseTerms(val enabled: Boolean, val urls: DataUseTermsUrls?)
 
 data class DataUseTermsUrls(val open: String, val restricted: String)
 

--- a/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
@@ -7,7 +7,7 @@ import org.loculus.backend.api.Organism
 data class BackendConfig(
     val organisms: Map<String, InstanceConfig>,
     val accessionPrefix: String,
-    // TODO changes to be made here: add the flag here. we can put the Urls in a "date use terms" section in the config
+    val dataUseTermsEnabled: Boolean,
     val dataUseTermsUrls: DataUseTermsUrls?,
 ) {
     fun getInstanceConfig(organism: Organism) = organisms[organism.name] ?: throw IllegalArgumentException(

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -100,12 +100,12 @@ open class SubmissionController(
                 " Format: YYYY-MM-DD",
         ) @RequestParam restrictedUntil: String?,
     ): List<SubmissionIdMapping> {
-        var dataUseTermsKind = DataUseTermsType.OPEN
+        var innerDataUseTermsType = DataUseTermsType.OPEN
         if (backendConfig.dataUseTerms.enabled) {
             if (dataUseTermsType == null) {
                 throw BadRequestException("the 'dataUseTermsType' needs to be provided.")
             } else {
-                dataUseTermsKind = dataUseTermsType
+                innerDataUseTermsType = dataUseTermsType
             }
         }
 
@@ -115,7 +115,7 @@ open class SubmissionController(
             metadataFile,
             sequenceFile,
             groupId,
-            DataUseTerms.fromParameters(dataUseTermsKind, restrictedUntil),
+            DataUseTerms.fromParameters(innerDataUseTermsType, restrictedUntil),
         )
         return submitModel.processSubmissions(UUID.randomUUID().toString(), params)
     }

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -101,7 +101,7 @@ open class SubmissionController(
         ) @RequestParam restrictedUntil: String?,
     ): List<SubmissionIdMapping> {
         var dataUseTermsKind = DataUseTermsType.OPEN
-        if (backendConfig.dataUseTermsEnabled) {
+        if (backendConfig.dataUseTerms.enabled) {
             if (dataUseTermsType == null) {
                 throw BadRequestException("the 'dataUseTermsType' needs to be provided.")
             } else {

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -33,6 +33,7 @@ import org.loculus.backend.api.SubmittedProcessedData
 import org.loculus.backend.api.UnprocessedData
 import org.loculus.backend.auth.AuthenticatedUser
 import org.loculus.backend.auth.HiddenParam
+import org.loculus.backend.config.BackendConfig
 import org.loculus.backend.controller.LoculusCustomHeaders.X_TOTAL_RECORDS
 import org.loculus.backend.log.REQUEST_ID_MDC_KEY
 import org.loculus.backend.log.RequestIdContext
@@ -76,11 +77,11 @@ open class SubmissionController(
     private val submissionDatabaseService: SubmissionDatabaseService,
     private val iteratorStreamer: IteratorStreamer,
     private val requestIdContext: RequestIdContext,
+    private val backendConfig: BackendConfig,
 ) {
-
-    /* TODO change to be made here - similar to restrictedUntil the parameter will conditionally be mandatory */
     @Operation(description = SUBMIT_DESCRIPTION)
     @ApiResponse(responseCode = "200", description = SUBMIT_RESPONSE_DESCRIPTION)
+    @ApiResponse(responseCode = "400", description = SUBMIT_ERROR_RESPONSE)
     @PostMapping("/submit", consumes = ["multipart/form-data"])
     fun submit(
         @PathVariable @Valid organism: Organism,
@@ -88,8 +89,10 @@ open class SubmissionController(
         @Parameter(description = GROUP_ID_DESCRIPTION) @RequestParam groupId: Int,
         @Parameter(description = METADATA_FILE_DESCRIPTION) @RequestParam metadataFile: MultipartFile,
         @Parameter(description = SEQUENCE_FILE_DESCRIPTION) @RequestParam sequenceFile: MultipartFile?,
-        @Parameter(description = "Data Use terms under which data is released.") @RequestParam dataUseTermsType:
-        DataUseTermsType,
+        @Parameter(
+            description =
+            "Data Use terms under which data is released. Mandatory when data use terms are enabled for this Instance.",
+        ) @RequestParam dataUseTermsType: DataUseTermsType?,
         @Parameter(
             description =
             "Mandatory when data use terms are set to 'RESTRICTED'." +
@@ -97,15 +100,22 @@ open class SubmissionController(
                 " Format: YYYY-MM-DD",
         ) @RequestParam restrictedUntil: String?,
     ): List<SubmissionIdMapping> {
-        // in here, just default to open DataUseTerms and then don't worry anymore
-        // throw an error if the parameter is given
+        var dataUseTermsKind = DataUseTermsType.OPEN
+        if (backendConfig.dataUseTermsEnabled) {
+            if (dataUseTermsType == null) {
+                throw BadRequestException("the 'dataUseTermsType' needs to be provided.")
+            } else {
+                dataUseTermsKind = dataUseTermsType
+            }
+        }
+
         val params = SubmissionParams.OriginalSubmissionParams(
             organism,
             authenticatedUser,
             metadataFile,
             sequenceFile,
             groupId,
-            DataUseTerms.fromParameters(dataUseTermsType, restrictedUntil),
+            DataUseTerms.fromParameters(dataUseTermsKind, restrictedUntil),
         )
         return submitModel.processSubmissions(UUID.randomUUID().toString(), params)
     }

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -78,6 +78,7 @@ open class SubmissionController(
     private val requestIdContext: RequestIdContext,
 ) {
 
+    /* TODO change to be made here - similar to restrictedUntil the parameter will conditionally be mandatory */
     @Operation(description = SUBMIT_DESCRIPTION)
     @ApiResponse(responseCode = "200", description = SUBMIT_RESPONSE_DESCRIPTION)
     @PostMapping("/submit", consumes = ["multipart/form-data"])
@@ -96,6 +97,8 @@ open class SubmissionController(
                 " Format: YYYY-MM-DD",
         ) @RequestParam restrictedUntil: String?,
     ): List<SubmissionIdMapping> {
+        // in here, just default to open DataUseTerms and then don't worry anymore
+        // throw an error if the parameter is given
         val params = SubmissionParams.OriginalSubmissionParams(
             organism,
             authenticatedUser,

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionControllerDescriptions.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionControllerDescriptions.kt
@@ -8,6 +8,10 @@ The accession is the (globally unique) id that the system assigned to the sequen
 You can use this response to associate the user provided submissionId with the system assigned accession.
 """
 
+const val SUBMIT_ERROR_RESPONSE = """
+The data use terms type have not been provided, even though they are enabled for this Loculus instance.
+"""
+
 const val METADATA_FILE_DESCRIPTION = """    
 A TSV (tab separated values) file containing the metadata of the submitted sequence entries. 
 The file may be compressed with zstd, xz, zip, gzip, lzma, bzip2 (with common extensions).

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -139,7 +139,6 @@ open class ReleasedDataModel(
                 ("versionStatus" to TextNode(versionStatus.name)),
                 ("pipelineVersion" to LongNode(rawProcessedData.pipelineVersion)),
             ) +
-            // TODO add a test for this change
             conditionalMetadata(
                 backendConfig.dataUseTermsEnabled,
                 {

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -115,7 +115,7 @@ open class ReleasedDataModel(
 
         val earliestReleaseDate = earliestReleaseDateFinder?.calculateEarliestReleaseDate(rawProcessedData)
 
-        val dataUseTermsUrl: String? = backendConfig.dataUseTermsUrls?.let { urls ->
+        val dataUseTermsUrl: String? = backendConfig.dataUseTerms.urls?.let { urls ->
             when (currentDataUseTerms) {
                 DataUseTerms.Open -> urls.open
                 is DataUseTerms.Restricted -> urls.restricted
@@ -140,7 +140,7 @@ open class ReleasedDataModel(
                 ("pipelineVersion" to LongNode(rawProcessedData.pipelineVersion)),
             ) +
             conditionalMetadata(
-                backendConfig.dataUseTermsEnabled,
+                backendConfig.dataUseTerms.enabled,
                 {
                     mapOf(
                         "dataUseTerms" to TextNode(currentDataUseTerms.type.name),

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.node.TextNode
 import mu.KotlinLogging
 import org.loculus.backend.api.DataUseTerms
 import org.loculus.backend.api.GeneticSequence
+import org.loculus.backend.api.MetadataMap
 import org.loculus.backend.api.Organism
 import org.loculus.backend.api.ProcessedData
 import org.loculus.backend.api.VersionStatus
@@ -94,6 +95,9 @@ open class ReleasedDataModel(
         return "\"$lastUpdateTime\"" // ETag must be enclosed in double quotes
     }
 
+    private fun conditionalMetadata(condition: Boolean, values: MetadataMap): MetadataMap =
+        if (condition) values else emptyMap()
+
     private fun computeAdditionalMetadataFields(
         rawProcessedData: RawProcessedData,
         latestVersions: Map<Accession, Version>,
@@ -111,6 +115,13 @@ open class ReleasedDataModel(
 
         val earliestReleaseDate = earliestReleaseDateFinder?.calculateEarliestReleaseDate(rawProcessedData)
 
+        val dataUseTermsUrl: String? = backendConfig.dataUseTermsUrls?.let { urls ->
+            when (currentDataUseTerms) {
+                DataUseTerms.Open -> urls.open
+                is DataUseTerms.Restricted -> urls.restricted
+            }
+        }
+
         var metadata = rawProcessedData.processedData.metadata +
             mapOf(
                 ("accession" to TextNode(rawProcessedData.accession)),
@@ -126,32 +137,34 @@ open class ReleasedDataModel(
                 ("releasedAtTimestamp" to LongNode(rawProcessedData.releasedAtTimestamp.toTimestamp())),
                 ("releasedDate" to TextNode(rawProcessedData.releasedAtTimestamp.toUtcDateString())),
                 ("versionStatus" to TextNode(versionStatus.name)),
-                // TODO changes made here - don't include these fields
-                ("dataUseTerms" to TextNode(currentDataUseTerms.type.name)),
-                ("dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil),
                 ("pipelineVersion" to LongNode(rawProcessedData.pipelineVersion)),
             ) +
-            if (rawProcessedData.isRevocation) {
-                mapOf("versionComment" to TextNode(rawProcessedData.versionComment))
-            } else {
-                emptyMap()
-            }.let {
-                when (backendConfig.dataUseTermsUrls) {
-                    null -> it
-                    else -> {
-                        val url = when (currentDataUseTerms) {
-                            DataUseTerms.Open -> backendConfig.dataUseTermsUrls.open
-                            is DataUseTerms.Restricted -> backendConfig.dataUseTermsUrls.restricted
-                        }
-                        it + ("dataUseTermsUrl" to TextNode(url))
-                    }
-                }
-            } +
-            if (earliestReleaseDate != null) {
-                mapOf("earliestReleaseDate" to TextNode(earliestReleaseDate.toUtcDateString()))
-            } else {
-                emptyMap()
-            }
+            // TODO add a test for this change
+            conditionalMetadata(
+                backendConfig.dataUseTermsEnabled,
+                mapOf(
+                    "dataUseTerms" to TextNode(currentDataUseTerms.type.name),
+                    "dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil,
+                ),
+            ) +
+            conditionalMetadata(
+                rawProcessedData.isRevocation,
+                mapOf(
+                    "versionComment" to TextNode(rawProcessedData.versionComment),
+                ),
+            ) +
+            conditionalMetadata(
+                earliestReleaseDate != null,
+                mapOf(
+                    "earliestReleaseDate" to TextNode(earliestReleaseDate!!.toUtcDateString()),
+                ),
+            ) +
+            conditionalMetadata(
+                dataUseTermsUrl != null,
+                mapOf(
+                    "dataUseTermsUrl" to TextNode(dataUseTermsUrl!!),
+                ),
+            )
 
         return ProcessedData(
             metadata = metadata,

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -95,8 +95,8 @@ open class ReleasedDataModel(
         return "\"$lastUpdateTime\"" // ETag must be enclosed in double quotes
     }
 
-    private fun conditionalMetadata(condition: Boolean, values: MetadataMap): MetadataMap =
-        if (condition) values else emptyMap()
+    private fun conditionalMetadata(condition: Boolean, values: () -> MetadataMap): MetadataMap =
+        if (condition) values() else emptyMap()
 
     private fun computeAdditionalMetadataFields(
         rawProcessedData: RawProcessedData,
@@ -142,28 +142,36 @@ open class ReleasedDataModel(
             // TODO add a test for this change
             conditionalMetadata(
                 backendConfig.dataUseTermsEnabled,
-                mapOf(
-                    "dataUseTerms" to TextNode(currentDataUseTerms.type.name),
-                    "dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil,
-                ),
+                {
+                    mapOf(
+                        "dataUseTerms" to TextNode(currentDataUseTerms.type.name),
+                        "dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil,
+                    )
+                },
             ) +
             conditionalMetadata(
                 rawProcessedData.isRevocation,
-                mapOf(
-                    "versionComment" to TextNode(rawProcessedData.versionComment),
-                ),
+                {
+                    mapOf(
+                        "versionComment" to TextNode(rawProcessedData.versionComment),
+                    )
+                },
             ) +
             conditionalMetadata(
                 earliestReleaseDate != null,
-                mapOf(
-                    "earliestReleaseDate" to TextNode(earliestReleaseDate!!.toUtcDateString()),
-                ),
+                {
+                    mapOf(
+                        "earliestReleaseDate" to TextNode(earliestReleaseDate!!.toUtcDateString()),
+                    )
+                },
             ) +
             conditionalMetadata(
                 dataUseTermsUrl != null,
-                mapOf(
-                    "dataUseTermsUrl" to TextNode(dataUseTermsUrl!!),
-                ),
+                {
+                    mapOf(
+                        "dataUseTermsUrl" to TextNode(dataUseTermsUrl!!),
+                    )
+                },
             )
 
         return ProcessedData(

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -126,6 +126,7 @@ open class ReleasedDataModel(
                 ("releasedAtTimestamp" to LongNode(rawProcessedData.releasedAtTimestamp.toTimestamp())),
                 ("releasedDate" to TextNode(rawProcessedData.releasedAtTimestamp.toUtcDateString())),
                 ("versionStatus" to TextNode(versionStatus.name)),
+                // TODO changes made here - don't include these fields
                 ("dataUseTerms" to TextNode(currentDataUseTerms.type.name)),
                 ("dataUseTermsRestrictedUntil" to restrictedDataUseTermsUntil),
                 ("pipelineVersion" to LongNode(rawProcessedData.pipelineVersion)),

--- a/backend/src/test/kotlin/org/loculus/backend/config/BackendSpringConfigTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/config/BackendSpringConfigTest.kt
@@ -70,5 +70,6 @@ fun backendConfig(metadataList: List<Metadata>, earliestReleaseDate: EarliestRel
         ),
     ),
     accessionPrefix = "FOO_",
+    dataUseTermsEnabled = true,
     dataUseTermsUrls = null,
 )

--- a/backend/src/test/kotlin/org/loculus/backend/config/BackendSpringConfigTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/config/BackendSpringConfigTest.kt
@@ -70,6 +70,5 @@ fun backendConfig(metadataList: List<Metadata>, earliestReleaseDate: EarliestRel
         ),
     ),
     accessionPrefix = "FOO_",
-    dataUseTermsEnabled = true,
-    dataUseTermsUrls = null,
+    dataUseTerms = DataUseTerms(true, null),
 )

--- a/backend/src/test/kotlin/org/loculus/backend/controller/EndpointTestExtension.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/EndpointTestExtension.kt
@@ -10,7 +10,6 @@ import org.junit.platform.launcher.TestExecutionListener
 import org.junit.platform.launcher.TestPlan
 import org.loculus.backend.api.Address
 import org.loculus.backend.api.NewGroup
-import org.loculus.backend.config.BackendSpringProperty
 import org.loculus.backend.controller.datauseterms.DataUseTermsControllerClient
 import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
 import org.loculus.backend.controller.seqsetcitations.SeqSetCitationsControllerClient
@@ -24,6 +23,7 @@ import org.loculus.backend.service.submission.METADATA_UPLOAD_AUX_TABLE_NAME
 import org.loculus.backend.service.submission.SEQUENCE_ENTRIES_PREPROCESSED_DATA_TABLE_NAME
 import org.loculus.backend.service.submission.SEQUENCE_ENTRIES_TABLE_NAME
 import org.loculus.backend.service.submission.SEQUENCE_UPLOAD_AUX_TABLE_NAME
+
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import
@@ -51,17 +51,7 @@ annotation class EndpointTest(@get:AliasFor(annotation = SpringBootTest::class) 
 
 const val SINGLE_SEGMENTED_REFERENCE_GENOME = "src/test/resources/backend_config_single_segment.json"
 
-@EndpointTest(
-    properties = ["${BackendSpringProperty.BACKEND_CONFIG_PATH}=$SINGLE_SEGMENTED_REFERENCE_GENOME"],
-)
-annotation class SingleSegmentedReferenceGenomeEndpointTest
-
 const val DATA_USE_TERMS_DISABLED_CONFIG = "src/test/resources/backend_config_data_use_terms_disabled.json"
-
-@EndpointTest(
-    properties = ["${BackendSpringProperty.BACKEND_CONFIG_PATH}=$DATA_USE_TERMS_DISABLED_CONFIG"],
-)
-annotation class DataUseTermsDisabledEndpointTest
 
 private const val SPRING_DATASOURCE_URL = "spring.datasource.url"
 private const val SPRING_DATASOURCE_USERNAME = "spring.datasource.username"

--- a/backend/src/test/kotlin/org/loculus/backend/controller/EndpointTestExtension.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/EndpointTestExtension.kt
@@ -23,7 +23,6 @@ import org.loculus.backend.service.submission.METADATA_UPLOAD_AUX_TABLE_NAME
 import org.loculus.backend.service.submission.SEQUENCE_ENTRIES_PREPROCESSED_DATA_TABLE_NAME
 import org.loculus.backend.service.submission.SEQUENCE_ENTRIES_TABLE_NAME
 import org.loculus.backend.service.submission.SEQUENCE_UPLOAD_AUX_TABLE_NAME
-
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import

--- a/backend/src/test/kotlin/org/loculus/backend/controller/EndpointTestExtension.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/EndpointTestExtension.kt
@@ -10,6 +10,7 @@ import org.junit.platform.launcher.TestExecutionListener
 import org.junit.platform.launcher.TestPlan
 import org.loculus.backend.api.Address
 import org.loculus.backend.api.NewGroup
+import org.loculus.backend.config.BackendSpringProperty
 import org.loculus.backend.controller.datauseterms.DataUseTermsControllerClient
 import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
 import org.loculus.backend.controller.seqsetcitations.SeqSetCitationsControllerClient
@@ -47,6 +48,20 @@ import org.testcontainers.containers.PostgreSQLContainer
     PublicJwtKeyConfig::class,
 )
 annotation class EndpointTest(@get:AliasFor(annotation = SpringBootTest::class) val properties: Array<String> = [])
+
+const val SINGLE_SEGMENTED_REFERENCE_GENOME = "src/test/resources/backend_config_single_segment.json"
+
+@EndpointTest(
+    properties = ["${BackendSpringProperty.BACKEND_CONFIG_PATH}=$SINGLE_SEGMENTED_REFERENCE_GENOME"],
+)
+annotation class SingleSegmentedReferenceGenomeEndpointTest
+
+const val DATA_USE_TERMS_DISABLED_CONFIG = "src/test/resources/backend_config_data_use_terms_disabled.json"
+
+@EndpointTest(
+    properties = ["${BackendSpringProperty.BACKEND_CONFIG_PATH}=$DATA_USE_TERMS_DISABLED_CONFIG"],
+)
+annotation class DataUseTermsDisabledEndpointTest
 
 private const val SPRING_DATASOURCE_URL = "spring.datasource.url"
 private const val SPRING_DATASOURCE_USERNAME = "spring.datasource.username"

--- a/backend/src/test/kotlin/org/loculus/backend/controller/EndpointTestExtension.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/EndpointTestExtension.kt
@@ -31,6 +31,12 @@ import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.testcontainers.containers.PostgreSQLContainer
 
+/**
+ * The main annotation for tests. It also loads the [EndpointTestExtension], which initializes
+ * a PostgreSQL test container.
+ * You can set additional properties to - for example - override the backend config file, like in
+ * [org.loculus.backend.controller.submission.GetReleasedDataDataUseTermsDisabledEndpointTest].
+ */
 @Target(AnnotationTarget.TYPE, AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 @AutoConfigureMockMvc

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataDataUseTermsDisabledEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataDataUseTermsDisabledEndpointTest.kt
@@ -57,7 +57,7 @@ class GetReleasedDataDataUseTermsDisabledEndpointTest(
     }
 
     @Test
-    fun `config has been read and data use terms are configred to be off`() {
+    fun `config has been read and data use terms are configured to be off`() {
         assertThat(backendConfig.dataUseTermsEnabled, `is`(false))
     }
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataDataUseTermsDisabledEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataDataUseTermsDisabledEndpointTest.kt
@@ -1,0 +1,8 @@
+package org.loculus.backend.controller.submission
+
+import org.loculus.backend.controller.DataUseTermsDisabledEndpointTest
+
+@DataUseTermsDisabledEndpointTest
+class GetReleasedDataDataUseTermsDisabledEndpointTest {
+    // TODO
+}

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataDataUseTermsDisabledEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataDataUseTermsDisabledEndpointTest.kt
@@ -16,13 +16,15 @@ import org.junit.jupiter.api.Test
 import org.keycloak.representations.idm.UserRepresentation
 import org.loculus.backend.api.GeneticSequence
 import org.loculus.backend.api.ProcessedData
+import org.loculus.backend.config.BackendConfig
+import org.loculus.backend.config.BackendSpringProperty
+import org.loculus.backend.controller.DATA_USE_TERMS_DISABLED_CONFIG
 import org.loculus.backend.controller.DEFAULT_GROUP
 import org.loculus.backend.controller.DEFAULT_GROUP_CHANGED
 import org.loculus.backend.controller.DEFAULT_GROUP_NAME_CHANGED
 import org.loculus.backend.controller.DEFAULT_PIPELINE_VERSION
 import org.loculus.backend.controller.DEFAULT_USER_NAME
-import org.loculus.backend.controller.DataUseTermsDisabledEndpointTest
-import org.loculus.backend.controller.datauseterms.DataUseTermsControllerClient
+import org.loculus.backend.controller.EndpointTest
 import org.loculus.backend.controller.expectNdjsonAndGetContent
 import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
 import org.loculus.backend.controller.groupmanagement.andGetGroupId
@@ -34,11 +36,14 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@DataUseTermsDisabledEndpointTest
+@EndpointTest(
+    properties = ["${BackendSpringProperty.BACKEND_CONFIG_PATH}=$DATA_USE_TERMS_DISABLED_CONFIG"],
+)
 class GetReleasedDataDataUseTermsDisabledEndpointTest(
     @Autowired private val convenienceClient: SubmissionConvenienceClient,
     @Autowired private val submissionControllerClient: SubmissionControllerClient,
     @Autowired private val groupClient: GroupManagementControllerClient,
+    @Autowired private val backendConfig: BackendConfig,
 ) {
     private val currentDate = Clock.System.now().toLocalDateTime(DateProvider.timeZone).date.toString()
 
@@ -49,6 +54,11 @@ class GetReleasedDataDataUseTermsDisabledEndpointTest(
     @BeforeEach
     fun setup() {
         every { keycloakAdapter.getUsersWithName(any()) } returns listOf(UserRepresentation())
+    }
+
+    @Test
+    fun `config has been read and data use terms are configred to be off`() {
+        assertThat(backendConfig.dataUseTermsEnabled, `is`(false));
     }
 
     @Test

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataDataUseTermsDisabledEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataDataUseTermsDisabledEndpointTest.kt
@@ -58,7 +58,7 @@ class GetReleasedDataDataUseTermsDisabledEndpointTest(
 
     @Test
     fun `config has been read and data use terms are configured to be off`() {
-        assertThat(backendConfig.dataUseTermsEnabled, `is`(false))
+        assertThat(backendConfig.dataUseTerms.enabled, `is`(false))
     }
 
     @Test

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataDataUseTermsDisabledEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataDataUseTermsDisabledEndpointTest.kt
@@ -1,8 +1,111 @@
 package org.loculus.backend.controller.submission
 
+import com.fasterxml.jackson.databind.node.BooleanNode
+import com.fasterxml.jackson.databind.node.IntNode
+import com.fasterxml.jackson.databind.node.NullNode
+import com.fasterxml.jackson.databind.node.TextNode
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import kotlinx.datetime.Clock
+import kotlinx.datetime.toLocalDateTime
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.matchesPattern
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.keycloak.representations.idm.UserRepresentation
+import org.loculus.backend.api.GeneticSequence
+import org.loculus.backend.api.ProcessedData
+import org.loculus.backend.controller.DEFAULT_GROUP
+import org.loculus.backend.controller.DEFAULT_GROUP_CHANGED
+import org.loculus.backend.controller.DEFAULT_GROUP_NAME_CHANGED
+import org.loculus.backend.controller.DEFAULT_PIPELINE_VERSION
+import org.loculus.backend.controller.DEFAULT_USER_NAME
 import org.loculus.backend.controller.DataUseTermsDisabledEndpointTest
+import org.loculus.backend.controller.datauseterms.DataUseTermsControllerClient
+import org.loculus.backend.controller.expectNdjsonAndGetContent
+import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
+import org.loculus.backend.controller.groupmanagement.andGetGroupId
+import org.loculus.backend.controller.jwtForDefaultUser
+import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles.NUMBER_OF_SEQUENCES
+import org.loculus.backend.service.KeycloakAdapter
+import org.loculus.backend.utils.DateProvider
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @DataUseTermsDisabledEndpointTest
-class GetReleasedDataDataUseTermsDisabledEndpointTest {
+class GetReleasedDataDataUseTermsDisabledEndpointTest(
+    @Autowired private val convenienceClient: SubmissionConvenienceClient,
+    @Autowired private val submissionControllerClient: SubmissionControllerClient,
+    @Autowired private val groupClient: GroupManagementControllerClient,
+) {
+    private val currentDate = Clock.System.now().toLocalDateTime(DateProvider.timeZone).date.toString()
+
+
+    @MockkBean
+    lateinit var keycloakAdapter: KeycloakAdapter
+
+    @BeforeEach
+    fun setup() {
+        every { keycloakAdapter.getUsersWithName(any()) } returns listOf(UserRepresentation())
+    }
+
+    @Test
+    fun `GIVEN released data exists THEN returns it with additional metadata fields`() {
+        val groupId = groupClient.createNewGroup(group = DEFAULT_GROUP, jwt = jwtForDefaultUser)
+            .andExpect(status().isOk)
+            .andGetGroupId()
+
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(groupId = groupId)
+
+        groupClient.updateGroup(
+            groupId = groupId,
+            group = DEFAULT_GROUP_CHANGED,
+            jwt = jwtForDefaultUser,
+        ).andExpect(status().isOk)
+
+        val response = submissionControllerClient.getReleasedData()
+
+        val responseBody = response.expectNdjsonAndGetContent<ProcessedData<GeneticSequence>>()
+
+        assertThat(responseBody.size, `is`(NUMBER_OF_SEQUENCES))
+
+        response.andExpect(header().string("x-total-records", NUMBER_OF_SEQUENCES.toString()))
+
+        responseBody.forEach {
+            val id = it.metadata["accession"]!!.asText()
+            val version = it.metadata["version"]!!.asLong()
+            assertThat(version, `is`(1))
+
+            val expectedMetadata = defaultProcessedData.metadata + mapOf(
+                "accession" to TextNode(id),
+                "version" to IntNode(version.toInt()),
+                "accessionVersion" to TextNode("$id.$version"),
+                "isRevocation" to BooleanNode.FALSE,
+                "submitter" to TextNode(DEFAULT_USER_NAME),
+                "groupName" to TextNode(DEFAULT_GROUP_NAME_CHANGED),
+                "versionStatus" to TextNode("LATEST_VERSION"),
+                "submittedDate" to TextNode(currentDate),
+                "dataUseTermsRestrictedUntil" to NullNode.getInstance(),
+                "pipelineVersion" to IntNode(DEFAULT_PIPELINE_VERSION.toInt()),
+            )
+
+            for ((key, value) in it.metadata) {
+                when (key) {
+                    "submittedAtTimestamp" -> expectIsTimestampWithCurrentYear(value)
+                    "releasedAtTimestamp" -> expectIsTimestampWithCurrentYear(value)
+                    "submissionId" -> assertThat(value.textValue(), matchesPattern("^custom\\d$"))
+                    "groupId" -> assertThat(value.intValue(), `is`(groupId))
+                    else -> assertThat(value, `is`(expectedMetadata[key]))
+                }
+            }
+            assertThat(it.alignedNucleotideSequences, `is`(defaultProcessedData.alignedNucleotideSequences))
+            assertThat(it.unalignedNucleotideSequences, `is`(defaultProcessedData.unalignedNucleotideSequences))
+            assertThat(it.alignedAminoAcidSequences, `is`(defaultProcessedData.alignedAminoAcidSequences))
+            assertThat(it.nucleotideInsertions, `is`(defaultProcessedData.nucleotideInsertions))
+            assertThat(it.aminoAcidInsertions, `is`(defaultProcessedData.aminoAcidInsertions))
+        }
+    }
     // TODO
 }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
@@ -419,7 +419,6 @@ class GetReleasedDataEndpointTest(
             latestVersion5 = 5L,
         )
     }
-
 }
 
 fun expectIsTimestampWithCurrentYear(value: JsonNode) {

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
@@ -555,11 +555,12 @@ class GetReleasedDataEndpointWithDataUseTermsUrlTest(
             @Value("\${${BackendSpringProperty.BACKEND_CONFIG_PATH}}") configPath: String,
         ): BackendConfig {
             val originalConfig = readBackendConfig(objectMapper = objectMapper, configPath = configPath)
-
             return originalConfig.copy(
-                dataUseTermsUrls = DataUseTermsUrls(
-                    open = OPEN_DATA_USE_TERMS_URL,
-                    restricted = RESTRICTED_DATA_USE_TERMS_URL,
+                dataUseTerms = originalConfig.dataUseTerms.copy(
+                    urls = DataUseTermsUrls(
+                        open = OPEN_DATA_USE_TERMS_URL,
+                        restricted = RESTRICTED_DATA_USE_TERMS_URL,
+                    ),
                 ),
             )
         }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
@@ -97,7 +97,6 @@ class GetReleasedDataEndpointTest(
     @Autowired private val groupClient: GroupManagementControllerClient,
     @Autowired private val dataUseTermsClient: DataUseTermsControllerClient,
 ) {
-    private val currentYear = Clock.System.now().toLocalDateTime(DateProvider.timeZone).year
     private val currentDate = Clock.System.now().toLocalDateTime(DateProvider.timeZone).date.toString()
 
     @MockkBean
@@ -421,10 +420,12 @@ class GetReleasedDataEndpointTest(
         )
     }
 
-    private fun expectIsTimestampWithCurrentYear(value: JsonNode) {
-        val dateTime = Instant.fromEpochSeconds(value.asLong()).toLocalDateTime(DateProvider.timeZone)
-        assertThat(dateTime.year, `is`(currentYear))
-    }
+}
+
+fun expectIsTimestampWithCurrentYear(value: JsonNode) {
+    val currentYear = Clock.System.now().toLocalDateTime(DateProvider.timeZone).year
+    val dateTime = Instant.fromEpochSeconds(value.asLong()).toLocalDateTime(DateProvider.timeZone)
+    assertThat(dateTime.year, `is`(currentYear))
 }
 
 private const val OPEN_DATA_USE_TERMS_URL = "openUrl"

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SingleSegmentedSubmitEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SingleSegmentedSubmitEndpointTest.kt
@@ -5,8 +5,7 @@ import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.hasEntry
 import org.junit.jupiter.api.Test
 import org.loculus.backend.config.BackendConfig
-import org.loculus.backend.config.BackendSpringProperty
-import org.loculus.backend.controller.EndpointTest
+import org.loculus.backend.controller.SingleSegmentedReferenceGenomeEndpointTest
 import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
 import org.loculus.backend.controller.groupmanagement.andGetGroupId
 import org.springframework.beans.factory.annotation.Autowired
@@ -15,13 +14,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-const val SINGLE_SEGMENTED_REFERENCE_GENOME = "src/test/resources/backend_config_single_segment.json"
-
 private const val DEFAULT_SEQUENCE_NAME = "main"
 
-@EndpointTest(
-    properties = ["${BackendSpringProperty.BACKEND_CONFIG_PATH}=$SINGLE_SEGMENTED_REFERENCE_GENOME"],
-)
+@SingleSegmentedReferenceGenomeEndpointTest
 class SingleSegmentedSubmitEndpointTest(
     @Autowired val submissionControllerClient: SubmissionControllerClient,
     @Autowired val convenienceClient: SubmissionConvenienceClient,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
@@ -56,6 +56,22 @@ class SubmissionControllerClient(private val mockMvc: MockMvc, private val objec
             .withAuth(jwt),
     )
 
+    fun submit_without_data_use_terms(
+        metadataFile: MockMultipartFile,
+        sequencesFile: MockMultipartFile? = null,
+        organism: String = DEFAULT_ORGANISM,
+        groupId: Int,
+        jwt: String? = jwtForDefaultUser,
+    ): ResultActions = mockMvc.perform(
+        multipart(addOrganismToPath("/submit", organism = organism))
+            .apply {
+                sequencesFile?.let { file(sequencesFile) }
+            }
+            .file(metadataFile)
+            .param("groupId", groupId.toString())
+            .withAuth(jwt),
+    )
+
     fun extractUnprocessedData(
         numberOfSequenceEntries: Int,
         organism: String = DEFAULT_ORGANISM,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
@@ -56,7 +56,7 @@ class SubmissionControllerClient(private val mockMvc: MockMvc, private val objec
             .withAuth(jwt),
     )
 
-    fun submit_without_data_use_terms(
+    fun submitWithoutDataUseTerms(
         metadataFile: MockMultipartFile,
         sequencesFile: MockMultipartFile? = null,
         organism: String = DEFAULT_ORGANISM,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointDataUseTermsDisabledTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointDataUseTermsDisabledTest.kt
@@ -1,0 +1,8 @@
+package org.loculus.backend.controller.submission
+
+import org.loculus.backend.controller.DataUseTermsDisabledEndpointTest
+
+@DataUseTermsDisabledEndpointTest
+class SubmitEndpointDataUseTermsDisabledTest {
+    // TODO
+}

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointDataUseTermsDisabledTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointDataUseTermsDisabledTest.kt
@@ -1,12 +1,58 @@
 package org.loculus.backend.controller.submission
 
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.loculus.backend.config.BackendConfig
 import org.loculus.backend.config.BackendSpringProperty
 import org.loculus.backend.controller.DATA_USE_TERMS_DISABLED_CONFIG
+import org.loculus.backend.controller.DEFAULT_ORGANISM
 import org.loculus.backend.controller.EndpointTest
+import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
+import org.loculus.backend.controller.groupmanagement.andGetGroupId
+import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles
+import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles.NUMBER_OF_SEQUENCES
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @EndpointTest(
     properties = ["${BackendSpringProperty.BACKEND_CONFIG_PATH}=$DATA_USE_TERMS_DISABLED_CONFIG"],
 )
-class SubmitEndpointDataUseTermsDisabledTest {
-    // TODO
+class SubmitEndpointDataUseTermsDisabledTest(
+    @Autowired val submissionControllerClient: SubmissionControllerClient,
+    @Autowired val backendConfig: BackendConfig,
+    @Autowired val groupManagementClient: GroupManagementControllerClient,
+) {
+    var groupId: Int = 0
+
+    @BeforeEach
+    fun prepareNewGroup() {
+        groupId = groupManagementClient.createNewGroup().andGetGroupId()
+    }
+
+    @Test
+    fun `config has been read and data use terms are configred to be off`() {
+        assertThat(backendConfig.dataUseTermsEnabled, `is`(false))
+    }
+
+    @Test
+    fun `GIVEN valid input multi segment data THEN returns mapping of provided custom ids to generated ids`() {
+        submissionControllerClient.submitWithoutDataUseTerms(
+            DefaultFiles.metadataFile,
+            DefaultFiles.sequencesFile,
+            organism = DEFAULT_ORGANISM,
+            groupId = groupId,
+        )
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("\$.length()").value(NUMBER_OF_SEQUENCES))
+            .andExpect(jsonPath("\$[0].submissionId").value("custom0"))
+            .andExpect(jsonPath("\$[0].accession", containsString(backendConfig.accessionPrefix)))
+            .andExpect(jsonPath("\$[0].version").value(1))
+    }
 }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointDataUseTermsDisabledTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointDataUseTermsDisabledTest.kt
@@ -36,8 +36,8 @@ class SubmitEndpointDataUseTermsDisabledTest(
     }
 
     @Test
-    fun `config has been read and data use terms are configred to be off`() {
-        assertThat(backendConfig.dataUseTermsEnabled, `is`(false))
+    fun `config has been read and data use terms are configured to be off`() {
+        assertThat(backendConfig.dataUseTerms.enabled, `is`(false))
     }
 
     @Test

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointDataUseTermsDisabledTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointDataUseTermsDisabledTest.kt
@@ -1,8 +1,12 @@
 package org.loculus.backend.controller.submission
 
-import org.loculus.backend.controller.DataUseTermsDisabledEndpointTest
+import org.loculus.backend.config.BackendSpringProperty
+import org.loculus.backend.controller.DATA_USE_TERMS_DISABLED_CONFIG
+import org.loculus.backend.controller.EndpointTest
 
-@DataUseTermsDisabledEndpointTest
+@EndpointTest(
+    properties = ["${BackendSpringProperty.BACKEND_CONFIG_PATH}=$DATA_USE_TERMS_DISABLED_CONFIG"],
+)
 class SubmitEndpointDataUseTermsDisabledTest {
     // TODO
 }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointSingleSegmentedTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointSingleSegmentedTest.kt
@@ -17,7 +17,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 private const val DEFAULT_SEQUENCE_NAME = "main"
 
 @SingleSegmentedReferenceGenomeEndpointTest
-class SingleSegmentedSubmitEndpointTest(
+class SubmitEndpointSingleSegmentedTest(
     @Autowired val submissionControllerClient: SubmissionControllerClient,
     @Autowired val convenienceClient: SubmissionConvenienceClient,
     @Autowired val backendConfig: BackendConfig,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointSingleSegmentedTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointSingleSegmentedTest.kt
@@ -5,7 +5,9 @@ import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.hasEntry
 import org.junit.jupiter.api.Test
 import org.loculus.backend.config.BackendConfig
-import org.loculus.backend.controller.SingleSegmentedReferenceGenomeEndpointTest
+import org.loculus.backend.config.BackendSpringProperty
+import org.loculus.backend.controller.EndpointTest
+import org.loculus.backend.controller.SINGLE_SEGMENTED_REFERENCE_GENOME
 import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
 import org.loculus.backend.controller.groupmanagement.andGetGroupId
 import org.springframework.beans.factory.annotation.Autowired
@@ -16,7 +18,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 private const val DEFAULT_SEQUENCE_NAME = "main"
 
-@SingleSegmentedReferenceGenomeEndpointTest
+@EndpointTest(
+    properties = ["${BackendSpringProperty.BACKEND_CONFIG_PATH}=$SINGLE_SEGMENTED_REFERENCE_GENOME"],
+)
 class SubmitEndpointSingleSegmentedTest(
     @Autowired val submissionControllerClient: SubmissionControllerClient,
     @Autowired val convenienceClient: SubmissionConvenienceClient,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
@@ -184,6 +184,8 @@ class SubmitEndpointTest(
         organism: Organism,
         dataUseTerm: DataUseTerms,
     ) {
+        println("Data use terms enabled: ")
+        println(backendConfig.dataUseTermsEnabled)
         submissionControllerClient.submit(
             metadataFile,
             sequencesFile,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
@@ -151,7 +151,7 @@ class SubmitEndpointTest(
 
     @Test
     fun `GIVEN submission without data use terms THEN returns an error`() {
-        submissionControllerClient.submit_without_data_use_terms(
+        submissionControllerClient.submitWithoutDataUseTerms(
             DefaultFiles.metadataFile,
             DefaultFiles.sequencesFileMultiSegmented,
             organism = OTHER_ORGANISM,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
@@ -150,6 +150,17 @@ class SubmitEndpointTest(
     }
 
     @Test
+    fun `GIVEN submission without data use terms THEN returns an error`() {
+        submissionControllerClient.submit_without_data_use_terms(
+            DefaultFiles.metadataFile,
+            DefaultFiles.sequencesFileMultiSegmented,
+            organism = OTHER_ORGANISM,
+            groupId = groupId,
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
     fun `GIVEN fasta data with unknown segment THEN data is accepted to let the preprocessing pipeline verify it`() {
         submissionControllerClient.submit(
             SubmitFiles.metadataFileWith(

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
@@ -195,8 +195,6 @@ class SubmitEndpointTest(
         organism: Organism,
         dataUseTerm: DataUseTerms,
     ) {
-        println("Data use terms enabled: ")
-        println(backendConfig.dataUseTermsEnabled)
         submissionControllerClient.submit(
             metadataFile,
             sequencesFile,

--- a/backend/src/test/kotlin/org/loculus/backend/service/GenerateAccessionFromNumberServiceTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/GenerateAccessionFromNumberServiceTest.kt
@@ -4,6 +4,7 @@ import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
 import org.loculus.backend.config.BackendConfig
+import org.loculus.backend.config.DataUseTerms
 import java.lang.Math.random
 import kotlin.math.pow
 
@@ -14,8 +15,7 @@ class GenerateAccessionFromNumberServiceTest {
         BackendConfig(
             accessionPrefix = PREFIX,
             organisms = emptyMap(),
-            dataUseTermsEnabled = true,
-            dataUseTermsUrls = null,
+            dataUseTerms = DataUseTerms(true, null),
         ),
     )
 

--- a/backend/src/test/kotlin/org/loculus/backend/service/GenerateAccessionFromNumberServiceTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/GenerateAccessionFromNumberServiceTest.kt
@@ -11,7 +11,12 @@ const val PREFIX = "LOC_"
 
 class GenerateAccessionFromNumberServiceTest {
     private val accessionFromNumberService = GenerateAccessionFromNumberService(
-        BackendConfig(accessionPrefix = PREFIX, organisms = emptyMap(), dataUseTermsUrls = null),
+        BackendConfig(
+            accessionPrefix = PREFIX,
+            organisms = emptyMap(),
+            dataUseTermsEnabled = true,
+            dataUseTermsUrls = null,
+        ),
     )
 
     @Test

--- a/backend/src/test/kotlin/org/loculus/backend/service/submission/EmptyProcessedDataProviderTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/submission/EmptyProcessedDataProviderTest.kt
@@ -46,6 +46,7 @@ class EmptyProcessedDataProviderTest {
                     ),
                 ),
             ),
+            dataUseTermsEnabled = true,
             dataUseTermsUrls = null,
         ),
     )

--- a/backend/src/test/kotlin/org/loculus/backend/service/submission/EmptyProcessedDataProviderTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/submission/EmptyProcessedDataProviderTest.kt
@@ -6,6 +6,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
 import org.loculus.backend.api.Organism
 import org.loculus.backend.config.BackendConfig
+import org.loculus.backend.config.DataUseTerms
 import org.loculus.backend.config.InstanceConfig
 import org.loculus.backend.config.Metadata
 import org.loculus.backend.config.MetadataType
@@ -46,8 +47,7 @@ class EmptyProcessedDataProviderTest {
                     ),
                 ),
             ),
-            dataUseTermsEnabled = true,
-            dataUseTermsUrls = null,
+            dataUseTerms = DataUseTerms(true, null),
         ),
     )
 

--- a/backend/src/test/resources/backend_config.json
+++ b/backend/src/test/resources/backend_config.json
@@ -226,5 +226,7 @@
             }
         }
     },
-    "dataUseTermsEnabled": true
+    "dataUseTerms": {
+        "enabled": true
+    }
 }

--- a/backend/src/test/resources/backend_config.json
+++ b/backend/src/test/resources/backend_config.json
@@ -225,5 +225,6 @@
                 ]
             }
         }
-    }
+    },
+    "dataUseTermsEnabled": true
 }

--- a/backend/src/test/resources/backend_config_data_use_terms_disabled.json
+++ b/backend/src/test/resources/backend_config_data_use_terms_disabled.json
@@ -1,0 +1,105 @@
+{
+  "accessionPrefix": "LOC_",
+  "organisms": {
+    "dummyOrganism": {
+      "referenceGenomes": {
+        "nucleotideSequences": [
+          {
+            "name": "main",
+            "sequence": "ATTAAAGGTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCT"
+          }
+        ],
+        "genes": [
+          {
+            "name": "someLongGene",
+            "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
+          },
+          {
+            "name": "someShortGene",
+            "sequence": "MADS"
+          }
+        ]
+      },
+      "schema": {
+        "organismName": "Test",
+        "allowSubmissionOfConsensusSequences": true,
+        "metadata": [
+          {
+            "name": "date",
+            "type": "date",
+            "required": true
+          },
+          {
+            "name": "dateSubmitted",
+            "type": "date"
+          },
+          {
+            "name": "region",
+            "type": "string",
+            "autocomplete": true,
+            "required": true
+          },
+          {
+            "name": "country",
+            "type": "string",
+            "autocomplete": true,
+            "required": true
+          },
+          {
+            "name": "division",
+            "type": "string",
+            "autocomplete": true
+          },
+          {
+            "name": "host",
+            "type": "string",
+            "autocomplete": true
+          },
+          {
+            "name": "age",
+            "type": "int"
+          },
+          {
+            "name": "sex",
+            "type": "string",
+            "autocomplete": true
+          },
+          {
+            "name": "pangoLineage",
+            "type": "string",
+            "autocomplete": true
+          },
+          {
+            "name": "qc",
+            "type": "float"
+          },
+          {
+            "name": "booleanColumn",
+            "type": "boolean"
+          },
+          {
+            "name": "insdcAccessionFull",
+            "type": "string"
+          },
+          {
+            "name": "other_db_accession",
+            "type": "string"
+          }
+        ],
+        "externalMetadata": [
+          {
+            "name": "insdcAccessionFull",
+            "type": "string",
+            "externalMetadataUpdater": "ena"
+          },
+          {
+            "name": "other_db_accession",
+            "type": "string",
+            "externalMetadataUpdater": "other_db"
+          }
+        ]
+      }
+    },
+  },
+  "dataUseTermsEnabled": false
+}

--- a/backend/src/test/resources/backend_config_data_use_terms_disabled.json
+++ b/backend/src/test/resources/backend_config_data_use_terms_disabled.json
@@ -99,7 +99,7 @@
           }
         ]
       }
-    },
+    }
   },
   "dataUseTermsEnabled": false
 }

--- a/backend/src/test/resources/backend_config_data_use_terms_disabled.json
+++ b/backend/src/test/resources/backend_config_data_use_terms_disabled.json
@@ -101,5 +101,7 @@
       }
     }
   },
-  "dataUseTermsEnabled": false
+  "dataUseTerms": {
+    "enabled": false
+  }
 }

--- a/backend/src/test/resources/backend_config_single_segment.json
+++ b/backend/src/test/resources/backend_config_single_segment.json
@@ -1,5 +1,6 @@
 {
     "accessionPrefix": "LOC_",
+    "dataUseTermsEnabled": true,
     "organisms": {
         "dummyOrganism": {
             "referenceGenomes": {

--- a/backend/src/test/resources/backend_config_single_segment.json
+++ b/backend/src/test/resources/backend_config_single_segment.json
@@ -1,6 +1,8 @@
 {
     "accessionPrefix": "LOC_",
-    "dataUseTermsEnabled": true,
+    "dataUseTerms": {
+        "enabled": true
+    },
     "organisms": {
         "dummyOrganism": {
             "referenceGenomes": {

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -73,6 +73,7 @@ export default defineConfig({
                             label: 'Build new preprocessing pipeline',
                             link: '/for-administrators/build-new-preprocessing-pipeline/',
                         },
+                        'for-administrators/data-use-terms',
                         { label: 'User administration', link: '/for-administrators/user-administration/' },
                     ],
                 },

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -73,7 +73,7 @@ export default defineConfig({
                             label: 'Build new preprocessing pipeline',
                             link: '/for-administrators/build-new-preprocessing-pipeline/',
                         },
-                        'for-administrators/data-use-terms',
+                        { label: 'Data use terms', link: '/for-administrators/data-use-terms/' },
                         { label: 'User administration', link: '/for-administrators/user-administration/' },
                     ],
                 },

--- a/docs/src/content/docs/for-administrators/data-use-terms.md
+++ b/docs/src/content/docs/for-administrators/data-use-terms.md
@@ -1,0 +1,6 @@
+---
+title: Data use terms
+description: What's the data use terms concept of Loculus and how to configure it.
+---
+
+TODO

--- a/docs/src/content/docs/for-administrators/data-use-terms.md
+++ b/docs/src/content/docs/for-administrators/data-use-terms.md
@@ -13,8 +13,7 @@ dataUseTerms:
   enabled: true
 ```
 
-To configure data use terms, you should specify them somewhere, at a URL.
-You can then enable data use terms like so:
+Optionally, you can provide links to pages where the data use terms are descripted:
 
 ```yaml
 dataUseTerms:

--- a/docs/src/content/docs/for-administrators/data-use-terms.md
+++ b/docs/src/content/docs/for-administrators/data-use-terms.md
@@ -25,7 +25,7 @@ dataUseTerms:
 
 ## Disabling data use terms
 
-To disable data use terms, set `enabled` to `false` (`urls` can be omitted in that case):
+To disable data use terms, set `enabled` to `false`:
 
 ```yaml
 dataUseTerms:

--- a/docs/src/content/docs/for-administrators/data-use-terms.md
+++ b/docs/src/content/docs/for-administrators/data-use-terms.md
@@ -6,6 +6,7 @@ description: What's the data use terms concept of Loculus and how to configure i
 Loculus comes with built-in handling of data use terms for submitted data, which means that data can either be _open_ or _restricted_. You can define, what restricted means yourself. Users can submit data as restricted, but they have to give a date at which point the sequences become open, this date can at most be one year from the submission date.
 
 When data use terms are enabled, you can also filter for only open or only restricted data, and when downloading you will have to accept the data use terms. The same applies to API usage.
+You can then enable data use terms like this:
 
 ```yaml
 dataUseTerms:

--- a/docs/src/content/docs/for-administrators/data-use-terms.md
+++ b/docs/src/content/docs/for-administrators/data-use-terms.md
@@ -3,4 +3,31 @@ title: Data use terms
 description: What's the data use terms concept of Loculus and how to configure it.
 ---
 
-TODO
+Loculus comes with built-in handling of data use terms for submitted data, which means that data can either be _open_ or _restricted_. You can define, what restricted means yourself. Users can submit data as restricted, but they have to give a date at which point the sequences become open, this date can at most be one year from the submission date.
+
+When data use terms are enabled, you can also filter for only open or only restricted data, and when downloading you will have to accept the data use terms. The same applies to API usage.
+
+```yaml
+dataUseTerms:
+  enabled: true
+```
+
+To configure data use terms, you should specify them somewhere, at a URL.
+You can then enable data use terms like so:
+
+```yaml
+dataUseTerms:
+  enabled: true
+  urls:
+    open: https://example.org/open
+    restricted: https://example.org/restricted
+```
+
+## Disabling data use terms
+
+To disable data use terms, set `enabled` to `false` (`urls` can be omitted in that case):
+
+```yaml
+dataUseTerms:
+  enabled: true
+```

--- a/docs/src/content/docs/for-users/submit-sequences.md
+++ b/docs/src/content/docs/for-users/submit-sequences.md
@@ -24,7 +24,7 @@ Uploading sequences via the website is a easy way to submit sequences without ha
 1. Log into your account, and then click 'Submit' in the top-right corner of the website
 2. Select the organism that you'd like to submit sequences for
 3. Drag-and-drop a `fasta` file with the sequences and a metadata file with the associated metadata into the box on the website, or click the 'Upload a file' link within the boxes to open a file-selection box
-4. Select the Terms of Use that you would like for your data
+4. If Terms of Use are enabled for your Loculus instance: Select the Terms of Use that you would like for your data
 5. Select 'Submit sequences' at the bottom of the page
 
 The data will now be processed, and you will have to approve your submission before it is finalized. You can see how to do this [here](../approve-submissions/).
@@ -39,13 +39,15 @@ To upload sequences through the HTTP API you will need to:
 2. Retrieve an authentication JSON web token: see the [Authenticating via API guide](../authenticate-via-api/).
 3. Identify the Group ID of your group: you can find it on the page of your group.
 4. Send a POST request:
-    - To upload sequences with the **open use terms**: `<Backend URL>/<organism>/submit?groupId=<group id>&dataUseTermsType=OPEN`
+    - The API path to use is: `<Backend URL>/<organism>/submit`
+    - Add your group ID to the query parameters: `?groupId=<group id>`
+    - If Data use Terms are configured for your Loculus instance, add `&dataUseTermsType=OPEN` for _open_ data use terms or `&dataUseTermsType=RESTRICTED&restrictedUntil=YYYY-MM-DD` (where `YYYY-MM-DD` refers to a date like 2025-01-31) for _restricted_ data use terms - with a date until when this restriction will be in place. If your Loculus instance doesn't use Data use Terms, you can leave out these settings.
     - The header should contain
         - `Authorization: Bearer <authentication-token>`
         - `Content-Type: multipart/form-data`
     - The request body should contain the FASTA and metadata TSV files with the keys `sequenceFile` and `metadataFile`
 
-With cURL, the corresponding command for sending the POST request can be:
+Below you can see an example of submitting to the API with cURL (with open data use terms):
 
 ```
 curl -X 'POST' \

--- a/docs/src/content/docs/reference/helm-chart-config.mdx
+++ b/docs/src/content/docs/reference/helm-chart-config.mdx
@@ -160,6 +160,24 @@ The configuration for the Helm chart is provided as a YAML file. It has the foll
             <td>"https://github.com/loculus-project/loculus"</td>
             <td>The link that the GitHub icon in the footer points to</td>
         </tr>
+        <tr>
+            <td>`dataUseTerms.enabled`</td>
+            <td>Boolean</td>
+            <td>true</td>
+            <td>Whether this Loculus instance handles data use terms.</td>
+        </tr>
+        <tr>
+            <td>`dataUseTerms.urls.open`</td>
+            <td>String</td>
+            <td></td>
+            <td>A URL describing the open data use terms.</td>
+        </tr>
+        <tr>
+            <td>`dataUseTerms.urls.restricted`</td>
+            <td>String</td>
+            <td></td>
+            <td>A URL describing the restricted data use terms.</td>
+        </tr>
         </tbody>
     </table>
 </div>

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -75,7 +75,7 @@ fields:
     autocomplete: true
     displayName: Date released (exact)
     columnWidth: 100
-    # TODO change to be done here - only include these fields if a flag is set 
+  {{- if $.Values.dataUseTermsEnabled }}
   - name: dataUseTerms
     type: string
     generateIndex: true
@@ -90,6 +90,7 @@ fields:
     displayName: Data use terms restricted until
     hideOnSequenceDetailsPage: true
     header: Data use terms
+  {{- end}}
   {{- if $.Values.dataUseTermsUrls }}
   - name: dataUseTermsUrl
     displayName: Data use terms URL

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -291,6 +291,7 @@ fields:
 {{- define "loculus.generateBackendConfig" }}
 accessionPrefix: {{ quote $.Values.accessionPrefix }}
 name: {{ quote $.Values.name }}
+dataUseTermsEnabled: {{$.Values.dataUseTermsEnabled }}
 dataUseTermsUrls:
   {{$.Values.dataUseTermsUrls | toYaml | nindent 2}}
 organisms:

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -75,7 +75,7 @@ fields:
     autocomplete: true
     displayName: Date released (exact)
     columnWidth: 100
-  {{- if $.Values.dataUseTermsEnabled }}
+  {{- if $.Values.dataUseTerms.enabled }}
   - name: dataUseTerms
     type: string
     generateIndex: true
@@ -91,7 +91,7 @@ fields:
     hideOnSequenceDetailsPage: true
     header: Data use terms
   {{- end}}
-  {{- if $.Values.dataUseTermsUrls }}
+  {{- if $.Values.dataUseTerms.urls }}
   - name: dataUseTermsUrl
     displayName: Data use terms URL
     type: string
@@ -162,7 +162,7 @@ enableLoginNavigationItem: {{ $.Values.website.websiteConfig.enableLoginNavigati
 enableSubmissionNavigationItem: {{ $.Values.website.websiteConfig.enableSubmissionNavigationItem }}
 enableSubmissionPages: {{ $.Values.website.websiteConfig.enableSubmissionPages }}
 enableSeqSets: {{ $.Values.seqSets.enabled }}
-enableDataUseTerms: {{ $.Values.dataUseTermsEnabled }}
+enableDataUseTerms: {{ $.Values.dataUseTerms.enabled }}
 accessionPrefix: {{ quote $.Values.accessionPrefix }}
 {{- $commonMetadata := (include "loculus.commonMetadata" . | fromYaml).fields }}
 organisms:
@@ -292,9 +292,8 @@ fields:
 {{- define "loculus.generateBackendConfig" }}
 accessionPrefix: {{ quote $.Values.accessionPrefix }}
 name: {{ quote $.Values.name }}
-dataUseTermsEnabled: {{$.Values.dataUseTermsEnabled }}
-dataUseTermsUrls:
-  {{$.Values.dataUseTermsUrls | toYaml | nindent 2}}
+dataUseTerms:
+  {{$.Values.dataUseTerms | toYaml | nindent 2}}
 organisms:
   {{- range $key, $instance := (.Values.organisms | default .Values.defaultOrganisms) }}
   {{ $key }}:

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -75,6 +75,7 @@ fields:
     autocomplete: true
     displayName: Date released (exact)
     columnWidth: 100
+    # TODO change to be done here - only include these fields if a flag is set 
   - name: dataUseTerms
     type: string
     generateIndex: true

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -90,7 +90,6 @@ fields:
     displayName: Data use terms restricted until
     hideOnSequenceDetailsPage: true
     header: Data use terms
-  {{- end}}
   {{- if $.Values.dataUseTerms.urls }}
   - name: dataUseTermsUrl
     displayName: Data use terms URL
@@ -100,6 +99,7 @@ fields:
     customDisplay:
       type: link
       url: "__value__"
+  {{- end}}
   {{- end}}
   - name: versionStatus
     type: string

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -161,6 +161,7 @@ enableLoginNavigationItem: {{ $.Values.website.websiteConfig.enableLoginNavigati
 enableSubmissionNavigationItem: {{ $.Values.website.websiteConfig.enableSubmissionNavigationItem }}
 enableSubmissionPages: {{ $.Values.website.websiteConfig.enableSubmissionPages }}
 enableSeqSets: {{ $.Values.seqSets.enabled }}
+enableDataUseTerms: {{ $.Values.dataUseTermsEnabled }}
 accessionPrefix: {{ quote $.Values.accessionPrefix }}
 {{- $commonMetadata := (include "loculus.commonMetadata" . | fromYaml).fields }}
 organisms:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -21,7 +21,7 @@ getSubmissionListLimitSeconds: 600
 preprocessingTimeout: 600
 accessionPrefix: "LOC_"
 dataUseTerms:
-  enabled: false
+  enabled: true
   urls:
     open: https://#TODO-MVP/open
     restricted: https://#TODO-MVP/restricted

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -20,10 +20,11 @@ ingestLimitSeconds: 1800
 getSubmissionListLimitSeconds: 600
 preprocessingTimeout: 600
 accessionPrefix: "LOC_"
-dataUseTermsEnabled: false
-dataUseTermsUrls:
-  open: https://#TODO-MVP/open
-  restricted: https://#TODO-MVP/restricted
+dataUseTerms:
+  enabled: false
+  urls:
+    open: https://#TODO-MVP/open
+    restricted: https://#TODO-MVP/restricted
 name: "Loculus"
 logo:
   url: "/favicon.svg"

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -20,6 +20,7 @@ ingestLimitSeconds: 1800
 getSubmissionListLimitSeconds: 600
 preprocessingTimeout: 600
 accessionPrefix: "LOC_"
+dataUseTermsEnabled: false
 dataUseTermsUrls:
   open: https://#TODO-MVP/open
   restricted: https://#TODO-MVP/restricted

--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx
@@ -24,16 +24,19 @@ const defaultOrganism = 'ebola';
 async function renderDialog({
     downloadParams = new SelectFilter(new Set()),
     allowSubmissionOfConsensusSequences = true,
+    dataUseTermsEnabled = true,
 }: {
     downloadParams?: SequenceFilter;
     allowSubmissionOfConsensusSequences?: boolean;
+    dataUseTermsEnabled?: boolean;
 } = {}) {
     render(
         <DownloadDialog
-            downloadUrlGenerator={new DownloadUrlGenerator(defaultOrganism, defaultLapisUrl)}
+            downloadUrlGenerator={new DownloadUrlGenerator(defaultOrganism, defaultLapisUrl, dataUseTermsEnabled)}
             sequenceFilter={downloadParams}
             referenceGenomesSequenceNames={defaultReferenceGenome}
             allowSubmissionOfConsensusSequences={allowSubmissionOfConsensusSequences}
+            dataUseTermsEnabled={dataUseTermsEnabled}
         />,
     );
 
@@ -157,6 +160,27 @@ describe('DownloadDialog', () => {
         expect(path).toBe(`${defaultLapisUrl}/sample/details`);
         expect(query).toMatch(/field2=/);
         expect(query).not.toMatch(/field1=/);
+    });
+
+    describe('DataUseTerms disabled', () => {
+        test('download button activated by default', async () => {
+            await renderDialog({ dataUseTermsEnabled: false });
+
+            const downloadButton = screen.getByRole('link', { name: 'Download' });
+            expect(downloadButton).not.toHaveClass('btn-disabled');
+        });
+
+        test('checkbox not in the document', async () => {
+            await renderDialog({ dataUseTermsEnabled: false });
+
+            expect(screen.queryByLabelText('I agree to the data use terms.')).not.toBeInTheDocument();
+        });
+
+        test('restricted data switch is not in the document', async () => {
+            await renderDialog({ dataUseTermsEnabled: false });
+
+            expect(screen.queryByLabelText(/restricted data/)).not.toBeInTheDocument();
+        });
     });
 });
 

--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
@@ -15,6 +15,7 @@ type DownloadDialogProps = {
     sequenceFilter: SequenceFilter;
     referenceGenomesSequenceNames: ReferenceGenomesSequenceNames;
     allowSubmissionOfConsensusSequences: boolean;
+    dataUseTermsEnabled: boolean;
 };
 
 export const DownloadDialog: FC<DownloadDialogProps> = ({
@@ -22,6 +23,7 @@ export const DownloadDialog: FC<DownloadDialogProps> = ({
     sequenceFilter,
     referenceGenomesSequenceNames,
     allowSubmissionOfConsensusSequences,
+    dataUseTermsEnabled,
 }) => {
     const [isOpen, setIsOpen] = useState(false);
 
@@ -29,7 +31,9 @@ export const DownloadDialog: FC<DownloadDialogProps> = ({
     const closeDialog = () => setIsOpen(false);
 
     const [downloadOption, setDownloadOption] = useState<DownloadOption | undefined>();
-    const [agreedToDataUseTerms, setAgreedToDataUseTerms] = useState(false);
+    const [agreedToDataUseTerms, setAgreedToDataUseTerms] = useState(dataUseTermsEnabled ? false : true);
+
+    // TODO remove DUT stuff
 
     return (
         <>
@@ -42,29 +46,31 @@ export const DownloadDialog: FC<DownloadDialogProps> = ({
                         onChange={setDownloadOption}
                         allowSubmissionOfConsensusSequences={allowSubmissionOfConsensusSequences}
                     />
-                    <div className='mb-4 py-4'>
-                        <label className='flex items-center'>
-                            <input
-                                type='checkbox'
-                                name='data-use-terms-agreement'
-                                className='mr-3 ml-1 h-5 w-5 rounded border-gray-300 text-primary-600 focus:ring-primary-600'
-                                checked={agreedToDataUseTerms}
-                                onChange={() => setAgreedToDataUseTerms(!agreedToDataUseTerms)}
-                            />
-                            <span className='text-sm'>
-                                I agree to the {/* TODO(862) */}
-                                <a
-                                    href={routes.datauseTermsPage()}
-                                    className='underline'
-                                    target='_blank'
-                                    rel='noopener noreferrer'
-                                >
-                                    data use terms
-                                </a>
-                                .
-                            </span>
-                        </label>
-                    </div>
+                    {dataUseTermsEnabled && (
+                        <div className='mb-4 py-4'>
+                            <label className='flex items-center'>
+                                <input
+                                    type='checkbox'
+                                    name='data-use-terms-agreement'
+                                    className='mr-3 ml-1 h-5 w-5 rounded border-gray-300 text-primary-600 focus:ring-primary-600'
+                                    checked={agreedToDataUseTerms}
+                                    onChange={() => setAgreedToDataUseTerms(!agreedToDataUseTerms)}
+                                />
+                                <span className='text-sm'>
+                                    I agree to the {/* TODO(862) */}
+                                    <a
+                                        href={routes.datauseTermsPage()}
+                                        className='underline'
+                                        target='_blank'
+                                        rel='noopener noreferrer'
+                                    >
+                                        data use terms
+                                    </a>
+                                    .
+                                </span>
+                            </label>
+                        </div>
+                    )}
                     <DownloadButton
                         downloadUrlGenerator={downloadUrlGenerator}
                         downloadOption={downloadOption}

--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
@@ -33,18 +33,17 @@ export const DownloadDialog: FC<DownloadDialogProps> = ({
     const [downloadOption, setDownloadOption] = useState<DownloadOption | undefined>();
     const [agreedToDataUseTerms, setAgreedToDataUseTerms] = useState(dataUseTermsEnabled ? false : true);
 
-    // TODO remove DUT stuff
-
     return (
         <>
             <DownloadDialogButton sequenceFilter={sequenceFilter} onClick={openDialog} />
-            <BaseDialog title='Download' isOpen={isOpen} onClose={closeDialog}>
+            <BaseDialog title='Download' isOpen={isOpen} onClose={closeDialog} fullWidth={false}>
                 <div className='mt-2'>
                     <ActiveFilters sequenceFilter={sequenceFilter} />
                     <DownloadForm
                         referenceGenomesSequenceNames={referenceGenomesSequenceNames}
                         onChange={setDownloadOption}
                         allowSubmissionOfConsensusSequences={allowSubmissionOfConsensusSequences}
+                        dataUseTermsEnabled={dataUseTermsEnabled}
                     />
                     {dataUseTermsEnabled && (
                         <div className='mb-4 py-4'>

--- a/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
@@ -10,12 +10,14 @@ type DownloadFormProps = {
     referenceGenomesSequenceNames: ReferenceGenomesSequenceNames;
     onChange: (value: DownloadOption) => void;
     allowSubmissionOfConsensusSequences: boolean;
+    dataUseTermsEnabled: boolean;
 };
 
 export const DownloadForm: FC<DownloadFormProps> = ({
     referenceGenomesSequenceNames,
     onChange,
     allowSubmissionOfConsensusSequences,
+    dataUseTermsEnabled,
 }) => {
     const [includeRestricted, setIncludeRestricted] = useState(0);
     const [includeOldData, setIncludeOldData] = useState(0);
@@ -136,27 +138,29 @@ export const DownloadForm: FC<DownloadFormProps> = ({
 
     return (
         <div className='flex flex-row flex-wrap mb-4 gap-y-2 py-4'>
-            <RadioOptionBlock
-                name='includeRestricted'
-                title='Include restricted data?'
-                options={[
-                    { label: <>No, only download open data</> },
-                    {
-                        label: (
-                            <>
-                                Yes, include restricted data
-                                <br />({/* TODO(862) */}
-                                <a href={routes.datauseTermsPage()} className='underline'>
-                                    What does it mean?
-                                </a>
-                                )
-                            </>
-                        ),
-                    },
-                ]}
-                selected={includeRestricted}
-                onSelect={setIncludeRestricted}
-            />
+            {dataUseTermsEnabled && (
+                <RadioOptionBlock
+                    name='includeRestricted'
+                    title='Include restricted data?'
+                    options={[
+                        { label: <>No, only download open data</> },
+                        {
+                            label: (
+                                <>
+                                    Yes, include restricted data
+                                    <br />({/* TODO(862) */}
+                                    <a href={routes.datauseTermsPage()} className='underline'>
+                                        What does it mean?
+                                    </a>
+                                    )
+                                </>
+                            ),
+                        },
+                    ]}
+                    selected={includeRestricted}
+                    onSelect={setIncludeRestricted}
+                />
+            )}
             <RadioOptionBlock
                 name='includeOlder'
                 title='Include older versions?'

--- a/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
@@ -19,18 +19,16 @@ export type DownloadOption = {
  * from which the selected data can be downloaded.
  */
 export class DownloadUrlGenerator {
-    private readonly organism: string;
-    private readonly lapisUrl: string;
-
     /**
      * Create new DownloadUrlGenerator with the given properties.
      * @param organism The organism, will be part of the filename.
      * @param lapisUrl The lapis API URL for downloading.
      */
-    constructor(organism: string, lapisUrl: string) {
-        this.organism = organism;
-        this.lapisUrl = lapisUrl;
-    }
+    constructor(
+        private readonly organism: string,
+        private readonly lapisUrl: string,
+        private readonly dataUseTermsEnabled: boolean,
+    ) {}
 
     public generateDownloadUrl(downloadParameters: SequenceFilter, option: DownloadOption) {
         const baseUrl = `${this.lapisUrl}${getEndpoint(option.dataType)}`;
@@ -46,8 +44,7 @@ export class DownloadUrlGenerator {
             params.set(VERSION_STATUS_FIELD, versionStatuses.latestVersion);
             params.set(IS_REVOCATION_FIELD, 'false');
         }
-
-        if (!option.includeRestricted) {
+        if (!option.includeRestricted && this.dataUseTermsEnabled) {
             params.set('dataUseTerms', 'OPEN');
             excludedParams.add('dataUseTerms');
         }

--- a/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
@@ -23,6 +23,7 @@ export class DownloadUrlGenerator {
      * Create new DownloadUrlGenerator with the given properties.
      * @param organism The organism, will be part of the filename.
      * @param lapisUrl The lapis API URL for downloading.
+     * @param dataUseTermsEnabled If false, the downloaded URLs won't include any data use terms related settings.
      */
     constructor(
         private readonly organism: string,

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -46,7 +46,7 @@ export interface InnerSearchFullUIProps {
     initialCount: number;
     initialQueryDict: QueryState;
     showEditDataUseTermsControls?: boolean;
-    showDataUseTermsControls?: boolean;
+    dataUseTermsEnabled?: boolean;
 }
 interface QueryState {
     [key: string]: string;
@@ -74,7 +74,7 @@ export const InnerSearchFullUI = ({
     initialCount,
     initialQueryDict,
     showEditDataUseTermsControls = false,
-    showDataUseTermsControls = true,
+    dataUseTermsEnabled = true,
 }: InnerSearchFullUIProps) => {
     if (!hiddenFieldValues) {
         hiddenFieldValues = {};
@@ -190,13 +190,13 @@ export const InnerSearchFullUI = ({
     };
 
     useEffect(() => {
-        if (showEditDataUseTermsControls && showDataUseTermsControls) {
+        if (showEditDataUseTermsControls && dataUseTermsEnabled) {
             setAColumnVisibility(DATA_USE_TERMS_FIELD, true);
         }
     }, []);
 
     const lapisUrl = getLapisUrl(clientConfig, organism);
-    const downloadUrlGenerator = new DownloadUrlGenerator(organism, lapisUrl);
+    const downloadUrlGenerator = new DownloadUrlGenerator(organism, lapisUrl, dataUseTermsEnabled);
 
     const hooks = lapisClientHooks(lapisUrl).zodiosHooks;
     const aggregatedHook = hooks.useAggregated({}, {});
@@ -355,7 +355,7 @@ export const InnerSearchFullUI = ({
                         </div>
 
                         <div className='flex'>
-                            {showEditDataUseTermsControls && showDataUseTermsControls && (
+                            {showEditDataUseTermsControls && dataUseTermsEnabled && (
                                 <EditDataUseTermsModal
                                     lapisUrl={lapisUrl}
                                     clientConfig={clientConfig}
@@ -383,7 +383,7 @@ export const InnerSearchFullUI = ({
                                 sequenceFilter={sequencesFilter}
                                 referenceGenomesSequenceNames={referenceGenomesSequenceNames}
                                 allowSubmissionOfConsensusSequences={schema.submissionDataTypes.consensusSequences}
-                                dataUseTermsEnabled={showDataUseTermsControls}
+                                dataUseTermsEnabled={dataUseTermsEnabled}
                             />
                         </div>
                     </div>

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -46,6 +46,7 @@ export interface InnerSearchFullUIProps {
     initialCount: number;
     initialQueryDict: QueryState;
     showEditDataUseTermsControls?: boolean;
+    showDataUseTermsControls?: boolean;
 }
 interface QueryState {
     [key: string]: string;
@@ -73,6 +74,7 @@ export const InnerSearchFullUI = ({
     initialCount,
     initialQueryDict,
     showEditDataUseTermsControls = false,
+    showDataUseTermsControls = true,
 }: InnerSearchFullUIProps) => {
     if (!hiddenFieldValues) {
         hiddenFieldValues = {};
@@ -188,7 +190,7 @@ export const InnerSearchFullUI = ({
     };
 
     useEffect(() => {
-        if (showEditDataUseTermsControls) {
+        if (showEditDataUseTermsControls && showDataUseTermsControls) {
             setAColumnVisibility(DATA_USE_TERMS_FIELD, true);
         }
     }, []);
@@ -353,7 +355,7 @@ export const InnerSearchFullUI = ({
                         </div>
 
                         <div className='flex'>
-                            {showEditDataUseTermsControls && (
+                            {showEditDataUseTermsControls && showDataUseTermsControls && (
                                 <EditDataUseTermsModal
                                     lapisUrl={lapisUrl}
                                     clientConfig={clientConfig}
@@ -381,6 +383,7 @@ export const InnerSearchFullUI = ({
                                 sequenceFilter={sequencesFilter}
                                 referenceGenomesSequenceNames={referenceGenomesSequenceNames}
                                 allowSubmissionOfConsensusSequences={schema.submissionDataTypes.consensusSequences}
+                                dataUseTermsEnabled={showDataUseTermsControls}
                             />
                         </div>
                     </div>

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -165,12 +165,12 @@ const InnerDataUploadForm = ({
     const handleSubmit = async (event: FormEvent) => {
         event.preventDefault();
 
-        if (!agreedToINSDCUploadTerms) {
+        if (dataUseTermsEnabled && !agreedToINSDCUploadTerms) {
             onError('Please tick the box to agree that you will not independently submit these sequences to INSDC');
             return;
         }
 
-        if (!confirmedNoPII) {
+        if (dataUseTermsEnabled && !confirmedNoPII) {
             onError(
                 'Please confirm the data you submitted does not include restricted or personally identifiable information.',
             );

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -328,6 +328,7 @@ const InnerDataUploadForm = ({
                         </div>
                     </form>
                 </div>
+                {/* TODO change to be done here */}
                 {action !== 'revise' && (
                     <DataUseTerms
                         dataUseTermsType={dataUseTermsType}
@@ -342,6 +343,7 @@ const InnerDataUploadForm = ({
                     </div>
                     <div className='sm:col-span-2  grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6 col-span-2'>
                         <div className='sm:col-span-4 px-8'>
+                            {/* TODO change to be done here */}
                             {dataUseTermsType === restrictedDataUseTermsOption && (
                                 <p className='block text-sm'>
                                     Your data will be available on Pathoplexus, under the restricted use terms until{' '}

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -43,6 +43,7 @@ type DataUploadFormProps = {
     onSuccess: () => void;
     onError: (message: string) => void;
     submissionDataTypes: SubmissionDataTypes;
+    dataUseTermsEnabled: boolean;
 };
 
 const logger = getClientLogger('DataUploadForm');
@@ -129,6 +130,7 @@ const InnerDataUploadForm = ({
     referenceGenomeSequenceNames,
     metadataTemplateFields,
     submissionDataTypes,
+    dataUseTermsEnabled,
 }: DataUploadFormProps) => {
     const [metadataFile, setMetadataFile] = useState<ProcessedFile | undefined>(undefined);
     // The columnMapping can be null; if null -> don't apply mapping.
@@ -328,88 +330,87 @@ const InnerDataUploadForm = ({
                         </div>
                     </form>
                 </div>
-                {/* TODO change to be done here */}
-                {action !== 'revise' && (
+                {action === 'submit' && dataUseTermsEnabled && (
                     <DataUseTerms
                         dataUseTermsType={dataUseTermsType}
                         setDataUseTermsType={setDataUseTermsType}
                         setRestrictedUntil={setRestrictedUntil}
                     />
                 )}
-                <div className='grid sm:grid-cols-3 gap-x-16 pt-10'>
-                    <div className=''>
-                        <h2 className='font-medium text-lg'>Acknowledgement</h2>
-                        <p className='text-gray-500 text-sm'>Acknowledge submission terms</p>
-                    </div>
-                    <div className='sm:col-span-2  grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6 col-span-2'>
-                        <div className='sm:col-span-4 px-8'>
-                            {/* TODO change to be done here */}
-                            {dataUseTermsType === restrictedDataUseTermsOption && (
-                                <p className='block text-sm'>
-                                    Your data will be available on Pathoplexus, under the restricted use terms until{' '}
-                                    {restrictedUntil.toFormat('yyyy-MM-dd')}. After the restricted period your data will
-                                    additionally be made publicly available through the{' '}
-                                    <a href='https://www.insdc.org/' className='text-primary-600 hover:underline'>
-                                        INSDC
-                                    </a>{' '}
-                                    databases (ENA, DDBJ, NCBI).
-                                </p>
-                            )}
-                            {dataUseTermsType === openDataUseTermsOption && (
-                                <p className='block text-sm'>
-                                    Your data will be available on Pathoplexus under the open use terms. It will
-                                    additionally be made publicly available through the{' '}
-                                    <a href='https://www.insdc.org/' className='text-primary-600 hover:underline'>
-                                        INSDC
-                                    </a>{' '}
-                                    databases (ENA, DDBJ, NCBI).
-                                </p>
-                            )}
-                            <div className='mt-2 py-5'>
-                                <label className='flex items-center'>
-                                    <input
-                                        type='checkbox'
-                                        name='confirmation-no-pii'
-                                        className='mr-3 ml-1 h-5 w-5 rounded border-gray-300 text-blue focus:ring-blue'
-                                        checked={confirmedNoPII}
-                                        onChange={() => setConfirmedNoPII(!confirmedNoPII)}
-                                    />
-                                    <div>
-                                        <p className='text-xs pl-4 text-gray-500'>
-                                            I confirm that the data submitted is not sensitive or human-identifiable
-                                        </p>
-                                    </div>
-                                </label>
-                            </div>
-                            <div className='mb-4 py-3'>
-                                <label className='flex items-center'>
-                                    <input
-                                        type='checkbox'
-                                        name='confirmation-INSDC-upload-terms'
-                                        className='mr-3 ml-1 h-5 w-5 rounded border-gray-300 text-blue focus:ring-blue'
-                                        checked={agreedToINSDCUploadTerms}
-                                        onChange={() => setAgreedToINSDCUploadTerms(!agreedToINSDCUploadTerms)}
-                                    />
-                                    <div>
-                                        <p className='text-xs pl-4 text-gray-500'>
-                                            I confirm I have not and will not submit this data independently to INSDC,
-                                            to avoid data duplication. I agree to Loculus handling the submission of
-                                            this data to INSDC.{' '}
-                                            <a
-                                                href='/docs/concepts/insdc-submission'
-                                                className='text-primary-600 hover:underline'
-                                            >
-                                                Find out more.
-                                            </a>
-                                        </p>
-                                    </div>
-                                </label>
+                {dataUseTermsEnabled && (
+                    <div className='grid sm:grid-cols-3 gap-x-16 pt-10'>
+                        <div className=''>
+                            <h2 className='font-medium text-lg'>Acknowledgement</h2>
+                            <p className='text-gray-500 text-sm'>Acknowledge submission terms</p>
+                        </div>
+                        <div className='sm:col-span-2  grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6 col-span-2'>
+                            <div className='sm:col-span-4 px-8'>
+                                {dataUseTermsType === restrictedDataUseTermsOption && (
+                                    <p className='block text-sm'>
+                                        Your data will be available on Pathoplexus, under the restricted use terms until{' '}
+                                        {restrictedUntil.toFormat('yyyy-MM-dd')}. After the restricted period your data
+                                        will additionally be made publicly available through the{' '}
+                                        <a href='https://www.insdc.org/' className='text-primary-600 hover:underline'>
+                                            INSDC
+                                        </a>{' '}
+                                        databases (ENA, DDBJ, NCBI).
+                                    </p>
+                                )}
+                                {dataUseTermsType === openDataUseTermsOption && (
+                                    <p className='block text-sm'>
+                                        Your data will be available on Pathoplexus under the open use terms. It will
+                                        additionally be made publicly available through the{' '}
+                                        <a href='https://www.insdc.org/' className='text-primary-600 hover:underline'>
+                                            INSDC
+                                        </a>{' '}
+                                        databases (ENA, DDBJ, NCBI).
+                                    </p>
+                                )}
+                                <div className='mt-2 py-5'>
+                                    <label className='flex items-center'>
+                                        <input
+                                            type='checkbox'
+                                            name='confirmation-no-pii'
+                                            className='mr-3 ml-1 h-5 w-5 rounded border-gray-300 text-blue focus:ring-blue'
+                                            checked={confirmedNoPII}
+                                            onChange={() => setConfirmedNoPII(!confirmedNoPII)}
+                                        />
+                                        <div>
+                                            <p className='text-xs pl-4 text-gray-500'>
+                                                I confirm that the data submitted is not sensitive or human-identifiable
+                                            </p>
+                                        </div>
+                                    </label>
+                                </div>
+                                <div className='mb-4 py-3'>
+                                    <label className='flex items-center'>
+                                        <input
+                                            type='checkbox'
+                                            name='confirmation-INSDC-upload-terms'
+                                            className='mr-3 ml-1 h-5 w-5 rounded border-gray-300 text-blue focus:ring-blue'
+                                            checked={agreedToINSDCUploadTerms}
+                                            onChange={() => setAgreedToINSDCUploadTerms(!agreedToINSDCUploadTerms)}
+                                        />
+                                        <div>
+                                            <p className='text-xs pl-4 text-gray-500'>
+                                                I confirm I have not and will not submit this data independently to
+                                                INSDC, to avoid data duplication. I agree to Loculus handling the
+                                                submission of this data to INSDC.{' '}
+                                                <a
+                                                    href='/docs/concepts/insdc-submission'
+                                                    className='text-primary-600 hover:underline'
+                                                >
+                                                    Find out more.
+                                                </a>
+                                            </p>
+                                        </div>
+                                    </label>
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
-
-                <div className='flex items-center justify-end gap-x-6 pt-3'>
+                )}
+                <div className='flex justify-end gap-x-6 pt-3 mt-auto'>
                     <button
                         name='submit'
                         type='submit'

--- a/website/src/components/Submission/RevisionForm.tsx
+++ b/website/src/components/Submission/RevisionForm.tsx
@@ -17,6 +17,7 @@ type RevisionFormProps = {
     referenceGenomeSequenceNames: ReferenceGenomesSequenceNames;
     metadataTemplateFields: Map<string, InputField[]>;
     submissionDataTypes: SubmissionDataTypes;
+    dataUseTermsEnabled: boolean;
 };
 
 export const RevisionForm: FC<RevisionFormProps> = ({
@@ -27,6 +28,7 @@ export const RevisionForm: FC<RevisionFormProps> = ({
     referenceGenomeSequenceNames,
     metadataTemplateFields,
     submissionDataTypes,
+    dataUseTermsEnabled,
 }) => {
     return (
         <div className='flex flex-col items-center'>
@@ -43,6 +45,7 @@ export const RevisionForm: FC<RevisionFormProps> = ({
                     window.location.href = routes.userSequenceReviewPage(organism, group.groupId);
                 }}
                 submissionDataTypes={submissionDataTypes}
+                dataUseTermsEnabled={dataUseTermsEnabled}
             />
         </div>
     );

--- a/website/src/components/Submission/SubmissionForm.spec.tsx
+++ b/website/src/components/Submission/SubmissionForm.spec.tsx
@@ -48,10 +48,7 @@ const defaultReferenceGenomesSequenceNames: ReferenceGenomesSequenceNames = {
     insdcAccessionFull: [defaultAccession],
 };
 
-function renderSubmissionForm({
-    allowSubmissionOfConsensusSequences = true,
-    dataUseTermsEnabled = true
-} = {}) {
+function renderSubmissionForm({ allowSubmissionOfConsensusSequences = true, dataUseTermsEnabled = true } = {}) {
     return render(
         <SubmissionForm
             accessToken={testAccessToken}
@@ -79,7 +76,7 @@ describe('SubmitForm', () => {
         vi.clearAllMocks();
     });
 
-    test.only('should handle file upload and server response', async () => {
+    test('should handle file upload and server response', async () => {
         mockRequest.backend.submit(200, testResponse);
         mockRequest.backend.getGroupsOfUser();
 
@@ -178,23 +175,6 @@ describe('SubmitForm', () => {
         );
     });
 
-    test.only('should allow submission without checkings boxes when data use terms are disabled', async () => {
-        mockRequest.backend.submit(200, testResponse);
-        mockRequest.backend.getGroupsOfUser();
-
-        const { getByLabelText, getByText } = renderSubmissionForm();
-
-        await userEvent.upload(getByLabelText(/Metadata File/i), metadataFile);
-        await userEvent.upload(getByLabelText(/Sequence File/i), sequencesFile);
-
-        const submitButton = getByText('Submit sequences');
-        await userEvent.click(submitButton);
-
-        await waitFor(() => {
-            expect(toast.error).not.toHaveBeenCalled();
-        });
-    });
-
     async function submitAndExpectErrorMessageContains(receivedUnexpectedMessageFromBackend: string) {
         const { getByLabelText, getByText } = renderSubmissionForm();
 
@@ -233,6 +213,23 @@ describe('SubmitForm', () => {
         await userEvent.click(
             getByLabelText(/I confirm that the data submitted is not sensitive or human-identifiable/i),
         );
+
+        await waitFor(() => {
+            expect(toast.error).not.toHaveBeenCalled();
+        });
+    });
+
+    test('should allow submission without checkings boxes when data use terms are disabled', async () => {
+        mockRequest.backend.submit(200, testResponse);
+        mockRequest.backend.getGroupsOfUser();
+
+        const { getByLabelText, getByText } = renderSubmissionForm({ dataUseTermsEnabled: false });
+
+        await userEvent.upload(getByLabelText(/Metadata File/i), metadataFile);
+        await userEvent.upload(getByLabelText(/Sequence File/i), sequencesFile);
+
+        const submitButton = getByText('Submit sequences');
+        await userEvent.click(submitButton);
 
         await waitFor(() => {
             expect(toast.error).not.toHaveBeenCalled();

--- a/website/src/components/Submission/SubmissionForm.spec.tsx
+++ b/website/src/components/Submission/SubmissionForm.spec.tsx
@@ -58,6 +58,7 @@ function renderSubmissionForm({ allowSubmissionOfConsensusSequences = true } = {
             group={group}
             metadataTemplateFields={new Map([['fooSection', [{ name: 'foo' }, { name: 'bar' }]]])}
             submissionDataTypes={{ consensusSequences: allowSubmissionOfConsensusSequences }}
+            dataUseTermsEnabled={true}
         />,
     );
 }

--- a/website/src/components/Submission/SubmissionForm.tsx
+++ b/website/src/components/Submission/SubmissionForm.tsx
@@ -17,6 +17,7 @@ type SubmissionFormProps = {
     referenceGenomeSequenceNames: ReferenceGenomesSequenceNames;
     metadataTemplateFields: Map<string, InputField[]>;
     submissionDataTypes: SubmissionDataTypes;
+    dataUseTermsEnabled: boolean;
 };
 
 export const SubmissionForm: FC<SubmissionFormProps> = ({
@@ -27,6 +28,7 @@ export const SubmissionForm: FC<SubmissionFormProps> = ({
     referenceGenomeSequenceNames,
     metadataTemplateFields,
     submissionDataTypes,
+    dataUseTermsEnabled,
 }) => {
     return (
         <div className='flex flex-col items-center'>
@@ -43,6 +45,7 @@ export const SubmissionForm: FC<SubmissionFormProps> = ({
                     window.location.href = routes.userSequenceReviewPage(organism, group.groupId);
                 }}
                 submissionDataTypes={submissionDataTypes}
+                dataUseTermsEnabled={dataUseTermsEnabled}
             />
         </div>
     );

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -206,9 +206,7 @@ export function seqSetsAreEnabled() {
 }
 
 export function dataUseTermsAreEnabled() {
-    // TODO
-    // return getWebsiteConfig().enableDataUseTerms
-    return false;
+    return getWebsiteConfig().enableDataUseTerms;
 }
 
 function readTypedConfigFile<T>(fileName: string, schema: z.ZodType<T>) {

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -205,6 +205,12 @@ export function seqSetsAreEnabled() {
     return getWebsiteConfig().enableSeqSets;
 }
 
+export function dataUseTermsAreEnabled() {
+    // TODO
+    // return getWebsiteConfig().enableDataUseTerms
+    return false;
+}
+
 function readTypedConfigFile<T>(fileName: string, schema: z.ZodType<T>) {
     const configFilePath = path.join(getConfigDir(), fileName);
     const json = JSON.parse(fs.readFileSync(configFilePath, 'utf8'));

--- a/website/src/pages/[organism]/search/index.astro
+++ b/website/src/pages/[organism]/search/index.astro
@@ -57,6 +57,6 @@ const { data, totalCount } = await performLapisSearchQueries(
         initialData={data}
         initialCount={totalCount}
         initialQueryDict={initialQueryDict}
-        showDataUseTermsControls={dataUseTermsAreEnabled()}
+        dataUseTermsEnabled={dataUseTermsAreEnabled()}
     />
 </BaseLayout>

--- a/website/src/pages/[organism]/search/index.astro
+++ b/website/src/pages/[organism]/search/index.astro
@@ -1,7 +1,7 @@
 ---
 import { cleanOrganism } from '../../../components/Navigation/cleanOrganism';
 import { SearchFullUI } from '../../../components/SearchPage/SearchFullUI';
-import { getRuntimeConfig, getSchema } from '../../../config';
+import { dataUseTermsAreEnabled, getRuntimeConfig, getSchema } from '../../../config';
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 import { VERSION_STATUS_FIELD, IS_REVOCATION_FIELD } from '../../../settings';
 import { versionStatuses } from '../../../types/lapis';
@@ -57,5 +57,6 @@ const { data, totalCount } = await performLapisSearchQueries(
         initialData={data}
         initialCount={totalCount}
         initialQueryDict={initialQueryDict}
+        showDataUseTermsControls={dataUseTermsAreEnabled()}
     />
 </BaseLayout>

--- a/website/src/pages/[organism]/submission/[groupId]/released.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/released.astro
@@ -62,7 +62,7 @@ const { data, totalCount } = await performLapisSearchQueries(
         initialData={data}
         initialCount={totalCount}
         initialQueryDict={initialQueryDict}
-        showDataUseTermsControls={dataUseTermsAreEnabled()}
+        dataUseTermsEnabled={dataUseTermsAreEnabled()}
         showEditDataUseTermsControls
     />
 </SubmissionPageWrapper>

--- a/website/src/pages/[organism]/submission/[groupId]/released.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/released.astro
@@ -2,7 +2,7 @@
 import { cleanOrganism } from '../../../../components/Navigation/cleanOrganism';
 import { SearchFullUI } from '../../../../components/SearchPage/SearchFullUI';
 import SubmissionPageWrapper from '../../../../components/Submission/SubmissionPageWrapper.astro';
-import { getRuntimeConfig, getSchema } from '../../../../config';
+import { dataUseTermsAreEnabled, getRuntimeConfig, getSchema } from '../../../../config';
 import { GROUP_ID_FIELD, VERSION_STATUS_FIELD } from '../../../../settings';
 import { versionStatuses } from '../../../../types/lapis';
 import { getAccessToken } from '../../../../utils/getAccessToken';
@@ -62,6 +62,6 @@ const { data, totalCount } = await performLapisSearchQueries(
         initialData={data}
         initialCount={totalCount}
         initialQueryDict={initialQueryDict}
-        showEditDataUseTermsControls
+        showEditDataUseTermsControls={dataUseTermsAreEnabled()}
     />
 </SubmissionPageWrapper>

--- a/website/src/pages/[organism]/submission/[groupId]/released.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/released.astro
@@ -62,6 +62,7 @@ const { data, totalCount } = await performLapisSearchQueries(
         initialData={data}
         initialCount={totalCount}
         initialQueryDict={initialQueryDict}
-        showEditDataUseTermsControls={dataUseTermsAreEnabled()}
+        showDataUseTermsControls={dataUseTermsAreEnabled()}
+        showEditDataUseTermsControls
     />
 </SubmissionPageWrapper>

--- a/website/src/pages/[organism]/submission/[groupId]/revise.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/revise.astro
@@ -2,7 +2,7 @@
 import { cleanOrganism } from '../../../../components/Navigation/cleanOrganism';
 import { RevisionForm } from '../../../../components/Submission/RevisionForm';
 import SubmissionPageWrapper from '../../../../components/Submission/SubmissionPageWrapper.astro';
-import { getGroupedInputFields, getRuntimeConfig, getSchema } from '../../../../config';
+import { dataUseTermsAreEnabled, getGroupedInputFields, getRuntimeConfig, getSchema } from '../../../../config';
 import { getAccessToken } from '../../../../utils/getAccessToken';
 import { getReferenceGenomesSequenceNames } from '../../../../utils/search';
 import { getGroupsAndCurrentGroup } from '../../../../utils/submissionPages';
@@ -37,6 +37,7 @@ const clientConfig = getRuntimeConfig().public;
                     clientConfig={clientConfig}
                     group={group}
                     submissionDataTypes={schema.submissionDataTypes}
+                    dataUseTermsEnabled={dataUseTermsAreEnabled()}
                     client:load
                 />
             ),

--- a/website/src/pages/[organism]/submission/[groupId]/submit.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/submit.astro
@@ -2,7 +2,7 @@
 import { cleanOrganism } from '../../../../components/Navigation/cleanOrganism';
 import { SubmissionForm } from '../../../../components/Submission/SubmissionForm';
 import SubmissionPageWrapper from '../../../../components/Submission/SubmissionPageWrapper.astro';
-import { getGroupedInputFields, getRuntimeConfig, getSchema } from '../../../../config';
+import { dataUseTermsAreEnabled, getGroupedInputFields, getRuntimeConfig, getSchema } from '../../../../config';
 import { getAccessToken } from '../../../../utils/getAccessToken';
 import { getReferenceGenomesSequenceNames } from '../../../../utils/search';
 import { getGroupsAndCurrentGroup } from '../../../../utils/submissionPages';
@@ -43,6 +43,7 @@ Astro.response.headers.append('Expires', '0');
                     clientConfig={clientConfig}
                     group={group}
                     submissionDataTypes={schema.submissionDataTypes}
+                    dataUseTermsEnabled={dataUseTermsAreEnabled()}
                     client:load
                 />
             ),

--- a/website/src/pages/api-documentation/index.astro
+++ b/website/src/pages/api-documentation/index.astro
@@ -48,6 +48,7 @@ const BUTTON_CLASS =
                 WARNING: Swagger incorrectly displays NDJSON examples in JSON format. For endpoints that require NDJSON
                 as input you must convert the JSON examples to NDJSON (e.g. by removing new lines) prior to testing.
             </p>
+            {/* TODO changes to be done here */}
             <p class='mt-4 mb-4'>
                 By using our API you agree to our
                 <a

--- a/website/src/pages/api-documentation/index.astro
+++ b/website/src/pages/api-documentation/index.astro
@@ -1,6 +1,6 @@
 ---
 import { authenticationApiDocsUrl } from './authenticationApiDocsUrl';
-import { getRuntimeConfig, getWebsiteConfig } from '../../config';
+import { dataUseTermsAreEnabled, getRuntimeConfig, getWebsiteConfig } from '../../config';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { routes } from '../../routes/routes.ts';
 import { getAuthBaseUrl } from '../../utils/getAuthUrl';
@@ -48,16 +48,20 @@ const BUTTON_CLASS =
                 WARNING: Swagger incorrectly displays NDJSON examples in JSON format. For endpoints that require NDJSON
                 as input you must convert the JSON examples to NDJSON (e.g. by removing new lines) prior to testing.
             </p>
-            {/* TODO changes to be done here */}
-            <p class='mt-4 mb-4'>
-                By using our API you agree to our
-                <a
-                    href={routes.datauseTermsPage()}
-                    class='underline text-primary-900 hover:text-primary-800 hover:no-underline'
-                >
-                    Data Use Terms
-                </a>.
-            </p>
+            {
+                dataUseTermsAreEnabled() && (
+                    <p class='mt-4 mb-4'>
+                        By using our API you agree to our
+                        <a
+                            href={routes.datauseTermsPage()}
+                            class='underline text-primary-900 hover:text-primary-800 hover:no-underline'
+                        >
+                            Data Use Terms
+                        </a>
+                        .
+                    </p>
+                )
+            }
         </div>
 
         <div class='mb-10'>

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -144,7 +144,7 @@ export const websiteConfig = z.object({
     enableLoginNavigationItem: z.boolean(),
     enableSubmissionNavigationItem: z.boolean(),
     enableSubmissionPages: z.boolean(),
-    //    enableDataUseTerms: z.boolean(),  // TODO
+    enableDataUseTerms: z.boolean(),
 });
 export type WebsiteConfig = z.infer<typeof websiteConfig>;
 

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -144,6 +144,7 @@ export const websiteConfig = z.object({
     enableLoginNavigationItem: z.boolean(),
     enableSubmissionNavigationItem: z.boolean(),
     enableSubmissionPages: z.boolean(),
+    //    enableDataUseTerms: z.boolean(),  // TODO
 });
 export type WebsiteConfig = z.infer<typeof websiteConfig>;
 


### PR DESCRIPTION
**BREAKING** `values.yaml` changes (see below)

resolves #3127 

preview URL: https://disable-dut.loculus.org

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

This PR makes it possible to disable data use terms (DUT) for the whole Loculus instance with a switch in the `values.yaml`. This disables DUT-related features and components in various places in the front- and backend (outline below). In the database, all submissions are treated as `OPEN`.

The new config setting is `dataUseTerms.enabled`(boolean). It is currently _required_. (which is **breaking** because you need to add it and set it to either true or false).

Furthermore, `dataUseTermsUrls` have been moved to `dataUseTerms.urls` (**breaking**).

Full config example:

```yaml

dataUseTerms:
  enabled: true
  urls:
    open: https://#TODO-MVP/open
    restricted: https://#TODO-MVP/restricted
```

Frontend changes:
- DUT elements removed on the submit dialog.
- 'bulk edit data use terms' removed on the 'released' page.
- DUT note removed on the API documentation page.
- DUT elements removed from the Download dialog.

Backend changes:
- When DUT are disabled, they do not need to be submitted to the `submit` endpoint
- When DUT are disabled, the DUT-related fields will not be returned by the `get-released-data` endpoint.

#### Testing 
- Frontend
  - Added a test that submission is possible when DUT is disabled
  - Added tests to check that the Download dialog doesn't have the DUT-components
- backend - add a new config to load, disabling the data use terms
  - Add a test that the DUT related things are not returned by get-released-data
  - Test that the submit endpoint can be called without the DUT type now (if disabled) and test that an error is raised if it is omitted but is required.
- e2e/integration: Since we cannot dynamically change the values.yaml config, we cannot do any tests at that level.

### Screenshot
The submission dialog without the DUT elements:
![image](https://github.com/user-attachments/assets/7680659a-540a-47a2-99e3-d6a62af9047d)

The download dialog without the DUT elements:
<img width="785" alt="image" src="https://github.com/user-attachments/assets/8868bb50-0ccf-4e19-a3f5-0980376f409f" />

The API docs don't mention the DUT anmore:
<img width="964" alt="image" src="https://github.com/user-attachments/assets/6f5f01b1-8fd6-424a-97dd-fb9e08370c1b" />

New docs page:
<img width="817" alt="image" src="https://github.com/user-attachments/assets/d09fc6a3-d267-4ede-9371-ccec45b5155c" />


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.

---

Discussion about config structure: https://loculus.slack.com/archives/C05G172HL6L/p1738166112981629
