### PR TITLE
Raw data / files sharing

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 
     implementation("org.redundent:kotlin-xml-builder:1.9.1")
     implementation("org.jsoup:jsoup:1.18.3")
+    implementation("io.minio:minio:8.5.17")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude group: "org.mockito"

--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.loculus.backend.service.s3files.S3FileHandle
 import org.loculus.backend.utils.Accession
 import org.loculus.backend.utils.Version
 import org.springframework.core.convert.converter.Converter
@@ -92,6 +93,7 @@ data class SubmittedProcessedData(
     override val accession: Accession,
     override val version: Version,
     val data: ProcessedData<GeneticSequence>,
+    val files: Map<String, String>? = null,
     @Schema(description = "The processing failed due to these errors.")
     val errors: List<PreprocessingAnnotation>? = null,
     @Schema(
@@ -242,6 +244,7 @@ data class UnprocessedData(
     @Schema(example = "LOC_000S01D") override val accession: Accession,
     @Schema(example = "1") override val version: Version,
     val data: OriginalData<GeneticSequence>,
+    val file: S3FileHandle, // TODO add @Schema
     @Schema(description = "The submission id that was used in the upload to link metadata and sequences")
     val submissionId: String,
     @Schema(description = "The username of the submitter")

--- a/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
@@ -8,6 +8,7 @@ data class BackendConfig(
     val organisms: Map<String, InstanceConfig>,
     val accessionPrefix: String,
     val dataUseTerms: DataUseTerms,
+    val s3Storage: S3Storage,
 ) {
     fun getInstanceConfig(organism: Organism) = organisms[organism.name] ?: throw IllegalArgumentException(
         "Organism: ${organism.name} not found in backend config. Available organisms: ${organisms.keys}",
@@ -81,3 +82,9 @@ data class ExternalMetadata(
 ) : BaseMetadata()
 
 data class EarliestReleaseDate(val enabled: Boolean = false, val externalFields: List<String>)
+
+data class S3Storage(val enabled: Boolean, val endpoint: String?, val auth: S3Auth?, val buckets: S3Buckets?)
+
+data class S3Auth(val accessKey: String, val secretKey: String)
+
+data class S3Buckets(val private: String, val public: String)

--- a/backend/src/main/kotlin/org/loculus/backend/controller/S3FileController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/S3FileController.kt
@@ -1,0 +1,46 @@
+package org.loculus.backend.controller
+
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import org.loculus.backend.auth.AuthenticatedUser
+import org.loculus.backend.auth.HiddenParam
+import org.loculus.backend.service.s3files.S3FileHandle
+import org.loculus.backend.service.s3files.S3FileUploadStatus
+import org.loculus.backend.service.s3files.S3FilesService
+import org.springframework.http.MediaType
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/files")
+@Validated
+@SecurityRequirement(name = "bearerAuth")
+class S3FileController (
+    private val s3FilesService: S3FilesService,
+) {
+
+    @PostMapping("/request-uploads", consumes = [MediaType.APPLICATION_JSON_VALUE])
+    fun requestUploads(
+        @HiddenParam authenticatedUser: AuthenticatedUser,
+        @Parameter(description = GROUP_ID_DESCRIPTION) @RequestParam groupId: Int,
+        @RequestParam numberFiles: Int,
+    ): List<S3FileHandle> {
+        // TODO Perform some checks
+        val handles = ArrayList<S3FileHandle>()
+        repeat(numberFiles) { s3FilesService.initiateUpload(authenticatedUser.username, groupId) }
+        return handles
+    }
+
+    @PostMapping("/confirm-uploads", consumes = [MediaType.APPLICATION_JSON_VALUE])
+    fun confirmUploads(
+        @HiddenParam authenticatedUser: AuthenticatedUser,
+        @Parameter(description = GROUP_ID_DESCRIPTION) @RequestParam fileIds: List<String>,
+    ): List<S3FileUploadStatus> {
+        // TODO Perform some checks
+        return fileIds.map { s3FilesService.confirmUpload(it) }
+    }
+
+}

--- a/backend/src/main/kotlin/org/loculus/backend/controller/S3FileController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/S3FileController.kt
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
+// TODO The controller should only be created if the S3 storage is enabled
 @RestController
 @RequestMapping("/files")
 @Validated

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -1,35 +1,13 @@
 package org.loculus.backend.model
 
-import com.fasterxml.jackson.databind.node.BooleanNode
-import com.fasterxml.jackson.databind.node.IntNode
-import com.fasterxml.jackson.databind.node.LongNode
-import com.fasterxml.jackson.databind.node.NullNode
-import com.fasterxml.jackson.databind.node.TextNode
+import com.fasterxml.jackson.databind.node.*
 import mu.KotlinLogging
-import org.loculus.backend.api.DataUseTerms
-import org.loculus.backend.api.GeneticSequence
-import org.loculus.backend.api.MetadataMap
-import org.loculus.backend.api.Organism
-import org.loculus.backend.api.ProcessedData
-import org.loculus.backend.api.VersionStatus
+import org.loculus.backend.api.*
 import org.loculus.backend.config.BackendConfig
 import org.loculus.backend.service.datauseterms.DATA_USE_TERMS_TABLE_NAME
 import org.loculus.backend.service.groupmanagement.GROUPS_TABLE_NAME
-import org.loculus.backend.service.submission.CURRENT_PROCESSING_PIPELINE_TABLE_NAME
-import org.loculus.backend.service.submission.EXTERNAL_METADATA_TABLE_NAME
-import org.loculus.backend.service.submission.METADATA_UPLOAD_AUX_TABLE_NAME
-import org.loculus.backend.service.submission.RawProcessedData
-import org.loculus.backend.service.submission.SEQUENCE_ENTRIES_PREPROCESSED_DATA_TABLE_NAME
-import org.loculus.backend.service.submission.SEQUENCE_ENTRIES_TABLE_NAME
-import org.loculus.backend.service.submission.SEQUENCE_UPLOAD_AUX_TABLE_NAME
-import org.loculus.backend.service.submission.SubmissionDatabaseService
-import org.loculus.backend.service.submission.UpdateTrackerTable
-import org.loculus.backend.utils.Accession
-import org.loculus.backend.utils.DateProvider
-import org.loculus.backend.utils.EarliestReleaseDateFinder
-import org.loculus.backend.utils.Version
-import org.loculus.backend.utils.toTimestamp
-import org.loculus.backend.utils.toUtcDateString
+import org.loculus.backend.service.submission.*
+import org.loculus.backend.utils.*
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -69,6 +47,7 @@ open class ReleasedDataModel(
 
         return submissionDatabaseService.streamReleasedSubmissions(organism)
             .map {
+                // TODO Copy non-public files to the public bucket using S3FilesService.publishFile()
                 computeAdditionalMetadataFields(
                     it,
                     latestVersions,
@@ -122,6 +101,7 @@ open class ReleasedDataModel(
             }
         }
 
+        // TODO Add the public URLs of the processed files to the metadata
         var metadata = rawProcessedData.processedData.metadata +
             mapOf(
                 ("accession" to TextNode(rawProcessedData.accession)),

--- a/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
@@ -14,6 +14,7 @@ import org.loculus.backend.controller.DuplicateKeyException
 import org.loculus.backend.controller.UnprocessableEntityException
 import org.loculus.backend.service.datauseterms.DataUseTermsPreconditionValidator
 import org.loculus.backend.service.groupmanagement.GroupManagementPreconditionValidator
+import org.loculus.backend.service.s3files.S3FilesService
 import org.loculus.backend.service.submission.CompressionAlgorithm
 import org.loculus.backend.service.submission.MetadataUploadAuxTable
 import org.loculus.backend.service.submission.SequenceUploadAuxTable
@@ -31,6 +32,7 @@ import java.io.InputStream
 
 const val HEADER_TO_CONNECT_METADATA_AND_SEQUENCES = "submissionId"
 const val ACCESSION_HEADER = "accession"
+const val FILE_HEADER = "file"
 private val log = KotlinLogging.logger { }
 
 typealias SubmissionId = String
@@ -78,6 +80,7 @@ class SubmitModel(
     private val dataUseTermsPreconditionValidator: DataUseTermsPreconditionValidator,
     private val dateProvider: DateProvider,
     private val backendConfig: BackendConfig,
+    private val s3FilesService: S3FilesService,
 ) {
 
     companion object AcceptedFileTypes {
@@ -237,6 +240,7 @@ class SubmitModel(
                     metadataEntryStreamAsSequence(metadataStream)
                         .chunked(batchSize)
                         .forEach { batch ->
+                            TODO("Check that the files have been uploaded and belong to the right group")
                             uploadDatabaseService.batchInsertMetadataInAuxTable(
                                 uploadId = uploadId,
                                 authenticatedUser = submissionParams.authenticatedUser,
@@ -252,6 +256,7 @@ class SubmitModel(
                     revisionEntryStreamAsSequence(metadataStream)
                         .chunked(batchSize)
                         .forEach { batch ->
+                            TODO("Check that the files have been uploaded and belong to the right group")
                             uploadDatabaseService.batchInsertRevisedMetadataInAuxTable(
                                 uploadId = uploadId,
                                 authenticatedUser = submissionParams.authenticatedUser,

--- a/backend/src/main/kotlin/org/loculus/backend/service/s3files/S3FileHandle.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/s3files/S3FileHandle.kt
@@ -1,0 +1,6 @@
+package org.loculus.backend.service.s3files
+
+data class S3FileHandle(
+    val fileId: String,
+    val preSignedUrl: String,
+)

--- a/backend/src/main/kotlin/org/loculus/backend/service/s3files/S3FileUploadStatus.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/s3files/S3FileUploadStatus.kt
@@ -1,0 +1,7 @@
+package org.loculus.backend.service.s3files
+
+data class S3FileUploadStatus(
+    val fileId: String,
+    val success: Boolean,
+    val message: String? = null,
+)

--- a/backend/src/main/kotlin/org/loculus/backend/service/s3files/S3FilesService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/s3files/S3FilesService.kt
@@ -1,0 +1,74 @@
+package org.loculus.backend.service.s3files
+
+import io.minio.GetPresignedObjectUrlArgs
+import io.minio.MinioClient
+import io.minio.http.Method
+import org.springframework.stereotype.Service
+import java.util.concurrent.TimeUnit
+
+
+// TODO Move to config
+private val MAX_FILE_SIZE_BYTES = 1024 * 1024 * 1024
+private val PRE_SIGNED_URL_EXPIRY_SECONDS = 60 * 30
+private val ENDPOINT = ""
+private val PRIVATE_BUCKET = ""
+private val PUBLIC_BUCKET = ""
+private val ACCESS_KEY = ""
+private val SECRET_KEY = ""
+
+
+
+@Service
+class S3FilesService {
+
+    val minioClient: MinioClient = MinioClient.builder()
+        .endpoint(ENDPOINT)
+        .credentials(ACCESS_KEY, SECRET_KEY)
+        .build()
+
+    private fun createPreSignedUrl(filePath: String, method: Method): String {
+        // TODO Limit file size to MAX_FILE_SIZE_BYTES
+        return minioClient.getPresignedObjectUrl(
+            GetPresignedObjectUrlArgs.builder()
+                .bucket(PRIVATE_BUCKET)
+                .expiry(PRE_SIGNED_URL_EXPIRY_SECONDS, TimeUnit.SECONDS)
+                .method(method)
+                .`object`(filePath)
+                .build(),
+        )
+    }
+
+    /**
+     * Returns the public URL of the file (it does not check whether the file has actually been published)
+     */
+    fun getPublicURL(fileId: String): String {
+        TODO()
+    }
+
+    fun initiateUpload(userName: String, ownerGroupId: Int): S3FileHandle {
+        // Create a UUID
+        // Create row in file_uploads
+        // Create pre-defined URL
+        TODO()
+    }
+
+
+    fun confirmUpload(fileId: String): S3FileUploadStatus {
+        // Move files
+        // Check file size
+        // Create row in files
+        // Delete from upload area
+        TODO()
+    }
+
+    fun readFile(fileId: String): S3FileHandle {
+        // Generate pre-signed URL
+        TODO()
+    }
+
+    fun publishFile(fileId: String) {
+        // Copy the file to the public bucket
+        TODO()
+    }
+
+}

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/MetadataUploadAuxTable.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/MetadataUploadAuxTable.kt
@@ -15,6 +15,7 @@ object MetadataUploadAuxTable : Table(METADATA_UPLOAD_AUX_TABLE_NAME) {
     val submitterColumn = varchar("submitter", 255)
     val groupIdColumn = integer("group_id").nullable()
     val uploadedAtColumn = datetime("uploaded_at")
+    val originalFileColumn = text("original_file").nullable()
     val metadataColumn =
         jacksonSerializableJsonb<Map<String, String>>("metadata").nullable()
     override val primaryKey = PrimaryKey(uploadIdColumn, submissionIdColumn)

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SequenceEntriesPreprocessedDataFileTable.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SequenceEntriesPreprocessedDataFileTable.kt
@@ -1,0 +1,15 @@
+package org.loculus.backend.service.submission
+
+import org.jetbrains.exposed.sql.Table
+
+const val SEQUENCE_ENTRIES_PREPROCESSED_DATA_FILE_TABLE_NAME = "sequence_entries_preprocessed_data_file"
+
+object SequenceEntriesPreprocessedDataFileTable : Table(SEQUENCE_ENTRIES_PREPROCESSED_DATA_FILE_TABLE_NAME) {
+    val accessionColumn = varchar("accession", 255)
+    val versionColumn = long("version")
+    val pipelineVersionColumn = long("pipeline_version")
+    val fileIdColumn = text("file_id")
+    val fileNameColumn = text("file_name")
+
+    override val primaryKey = PrimaryKey(accessionColumn, versionColumn, pipelineVersionColumn, fileColumn)
+}

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SequenceEntriesTable.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SequenceEntriesTable.kt
@@ -18,6 +18,7 @@ const val SEQUENCE_ENTRIES_TABLE_NAME = "sequence_entries"
 
 object SequenceEntriesTable : Table(SEQUENCE_ENTRIES_TABLE_NAME) {
     val originalDataColumn = jacksonSerializableJsonb<OriginalData<CompressedSequence>>("original_data").nullable()
+    val originalFileColumn = text("original_file")
 
     val accessionColumn = varchar("accession", 255)
     val versionColumn = long("version")

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
@@ -24,6 +24,7 @@ import org.loculus.backend.service.submission.MetadataUploadAuxTable.accessionCo
 import org.loculus.backend.service.submission.MetadataUploadAuxTable.groupIdColumn
 import org.loculus.backend.service.submission.MetadataUploadAuxTable.metadataColumn
 import org.loculus.backend.service.submission.MetadataUploadAuxTable.organismColumn
+import org.loculus.backend.service.submission.MetadataUploadAuxTable.originalFileColumn
 import org.loculus.backend.service.submission.MetadataUploadAuxTable.submissionIdColumn
 import org.loculus.backend.service.submission.MetadataUploadAuxTable.submitterColumn
 import org.loculus.backend.service.submission.MetadataUploadAuxTable.uploadIdColumn
@@ -69,6 +70,7 @@ class UploadDatabaseService(
             this[metadataColumn] = it.metadata
             this[organismColumn] = submittedOrganism.name
             this[uploadIdColumn] = uploadId
+            this[originalFileColumn] = it.fileId
         }
     }
 
@@ -87,6 +89,7 @@ class UploadDatabaseService(
             this[metadataColumn] = it.metadata
             this[organismColumn] = submittedOrganism.name
             this[uploadIdColumn] = uploadId
+            this[originalFileColumn] = it.fileId
         }
     }
 
@@ -136,6 +139,7 @@ class UploadDatabaseService(
                 submitter,
                 group_id,
                 submitted_at,
+                original_file,
                 original_data
             )
             SELECT
@@ -146,6 +150,7 @@ class UploadDatabaseService(
                 metadata_upload_aux_table.submitter,
                 metadata_upload_aux_table.group_id,
                 metadata_upload_aux_table.uploaded_at,
+                metadata_upload_aux_table.original_file,
                 jsonb_build_object(
                     'metadata', metadata_upload_aux_table.metadata,
                     'unalignedNucleotideSequences', 

--- a/backend/src/main/resources/db/migration/V1.20__add_files.sql
+++ b/backend/src/main/resources/db/migration/V1.20__add_files.sql
@@ -41,4 +41,4 @@ create table sequence_entries_preprocessed_data_files (
 
 
 -- TODO Update sequence_entries_view to include the file information
---  (file_id, file_name, and public) -> combined into a JSON?
+--    combine into a JSON? -> [{fileId: "...", fileName: "...", public: true}, ...]

--- a/backend/src/main/resources/db/migration/V1.20__add_files.sql
+++ b/backend/src/main/resources/db/migration/V1.20__add_files.sql
@@ -1,0 +1,44 @@
+-- TODO Add useful indices
+
+
+create table file_uploads (
+    id uuid primary key,
+    uploaded_by text not null,
+    upload_initiated_at timestamp not null,
+    owner_group_id integer not null references groups_table (group_id),
+);
+
+
+create table files (
+    id uuid primary key,
+    uploaded_by text not null,
+    upload_initiated_at timestamp not null,
+    upload_confirmed_at timestamp not null,
+    owner_group_id integer not null references groups_table (group_id),
+    size_byes bigint not null,
+    public boolean not null
+);
+
+
+alter table sequence_entries
+    add original_file uuid references files (id);
+
+
+alter table metadata_upload_aux_table
+    add original_file uuid references files (id);
+
+
+create table sequence_entries_preprocessed_data_files (
+    accession text not null,
+    version bigint not null,
+    pipeline_version bigint not null,
+    file_id uuid not null,
+    file_name text not null,
+    foreign key (accession, version, pipeline_version) references sequence_entries_preprocessed_data (accession, version, pipeline_version),
+    foreign key (file_id) references files (id),
+    primary key (accession, version, pipeline_version, file_id, file_name)
+);
+
+
+-- TODO Update sequence_entries_view to include the file information
+--  (file_id, file_name, and public) -> combined into a JSON?


### PR DESCRIPTION
This is a rough sketch of the implementation of the raw data/files sharing. Based on feedback, further thoughts and looking through the code, I further refined the proposal that I posted in https://github.com/loculus-project/loculus/issues/3344#issuecomment-2647154289.

The basic flow:

1. To submit files (which may contain raw reads), the client (of the user) calls `/files/request-uploads`, providing the number of files that it wants to upload.
2. The backend generates S3 pre-signed URLs to upload files to `<private bucket>/files_uploads/<file id>` where the file id is a UUID. It sends the pre-signed URLs to the client.
3. The client uploads the files to S3.
4. The client calls `/files/confirm-uploads` with the IDs of the uploaded files.
5. The backend checks that the files exist and moves them to `<private bucket>/files/<file id>`.
6. The client calls `/submit` and provides in the metadata file in the column `file` the file ID for each entry.
7. The backend checks that all mentioned files exist (i.e., uploaded and confirmed) and belong to the same group.
8. The pipeline asks the backend for unprocessed entries.
9. The backend creates pre-signed URLs to download the original files and sends them together with the metadata and FASTA to the pipeline.
10. The pipeline calls `/files/request-uploads` to get pre-signed URLs to upload processed files, and uploads the processed files, and calls `/files/confirm-uploads` to confirm the uploads.
11. The pipeline calls the `/submit-processed-data` with the processed metadata, consensus sequences, and associated file IDs.
12. The backend checks that all files exist.
13. The user can review the processed data. The backend creates pre-signed URLs to download the processed files.
14. The user approves.
15. The SILO importer calls `/get-released-data`
16. The backend fetches the released data from the database. It copies all associated, processed files to the public bucket if they are not there yet. It then includes the public URLs in the response.

Some notes:

- Each file is owned by a group. The backend ensures that files are only linked with sequence entries of the same group.
- A file can be reused: it is possible to link to the same file from different sequence entries, versions, processed files, etc. That means that a user can revise the metadata without re-uploading the files.
- By moving the files from `/files_uploads` to `/files`, we ensure that the file cannot be edited afterward. This is needed because it is not possible to invalidate a pre-signed URL.
- We have to implement a garbage collector to delete unused/unlinked files.
