### PR TITLE
feat(silo): increase silo query materialization cutoff to 20000

### DIFF
--- a/kubernetes/loculus/templates/lapis-silo-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-deployment.yaml
@@ -33,8 +33,7 @@ spec:
           {{- include "loculus.resources" (list "silo" $.Values $key) | nindent 10 }}
           ports:
             - containerPort: 8081
-          args:
-            - "api"
+          args: ["api", "--query-materialization-cutoff", "20000"]
           volumeMounts:
             - name: lapis-silo-shared-data
               mountPath: /data


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://silo-materialization-thre.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

SILO has a materialization cutoff of 10000 by default:
```
  --query-materialization-cutoff u32
    Env var : SILO_QUERY_MATERIALIZATION_CUTOFF
    YAML key: query.materializationCutoff

    If a query results in fewer rows, the query result will be collected 
    in memory before sending it to the client. If it affects more rows, 
    it will be streamed by constructing the result items lazily.

    Default: 10000
```

If this limit is exceeded, SILO will return an error explaining that the feature is not yet supported. Therefore, this PR lifts the materialization cutoff to 20000. SILO's streaming query engine for sequence data is worked on at the moment, and will resolve this soon.

- [x] I tested that the preview works and can return all sequence data
- [x] I tested that after submitting more than 10000 sequences I can still download all sequence data
- [ ] I validated that after submitting more than 20000 sequences, SILO is returning a readable error

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
