### PR TITLE
Remove silo preprocessing_config_merged

### DIFF
--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -5,8 +5,6 @@ set -e
 root_dir=""
 last_etag=""
 lineage_definition_file=/preprocessing/input/lineage_definitions.yaml
-preprocessing_config_file=preprocessing_config.yaml
-preprocessing_config_file_merged=preprocessing_config_merged.yaml
 
 # Parse command-line arguments
 usage() {
@@ -151,14 +149,9 @@ download_data() {
   echo
 }
 
-# Generate the preprocessing config file with the lineage file for the current pipeline version.
-# the lineage definition file needs to be downloaded first.
-prepare_preprocessing_config() {
-  rm -f $lineage_definition_file $preprocessing_config_file_merged
-
+download_lineage_definitions() {
   if [[ -z "$LINEAGE_DEFINITIONS" ]]; then
     echo "No LINEAGE_DEFINITIONS given, nothing to configure;"
-    cp $preprocessing_config_file $preprocessing_config_file_merged
     return
   fi
 
@@ -186,11 +179,6 @@ prepare_preprocessing_config() {
     echo "Multiple pipeline versions in data to import: $pipelineVersion"
     exit 1
   fi
-
-  # the lineage definition filename needs to be set in the config
-  # Once https://github.com/GenSpectrum/LAPIS-SILO/pull/633 is merged, it can be done as a commandline arg
-  cp $preprocessing_config_file $preprocessing_config_file_merged
-  echo -e "lineageDefinitionsFilename: \"$lineage_definition_file\"\n" >> $preprocessing_config_file_merged
 }
 
 preprocessing() {
@@ -203,7 +191,7 @@ preprocessing() {
   cp "$new_input_data_path" "$silo_input_data_path"
   
   set +e
-  time /app/silo preprocessing --preprocessing-config=$preprocessing_config_file_merged
+  time /app/silo preprocessing
   exit_code=$?
   set -e
 
@@ -274,7 +262,7 @@ main() {
   # cleanup at start in case we fail later
   cleanup_output_data
   download_data
-  prepare_preprocessing_config
+  download_lineage_definitions
   preprocessing
 
   echo "done"

--- a/kubernetes/loculus/templates/lapis-silo-database-config.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-database-config.yaml
@@ -4,7 +4,8 @@
 
 {{- range $key, $instance := (.Values.organisms | default .Values.defaultOrganisms) }}
 
-{{ $referenceGenomes:= include "loculus.generateReferenceGenome" $instance.referenceGenomes | fromYaml }}
+{{- $referenceGenomes:= include "loculus.generateReferenceGenome" $instance.referenceGenomes | fromYaml }}
+{{- $lineageSystem := $instance | include "loculus.lineageSystemForOrganism" }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -20,6 +21,9 @@ data:
   preprocessing_config.yaml: |
     ndjsonInputFilename: data.ndjson.zst
     referenceGenomeFilename: reference_genomes.json
+    {{- if $lineageSystem }}
+    lineageDefinitionsFilename: lineage_definitions.yaml
+    {{- end }}
 
   reference_genomes.json: |
     {{ $referenceGenomes | toJson }}


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves `TODO` in comment of `silo_import_job.sh`

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://tae-remove-silo-preproces.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

~SILO 0.5.0 has much better CLI support. We now use this to simplify some of the logic which was in place for the silo import job. This also removed a file template and accompanying docker file mount.~

It is cumbersome to decide whether to supply the lineageDefinitionsFilename or not, if we do it via CLI. Therefore, moving it to the template where the `preprocessing_config` is generated is a much simpler change. Also this lends itself for extensibility once more lineage definitions are supplied for the same organism

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
