### PR TITLE
fix(website)!: use `box-content` for consistent column widths regardless of position

### DIFF
--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -161,7 +161,7 @@ export const Table: FC<TableProps> = ({
                                     <th
                                         key={c.field}
                                         onClick={() => handleSort(c.field)}
-                                        className='px-2 py-2 text-xs font-medium tracking-wider text-gray-500 uppercase cursor-pointer last:pr-6 text-left'
+                                        className='px-2 py-2 text-xs font-medium tracking-wider text-gray-500 uppercase cursor-pointer box-content last:pr-6 text-left'
                                         style={{
                                             minWidth: getColumnWidthStyle(c.columnWidth),
                                         }}
@@ -220,7 +220,7 @@ export const Table: FC<TableProps> = ({
                                     {columns.map((c) => (
                                         <td
                                             key={`${index}-${c.field}`}
-                                            className='px-2 py-2 text-primary-900 last:pr-6'
+                                            className='px-2 py-2 text-primary-900 box-content last:pr-6'
                                             style={{
                                                 minWidth: getColumnWidthStyle(c.columnWidth),
                                             }}


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://box-content.loculus.org/ebola-sudan/search? vs https://main.loculus.org/ebola-sudan/search?

### Summary
We specifically add padding to the last column in the table for aesthetic reasons (`last:pr-6`), but this is problematic because we specify widths for each column but those widths include the padding and we don't know which column the user will choose to be last. Here we use [`box-content`](https://tailwindcss.com/docs/box-sizing) so that the specified width is just for the content, excluding any padding. This will likely require us to update all widths to take account of this.

All columns get a bit bigger on our current previews but I think that's ok as they are not tuned much on Loculus (they are more so on PPX)

### Details of breaking changes

We may want to make all specified column widths on PPX 16 pixels narrower to account for the fact that padding is not longer being taken out