### PR TITLE
feat(website): support HTML custom display of table entries

### DIFF
--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -244,6 +244,9 @@ organisms:
     {{- if .customDisplay.displayGroup }}
     displayGroup: {{ quote .customDisplay.displayGroup }}
     {{- end }}
+    {{- if .customDisplay.html }}
+    html: {{ .customDisplay.html }}
+    {{- end }}
   {{- end }}
 {{- end }}
 

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -168,6 +168,9 @@ defaultOrganismConfig: &defaultOrganismConfig
         guidance: Geo-coordinate longitude in decimal degree (WGS84) format, i.e. values in range -180 to 180, where positive values are east of the Prime Meridian.
       - name: geoLocCountry
         displayName: Collection country
+        customDisplay:
+          type: html
+          html: "<b>__value__</b>"
         generateIndex: true
         autocomplete: true
         initiallyVisible: true

--- a/website/src/components/SequenceDetailsPage/DataTableEntryValue.tsx
+++ b/website/src/components/SequenceDetailsPage/DataTableEntryValue.tsx
@@ -45,6 +45,13 @@ const CustomDisplayComponent: React.FC<Props> = ({ data, dataUseTermsHistory }) 
                         {value}
                     </a>
                 )}
+                {customDisplay?.type === 'html' && customDisplay.html !== undefined && (
+                    /* eslint-disable @typescript-eslint/naming-convention */
+                    <div
+                        dangerouslySetInnerHTML={{ __html: customDisplay.html.replace('__value__', value.toString()) }}
+                    />
+                    /* eslint-enable @typescript-eslint/naming-convention */
+                )}
                 {customDisplay?.type === 'dataUseTerms' && (
                     <>
                         {value} <DataUseTermsHistoryModal dataUseTermsHistory={dataUseTermsHistory} />

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -22,6 +22,7 @@ export const segmentedMutations = z.object({
 export const customDisplay = z.object({
     type: z.string(),
     url: z.string().optional(),
+    html: z.string().optional(),
     value: z.array(segmentedMutations).optional(),
     displayGroup: z.string().optional(),
 });


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://html-custom-display.loculus.org

### Summary

This adds a new type of custom display "html" that allows the maintainer to provide an HTML template to render a table entry.

Background: I'd like to use that to improve the display of the frequency JSONs [here](https://wise-loculus.genspectrum.org/seq/LOC_0000BEV.1).

To demonstrate the feature, the feature was used to make the country bold in the below screenshot.

### Screenshot

<img width="305" alt="image" src="https://github.com/user-attachments/assets/eb06b2f4-968f-4968-bf6c-33d85bb0f506" />


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~ Documentation is missing for the custom display feature and I propose adding it separately (#3574).
- ~~[ ] The implemented feature is covered by an appropriate test.~~ We don't have any tests for the other custom displays and I hope it's ok that we don't have one in this PR.
