### PR TITLE
fix!(deposition): allow explicit specification of ENA deposition blocking fields

### DIFF
--- a/ena-submission/src/ena_deposition/config.py
+++ b/ena-submission/src/ena_deposition/config.py
@@ -7,7 +7,7 @@ import yaml
 @dataclass
 class Config:
     test: bool
-    organisms: dict[dict[str, str]]
+    organisms: dict[str, dict[str, str]]
     backend_url: str
     keycloak_token_url: str
     keycloak_client_id: str
@@ -17,6 +17,7 @@ class Config:
     db_password: str
     db_url: str
     db_name: str
+    deposition_blocking_fields: list[str]
     unique_project_suffix: str
     ena_submission_url: str
     ena_submission_password: str

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -375,6 +375,7 @@ fields:
 {{- end}}
 
 {{/* Generate backend metadata from passed metadata array */}}
+{{/* External Metadata is defined to be those metadata fields that are under the "INSDC" header */}}
 {{- define "loculus.generateBackendExternalMetadata" }}
 fields:
 {{- $metadataList := .metadata }}

--- a/kubernetes/loculus/templates/ena-submission-config.yaml
+++ b/kubernetes/loculus/templates/ena-submission-config.yaml
@@ -19,5 +19,6 @@ data:
     unique_project_suffix: {{ $enaUniqueSuffix }}
     backend_url: {{ $backendHost }}
     keycloak_token_url: {{ $keycloakHost -}}/realms/loculus/protocol/openid-connect/token
+    deposition_blocking_fields: {{ .Values.depositionBlockingFields | toJson }}
     {{- include "loculus.generateENASubmissionConfig" . | nindent 4 }}
 {{- end }}

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -9,7 +9,8 @@ disableWebsite: false
 disableBackend: false
 disablePreprocessing: false
 disableIngest: false
-disableEnaSubmission: true
+disableEnaSubmission: false
+depositionBlockingFields: []
 website:
   websiteConfig:
     enableLoginNavigationItem: true


### PR DESCRIPTION
Breaking in that Pathoplexus needs to add:

```yaml
depositionBlockingFields:
  - ncbiReleaseDate
  - ncbiUpdateDate
  - ncbiSubmitterCountry
  - insdcAccessionBase
  - insdcVersion
  - insdcAccessionFull
  - bioprojectAccession
  - gcaAccession
  - biosampleAccession
  - ncbiSourceDb
  - ncbiVirusName
  - ncbiVirusTaxId
```
to values.yaml

We now accept SRA accession from users, so we shouldn't block if that is present anymore.

See https://loculus.slack.com/archives/C0757PTR607/p1738953208387609

Tested on staging and it work:

<img width="1176" alt="image" src="https://github.com/user-attachments/assets/84fa5889-0d32-4d00-b147-05adf5ff0819" />
