### PR TITLE
feat(ci): Mirror NCBI datasets results to Hetzner object storage to reduce NIH load and get independence from external service

### DIFF
--- a/.github/workflows/datasets-mirror.yml
+++ b/.github/workflows/datasets-mirror.yml
@@ -1,0 +1,32 @@
+name: Mirror NCBI Datasets to Object Storage
+on:
+  workflow_dispatch: # Allows manual triggering
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at midnight UTC
+  push:
+jobs:
+  download-and-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: false
+          create-args: >-
+            ncbi-datasets-cli
+      - name: Download NCBI Dataset
+        shell: bash -l {0}
+        run: |
+          datasets download virus genome taxon 186540 --no-progressbar --filename 186540.zip
+      - name: Set up S3cmd
+        uses: corneliusroemer/s3cmd@main
+        with:
+          provider: hcloud
+          region: 'hel1'
+          access_key: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
+          secret_key: ${{ secrets.HETZNER_S3_SECRET_KEY }}
+      - name: Upload to Object Storage
+        run: |-
+          s3cmd put 186540.zip s3://loculus-public/mirror/test_186540.zip

--- a/.github/workflows/datasets-mirror.yml
+++ b/.github/workflows/datasets-mirror.yml
@@ -14,24 +14,12 @@ jobs:
         with:
           environment-name: datasets
           create-args: >-
-            ncbi-datasets-cli
+            ncbi-datasets-cli s3cmd
       - name: Download NCBI Dataset
         shell: bash -l {0}
         run: |
           datasets download virus genome taxon 186540 --no-progressbar --filename 186540.zip
-      - name: Set up S3cmd
-        uses: corneliusroemer/s3cmd@4df3c00f903d81ab1effb8f565ede47c5dd0ea7a
-        with:
-          provider: hcloud
-          region: 'hel1'
-          access_key: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
-          secret_key: ${{ secrets.HETZNER_S3_SECRET_KEY }}
-      # Print config file
-      - name: Print S3cmd config
-        run: cat ~/.s3cfg
-      # Create config file
       - name: Create S3cmd config
-        # use EOF to preserve newlines
         run: |
           cat <<EOF > ~/.s3cfg
           [default]
@@ -41,9 +29,6 @@ jobs:
           host_bucket = %(bucket)s.hel1.your-objectstorage.com
           verbosity = DEBUG
           EOF
-      # Print config file
-      - name: Print S3cmd config
-        run: cat ~/.s3cfg
       - name: Upload to Object Storage
         run: |-
           s3cmd put 186540.zip s3://loculus-public/mirror/test_186540.zip

--- a/.github/workflows/datasets-mirror.yml
+++ b/.github/workflows/datasets-mirror.yml
@@ -22,9 +22,7 @@ jobs:
       - uses: mamba-org/setup-micromamba@v1
         with:
           environment-name: datasets
-          create-args: |-
-            ncbi-datasets-cli
-            s3cmd
+          create-args: ncbi-datasets-cli s3cmd
       - name: Download NCBI Dataset
         shell: bash -l {0}
         run: |

--- a/.github/workflows/datasets-mirror.yml
+++ b/.github/workflows/datasets-mirror.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           datasets download virus genome taxon 186540 --no-progressbar --filename 186540.zip
       - name: Set up S3cmd
-        uses: corneliusroemer/s3cmd@main
+        uses: corneliusroemer/s3cmd@4df3c00f903d81ab1effb8f565ede47c5dd0ea7a
         with:
           provider: hcloud
           region: 'hel1'

--- a/.github/workflows/datasets-mirror.yml
+++ b/.github/workflows/datasets-mirror.yml
@@ -21,7 +21,9 @@ jobs:
       - uses: mamba-org/setup-micromamba@v1
         with:
           environment-name: datasets
-          create-args: ncbi-datasets-cli s3cmd
+          create-args: |-
+            ncbi-datasets-cli
+            s3cmd
       - name: Download NCBI Dataset
         shell: bash -l {0}
         run: |
@@ -37,5 +39,6 @@ jobs:
           verbosity = DEBUG
           EOF
       - name: Upload to Object Storage
-        run: |-
+        shell: bash -l {0}
+        run: |
           s3cmd put ${{ matrix.taxon_id }}.zip s3://loculus-public/mirror/${{ matrix.taxon_id }}.zip

--- a/.github/workflows/datasets-mirror.yml
+++ b/.github/workflows/datasets-mirror.yml
@@ -3,7 +3,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *' # Runs daily at midnight UTC
-  push:
 jobs:
   download-and-upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/datasets-mirror.yml
