### PR TITLE
fix(k8s): treat LAPIS as healthy, even if SILO not up

### DIFF
--- a/kubernetes/loculus/templates/lapis-silo-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-deployment.yaml
@@ -57,14 +57,14 @@ spec:
               subPath: reference_genomes.json
           startupProbe:
             httpGet:
-              path: /sample/info
+              path: /actuator/health
               port: 8080
             periodSeconds: 10
             failureThreshold: 5
             timeoutSeconds: 5
           livenessProbe:
             httpGet:
-              path: /sample/info
+              path: /actuator/health
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 10


### PR DESCRIPTION
Switch to using the intrinsic `/actuator/health` instead of the `/sample/info` endpoint for liveness/startupProbe.

`/sample/info` returns 503 when SILO is down, causing LAPIS container to be restarted whenever SILO is down which makes no sense.

We could potentially add a readinessProbe to fine tune restart behaviors.

If we don't want LAPIS to receive traffic if SILO is down, then we could set a _readinessProbe_. But it might be ok for LAPIS to accept traffic if it caches things and doesn't always rely on SILO to be up. Some tradeoffs there.

This PR should remove the restarts that we always get for LAPIS - even under normal operating conditions. Keeps everything cleaner, less noise in event logs etc

<img width="1710" alt="image" src="https://github.com/user-attachments/assets/4a0837e0-ab2f-44da-9989-1ac4b270aaba" />

