### PR TITLE
feat(website): Make all metadata sections in format page expanded by default

### DIFF
--- a/website/src/components/OrganismMetadataTable/OrganismMetadataTable.tsx
+++ b/website/src/components/OrganismMetadataTable/OrganismMetadataTable.tsx
@@ -59,10 +59,10 @@ const MetadataTable: FC<TableProps> = ({ fields, metadata }) => {
         <table className='table-auto border-collapse border border-gray-200 w-full'>
             <thead>
                 <tr>
-                    <th className='border border-gray-300 px-4 py-2 w-[20%]'>Field Name</th>
+                    <th className='border border-gray-300 px-4 py-2 w-[25%]'>Field Name</th>
                     <th className='border border-gray-300 px-4 py-2 w-[13%]'>Type</th>
                     <th className='border border-gray-300 px-4 py-2 w-[37%]'>Description</th>
-                    <th className='border border-gray-300 px-4 py-2 w-[30%]'>Example</th>
+                    <th className='border border-gray-300 px-4 py-2 w-[25%]'>Example</th>
                 </tr>
             </thead>
             <tbody>

--- a/website/src/components/OrganismMetadataTable/OrganismMetadataTable.tsx
+++ b/website/src/components/OrganismMetadataTable/OrganismMetadataTable.tsx
@@ -10,7 +10,9 @@ type Props = {
 };
 
 export const OrganismMetadataTable: FC<Props> = ({ organism }) => {
-    const [expandedHeaders, setExpandedHeaders] = useState<Set<string>>(new Set(Array.from(organism.groupedInputFields.keys())));
+    const [expandedHeaders, setExpandedHeaders] = useState<Set<string>>(
+        new Set(Array.from(organism.groupedInputFields.keys())),
+    );
 
     const toggleHeader = (header: string) => {
         const updatedExpandedHeaders = new Set(expandedHeaders);

--- a/website/src/components/OrganismMetadataTable/OrganismMetadataTable.tsx
+++ b/website/src/components/OrganismMetadataTable/OrganismMetadataTable.tsx
@@ -12,7 +12,7 @@ type Props = {
 export const OrganismMetadataTable: FC<Props> = ({ organism }) => {
     const [expandedHeaders, setExpandedHeaders] = useState<Set<string>>(
         new Set(Array.from(organism.groupedInputFields.keys())),
-    ); 
+    );
 
     const toggleHeader = (header: string) => {
         const updatedExpandedHeaders = new Set(expandedHeaders);

--- a/website/src/components/OrganismMetadataTable/OrganismMetadataTable.tsx
+++ b/website/src/components/OrganismMetadataTable/OrganismMetadataTable.tsx
@@ -10,6 +10,7 @@ type Props = {
 };
 
 export const OrganismMetadataTable: FC<Props> = ({ organism }) => {
+
     const [expandedHeaders, setExpandedHeaders] = useState<Set<string>>(
         new Set(Array.from(organism.groupedInputFields.keys())),
     );

--- a/website/src/components/OrganismMetadataTable/OrganismMetadataTable.tsx
+++ b/website/src/components/OrganismMetadataTable/OrganismMetadataTable.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 export const OrganismMetadataTable: FC<Props> = ({ organism }) => {
-    const [expandedHeaders, setExpandedHeaders] = useState<Set<string>>(new Set(['Required fields', 'Desired fields']));
+    const [expandedHeaders, setExpandedHeaders] = useState<Set<string>>(new Set(Array.from(organism.groupedInputFields.keys())));
 
     const toggleHeader = (header: string) => {
         const updatedExpandedHeaders = new Set(expandedHeaders);

--- a/website/src/components/OrganismMetadataTable/OrganismMetadataTable.tsx
+++ b/website/src/components/OrganismMetadataTable/OrganismMetadataTable.tsx
@@ -12,7 +12,7 @@ type Props = {
 export const OrganismMetadataTable: FC<Props> = ({ organism }) => {
     const [expandedHeaders, setExpandedHeaders] = useState<Set<string>>(
         new Set(Array.from(organism.groupedInputFields.keys())),
-    );
+    ); 
 
     const toggleHeader = (header: string) => {
         const updatedExpandedHeaders = new Set(expandedHeaders);

--- a/website/src/components/OrganismMetadataTable/OrganismMetadataTable.tsx
+++ b/website/src/components/OrganismMetadataTable/OrganismMetadataTable.tsx
@@ -10,7 +10,6 @@ type Props = {
 };
 
 export const OrganismMetadataTable: FC<Props> = ({ organism }) => {
-
     const [expandedHeaders, setExpandedHeaders] = useState<Set<string>>(
         new Set(Array.from(organism.groupedInputFields.keys())),
     );


### PR DESCRIPTION
Otherwise searching is really hard
https://expanded.loculus.org/ebola-sudan/submission/metadataformat

https://loculus.slack.com/archives/C061ZQQM3N1/p1738851331300799

Stop gap while we consider other options

Also expands the width of the name column to avoid too much wrapping