### PR TITLE
argocd: replace all '.' in branch names with '-' for preview URLs

### DIFF
--- a/kubernetes/appset.yaml
+++ b/kubernetes/appset.yaml
@@ -24,23 +24,23 @@ spec:
   goTemplate: true
   template:
     metadata:
-      name: pp-{{ (printf "%.25s" .branch) | replace "_" "-" | replace "/" "-" | trimSuffix "-" | lower }}-{{.number}}
+      name: pp-{{ (printf "%.25s" .branch) | replace "_" "-" | replace "/" "-" | replace "." "-" | trimSuffix "-" | lower }}-{{.number}}
     spec:
       destination:
-        namespace: prev-{{ (printf "%.25s" .branch) | replace "_" "-" | replace "/" "-" | trimSuffix "-" | lower  }}
+        namespace: prev-{{ (printf "%.25s" .branch) | replace "_" "-" | replace "/" "-" | replace "." "-" | trimSuffix "-" | lower  }}
         server: https://kubernetes.default.svc
       project: default
       source:
         helm:
           parameters:
             - name: shortbranch
-              value: '{{ (printf "%.25s" .branch) | replace "_" "-" | replace "/" "-" | trimSuffix "-" | lower  }}'
+              value: '{{ (printf "%.25s" .branch) | replace "_" "-" | replace "/" "-" | replace "." "-"  | trimSuffix "-" | lower  }}'
             - name: sha
               value: '{{.head_short_sha_7}}'
             - name: branch
               value: '{{.branch}}'
             - name: host
-              value: '{{ (printf "%.25s" .branch) | replace "_" "-" | replace "/" "-" | trimSuffix "-" | lower  }}.loculus.org'
+              value: '{{ (printf "%.25s" .branch) | replace "_" "-" | replace "/" "-" | replace "." "-"  | trimSuffix "-" | lower  }}.loculus.org'
           valueFiles:
             - values.yaml
             - values_preview_server.yaml


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves preview not showing up in https://github.com/loculus-project/loculus/pull/3529

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

I opened the PR to update SILO with a branch containing the version number `0.5.0`. This prevented argocd to spin up a preview instance with the following error:

![image](https://github.com/user-attachments/assets/ab04332b-4104-4b47-9330-6cb6f67746ed)

...while dots in branch names are arguably a bad idea in general, we already have special logic in place to replace many other characters, therefore, I think it is worthwhile to also add this case. In case someone else does the same mistake in the future it will not clutter our PRs as it is not possible to change the branch of a PR. (I would need to close the PR and open a new one, adding noise to our closed PR list)



### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
