### PR TITLE
feat!: Improve error message for fastas with missing segment names

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/utils/ParseFastaHeader.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/ParseFastaHeader.kt
@@ -30,7 +30,7 @@ class ParseFastaHeader(private val backendConfig: BackendConfig) {
         if (!validSegmentIds.contains(segmentId)) {
             throw BadRequestException(
                 "The FASTA header $submissionId ends with the segment name $segmentId, which is not valid. " +
-                    "Valid segment IDs: ${validSegmentIds.joinToString(", ")}",
+                    "Valid segment names: ${validSegmentIds.joinToString(", ")}",
             )
         }
 

--- a/backend/src/main/kotlin/org/loculus/backend/utils/ParseFastaHeader.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/ParseFastaHeader.kt
@@ -16,6 +16,8 @@ class ParseFastaHeader(private val backendConfig: BackendConfig) {
             return Pair(submissionId, "main")
         }
 
+        val validSegmentIds = referenceGenome.nucleotideSequences.map { it.name }
+
         val lastDelimiter = submissionId.lastIndexOf("_")
         if (lastDelimiter == -1) {
             throw BadRequestException(
@@ -23,6 +25,15 @@ class ParseFastaHeader(private val backendConfig: BackendConfig) {
                     " segment name in the format <submissionId>_<segment name>",
             )
         }
-        return Pair(submissionId.substring(0, lastDelimiter), submissionId.substring(lastDelimiter + 1))
+        val isolateId = submissionId.substring(0, lastDelimiter)
+        val segmentId = submissionId.substring(lastDelimiter + 1)
+        if (!validSegmentIds.contains(segmentId)) {
+            throw BadRequestException(
+                "The FASTA header $submissionId ends with the segment name $segmentId, which is not valid. " +
+                    "Valid segment IDs: ${validSegmentIds.joinToString(", ")}",
+            )
+        }
+
+        return Pair(isolateId, segmentId)
     }
 }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
@@ -179,6 +179,14 @@ class SubmitEndpointTest(
             groupId = groupId,
         )
             .andExpect(status().isBadRequest)
+            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(
+                jsonPath(
+                    "\$.detail",
+                ).value(
+                    "The FASTA header commonHeader_nonExistingSegmentName ends with the segment name nonExistingSegmentName, which is not valid. Valid segment names: notOnlySegment, secondSegment",
+                ),
+            )
     }
 
     @ParameterizedTest(name = "GIVEN {0} THEN throws error \"{5}\"")

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
@@ -161,7 +161,7 @@ class SubmitEndpointTest(
     }
 
     @Test
-    fun `GIVEN fasta data with unknown segment THEN data is accepted to let the preprocessing pipeline verify it`() {
+    fun `  GIVEN fasta data with unknown segment THEN data is not accepted`() {
         submissionControllerClient.submit(
             SubmitFiles.metadataFileWith(
                 content = """
@@ -178,9 +178,7 @@ class SubmitEndpointTest(
             organism = OTHER_ORGANISM,
             groupId = groupId,
         )
-            .andExpect(status().isOk)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
-            .andExpect(jsonPath("\$.length()").value(1))
+            .andExpect(status().isBadRequest)
     }
 
     @ParameterizedTest(name = "GIVEN {0} THEN throws error \"{5}\"")

--- a/backend/src/test/resources/sequences_multi_segment.fasta
+++ b/backend/src/test/resources/sequences_multi_segment.fasta
@@ -1,31 +1,31 @@
->custom1_main
+>custom1_notOnlySegment
 ACTG
 
 >custom1_secondSegment
 ACTG
 
->custom2_main
+>custom2_notOnlySegment
 ACTG
 
->custom3_main
+>custom3_notOnlySegment
 ACTG
 
->custom4_main
+>custom4_notOnlySegment
 ACTG
 
 >custom4_secondSegment
 ACTG
 
->custom5_main
+>custom5_notOnlySegment
 ACTG
 
 >custom5_secondSegment
 ACTG
 
->custom6_main
+>custom6_notOnlySegment
 ACTG
 
->custom7_main
+>custom7_notOnlySegment
 ACTG
 
 >custom8_secondSegment
@@ -34,5 +34,5 @@ ACTG
 >custom9_secondSegment
 ACTG
 
->custom0_main
+>custom0_notOnlySegment
 ACTG


### PR DESCRIPTION
**BREAKING** because now we do not accept arbitrary segment names in FASTAs anymore.

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #3683 

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
~~preview URL: https://better-error-msg.loculus.org~~ (currently preview isn't on)

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
- when parsing the fasta headers, already check that the segment ID is in the list of valid segment IDs.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

<img width="536" alt="image" src="https://github.com/user-attachments/assets/669ccc21-2d8e-43ac-8108-8cb156334a26" />

(The "IDs" in the error message has been changed to "names")

<img width="536" alt="image" src="https://github.com/user-attachments/assets/18f95aa5-0db7-4083-805b-28834a5914b1" />



### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
