### PR TITLE
fix(website): Fix alignment of seq details page

### DIFF
--- a/website/src/components/SearchPage/SeqPreviewModal.tsx
+++ b/website/src/components/SearchPage/SeqPreviewModal.tsx
@@ -79,13 +79,13 @@ export const SeqPreviewModal: React.FC<SeqPreviewModalProps> = ({
             {isLoading ? (
                 <div>Loading...</div>
             ) : data !== null && !isError ? (
-                <div className="px-6">
-                <SequenceDataUI
-                    {...data}
-                    referenceGenomeSequenceNames={referenceGenomeSequenceNames}
-                    myGroups={myGroups}
-                    accessToken={accessToken}
-                />
+                <div className='px-6'>
+                    <SequenceDataUI
+                        {...data}
+                        referenceGenomeSequenceNames={referenceGenomeSequenceNames}
+                        myGroups={myGroups}
+                        accessToken={accessToken}
+                    />
                 </div>
             ) : (
                 <div>Failed to load sequence data</div>

--- a/website/src/components/SearchPage/SeqPreviewModal.tsx
+++ b/website/src/components/SearchPage/SeqPreviewModal.tsx
@@ -79,12 +79,14 @@ export const SeqPreviewModal: React.FC<SeqPreviewModalProps> = ({
             {isLoading ? (
                 <div>Loading...</div>
             ) : data !== null && !isError ? (
+                <div className="px-6">
                 <SequenceDataUI
                     {...data}
                     referenceGenomeSequenceNames={referenceGenomeSequenceNames}
                     myGroups={myGroups}
                     accessToken={accessToken}
                 />
+                </div>
             ) : (
                 <div>Failed to load sequence data</div>
             )}

--- a/website/src/components/SearchPage/SeqPreviewModal.tsx
+++ b/website/src/components/SearchPage/SeqPreviewModal.tsx
@@ -86,7 +86,7 @@ export const SeqPreviewModal: React.FC<SeqPreviewModalProps> = ({
                         myGroups={myGroups}
                         accessToken={accessToken}
                     />
-                </div> 
+                </div>
             ) : (
                 <div>Failed to load sequence data</div>
             )}

--- a/website/src/components/SearchPage/SeqPreviewModal.tsx
+++ b/website/src/components/SearchPage/SeqPreviewModal.tsx
@@ -86,7 +86,7 @@ export const SeqPreviewModal: React.FC<SeqPreviewModalProps> = ({
                         myGroups={myGroups}
                         accessToken={accessToken}
                     />
-                </div>
+                </div> 
             ) : (
                 <div>Failed to load sequence data</div>
             )}

--- a/website/src/components/SequenceDetailsPage/DataTable.tsx
+++ b/website/src/components/SequenceDetailsPage/DataTable.tsx
@@ -37,10 +37,10 @@ const DataTableComponent: React.FC<Props> = ({ dataTableData, dataUseTermsHistor
     return (
         <div>
             {dataTableData.topmatter.sequenceDisplayName !== undefined && (
-                <div className='px-6 mb-4 italic'>Display Name: {dataTableData.topmatter.sequenceDisplayName}</div>
+                <div className='pr-6 mb-4 italic'>Display Name: {dataTableData.topmatter.sequenceDisplayName}</div>
             )}
             {dataTableData.topmatter.authors !== undefined && dataTableData.topmatter.authors.length > 0 && (
-                <div className='px-6 mb-4'>
+                <div className='pr-6 mb-4'>
                     <AuthorList authors={dataTableData.topmatter.authors} />
                 </div>
             )}
@@ -49,7 +49,7 @@ const DataTableComponent: React.FC<Props> = ({ dataTableData, dataUseTermsHistor
                 style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(min(100vw, 32rem), 1fr))' }}
             >
                 {dataTableData.table.map(({ header, rows }) => (
-                    <div key={header} className='p-4'>
+                    <div key={header} className='p-4 pl-0'>
                         <div className='flex flex-row'>
                             <h1 className='py-2 text-lg font-semibold border-b mr-2'>{header}</h1>
                             {hasReferenceAccession && header.includes('Alignment') && (


### PR DESCRIPTION
https://alignment.loculus.org/

Fixes alignment on sequence details page in full screen mode:

before:
<img width="1140" alt="image" src="https://github.com/user-attachments/assets/9c5a47b4-d0d4-46e2-a70a-16d662c22c20" />

after:
<img width="1133" alt="image" src="https://github.com/user-attachments/assets/e377e4ca-d551-49ef-9afb-63e6c1292f7c" />
