### PR TITLE
Revert "chore(deps-dev): bump vite from 6.0.7 to 6.0.9 in /keycloak/keycloakify in the npm_and_yarn group"

### DIFF
--- a/keycloak/keycloakify/package.json
+++ b/keycloak/keycloakify/package.json
@@ -38,7 +38,7 @@
         "prettier": "3.4.2",
         "storybook": "^8.4.7",
         "typescript": "^5.2.2",
-        "vite": "^6.0.9"
+        "vite": "^6.0.7"
     },
     "engines": {
         "node": "^18.0.0 || >=20.0.0"

--- a/keycloak/keycloakify/yarn.lock
+++ b/keycloak/keycloakify/yarn.lock
@@ -3263,7 +3263,7 @@ __metadata:
     react-dom: "npm:^18.2.0"
     storybook: "npm:^8.4.7"
     typescript: "npm:^5.2.2"
-    vite: "npm:^6.0.9"
+    vite: "npm:^6.0.7"
   languageName: unknown
   linkType: soft
 
@@ -4402,9 +4402,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^6.0.9":
-  version: 6.0.11
-  resolution: "vite@npm:6.0.11"
+"vite@npm:^6.0.7":
+  version: 6.0.7
+  resolution: "vite@npm:6.0.7"
   dependencies:
     esbuild: "npm:^0.24.2"
     fsevents: "npm:~2.3.3"
@@ -4450,7 +4450,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10c0/a0537f9bf8d6ded740646a4aa44b8dbf442d3005e75f7b27e981ef6011f22d4759f5eb643a393c0ffb8d21e2f50fb5f774d3a53108fb96a10b0f83697e8efe84
+  checksum: 10c0/ae81047b4290a7206b9394a39a782d509e9610462e7946422ba22d5bc615b5a322c07e33d7bf9dd0b3312ec3f5c63353b725913d1519324bfdf539b4f1e03f52
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts loculus-project/loculus#3565 - testing to see if this fixes https://github.com/loculus-project/loculus/issues/3618