### PR TITLE
chore(deps): SILO v0.5.4

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1620,7 +1620,7 @@ bannerMessage: "This is a demonstration environment. It may contain non-accurate
 welcomeMessageHTML: null
 additionalHeadHTML: ""
 images:
-  lapisSilo: "ghcr.io/genspectrum/lapis-silo:0.5.3"
+  lapisSilo: "ghcr.io/genspectrum/lapis-silo:0.5.4"
   lapis: "ghcr.io/genspectrum/lapis:0.3.14"
 secrets:
   smtp-password:


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://tae-silo-0-5-4.loculus.org

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

This updates SILO to 0.5.4. That is the version that also contains 2 additional improvements to excessive memory usage

https://github.com/GenSpectrum/LAPIS-SILO/releases/tag/v0.5.4

## [0.5.4](https://github.com/GenSpectrum/LAPIS-SILO/compare/v0.5.3...v0.5.4) (2025-02-20)


### Features

* add monitoring to log the swapover to datasets ([39f1ed2](https://github.com/GenSpectrum/LAPIS-SILO/commit/39f1ed2ddba4e4711ce850380674b8d41d645d52))
* call malloc_trim after all connections to the old database are finished ([5742a52](https://github.com/GenSpectrum/LAPIS-SILO/commit/5742a521b467d153a2dd633cdacfd7ec3b8080bb))
* tell malloc to give empty heap space back to the OS before every fasta call ([16ce850](https://github.com/GenSpectrum/LAPIS-SILO/commit/16ce850145db75d81f702368f3944692dd0da080))


### Bug Fixes

* prohibit allocation of new Poco threads for incoming requests ([7c2994f](https://github.com/GenSpectrum/LAPIS-SILO/commit/7c2994f515e8750eb5c43a882d76788b59dfc11c))
