### PR TITLE
feat(website): Add more notifications to the Review page

### DIFF
--- a/website/src/components/ReviewPage/ReviewPage.tsx
+++ b/website/src/components/ReviewPage/ReviewPage.tsx
@@ -268,6 +268,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({ clientConfig, organism, group, a
                                                     'Are you sure you want to discard all sequences with errors?',
                                                 confirmButtonText: 'Discard',
                                                 onConfirmation: () => {
+                                                    toast.info(`Discarding ${errorCount} sequences.`);
                                                     hooks.deleteSequenceEntries({
                                                         groupIdsFilter: [group.groupId],
                                                         scope: deleteProcessedDataWithErrorsScope.value,
@@ -289,6 +290,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({ clientConfig, organism, group, a
                                             dialogText: `Are you sure you want to discard all ${processedCount} processed sequences?`,
                                             confirmButtonText: 'Discard',
                                             onConfirmation: () => {
+                                                toast.info(`Discarding ${processedCount} sequences.`)
                                                 hooks.deleteSequenceEntries({
                                                     groupIdsFilter: [group.groupId],
                                                     scope: deleteAllDataScope.value,
@@ -313,6 +315,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({ clientConfig, organism, group, a
                             dialogText: 'Are you sure you want to release all valid sequences?',
                             confirmButtonText: 'Release',
                             onConfirmation: () => {
+                                toast.info(`Releasing ${validCount} sequences.`);
                                 hooks.approveProcessedData({
                                     groupIdsFilter: [group.groupId],
                                     scope: approveAllDataScope.value,


### PR DESCRIPTION
resolves #2561, resolves #3412

preview URL: https://more-toast.loculus.org

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
- Info notifications added on both delete buttons and the release button. (Style of the popups still to be refined)

But I think maybe we don't need this anymore, as deleting and releasing is now very fast? I can't reproduce the 15 second delay, even for 4000 sequences.

IMO I might just close both issues as not relevant anymore.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)
