### PR TITLE
feat(deposition): stream get-released-data in cronjob to avoid OOM

### DIFF
--- a/ena-submission/scripts/get_ena_submission_list.py
+++ b/ena-submission/scripts/get_ena_submission_list.py
@@ -2,6 +2,7 @@ import json
 import logging
 from pathlib import Path
 from typing import Any
+from collections.abc import Iterator
 
 import click
 from ena_deposition.config import Config, get_config
@@ -20,7 +21,10 @@ logging.basicConfig(
 
 
 def filter_for_submission(
-    config: Config, db_config: SimpleConnectionPool, entries: dict[str, str], organism: str
+    config: Config,
+    db_config: SimpleConnectionPool,
+    entries_iterator: Iterator[dict[str, Any]],
+    organism: str,
 ) -> dict[str, Any]:
     """
     Filter data in state APPROVED_FOR_RELEASE:
@@ -33,22 +37,23 @@ def filter_for_submission(
         (if users uploaded correctly this should not be needed)
     """
     data_dict: dict[str, Any] = {}
-    for key, item in entries.items():
-        accession, version = key.split(".")
-        if item["metadata"]["dataUseTerms"] != "OPEN":
+    for entry in entries_iterator:
+        key = entry["metadata"]["accessionVersion"]
+        accession, version = entry["metadata"]["accessionVersion"].split(".")
+        if entry["metadata"]["dataUseTerms"] != "OPEN":
             continue
-        if item["metadata"]["groupId"] == config.ingest_pipeline_submission_group:
+        if entry["metadata"]["groupId"] == config.ingest_pipeline_submission_group:
             continue
         if in_submission_table(db_config, {"accession": accession, "version": version}):
             continue
-        if any(item["metadata"].get(field, False) for field in config.ena_specific_metadata):
+        if any(entry["metadata"].get(field, False) for field in config.ena_specific_metadata):
             logger.warning(
                 f"Found sequence: {key} with ena-specific-metadata fields and not submitted by us "
                 f"or {config.ingest_pipeline_submission_group}. Potential user error: discarding sequence."
             )
             continue
-        item["organism"] = organism
-        data_dict[key] = item
+        entry["organism"] = organism
+        data_dict[key] = entry
     return data_dict
 
 

--- a/ena-submission/src/ena_deposition/call_loculus.py
+++ b/ena-submission/src/ena_deposition/call_loculus.py
@@ -140,8 +140,7 @@ def fetch_released_entries(config: Config, organism: str) -> Iterator[dict[str, 
 
     headers = {"Content-Type": "application/json"}
 
-    response = make_request(HTTPMethod.GET, url, config, headers=headers)
-    with requests.get(url, headers=headers, params=config.params, timeout=60) as response:
+    with requests.get(url, headers=headers, timeout=60) as response:
         response.raise_for_status()
         for line in response.iter_lines():
             full_json = json.loads(line)


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves https://github.com/loculus-project/loculus/issues/3602

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://fix-cronjob-memory.loculus.org/

### Summary

Instead of loading the whole released data into memory, we now process the ndjson line by line using a Python generator (pair programmed together with @corneliusroemer)

### Testing

I confirmed this sends notifications correctly on Loculus preview.