### PR TITLE
chore(deployment): Change python3 to python in deploy.py

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import argparse
 import json
@@ -336,7 +336,7 @@ def generate_configs(from_live, live_host, enable_ena):
 
     run_command(
         [
-            "python3",
+            "python",
             "kubernetes/config-processor/config-processor.py",
             temp_dir_path,
             output_dir,


### PR DESCRIPTION
I always find myself having to make this change locally as I use conda environments and they don't change `python3`, just `python` to point to the right place. Seeing if (A) it passes CI [it does] (B) anyone objects to it.