### PR TITLE
(merging into Anya's PR) Suggestions for data use terms selector

### DIFF
--- a/docs/src/content/docs/for-administrators/data-use-terms.mdx
+++ b/docs/src/content/docs/for-administrators/data-use-terms.mdx
@@ -3,6 +3,10 @@ title: Data use terms
 description: What's the data use terms concept of Loculus and how to configure it.
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="caution">The data use terms currently hardcode textual descriptions and behaviour designed around the Pathoplexus database. You can disable the data use terms entirely, as below. If you require custom data use terms handling please feel free to reach out to us by raising a Github issue.</Aside>
+
 Loculus comes with built-in handling of data use terms for submitted data, which means that data can either be _open_ or _restricted_. You can define, what restricted means yourself. Users can submit data as restricted, but they have to give a date at which point the sequences become open, this date can at most be one year from the submission date.
 
 When data use terms are enabled, you can also filter for only open or only restricted data, and when downloading you will have to accept the data use terms. The same applies to API usage.

--- a/website/src/components/DataUseTerms/DataUseTermsSelector.tsx
+++ b/website/src/components/DataUseTerms/DataUseTermsSelector.tsx
@@ -89,7 +89,7 @@ const DataUseTermsSelector: FC<DataUseTermsSelectorProps> = ({
                 <div className='text-xs pl-8 text-gray-500 pb-4'>
                     Anyone can use and share the data (though we believe researchers should exercise scientific
                     etiquette, including the importance of citation).{' '}
-                    <a href={routes.datauseTermsPage()} className='text-primary-600'>
+                    <a href="/about/terms-of-use/open-data" className='text-primary-600'>
                         Find out more
                     </a>
                     .
@@ -114,7 +114,7 @@ const DataUseTermsSelector: FC<DataUseTermsSelectorProps> = ({
                 <div className='text-xs pl-8 text-gray-500 mb-4'>
                     Data use will be restricted for a period of time. The sequences will be available but there will be
                     limitations on how they can be used by others.{' '}
-                    <a href={routes.datauseTermsPage()} className='text-primary-600'>
+                    <a href="/about/terms-of-use/restricted-data" className='text-primary-600'>
                         Find out more
                     </a>
                     .

--- a/website/src/components/DataUseTerms/DataUseTermsSelector.tsx
+++ b/website/src/components/DataUseTerms/DataUseTermsSelector.tsx
@@ -88,7 +88,7 @@ const DataUseTermsSelector: FC<DataUseTermsSelectorProps> = ({
                 <div className='text-xs pl-8 text-gray-500 pb-4'>
                     Anyone can use and share the data (though we believe researchers should exercise scientific
                     etiquette, including the importance of citation).{' '}
-                    <a href="/about/terms-of-use/open-data" className='text-primary-600'>
+                    <a href='/about/terms-of-use/open-data' className='text-primary-600'>
                         Find out more
                     </a>
                     .
@@ -113,7 +113,7 @@ const DataUseTermsSelector: FC<DataUseTermsSelectorProps> = ({
                 <div className='text-xs pl-8 text-gray-500 mb-4'>
                     Data use will be restricted for a period of time. The sequences will be available but there will be
                     limitations on how they can be used by others.{' '}
-                    <a href="/about/terms-of-use/restricted-data" className='text-primary-600'>
+                    <a href='/about/terms-of-use/restricted-data' className='text-primary-600'>
                         Find out more
                     </a>
                     .

--- a/website/src/components/DataUseTerms/DataUseTermsSelector.tsx
+++ b/website/src/components/DataUseTerms/DataUseTermsSelector.tsx
@@ -4,7 +4,6 @@ import { useState, type FC } from 'react';
 
 import { DateChangeModal, datePickerTheme } from './DateChangeModal.tsx';
 import { getClientLogger } from '../../clientLogger.ts';
-import { routes } from '../../routes/routes.ts';
 import {
     type DataUseTermsOption,
     openDataUseTermsOption,

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -349,7 +349,7 @@ const InnerDataUploadForm = ({
                                     <p className='block text-sm'>
                                         Until the end of the restricted period ({restrictedUntil.toFormat('yyyy-MM-dd')}),{' '}
                                         your data will be available on Pathoplexus under the <a 
-                                href="https://pathoplexus.org/about/terms-of-use/restricted-data"
+                                href="/about/terms-of-use/restricted-data"
                                 className="text-primary-600 hover:underline"
                                 target="_blank"
                                 rel="noopener noreferrer"
@@ -357,7 +357,7 @@ const InnerDataUploadForm = ({
                                 restricted terms of use
                             </a>. After the
                                         restricted period, the data will be available under the <a 
-                                href="https://pathoplexus.org/about/terms-of-use/open-data"
+                                href="/about/terms-of-use/open-data"
                                 className="text-primary-600 hover:underline"
                                 target="_blank"
                                 rel="noopener noreferrer"

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -347,10 +347,23 @@ const InnerDataUploadForm = ({
                             <div className='sm:col-span-4 px-8'>
                                 {dataUseTermsType === restrictedDataUseTermsOption && (
                                     <p className='block text-sm'>
-                                        Your data will be available on Pathoplexus, under the restricted use terms until{' '}
-                                        {restrictedUntil.toFormat('yyyy-MM-dd')}. After the restricted period your data
-                                        will be available on Pathoplexus under the open use terms and will additionally{' '}
-                                        be made publicly available through the{' '}
+                                        Until the end of the restricted period ({restrictedUntil.toFormat('yyyy-MM-dd')}),{' '}
+                                        your data will be available on Pathoplexus under the <a 
+                                href="https://pathoplexus.org/about/terms-of-use/restricted-data"
+                                className="text-primary-600 hover:underline"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                restricted terms of use
+                            </a>. After the
+                                        restricted period, the data will be available under the <a 
+                                href="https://pathoplexus.org/about/terms-of-use/open-data"
+                                className="text-primary-600 hover:underline"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                open
+                            </a> terms of use, and will also be made publicly available through the{' '}
                                         <a href='https://www.insdc.org/' className='text-primary-600 hover:underline'>
                                             INSDC
                                         </a>{' '}
@@ -394,9 +407,9 @@ const InnerDataUploadForm = ({
                                         />
                                         <div>
                                             <p className='text-xs pl-4 text-gray-500'>
-                                                I confirm I have not and will not submit this data independently to
-                                                INSDC, to avoid data duplication. I agree to Loculus handling the
-                                                submission of this data to INSDC.{' '}
+                                                I confirm I have not and will not submit this data independently to INSDC,
+                                                to avoid data duplication. I agree to Pathoplexus handling the submission of
+                                                this data to INSDC.{' '}
                                                 <a
                                                     href='/docs/concepts/insdc-submission'
                                                     className='text-primary-600 hover:underline'

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -347,23 +347,26 @@ const InnerDataUploadForm = ({
                             <div className='sm:col-span-4 px-8'>
                                 {dataUseTermsType === restrictedDataUseTermsOption && (
                                     <p className='block text-sm'>
-                                        Until the end of the restricted period ({restrictedUntil.toFormat('yyyy-MM-dd')}),{' '}
-                                        your data will be available on Pathoplexus under the <a 
-                                href="/about/terms-of-use/restricted-data"
-                                className="text-primary-600 hover:underline"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >
-                                restricted terms of use
-                            </a>. After the
-                                        restricted period, the data will be available under the <a 
-                                href="/about/terms-of-use/open-data"
-                                className="text-primary-600 hover:underline"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >
-                                open
-                            </a> terms of use, and will also be made publicly available through the{' '}
+                                        Until the end of the restricted period ({restrictedUntil.toFormat('yyyy-MM-dd')}
+                                        ), your data will be available on Pathoplexus under the{' '}
+                                        <a
+                                            href='/about/terms-of-use/restricted-data'
+                                            className='text-primary-600 hover:underline'
+                                            target='_blank'
+                                            rel='noopener noreferrer'
+                                        >
+                                            restricted terms of use
+                                        </a>
+                                        . After the restricted period, the data will be available under the{' '}
+                                        <a
+                                            href='/about/terms-of-use/open-data'
+                                            className='text-primary-600 hover:underline'
+                                            target='_blank'
+                                            rel='noopener noreferrer'
+                                        >
+                                            open
+                                        </a>{' '}
+                                        terms of use, and will also be made publicly available through the{' '}
                                         <a href='https://www.insdc.org/' className='text-primary-600 hover:underline'>
                                             INSDC
                                         </a>{' '}
@@ -407,9 +410,9 @@ const InnerDataUploadForm = ({
                                         />
                                         <div>
                                             <p className='text-xs pl-4 text-gray-500'>
-                                                I confirm I have not and will not submit this data independently to INSDC,
-                                                to avoid data duplication. I agree to Pathoplexus handling the submission of
-                                                this data to INSDC.{' '}
+                                                I confirm I have not and will not submit this data independently to
+                                                INSDC, to avoid data duplication. I agree to Pathoplexus handling the
+                                                submission of this data to INSDC.{' '}
                                                 <a
                                                     href='/docs/concepts/insdc-submission'
                                                     className='text-primary-600 hover:underline'


### PR DESCRIPTION
- very slightly rephrases text
- links to the specific pages on the two terms of use
- corrects a reference to "Loculus" to Pathoplexus

At some point we should disentangle all references to Pathoplexus and Pathoplexus paths from this, but:
- we can now disable data use terms entirely
- there were already references to Pathoplexus so this doesn't really make it worse

amends docs (to clarify something that was already true):
![image](https://github.com/user-attachments/assets/abf0f100-01b8-4eac-b076-c4367d0ad8c2)
