### PR TITLE
chore!: move preview/ppx specific Helm Chart settings out of the default values

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1602,19 +1602,9 @@ defaultOrganisms:
         - name: NP
           sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/cchf/NP.fasta]]"
 auth:
-  smtp:
-    host: "in-v3.mailjet.com"
-    port: 587
-    user: "fafd505de339dd2e9c3e85ad9981af8a"
-    replyTo: "noreply@loculus.org"
-    from: "noreply@loculus.org"
-    envelopeFrom: "noreply@loculus.org"
-  verifyEmail: true
+  verifyEmail: false
   resetPasswordAllowed: true
   registrationAllowed: true
-  identityProviders:
-    orcid:
-      clientId: "APP-P1P7N7T9YVBHQ4EH"
 insecureCookies: false
 bannerMessage: "This is a demonstration environment. It may contain non-accurate test data and should not be used for real-world applications. Data will be deleted regularly."
 welcomeMessageHTML: null

--- a/kubernetes/loculus/values_preview_server.yaml
+++ b/kubernetes/loculus/values_preview_server.yaml
@@ -52,3 +52,6 @@ auth:
   verifyEmail: true
   resetPasswordAllowed: true
   registrationAllowed: true
+  identityProviders:
+    orcid:
+      clientId: "APP-P1P7N7T9YVBHQ4EH"

--- a/kubernetes/loculus/values_preview_server.yaml
+++ b/kubernetes/loculus/values_preview_server.yaml
@@ -41,3 +41,14 @@ sequenceFlagging:
     organization: pathoplexus
     repository: curation_reports
     issueTemplate: sequence-metadata-issue.md
+auth:
+  smtp:
+    host: "in-v3.mailjet.com"
+    port: 587
+    user: "fafd505de339dd2e9c3e85ad9981af8a"
+    replyTo: "noreply@loculus.org"
+    from: "noreply@loculus.org"
+    envelopeFrom: "noreply@loculus.org"
+  verifyEmail: true
+  resetPasswordAllowed: true
+  registrationAllowed: true


### PR DESCRIPTION
**BREAKING** for PPX - because the ORCiD settings have been removed. To migrate, please include these settings in your own values.yaml.

resolves #3637 

preview URL: https://untangle-values.loculus.org

### Summary
- move email SMTP settings out.
- remove ORCID setting.

#### manual testing
I created an account on the preview, and still got the mail.

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by appropriate, automated tests.~~ (I don't think a test is needed)
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
