### PR TITLE
fix(website): Fix scroll issue on browse page split view

### DIFF
--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -304,7 +304,7 @@ export const InnerSearchFullUI = ({
             <div
                 className={`md:w-[calc(100%-18.1rem)]`}
                 style={{ paddingBottom: previewedSeqId !== null && previewHalfScreen ? '50vh' : '0' }}
-            >
+            > 
                 <RecentSequencesBanner organism={organism} />
 
                 {(detailsHook.isError || aggregatedHook.isError) &&

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -301,7 +301,7 @@ export const InnerSearchFullUI = ({
                     showMutationSearch={schema.submissionDataTypes.consensusSequences}
                 />
             </div>
-            <div className={`md:w-[calc(100%-18.1rem)] ${previewHalfScreen ? 'pb-96' : ''}`}>
+            <div className={`md:w-[calc(100%-18.1rem)]`} style={{ paddingBottom: previewHalfScreen ? '50vh' : '0' }}>
                 <RecentSequencesBanner organism={organism} />
 
                 {(detailsHook.isError || aggregatedHook.isError) &&

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -301,7 +301,7 @@ export const InnerSearchFullUI = ({
                     showMutationSearch={schema.submissionDataTypes.consensusSequences}
                 />
             </div>
-            <div className={`md:w-[calc(100%-18.1rem)]`} style={{ paddingBottom: previewHalfScreen ? '50vh' : '0' }}>
+            <div className={`md:w-[calc(100%-18.1rem)]`} style={{ paddingBottom: (previewedSeqId !== null && previewHalfScreen) ? '50vh' : '0' }}>
                 <RecentSequencesBanner organism={organism} />
 
                 {(detailsHook.isError || aggregatedHook.isError) &&

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -304,7 +304,7 @@ export const InnerSearchFullUI = ({
             <div
                 className={`md:w-[calc(100%-18.1rem)]`}
                 style={{ paddingBottom: previewedSeqId !== null && previewHalfScreen ? '50vh' : '0' }}
-            > 
+            >
                 <RecentSequencesBanner organism={organism} />
 
                 {(detailsHook.isError || aggregatedHook.isError) &&

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -301,7 +301,10 @@ export const InnerSearchFullUI = ({
                     showMutationSearch={schema.submissionDataTypes.consensusSequences}
                 />
             </div>
-            <div className={`md:w-[calc(100%-18.1rem)]`} style={{ paddingBottom: (previewedSeqId !== null && previewHalfScreen) ? '50vh' : '0' }}>
+            <div
+                className={`md:w-[calc(100%-18.1rem)]`}
+                style={{ paddingBottom: previewedSeqId !== null && previewHalfScreen ? '50vh' : '0' }}
+            >
                 <RecentSequencesBanner organism={organism} />
 
                 {(detailsHook.isError || aggregatedHook.isError) &&

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -301,7 +301,7 @@ export const InnerSearchFullUI = ({
                     showMutationSearch={schema.submissionDataTypes.consensusSequences}
                 />
             </div>
-            <div className='md:w-[calc(100%-18.1rem)]'>
+            <div className={`md:w-[calc(100%-18.1rem)] ${previewHalfScreen ? 'pb-96' : ''}`}>
                 <RecentSequencesBanner organism={organism} />
 
                 {(detailsHook.isError || aggregatedHook.isError) &&

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -301,7 +301,7 @@ export const InnerSearchFullUI = ({
                     showMutationSearch={schema.submissionDataTypes.consensusSequences}
                 />
             </div>
-            <div 
+            <div
                 className={`md:w-[calc(100%-18.1rem)]`}
                 style={{ paddingBottom: previewedSeqId !== null && previewHalfScreen ? '50vh' : '0' }}
             >

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -301,7 +301,7 @@ export const InnerSearchFullUI = ({
                     showMutationSearch={schema.submissionDataTypes.consensusSequences}
                 />
             </div>
-            <div
+            <div 
                 className={`md:w-[calc(100%-18.1rem)]`}
                 style={{ paddingBottom: previewedSeqId !== null && previewHalfScreen ? '50vh' : '0' }}
             >


### PR DESCRIPTION
Fixes #3572

Add conditional padding to the split view in the browse page to allow scrolling to reach the pagination

* Modify `SearchFullUI.tsx` to add a conditional class to the div containing the recent sequences banner, applying additional padding when `previewHalfScreen` is true.

https://theosanderson-fix-scroll.loculus.org/west-nile/search?

![image](https://github.com/user-attachments/assets/559b71ec-31d8-4187-975f-a5b22c5dbed1)

Probably not 100% the most perfect - but does the job for now for a niche component.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/loculus-project/loculus/pull/3669?shareId=9e56555a-41e6-415b-968b-53eec423f3da).