### PR TITLE
fix(deployment): add old keycloak flags

### DIFF
--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -71,9 +71,16 @@ spec:
                 secretKeyRef:
                   name: keycloak-database
                   key: password
-            - name: KC_BOOTSTRAP_ADMIN_USERNAME
+            - name: KC_BOOTSTRAP_ADMIN_USERNAME # TODO: delete after upgrading keycloak
               value: "admin"
-            - name: KC_BOOTSTRAP_ADMIN_PASSWORD
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD # TODO: delete after upgrading keycloak
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-admin
+                  key: initialAdminPassword
+            - name: KEYCLOAK_ADMIN
+              value: "admin"
+            - name: KEYCLOAK_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: keycloak-admin

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -71,9 +71,9 @@ spec:
                 secretKeyRef:
                   name: keycloak-database
                   key: password
-            - name: KC_BOOTSTRAP_ADMIN_USERNAME # TODO: delete after upgrading keycloak
+            - name: KC_BOOTSTRAP_ADMIN_USERNAME # TODO: delete after upgrading keycloak (#3736 )
               value: "admin"
-            - name: KC_BOOTSTRAP_ADMIN_PASSWORD # TODO: delete after upgrading keycloak
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD # TODO: delete after upgrading keycloak (#3736 )
               valueFrom:
                 secretKeyRef:
                   name: keycloak-admin


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #3618 for now

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://authentication-kcflags.loculus.org/admin/master/console (admin/admin)

### Summary
We upgraded the keycloak environment variable flags without upgrading keycloak itself, meaning an admin account with a known admin password is not created. This is an unfortunate breakage on main for anyone wanting to try out Loculus for their own use, and prevents us logging in ourselves (except on pathoplexus).

Here I add the old flags back as duplicates to mitigate.