### PR TITLE
fix(website): Add special color for organism selector in Loculus color scheme

### DIFF
--- a/website/colors.cjs
+++ b/website/colors.cjs
@@ -10,6 +10,7 @@ const mainTailwindColor = {
     800: '#3e467e',
     900: '#3a416e',
     950: '#272b44',
+    1500: '#25396e',
 };
 
 module.exports = {


### PR DESCRIPTION
In https://github.com/loculus-project/loculus/pull/2085/commits/027c5786f34bc038a93b54e76390a206e5443d33 we added a special color number, `1500`, used for the organism selector.

It looked like this:
![image](https://github.com/user-attachments/assets/228f2e80-ce87-40ab-b2b5-d99ddd2bb897)

(as Pathoplexus still looks).

Later we moved the old Loculus color scheme to Pathoplexus and gave Loculus it's own purpler color scheme. In the new purpler color scheme we forgot to define color `1500` so the organism selector shows up as black.

![image](https://github.com/user-attachments/assets/f240c700-136b-4813-a4ab-fbe815ba927d)

This looks suboptimal. Here we add a `1500` colour for Loculus.

![image](https://github.com/user-attachments/assets/733b5825-37dd-423e-a3f7-5ff69e46583a)


https://orgselector.loculus.org