### PR TITLE
feat(website): Group metadata fields on the revision page

### DIFF
--- a/website/src/components/Edit/DataRow.tsx
+++ b/website/src/components/Edit/DataRow.tsx
@@ -21,7 +21,7 @@ export const EditableDataRow: FC<EditableRowProps> = ({ label, inputField, row, 
         <tr className='table-fixed w-full'>
             <div>
                 <td className={`w-1/4 relative ${colorClassName}`} data-tooltip-id={'field-tooltip' + row.key}>
-                    {label ?? row.key}:
+                    {`${label ?? row.key}:`}
                 </td>
                 <Tooltip
                     id={'field-tooltip' + row.key}

--- a/website/src/components/Edit/EditPage.spec.tsx
+++ b/website/src/components/Edit/EditPage.spec.tsx
@@ -5,8 +5,15 @@ import { sentenceCase } from 'change-case';
 import { beforeEach, describe, expect, test } from 'vitest';
 
 import { EditPage } from './EditPage.tsx';
-import { defaultReviewData, editableEntry, metadataDisplayName, testAccessToken, testOrganism } from '../../../vitest.setup.ts';
-import type { UnprocessedMetadataRecord } from '../../types/backend.ts';
+import {
+    defaultReviewData,
+    editableEntry,
+    metadataDisplayName,
+    metadataKey,
+    testAccessToken,
+    testOrganism,
+} from '../../../vitest.setup.ts';
+import { type UnprocessedMetadataRecord } from '../../types/backend.ts';
 import type { InputField } from '../../types/config.ts';
 import type { ClientConfig } from '../../types/runtimeConfig.ts';
 
@@ -18,8 +25,8 @@ const groupedInputFields = new Map<string, InputField[]>([
         'Header',
         [
             {
-                name: 'originalMetaDataField',
-                displayName: 'Original meta data field',
+                name: metadataKey,
+                displayName: metadataDisplayName,
             },
         ],
     ],

--- a/website/src/components/Edit/EditPage.spec.tsx
+++ b/website/src/components/Edit/EditPage.spec.tsx
@@ -5,19 +5,25 @@ import { sentenceCase } from 'change-case';
 import { beforeEach, describe, expect, test } from 'vitest';
 
 import { EditPage } from './EditPage.tsx';
-import { defaultReviewData, editableEntry, metadataKey, testAccessToken, testOrganism } from '../../../vitest.setup.ts';
+import { defaultReviewData, editableEntry, metadataDisplayName, testAccessToken, testOrganism } from '../../../vitest.setup.ts';
 import type { UnprocessedMetadataRecord } from '../../types/backend.ts';
+import type { InputField } from '../../types/config.ts';
 import type { ClientConfig } from '../../types/runtimeConfig.ts';
 
 const queryClient = new QueryClient();
 
 const dummyConfig = { backendUrl: 'dummy' } as ClientConfig;
-const inputFields = [
-    {
-        name: 'originalMetaDataField',
-        dispayName: 'Original Meta Data Field',
-    },
-];
+const groupedInputFields = new Map<string, InputField[]>([
+    [
+        'Header',
+        [
+            {
+                name: 'originalMetaDataField',
+                displayName: 'Original meta data field',
+            },
+        ],
+    ],
+]);
 
 function renderEditPage({
     editedData = defaultReviewData,
@@ -31,7 +37,7 @@ function renderEditPage({
                 dataToEdit={editedData}
                 clientConfig={clientConfig}
                 accessToken={testAccessToken}
-                inputFields={inputFields}
+                groupedInputFields={groupedInputFields}
                 submissionDataTypes={{ consensusSequences: allowSubmissionOfConsensusSequences }}
             />
         </QueryClientProvider>,
@@ -98,7 +104,7 @@ describe('EditPage', () => {
         await userEvent.type(screen.getByDisplayValue(editableEntry), someTextToAdd);
 
         expectTextInSequenceData.originalMetadata({
-            [metadataKey]: editableEntry + someTextToAdd,
+            [metadataDisplayName]: editableEntry + someTextToAdd,
         });
         const undoButton = document.querySelector(`.tooltip[data-tip="Revert to: ${editableEntry}"]`);
         expect(undoButton).not.toBeNull();

--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -27,7 +27,6 @@ type EditPageProps = {
     clientConfig: ClientConfig;
     dataToEdit: SequenceEntryToEdit;
     accessToken: string;
-    inputFields: InputField[];
     groupedInputFields: Map<string, InputField[]>;
     submissionDataTypes: SubmissionDataTypes;
 };
@@ -76,7 +75,6 @@ const InnerEditPage: FC<EditPageProps> = ({
     dataToEdit,
     clientConfig,
     accessToken,
-    inputFields,
     groupedInputFields,
     submissionDataTypes,
 }) => {
@@ -145,7 +143,6 @@ const InnerEditPage: FC<EditPageProps> = ({
                     <EditableOriginalData
                         editedMetadata={editedMetadata.filter(({ key }) => key !== ACCESSION_FIELD)}
                         setEditedMetadata={setEditedMetadata}
-                        inputFields={inputFields}
                         groupedInputFields={groupedInputFields}
                     />
                     {submissionDataTypes.consensusSequences && (
@@ -325,24 +322,29 @@ const Subtitle: FC<SubtitleProps> = ({ title, bold, small, customKey }) => (
 type EditableOriginalDataProps = {
     editedMetadata: Row[];
     setEditedMetadata: Dispatch<SetStateAction<Row[]>>;
-    inputFields: InputField[];
     groupedInputFields: Map<string, InputField[]>;
 };
-const EditableOriginalData: FC<EditableOriginalDataProps> = ({ editedMetadata, setEditedMetadata, inputFields, groupedInputFields }) => (
+const EditableOriginalData: FC<EditableOriginalDataProps> = ({
+    editedMetadata,
+    setEditedMetadata,
+    groupedInputFields,
+}) => (
     <>
         <Subtitle title='Metadata' />
         {Array.from(groupedInputFields.entries()).map(([group, fields]) => (
             <Fragment key={group}>
                 <Subtitle title={group} small />
                 {fields.map((inputField) => {
-                    const field = editedMetadata.find((editedMetadataField) => editedMetadataField.key === inputField.name) ?? {
+                    const field = editedMetadata.find(
+                        (editedMetadataField) => editedMetadataField.key === inputField.name,
+                    ) ?? {
                         key: inputField.name,
                         value: '',
                         initialValue: '',
                         warnings: [],
                         errors: [],
                     };
-                    
+
                     return !inputField.noEdit ? (
                         <EditableDataRow
                             label={inputField.displayName ?? sentenceCase(inputField.name)}
@@ -354,7 +356,9 @@ const EditableOriginalData: FC<EditableOriginalDataProps> = ({ editedMetadata, s
                                     const relevantOldRow = prevRows.find((oldRow) => oldRow.key === editedRow.key);
                                     return relevantOldRow
                                         ? prevRows.map((prevRow) =>
-                                              prevRow.key === editedRow.key ? { ...prevRow, value: editedRow.value } : prevRow,
+                                              prevRow.key === editedRow.key
+                                                  ? { ...prevRow, value: editedRow.value }
+                                                  : prevRow,
                                           )
                                         : [...prevRows, editedRow];
                                 })

--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -28,6 +28,7 @@ type EditPageProps = {
     dataToEdit: SequenceEntryToEdit;
     accessToken: string;
     inputFields: InputField[];
+    groupedInputFields: Map<string, InputField[]>;
     submissionDataTypes: SubmissionDataTypes;
 };
 
@@ -76,6 +77,7 @@ const InnerEditPage: FC<EditPageProps> = ({
     clientConfig,
     accessToken,
     inputFields,
+    groupedInputFields,
     submissionDataTypes,
 }) => {
     const [editedMetadata, setEditedMetadata] = useState(mapMetadataToRow(dataToEdit));
@@ -144,6 +146,7 @@ const InnerEditPage: FC<EditPageProps> = ({
                         editedMetadata={editedMetadata.filter(({ key }) => key !== ACCESSION_FIELD)}
                         setEditedMetadata={setEditedMetadata}
                         inputFields={inputFields}
+                        groupedInputFields={groupedInputFields}
                     />
                     {submissionDataTypes.consensusSequences && (
                         <EditableOriginalSequences
@@ -322,8 +325,9 @@ type EditableOriginalDataProps = {
     editedMetadata: Row[];
     setEditedMetadata: Dispatch<SetStateAction<Row[]>>;
     inputFields: InputField[];
+    groupedInputFields: Map<string, InputField[]>;
 };
-const EditableOriginalData: FC<EditableOriginalDataProps> = ({ editedMetadata, setEditedMetadata, inputFields }) => (
+const EditableOriginalData: FC<EditableOriginalDataProps> = ({ editedMetadata, setEditedMetadata, inputFields, groupedInputFields }) => (
     // TODO Edit here - sort
     <>
         <Subtitle title='Metadata' />

--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -324,6 +324,7 @@ type EditableOriginalDataProps = {
     inputFields: InputField[];
 };
 const EditableOriginalData: FC<EditableOriginalDataProps> = ({ editedMetadata, setEditedMetadata, inputFields }) => (
+    // TODO Edit here - sort
     <>
         <Subtitle title='Metadata' />
         {inputFields.map((inputField) => {

--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -331,43 +331,46 @@ const EditableOriginalData: FC<EditableOriginalDataProps> = ({
 }) => (
     <>
         <Subtitle title='Metadata' />
-        {Array.from(groupedInputFields.entries()).map(([group, fields]) => (
-            <Fragment key={group}>
-                <Subtitle title={group} small />
-                {fields.map((inputField) => {
-                    const field = editedMetadata.find(
-                        (editedMetadataField) => editedMetadataField.key === inputField.name,
-                    ) ?? {
-                        key: inputField.name,
-                        value: '',
-                        initialValue: '',
-                        warnings: [],
-                        errors: [],
-                    };
+        {Array.from(groupedInputFields.entries()).map(([group, fields]) => {
+            if (fields.length === 0) return undefined;
+            return (
+                <Fragment key={group}>
+                    <Subtitle title={group} small />
+                    {fields.map((inputField) => {
+                        const field = editedMetadata.find(
+                            (editedMetadataField) => editedMetadataField.key === inputField.name,
+                        ) ?? {
+                            key: inputField.name,
+                            value: '',
+                            initialValue: '',
+                            warnings: [],
+                            errors: [],
+                        };
 
-                    return !inputField.noEdit ? (
-                        <EditableDataRow
-                            label={inputField.displayName ?? sentenceCase(inputField.name)}
-                            inputField={inputField.name}
-                            key={'raw_metadata' + inputField.name}
-                            row={field}
-                            onChange={(editedRow: Row) =>
-                                setEditedMetadata((prevRows) => {
-                                    const relevantOldRow = prevRows.find((oldRow) => oldRow.key === editedRow.key);
-                                    return relevantOldRow
-                                        ? prevRows.map((prevRow) =>
-                                              prevRow.key === editedRow.key
-                                                  ? { ...prevRow, value: editedRow.value }
-                                                  : prevRow,
-                                          )
-                                        : [...prevRows, editedRow];
-                                })
-                            }
-                        />
-                    ) : null;
-                })}
-            </Fragment>
-        ))}
+                        return !inputField.noEdit ? (
+                            <EditableDataRow
+                                label={inputField.displayName ?? sentenceCase(inputField.name)}
+                                inputField={inputField.name}
+                                key={'raw_metadata' + inputField.name}
+                                row={field}
+                                onChange={(editedRow: Row) =>
+                                    setEditedMetadata((prevRows) => {
+                                        const relevantOldRow = prevRows.find((oldRow) => oldRow.key === editedRow.key);
+                                        return relevantOldRow
+                                            ? prevRows.map((prevRow) =>
+                                                  prevRow.key === editedRow.key
+                                                      ? { ...prevRow, value: editedRow.value }
+                                                      : prevRow,
+                                              )
+                                            : [...prevRows, editedRow];
+                                    })
+                                }
+                            />
+                        ) : null;
+                    })}
+                </Fragment>
+            );
+        })}
     </>
 );
 

--- a/website/src/pages/[organism]/submission/edit/[accession]/[version].astro
+++ b/website/src/pages/[organism]/submission/edit/[accession]/[version].astro
@@ -1,6 +1,7 @@
 ---
 import { EditPage } from '../../../../../components/Edit/EditPage';
-import { getRuntimeConfig, getSchema } from '../../../../../config';
+import { cleanOrganism } from '../../../../../components/Navigation/cleanOrganism';
+import { getGroupedInputFields, getRuntimeConfig, getSchema } from '../../../../../config';
 import BaseLayout from '../../../../../layouts/BaseLayout.astro';
 import { BackendClient } from '../../../../../services/backendClient';
 import { getAccessToken } from '../../../../../utils/getAccessToken';
@@ -9,7 +10,17 @@ const version = Astro.params.version!;
 const accession = Astro.params.accession!;
 
 const organism = Astro.params.organism!;
+const { organism: cleanedOrganism } = cleanOrganism(Astro.params.organism);
+
+if (!cleanedOrganism) {
+    return {
+        statusCode: 404,
+        body: 'Organism not found',
+    };
+}
+
 const { inputFields } = getSchema(organism);
+const groupedInputFields = getGroupedInputFields(cleanedOrganism.key, 'revise', true);
 const accessToken = getAccessToken(Astro.locals.session)!;
 
 const clientConfig = getRuntimeConfig().public;
@@ -28,6 +39,7 @@ const dataToEdit = await BackendClient.create().getDataToEdit(organism, accessTo
                     dataToEdit={dataToEdit}
                     clientConfig={clientConfig}
                     inputFields={inputFields}
+                    groupedInputFields={groupedInputFields}
                     submissionDataTypes={schema.submissionDataTypes}
                     client:load
                 />

--- a/website/src/pages/[organism]/submission/edit/[accession]/[version].astro
+++ b/website/src/pages/[organism]/submission/edit/[accession]/[version].astro
@@ -19,7 +19,6 @@ if (!cleanedOrganism) {
     };
 }
 
-const { inputFields } = getSchema(organism);
 const groupedInputFields = getGroupedInputFields(cleanedOrganism.key, 'revise', true);
 const accessToken = getAccessToken(Astro.locals.session)!;
 
@@ -38,7 +37,6 @@ const dataToEdit = await BackendClient.create().getDataToEdit(organism, accessTo
                     accessToken={accessToken}
                     dataToEdit={dataToEdit}
                     clientConfig={clientConfig}
-                    inputFields={inputFields}
                     groupedInputFields={groupedInputFields}
                     submissionDataTypes={schema.submissionDataTypes}
                     client:load

--- a/website/vitest.setup.ts
+++ b/website/vitest.setup.ts
@@ -43,8 +43,8 @@ export const testConfig = {
 // See https://github.com/tailwindlabs/headlessui/issues/3268
 vi.stubGlobal('ResizeObserver', ResizeObserver);
 
-export const metadataKey = 'originalMetaDataField';
-export const metadataDisplayName ='Original Meta Data Field';
+export const metadataKey = 'originalMetadataField';
+export const metadataDisplayName = 'Original Metadata Field';
 export const editableEntry = 'originalMetaDataValue';
 export const defaultReviewData: SequenceEntryToEdit = {
     accession: '1',

--- a/website/vitest.setup.ts
+++ b/website/vitest.setup.ts
@@ -44,6 +44,7 @@ export const testConfig = {
 vi.stubGlobal('ResizeObserver', ResizeObserver);
 
 export const metadataKey = 'originalMetaDataField';
+export const metadataDisplayName ='Original Meta Data Field';
 export const editableEntry = 'originalMetaDataValue';
 export const defaultReviewData: SequenceEntryToEdit = {
     accession: '1',


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #3544 

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://edit-page-sections.loculus.org

### Summary
Input fields are grouped by the _Headers_ in the metadata definitions.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->
<img width="913" alt="image" src="https://github.com/user-attachments/assets/906f0bd5-53cf-4019-bd43-d4d95599e033" />


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~All necessary documentation has been adapted.~~ (n/a)
- ~~The implemented feature is covered by an appropriate test.~~ (n/a)
