### PR TITLE
fix: false positive test 'notSearchable' test

### DIFF
--- a/website/src/components/SearchPage/SearchFullUI.spec.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.spec.tsx
@@ -168,9 +168,9 @@ describe('SearchFullUI', () => {
     it('should not render the form with fields with flag notSearchable', () => {
         renderSearchFullUI({
             searchFormFilters: [
-                ...defaultSearchFormFilters,
                 {
                     name: 'NotSearchable',
+                    label: 'Not searchable',
                     type: 'string',
                     autocomplete: false,
                     notSearchable: true,
@@ -180,7 +180,7 @@ describe('SearchFullUI', () => {
         });
 
         expect(screen.getByLabelText('Accession')).toBeInTheDocument();
-        expect(screen.queryByLabelText('NotSearchable')).not.toBeInTheDocument();
+        expect(screen.queryByLabelText('Not searchable')).not.toBeInTheDocument();
     });
 
     it('should display timestamp field', () => {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #3326

### Summary
- The test failed because it searched for the search field by `name`, but the if the `label` is not given, the sentence case of the name is used. That's why the query returned no results, but the search field was actually there.
- The test now has the label set explicitly.