### PR TITLE
Make it possible to hide fields from the table

### DIFF
--- a/docs/src/content/docs/reference/helm-chart-config.mdx
+++ b/docs/src/content/docs/reference/helm-chart-config.mdx
@@ -815,6 +815,12 @@ Each organism object has the following fields:
             <td>If true, hides the field on the sequence details page.</td>
         </tr>
         <tr>
+            <td>`hideInSearchResultsTable`</td>
+            <td>Boolean</td>
+            <td></td>
+            <td>If true, hides the field in the search results table (and makes it impossible to show).</td>
+        </tr>
+        <tr>
             <td>`perSegment`</td>
             <td>Boolean</td>
             <td></td>

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -212,6 +212,9 @@ organisms:
   {{- if .initiallyVisible }}
   initiallyVisible: {{ .initiallyVisible }}
   {{- end }}
+  {{- if hasKey . "isDisplayableInTable" }}
+  isDisplayableInTable: {{ .isDisplayableInTable }}
+  {{- end }}
   {{- if or (or (eq .type "timestamp") (eq .type "date")) .rangeSearch }}
   rangeSearch: true
   {{- end }}

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -212,8 +212,8 @@ organisms:
   {{- if .initiallyVisible }}
   initiallyVisible: {{ .initiallyVisible }}
   {{- end }}
-  {{- if hasKey . "isDisplayableInTable" }}
-  isDisplayableInTable: {{ .isDisplayableInTable }}
+  {{- if .hideInSearchResultsTable }}
+  hideInSearchResultsTable: {{ .hideInSearchResultsTable }}
   {{- end }}
   {{- if or (or (eq .type "timestamp") (eq .type "date")) .rangeSearch }}
   rangeSearch: true

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1325,6 +1325,11 @@ defaultOrganisms:
           required: true
           type: string
           lineageSystem: pangoLineage
+        - name: hiddenField
+          displayName: "Hidden Field"
+          initiallyVisible: false
+          type: string
+          hideInSearchResultsTable: true
       website:
         tableColumns:
           - country

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -86,6 +86,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Collection date (lower bound)
         type: date
         initiallyVisible: true
+        isDisplayableInTable: false
         header: Sample details
         preprocessing:
           function: parse_date_into_range
@@ -103,6 +104,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Collection date (upper bound)
         type: date
         initiallyVisible: true
+        isDisplayableInTable: false
         header: Sample details
         preprocessing:
           function: parse_date_into_range

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -86,7 +86,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Collection date (lower bound)
         type: date
         initiallyVisible: true
-        isDisplayableInTable: false
+        hideInSearchResultsTable: true
         header: Sample details
         preprocessing:
           function: parse_date_into_range
@@ -104,7 +104,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Collection date (upper bound)
         type: date
         initiallyVisible: true
-        isDisplayableInTable: false
+        hideInSearchResultsTable: true
         header: Sample details
         preprocessing:
           function: parse_date_into_range

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -46,6 +46,7 @@ export const metadata = z.object({
     type: metadataPossibleTypes,
     autocomplete: z.boolean().optional(),
     notSearchable: z.boolean().optional(),
+    isDisplayableInTable: z.boolean().optional(),
     customDisplay: customDisplay.optional(),
     truncateColumnDisplayTo: z.number().optional(),
     initiallyVisible: z.boolean().optional(),

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -46,7 +46,7 @@ export const metadata = z.object({
     type: metadataPossibleTypes,
     autocomplete: z.boolean().optional(),
     notSearchable: z.boolean().optional(),
-    isDisplayableInTable: z.boolean().optional(),
+    hideInSearchResultsTable: z.boolean().optional(),
     customDisplay: customDisplay.optional(),
     truncateColumnDisplayTo: z.number().optional(),
     initiallyVisible: z.boolean().optional(),

--- a/website/src/utils/search.ts
+++ b/website/src/utils/search.ts
@@ -97,7 +97,7 @@ export const getFieldVisibilitiesFromQuery = (schema: Schema, state: Record<stri
 
 export const getColumnVisibilitiesFromQuery = (schema: Schema, state: Record<string, string>): Map<string, boolean> => {
     const initiallyVisibleAccessor: InitialVisibilityAccessor = (field) => schema.tableColumns.includes(field.name);
-    const isFieldSelectable: VisiblitySelectableAccessor = (field) => field.isDisplayableInTable ?? true;
+    const isFieldSelectable: VisiblitySelectableAccessor = (field) => !(field.hideInSearchResultsTable ?? false);
     return getFieldOrColumnVisibilitiesFromQuery(
         schema,
         state,

--- a/website/src/utils/search.ts
+++ b/website/src/utils/search.ts
@@ -97,9 +97,7 @@ export const getFieldVisibilitiesFromQuery = (schema: Schema, state: Record<stri
 
 export const getColumnVisibilitiesFromQuery = (schema: Schema, state: Record<string, string>): Map<string, boolean> => {
     const initiallyVisibleAccessor: InitialVisibilityAccessor = (field) => schema.tableColumns.includes(field.name);
-    // hacky, fix later -- https://github.com/loculus-project/loculus/issues/3325
-    const isFieldSelectable: VisiblitySelectableAccessor = (field) =>
-        field.name !== 'sampleCollectionDateRangeUpper' && field.name !== 'sampleCollectionDateRangeLower';
+    const isFieldSelectable: VisiblitySelectableAccessor = (field) => field.isDisplayableInTable ?? true;
     return getFieldOrColumnVisibilitiesFromQuery(
         schema,
         state,
@@ -110,7 +108,7 @@ export const getColumnVisibilitiesFromQuery = (schema: Schema, state: Record<str
 };
 
 export const getMetadataSchemaWithExpandedRanges = (metadataSchema: Metadata[]): MetadataFilter[] => {
-    const result = [];
+    const result: MetadataFilter[] = [];
     for (const field of metadataSchema) {
         if (field.rangeOverlapSearch) {
             const fieldGroupProps = {

--- a/website/tests/pages/search/index.spec.ts
+++ b/website/tests/pages/search/index.spec.ts
@@ -156,5 +156,5 @@ test.describe('The search page', () => {
         void page.getByText('Toggle the visibility of columns').waitFor();
         void expect(page.getByRole('checkbox', { name: 'Pango lineage' })).toBeVisible();
         void expect(page.getByRole('checkbox', { name: 'Hidden Field' })).not.toBeVisible();
-    })
+    });
 });

--- a/website/tests/pages/search/index.spec.ts
+++ b/website/tests/pages/search/index.spec.ts
@@ -149,4 +149,12 @@ test.describe('The search page', () => {
 
         expect(filePath).toBeTruthy();
     });
+
+    test('should show visible columns and hide others in the customization modal', async ({ searchPage, page }) => {
+        await searchPage.goto();
+        await page.getByText('Customize columns').click();
+        void page.getByText('Toggle the visibility of columns').waitFor();
+        void expect(page.getByRole('checkbox', { name: 'Pango lineage' })).toBeVisible();
+        void expect(page.getByRole('checkbox', { name: 'Hidden Field' })).not.toBeVisible();
+    })
 });


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #3325 

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: http://column-hiding.loculus.org

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
- Adds a new metadata config setting: `hideInSearchResultsTable` which you can set to hide a column in the Column visibility dialog.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->
Nothing to see really.

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- ~~The implemented feature is covered by an appropriate test.~~
