### PR TITLE
fix(ingest): add back api-key to env variables

### DIFF
--- a/kubernetes/loculus/templates/ingest-deployment.yaml
+++ b/kubernetes/loculus/templates/ingest-deployment.yaml
@@ -76,6 +76,11 @@ spec:
                 secretKeyRef:
                   name: slack-notifications
                   key: slack-hook
+            - name: NCBI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ingest-ncbi
+                  key: api-key
           args:
             - snakemake
             - results/submitted


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: http://www.add-back-apikey.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Discovered by @theosanderson - the api-key was accidentally removed from ingest's env variables: https://github.com/loculus-project/loculus/pull/2473. 

This adds back the api-key - sadly it still doesn't fix our connectivity issue but it good to have!

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
