### PR TITLE
feat(website): Explicitly set `dataFormat=fasta` for sequence downloads

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx
@@ -89,7 +89,7 @@ describe('DownloadDialog', () => {
         [path, query] = getDownloadHref()?.split('?') ?? [];
         expect(path).toBe(`${defaultLapisUrl}/sample/unalignedNucleotideSequences`);
         expect(query).toMatch(
-            /downloadAsFile=true&downloadFileBasename=ebola_nuc_\d{4}-\d{2}-\d{2}T\d{4}&dataUseTerms=OPEN&compression=gzip&accession=accession1&accession=accession2&field1=value1/,
+            /downloadAsFile=true&downloadFileBasename=ebola_nuc_\d{4}-\d{2}-\d{2}T\d{4}&dataUseTerms=OPEN&dataFormat=fasta&compression=gzip&accession=accession1&accession=accession2&field1=value1/,
         );
 
         await userEvent.click(screen.getByLabelText(/include restricted data/));
@@ -98,7 +98,7 @@ describe('DownloadDialog', () => {
         [path, query] = getDownloadHref()?.split('?') ?? [];
         expect(path).toBe(`${defaultLapisUrl}/sample/unalignedNucleotideSequences`);
         expect(query).toMatch(
-            /downloadAsFile=true&downloadFileBasename=ebola_nuc_\d{4}-\d{2}-\d{2}T\d{4}&compression=zstd&accession=accession1&accession=accession2&field1=value1/,
+            /downloadAsFile=true&downloadFileBasename=ebola_nuc_\d{4}-\d{2}-\d{2}T\d{4}&dataFormat=fasta&compression=zstd&accession=accession1&accession=accession2&field1=value1/,
         );
     });
 
@@ -119,7 +119,7 @@ describe('DownloadDialog', () => {
         [path, query] = getDownloadHref()?.split('?') ?? [];
         expect(path).toBe(`${defaultLapisUrl}/sample/unalignedNucleotideSequences`);
         expect(query).toMatch(
-            /downloadAsFile=true&downloadFileBasename=ebola_nuc_\d{4}-\d{2}-\d{2}T\d{4}&dataUseTerms=OPEN&compression=gzip&accessionVersion=SEQID1&accessionVersion=SEQID2/,
+            /downloadAsFile=true&downloadFileBasename=ebola_nuc_\d{4}-\d{2}-\d{2}T\d{4}&dataUseTerms=OPEN&dataFormat=fasta&compression=gzip&accessionVersion=SEQID1&accessionVersion=SEQID2/,
         );
 
         await userEvent.click(screen.getByLabelText(/include restricted data/));
@@ -128,7 +128,7 @@ describe('DownloadDialog', () => {
         [path, query] = getDownloadHref()?.split('?') ?? [];
         expect(path).toBe(`${defaultLapisUrl}/sample/unalignedNucleotideSequences`);
         expect(query).toMatch(
-            /downloadAsFile=true&downloadFileBasename=ebola_nuc_\d{4}-\d{2}-\d{2}T\d{4}&compression=zstd&accessionVersion=SEQID1&accessionVersion=SEQID2/,
+            /downloadAsFile=true&downloadFileBasename=ebola_nuc_\d{4}-\d{2}-\d{2}T\d{4}&dataFormat=fasta&compression=zstd&accessionVersion=SEQID1&accessionVersion=SEQID2/,
         );
     });
 

--- a/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
@@ -2,7 +2,12 @@ import kebabCase from 'just-kebab-case';
 
 import { getEndpoint, dataTypeForFilename, type DownloadDataType } from './DownloadDataType.ts';
 import type { SequenceFilter } from './SequenceFilters.tsx';
-import { IS_REVOCATION_FIELD, metadataDefaultDownloadDataFormat, VERSION_STATUS_FIELD } from '../../../settings.ts';
+import {
+    IS_REVOCATION_FIELD,
+    metadataDefaultDownloadDataFormat,
+    sequenceDefaultDownloadDataFormat,
+    VERSION_STATUS_FIELD,
+} from '../../../settings.ts';
 import { versionStatuses } from '../../../types/lapis.ts';
 
 export type Compression = 'zstd' | 'gzip' | undefined;
@@ -52,6 +57,8 @@ export class DownloadUrlGenerator {
 
         if (option.dataType.type === 'metadata') {
             params.set('dataFormat', metadataDefaultDownloadDataFormat);
+        } else {
+            params.set('dataFormat', sequenceDefaultDownloadDataFormat);
         }
         if (option.compression !== undefined) {
             params.set('compression', option.compression);

--- a/website/src/settings.ts
+++ b/website/src/settings.ts
@@ -16,5 +16,6 @@ export const VERSION_COMMENT_FIELD = 'versionComment';
 export const SUBMISSION_ID_FIELD = 'submissionId';
 
 export const metadataDefaultDownloadDataFormat = 'tsv';
+export const sequenceDefaultDownloadDataFormat = 'fasta';
 
 export const DEFAULT_LOCALE = 'en-US';


### PR DESCRIPTION
resolves #3438

preview URL: https://explicit-seq-dataformat.loculus.org

### Summary
`dataFormat` now specified explicitly for all download links.

### Manual testing
For ebola sudan: I checked the links for all download types (metadata, unaligned seq, aligned, ...) and verified they all have the dataFormat parameter. I downloaded all for variants and the downloads all returned a file (no error).

### PR Checklist
- ~~All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by appropriate, automated tests. (tests existed already and where updated)
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
