### PR TITLE
feat!(deployment): allow ena submission cronjob resources to be specified in values

### DIFF
--- a/kubernetes/loculus/templates/ena-submission-deployment.yaml
+++ b/kubernetes/loculus/templates/ena-submission-deployment.yaml
@@ -135,12 +135,7 @@ spec:
             - name: ena-submission
               image: "ghcr.io/loculus-project/ena-submission:{{ $dockerTag }}"
               imagePullPolicy: Always
-              resources:
-                requests:
-                  memory: "80Mi"
-                  cpu: "10m"
-                limits:
-                  memory: "10Gi"
+              {{- include "loculus.resources" (list "ena-submission-list-cronjob" $.Values) | nindent 12 }}
               env:
                 - name: EXTERNAL_METADATA_UPDATER_PASSWORD
                   valueFrom:

--- a/kubernetes/loculus/templates/ena-submission-deployment.yaml
+++ b/kubernetes/loculus/templates/ena-submission-deployment.yaml
@@ -135,7 +135,7 @@ spec:
             - name: ena-submission
               image: "ghcr.io/loculus-project/ena-submission:{{ $dockerTag }}"
               imagePullPolicy: Always
-              {{- include "loculus.resources" (list "ena-submission-list-cronjob" $.Values) | nindent 12 }}
+              {{- include "loculus.resources" (list "ena-submission-list-cronjob" $.Values) | nindent 14 }}
               env:
                 - name: EXTERNAL_METADATA_UPDATER_PASSWORD
                   valueFrom:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1704,6 +1704,12 @@ resources:
       cpu: "10m"
     limits:
       memory: "10Gi"
+  ena-submission-list-cronjob:
+    requests:
+      memory: "80Mi"
+      cpu: "10m"
+    limits:
+      memory: "10Gi"
   ingest:
     requests:
       memory: "1Gi"


### PR DESCRIPTION
preview URL: https://config-resources.loculus.org

### What's breaking

One should now specify an extra resource dict like this (if one uses ena-submission)

https://github.com/loculus-project/loculus/blob/805cebd1d0e5ac466ae93e5c9e40b46438fbd8cf/kubernetes/loculus/values.yaml#L1707-L1712

### Summary
Allow ENA submission cronjob resources to be configured through values.yaml, so we can give it more memory in production.