### PR TITLE
fix(k8s): Also accept integers as shas/branch names in values schema

### DIFF
--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1011,15 +1011,15 @@
       "additionalProperties": false
     },
     "branch": {
-      "type": "string",
+      "type": ["string", "integer"],
       "description": "TODO"
     },
     "sha": {
-      "type": "string",
+      "type": ["string", "integer"],
       "description": "TODO"
     },
     "shortbranch": {
-      "type": "string",
+      "type": ["string", "integer"],
       "description": "TODO - this is required/set by ArgoCD"
     },
     "podPriorityClassName": {


### PR DESCRIPTION
Resolves #3691

Schema was too strict - as strings that happen to also be integers end up interpreted as integers (at least by Helm).

Same issue also manifests in Pathoplexus, so just excluding Loculus previews from schema check isn't enough.