### PR TITLE
feat(ingest): decrease memory usage of submission batching

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -36,14 +36,26 @@ if SEGMENTED:
         ALIGN = False
     if ALIGN:
         for segment in config["nucleotide_sequences"]:
-            if config.get("nextclade_dataset_server_map") and segment in config["nextclade_dataset_server_map"]:
-                dataset_server_map[segment] = config["nextclade_dataset_server_map"][segment]
+            if (
+                config.get("nextclade_dataset_server_map")
+                and segment in config["nextclade_dataset_server_map"]
+            ):
+                dataset_server_map[segment] = config["nextclade_dataset_server_map"][
+                    segment
+                ]
             else:
                 dataset_server_map[segment] = config.get("nextclade_dataset_server")
-            if config.get("nextclade_dataset_name_map") and segment in config["nextclade_dataset_name_map"]:
-                dataset_name_map[segment] = config["nextclade_dataset_name_map"][segment]
+            if (
+                config.get("nextclade_dataset_name_map")
+                and segment in config["nextclade_dataset_name_map"]
+            ):
+                dataset_name_map[segment] = config["nextclade_dataset_name_map"][
+                    segment
+                ]
             else:
-                dataset_name_map[segment] = config.get("nextclade_dataset_name") + "/" + segment
+                dataset_name_map[segment] = (
+                    config.get("nextclade_dataset_name") + "/" + segment
+                )
 
 if os.uname().sysname == "Darwin":
     # Don't use conda-forge unzip on macOS
@@ -205,37 +217,15 @@ if FILTER_FASTA_HEADERS:
             """
 
 
-if FILTER_FASTA_HEADERS:
-
-    rule filter_fasta_headers:
-        input:
-            sequences="results/sequences.fasta",
-            script="scripts/filter_sequences.py",
-            config="results/config.yaml",
-        output:
-            results="results/sequences_filtered.fasta",
-        params:
-            filter_fasta_headers=FILTER_FASTA_HEADERS,
-            log_level=LOG_LEVEL,
-        shell:
-            """
-            python {input.script} \
-            --input-seq {input.sequences} \
-            --output-seq {output.results} \
-            --log-level {params.log_level} \
-            --config-file {input.config} \
-            """
-
-
 if ALIGN:
 
     rule align:
         input:
             sequences=(
-            "results/sequences_filtered.fasta"
-            if FILTER_FASTA_HEADERS
-            else "results/sequences.fasta"
-        ),
+                "results/sequences_filtered.fasta"
+                if FILTER_FASTA_HEADERS
+                else "results/sequences.fasta"
+            ),
         output:
             results="results/nextclade_{segment}.tsv",
         params:
@@ -279,11 +269,12 @@ if ALIGN:
 
 
 if not ALIGN:
+
     rule download:
         output:
             results="results/minimzer.json",
         params:
-            minimizer=config.get("minimizer_index")
+            minimizer=config.get("minimizer_index"),
         shell:
             """
             curl -L -o {output.results} {params.minimizer}
@@ -507,7 +498,7 @@ rule sort_fasta:
 
 
 rule sort_metadata:
-    input: 
+    input:
         metadata="results/{basename}.tsv",
     output:
         sorted="results/{basename}_sorted.tsv",

--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -484,16 +484,14 @@ rule prepare_files:
 
 
 rule sort_fasta:
+    """Sort FASTA sequences by submissionId using two-pass to avoid memory issues"""
     input:
         sequences="results/{basename}.fasta",
     output:
         sorted="results/{basename}_sorted.fasta",
     shell:
         """
-        awk '/^>/ {{if (seq) print seq; seq=""; print; next}} {{seq = seq $0}} END {{if (seq) print seq}}' {input.sequences} | \
-        paste - - | \
-        sort -k1,1 | \
-        tr "\\t" "\\n" > {output.sorted}
+        seqkit sort -N --two-pass {input.sequences} > {output.sorted}
         """
 
 

