### PR TITLE
feat(deposition)!: Allow groups to specify which BioProject (and BioSample) we upload their sequences into 

### DIFF
--- a/ena-submission/README.md
+++ b/ena-submission/README.md
@@ -205,7 +205,7 @@ pip install -e .
 flyway -user=postgres -password=unsecure -url=jdbc:postgresql://127.0.0.1:5432/loculus -schemas=ena_deposition_schema -locations=filesystem:./flyway/sql migrate
 ```
 
-2. Submit data to the backend as test user (create group, submit and approve), e.g. using [example data](https://github.com/pathoplexus/example_data). (To test the full submission cycle with insdc accessions submit cchf example data with only 2 segments.)
+2. Submit data to the backend as test user (create group, submit and approve - create 2 groups if insdc_ingest_group has not be created), e.g. using [example data](https://github.com/pathoplexus/example_data). (To test the full submission cycle with insdc accessions submit cchf example data with only 2 segments.)
 
 ```sh
 KEYCLOAK_TOKEN_URL="http://localhost:8083/realms/loculus/protocol/openid-connect/token"
@@ -230,7 +230,7 @@ curl -X 'POST' 'http://localhost:8079/groups' \
   },
   "contactEmail": "something@loculus.org"}'
 LOCULUS_ACCESSION=$(curl -X 'POST' \
-  'http://localhost:8079/cchf/submit?groupId=1&dataUseTermsType=OPEN' \
+  'http://localhost:8079/cchf/submit?groupId=2&dataUseTermsType=OPEN' \
   -H 'accept: application/json' \
   -H "Authorization: Bearer ${JWT}" \
   -H 'Content-Type: multipart/form-data' \
@@ -243,9 +243,10 @@ curl -X 'POST' 'http://localhost:8079/cchf/approve-processed-data' \
   -d '{"scope": "ALL"}'
 ```
 
-3. Get list of sequences ready to submit to ENA, locally this will write `results/ena_submission_list.json`.
+3. Get list of sequences ready to submit to ENA, locally this will write `results/ena_submission_list.json`, you need to copy the config produced by `../generate_local_test_config.sh`.
 
 ```sh
+cp ../website/tests/config/ena-submission-config.yaml config/config.yaml
 python scripts/get_ena_submission_list.py --config-file=config/config.yaml --output-file=results/ena_submission_list.json
 ```
 

--- a/ena-submission/README.md
+++ b/ena-submission/README.md
@@ -31,8 +31,8 @@ This script runs once daily as a kubernetes cronjob. It calls the Loculus backen
 - data must be state "OPEN" for use
 - data must not already exist in ENA or be in the submission process, this means:
   - data was not submitted by the `config.ingest_pipeline_submitter`
-  - data is not in the `ena-submission.submission_table`
-  - as an extra check we discard all sequences with `ena-specific-metadata` fields
+  - data is not in the `ena-submission.submission_table` (and data with a later version is also not in the table)
+  - as an extra check we upload data with `ena-specific-metadata` fields in a separate file with a warning
 
 ## Threads
 
@@ -47,10 +47,14 @@ Download file in `github_url` every 30s. If data is not in submission table alre
 In a loop:
 
 - Get sequences in `submission_table` in state READY_TO_SUBMIT
+  - if (bioprojectAccession exists in the metadata):
+    - if (for (group_id, organism) a project entry with this accession already exists use that project_id)
+      and update submission_table to SUBMITTED_PROJECT (add center_name and project_id)
+    - else: create an entry in `project_table` and then update `submission_table` with results (center_name and project_id)
   - if (there exists an entry in the project_table for the corresponding (group_id, organism)):
     - if (entry is in status SUBMITTED): update `submission_table` to SUBMITTED_PROJECT.
     - else: update submission_table to SUBMITTING_PROJECT.
-  - else: create project entry in `project_table` for (group_id, organism).
+  - else: create project entry in `project_table` for (group_id, organism) -> creates a unique `project_id`.
 - Get sequences in `submission_table` in state SUBMITTING_PROJECT
   - if (corresponding `project_table` entry is in state SUBMITTED): update entries to state SUBMITTED_PROJECT.
 - Get sequences in `project_table` in state READY, prepare submission object, set status to SUBMITTING
@@ -69,6 +73,10 @@ Maps loculus metadata to ena metadata using template: https://www.ebi.ac.uk/ena/
 In a loop
 
 - Get sequences in `submission_table` in state SUBMITTED_PROJECT
+  - if (biosampleAccession exists in the metadata):
+    - if (for (accession, version) entry with this accession already exists use that sample_id)
+      and update submission_table to SUBMITTED_SAMPLE
+    - else: create an entry in `sample_table` and then update `submission_table` with results
   - if (there exists an entry in the `sample_table` for the corresponding (accession, version)):
     - if (entry is in status SUBMITTED): update `submission_table` to SUBMITTED_SAMPLE.
     - else: update submission_table to SUBMITTING_SAMPLE.

--- a/ena-submission/README.md
+++ b/ena-submission/README.md
@@ -191,6 +191,8 @@ python scripts/deposition_dry_run.py --log-level=DEBUG --data-to-submit=results/
 
 ### Testing submission locally
 
+0. Remove `disableEnaSubmission: true` from the `kubernetes/loculus/values_e2e_and_dev.yaml` if you want to run locally.
+
 1. Run loculus locally (need prepro, backend and ena-submission pod), e.g.
 
 ```sh

--- a/ena-submission/README.md
+++ b/ena-submission/README.md
@@ -191,8 +191,6 @@ python scripts/deposition_dry_run.py --log-level=DEBUG --data-to-submit=results/
 
 ### Testing submission locally
 
-0. Remove `disableEnaSubmission: true` from the `kubernetes/loculus/values_e2e_and_dev.yaml` if you want to run locally.
-
 1. Run loculus locally (need prepro, backend and ena-submission pod), e.g.
 
 ```sh

--- a/ena-submission/flyway/sql/V1.2__alter_project_table_id.sql
+++ b/ena-submission/flyway/sql/V1.2__alter_project_table_id.sql
@@ -1,8 +1,8 @@
 
-ALTER TABLE project_table ADD COLUMN project_id BIGSERIAL PRIMARY KEY;
-ALTER TABLE submission_table ADD project_id text;
-
 ALTER TABLE project_table DROP CONSTRAINT project_table_pkey;
+ALTER TABLE project_table ADD COLUMN project_id BIGSERIAL PRIMARY KEY;
+
+ALTER TABLE submission_table ADD project_id text;
 
 CREATE INDEX idx_project_table_group_id ON project_table(group_id);
 CREATE INDEX idx_project_table_organism ON project_table(organism);

--- a/ena-submission/flyway/sql/V1.2__alter_project_table_id.sql
+++ b/ena-submission/flyway/sql/V1.2__alter_project_table_id.sql
@@ -1,0 +1,8 @@
+
+ALTER TABLE project_table ADD COLUMN project_id BIGSERIAL PRIMARY KEY;
+ALTER TABLE submission_table ADD project_id text;
+
+ALTER TABLE project_table DROP CONSTRAINT project_table_pkey;
+
+CREATE INDEX idx_project_table_group_id ON project_table(group_id);
+CREATE INDEX idx_project_table_organism ON project_table(organism);

--- a/ena-submission/scripts/deposition_dry_run.py
+++ b/ena-submission/scripts/deposition_dry_run.py
@@ -139,7 +139,7 @@ def local_ena_submission_generator(
         logger.info(f"Writing results to {directory}")
 
         manifest_object = create_manifest_object(
-            config, dummy_sample_dict, dummy_project_dict, entry, entry, entry, dir=directory
+            config, dummy_sample_dict, dummy_project_dict, entry, entry, dir=directory
         )
         create_manifest(manifest_object, is_broker=config.is_broker, dir=directory)
         logger.info(

--- a/ena-submission/scripts/get_ena_submission_list.py
+++ b/ena-submission/scripts/get_ena_submission_list.py
@@ -146,10 +146,10 @@ def get_ena_submission_list(config_file):
             message = (
                 f"{config.backend_url}: {organism} - ENA Submission pipeline found "
                 f"{len(entries_with_external_metadata)} sequences with ena-specific-metadata fields"
-                " and not submitted by us or ingested from the INSDC, this might be a user error or"
-                " require manual submission to ENA (e.g. manually setting the bioproject in the "
-                "PROJECT and the biosample in the SAMPLE table - see details in "
-                "https://loculus.slack.com/archives/C07HW5NAL03/p1724960217646709)"
+                " and not submitted by us or ingested from the INSDC, this might be a user error."
+                " If you think this is accurate ensure bioproject and biosample are set correctly."
+                " Bioprojects should be public and SRA accessions should also include bioprojects"
+                " and biosamples."
             )
             output_file = f"{organism}_with_ena_fields_{output_file_suffix}"
             send_slack_notification_with_file(

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -247,13 +247,14 @@ class AssemblyCreationTests(unittest.TestCase):
 
     def test_create_manifest(self):
         config = mock_config()
-        group_key = {"group_id": 1, "organism": "Test organism"}
         study_accession = "Test Study Accession"
         sample_accession = "Test Sample Accession"
         results_in_sample_table = {"result": {"ena_sample_accession": sample_accession}}
         results_in_project_table = {
             "result": {"bioproject_accession": study_accession},
             "center_name": "generic_center_name",
+            "group_id": 1,
+            "organism": "Test organism",
         }
         manifest = create_manifest_object(
             config,

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -261,7 +261,6 @@ class AssemblyCreationTests(unittest.TestCase):
             results_in_project_table,
             sample_data_in_submission_table,
             self.seq_key,
-            group_key,
         )
         manifest_file_name = create_manifest(manifest)
         data = {}

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -122,9 +122,7 @@ def create_manifest_object(
             address_string = ", ".join([x for x in address_list if x is not None])
             logger.debug("Created address from group_info")
         except Exception as e:
-            logger.error(
-                f"Was unable to create address, setting address to center_name due to {e}"
-            )
+            logger.error(f"Was unable to create address, setting address to center_name due to {e}")
 
     metadata = submission_table_entry["metadata"]
     unaligned_nucleotide_sequences = submission_table_entry["unaligned_nucleotide_sequences"]
@@ -196,6 +194,8 @@ def create_manifest_object(
 
     if metadata.get("insdcRawReadsAccession") and metadata["insdcRawReadsAccession"]:
         run_ref = [metadata["insdcRawReadsAccession"]]
+    else:
+        run_ref = None
 
     return AssemblyManifest(
         study=study_accession,

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -89,7 +89,6 @@ def create_manifest_object(
     project_table_entry: dict[str, str],
     submission_table_entry: dict[str, str],
     seq_key: dict[str, str],
-    group_key: dict[str, str],
     test=False,
     dir: str | None = None,
 ) -> AssemblyManifest:
@@ -129,7 +128,7 @@ def create_manifest_object(
 
     metadata = submission_table_entry["metadata"]
     unaligned_nucleotide_sequences = submission_table_entry["unaligned_nucleotide_sequences"]
-    organism_metadata = config.organisms[group_key["organism"]]["enaDeposition"]
+    organism_metadata = config.organisms[project_table_entry["organism"]]["enaDeposition"]
     chromosome_list_object = create_chromosome_list_object(unaligned_nucleotide_sequences, seq_key)
     logger.debug("Created chromosome list object")
     chromosome_list_file = create_chromosome_list(list_object=chromosome_list_object, dir=dir)
@@ -341,9 +340,8 @@ def assembly_table_create(
         if len(sample_data_in_submission_table) == 0:
             error_msg = f"Entry {row['accession']} not found in submitting_table"
             raise RuntimeError(error_msg)
-        group_key = {
-            "group_id": sample_data_in_submission_table[0]["group_id"],
-            "organism": sample_data_in_submission_table[0]["organism"],
+        project_id = {
+            "project_id": sample_data_in_submission_table[0]["project_id"],
         }
         center_name = sample_data_in_submission_table[0]["center_name"]
 
@@ -355,7 +353,7 @@ def assembly_table_create(
             raise RuntimeError(error_msg)
 
         results_in_project_table = find_conditions_in_db(
-            db_config, table_name="project_table", conditions=group_key
+            db_config, table_name="project_table", conditions=project_id
         )
         if len(results_in_project_table) == 0:
             error_msg = f"Entry {row['accession']} not found in project_table"
@@ -368,7 +366,6 @@ def assembly_table_create(
                 results_in_project_table[0],
                 sample_data_in_submission_table[0],
                 seq_key,
-                group_key,
                 test,
             )
             manifest_file = create_manifest(manifest_object, is_broker=config.is_broker)

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -194,6 +194,9 @@ def create_manifest_object(
         else seq_key["accession"]
     )
 
+    if metadata.get("insdcRawReadsAccession") and metadata["insdcRawReadsAccession"]:
+        run_ref = [metadata["insdcRawReadsAccession"]]
+
     return AssemblyManifest(
         study=study_accession,
         sample=sample_accession,
@@ -206,6 +209,7 @@ def create_manifest_object(
         chromosome_list=chromosome_list_file,
         description=description,
         moleculetype=moleculetype,
+        run_ref=run_ref,
         authors=authors,
         address=address_string,
     )

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -178,6 +178,7 @@ def submission_table_update(db_config: SimpleConnectionPool):
             update_values = {
                 "status_all": StatusAll.SUBMITTED_PROJECT,
                 "center_name": corresponding_project[0]["center_name"],
+                "project_id": corresponding_project[0]["project_id"]
             }
             update_db_where_conditions(
                 db_config,

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -182,6 +182,7 @@ def submission_table_start(db_config: SimpleConnectionPool, config: Config):
                 update_values = {
                     "status_all": StatusAll.SUBMITTED_PROJECT,
                     "center_name": corresponding_project[0]["center_name"],
+                    "project_id": corresponding_project[0]["project_id"],
                 }
                 update_db_where_conditions(
                     db_config,

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -128,7 +128,7 @@ def set_project_table_entry(db_config, config, row):
     logger.info("Checking if bioproject actually exists and is public")
     if (
         set_error_if_accession_not_exists(
-            accession=bioproject, accession_type="BIOPROJECT", db_pool=db_config
+            conditions=seq_key, accession=bioproject, accession_type="BIOPROJECT", db_pool=db_config
         )
         is False
     ):

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -112,15 +112,15 @@ def submission_table_start(db_config: SimpleConnectionPool):
         group_key = {"group_id": row["group_id"], "organism": row["organism"]}
         seq_key = {"accession": row["accession"], "version": row["version"]}
 
-        if "bioproject" in row["metadata"]:
-            bioproject = row["metadata"]["bioproject"]
+        if "bioprojectAccession" in row["metadata"]:
+            bioproject = row["metadata"]["bioprojectAccession"]
             corresponding_group = find_conditions_in_db(
                 db_config, table_name="project_table", conditions=group_key
             )
             corresponding_project = [
                 project
                 for project in corresponding_group
-                if project["results"].get("bioproject") == bioproject
+                if project["results"].get("bioproject_accession") == bioproject
             ]
             if len(corresponding_project) == 1:
                 update_values = {
@@ -138,7 +138,7 @@ def submission_table_start(db_config: SimpleConnectionPool):
             entry = {
                 "group_id": row["group_id"],
                 "organism": row["organism"],
-                "results": {"bioproject": bioproject},
+                "results": {"bioproject_accession": bioproject},
                 "status": Status.SUBMITTED,
             }
             project_table_entry = ProjectTableEntry(**entry)
@@ -147,7 +147,7 @@ def submission_table_start(db_config: SimpleConnectionPool):
                 update_values = {
                     "status_all": StatusAll.SUBMITTED_PROJECT,
                     "center_name": row["center_name"],
-                    "project_id": bioproject,
+                    "project_id": succeeded,
                 }
                 update_db_where_conditions(
                     db_config,
@@ -190,7 +190,10 @@ def submission_table_start(db_config: SimpleConnectionPool):
             project_table_entry = ProjectTableEntry(**entry)
             succeeded = add_to_project_table(db_config, project_table_entry)
             if succeeded:
-                update_values = {"status_all": StatusAll.SUBMITTING_PROJECT}
+                update_values = {
+                    "status_all": StatusAll.SUBMITTING_PROJECT,
+                    "project_id": succeeded,
+                }
                 update_db_where_conditions(
                     db_config,
                     table_name="submission_table",

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -167,7 +167,7 @@ def submission_table_start(db_config: SimpleConnectionPool):
     for row in ready_to_submit:
         seq_key = {"accession": row["accession"], "version": row["version"]}
 
-        if "biosampleAccession" in row["metadata"]:
+        if "biosampleAccession" in row["metadata"] and row["metadata"]["biosampleAccession"]:
             logger.debug(
                 f"Accession {row['accession']} already has biosampleAccession in metadata"
             )

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -144,7 +144,7 @@ def construct_sample_set_object(
 
 
 def set_sample_table_entry(db_config, row, seq_key):
-    """Set sample_table entry for accession with biosampleAccession"""
+    """Set sample_table entry for entry with biosampleAccession"""
     logger.debug(
         f"Accession: {row['accession']} already has biosampleAccession, adding to sample_table"
     )

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -156,9 +156,10 @@ def set_sample_table_entry(db_config, row, seq_key):
     biosample = row["metadata"]["biosampleAccession"]
 
     logger.info("Checking if biosample actually exists and is public")
+    seq_key = {"accession": row["accession"], "version": row["version"]}
     if (
         set_error_if_accession_not_exists(
-            accession=biosample, accession_type="BIOSAMPLE", db_pool=db_config
+            conditions=seq_key, accession=biosample, accession_type="BIOSAMPLE", db_pool=db_config
         )
         is False
     ):

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -432,6 +432,8 @@ def create_manifest(
             f.write(f"DESCRIPTION\t{manifest.description}\n")
         if manifest.moleculetype:
             f.write(f"MOLECULETYPE\t{manifest.moleculetype!s}\n")
+        if manifest.run_ref:
+            f.write(f"RUN_REF\t{",".join(manifest.run_ref)}\n")
         if manifest.authors:
             if not is_broker:
                 logger.error("Cannot set authors field for non broker")

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -355,12 +355,12 @@ def add_to_sample_table(
                 (
                     sample_table_entry.accession,
                     sample_table_entry.version,
-                    sample_table_entry.errors,
-                    sample_table_entry.warnings,
+                    json.dumps(sample_table_entry.errors),
+                    json.dumps(sample_table_entry.warnings),
                     str(sample_table_entry.status),
                     sample_table_entry.started_at,
                     sample_table_entry.finished_at,
-                    sample_table_entry.result,
+                    json.dumps(sample_table_entry.result),
                 ),
             )
             con.commit()

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -127,10 +127,12 @@ class SubmissionTableEntry:
     unaligned_nucleotide_sequences: str | None = None
     center_name: str | None = None
     external_metadata: str | None = None
+    project_id: int | None = None
 
 
 @dataclass
 class ProjectTableEntry:
+    project_id: int
     group_id: int
     organism: str
     errors: str | None = None

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 from dataclasses import dataclass
@@ -132,9 +133,9 @@ class SubmissionTableEntry:
 
 @dataclass
 class ProjectTableEntry:
-    project_id: int
     group_id: int
     organism: str
+    project_id: int | None = None
     errors: str | None = None
     warnings: str | None = None
     status: Status = Status.READY
@@ -318,16 +319,16 @@ def add_to_project_table(
             project_table_entry.started_at = datetime.now(tz=pytz.utc)
 
             id = cur.execute(
-                "INSERT INTO project_table VALUES (%s, %s, %s, %s, %s, %s, %s, %s) RETURNING ID",
+                "INSERT INTO project_table VALUES (%s, %s, %s, %s, %s, %s, %s, %s) RETURNING project_id",
                 (
                     project_table_entry.group_id,
                     project_table_entry.organism,
-                    project_table_entry.errors,
-                    project_table_entry.warnings,
+                    json.dumps(project_table_entry.errors),
+                    json.dumps(project_table_entry.warnings),
                     str(project_table_entry.status),
                     project_table_entry.started_at,
                     project_table_entry.finished_at,
-                    project_table_entry.result,
+                    json.dumps(project_table_entry.result),
                 ),
             )
 

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -311,14 +311,14 @@ def update_db_where_conditions(
 
 def add_to_project_table(
     db_conn_pool: SimpleConnectionPool, project_table_entry: ProjectTableEntry
-) -> bool:
+) -> int | None:
     con = db_conn_pool.getconn()
     try:
         with con, con.cursor() as cur:
             project_table_entry.started_at = datetime.now(tz=pytz.utc)
 
-            cur.execute(
-                "INSERT INTO project_table VALUES (%s, %s, %s, %s, %s, %s, %s, %s)",
+            id = cur.execute(
+                "INSERT INTO project_table VALUES (%s, %s, %s, %s, %s, %s, %s, %s) RETURNING ID",
                 (
                     project_table_entry.group_id,
                     project_table_entry.organism,
@@ -332,11 +332,11 @@ def add_to_project_table(
             )
 
             con.commit()
-        return True
+        return id
     except Exception as e:
         con.rollback()
         print(f"add_to_project_table errored with: {e}")
-        return False
+        return None
     finally:
         db_conn_pool.putconn(con)
 

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -319,7 +319,7 @@ def add_to_project_table(
             project_table_entry.started_at = datetime.now(tz=pytz.utc)
 
             id = cur.execute(
-                "INSERT INTO project_table VALUES (%s, %s, %s, %s, %s, %s, %s, %s) RETURNING project_id",
+                "INSERT INTO project_table VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING project_id",
                 (
                     project_table_entry.group_id,
                     project_table_entry.organism,
@@ -329,6 +329,7 @@ def add_to_project_table(
                     project_table_entry.started_at,
                     project_table_entry.finished_at,
                     json.dumps(project_table_entry.result),
+                    project_table_entry.center_name,
                 ),
             )
 

--- a/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
+++ b/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
@@ -30,12 +30,12 @@ def get_external_metadata(db_config: SimpleConnectionPool, entry: dict[str, Any]
         "version": entry["version"],
         "externalMetadata": {},
     }
-    group_key = {"group_id": entry["group_id"], "organism": entry["organism"]}
+    project_id = {"project_id": entry["project_id"]}
     seq_key = {"accession": accession, "version": entry["version"]}
 
     # Get corresponding entry in the project table for (group_id, organism)
     corresponding_project = find_conditions_in_db(
-        db_config, table_name="project_table", conditions=group_key
+        db_config, table_name="project_table", conditions=project_id
     )
     if len(corresponding_project) == 1:
         data["externalMetadata"]["bioprojectAccession"] = corresponding_project[0]["result"][

--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -169,7 +169,6 @@ data:
               ]
             }
           },
-          {{- if not .Values.disableEnaSubmission }}
           {
             "username": "external_metadata_updater",
             "enabled": true,
@@ -197,7 +196,6 @@ data:
               ]
             }
           },
-          {{ end }}
         {
           "username": "backend",
           "enabled": true,

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -594,7 +594,7 @@ defaultOrganismConfig: &defaultOrganismConfig
           type: link
           url: "https://www.ncbi.nlm.nih.gov/biosample/__value__"
         header: "INSDC"
-        guidance: "Only add this field if you have already submitted the raw reads to the INSDC, read more at https://pathoplexus.org/docs/how-to/upload-sequences."
+        guidance: "Only add this field if you have already submitted the raw reads to the INSDC, read more at https://pathoplexus.org/docs/how-to/upload-sequences. If you add this field we will not create a new biosample for you and assume you have submitted all required metadata in the linked biosample."
         definition: "Accession of corresponding public biosample of the raw reads in the INSDC"
         example: "SAMN12345678"
         oneHeader: true

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -578,7 +578,9 @@ defaultOrganismConfig: &defaultOrganismConfig
           url: "https://www.ncbi.nlm.nih.gov/bioproject/__value__"
         header: "INSDC"
         ingest: bioprojects
-        noInput: true
+        guidance: "Only add this field if you want your sequences to be linked to an existing public bioproject in the INSDC. If you do not have a bioproject, leave this field blank - we will create a bioproject for you on submission of your consensus sequence."
+        definition: "Accession of public bioproject in the INSDC your consensus sequences should be uploaded tp"
+        example: "PRJNA123456"
       - name: gcaAccession
         displayName: GCA accession
         customDisplay:
@@ -592,7 +594,9 @@ defaultOrganismConfig: &defaultOrganismConfig
           type: link
           url: "https://www.ncbi.nlm.nih.gov/biosample/__value__"
         header: "INSDC"
-        noInput: true
+        guidance: "Only add this field if you have already submitted the raw reads to the INSDC, read more at https://pathoplexus.org/docs/how-to/upload-sequences."
+        definition: "Accession of corresponding public biosample of the raw reads in the INSDC"
+        example: "SAMN12345678"
         oneHeader: true
       - name: cultureId
         displayName: Culture ID


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves https://github.com/loculus-project/loculus/issues/3466

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:

Breaking changes: Please merge the corresponding PP PR with these changes - https://github.com/pathoplexus/pathoplexus/pull/375

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
1. Allow input of bioproject and biosample (remove noInput in values.yaml), add description to tell users when to add this
2. Modify the DB table PROJECT_table to not use (group_id, organism) as unique ID -> small DB migration
3. Modify the SUBMISSION_table code to store PROJECT_table's new id for new created bioproject
4. Modify code: if bioproject exists create a new entry in PROJECT_table with the details - do not create a new bioproject, else create new bioproject for (group_id, organism) as before
5. Modify code: if biosample exists create a new entry in SAMPLE_table with details - do not create a new biosample, else create a new biosample as before
6. Add `RUN-REF` to manifest if `insdcRawReadsAccession` exists in metadata: 
![image](https://github.com/user-attachments/assets/f9d5ab74-05d4-4dc3-9958-bd5139cf5d71)


### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] Testing: ran locally and submitted to the ENA dev server, checked that I: 
- can submit sequences without bioproject and biosample 
- can submit sequences with preexisting bioproject
- can submit sequences with preexisting bioproject and biosample
- can add RUN_REF if `insdcRawReadsAccession` is given
