### PR TITLE
fix!(deployment): update Alignment states and QC metrics header

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1013,7 +1013,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         header: Diagnostics
       - name: length
         type: int
-        header: "Alignment states and QC metrics"
+        header: "Alignment and QC metrics"
         noInput: true
         rangeSearch: true
         initiallyVisible: true
@@ -1085,7 +1085,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         ingest: ncbiSraAccessions
       - name: totalSnps
         type: int
-        header: "Alignment states and QC metrics"
+        header: "Alignment and QC metrics"
         noInput: true
         rangeSearch: true
         perSegment: true
@@ -1094,7 +1094,7 @@ defaultOrganismConfig: &defaultOrganismConfig
           inputs: {input: nextclade.totalSubstitutions}
       - name: totalInsertedNucs
         type: int
-        header: "Alignment states and QC metrics"
+        header: "Alignment and QC metrics"
         noInput: true
         rangeSearch: true
         perSegment: true
@@ -1103,7 +1103,7 @@ defaultOrganismConfig: &defaultOrganismConfig
           inputs: {input: nextclade.totalInsertions}
       - name: totalDeletedNucs
         type: int
-        header: "Alignment states and QC metrics"
+        header: "Alignment and QC metrics"
         noInput: true
         rangeSearch: true
         perSegment: true
@@ -1112,7 +1112,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Total deleted nucs
       - name: totalAmbiguousNucs
         type: int
-        header: "Alignment states and QC metrics"
+        header: "Alignment and QC metrics"
         noInput: true
         rangeSearch: true
         perSegment: true
@@ -1121,7 +1121,7 @@ defaultOrganismConfig: &defaultOrganismConfig
           inputs: {input: "nextclade.totalNonACGTNs"}
       - name: totalUnknownNucs
         type: int
-        header: "Alignment states and QC metrics"
+        header: "Alignment and QC metrics"
         noInput: true
         rangeSearch: true
         perSegment: true
@@ -1131,14 +1131,14 @@ defaultOrganismConfig: &defaultOrganismConfig
       - name: totalFrameShifts
         type: int
         rangeSearch: true
-        header: "Alignment states and QC metrics"
+        header: "Alignment and QC metrics"
         noInput: true
         perSegment: true
         displayName: Total frame shifts
         preprocessing:
           inputs: {input: nextclade.totalFrameShifts}
       - name: frameShifts
-        header: "Alignment states and QC metrics"
+        header: "Alignment and QC metrics"
         noInput: true
         perSegment: true
         displayName: Frame shifts
@@ -1146,7 +1146,7 @@ defaultOrganismConfig: &defaultOrganismConfig
           inputs: {input: nextclade.frameShifts}
       - name: completeness
         type: float
-        header: "Alignment states and QC metrics"
+        header: "Alignment and QC metrics"
         noInput: true
         perSegment: true
         displayName: Completeness
@@ -1242,12 +1242,12 @@ defaultOrganisms:
             inputs: {input: nextclade.clade}
         - name: totalStopCodons
           type: int
-          header: "Alignment states and QC metrics"
+          header: "Alignment and QC metrics"
           noInput: true
           preprocessing:
             inputs: {input: nextclade.qc.stopCodons.totalStopCodons}
         - name: stopCodons
-          header: "Alignment states and QC metrics"
+          header: "Alignment and QC metrics"
           noInput: true
           preprocessing:
             inputs: {input: nextclade.qc.stopCodons.stopCodons}
@@ -1539,12 +1539,12 @@ defaultOrganisms:
           initiallyVisible: true
         - name: totalStopCodons
           type: int
-          header: "Alignment states and QC metrics"
+          header: "Alignment and QC metrics"
           noInput: true
           preprocessing:
             inputs: {input: nextclade.qc.stopCodons.totalStopCodons}
         - name: stopCodons
-          header: "Alignment states and QC metrics"
+          header: "Alignment and QC metrics"
           noInput: true
           preprocessing:
             inputs: {input: nextclade.qc.stopCodons.stopCodons}


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves https://github.com/loculus-project/loculus/issues/3689

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: http://alig.loculus.org

### Summary
Renames unexpected header `Alignment states and QC metrics` header to `Alignment and QC metrics`.

# Breaking changes
Requires same changes made to Pathoplexus

Corresponding PP PR: https://github.com/pathoplexus/pathoplexus/pull/388
