### PR TITLE
feat(website): Append `&` to URLs that end in `*`.

### DIFF
--- a/website/src/components/SearchPage/useQueryAsState.js
+++ b/website/src/components/SearchPage/useQueryAsState.js
@@ -25,7 +25,12 @@ export default function useQueryAsState(defaultDict) {
             for (const [key, value] of Object.entries(valueDict)) {
                 urlParams.set(key, value);
             }
-            const newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + "?" + urlParams.toString();
+            let newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + "?" + urlParams.toString();
+
+            // Avoid '*' at the end because some systems do not recognize it as part of the link
+            if (newurl.endsWith("*")) {
+                newurl.concat("&");
+            }
             
             if (newurl.length > MAX_URL_LENGTH) {
                 setUseUrlStorage(false);

--- a/website/src/components/SearchPage/useQueryAsState.js
+++ b/website/src/components/SearchPage/useQueryAsState.js
@@ -25,18 +25,18 @@ export default function useQueryAsState(defaultDict) {
             for (const [key, value] of Object.entries(valueDict)) {
                 urlParams.set(key, value);
             }
-            let newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + "?" + urlParams.toString();
+            let newUrl = window.location.protocol + "//" + window.location.host + window.location.pathname + "?" + urlParams.toString();
 
             // Avoid '*' at the end because some systems do not recognize it as part of the link
-            if (newurl.endsWith("*")) {
-                newurl.concat("&");
+            if (newUrl.endsWith("*")) {
+                newUrl.concat("&");
             }
             
-            if (newurl.length > MAX_URL_LENGTH) {
+            if (newUrl.length > MAX_URL_LENGTH) {
                 setUseUrlStorage(false);
                 window.history.replaceState({ path: window.location.pathname }, '', window.location.pathname);
             } else {
-                window.history.replaceState({ path: newurl }, '', newurl);
+                window.history.replaceState({ path: newUrl }, '', newUrl);
             }
         }
     }, [valueDict, useUrlStorage]);


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #3518 

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://avoid-star.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

### Screenshot


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)
