### PR TITLE
feat(deployment): improve observability of silo preprocessing errors by force replacing pod in development and exiting the process if failed

### DIFF
--- a/kubernetes/loculus/silo_import_wrapper.sh
+++ b/kubernetes/loculus/silo_import_wrapper.sh
@@ -14,6 +14,8 @@ get_value_from_file() {
     fi
 }
 
+exit 1
+
 while true; do
     echo "Checking for new data in SILO"
     last_etag=$(get_value_from_file "$current_etag_path")

--- a/kubernetes/loculus/silo_import_wrapper.sh
+++ b/kubernetes/loculus/silo_import_wrapper.sh
@@ -14,8 +14,6 @@ get_value_from_file() {
     fi
 }
 
-exit 1
-
 while true; do
     echo "Checking for new data in SILO"
     last_etag=$(get_value_from_file "$current_etag_path")

--- a/kubernetes/loculus/silo_import_wrapper.sh
+++ b/kubernetes/loculus/silo_import_wrapper.sh
@@ -14,17 +14,16 @@ get_value_from_file() {
     fi
 }
 
-while true
-do
+while true; do
     echo "Checking for new data in SILO"
     last_etag=$(get_value_from_file "$current_etag_path")
     echo "Last download of released data had etag: $last_etag"
 
     last_hard_refresh_time=$(get_value_from_file "$last_hard_refresh_time_path")
     echo "Last hard refresh was at: $last_hard_refresh_time"
-    
+
     # Check if the difference is greater than or equal to 3600 seconds (1 hour)
-    # We only use cache 
+    # We only use cache
     current_time=$(date +%s)
     echo "Current timestamp: $current_time"
     time_diff=$((current_time - last_hard_refresh_time))
@@ -34,13 +33,21 @@ do
         exit_code=$?
         if [ "$exit_code" -ne 0 ]; then
             echo "Error: Hard refresh failed with exit code $exit_code"
+            exit $exit_code
         else
             echo "Hard refresh completed successfully"
-            echo "$current_time" > "$last_hard_refresh_time_path"
+            echo "$current_time" >"$last_hard_refresh_time_path"
         fi
     else
         echo "Last hard refresh was less than 1 hour ago. Passing last etag time to import job: $last_etag"
         bash /silo_import_job.sh --last-etag="$last_etag" --backend-base-url="$BACKEND_BASE_URL"
+        exit_code=$?
+        if [ "$exit_code" -ne 0 ]; then
+            echo "Error: Soft refresh failed with exit code $exit_code"
+            exit $exit_code
+        else
+            echo "Soft refresh completed successfully"
+        fi
     fi
     echo "Sleeping for 30 seconds"
     sleep 30

--- a/kubernetes/loculus/templates/lapis-silo-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-deployment.yaml
@@ -9,7 +9,7 @@ kind: Deployment
 metadata:
   name: loculus-lapis-silo-{{ $key }}
   annotations:
-    argocd.argoproj.io/sync-options: Replace=true
+    argocd.argoproj.io/sync-options: Replace=true,Force=true # TODO: Make configurable, only for previews should force be set
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1

--- a/kubernetes/loculus/templates/lapis-silo-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-deployment.yaml
@@ -9,7 +9,7 @@ kind: Deployment
 metadata:
   name: loculus-lapis-silo-{{ $key }}
   annotations:
-    # Replace when run in preview to ensure silo prepro fails loudly
+    # Force replace when run a) with dev db and b) without persistence to ensure silo prepro fails loudly
     argocd.argoproj.io/sync-options: Replace=true{{ if (and (not $.Values.developmentDatabasePersistence) $.Values.runDevelopmentMainDatabase) }},Force=true{{ end }}
     reloader.stakater.com/auto: "true"
 spec:

--- a/kubernetes/loculus/templates/lapis-silo-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-deployment.yaml
@@ -9,7 +9,8 @@ kind: Deployment
 metadata:
   name: loculus-lapis-silo-{{ $key }}
   annotations:
-    argocd.argoproj.io/sync-options: Replace=true,Force=true # TODO: Make configurable, only for previews should force be set
+    # Replace when run in preview to ensure silo prepro fails loudly
+    argocd.argoproj.io/sync-options: Replace=true{{ if not $.Values.developmentDatabasePersistence and not $.Values.runDevelopmentMainDatabase }},Force=true{{ end }}
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1

--- a/kubernetes/loculus/templates/lapis-silo-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   name: loculus-lapis-silo-{{ $key }}
   annotations:
     # Replace when run in preview to ensure silo prepro fails loudly
-    argocd.argoproj.io/sync-options: Replace=true{{ if not $.Values.developmentDatabasePersistence and not $.Values.runDevelopmentMainDatabase }},Force=true{{ end }}
+    argocd.argoproj.io/sync-options: Replace=true{{ if (and (not $.Values.developmentDatabasePersistence) $.Values.runDevelopmentMainDatabase) }},Force=true{{ end }}
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1


### PR DESCRIPTION
Previously, when silo preprocessing started failing after an update to a preview but there was still successful processed data in the shared volume we would not easily observe the processing failure as "-1/0 sequences" in the UI. One would only see the failure in processing logs which would often not be checked (e.g. in testing https://github.com/loculus-project/loculus/pull/3534).

This PR makes silo preprocessing errors more easily observable _in dev environments only_ by _force replacing_ the LAPIS/SILO pod including the shared volume even if there are no code changes between updates (e.g. when only the backend code changes).

Also, we make the silo preprocessing crash rather than happily error without crashing when there are preprocessing errors.

Force replacing is switched on iff `Values.developmentDatabasePersistence == False` AND `Values.runDevelopmentMainDatabase == True`: this means no force replace in production environments (there we don't run a development database) and also not in development if one sets development database persistence to True.