### PR TITLE
feat(deployment): organism scoped resource specification

### DIFF
--- a/kubernetes/loculus/templates/_resources.tpl
+++ b/kubernetes/loculus/templates/_resources.tpl
@@ -2,7 +2,11 @@
 {{- $args := . -}}
 {{- $containerName := index $args 0 -}}
 {{- $values := index $args 1 -}}
-{{- if and $values.resources (index $values.resources $containerName) }}
+{{- $organism := index $args 2 | default "" -}}
+{{- if and $organism $values.resources.organismSpecific (index $values.resources.organismSpecific $organism) (index (index $values.resources.organismSpecific $organism) $containerName) }}
+resources:
+{{ toYaml (index (index $values.resources.organismSpecific $organism) $containerName) | indent 2 }}
+{{- else if and $values.resources (index $values.resources $containerName) }}
 resources:
 {{ toYaml (index $values.resources $containerName) | indent 2 }}
 {{- else if $values.defaultResources }}

--- a/kubernetes/loculus/templates/_resources.tpl
+++ b/kubernetes/loculus/templates/_resources.tpl
@@ -2,8 +2,15 @@
 {{- $args := . -}}
 {{- $containerName := index $args 0 -}}
 {{- $values := index $args 1 -}}
-{{- $organism := index $args 2 | default "" -}}
-{{- if and $organism $values.resources.organismSpecific (index $values.resources.organismSpecific $organism) (index (index $values.resources.organismSpecific $organism) $containerName) }}
+{{- $organism := "" -}}
+{{- if gt (len $args) 2 -}}
+  {{- $organism = index $args 2 -}}
+{{- end -}}
+
+{{- if and $organism 
+         $values.resources.organismSpecific 
+         (index $values.resources.organismSpecific $organism) 
+         (index (index $values.resources.organismSpecific $organism) $containerName) }}
 resources:
 {{ toYaml (index (index $values.resources.organismSpecific $organism) $containerName) | indent 2 }}
 {{- else if and $values.resources (index $values.resources $containerName) }}

--- a/kubernetes/loculus/templates/lapis-silo-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: silo
           image: {{ $.Values.images.lapisSilo }}
-          {{- include "loculus.resources" (list "silo" $.Values) | nindent 10 }}
+          {{- include "loculus.resources" (list "silo" $.Values $key) | nindent 10 }}
           ports:
             - containerPort: 8081
           args:
@@ -39,7 +39,7 @@ spec:
               mountPath: /data
         - name: lapis
           image: {{ $.Values.images.lapis }}
-          {{- include "loculus.resources" (list "lapis" $.Values) | nindent 10 }}
+          {{- include "loculus.resources" (list "lapis" $.Values $key) | nindent 10 }}
           ports:
             - containerPort: 8080
           args:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1692,10 +1692,11 @@ gitHubMainUrl: https://github.com/loculus-project/loculus
 resources:
   organismSpecific:
     dummy-organism:
-      requests:
-        memory: "10Mi"
-      limits:
-        memory: "10Mi"
+      silo:
+        requests:
+          memory: "10Mi"
+        limits:
+          memory: "10Mi"
   website:
     requests:
       memory: "200Mi"

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1690,6 +1690,12 @@ replicas:
 gitHubEditLink: "https://github.com/loculus-project/loculus/edit/main/monorepo/website/"
 gitHubMainUrl: https://github.com/loculus-project/loculus
 resources:
+  organismSpecific:
+    default-organism:
+       requests:
+        memory: "10Mi"
+      limits:
+        memory: "10Mi"
   website:
     requests:
       memory: "200Mi"

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1690,13 +1690,6 @@ replicas:
 gitHubEditLink: "https://github.com/loculus-project/loculus/edit/main/monorepo/website/"
 gitHubMainUrl: https://github.com/loculus-project/loculus
 resources:
-  organismSpecific:
-    dummy-organism:
-      silo:
-        requests:
-          memory: "10Mi"
-        limits:
-          memory: "10Mi"
   website:
     requests:
       memory: "200Mi"

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1691,7 +1691,7 @@ gitHubEditLink: "https://github.com/loculus-project/loculus/edit/main/monorepo/w
 gitHubMainUrl: https://github.com/loculus-project/loculus
 resources:
   organismSpecific:
-    default-organism:
+    dummy-organism:
       requests:
         memory: "10Mi"
       limits:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1692,7 +1692,7 @@ gitHubMainUrl: https://github.com/loculus-project/loculus
 resources:
   organismSpecific:
     default-organism:
-       requests:
+      requests:
         memory: "10Mi"
       limits:
         memory: "10Mi"


### PR DESCRIPTION
Preview: https://organism-scoped-resources.loculus.org/

Adds `organismSpecific` resource requirements, keyed by organism. These are optional - without them everything works as before

Example:

```
resources:
  organismSpecific:
    dummy-organism:
      silo:
        requests:
          memory: "10Mi"
        limits:
          memory: "10Mi"
```

Tested working: 
![image](https://github.com/user-attachments/assets/3e7d2189-c7c3-428a-b4b8-aaee50f1a1b7)
