### PR TITLE
fix(website): fasta was incorrectly generated with empty segments

### DIFF
--- a/website/src/components/Edit/InputForm.spec.tsx
+++ b/website/src/components/Edit/InputForm.spec.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest';
+
+import { EditableSequences } from './InputForm';
+
+describe('InputForm', () => {
+    test('Empty editable sequences produces `undefined`', () => {
+        const emptyEditableSequences = EditableSequences.empty();
+        expect(emptyEditableSequences.getSequenceFasta('subId')).toBeUndefined();
+    });
+
+    test('Empty editable sequences (with names only) produces `undefined`', () => {
+        const emptyEditableSequences = EditableSequences.fromSequenceNames(['foo', 'bar']);
+        expect(emptyEditableSequences.getSequenceFasta('subId')).toBeUndefined();
+    });
+
+    test('GIVEN only a single segment has data THEN the fasta has only that segment', async () => {
+        let editableSequences = EditableSequences.fromSequenceNames(['foo', 'bar']);
+        editableSequences = editableSequences.update({ key: 'foo', value: 'ATCG' });
+        const fasta = editableSequences.getSequenceFasta('subId');
+        expect(fasta).not.toBeUndefined();
+        const fastaText = await fasta!.text();
+        expect(fastaText).toBe('>subId_foo\nATCG');
+    });
+});

--- a/website/src/components/Edit/InputForm.tsx
+++ b/website/src/components/Edit/InputForm.tsx
@@ -3,7 +3,7 @@ import Papa from 'papaparse';
 import { Fragment, type Dispatch, type FC, type SetStateAction } from 'react';
 
 import { EditableDataRow } from './DataRow.tsx';
-import type { Row } from './InputField';
+import type { KeyValuePair, Row } from './InputField';
 import { ACCESSION_FIELD, SUBMISSION_ID_FIELD } from '../../settings.ts';
 import type { ProcessingAnnotationSourceType, SequenceEntryToEdit } from '../../types/backend.ts';
 import type { InputField } from '../../types/config';
@@ -194,7 +194,7 @@ export class EditableSequences {
         return new EditableSequences([]);
     }
 
-    update(editedRow: Row): EditableSequences {
+    update(editedRow: KeyValuePair & {}): EditableSequences {
         return new EditableSequences(
             this.rows.map((prevRow) =>
                 prevRow.key === editedRow.key ? { ...prevRow, value: editedRow.value } : prevRow,
@@ -210,7 +210,16 @@ export class EditableSequences {
         const fastaContent =
             sequences.length === 1
                 ? `>${submissionId}\n${sequences[0].value}`
-                : sequences.map((sequence) => `>${submissionId}_${sequence.key}\n${sequence.value}`).join('\n');
+                : sequences
+                      .map((sequence) => {
+                          if (sequence.value.trim().length > 0) {
+                              return `>${submissionId}_${sequence.key}\n${sequence.value}`;
+                          } else {
+                              return null;
+                          }
+                      })
+                      .filter(Boolean)
+                      .join('\n');
 
         return new File([fastaContent], 'sequences.fasta', { type: 'text/plain' });
     }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #3798 

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
the frontend code for the edit and single-submit form generated FASTAs that had segment headers with no data.
This PR adds a test for this case and fixes it, so empty segments aren't added to the FASTA anymore.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->
n/A

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?) - @anna-parker: submitted a CCHF sequence with only the L segment and the submission was successful can be seen here: https://single-segment-bug.loculus.org/seq/LOC_000PERQ.1
