### PR TITLE
fix(website): Don't propagate date parsing errors to concatenated fields

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -619,15 +619,11 @@ class ProcessingFunctions:
                         {"date": input_data[order[i]]}, output_field, input_fields
                     )
                     formatted_input_data.append("" if processed.datum is None else processed.datum)
-                    errors += processed.errors
-                    warnings += processed.warnings
                 elif type[i] == "timestamp":
                     processed = ProcessingFunctions.parse_timestamp(
                         {"timestamp": input_data[order[i]]}, output_field, input_fields
                     )
                     formatted_input_data.append("" if processed.datum is None else processed.datum)
-                    errors += processed.errors
-                    warnings += processed.warnings
                 elif order[i] in input_data:
                     formatted_input_data.append(
                         "" if input_data[order[i]] is None else input_data[order[i]]


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #3566 and partly https://github.com/loculus-project/loculus/issues/3460

We may want to make this configurable in some way in the future, but for now it addresses the issue that displayName gets referenced when there are date problems which is confusing to users.

When would this change potentially cause a problem: if an admin had a field that was only part of a concatenation, and not used as a standalone field, so the date parsing would never cause an error.

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://prop.loculus.org/

<img width="908" alt="image" src="https://github.com/user-attachments/assets/3afebcc7-1493-4b37-9414-63554ce46899" />


