### PR TITLE
add support for NCBI gateway URL

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -96,7 +96,7 @@ rule fetch_ncbi_dataset_package:
             --no-progressbar \
             --filename {output.dataset_package} \
             --api-key {params.api_key} \
-            {f'--gateway-url {params.gateway_url}' if params.gateway_url else ''}\
+            {('--gateway-url ' + params.gateway_url) if params.gateway_url else ''}
         """
 
 

--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -23,6 +23,7 @@ TAXON_ID = config["taxon_id"]
 SEGMENTED = config["segmented"]
 LOG_LEVEL = config.get("log_level", "INFO")
 NCBI_API_KEY = os.getenv("NCBI_API_KEY")
+NCBI_GATEWAY_URL = config.get("ncbi_gateway_url")
 FILTER_FASTA_HEADERS = config.get("filter_fasta_headers", None)
 APPROVE_TIMEOUT_MIN = config.get("approve_timeout_min")  # time in minutes
 CHECK_ENA_DEPOSITION = config.get("check_ena_deposition", False)
@@ -88,12 +89,14 @@ rule fetch_ncbi_dataset_package:
     params:
         taxon_id=TAXON_ID,
         api_key=NCBI_API_KEY,
+        gateway_url=NCBI_GATEWAY_URL,
     shell:
         """
         datasets download virus genome taxon {params.taxon_id} \
             --no-progressbar \
             --filename {output.dataset_package} \
-            --api-key {params.api_key}\
+            --api-key {params.api_key} \
+            {f'--gateway-url {params.gateway_url}' if params.gateway_url else ''}\
         """
 
 

--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -89,14 +89,14 @@ rule fetch_ncbi_dataset_package:
     params:
         taxon_id=TAXON_ID,
         api_key=NCBI_API_KEY,
-        gateway_url=NCBI_GATEWAY_URL,
+        gateway=f'--gateway-url {NCBI_GATEWAY_URL}' if NCBI_GATEWAY_URL else '',
     shell:
         """
         datasets download virus genome taxon {params.taxon_id} \
             --no-progressbar \
             --filename {output.dataset_package} \
             --api-key {params.api_key} \
-            {('--gateway-url ' + params.gateway_url) if params.gateway_url else ''}
+            {params.gateway}
         """
 
 

--- a/kubernetes/loculus/templates/ingest-config.yaml
+++ b/kubernetes/loculus/templates/ingest-config.yaml
@@ -20,7 +20,7 @@ data:
     organism: {{ $key }}
     backend_url: {{ $backendHost }}
     keycloak_token_url: {{ $keycloakHost -}}/realms/loculus/protocol/openid-connect/token
-    {{- if $.Values.ncbiGatewayUrl }}
+    {{- if $.Values.ingest.ncbiGatewayUrl }}
     ncbi_gateway_url: {{ $.Values.ingest.ncbiGatewayUrl }}
     {{- end }}
     {{- include "loculus.ingestRename" $metadata | nindent 4 }}

--- a/kubernetes/loculus/templates/ingest-config.yaml
+++ b/kubernetes/loculus/templates/ingest-config.yaml
@@ -21,7 +21,7 @@ data:
     backend_url: {{ $backendHost }}
     keycloak_token_url: {{ $keycloakHost -}}/realms/loculus/protocol/openid-connect/token
     {{- if $.Values.ncbiGatewayUrl }}
-    ncbi_gateway_url: {{ $.Values.ncbiGatewayUrl }}
+    ncbi_gateway_url: {{ $.Values.ingest.ncbiGatewayUrl }}
     {{- end }}
     {{- include "loculus.ingestRename" $metadata | nindent 4 }}
     insdc_segment_specific_fields:

--- a/kubernetes/loculus/templates/ingest-config.yaml
+++ b/kubernetes/loculus/templates/ingest-config.yaml
@@ -20,6 +20,9 @@ data:
     organism: {{ $key }}
     backend_url: {{ $backendHost }}
     keycloak_token_url: {{ $keycloakHost -}}/realms/loculus/protocol/openid-connect/token
+    {{- if $.Values.ncbiGatewayUrl }}
+    ncbi_gateway_url: {{ $.Values.ncbiGatewayUrl }}
+    {{- end }}
     {{- include "loculus.ingestRename" $metadata | nindent 4 }}
     insdc_segment_specific_fields:
     {{- range $metadata }}

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1,6 +1,6 @@
 environment: server
 robotsNoindexHeader: false
-ncbiGatewayUrl: ""
+ncbiGatewayUrl: "https://ncbi-temp-proxy.api.taxonium.org/datasets/v2 "
 seqSets:
   enabled: true
   crossRef:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1,6 +1,5 @@
 environment: server
 robotsNoindexHeader: false
-ncbiGatewayUrl: "https://ncbi-temp-proxy.api.taxonium.org/datasets/v2"
 seqSets:
   enabled: true
   crossRef:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1,5 +1,6 @@
 environment: server
 robotsNoindexHeader: false
+ncbiGatewayUrl: ""
 seqSets:
   enabled: true
   crossRef:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1760,3 +1760,5 @@ defaultResources:
   limits:
     memory: "1Gi"
     cpu: "20m"
+ingest:
+  ncbiGatewayUrl: null

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1,6 +1,6 @@
 environment: server
 robotsNoindexHeader: false
-ncbiGatewayUrl: "https://ncbi-temp-proxy.api.taxonium.org/datasets/v2 "
+ncbiGatewayUrl: "https://ncbi-temp-proxy.api.taxonium.org/datasets/v2"
 seqSets:
   enabled: true
   crossRef:

--- a/kubernetes/loculus/values_preview_server.yaml
+++ b/kubernetes/loculus/values_preview_server.yaml
@@ -33,4 +33,5 @@ previewDocs: true
 robotsNoindexHeader: true
 disableEnaSubmission: false
 additionalHeadHTML: '<script defer data-domain="loculus.org" src="https://plausible.io/js/script.js"></script>'
-ncbiGatewayUrl: "https://ncbi-temp-proxy.api.taxonium.org/datasets/v2"
+ingest:
+  ncbiGatewayUrl: "https://ncbi-temp-proxy.api.taxonium.org/datasets/v2"

--- a/kubernetes/loculus/values_preview_server.yaml
+++ b/kubernetes/loculus/values_preview_server.yaml
@@ -33,3 +33,4 @@ previewDocs: true
 robotsNoindexHeader: true
 disableEnaSubmission: false
 additionalHeadHTML: '<script defer data-domain="loculus.org" src="https://plausible.io/js/script.js"></script>'
+ncbiGatewayUrl: "https://ncbi-temp-proxy.api.taxonium.org/datasets/v2"


### PR DESCRIPTION
https://support-gateay-url.loculus.org/

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #3629 for now

We are currently unable to connect from NCBI datasets from our Hetzner server

We add the capacity for NCBI datasets to be configured to receive an alternative gateway URL. Atm for our preview servers this is a proxy I am hosting on one of my servers. Hopefully if this causes our traffic to decrease we will get unblacklisted and we can move to a proxy hosted here at Loculus.
