### PR TITLE
fix(website): improve alignment of download button on search page

### DIFF
--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -348,7 +348,7 @@ export const InnerSearchFullUI = ({
                         }
                         `}
                 >
-                    <div className='text-sm text-gray-800 mb-6 justify-between flex md:px-6 items-baseline'>
+                    <div className='text-sm text-gray-800 mb-6 justify-between flex md:pl-6 items-baseline'>
                         <div className='mt-auto'>
                             {buildSequenceCountText(totalSequences, oldCount, initialCount)}
                             {detailsHook.isLoading ||


### PR DESCRIPTION
(imo no preview needed)

makes download button line up with table:

<img width="437" alt="image" src="https://github.com/user-attachments/assets/fa26afbc-9c52-426e-b3b6-c574cec91076" />

vs before:

<img width="465" alt="image" src="https://github.com/user-attachments/assets/fe325b0b-fa6c-48f6-a80e-938830f1e054" />

(ignore the button styling difference - one is moused over)