### PR TITLE
feat(website): Improve scroll behaviour in search table

### DIFF
--- a/website/src/components/SearchPage/ScrollContainer.tsx
+++ b/website/src/components/SearchPage/ScrollContainer.tsx
@@ -28,7 +28,7 @@ const ScrollContainer: React.FC<ScrollContainerProps> = ({ children }) => {
 
             setMaxScroll(scrollWidth - clientWidth);
 
-            const computedTrackWidth = clientWidth * 0.95;
+            const computedTrackWidth = clientWidth - 40;
             setHandleWidth((clientWidth / scrollWidth) * computedTrackWidth);
 
             const computedLeft = rect.left + (clientWidth - computedTrackWidth) / 2;

--- a/website/src/components/SearchPage/ScrollContainer.tsx
+++ b/website/src/components/SearchPage/ScrollContainer.tsx
@@ -50,7 +50,7 @@ const ScrollContainer: React.FC<ScrollContainerProps> = ({ children }) => {
     setScrollLeft(e.currentTarget.scrollLeft);
   };
 
-  const onMouseDownHandle = (e: ReactMouseEvent<HTMLDivElement, MouseEvent>) => {
+  const onMouseDownHandle = (e: ReactMouseEvent) => {
     setDragging(true);
     setStartX(e.clientX);
     setStartScrollLeft(scrollLeft);

--- a/website/src/components/SearchPage/ScrollContainer.tsx
+++ b/website/src/components/SearchPage/ScrollContainer.tsx
@@ -132,36 +132,38 @@ const ScrollContainer: React.FC<ScrollContainerProps> = ({ children }) => {
         {children}
       </div>
 
-      {/* Custom scrollbar track: fixed so it is always visible on screen */}
-      <div
-        className="bg-gray-100"
-        style={{
-          position: 'fixed',
-          bottom: '4px',
-          left: `${trackStyle.left}px`,
-          width: `${trackStyle.width}px`,
-          height: '12px',
-          borderRadius: '6px',
-          zIndex: 1000,
-        }}
-      >
-        {/* The draggable handle */}
+      {/* Render the custom scrollbar only when there is overflow (maxScroll > 0) */}
+      {maxScroll > 0 && (
         <div
-          onMouseDown={onMouseDownHandle}
-          className="bg-gray-500"
+          className="bg-gray-100"
           style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            height: '100%',
-            width: `${handleWidth}px`,
+            position: 'fixed',
+            bottom: '4px',
+            left: `${trackStyle.left}px`,
+            width: `${trackStyle.width}px`,
+            height: '12px',
             borderRadius: '6px',
-            transform: `translateX(${handlePosition}px)`,
-            cursor: dragging ? 'grabbing' : 'grab',
-            transition: 'transform 75ms',
+            zIndex: 1000,
           }}
-        />
-      </div>
+        >
+          {/* The draggable handle */}
+          <div
+            onMouseDown={onMouseDownHandle}
+            className="bg-gray-500"
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              height: '100%',
+              width: `${handleWidth}px`,
+              borderRadius: '6px',
+              transform: `translateX(${handlePosition}px)`,
+              cursor: dragging ? 'grabbing' : 'grab',
+              transition: 'transform 75ms',
+            }}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/website/src/components/SearchPage/ScrollContainer.tsx
+++ b/website/src/components/SearchPage/ScrollContainer.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useRef, useState } from 'react';
+
+export default function ScrollContainer({ children }) {
+  const scrollRef = useRef(null);
+  const trackRef = useRef(null);
+  const [scrollLeft, setScrollLeft] = useState(0);
+  const [maxScroll, setMaxScroll] = useState(0);
+  const [handleWidth, setHandleWidth] = useState(0);
+  const [dragging, setDragging] = useState(false);
+  const [startX, setStartX] = useState(0);
+  const [startScrollLeft, setStartScrollLeft] = useState(0);
+
+  useEffect(() => {
+    function updateSizes() {
+      if (scrollRef.current && trackRef.current) {
+        const clientWidth = scrollRef.current.clientWidth;
+        const scrollWidth = scrollRef.current.scrollWidth;
+        setMaxScroll(scrollWidth - clientWidth);
+        const trackWidth = trackRef.current.offsetWidth;
+        setHandleWidth((clientWidth / scrollWidth) * trackWidth);
+      }
+    }
+    updateSizes();
+    window.addEventListener('resize', updateSizes);
+    return () => window.removeEventListener('resize', updateSizes);
+  }, []);
+
+  const handleScroll = (e) => {
+    setScrollLeft(e.target.scrollLeft);
+  };
+
+  const onMouseDownHandle = (e) => {
+    setDragging(true);
+    setStartX(e.clientX);
+    setStartScrollLeft(scrollLeft);
+    e.preventDefault();
+  };
+
+  const onMouseMove = (e) => {
+    if (!dragging) return;
+    if (scrollRef.current && trackRef.current) {
+      const trackWidth = trackRef.current.offsetWidth;
+      const clientWidth = scrollRef.current.clientWidth;
+      const scrollWidth = scrollRef.current.scrollWidth;
+      const maxScrollVal = scrollWidth - clientWidth;
+      const deltaX = e.clientX - startX;
+      const scrollDelta = (deltaX / (trackWidth - handleWidth)) * maxScrollVal;
+      scrollRef.current.scrollLeft = startScrollLeft + scrollDelta;
+    }
+  };
+
+  const onMouseUp = () => {
+    if (dragging) {
+      setDragging(false);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', onMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+    };
+  }, [dragging, startX, startScrollLeft, handleWidth]);
+
+  let handlePosition = 0;
+  if (trackRef.current && maxScroll > 0) {
+    const trackWidth = trackRef.current.offsetWidth;
+    handlePosition = (scrollLeft / maxScroll) * (trackWidth - handleWidth);
+  }
+
+  return (
+    <div>
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className="overflow-x-scroll"
+      >
+        {children}
+      </div>
+
+      <div
+        ref={trackRef}
+        className="fixed bottom-4 left-0 right-0 mx-auto"
+        style={{
+          width: '80%',
+          height: '12px',
+          backgroundColor: '#ccc',
+          borderRadius: '6px',
+        }}
+      >
+        <div
+          onMouseDown={onMouseDownHandle}
+          className="absolute top-0 left-0 h-full bg-blue-500 rounded"
+          style={{
+            width: `${handleWidth}px`,
+            transform: `translateX(${handlePosition}px)`,
+            cursor: dragging ? 'grabbing' : 'grab',
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/website/src/components/SearchPage/ScrollContainer.tsx
+++ b/website/src/components/SearchPage/ScrollContainer.tsx
@@ -1,11 +1,5 @@
-import React, {
-  useEffect,
-  useRef,
-  useState,
-  ReactNode,
-  MouseEvent as ReactMouseEvent,
-  UIEvent,
-} from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import type { ReactNode, MouseEvent as ReactMouseEvent, UIEvent } from 'react';
 
 interface ScrollContainerProps {
   children: ReactNode;
@@ -46,8 +40,7 @@ const ScrollContainer: React.FC<ScrollContainerProps> = ({ children }) => {
       // Set the maximum scroll (the difference between total and visible width)
       setMaxScroll(scrollWidth - clientWidth);
 
-      // Define the track width as 80% of the container’s width.
-      const computedTrackWidth = clientWidth * 0.8;
+      const computedTrackWidth = clientWidth * 0.95;
       // The handle’s width is proportional to the visible area.
       setHandleWidth((clientWidth / scrollWidth) * computedTrackWidth);
 
@@ -74,9 +67,7 @@ const ScrollContainer: React.FC<ScrollContainerProps> = ({ children }) => {
   };
 
   // When the user starts dragging the scrollbar handle.
-  const onMouseDownHandle = (
-    e: ReactMouseEvent<HTMLDivElement, MouseEvent>
-  ) => {
+  const onMouseDownHandle = (e: ReactMouseEvent<HTMLDivElement, MouseEvent>) => {
     setDragging(true);
     setStartX(e.clientX);
     setStartScrollLeft(scrollLeft);

--- a/website/src/components/SearchPage/ScrollContainer.tsx
+++ b/website/src/components/SearchPage/ScrollContainer.tsx
@@ -123,11 +123,11 @@ const ScrollContainer: React.FC<ScrollContainerProps> = ({ children }) => {
 
   return (
     <div>
-      {/* Scrollable content */}
+      {/* Scrollable content with hidden default scrollbars */}
       <div
         ref={scrollRef}
         onScroll={handleScroll}
-        className="overflow-x-scroll"
+        className="overflow-x-scroll hide-scrollbar"
       >
         {children}
       </div>

--- a/website/src/components/SearchPage/ScrollContainer.tsx
+++ b/website/src/components/SearchPage/ScrollContainer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
-export default function ScrollContainer({ children }) {
+const ScrollContainer = ({ children }) => {
   const scrollRef = useRef(null);
   const trackRef = useRef(null);
   const [scrollLeft, setScrollLeft] = useState(0);
@@ -11,7 +11,7 @@ export default function ScrollContainer({ children }) {
   const [startScrollLeft, setStartScrollLeft] = useState(0);
 
   useEffect(() => {
-    function updateSizes() {
+    const updateSizes = () => {
       if (scrollRef.current && trackRef.current) {
         const clientWidth = scrollRef.current.clientWidth;
         const scrollWidth = scrollRef.current.scrollWidth;
@@ -19,15 +19,13 @@ export default function ScrollContainer({ children }) {
         const trackWidth = trackRef.current.offsetWidth;
         setHandleWidth((clientWidth / scrollWidth) * trackWidth);
       }
-    }
+    };
     updateSizes();
     window.addEventListener('resize', updateSizes);
     return () => window.removeEventListener('resize', updateSizes);
   }, []);
 
-  const handleScroll = (e) => {
-    setScrollLeft(e.target.scrollLeft);
-  };
+  const handleScroll = (e) => setScrollLeft(e.target.scrollLeft);
 
   const onMouseDownHandle = (e) => {
     setDragging(true);
@@ -49,11 +47,7 @@ export default function ScrollContainer({ children }) {
     }
   };
 
-  const onMouseUp = () => {
-    if (dragging) {
-      setDragging(false);
-    }
-  };
+  const onMouseUp = () => dragging && setDragging(false);
 
   useEffect(() => {
     window.addEventListener('mousemove', onMouseMove);
@@ -64,14 +58,12 @@ export default function ScrollContainer({ children }) {
     };
   }, [dragging, startX, startScrollLeft, handleWidth]);
 
-  let handlePosition = 0;
-  if (trackRef.current && maxScroll > 0) {
-    const trackWidth = trackRef.current.offsetWidth;
-    handlePosition = (scrollLeft / maxScroll) * (trackWidth - handleWidth);
-  }
+  const handlePosition = trackRef.current && maxScroll > 0 
+    ? (scrollLeft / maxScroll) * (trackRef.current.offsetWidth - handleWidth)
+    : 0;
 
   return (
-    <div>
+    <div className="w-full">
       <div
         ref={scrollRef}
         onScroll={handleScroll}
@@ -92,7 +84,7 @@ export default function ScrollContainer({ children }) {
       >
         <div
           onMouseDown={onMouseDownHandle}
-          className="absolute top-0 left-0 h-full bg-blue-500 rounded"
+          className="absolute top-0 left-0 h-full bg-blue-500 rounded transition-transform duration-75"
           style={{
             width: `${handleWidth}px`,
             transform: `translateX(${handlePosition}px)`,
@@ -102,4 +94,6 @@ export default function ScrollContainer({ children }) {
       </div>
     </div>
   );
-}
+};
+
+export default ScrollContainer;

--- a/website/src/components/SearchPage/ScrollContainer.tsx
+++ b/website/src/components/SearchPage/ScrollContainer.tsx
@@ -11,46 +11,31 @@ interface TrackStyle {
 }
 
 const ScrollContainer: React.FC<ScrollContainerProps> = ({ children }) => {
-  // Ref to the scrollable container.
   const scrollRef = useRef<HTMLDivElement>(null);
-
-  // Scroll-related state.
   const [scrollLeft, setScrollLeft] = useState<number>(0);
   const [maxScroll, setMaxScroll] = useState<number>(0);
   const [handleWidth, setHandleWidth] = useState<number>(0);
-
-  // Drag state.
   const [dragging, setDragging] = useState<boolean>(false);
   const [startX, setStartX] = useState<number>(0);
   const [startScrollLeft, setStartScrollLeft] = useState<number>(0);
-
-  // State for the fixed scrollbar track style.
   const [trackStyle, setTrackStyle] = useState<TrackStyle>({ left: 0, width: 0 });
 
-  // This combined update function recalculates:
-  // 1. The maximum scroll value.
-  // 2. The handle's width (proportional to visible content).
-  // 3. The fixed track's left position and width.
   const updatePositions = () => {
     if (scrollRef.current) {
       const rect = scrollRef.current.getBoundingClientRect();
       const clientWidth = scrollRef.current.clientWidth;
       const scrollWidth = scrollRef.current.scrollWidth;
 
-      // Set the maximum scroll (the difference between total and visible width)
       setMaxScroll(scrollWidth - clientWidth);
 
       const computedTrackWidth = clientWidth * 0.95;
-      // The handle’s width is proportional to the visible area.
       setHandleWidth((clientWidth / scrollWidth) * computedTrackWidth);
 
-      // Center the track horizontally relative to the container.
       const computedLeft = rect.left + (clientWidth - computedTrackWidth) / 2;
       setTrackStyle({ left: computedLeft, width: computedTrackWidth });
     }
   };
 
-  // On mount, update positions. Also update on window resize or scroll.
   useEffect(() => {
     updatePositions();
     window.addEventListener('resize', updatePositions);
@@ -61,12 +46,10 @@ const ScrollContainer: React.FC<ScrollContainerProps> = ({ children }) => {
     };
   }, []);
 
-  // When the user scrolls the container, update our scrollLeft state.
   const handleScroll = (e: UIEvent<HTMLDivElement>) => {
     setScrollLeft(e.currentTarget.scrollLeft);
   };
 
-  // When the user starts dragging the scrollbar handle.
   const onMouseDownHandle = (e: ReactMouseEvent<HTMLDivElement, MouseEvent>) => {
     setDragging(true);
     setStartX(e.clientX);
@@ -74,7 +57,6 @@ const ScrollContainer: React.FC<ScrollContainerProps> = ({ children }) => {
     e.preventDefault();
   };
 
-  // While dragging, calculate the new scroll position.
   const onMouseMove = (e: MouseEvent) => {
     if (!dragging || !scrollRef.current) return;
 
@@ -84,19 +66,16 @@ const ScrollContainer: React.FC<ScrollContainerProps> = ({ children }) => {
     const trackWidth = trackStyle.width;
 
     const deltaX = e.clientX - startX;
-    // Determine how far to scroll based on the handle’s movement relative to the track.
     const scrollDelta = (deltaX / (trackWidth - handleWidth)) * maxScrollVal;
     scrollRef.current.scrollLeft = startScrollLeft + scrollDelta;
   };
 
-  // When the mouse is released, stop dragging.
   const onMouseUp = () => {
     if (dragging) {
       setDragging(false);
     }
   };
 
-  // Listen for mouse move/up events on the window.
   useEffect(() => {
     window.addEventListener('mousemove', onMouseMove);
     window.addEventListener('mouseup', onMouseUp);
@@ -106,7 +85,6 @@ const ScrollContainer: React.FC<ScrollContainerProps> = ({ children }) => {
     };
   }, [dragging, startX, startScrollLeft, handleWidth, trackStyle.width]);
 
-  // Compute the handle’s position on the track based on current scroll.
   const handlePosition =
     trackStyle.width && maxScroll > 0
       ? (scrollLeft / maxScroll) * (trackStyle.width - handleWidth)
@@ -114,7 +92,6 @@ const ScrollContainer: React.FC<ScrollContainerProps> = ({ children }) => {
 
   return (
     <div>
-      {/* Scrollable content with hidden default scrollbars */}
       <div
         ref={scrollRef}
         onScroll={handleScroll}
@@ -123,7 +100,6 @@ const ScrollContainer: React.FC<ScrollContainerProps> = ({ children }) => {
         {children}
       </div>
 
-      {/* Render the custom scrollbar only when there is overflow (maxScroll > 0) */}
       {maxScroll > 0 && (
         <div
           className="bg-gray-100"
@@ -137,7 +113,6 @@ const ScrollContainer: React.FC<ScrollContainerProps> = ({ children }) => {
             zIndex: 1000,
           }}
         >
-          {/* The draggable handle */}
           <div
             onMouseDown={onMouseDownHandle}
             className="bg-gray-500"

--- a/website/src/components/SearchPage/ScrollContainer.tsx
+++ b/website/src/components/SearchPage/ScrollContainer.tsx
@@ -134,13 +134,13 @@ const ScrollContainer: React.FC<ScrollContainerProps> = ({ children }) => {
 
       {/* Custom scrollbar track: fixed so it is always visible on screen */}
       <div
+        className="bg-gray-100"
         style={{
           position: 'fixed',
           bottom: '4px',
           left: `${trackStyle.left}px`,
           width: `${trackStyle.width}px`,
           height: '12px',
-          backgroundColor: '#ccc',
           borderRadius: '6px',
           zIndex: 1000,
         }}
@@ -148,13 +148,13 @@ const ScrollContainer: React.FC<ScrollContainerProps> = ({ children }) => {
         {/* The draggable handle */}
         <div
           onMouseDown={onMouseDownHandle}
+          className="bg-gray-500"
           style={{
             position: 'absolute',
             top: 0,
             left: 0,
             height: '100%',
             width: `${handleWidth}px`,
-            backgroundColor: '#007bff',
             borderRadius: '6px',
             transform: `translateX(${handlePosition}px)`,
             cursor: dragging ? 'grabbing' : 'grab',

--- a/website/src/components/SearchPage/ScrollContainer.tsx
+++ b/website/src/components/SearchPage/ScrollContainer.tsx
@@ -2,136 +2,130 @@ import React, { useEffect, useRef, useState } from 'react';
 import type { ReactNode, MouseEvent as ReactMouseEvent, UIEvent } from 'react';
 
 interface ScrollContainerProps {
-  children: ReactNode;
+    children: ReactNode;
 }
 
 interface TrackStyle {
-  left: number;
-  width: number;
+    left: number;
+    width: number;
 }
 
 const ScrollContainer: React.FC<ScrollContainerProps> = ({ children }) => {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [scrollLeft, setScrollLeft] = useState<number>(0);
-  const [maxScroll, setMaxScroll] = useState<number>(0);
-  const [handleWidth, setHandleWidth] = useState<number>(0);
-  const [dragging, setDragging] = useState<boolean>(false);
-  const [startX, setStartX] = useState<number>(0);
-  const [startScrollLeft, setStartScrollLeft] = useState<number>(0);
-  const [trackStyle, setTrackStyle] = useState<TrackStyle>({ left: 0, width: 0 });
+    const scrollRef = useRef<HTMLDivElement>(null);
+    const [scrollLeft, setScrollLeft] = useState<number>(0);
+    const [maxScroll, setMaxScroll] = useState<number>(0);
+    const [handleWidth, setHandleWidth] = useState<number>(0);
+    const [dragging, setDragging] = useState<boolean>(false);
+    const [startX, setStartX] = useState<number>(0);
+    const [startScrollLeft, setStartScrollLeft] = useState<number>(0);
+    const [trackStyle, setTrackStyle] = useState<TrackStyle>({ left: 0, width: 0 });
 
-  const updatePositions = () => {
-    if (scrollRef.current) {
-      const rect = scrollRef.current.getBoundingClientRect();
-      const clientWidth = scrollRef.current.clientWidth;
-      const scrollWidth = scrollRef.current.scrollWidth;
+    const updatePositions = () => {
+        if (scrollRef.current) {
+            const rect = scrollRef.current.getBoundingClientRect();
+            const clientWidth = scrollRef.current.clientWidth;
+            const scrollWidth = scrollRef.current.scrollWidth;
 
-      setMaxScroll(scrollWidth - clientWidth);
+            setMaxScroll(scrollWidth - clientWidth);
 
-      const computedTrackWidth = clientWidth * 0.95;
-      setHandleWidth((clientWidth / scrollWidth) * computedTrackWidth);
+            const computedTrackWidth = clientWidth * 0.95;
+            setHandleWidth((clientWidth / scrollWidth) * computedTrackWidth);
 
-      const computedLeft = rect.left + (clientWidth - computedTrackWidth) / 2;
-      setTrackStyle({ left: computedLeft, width: computedTrackWidth });
-    }
-  };
-
-  useEffect(() => {
-    updatePositions();
-    window.addEventListener('resize', updatePositions);
-    window.addEventListener('scroll', updatePositions);
-    return () => {
-      window.removeEventListener('resize', updatePositions);
-      window.removeEventListener('scroll', updatePositions);
+            const computedLeft = rect.left + (clientWidth - computedTrackWidth) / 2;
+            setTrackStyle({ left: computedLeft, width: computedTrackWidth });
+        }
     };
-  }, []);
 
-  const handleScroll = (e: UIEvent<HTMLDivElement>) => {
-    setScrollLeft(e.currentTarget.scrollLeft);
-  };
+    useEffect(() => {
+        updatePositions();
+        window.addEventListener('resize', updatePositions);
+        window.addEventListener('scroll', updatePositions);
+        return () => {
+            window.removeEventListener('resize', updatePositions);
+            window.removeEventListener('scroll', updatePositions);
+        };
+    }, []);
 
-  const onMouseDownHandle = (e: ReactMouseEvent) => {
-    setDragging(true);
-    setStartX(e.clientX);
-    setStartScrollLeft(scrollLeft);
-    e.preventDefault();
-  };
-
-  const onMouseMove = (e: MouseEvent) => {
-    if (!dragging || !scrollRef.current) return;
-
-    const clientWidth = scrollRef.current.clientWidth;
-    const scrollWidth = scrollRef.current.scrollWidth;
-    const maxScrollVal = scrollWidth - clientWidth;
-    const trackWidth = trackStyle.width;
-
-    const deltaX = e.clientX - startX;
-    const scrollDelta = (deltaX / (trackWidth - handleWidth)) * maxScrollVal;
-    scrollRef.current.scrollLeft = startScrollLeft + scrollDelta;
-  };
-
-  const onMouseUp = () => {
-    if (dragging) {
-      setDragging(false);
-    }
-  };
-
-  useEffect(() => {
-    window.addEventListener('mousemove', onMouseMove);
-    window.addEventListener('mouseup', onMouseUp);
-    return () => {
-      window.removeEventListener('mousemove', onMouseMove);
-      window.removeEventListener('mouseup', onMouseUp);
+    const handleScroll = (e: UIEvent<HTMLDivElement>) => {
+        setScrollLeft(e.currentTarget.scrollLeft);
     };
-  }, [dragging, startX, startScrollLeft, handleWidth, trackStyle.width]);
 
-  const handlePosition =
-    trackStyle.width && maxScroll > 0
-      ? (scrollLeft / maxScroll) * (trackStyle.width - handleWidth)
-      : 0;
+    const onMouseDownHandle = (e: ReactMouseEvent) => {
+        setDragging(true);
+        setStartX(e.clientX);
+        setStartScrollLeft(scrollLeft);
+        e.preventDefault();
+    };
 
-  return (
-    <div>
-      <div
-        ref={scrollRef}
-        onScroll={handleScroll}
-        className="overflow-x-scroll hide-scrollbar"
-      >
-        {children}
-      </div>
+    const onMouseMove = (e: MouseEvent) => {
+        if (!dragging || !scrollRef.current) return;
 
-      {maxScroll > 0 && (
-        <div
-          className="bg-gray-100"
-          style={{
-            position: 'fixed',
-            bottom: '4px',
-            left: `${trackStyle.left}px`,
-            width: `${trackStyle.width}px`,
-            height: '12px',
-            borderRadius: '6px',
-            zIndex: 1000,
-          }}
-        >
-          <div
-            onMouseDown={onMouseDownHandle}
-            className="bg-gray-500"
-            style={{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              height: '100%',
-              width: `${handleWidth}px`,
-              borderRadius: '6px',
-              transform: `translateX(${handlePosition}px)`,
-              cursor: dragging ? 'grabbing' : 'grab',
-              transition: 'transform 75ms',
-            }}
-          />
+        const clientWidth = scrollRef.current.clientWidth;
+        const scrollWidth = scrollRef.current.scrollWidth;
+        const maxScrollVal = scrollWidth - clientWidth;
+        const trackWidth = trackStyle.width;
+
+        const deltaX = e.clientX - startX;
+        const scrollDelta = (deltaX / (trackWidth - handleWidth)) * maxScrollVal;
+        scrollRef.current.scrollLeft = startScrollLeft + scrollDelta;
+    };
+
+    const onMouseUp = () => {
+        if (dragging) {
+            setDragging(false);
+        }
+    };
+
+    useEffect(() => {
+        window.addEventListener('mousemove', onMouseMove);
+        window.addEventListener('mouseup', onMouseUp);
+        return () => {
+            window.removeEventListener('mousemove', onMouseMove);
+            window.removeEventListener('mouseup', onMouseUp);
+        };
+    }, [dragging, startX, startScrollLeft, handleWidth, trackStyle.width]);
+
+    const handlePosition =
+        trackStyle.width && maxScroll > 0 ? (scrollLeft / maxScroll) * (trackStyle.width - handleWidth) : 0;
+
+    return (
+        <div>
+            <div ref={scrollRef} onScroll={handleScroll} className='overflow-x-scroll hide-scrollbar'>
+                {children}
+            </div>
+
+            {maxScroll > 0 && (
+                <div
+                    className='bg-gray-100'
+                    style={{
+                        position: 'fixed',
+                        bottom: '4px',
+                        left: `${trackStyle.left}px`,
+                        width: `${trackStyle.width}px`,
+                        height: '12px',
+                        borderRadius: '6px',
+                        zIndex: 1000,
+                    }}
+                >
+                    <div
+                        onMouseDown={onMouseDownHandle}
+                        className='bg-gray-500'
+                        style={{
+                            position: 'absolute',
+                            top: 0,
+                            left: 0,
+                            height: '100%',
+                            width: `${handleWidth}px`,
+                            borderRadius: '6px',
+                            transform: `translateX(${handlePosition}px)`,
+                            cursor: dragging ? 'grabbing' : 'grab',
+                            transition: 'transform 75ms',
+                        }}
+                    />
+                </div>
+            )}
         </div>
-      )}
-    </div>
-  );
+    );
 };
 
 export default ScrollContainer;

--- a/website/src/components/SearchPage/ScrollContainer.tsx
+++ b/website/src/components/SearchPage/ScrollContainer.tsx
@@ -28,7 +28,7 @@ const ScrollContainer: React.FC<ScrollContainerProps> = ({ children }) => {
 
             setMaxScroll(scrollWidth - clientWidth);
 
-            const computedTrackWidth = clientWidth - 40;
+            const computedTrackWidth = clientWidth - 10;
             setHandleWidth((clientWidth / scrollWidth) * computedTrackWidth);
 
             const computedLeft = rect.left + (clientWidth - computedTrackWidth) / 2;
@@ -99,12 +99,11 @@ const ScrollContainer: React.FC<ScrollContainerProps> = ({ children }) => {
                     className='bg-gray-100'
                     style={{
                         position: 'fixed',
-                        bottom: '4px',
+                        bottom: '3px',
                         left: `${trackStyle.left}px`,
                         width: `${trackStyle.width}px`,
-                        height: '12px',
-                        borderRadius: '6px',
-                        zIndex: 1000,
+                        height: '10px',
+                        borderRadius: '5px',
                     }}
                 >
                     <div

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -1,32 +1,18 @@
-import { useEffect, useRef, useState } from 'react';
 import { capitalCase } from 'change-case';
+import type { Dispatch, FC, ReactElement, SetStateAction } from 'react';
 import { Tooltip } from 'react-tooltip';
+
+import { routes } from '../../routes/routes.ts';
+import type { Schema } from '../../types/config.ts';
+import type { Metadatum, OrderBy } from '../../types/lapis.ts';
+import { formatNumberWithDefaultLocale } from '../../utils/formatNumber.tsx';
 import MaterialSymbolsClose from '~icons/material-symbols/close';
 import MdiTriangle from '~icons/mdi/triangle';
 import MdiTriangleDown from '~icons/mdi/triangle-down';
-import ScrollContainer from './ScrollContainer';
+import ScrollContainer from './ScrollContainer.jsx';
 
-type Metadatum = {
-    name: string;
-    displayName?: string;
-    truncateColumnDisplayTo?: number;
-    type?: string;
-    columnWidth?: number;
-    order?: number;
-};
-
-type Schema = {
-    primaryKey: string;
-    metadata: Metadatum[];
-};
-
-type OrderBy = {
-    field: string;
-    type: 'ascending' | 'descending';
-};
-
-type TableSequenceData = {
-    [key: string]: any;
+export type TableSequenceData = {
+    [key: string]: Metadatum;
 };
 
 function formatField(value: unknown, maxLength: number, type: string): string {
@@ -36,18 +22,32 @@ function formatField(value: unknown, maxLength: number, type: string): string {
         if (type === 'timestamp') {
             return new Date(value * 1000).toISOString().slice(0, 10);
         }
-        return new Intl.NumberFormat().format(value);
+        return formatNumberWithDefaultLocale(value);
     } else if (typeof value === 'boolean') {
         return value ? 'True' : 'False';
     } else {
-        return value as string;
+        // @ts-expect-error: TODO(#3451) add proper types
+        return value;
     }
 }
 
-const getColumnWidthStyle = (columnWidth: number | undefined) =>
-    columnWidth !== undefined ? `${columnWidth}px` : '130px';
+type TableProps = {
+    schema: Schema;
+    data: TableSequenceData[];
+    selectedSeqs: Set<string>;
+    setSelectedSeqs: Dispatch<SetStateAction<Set<string>>>;
+    previewedSeqId: string | null;
+    setPreviewedSeqId: (seqId: string | null) => void;
+    orderBy: OrderBy;
+    setOrderByField: (field: string) => void;
+    setOrderDirection: (direction: 'ascending' | 'descending') => void;
+    columnsToShow: string[];
+};
 
-export const Table = ({
+const getColumnWidthStyle = (columnWidth: number | undefined) =>
+    columnWidth !== undefined ? `${columnWidth}px` : `130px`;
+
+export const Table: FC<TableProps> = ({
     data,
     schema,
     selectedSeqs,
@@ -58,19 +58,9 @@ export const Table = ({
     setOrderByField,
     setOrderDirection,
     columnsToShow,
-}: {
-    schema: Schema;
-    data: TableSequenceData[];
-    selectedSeqs: Set<string>;
-    setSelectedSeqs: React.Dispatch<React.SetStateAction<Set<string>>>;
-    previewedSeqId: string | null;
-    setPreviewedSeqId: (seqId: string | null) => void;
-    orderBy: OrderBy;
-    setOrderByField: (field: string) => void;
-    setOrderDirection: (direction: 'ascending' | 'descending') => void;
-    columnsToShow: string[];
 }) => {
     const primaryKey = schema.primaryKey;
+
     const maxLengths = Object.fromEntries(schema.metadata.map((m) => [m.name, m.truncateColumnDisplayTo ?? 100]));
 
     const columns = columnsToShow
@@ -89,7 +79,11 @@ export const Table = ({
 
     const handleSort = (field: string) => {
         if (orderBy.field === field) {
-            setOrderDirection(orderBy.type === 'ascending' ? 'descending' : 'ascending');
+            if (orderBy.type === 'ascending') {
+                setOrderDirection('descending');
+            } else {
+                setOrderDirection('ascending');
+            }
         } else {
             setOrderByField(field);
             setOrderDirection('ascending');
@@ -99,15 +93,23 @@ export const Table = ({
     const handleRowClick = (e: React.MouseEvent<HTMLTableRowElement>, seqId: string) => {
         const detectMob = () => {
             const toMatch = [/Android/i, /webOS/i, /iPhone/i, /iPod/i, /BlackBerry/i, /Windows Phone/i];
-            return toMatch.some((toMatchItem) => navigator.userAgent.match(toMatchItem));
+
+            return toMatch.some((toMatchItem) => {
+                return navigator.userAgent.match(toMatchItem);
+            });
         };
 
         if (e.button === 0) {
             const screenWidth = window.screen.width;
+
             if (!e.ctrlKey && !e.metaKey && screenWidth > 1024 && !detectMob()) {
                 e.preventDefault();
                 setPreviewedSeqId(seqId);
+            } else {
+                window.open(routes.sequenceEntryDetailsPage(seqId));
             }
+        } else if (e.button === 1) {
+            window.open(routes.sequenceEntryDetailsPage(seqId));
         }
     };
 
@@ -125,27 +127,28 @@ export const Table = ({
 
     const clearSelection = () => setSelectedSeqs(new Set());
 
-    const orderIcon = orderBy.type === 'ascending' ? (
-        <MdiTriangle className="w-3 h-3 ml-1 inline" />
-    ) : (
-        <MdiTriangleDown className="w-3 h-3 ml-1 inline" />
-    );
+    const orderIcon: ReactElement =
+        orderBy.type === 'ascending' ? (
+            <MdiTriangle className='w-3 h-3 ml-1 inline' />
+        ) : (
+            <MdiTriangleDown className='w-3 h-3 ml-1 inline' />
+        );
 
     return (
-            <ScrollContainer>
-            <Tooltip id="table-tip" />
+       <ScrollContainer>
+            <Tooltip id='table-tip' />
             {data.length !== 0 ? (
-                <table className="min-w-full text-left border-collapse">
+                <table className='min-w-full text-left border-collapse'>
                     <thead>
-                        <tr className="border-gray-400 border-b mb-100">
-                            <th className="px-2 py-2 md:pl-6 text-xs text-gray-500 cursor-pointer text-left">
+                        <tr className='border-gray-400 border-b mb-100'>
+                            <th className='px-2 py-2 md:pl-6 text-xs text-gray-500 cursor-pointer text-left'>
                                 {selectedSeqs.size > 0 && (
-                                    <MaterialSymbolsClose className="inline w-3 h-3 mx-0.5" onClick={clearSelection} />
+                                    <MaterialSymbolsClose className='inline w-3 h-3 mx-0.5' onClick={clearSelection} />
                                 )}
                             </th>
                             <th
                                 onClick={() => handleSort(primaryKey)}
-                                className="px-2 py-2 md:pl-6 text-xs font-medium tracking-wider text-gray-500 uppercase cursor-pointer text-left"
+                                className='px-2 py-2 md:pl-6 text-xs font-medium tracking-wider text-gray-500 uppercase cursor-pointer text-left'
                             >
                                 {capitalCase(primaryKey)} {orderBy.field === primaryKey && orderIcon}
                             </th>
@@ -153,7 +156,7 @@ export const Table = ({
                                 <th
                                     key={c.field}
                                     onClick={() => handleSort(c.field)}
-                                    className="px-2 py-2 text-xs font-medium tracking-wider text-gray-500 uppercase cursor-pointer last:pr-6 text-left"
+                                    className='px-2 py-2 text-xs font-medium tracking-wider text-gray-500 uppercase cursor-pointer last:pr-6 text-left'
                                     style={{
                                         minWidth: getColumnWidthStyle(c.columnWidth),
                                     }}
@@ -163,7 +166,7 @@ export const Table = ({
                             ))}
                         </tr>
                     </thead>
-                    <tbody className="bg-white">
+                    <tbody className='bg-white'>
                         {data.map((row, index) => (
                             <tr
                                 key={index}
@@ -171,11 +174,13 @@ export const Table = ({
                                     row[primaryKey] === previewedSeqId ? 'bg-gray-200' : ''
                                 } cursor-pointer`}
                                 onClick={(e) => handleRowClick(e, row[primaryKey] as string)}
+                                onAuxClick={(e) => handleRowClick(e, row[primaryKey] as string)}
                             >
                                 <td
-                                    className="px-2 whitespace-nowrap text-primary-900 md:pl-6"
+                                    className='px-2 whitespace-nowrap text-primary-900 md:pl-6'
                                     onClick={(e) => {
-                                        e.stopPropagation();
+                                        e.stopPropagation(); // Prevent row-level click events from triggering
+                                        // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style -- we need to cast to the special HTML element type
                                         const checkbox = e.currentTarget.querySelector(
                                             'input[type="checkbox"]',
                                         ) as HTMLInputElement;
@@ -184,20 +189,31 @@ export const Table = ({
                                     }}
                                 >
                                     <input
-                                        type="checkbox"
-                                        className="text-primary-900 hover:text-primary-800 hover:no-underline"
+                                        type='checkbox'
+                                        className='text-primary-900 hover:text-primary-800 hover:no-underline'
                                         onChange={(e) => setRowSelected(row[primaryKey] as string, e.target.checked)}
                                         onClick={(e) => e.stopPropagation()}
                                         checked={selectedSeqs.has(row[primaryKey] as string)}
                                     />
                                 </td>
-                                <td className="px-2 whitespace-nowrap text-primary-900 md:pl-6">
-                                    {row[primaryKey]}
+
+                                <td
+                                    className='px-2 whitespace-nowrap text-primary-900 md:pl-6'
+                                    aria-label='SearchResult'
+                                >
+                                    <a
+                                        href={routes.sequenceEntryDetailsPage(row[primaryKey] as string)}
+                                        className='text-primary-900 hover:text-primary-800 hover:no-underline'
+                                        onClick={(e) => e.preventDefault()}
+                                        onAuxClick={(e) => e.preventDefault()}
+                                    >
+                                        {row[primaryKey]}
+                                    </a>
                                 </td>
                                 {columns.map((c) => (
                                     <td
                                         key={`${index}-${c.field}`}
-                                        className="px-2 py-2 text-primary-900 last:pr-6"
+                                        className='px-2 py-2 text-primary-900 last:pr-6'
                                         style={{
                                             minWidth: getColumnWidthStyle(c.columnWidth),
                                         }}
@@ -207,7 +223,7 @@ export const Table = ({
                                                 ? row[c.field]!.toString()
                                                 : ''
                                         }
-                                        data-tooltip-id="table-tip"
+                                        data-tooltip-id='table-tip'
                                     >
                                         {formatField(row[c.field], c.maxLength, c.type)}
                                     </td>
@@ -217,130 +233,8 @@ export const Table = ({
                     </tbody>
                 </table>
             ) : (
-                <div className="flex justify-center font-bold text-xl my-8">No Data</div>
+                <div className='flex justify-center font-bold text-xl my-8'>No Data</div>
             )}
-    
-        </ScrollContainer>
+      </ScrollContainer>
     );
 };
-
-export default function LargeComponent() {
-    const scrollRef = useRef(null);
-    const trackRef = useRef(null);
-    const [scrollLeft, setScrollLeft] = useState(0);
-    const [maxScroll, setMaxScroll] = useState(0);
-    const [handleWidth, setHandleWidth] = useState(0);
-    const [dragging, setDragging] = useState(false);
-    const [startX, setStartX] = useState(0);
-    const [startScrollLeft, setStartScrollLeft] = useState(0);
-
-    useEffect(() => {
-        function updateSizes() {
-            if (scrollRef.current && trackRef.current) {
-                const clientWidth = scrollRef.current.clientWidth;
-                const scrollWidth = scrollRef.current.scrollWidth;
-                setMaxScroll(scrollWidth - clientWidth);
-                const trackWidth = trackRef.current.offsetWidth;
-                setHandleWidth((clientWidth / scrollWidth) * trackWidth);
-            }
-        }
-        updateSizes();
-        window.addEventListener('resize', updateSizes);
-        return () => window.removeEventListener('resize', updateSizes);
-    }, []);
-
-    const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
-        setScrollLeft(e.currentTarget.scrollLeft);
-    };
-
-    const onMouseDownHandle = (e: React.MouseEvent) => {
-        setDragging(true);
-        setStartX(e.clientX);
-        setStartScrollLeft(scrollLeft);
-        e.preventDefault();
-    };
-
-    const onMouseMove = (e: MouseEvent) => {
-        if (!dragging) return;
-        if (scrollRef.current && trackRef.current) {
-            const trackWidth = trackRef.current.offsetWidth;
-            const clientWidth = (scrollRef.current as HTMLDivElement).clientWidth;
-            const scrollWidth = (scrollRef.current as HTMLDivElement).scrollWidth;
-            const maxScrollVal = scrollWidth - clientWidth;
-            const deltaX = e.clientX - startX;
-            const scrollDelta = (deltaX / (trackWidth - handleWidth)) * maxScrollVal;
-            (scrollRef.current as HTMLDivElement).scrollLeft = startScrollLeft + scrollDelta;
-        }
-    };
-
-    const onMouseUp = () => {
-        if (dragging) {
-            setDragging(false);
-        }
-    };
-
-    useEffect(() => {
-        window.addEventListener('mousemove', onMouseMove);
-        window.addEventListener('mouseup', onMouseUp);
-        return () => {
-            window.removeEventListener('mousemove', onMouseMove);
-            window.removeEventListener('mouseup', onMouseUp);
-        };
-    }, [dragging, startX, startScrollLeft, handleWidth]);
-
-    let handlePosition = 0;
-    if (trackRef.current && maxScroll > 0) {
-        const trackWidth = trackRef.current.offsetWidth;
-        handlePosition = (scrollLeft / maxScroll) * (trackWidth - handleWidth);
-    }
-
-    const sampleData = Array.from({ length: 100 }, (_, i) => ({
-        id: `ID${i + 1}`,
-        name: `Item ${i + 1}`,
-        description: `Description for item ${i + 1}`,
-        value: Math.floor(Math.random() * 1000),
-        date: new Date(2024, 0, i + 1).getTime() / 1000
-    }));
-
-    return (
-        <div>
-            <div ref={scrollRef} onScroll={handleScroll} className="overflow-x-scroll">
-                <Table
-                    data={sampleData}
-                    schema={{
-                        primaryKey: 'id',
-                        metadata: [
-                            { name: 'id', displayName: 'ID', truncateColumnDisplayTo: 100 },
-                            { name: 'name', displayName: 'Name', truncateColumnDisplayTo: 100 },
-                            { name: 'description', displayName: 'Description', truncateColumnDisplayTo: 50 },
-                            { name: 'value', displayName: 'Value', type: 'number' },
-                            { name: 'date', displayName: 'Date', type: 'timestamp' }
-                        ],
-                    }}
-                    selectedSeqs={new Set()}
-                    setSelectedSeqs={() => {}}
-                    previewedSeqId={null}
-                    setPreviewedSeqId={() => {}}
-                    orderBy={{ field: 'id', type: 'ascending' }}
-                    setOrderByField={() => {}}
-                    setOrderDirection={() => {}}
-                    columnsToShow={['id', 'name', 'description', 'value', 'date']}
-                />
-            </div>
-
-            <div
-                ref={trackRef}
-                className="fixed bottom-4 left-0 right-0 mx-auto h-3 w-4/5 bg-gray-200 rounded-full"
-            >
-                <div
-                    onMouseDown={onMouseDownHandle}
-                    className="absolute top-0 left-0 h-full bg-blue-500 rounded-full cursor-grab active:cursor-grabbing"
-                    style={{
-                        width: `${handleWidth}px`,
-                        transform: `translateX(${handlePosition}px)`,
-                    }}
-                />
-            </div>
-        </div>
-    );
-}

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -220,7 +220,7 @@ export const Table: FC<TableProps> = ({
                                         data-tooltip-content={
                                             typeof row[c.field] === 'string' &&
                                             row[c.field]!.toString().length > c.maxLength
-                                                ? row[c.field]!.toString().slice(0,MAX_TOOLTIP_LENGTH) + row[c.field]!.toString().length>MAX_TOOLTIP_LENGTH? '..':''
+                                                ? row[c.field]!.toString().slice(0,MAX_TOOLTIP_LENGTH) + (row[c.field]!.toString().length>MAX_TOOLTIP_LENGTH ? '..':'')
                                                 : ''
                                         }
                                         data-tooltip-id='table-tip'

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -9,7 +9,7 @@ import { formatNumberWithDefaultLocale } from '../../utils/formatNumber.tsx';
 import MaterialSymbolsClose from '~icons/material-symbols/close';
 import MdiTriangle from '~icons/mdi/triangle';
 import MdiTriangleDown from '~icons/mdi/triangle-down';
-
+const MAX_TOOLTIP_LENGTH = 50;
 
 export type TableSequenceData = {
     [key: string]: Metadatum;
@@ -220,7 +220,7 @@ export const Table: FC<TableProps> = ({
                                         data-tooltip-content={
                                             typeof row[c.field] === 'string' &&
                                             row[c.field]!.toString().length > c.maxLength
-                                                ? row[c.field]!.toString()
+                                                ? row[c.field]!.toString().slice(0,MAX_TOOLTIP_LENGTH) + row[c.field]!.toString().length>MAX_TOOLTIP_LENGTH? '..':''
                                                 : ''
                                         }
                                         data-tooltip-id='table-tip'

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -10,7 +10,7 @@ import { formatNumberWithDefaultLocale } from '../../utils/formatNumber.tsx';
 import MaterialSymbolsClose from '~icons/material-symbols/close';
 import MdiTriangle from '~icons/mdi/triangle';
 import MdiTriangleDown from '~icons/mdi/triangle-down';
-const MAX_TOOLTIP_LENGTH = 50;
+const MAX_TOOLTIP_LENGTH = 150;
 
 export type TableSequenceData = {
     [key: string]: Metadatum;

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -136,109 +136,114 @@ export const Table: FC<TableProps> = ({
         );
 
     return (
-    <div className="text-sm">
-       <ScrollContainer>
-            <Tooltip id='table-tip' />
-            {data.length !== 0 ? (
-                <table className='min-w-full text-left border-collapse'>
-                    <thead>
-                        <tr className='border-gray-400 border-b mb-100'>
-                            <th className='px-2 py-2 md:pl-6 text-xs text-gray-500 cursor-pointer text-left'>
-                                {selectedSeqs.size > 0 && (
-                                    <MaterialSymbolsClose className='inline w-3 h-3 mx-0.5' onClick={clearSelection} />
-                                )}
-                            </th>
-                            <th
-                                onClick={() => handleSort(primaryKey)}
-                                className='px-2 py-2 md:pl-6 text-xs font-medium tracking-wider text-gray-500 uppercase cursor-pointer text-left'
-                            >
-                                {capitalCase(primaryKey)} {orderBy.field === primaryKey && orderIcon}
-                            </th>
-                            {columns.map((c) => (
-                                <th
-                                    key={c.field}
-                                    onClick={() => handleSort(c.field)}
-                                    className='px-2 py-2 text-xs font-medium tracking-wider text-gray-500 uppercase cursor-pointer last:pr-6 text-left'
-                                    style={{
-                                        minWidth: getColumnWidthStyle(c.columnWidth),
-                                    }}
-                                >
-                                    {c.headerName} {orderBy.field === c.field && orderIcon}
+        <div className='text-sm'>
+            <ScrollContainer>
+                <Tooltip id='table-tip' />
+                {data.length !== 0 ? (
+                    <table className='min-w-full text-left border-collapse'>
+                        <thead>
+                            <tr className='border-gray-400 border-b mb-100'>
+                                <th className='px-2 py-2 md:pl-6 text-xs text-gray-500 cursor-pointer text-left'>
+                                    {selectedSeqs.size > 0 && (
+                                        <MaterialSymbolsClose
+                                            className='inline w-3 h-3 mx-0.5'
+                                            onClick={clearSelection}
+                                        />
+                                    )}
                                 </th>
-                            ))}
-                        </tr>
-                    </thead>
-                    <tbody className='bg-white'>
-                        {data.map((row, index) => (
-                            <tr
-                                key={index}
-                                className={`hover:bg-primary-100 border-b border-gray-200 ${
-                                    row[primaryKey] === previewedSeqId ? 'bg-gray-200' : ''
-                                } cursor-pointer`}
-                                onClick={(e) => handleRowClick(e, row[primaryKey] as string)}
-                                onAuxClick={(e) => handleRowClick(e, row[primaryKey] as string)}
-                            >
-                                <td
-                                    className='px-2 whitespace-nowrap text-primary-900 md:pl-6'
-                                    onClick={(e) => {
-                                        e.stopPropagation(); // Prevent row-level click events from triggering
-                                        // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style -- we need to cast to the special HTML element type
-                                        const checkbox = e.currentTarget.querySelector(
-                                            'input[type="checkbox"]',
-                                        ) as HTMLInputElement;
-                                        checkbox.checked = !checkbox.checked;
-                                        setRowSelected(row[primaryKey] as string, checkbox.checked);
-                                    }}
+                                <th
+                                    onClick={() => handleSort(primaryKey)}
+                                    className='px-2 py-2 md:pl-6 text-xs font-medium tracking-wider text-gray-500 uppercase cursor-pointer text-left'
                                 >
-                                    <input
-                                        type='checkbox'
-                                        className='text-primary-900 hover:text-primary-800 hover:no-underline'
-                                        onChange={(e) => setRowSelected(row[primaryKey] as string, e.target.checked)}
-                                        onClick={(e) => e.stopPropagation()}
-                                        checked={selectedSeqs.has(row[primaryKey] as string)}
-                                    />
-                                </td>
-
-                                <td
-                                    className='px-2 whitespace-nowrap text-primary-900 md:pl-6'
-                                    aria-label='SearchResult'
-                                >
-                                    <a
-                                        href={routes.sequenceEntryDetailsPage(row[primaryKey] as string)}
-                                        className='text-primary-900 hover:text-primary-800 hover:no-underline'
-                                        onClick={(e) => e.preventDefault()}
-                                        onAuxClick={(e) => e.preventDefault()}
-                                    >
-                                        {row[primaryKey]}
-                                    </a>
-                                </td>
+                                    {capitalCase(primaryKey)} {orderBy.field === primaryKey && orderIcon}
+                                </th>
                                 {columns.map((c) => (
-                                    <td
-                                        key={`${index}-${c.field}`}
-                                        className='px-2 py-2 text-primary-900 last:pr-6'
+                                    <th
+                                        key={c.field}
+                                        onClick={() => handleSort(c.field)}
+                                        className='px-2 py-2 text-xs font-medium tracking-wider text-gray-500 uppercase cursor-pointer last:pr-6 text-left'
                                         style={{
                                             minWidth: getColumnWidthStyle(c.columnWidth),
                                         }}
-                                        data-tooltip-content={
-                                            typeof row[c.field] === 'string' &&
-                                            row[c.field]!.toString().length > c.maxLength
-                                                ? row[c.field]!.toString().slice(0, MAX_TOOLTIP_LENGTH) +
-                                                  (row[c.field]!.toString().length > MAX_TOOLTIP_LENGTH ? '..' : '')
-                                                : ''
-                                        }
-                                        data-tooltip-id='table-tip'
                                     >
-                                        {formatField(row[c.field], c.maxLength, c.type)}
-                                    </td>
+                                        {c.headerName} {orderBy.field === c.field && orderIcon}
+                                    </th>
                                 ))}
                             </tr>
-                        ))}
-                    </tbody>
-                </table>
-            ) : (
-                <div className='flex justify-center font-bold text-xl my-8'>No Data</div>
-            )}
-      </ScrollContainer>
-      </div>
+                        </thead>
+                        <tbody className='bg-white'>
+                            {data.map((row, index) => (
+                                <tr
+                                    key={index}
+                                    className={`hover:bg-primary-100 border-b border-gray-200 ${
+                                        row[primaryKey] === previewedSeqId ? 'bg-gray-200' : ''
+                                    } cursor-pointer`}
+                                    onClick={(e) => handleRowClick(e, row[primaryKey] as string)}
+                                    onAuxClick={(e) => handleRowClick(e, row[primaryKey] as string)}
+                                >
+                                    <td
+                                        className='px-2 whitespace-nowrap text-primary-900 md:pl-6'
+                                        onClick={(e) => {
+                                            e.stopPropagation(); // Prevent row-level click events from triggering
+                                            // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style -- we need to cast to the special HTML element type
+                                            const checkbox = e.currentTarget.querySelector(
+                                                'input[type="checkbox"]',
+                                            ) as HTMLInputElement;
+                                            checkbox.checked = !checkbox.checked;
+                                            setRowSelected(row[primaryKey] as string, checkbox.checked);
+                                        }}
+                                    >
+                                        <input
+                                            type='checkbox'
+                                            className='text-primary-900 hover:text-primary-800 hover:no-underline'
+                                            onChange={(e) =>
+                                                setRowSelected(row[primaryKey] as string, e.target.checked)
+                                            }
+                                            onClick={(e) => e.stopPropagation()}
+                                            checked={selectedSeqs.has(row[primaryKey] as string)}
+                                        />
+                                    </td>
+
+                                    <td
+                                        className='px-2 whitespace-nowrap text-primary-900 md:pl-6'
+                                        aria-label='SearchResult'
+                                    >
+                                        <a
+                                            href={routes.sequenceEntryDetailsPage(row[primaryKey] as string)}
+                                            className='text-primary-900 hover:text-primary-800 hover:no-underline'
+                                            onClick={(e) => e.preventDefault()}
+                                            onAuxClick={(e) => e.preventDefault()}
+                                        >
+                                            {row[primaryKey]}
+                                        </a>
+                                    </td>
+                                    {columns.map((c) => (
+                                        <td
+                                            key={`${index}-${c.field}`}
+                                            className='px-2 py-2 text-primary-900 last:pr-6'
+                                            style={{
+                                                minWidth: getColumnWidthStyle(c.columnWidth),
+                                            }}
+                                            data-tooltip-content={
+                                                typeof row[c.field] === 'string' &&
+                                                row[c.field]!.toString().length > c.maxLength
+                                                    ? row[c.field]!.toString().slice(0, MAX_TOOLTIP_LENGTH) +
+                                                      (row[c.field]!.toString().length > MAX_TOOLTIP_LENGTH ? '..' : '')
+                                                    : ''
+                                            }
+                                            data-tooltip-id='table-tip'
+                                        >
+                                            {formatField(row[c.field], c.maxLength, c.type)}
+                                        </td>
+                                    ))}
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                ) : (
+                    <div className='flex justify-center font-bold text-xl my-8'>No Data</div>
+                )}
+            </ScrollContainer>
+        </div>
     );
 };

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -1,6 +1,7 @@
 import { capitalCase } from 'change-case';
 import type { Dispatch, FC, ReactElement, SetStateAction } from 'react';
 import { Tooltip } from 'react-tooltip';
+
 import ScrollContainer from './ScrollContainer.jsx';
 import { routes } from '../../routes/routes.ts';
 import type { Schema } from '../../types/config.ts';
@@ -135,7 +136,7 @@ export const Table: FC<TableProps> = ({
         );
 
     return (
-       <ScrollContainer>
+        <ScrollContainer>
             <Tooltip id='table-tip' />
             {data.length !== 0 ? (
                 <table className='min-w-full text-left border-collapse'>
@@ -220,7 +221,8 @@ export const Table: FC<TableProps> = ({
                                         data-tooltip-content={
                                             typeof row[c.field] === 'string' &&
                                             row[c.field]!.toString().length > c.maxLength
-                                                ? row[c.field]!.toString().slice(0,MAX_TOOLTIP_LENGTH) + (row[c.field]!.toString().length>MAX_TOOLTIP_LENGTH ? '..':'')
+                                                ? row[c.field]!.toString().slice(0, MAX_TOOLTIP_LENGTH) +
+                                                  (row[c.field]!.toString().length > MAX_TOOLTIP_LENGTH ? '..' : '')
                                                 : ''
                                         }
                                         data-tooltip-id='table-tip'
@@ -235,6 +237,6 @@ export const Table: FC<TableProps> = ({
             ) : (
                 <div className='flex justify-center font-bold text-xl my-8'>No Data</div>
             )}
-      </ScrollContainer>
+        </ScrollContainer>
     );
 };

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -4,6 +4,7 @@ import { Tooltip } from 'react-tooltip';
 import MaterialSymbolsClose from '~icons/material-symbols/close';
 import MdiTriangle from '~icons/mdi/triangle';
 import MdiTriangleDown from '~icons/mdi/triangle-down';
+import ScrollContainer from './ScrollContainer';
 
 type Metadatum = {
     name: string;
@@ -131,7 +132,7 @@ export const Table = ({
     );
 
     return (
-        <div className="w-full overflow-x-auto text-sm" aria-label="Search Results Table">
+            <ScrollContainer>
             <Tooltip id="table-tip" />
             {data.length !== 0 ? (
                 <table className="min-w-full text-left border-collapse">
@@ -218,7 +219,8 @@ export const Table = ({
             ) : (
                 <div className="flex justify-center font-bold text-xl my-8">No Data</div>
             )}
-        </div>
+    
+        </ScrollContainer>
     );
 };
 

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -136,7 +136,8 @@ export const Table: FC<TableProps> = ({
         );
 
     return (
-        <ScrollContainer>
+    <div className="text-sm">
+       <ScrollContainer>
             <Tooltip id='table-tip' />
             {data.length !== 0 ? (
                 <table className='min-w-full text-left border-collapse'>
@@ -237,6 +238,7 @@ export const Table: FC<TableProps> = ({
             ) : (
                 <div className='flex justify-center font-bold text-xl my-8'>No Data</div>
             )}
-        </ScrollContainer>
+      </ScrollContainer>
+      </div>
     );
 };

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -1,7 +1,7 @@
 import { capitalCase } from 'change-case';
 import type { Dispatch, FC, ReactElement, SetStateAction } from 'react';
 import { Tooltip } from 'react-tooltip';
-
+import ScrollContainer from './ScrollContainer.jsx';
 import { routes } from '../../routes/routes.ts';
 import type { Schema } from '../../types/config.ts';
 import type { Metadatum, OrderBy } from '../../types/lapis.ts';
@@ -9,7 +9,7 @@ import { formatNumberWithDefaultLocale } from '../../utils/formatNumber.tsx';
 import MaterialSymbolsClose from '~icons/material-symbols/close';
 import MdiTriangle from '~icons/mdi/triangle';
 import MdiTriangleDown from '~icons/mdi/triangle-down';
-import ScrollContainer from './ScrollContainer.jsx';
+
 
 export type TableSequenceData = {
     [key: string]: Metadatum;

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -46,7 +46,7 @@ function formatField(value: unknown, maxLength: number, type: string): string {
 const getColumnWidthStyle = (columnWidth: number | undefined) =>
     columnWidth !== undefined ? `${columnWidth}px` : '130px';
 
-const Table = ({
+export const Table = ({
     data,
     schema,
     selectedSeqs,

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -1,17 +1,31 @@
+import { useEffect, useRef, useState } from 'react';
 import { capitalCase } from 'change-case';
-import type { Dispatch, FC, ReactElement, SetStateAction } from 'react';
 import { Tooltip } from 'react-tooltip';
-
-import { routes } from '../../routes/routes.ts';
-import type { Schema } from '../../types/config.ts';
-import type { Metadatum, OrderBy } from '../../types/lapis.ts';
-import { formatNumberWithDefaultLocale } from '../../utils/formatNumber.tsx';
 import MaterialSymbolsClose from '~icons/material-symbols/close';
 import MdiTriangle from '~icons/mdi/triangle';
 import MdiTriangleDown from '~icons/mdi/triangle-down';
 
-export type TableSequenceData = {
-    [key: string]: Metadatum;
+type Metadatum = {
+    name: string;
+    displayName?: string;
+    truncateColumnDisplayTo?: number;
+    type?: string;
+    columnWidth?: number;
+    order?: number;
+};
+
+type Schema = {
+    primaryKey: string;
+    metadata: Metadatum[];
+};
+
+type OrderBy = {
+    field: string;
+    type: 'ascending' | 'descending';
+};
+
+type TableSequenceData = {
+    [key: string]: any;
 };
 
 function formatField(value: unknown, maxLength: number, type: string): string {
@@ -21,32 +35,18 @@ function formatField(value: unknown, maxLength: number, type: string): string {
         if (type === 'timestamp') {
             return new Date(value * 1000).toISOString().slice(0, 10);
         }
-        return formatNumberWithDefaultLocale(value);
+        return new Intl.NumberFormat().format(value);
     } else if (typeof value === 'boolean') {
         return value ? 'True' : 'False';
     } else {
-        // @ts-expect-error: TODO(#3451) add proper types
-        return value;
+        return value as string;
     }
 }
 
-type TableProps = {
-    schema: Schema;
-    data: TableSequenceData[];
-    selectedSeqs: Set<string>;
-    setSelectedSeqs: Dispatch<SetStateAction<Set<string>>>;
-    previewedSeqId: string | null;
-    setPreviewedSeqId: (seqId: string | null) => void;
-    orderBy: OrderBy;
-    setOrderByField: (field: string) => void;
-    setOrderDirection: (direction: 'ascending' | 'descending') => void;
-    columnsToShow: string[];
-};
-
 const getColumnWidthStyle = (columnWidth: number | undefined) =>
-    columnWidth !== undefined ? `${columnWidth}px` : `130px`;
+    columnWidth !== undefined ? `${columnWidth}px` : '130px';
 
-export const Table: FC<TableProps> = ({
+const Table = ({
     data,
     schema,
     selectedSeqs,
@@ -57,9 +57,19 @@ export const Table: FC<TableProps> = ({
     setOrderByField,
     setOrderDirection,
     columnsToShow,
+}: {
+    schema: Schema;
+    data: TableSequenceData[];
+    selectedSeqs: Set<string>;
+    setSelectedSeqs: React.Dispatch<React.SetStateAction<Set<string>>>;
+    previewedSeqId: string | null;
+    setPreviewedSeqId: (seqId: string | null) => void;
+    orderBy: OrderBy;
+    setOrderByField: (field: string) => void;
+    setOrderDirection: (direction: 'ascending' | 'descending') => void;
+    columnsToShow: string[];
 }) => {
     const primaryKey = schema.primaryKey;
-
     const maxLengths = Object.fromEntries(schema.metadata.map((m) => [m.name, m.truncateColumnDisplayTo ?? 100]));
 
     const columns = columnsToShow
@@ -78,11 +88,7 @@ export const Table: FC<TableProps> = ({
 
     const handleSort = (field: string) => {
         if (orderBy.field === field) {
-            if (orderBy.type === 'ascending') {
-                setOrderDirection('descending');
-            } else {
-                setOrderDirection('ascending');
-            }
+            setOrderDirection(orderBy.type === 'ascending' ? 'descending' : 'ascending');
         } else {
             setOrderByField(field);
             setOrderDirection('ascending');
@@ -92,23 +98,15 @@ export const Table: FC<TableProps> = ({
     const handleRowClick = (e: React.MouseEvent<HTMLTableRowElement>, seqId: string) => {
         const detectMob = () => {
             const toMatch = [/Android/i, /webOS/i, /iPhone/i, /iPod/i, /BlackBerry/i, /Windows Phone/i];
-
-            return toMatch.some((toMatchItem) => {
-                return navigator.userAgent.match(toMatchItem);
-            });
+            return toMatch.some((toMatchItem) => navigator.userAgent.match(toMatchItem));
         };
 
         if (e.button === 0) {
             const screenWidth = window.screen.width;
-
             if (!e.ctrlKey && !e.metaKey && screenWidth > 1024 && !detectMob()) {
                 e.preventDefault();
                 setPreviewedSeqId(seqId);
-            } else {
-                window.open(routes.sequenceEntryDetailsPage(seqId));
             }
-        } else if (e.button === 1) {
-            window.open(routes.sequenceEntryDetailsPage(seqId));
         }
     };
 
@@ -126,28 +124,27 @@ export const Table: FC<TableProps> = ({
 
     const clearSelection = () => setSelectedSeqs(new Set());
 
-    const orderIcon: ReactElement =
-        orderBy.type === 'ascending' ? (
-            <MdiTriangle className='w-3 h-3 ml-1 inline' />
-        ) : (
-            <MdiTriangleDown className='w-3 h-3 ml-1 inline' />
-        );
+    const orderIcon = orderBy.type === 'ascending' ? (
+        <MdiTriangle className="w-3 h-3 ml-1 inline" />
+    ) : (
+        <MdiTriangleDown className="w-3 h-3 ml-1 inline" />
+    );
 
     return (
-        <div className='w-full overflow-x-auto text-sm' aria-label='Search Results Table'>
-            <Tooltip id='table-tip' />
+        <div className="w-full overflow-x-auto text-sm" aria-label="Search Results Table">
+            <Tooltip id="table-tip" />
             {data.length !== 0 ? (
-                <table className='min-w-full text-left border-collapse'>
+                <table className="min-w-full text-left border-collapse">
                     <thead>
-                        <tr className='border-gray-400 border-b mb-100'>
-                            <th className='px-2 py-2 md:pl-6 text-xs text-gray-500 cursor-pointer text-left'>
+                        <tr className="border-gray-400 border-b mb-100">
+                            <th className="px-2 py-2 md:pl-6 text-xs text-gray-500 cursor-pointer text-left">
                                 {selectedSeqs.size > 0 && (
-                                    <MaterialSymbolsClose className='inline w-3 h-3 mx-0.5' onClick={clearSelection} />
+                                    <MaterialSymbolsClose className="inline w-3 h-3 mx-0.5" onClick={clearSelection} />
                                 )}
                             </th>
                             <th
                                 onClick={() => handleSort(primaryKey)}
-                                className='px-2 py-2 md:pl-6 text-xs font-medium tracking-wider text-gray-500 uppercase cursor-pointer text-left'
+                                className="px-2 py-2 md:pl-6 text-xs font-medium tracking-wider text-gray-500 uppercase cursor-pointer text-left"
                             >
                                 {capitalCase(primaryKey)} {orderBy.field === primaryKey && orderIcon}
                             </th>
@@ -155,7 +152,7 @@ export const Table: FC<TableProps> = ({
                                 <th
                                     key={c.field}
                                     onClick={() => handleSort(c.field)}
-                                    className='px-2 py-2 text-xs font-medium tracking-wider text-gray-500 uppercase cursor-pointer last:pr-6 text-left'
+                                    className="px-2 py-2 text-xs font-medium tracking-wider text-gray-500 uppercase cursor-pointer last:pr-6 text-left"
                                     style={{
                                         minWidth: getColumnWidthStyle(c.columnWidth),
                                     }}
@@ -165,7 +162,7 @@ export const Table: FC<TableProps> = ({
                             ))}
                         </tr>
                     </thead>
-                    <tbody className='bg-white'>
+                    <tbody className="bg-white">
                         {data.map((row, index) => (
                             <tr
                                 key={index}
@@ -173,13 +170,11 @@ export const Table: FC<TableProps> = ({
                                     row[primaryKey] === previewedSeqId ? 'bg-gray-200' : ''
                                 } cursor-pointer`}
                                 onClick={(e) => handleRowClick(e, row[primaryKey] as string)}
-                                onAuxClick={(e) => handleRowClick(e, row[primaryKey] as string)}
                             >
                                 <td
-                                    className='px-2 whitespace-nowrap text-primary-900 md:pl-6'
+                                    className="px-2 whitespace-nowrap text-primary-900 md:pl-6"
                                     onClick={(e) => {
-                                        e.stopPropagation(); // Prevent row-level click events from triggering
-                                        // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style -- we need to cast to the special HTML element type
+                                        e.stopPropagation();
                                         const checkbox = e.currentTarget.querySelector(
                                             'input[type="checkbox"]',
                                         ) as HTMLInputElement;
@@ -188,31 +183,20 @@ export const Table: FC<TableProps> = ({
                                     }}
                                 >
                                     <input
-                                        type='checkbox'
-                                        className='text-primary-900 hover:text-primary-800 hover:no-underline'
+                                        type="checkbox"
+                                        className="text-primary-900 hover:text-primary-800 hover:no-underline"
                                         onChange={(e) => setRowSelected(row[primaryKey] as string, e.target.checked)}
                                         onClick={(e) => e.stopPropagation()}
                                         checked={selectedSeqs.has(row[primaryKey] as string)}
                                     />
                                 </td>
-
-                                <td
-                                    className='px-2 whitespace-nowrap text-primary-900 md:pl-6'
-                                    aria-label='SearchResult'
-                                >
-                                    <a
-                                        href={routes.sequenceEntryDetailsPage(row[primaryKey] as string)}
-                                        className='text-primary-900 hover:text-primary-800 hover:no-underline'
-                                        onClick={(e) => e.preventDefault()}
-                                        onAuxClick={(e) => e.preventDefault()}
-                                    >
-                                        {row[primaryKey]}
-                                    </a>
+                                <td className="px-2 whitespace-nowrap text-primary-900 md:pl-6">
+                                    {row[primaryKey]}
                                 </td>
                                 {columns.map((c) => (
                                     <td
                                         key={`${index}-${c.field}`}
-                                        className='px-2 py-2 text-primary-900 last:pr-6'
+                                        className="px-2 py-2 text-primary-900 last:pr-6"
                                         style={{
                                             minWidth: getColumnWidthStyle(c.columnWidth),
                                         }}
@@ -222,7 +206,7 @@ export const Table: FC<TableProps> = ({
                                                 ? row[c.field]!.toString()
                                                 : ''
                                         }
-                                        data-tooltip-id='table-tip'
+                                        data-tooltip-id="table-tip"
                                     >
                                         {formatField(row[c.field], c.maxLength, c.type)}
                                     </td>
@@ -232,8 +216,129 @@ export const Table: FC<TableProps> = ({
                     </tbody>
                 </table>
             ) : (
-                <div className='flex justify-center font-bold text-xl my-8'>No Data</div>
+                <div className="flex justify-center font-bold text-xl my-8">No Data</div>
             )}
         </div>
     );
 };
+
+export default function LargeComponent() {
+    const scrollRef = useRef(null);
+    const trackRef = useRef(null);
+    const [scrollLeft, setScrollLeft] = useState(0);
+    const [maxScroll, setMaxScroll] = useState(0);
+    const [handleWidth, setHandleWidth] = useState(0);
+    const [dragging, setDragging] = useState(false);
+    const [startX, setStartX] = useState(0);
+    const [startScrollLeft, setStartScrollLeft] = useState(0);
+
+    useEffect(() => {
+        function updateSizes() {
+            if (scrollRef.current && trackRef.current) {
+                const clientWidth = scrollRef.current.clientWidth;
+                const scrollWidth = scrollRef.current.scrollWidth;
+                setMaxScroll(scrollWidth - clientWidth);
+                const trackWidth = trackRef.current.offsetWidth;
+                setHandleWidth((clientWidth / scrollWidth) * trackWidth);
+            }
+        }
+        updateSizes();
+        window.addEventListener('resize', updateSizes);
+        return () => window.removeEventListener('resize', updateSizes);
+    }, []);
+
+    const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+        setScrollLeft(e.currentTarget.scrollLeft);
+    };
+
+    const onMouseDownHandle = (e: React.MouseEvent) => {
+        setDragging(true);
+        setStartX(e.clientX);
+        setStartScrollLeft(scrollLeft);
+        e.preventDefault();
+    };
+
+    const onMouseMove = (e: MouseEvent) => {
+        if (!dragging) return;
+        if (scrollRef.current && trackRef.current) {
+            const trackWidth = trackRef.current.offsetWidth;
+            const clientWidth = (scrollRef.current as HTMLDivElement).clientWidth;
+            const scrollWidth = (scrollRef.current as HTMLDivElement).scrollWidth;
+            const maxScrollVal = scrollWidth - clientWidth;
+            const deltaX = e.clientX - startX;
+            const scrollDelta = (deltaX / (trackWidth - handleWidth)) * maxScrollVal;
+            (scrollRef.current as HTMLDivElement).scrollLeft = startScrollLeft + scrollDelta;
+        }
+    };
+
+    const onMouseUp = () => {
+        if (dragging) {
+            setDragging(false);
+        }
+    };
+
+    useEffect(() => {
+        window.addEventListener('mousemove', onMouseMove);
+        window.addEventListener('mouseup', onMouseUp);
+        return () => {
+            window.removeEventListener('mousemove', onMouseMove);
+            window.removeEventListener('mouseup', onMouseUp);
+        };
+    }, [dragging, startX, startScrollLeft, handleWidth]);
+
+    let handlePosition = 0;
+    if (trackRef.current && maxScroll > 0) {
+        const trackWidth = trackRef.current.offsetWidth;
+        handlePosition = (scrollLeft / maxScroll) * (trackWidth - handleWidth);
+    }
+
+    const sampleData = Array.from({ length: 100 }, (_, i) => ({
+        id: `ID${i + 1}`,
+        name: `Item ${i + 1}`,
+        description: `Description for item ${i + 1}`,
+        value: Math.floor(Math.random() * 1000),
+        date: new Date(2024, 0, i + 1).getTime() / 1000
+    }));
+
+    return (
+        <div>
+            <div ref={scrollRef} onScroll={handleScroll} className="overflow-x-scroll">
+                <Table
+                    data={sampleData}
+                    schema={{
+                        primaryKey: 'id',
+                        metadata: [
+                            { name: 'id', displayName: 'ID', truncateColumnDisplayTo: 100 },
+                            { name: 'name', displayName: 'Name', truncateColumnDisplayTo: 100 },
+                            { name: 'description', displayName: 'Description', truncateColumnDisplayTo: 50 },
+                            { name: 'value', displayName: 'Value', type: 'number' },
+                            { name: 'date', displayName: 'Date', type: 'timestamp' }
+                        ],
+                    }}
+                    selectedSeqs={new Set()}
+                    setSelectedSeqs={() => {}}
+                    previewedSeqId={null}
+                    setPreviewedSeqId={() => {}}
+                    orderBy={{ field: 'id', type: 'ascending' }}
+                    setOrderByField={() => {}}
+                    setOrderDirection={() => {}}
+                    columnsToShow={['id', 'name', 'description', 'value', 'date']}
+                />
+            </div>
+
+            <div
+                ref={trackRef}
+                className="fixed bottom-4 left-0 right-0 mx-auto h-3 w-4/5 bg-gray-200 rounded-full"
+            >
+                <div
+                    onMouseDown={onMouseDownHandle}
+                    className="absolute top-0 left-0 h-full bg-blue-500 rounded-full cursor-grab active:cursor-grabbing"
+                    style={{
+                        width: `${handleWidth}px`,
+                        transform: `translateX(${handlePosition}px)`,
+                    }}
+                />
+            </div>
+        </div>
+    );
+}

--- a/website/src/styles/base.scss
+++ b/website/src/styles/base.scss
@@ -135,9 +135,9 @@ a {
 .hide-scrollbar {
     scrollbar-width: none; /* Firefox */
     -ms-overflow-style: none; /* Internet Explorer 10+ */
-  }
-  
-  /* Hide scrollbars for Chrome, Safari, and Opera */
-  .hide-scrollbar::-webkit-scrollbar {
+}
+
+/* Hide scrollbars for Chrome, Safari, and Opera */
+.hide-scrollbar::-webkit-scrollbar {
     display: none;
-  }
+}

--- a/website/src/styles/base.scss
+++ b/website/src/styles/base.scss
@@ -137,7 +137,7 @@ a {
     -ms-overflow-style: none; /* Internet Explorer 10+ */
 }
 
-/* Hide scrollbars for Chrome, Safari, & Opera */
+/* Hide scrollbars for Chrome, Safari, and Opera */
 .hide-scrollbar::-webkit-scrollbar {
     display: none;
 }

--- a/website/src/styles/base.scss
+++ b/website/src/styles/base.scss
@@ -137,7 +137,7 @@ a {
     -ms-overflow-style: none; /* Internet Explorer 10+ */
 }
 
-/* Hide scrollbars for Chrome, Safari, and Opera */
+/* Hide scrollbars for Chrome, Safari, & Opera */
 .hide-scrollbar::-webkit-scrollbar {
     display: none;
 }

--- a/website/src/styles/base.scss
+++ b/website/src/styles/base.scss
@@ -131,3 +131,13 @@ a {
         opacity: 1;
     }
 }
+
+.hide-scrollbar {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* Internet Explorer 10+ */
+  }
+  
+  /* Hide scrollbars for Chrome, Safari, and Opera */
+  .hide-scrollbar::-webkit-scrollbar {
+    display: none;
+  }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves https://github.com/loculus-project/loculus/issues/3457

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://improve-scroll.loculus.org/

![image](https://github.com/user-attachments/assets/1d58c7df-0180-4166-b27e-abf1a7e8a999)

the scrollbar at the bottom of the page is the result of this PR

Makes it obvious you can scroll the table by implementing a custom horizontal scroll bar that always appears. (Written with o3-mini)
Also truncates tooltip expansions on the field which was always a todo and became more important with this since over-long tooltips make native scrollbars appear.
Negatives: will not match the users expected scroll appearance e.g. on windows probably