--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -502,14 +502,30 @@ rule sort_fasta:
         awk '/^>/ {{if (seq) print seq; seq=""; print; next}} {{seq = seq $0}} END {{if (seq) print seq}}' {input.sequences} | \
         paste - - | \
         sort -k1,1 | \
-        tr "\t" "\n" > {output.sorted}
+        tr "\\t" "\\n" > {output.sorted}
+        """
+
+
+rule sort_metadata:
+    input: 
+        metadata="results/{basename}.tsv",
+    output:
+        sorted="results/{basename}_sorted.tsv",
+    shell:
+        """
+        columnNumber=$(awk -F'\\t' '{{for(i=1;i<=NF;i++) if($i=="submissionId") print i}}' {input.metadata});
+        if [ ${{columnNumber}} ]; then
+        (head -n 1 {input.metadata} && tail -n +2 {input.metadata} | sort -t$'\t' -k${{columnNumber}},${{columnNumber}}) > {output.sorted}
+        else
+        cat {input.metadata} > {output.sorted}
+        fi
         """
 
 
 rule submit:
     input:
         script="scripts/call_loculus.py",
-        metadata="results/submit_metadata.tsv",
+        metadata="results/submit_metadata_sorted.tsv",
         sequences="results/submit_sequences_sorted.fasta",
         config="results/config.yaml",
     output:
@@ -532,7 +548,7 @@ rule submit:
 rule revise:
     input:
         script="scripts/call_loculus.py",
-        metadata="results/revise_metadata.tsv",
+        metadata="results/revise_metadata_sorted.tsv",
         sequences="results/revise_sequences_sorted.fasta",
         config="results/config.yaml",
     output:
@@ -555,7 +571,7 @@ rule revise:
 rule regroup_and_revoke:
     input:
         script="scripts/call_loculus.py",
-        metadata="results/metadata_to_submit_prior_to_revoke.tsv",
+        metadata="results/metadata_to_submit_prior_to_revoke_sorted.tsv",
         sequences="results/sequences_to_submit_prior_to_revoke_sorted.fasta",
         map="results/to_revoke.json",
         config="results/config.yaml",

--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -204,7 +204,31 @@ if FILTER_FASTA_HEADERS:
             --config-file {input.config} \
             """
 
+
+if FILTER_FASTA_HEADERS:
+
+    rule filter_fasta_headers:
+        input:
+            sequences="results/sequences.fasta",
+            script="scripts/filter_sequences.py",
+            config="results/config.yaml",
+        output:
+            results="results/sequences_filtered.fasta",
+        params:
+            filter_fasta_headers=FILTER_FASTA_HEADERS,
+            log_level=LOG_LEVEL,
+        shell:
+            """
+            python {input.script} \
+            --input-seq {input.sequences} \
+            --output-seq {output.results} \
+            --log-level {params.log_level} \
+            --config-file {input.config} \
+            """
+
+
 if ALIGN:
