### PR TITLE
feat(website): Use a row separator in the search table

### DIFF
--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -140,14 +140,14 @@ export const Table: FC<TableProps> = ({
                 <table className='min-w-full text-left border-collapse'>
                     <thead>
                         <tr className='border-gray-400 border-b mb-100'>
-                            <th className='px-2 py-3 md:pl-6 text-xs text-gray-500 cursor-pointer text-left'>
+                            <th className='px-2 py-2 md:pl-6 text-xs text-gray-500 cursor-pointer text-left'>
                                 {selectedSeqs.size > 0 && (
                                     <MaterialSymbolsClose className='inline w-3 h-3 mx-0.5' onClick={clearSelection} />
                                 )}
                             </th>
                             <th
                                 onClick={() => handleSort(primaryKey)}
-                                className='px-2 py-3 md:pl-6 text-xs font-medium tracking-wider text-gray-500 uppercase cursor-pointer text-left'
+                                className='px-2 py-2 md:pl-6 text-xs font-medium tracking-wider text-gray-500 uppercase cursor-pointer text-left'
                             >
                                 {capitalCase(primaryKey)} {orderBy.field === primaryKey && orderIcon}
                             </th>
@@ -155,7 +155,7 @@ export const Table: FC<TableProps> = ({
                                 <th
                                     key={c.field}
                                     onClick={() => handleSort(c.field)}
-                                    className='px-2 py-3 text-xs font-medium tracking-wider text-gray-500 uppercase cursor-pointer last:pr-6 text-left'
+                                    className='px-2 py-2 text-xs font-medium tracking-wider text-gray-500 uppercase cursor-pointer last:pr-6 text-left'
                                     style={{
                                         minWidth: getColumnWidthStyle(c.columnWidth),
                                     }}

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -169,7 +169,7 @@ export const Table: FC<TableProps> = ({
                         {data.map((row, index) => (
                             <tr
                                 key={index}
-                                className={`hover:bg-primary-100 border-gray-100 ${
+                                className={`hover:bg-primary-100 border-gray-100 border-b border-gray-200 ${
                                     row[primaryKey] === previewedSeqId ? 'bg-gray-200' : ''
                                 } cursor-pointer`}
                                 onClick={(e) => handleRowClick(e, row[primaryKey] as string)}

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -139,7 +139,9 @@ export const Table: FC<TableProps> = ({
             {data.length !== 0 ? (
                 <table className='min-w-full text-left border-collapse'>
                     <thead>
-                        <tr>
+                        <tr
+                        className="border-gray-300 border-b"
+                        >
                             <th className='px-2 py-3 md:pl-6 text-xs text-gray-500 cursor-pointer text-left'>
                                 {selectedSeqs.size > 0 && (
                                     <MaterialSymbolsClose className='inline w-3 h-3 mx-0.5' onClick={clearSelection} />
@@ -169,7 +171,7 @@ export const Table: FC<TableProps> = ({
                         {data.map((row, index) => (
                             <tr
                                 key={index}
-                                className={`hover:bg-primary-100 border-gray-100 border-b border-gray-200 ${
+                                className={`hover:bg-primary-100 border-b border-gray-200 ${
                                     row[primaryKey] === previewedSeqId ? 'bg-gray-200' : ''
                                 } cursor-pointer`}
                                 onClick={(e) => handleRowClick(e, row[primaryKey] as string)}

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -139,7 +139,7 @@ export const Table: FC<TableProps> = ({
             {data.length !== 0 ? (
                 <table className='min-w-full text-left border-collapse'>
                     <thead>
-                        <tr className='border-gray-300 border-b'>
+                        <tr className='border-gray-400 border-b mb-100'>
                             <th className='px-2 py-3 md:pl-6 text-xs text-gray-500 cursor-pointer text-left'>
                                 {selectedSeqs.size > 0 && (
                                     <MaterialSymbolsClose className='inline w-3 h-3 mx-0.5' onClick={clearSelection} />

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -139,9 +139,7 @@ export const Table: FC<TableProps> = ({
             {data.length !== 0 ? (
                 <table className='min-w-full text-left border-collapse'>
                     <thead>
-                        <tr
-                        className="border-gray-300 border-b"
-                        >
+                        <tr className='border-gray-300 border-b'>
                             <th className='px-2 py-3 md:pl-6 text-xs text-gray-500 cursor-pointer text-left'>
                                 {selectedSeqs.size > 0 && (
                                     <MaterialSymbolsClose className='inline w-3 h-3 mx-0.5' onClick={clearSelection} />

--- a/website/src/styles/base.scss
+++ b/website/src/styles/base.scss
@@ -68,9 +68,10 @@ a {
     display: table;
     border: none;
 }
-table,
-tr,
-td {
+
+.customTable table,
+.customTable tr,
+.customTable td {
     border: none;
     padding: 5px 0;
 }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://tablerowsep.loculus.org/ebola-sudan/search?


### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->


This PR adds separators between table rows on the search page. I think it looks quite a bit cleaner:

<img width="1302" alt="image" src="https://github.com/user-attachments/assets/0690c3ca-81ae-4077-a521-ab7e645edc85" />

In the process of implementing it I realised that we, I guess accidentally, basically disabled borders on all tables with hardcoded CSS. Therefore I've removed that. 
