### PR TITLE
fix(deployment): make `memory` / `cpu` optional settings in Helm schema

### DIFF
--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -962,7 +962,6 @@
             "memory": { "type": "string" },
             "cpu": { "type": "string" }
           },
-          "required": ["memory", "cpu"],
           "additionalProperties": false
         },
         "limits": {

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -971,11 +971,9 @@
             "memory": { "type": "string" },
             "cpu": { "type": "string" }
           },
-          "required": ["memory", "cpu"],
           "additionalProperties": false
         }
       },
-      "required": ["requests", "limits"],
       "additionalProperties": false
     },
     "resources": {


### PR DESCRIPTION
Fixes #3720

Modify the helm schema to allow only a `memory` or only a `cpu` setting in `limits` for `defaultResources`.

* Make `memory` property in `limits` optional.
* Make `cpu` property in `limits` optional.
* Remove the requirement for both `memory` and `cpu` settings in `limits` and `requests`.
* Remove the requirement for both `requests` and `limits` in `defaultResources`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/loculus-project/loculus/pull/3723?shareId=5c4d8cf3-3953-4997-9bd6-f76378d0cc8c).