+
     rule align:
         input:
             sequences=(
@@ -225,7 +249,6 @@ if ALIGN:
                 --server {params.dataset_server} \
                 --dataset-name {params.dataset_name} \
             """
-
 
     rule process_alignments:
         input:
@@ -254,6 +277,7 @@ if ALIGN:
             > {output.merged}
             """
 
+
 if not ALIGN:
     rule download:
         output:
@@ -267,7 +291,7 @@ if not ALIGN:
 
     rule nextclade_sort:
         input:
-            sequences= "results/sequences.fasta",
+            sequences="results/sequences.fasta",
             minimizer="results/minimzer.json",
         output:
             results="results/sort_results.tsv",
@@ -468,11 +492,25 @@ rule prepare_files:
         """
 
 
+rule sort_fasta:
+    input:
+        sequences="results/{basename}.fasta",
+    output:
+        sorted="results/{basename}_sorted.fasta",
+    shell:
+        """
+        awk '/^>/ {{if (seq) print seq; seq=""; print; next}} {{seq = seq $0}} END {{if (seq) print seq}}' {input.sequences} | \
+        paste - - | \
+        sort -k1,1 | \
+        tr "\t" "\n" > {output.sorted}
+        """
+
+
 rule submit:
     input:
         script="scripts/call_loculus.py",
         metadata="results/submit_metadata.tsv",
-        sequences="results/submit_sequences.fasta",
+        sequences="results/submit_sequences_sorted.fasta",
         config="results/config.yaml",
     output:
         submitted=touch("results/submitted"),
@@ -495,7 +533,7 @@ rule revise:
     input:
         script="scripts/call_loculus.py",
         metadata="results/revise_metadata.tsv",
-        sequences="results/revise_sequences.fasta",
+        sequences="results/revise_sequences_sorted.fasta",
         config="results/config.yaml",
     output:
         revised=touch("results/revised"),
@@ -518,7 +556,7 @@ rule regroup_and_revoke:
     input:
         script="scripts/call_loculus.py",
         metadata="results/metadata_to_submit_prior_to_revoke.tsv",
-        sequences="results/sequences_to_submit_prior_to_revoke.fasta",
+        sequences="results/sequences_to_submit_prior_to_revoke_sorted.fasta",
         map="results/to_revoke.json",
         config="results/config.yaml",
     output:

--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -491,11 +491,12 @@ rule sort_fasta:
         sorted="results/{basename}_sorted.fasta",
     shell:
         """
-        seqkit sort -N --two-pass {input.sequences} > {output.sorted}
+        seqkit sort -N --two-pass {input.sequences} | seqkit seq -w 0 > {output.sorted}
         """
 
 
 rule sort_metadata:
+    """Sort metadata by submissionId, keep header at top of file. If file is empty or submissionId column is missing, do nothing."""
     input:
         metadata="results/{basename}.tsv",
     output:

--- a/ingest/config/defaults.yaml
+++ b/ingest/config/defaults.yaml
@@ -71,3 +71,4 @@ approve_timeout_min: "25" # Cronjobs run every 30min, make approve stop before i
 db_username: postgres
 db_password: unsecure
 db_url: "jdbc:postgresql://127.0.0.1:5432/loculus"
+batch_chunk_size: 10000

--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -204,6 +204,7 @@ def post_fasta_batches(
     submission_id_chunk = []
     fasta_submission_id = None
     fasta_header = None
+    table_header = None
 
     sequences_output = ""
     metadata_output = ""
@@ -214,12 +215,17 @@ def post_fasta_batches(
     ):
         for record in metadata_file_stream:
             number_of_submissions += 1
-            metadata_output += record
             if number_of_submissions == 0:
                 # get column index of submissionId
                 print(record.split("\t"))
                 header_index = record.strip().split("\t").index("submissionId")
+                table_header = record
+                metadata_output += table_header
                 continue
+            if number_of_submissions > 1 and number_of_submissions % chunk_size == 1:
+                metadata_output += table_header
+
+            metadata_output += record
 
             metadata_submission_id = record.split("\t")[header_index].strip()
 

--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -186,8 +186,8 @@ def post_fasta_batches(
         batch_num = -(number_of_submissions // -chunk_size)  # ceiling division
         logger.info(f"Submitting batch {batch_num}")
 
-        metadata_in_memory = BytesIO(metadata_batch_output.encode("utf-8"))
-        fasta_in_memory = BytesIO(sequences_batch_output.encode("utf-8"))
+        metadata_in_memory = BytesIO("".join(metadata_batch_output).encode("utf-8"))
+        fasta_in_memory = BytesIO("".join(sequences_batch_output).encode("utf-8"))
 
         files = {
             "metadataFile": ("metadata.tsv", metadata_in_memory, "text/tab-separated-values"),
@@ -205,8 +205,8 @@ def post_fasta_batches(
     fasta_record_header = None
     metadata_header = None
 
-    sequences_batch_output = ""
-    metadata_batch_output = ""
+    sequences_batch_output = []
+    metadata_batch_output = []
 
     with (
         open(fasta_file, encoding="utf-8") as fasta_file_stream,
@@ -255,15 +255,14 @@ def post_fasta_batches(
                     break
 
                 # add to batch sequences output
-                sequences_batch_output += fasta_record_header
-                sequences_batch_output += line
+                sequences_batch_output.extend((fasta_record_header, line))
 
             if number_of_submissions % chunk_size == 0:
                 response = submit(
                     metadata_batch_output, sequences_batch_output, number_of_submissions
                 )
-                sequences_batch_output = ""
-                metadata_batch_output = ""
+                sequences_batch_output = []
+                metadata_batch_output = []
 
     if number_of_submissions % chunk_size != 0:
         # submit the last chunk

--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -177,8 +177,8 @@ def get_or_create_group_and_return_group_id(config: Config, allow_creation: bool
 
 @dataclass
 class BatchIterator:
-    current_fasta_submission_id: str | None
-    current_fasta_record: SeqIO.SeqRecord | None
+    current_fasta_submission_id: str | None = None
+    current_fasta_record: SeqIO.SeqRecord | None = None
 
     record_counter: int = 0
 

--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -177,12 +177,13 @@ def get_or_create_group_and_return_group_id(config: Config, allow_creation: bool
 
 @dataclass
 class BatchIterator:
-    record_counter: int = 0
     current_fasta_submission_id: str | None
     current_fasta_record: SeqIO.SeqRecord | None
 
-    metadata_header: str | None
-    submission_id_index: int | None  # index of submissionId in metadata header
+    record_counter: int = 0
+
+    metadata_header: str | None = None
+    submission_id_index: int | None = None  # index of submissionId in metadata header
 
     sequences_batch_output: list[str] = dataclasses.field(default_factory=list)
     metadata_batch_output: list[str] = dataclasses.field(default_factory=list)

--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -262,6 +262,8 @@ def post_fasta_batches(
                     metadata_output, sequences_output, number_of_submissions
                 )
                 submission_id_chunk = []
+                sequences_output = ""
+                metadata_output = ""
 
     if submission_id_chunk:
         # submit the last chunk

--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -179,7 +179,7 @@ def post_fasta_batches(
     metadata_file: str,
     config: Config,
     params: dict[str, str],
-    chunk_size=1000,
+    chunk_size=10000,
 ) -> requests.Response:
     """Chunks metadata files, joins with sequences and submits each chunk via POST."""
     sequences_output_file = "results/batch_sequences.fasta"
@@ -226,10 +226,10 @@ def post_fasta_batches(
             if number_of_submissions == 0:
                 # get column index of submissionId
                 print(record.split("\t"))
-                header_index = record.split("\t").index("submissionId")
+                header_index = record.strip().split("\t").index("submissionId")
                 continue
 
-            metadata_submission_id = record.split("\t")[header_index]
+            metadata_submission_id = record.split("\t")[header_index].strip()
 
             if fasta_submission_id and metadata_submission_id != fasta_submission_id:
                 msg = f"Fasta SubmissionId {fasta_submission_id} not in correct order in metadata"
@@ -316,7 +316,7 @@ def submit_or_revise(
     if mode == "submit":
         params["dataUseTermsType"] = "OPEN"
 
-    response = post_fasta_batches(url, sequences, metadata, config, params=params, chunk_size=60000)
+    response = post_fasta_batches(url, sequences, metadata, config, params=params, chunk_size=1000)
 
     return response.json()
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://stream-batching.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
The backend cannot handle submission of over 60k sequences at once, therefore they must be batched. I introduced batching in https://github.com/loculus-project/loculus/pull/3429 but my script required ingest to read both the sequences and metadata files into memory to merge the batches. This was very memory inefficient. 

I now switch to sorting the files using gnu-sort (which should even work for files that are larger than working memory) and then refactor my batching script to read in both metadata and sequence files line by line, creating batched files to be then submitted to the backend. 

### Testing
Use https://github.com/pathoplexus/pathoplexus/tree/main/data-integrity-tests/regression-testing and switch the URLs to this branch and main :-)
