### PR TITLE
fix(website): avoid duplicated items in download url and respect choice to include old versions

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
@@ -40,7 +40,6 @@ export class DownloadUrlGenerator {
         params.set('downloadAsFile', 'true');
         params.set('downloadFileBasename', this.generateFilename(option.dataType));
 
-        console.log('option', option);
         excludedParams.add(VERSION_STATUS_FIELD);
         excludedParams.add(IS_REVOCATION_FIELD);
         if (!option.includeOldData) {

--- a/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
@@ -46,9 +46,7 @@ export class DownloadUrlGenerator {
         if (!option.includeOldData) {
             params.set(VERSION_STATUS_FIELD, versionStatuses.latestVersion);
             params.set(IS_REVOCATION_FIELD, 'false');
-
         }
-
 
         if (!option.includeRestricted) {
             params.set('dataUseTerms', 'OPEN');

--- a/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
@@ -35,29 +35,37 @@ export class DownloadUrlGenerator {
     public generateDownloadUrl(downloadParameters: SequenceFilter, option: DownloadOption) {
         const baseUrl = `${this.lapisUrl}${getEndpoint(option.dataType)}`;
         const params = new URLSearchParams();
-
+        const filteredParams = new Map(downloadParameters.toUrlSearchParams());
+    
         params.set('downloadAsFile', 'true');
         params.set('downloadFileBasename', this.generateFilename(option.dataType));
+    
         if (!option.includeOldData) {
             params.set(VERSION_STATUS_FIELD, versionStatuses.latestVersion);
             params.set(IS_REVOCATION_FIELD, 'false');
+            filteredParams.delete(VERSION_STATUS_FIELD);
+            filteredParams.delete(IS_REVOCATION_FIELD);
         }
+        
         if (!option.includeRestricted) {
             params.set('dataUseTerms', 'OPEN');
+            filteredParams.delete('dataUseTerms');
         }
+        
         if (option.dataType.type === 'metadata') {
             params.set('dataFormat', metadataDefaultDownloadDataFormat);
         }
+        
         if (option.compression !== undefined) {
             params.set('compression', option.compression);
         }
-
-        downloadParameters.toUrlSearchParams().forEach(([name, value]) => {
-            if (value.length && !params.has(name)) {
+    
+        filteredParams.forEach((value, name) => {
+            if (value.length > 0) {
                 params.append(name, value);
             }
         });
-
+    
         return {
             url: `${baseUrl}?${params}`,
             baseUrl,

--- a/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
@@ -40,12 +40,15 @@ export class DownloadUrlGenerator {
         params.set('downloadAsFile', 'true');
         params.set('downloadFileBasename', this.generateFilename(option.dataType));
 
+        console.log('option', option);
+        excludedParams.add(VERSION_STATUS_FIELD);
+        excludedParams.add(IS_REVOCATION_FIELD);
         if (!option.includeOldData) {
             params.set(VERSION_STATUS_FIELD, versionStatuses.latestVersion);
             params.set(IS_REVOCATION_FIELD, 'false');
-            excludedParams.add(VERSION_STATUS_FIELD);
-            excludedParams.add(IS_REVOCATION_FIELD);
+
         }
+
 
         if (!option.includeRestricted) {
             params.set('dataUseTerms', 'OPEN');

--- a/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
@@ -60,7 +60,8 @@ export class DownloadUrlGenerator {
             params.set('compression', option.compression);
         }
 
-        downloadParameters.toUrlSearchParams()
+        downloadParameters
+            .toUrlSearchParams()
             .filter(([name]) => !excludedParams.has(name))
             .forEach(([name, value]) => {
                 if (value.length > 0) {

--- a/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
@@ -53,7 +53,7 @@ export class DownloadUrlGenerator {
         }
 
         downloadParameters.toUrlSearchParams().forEach(([name, value]) => {
-            if (value.length > 0) {
+            if (value.length && !params.has(name)) {
                 params.append(name, value);
             }
         });

--- a/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
@@ -55,7 +55,6 @@ export class DownloadUrlGenerator {
         if (option.dataType.type === 'metadata') {
             params.set('dataFormat', metadataDefaultDownloadDataFormat);
         }
-
         if (option.compression !== undefined) {
             params.set('compression', option.compression);
         }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #3626

We ended up with duplicate parameters in our download URL - because they were being set both from the download form and from the original search query. Now we overwrite the original search query with whatever is in the form. It's possible that previously we were not actually respecting the form about open data - depending how LAPIS processed duplicate entries. Also we were not respecting the choice about including old versions.

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: http://dupe.loculus.org (no sequences due to ingest issues currently, but you can check the download URLs)