+++ b/.github/workflows/datasets-mirror.yml
@@ -7,18 +7,25 @@ on:
 jobs:
   download-and-upload:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        taxon_id:
+          - 10244 # mpox
+          - 3048448 # West nile virus
+          - 3052460 # Orthoebolavirus sudanense
+          - 3052462 # Orthoebolavirus zairense
+          - 3052518 # CCHFV
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
       - uses: mamba-org/setup-micromamba@v1
         with:
           environment-name: datasets
-          create-args: >-
-            ncbi-datasets-cli s3cmd
+          create-args: ncbi-datasets-cli s3cmd
       - name: Download NCBI Dataset
         shell: bash -l {0}
         run: |
-          datasets download virus genome taxon 186540 --no-progressbar --filename 186540.zip
+          datasets download virus genome taxon ${{ matrix.taxon_id }} --no-progressbar --filename ${{ matrix.taxon_id }}.zip
       - name: Create S3cmd config
         run: |
           cat <<EOF > ~/.s3cfg
@@ -31,4 +38,4 @@ jobs:
           EOF
       - name: Upload to Object Storage
         run: |-
-          s3cmd put 186540.zip s3://loculus-public/mirror/test_186540.zip
+          s3cmd put ${{ matrix.taxon_id }}.zip s3://loculus-public/mirror/${{ matrix.taxon_id }}.zip

--- a/.github/workflows/datasets-mirror.yml
+++ b/.github/workflows/datasets-mirror.yml
@@ -15,6 +15,7 @@ jobs:
           - 3052460 # Orthoebolavirus sudanense
           - 3052462 # Orthoebolavirus zairense
           - 3052518 # CCHFV
+      fail-fast: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/datasets-mirror.yml
+++ b/.github/workflows/datasets-mirror.yml
@@ -1,6 +1,6 @@
 name: Mirror NCBI Datasets to Object Storage
 on:
-  workflow_dispatch: # Allows manual triggering
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *' # Runs daily at midnight UTC
   push:

--- a/.github/workflows/datasets-mirror.yml
+++ b/.github/workflows/datasets-mirror.yml
@@ -10,10 +10,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Setup Micromamba
-        uses: mamba-org/setup-micromamba@v1
+      - uses: mamba-org/setup-micromamba@v1
         with:
-          environment-file: false
+          environment-name: datasets
           create-args: >-
             ncbi-datasets-cli
       - name: Download NCBI Dataset

--- a/.github/workflows/datasets-mirror.yml
+++ b/.github/workflows/datasets-mirror.yml
@@ -26,6 +26,24 @@ jobs:
           region: 'hel1'
           access_key: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
           secret_key: ${{ secrets.HETZNER_S3_SECRET_KEY }}
+      # Print config file
+      - name: Print S3cmd config
+        run: cat ~/.s3cfg
+      # Create config file
+      - name: Create S3cmd config
+        # use EOF to preserve newlines
+        run: |
+          cat <<EOF > ~/.s3cfg
+          [default]
+          access_key = ${{ secrets.HETZNER_S3_ACCESS_KEY }}
+          secret_key = ${{ secrets.HETZNER_S3_SECRET_KEY }}
+          host_base = hel1.your-objectstorage.com
+          host_bucket = %(bucket)s.hel1.your-objectstorage.com
+          verbosity = DEBUG
+          EOF
+      # Print config file
+      - name: Print S3cmd config
+        run: cat ~/.s3cfg
       - name: Upload to Object Storage
         run: |-
           s3cmd put 186540.zip s3://loculus-public/mirror/test_186540.zip


### PR DESCRIPTION
Mirror NCBI datasets zip folders to Hetzner object storage to reduce load on NIH servers and uncouple our CI from external services.

Right now all Loculus/PPX organisms are covered, we can easily add Taxon IDs for Genspectrum ones @anna-parker 

It scrapes once a day. The zip folder can be downloaded at:

```
https://hel1.your-objectstorage.com/loculus-public/mirror/{TAXONID}.zip
```

Where TAXONID is the taxonid we scrape, e.g. `10244` for mpox.

As a next step, we can optionally use these paths to download the zip folders in ingest.

### What happens if I overwrite an object and the upload fails midway?
- Single PUT: The old object remains unchanged; no partial overwrite.
- Multipart Upload: Incomplete parts stay temporarily; must complete or abort the upload.

### What happens if someone downloads while I overwrite an object?
- They get the old version until the new upload is fully completed.
- No partial or mixed content; updates are atomic.

### Does S3 allow partial writes when overwriting?
- No, an object is only replaced when the upload fully succeeds.