### PR TITLE
fix(website): pagination reset on search page table resort

### DIFF
--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -136,12 +136,14 @@ export const InnerSearchFullUI = ({
         setState((prev: QueryState) => ({
             ...prev,
             orderBy: field,
+            page: '1',
         }));
     };
     const setOrderDirection = (direction: string) => {
         setState((prev: QueryState) => ({
             ...prev,
             order: direction,
+            page: '1',
         }));
     };
 


### PR DESCRIPTION
Fixes #3665 fixes https://github.com/loculus-project/loculus/issues/2044

https://theosanderson-fix-paginat.loculus.org/ebola-sudan/search?page=1&orderBy=authors&order=ascending

Update `setOrderByField` and `setOrderDirection` functions to reset pagination to page 1 when sorting.

* Modify `setOrderByField` to set the page state to '1' when changing the order by field.
* Modify `setOrderDirection` to set the page state to '1' when changing the order direction.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/loculus-project/loculus/pull/3667?shareId=f78821ff-7852-4c27-ab7b-6679a4c7a7db).