### PR TITLE
chore(deposition): Improve deposition logging with ruff suggestions

### DIFF
--- a/ena-submission/src/ena_deposition/__main__.py
+++ b/ena-submission/src/ena_deposition/__main__.py
@@ -13,6 +13,8 @@ from .upload_external_metadata_to_loculus import upload_external_metadata
 
 stop_event = threading.Event()
 
+logger = logging.getLogger(__name__)
+
 
 @click.command()
 @click.option(
@@ -35,12 +37,12 @@ def run(config_file, input_file):
     config: Config = get_config(config_file)
     logging.getLogger().setLevel(config.log_level)
     logging.getLogger("requests").setLevel(logging.INFO)
-    logging.info(f"Config: {config}")
+    logger.info(f"Config: {config}")
 
     global stop_event
 
     if input_file:
-        logging.info("Triggering submission from file")
+        logger.info("Triggering submission from file")
         trigger_submission_to_ena(config, stop_event, input_file=input_file)
 
     with concurrent.futures.ThreadPoolExecutor() as executor:

--- a/ena-submission/src/ena_deposition/call_loculus.py
+++ b/ena-submission/src/ena_deposition/call_loculus.py
@@ -140,13 +140,13 @@ def fetch_released_entries(config: Config, organism: str) -> Iterator[dict[str, 
 
     headers = {"Content-Type": "application/json"}
 
-    with requests.get(url, headers=headers, timeout=60) as response:
+    with requests.get(url, headers=headers, timeout=3600, stream=True) as response:
         response.raise_for_status()
         for line in response.iter_lines():
             full_json = json.loads(line)
             filtered_json = {
                 k: v
                 for k, v in full_json.items()
-                if k in ["metadata", "unalignedNucleotideSequences"]
+                if k in {"metadata", "unalignedNucleotideSequences"}
             }
             yield filtered_json

--- a/ena-submission/src/ena_deposition/call_loculus.py
+++ b/ena-submission/src/ena_deposition/call_loculus.py
@@ -10,6 +10,8 @@ import requests
 
 from .config import Config
 
+logger = logging.getLogger(__name__)
+
 
 def backend_url(config: Config) -> str:
     """Right strip the URL to remove trailing slashes"""
@@ -48,13 +50,15 @@ def make_request(  # noqa: PLR0913, PLR0917
     method: HTTPMethod,
     url: str,
     config: Config,
-    headers: dict[str, str] = {},
+    headers: dict[str, str] | None = None,
     params: dict[str, Any] | None = None,
     files: dict[str, Any] | None = None,
     json_body: dict[str, Any] | None = None,
     data: str | None = None,
 ) -> requests.Response:
     """Generic request function to handle repetitive tasks like fetching JWT and setting headers."""
+    if headers is None:
+        headers = {}
     jwt = get_jwt(config)
     headers["Authorization"] = f"Bearer {jwt}"
 
@@ -104,7 +108,7 @@ def submit_external_metadata(
 
     if not response.ok:
         msg = f"External metadata submission failed with: {response.status_code} - {response.text}"
-        logging.error(msg)
+        logger.error(msg)
         raise requests.exceptions.HTTPError(msg)
 
     return response
@@ -125,9 +129,10 @@ def get_group_info(config: Config, group_id: int) -> dict[str, Any]:
         entries = list(jsonlines.Reader(response.iter_lines()).iter())
     except jsonlines.Error as err:
         response_summary = response.text
-        if len(response_summary) > 100:
+        error_length_limit = 100
+        if len(response_summary) > error_length_limit:
             response_summary = response_summary[:50] + "\n[..]\n" + response_summary[-50:]
-        logging.error(f"Error decoding JSON from /groups/{group_id}: {response_summary}")
+        logger.error(f"Error decoding JSON from /groups/{group_id}: {response_summary}")
         raise ValueError from err
 
     return entries

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -34,6 +34,8 @@ from .ena_types import (
     XmlNone,
 )
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class ENAConfig:
@@ -165,7 +167,7 @@ def create_ena_project(config: ENAConfig, project_set: ProjectSet) -> CreationRe
         response = post_webin(config, xml)
     except requests.exceptions.RequestException as e:
         error_message = f"Request failed with exception: {e}."
-        logging.error(error_message)
+        logger.error(error_message)
         errors.append(error_message)
         return CreationResult(results=None, errors=errors, warnings=warnings)
 
@@ -173,7 +175,7 @@ def create_ena_project(config: ENAConfig, project_set: ProjectSet) -> CreationRe
         error_message = (
             f"Request failed with status:{response.status_code}. " f"Response: {response.text}."
         )
-        logging.warning(error_message)
+        logger.warning(error_message)
         errors.append(error_message)
         return CreationResult(result=None, errors=errors, warnings=warnings)
     try:
@@ -187,7 +189,7 @@ def create_ena_project(config: ENAConfig, project_set: ProjectSet) -> CreationRe
             raise requests.exceptions.RequestException
     except Exception as e:
         error_message = f"Response is in unexpected format: {e}. " f"Response: {response.text}."
-        logging.warning(error_message)
+        logger.warning(error_message)
         errors.append(error_message)
         return CreationResult(result=None, errors=errors, warnings=warnings)
     project_results = {
@@ -223,7 +225,7 @@ def create_ena_sample(config: ENAConfig, sample_set: SampleSetType) -> CreationR
         response = post_webin(config, xml)
     except requests.exceptions.RequestException as e:
         error_message = f"Request failed with exception: {e}."
-        logging.error(error_message)
+        logger.error(error_message)
         errors.append(error_message)
         return CreationResult(results=None, errors=errors, warnings=warnings)
 
@@ -232,7 +234,7 @@ def create_ena_sample(config: ENAConfig, sample_set: SampleSetType) -> CreationR
             f"Request failed with status:{response.status_code}. "
             f"Request: {response.request}, Response: {response.text}"
         )
-        logging.warning(error_message)
+        logger.warning(error_message)
         errors.append(error_message)
         return CreationResult(result=None, errors=errors, warnings=warnings)
     try:
@@ -251,7 +253,7 @@ def create_ena_sample(config: ENAConfig, sample_set: SampleSetType) -> CreationR
             f"Response is in unexpected format. "
             f"Request: {response.request}, Response: {response.text}"
         )
-        logging.warning(error_message)
+        logger.warning(error_message)
         errors.append(error_message)
         return CreationResult(result=None, errors=errors, warnings=warnings)
     sample_results = {
@@ -432,12 +434,12 @@ def create_manifest(
             f.write(f"MOLECULETYPE\t{manifest.moleculetype!s}\n")
         if manifest.authors:
             if not is_broker:
-                logging.error("Cannot set authors field for non broker")
+                logger.error("Cannot set authors field for non broker")
             else:
                 f.write(f"AUTHORS\t{manifest.authors}\n")
         if manifest.address:
             if not is_broker:
-                logging.error("Cannot set address field for non broker")
+                logger.error("Cannot set address field for non broker")
             else:
                 f.write(f"ADDRESS\t{manifest.address}\n")
 
@@ -484,7 +486,7 @@ def create_ena_assembly(
     errors = []
     warnings = []
     response = post_webin_cli(config, manifest_filename, center_name=center_name, test=test)
-    logging.info(response.stdout)
+    logger.info(response.stdout)
     if response.returncode != 0:
         error_message = (
             f"Request failed with status:{response.returncode}. "
@@ -496,16 +498,16 @@ def create_ena_assembly(
         ]
 
         if not matching_files:
-            logging.error(f"No files found in {validate_log_path}.")
+            logger.error(f"No files found in {validate_log_path}.")
         else:
             for file_path in matching_files:
-                logging.info(f"Matching file found: {file_path}")
+                logger.info(f"Matching file found: {file_path}")
                 try:
                     with open(file_path, "r") as file:
                         contents = file.read()
-                        logging.info(f"Contents of the file:\n{contents}")
+                        logger.info(f"Contents of the file:\n{contents}")
                 except Exception as e:
-                    logging.error(f"Error reading file {file_path}: {e}")
+                    logger.error(f"Error reading file {file_path}: {e}")
         errors.append(error_message)
         return CreationResult(result=None, errors=errors, warnings=warnings)
 
@@ -522,7 +524,7 @@ def create_ena_assembly(
             f"Response is in unexpected format. "
             f"Stdout: {response.stdout}, Stderr: {response.stderr}"
         )
-        logging.warning(error_message)
+        logger.warning(error_message)
         errors.append(error_message)
         return CreationResult(result=None, errors=errors, warnings=warnings)
     assembly_results = {
@@ -555,7 +557,7 @@ def get_ena_analysis_process(
         )
     except requests.exceptions.RequestException as e:
         error_message = f"Request failed with exception: {e}."
-        logging.error(error_message)
+        logger.error(error_message)
         errors.append(error_message)
         return CreationResult(results=None, errors=errors, warnings=warnings)
     if not response.ok:
@@ -563,7 +565,7 @@ def get_ena_analysis_process(
             f"ENA check failed with status:{response.status_code}. "
             f"Request: {response.request}, Response: {response.text}"
         )
-        logging.warning(error_message)
+        logger.warning(error_message)
         errors.append(error_message)
         return CreationResult(result=None, errors=errors, warnings=warnings)
     if response.text == "[]":
@@ -599,7 +601,7 @@ def get_ena_analysis_process(
             f"ENA Check returned errors or is in unexpected format. "
             f"Request: {response.request}, Response: {response.text}"
         )
-        logging.warning(error_message)
+        logger.warning(error_message)
         errors.append(error_message)
         return CreationResult(result=None, errors=errors, warnings=warnings)
     return CreationResult(result=assembly_results, errors=errors, warnings=warnings)
@@ -637,7 +639,7 @@ def get_chromsome_accessions(
         end_num = int(end[2:])
 
         if end_num - start_num != len(segment_order) - 1:
-            logging.error(
+            logger.error(
                 "Unexpected response format: chromosome does not have expected number of segments"
             )
             raise ValueError("Unexpected number of segments")
@@ -658,5 +660,5 @@ def get_chromsome_accessions(
                 return results
 
     except Exception as e:
-        logging.error(f"Error processing chromosome accessions: {str(e)}")
+        logger.error(f"Error processing chromosome accessions: {str(e)}")
         raise ValueError("Failed to process chromosome accessions") from e

--- a/ena-submission/src/ena_deposition/notifications.py
+++ b/ena-submission/src/ena_deposition/notifications.py
@@ -8,6 +8,8 @@ from datetime import datetime, timedelta
 import requests
 from slack_sdk import WebClient, web
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class SlackConfig:
@@ -76,15 +78,15 @@ def send_slack_notification(
     since slack_config.last_notification_sent.
     """
     if not slack_config.slack_hook:
-        logging.info("Could not find slack hook cannot send message")
+        logger.info("Could not find slack hook cannot send message")
         return
     if (
         not slack_config.last_notification_sent
         or time - timedelta(hours=time_threshold) > slack_config.last_notification_sent
     ):
-        logging.warning(comment)
+        logger.warning(comment)
         try:
             notify(slack_config, comment)
             slack_config.last_notification_sent = time
         except requests.exceptions.RequestException as e:
-            logging.error(f"Error sending slack notification: {e}")
+            logger.error(f"Error sending slack notification: {e}")


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Fixes ruff warning: https://docs.astral.sh/ruff/rules/root-logger-call/
Logs look the same as on main, and still include which file the log message comes from, e.g.:
```
21:29:26    DEBUG (upload_external_metadata_to_loculus.py: 190) - Checking for external metadata to upload to Loculus
21:29:26    DEBUG (    create_sample.py: 383) - Checking for samples to create
21:29:26    DEBUG (    create_sample.py: 159) - Found 0 entries in submission_table in status SUBMITTED_PROJECT
21:29:26    DEBUG (    create_sample.py: 211) - Found 0 entries in submission_table in status SUBMITTING_SAMPLE
21:29:26    DEBUG (    create_sample.py: 263) - Found 0 entries in sample_table in status READY
21:29:27    DEBUG (  create_assembly.py: 608) - Checking for assemblies to create
21:29:27    DEBUG (  create_assembly.py: 477) - Checking state in ENA
21:29:36    DEBUG (upload_external_metadata_to_loculus.py: 190) - Checking for external metadata to upload to Loculus
```

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
