### PR TITLE
feat(website): better lineage search

### DIFF
--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -203,10 +203,14 @@ const SearchField = ({ field, lapisUrl, fieldValues, setSomeFieldValues, lapisSe
                 return (
                     <AutoCompleteField
                         field={field}
-                        lapisUrl={lapisUrl}
-                        lapsiSearchParameters={lapisSearchParameters}
-                        setSomeFieldValues={setSomeFieldValues}
                         fieldValue={fieldValues[field.name] ?? ''}
+                        setSomeFieldValues={setSomeFieldValues}
+                        optionsProvider={{
+                            type: 'generic',
+                            lapisUrl,
+                            lapisSearchParameters,
+                            fieldName: field.name,
+                        }}
                     />
                 );
             }

--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import { CustomizeModal } from './CustomizeModal.tsx';
 import { AccessionField } from './fields/AccessionField.tsx';
-import { AutoCompleteField } from './fields/AutoCompleteField';
+import { AutoCompleteField, createLapisAutocompleteOptionsHook } from './fields/AutoCompleteField';
 import { DateField, TimestampField } from './fields/DateField.tsx';
 import { DateRangeField } from './fields/DateRangeField.tsx';
 import { LineageField } from './fields/LineageField.tsx';
@@ -200,13 +200,13 @@ const SearchField = ({ field, lapisUrl, fieldValues, setSomeFieldValues, lapisSe
                 );
             }
             if (field.autocomplete === true) {
+                const hook = createLapisAutocompleteOptionsHook(lapisUrl, field.name, lapisSearchParameters);
                 return (
                     <AutoCompleteField
                         field={field}
-                        lapisUrl={lapisUrl}
+                        hook={hook}
                         setSomeFieldValues={setSomeFieldValues}
                         fieldValue={fieldValues[field.name] ?? ''}
-                        lapisSearchParameters={lapisSearchParameters}
                     />
                 );
             }

--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -195,6 +195,7 @@ const SearchField = ({ field, lapisUrl, fieldValues, setSomeFieldValues, lapisSe
                         fieldValue={(fieldValues[field.name] ?? '') as string}
                         setSomeFieldValues={setSomeFieldValues}
                         lapisUrl={lapisUrl}
+                        lapisSearchParameters={lapisSearchParameters}
                     />
                 );
             }

--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import { CustomizeModal } from './CustomizeModal.tsx';
 import { AccessionField } from './fields/AccessionField.tsx';
-import { AutoCompleteField, createLapisAutocompleteOptionsHook } from './fields/AutoCompleteField';
+import { AutoCompleteField } from './fields/AutoCompleteField';
 import { DateField, TimestampField } from './fields/DateField.tsx';
 import { DateRangeField } from './fields/DateRangeField.tsx';
 import { LineageField } from './fields/LineageField.tsx';
@@ -200,11 +200,11 @@ const SearchField = ({ field, lapisUrl, fieldValues, setSomeFieldValues, lapisSe
                 );
             }
             if (field.autocomplete === true) {
-                const hook = createLapisAutocompleteOptionsHook(lapisUrl, field.name, lapisSearchParameters);
                 return (
                     <AutoCompleteField
                         field={field}
-                        hook={hook}
+                        lapisUrl={lapisUrl}
+                        lapsiSearchParameters={lapisSearchParameters}
                         setSomeFieldValues={setSomeFieldValues}
                         fieldValue={fieldValues[field.name] ?? ''}
                     />

--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -195,7 +195,6 @@ const SearchField = ({ field, lapisUrl, fieldValues, setSomeFieldValues, lapisSe
                         fieldValue={(fieldValues[field.name] ?? '') as string}
                         setSomeFieldValues={setSomeFieldValues}
                         lapisUrl={lapisUrl}
-                        lapisSearchParameters={lapisSearchParameters}
                     />
                 );
             }

--- a/website/src/components/SearchPage/fields/AutoCompleteField.spec.tsx
+++ b/website/src/components/SearchPage/fields/AutoCompleteField.spec.tsx
@@ -1,8 +1,8 @@
-import { render, screen, act, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-import { AutoCompleteField, createLapisAutocompleteOptionsHook } from './AutoCompleteField';
+import { AutoCompleteField } from './AutoCompleteField';
 import { lapisClientHooks } from '../../../services/serviceHooks.ts';
 import { type MetadataFilter } from '../../../types/config.ts';
 
@@ -49,13 +49,11 @@ describe('AutoCompleteField', () => {
             error: null,
             mutate: vi.fn(),
         });
-
-        const hook = createLapisAutocompleteOptionsHook(lapisUrl, field.name, lapisSearchParameters);
-
         render(
             <AutoCompleteField
                 field={field}
-                hook={hook}
+                lapisUrl={lapisUrl}
+                lapsiSearchParameters={lapisSearchParameters}
                 setSomeFieldValues={setSomeFieldValues}
             />,
         );
@@ -83,11 +81,11 @@ describe('AutoCompleteField', () => {
             error: null,
             mutate: vi.fn(),
         });
-        const hook = createLapisAutocompleteOptionsHook(lapisUrl, field.name, lapisSearchParameters);
         render(
             <AutoCompleteField
                 field={field}
-                hook={hook}
+                lapisUrl={lapisUrl}
+                lapsiSearchParameters={lapisSearchParameters}
                 setSomeFieldValues={setSomeFieldValues}
             />,
         );
@@ -109,11 +107,11 @@ describe('AutoCompleteField', () => {
             error: null,
             mutate: vi.fn(),
         });
-        const hook = createLapisAutocompleteOptionsHook(lapisUrl, field.name, lapisSearchParameters);
         render(
             <AutoCompleteField
                 field={field}
-                hook={hook}
+                lapisUrl={lapisUrl}
+                lapsiSearchParameters={lapisSearchParameters}
                 setSomeFieldValues={setSomeFieldValues}
             />,
         );
@@ -131,11 +129,11 @@ describe('AutoCompleteField', () => {
             error: { message: 'Error message', stack: 'Error stack' },
             mutate: vi.fn(),
         });
-        const hook = createLapisAutocompleteOptionsHook(lapisUrl, field.name, lapisSearchParameters);
         render(
             <AutoCompleteField
                 field={field}
-                hook={hook}
+                lapisUrl={lapisUrl}
+                lapsiSearchParameters={lapisSearchParameters}
                 setSomeFieldValues={setSomeFieldValues}
             />,
         );
@@ -158,11 +156,11 @@ describe('AutoCompleteField', () => {
             error: null,
             mutate: vi.fn(),
         });
-        const hook = createLapisAutocompleteOptionsHook(lapisUrl, field.name, lapisSearchParameters);
         render(
             <AutoCompleteField
                 field={field}
-                hook={hook!}
+                lapisUrl={lapisUrl}
+                lapsiSearchParameters={lapisSearchParameters}
                 setSomeFieldValues={setSomeFieldValues}
             />,
         );
@@ -188,13 +186,15 @@ describe('AutoCompleteField', () => {
             error: null,
             mutate: vi.fn(),
         });
-        const hook = createLapisAutocompleteOptionsHook(lapisUrl, field.name, lapisSearchParameters);
-        render(<AutoCompleteField
-            field={field}
-            hook={hook}
-            setSomeFieldValues={setSomeFieldValues}
-            fieldValue="Option 1"
-        />);
+        render(
+            <AutoCompleteField
+                field={field}
+                lapisUrl={lapisUrl}
+                lapsiSearchParameters={lapisSearchParameters}
+                setSomeFieldValues={setSomeFieldValues}
+                fieldValue='Option 1'
+            />,
+        );
 
         const input = screen.getByLabelText('Test Field');
         await userEvent.click(input);

--- a/website/src/components/SearchPage/fields/AutoCompleteField.spec.tsx
+++ b/website/src/components/SearchPage/fields/AutoCompleteField.spec.tsx
@@ -1,8 +1,8 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-import { AutoCompleteField } from './AutoCompleteField';
+import { AutoCompleteField, createLapisAutocompleteOptionsHook } from './AutoCompleteField';
 import { lapisClientHooks } from '../../../services/serviceHooks.ts';
 import { type MetadataFilter } from '../../../types/config.ts';
 
@@ -50,12 +50,13 @@ describe('AutoCompleteField', () => {
             mutate: vi.fn(),
         });
 
+        const hook = createLapisAutocompleteOptionsHook(lapisUrl, field.name, lapisSearchParameters);
+
         render(
             <AutoCompleteField
                 field={field}
+                hook={hook}
                 setSomeFieldValues={setSomeFieldValues}
-                lapisUrl={lapisUrl}
-                lapisSearchParameters={lapisSearchParameters}
             />,
         );
 
@@ -82,12 +83,12 @@ describe('AutoCompleteField', () => {
             error: null,
             mutate: vi.fn(),
         });
+        const hook = createLapisAutocompleteOptionsHook(lapisUrl, field.name, lapisSearchParameters);
         render(
             <AutoCompleteField
                 field={field}
+                hook={hook}
                 setSomeFieldValues={setSomeFieldValues}
-                lapisUrl={lapisUrl}
-                lapisSearchParameters={lapisSearchParameters}
             />,
         );
 
@@ -108,13 +109,12 @@ describe('AutoCompleteField', () => {
             error: null,
             mutate: vi.fn(),
         });
-
+        const hook = createLapisAutocompleteOptionsHook(lapisUrl, field.name, lapisSearchParameters);
         render(
             <AutoCompleteField
                 field={field}
+                hook={hook}
                 setSomeFieldValues={setSomeFieldValues}
-                lapisUrl={lapisUrl}
-                lapisSearchParameters={lapisSearchParameters}
             />,
         );
 
@@ -131,13 +131,12 @@ describe('AutoCompleteField', () => {
             error: { message: 'Error message', stack: 'Error stack' },
             mutate: vi.fn(),
         });
-
+        const hook = createLapisAutocompleteOptionsHook(lapisUrl, field.name, lapisSearchParameters);
         render(
             <AutoCompleteField
                 field={field}
+                hook={hook}
                 setSomeFieldValues={setSomeFieldValues}
-                lapisUrl={lapisUrl}
-                lapisSearchParameters={lapisSearchParameters}
             />,
         );
 
@@ -159,12 +158,12 @@ describe('AutoCompleteField', () => {
             error: null,
             mutate: vi.fn(),
         });
+        const hook = createLapisAutocompleteOptionsHook(lapisUrl, field.name, lapisSearchParameters);
         render(
             <AutoCompleteField
                 field={field}
+                hook={hook!}
                 setSomeFieldValues={setSomeFieldValues}
-                lapisUrl={lapisUrl}
-                lapisSearchParameters={lapisSearchParameters}
             />,
         );
 
@@ -189,15 +188,13 @@ describe('AutoCompleteField', () => {
             error: null,
             mutate: vi.fn(),
         });
-        render(
-            <AutoCompleteField
-                field={field}
-                setSomeFieldValues={setSomeFieldValues}
-                lapisUrl={lapisUrl}
-                fieldValue='Option 1'
-                lapisSearchParameters={lapisSearchParameters}
-            />,
-        );
+        const hook = createLapisAutocompleteOptionsHook(lapisUrl, field.name, lapisSearchParameters);
+        render(<AutoCompleteField
+            field={field}
+            hook={hook}
+            setSomeFieldValues={setSomeFieldValues}
+            fieldValue="Option 1"
+        />);
 
         const input = screen.getByLabelText('Test Field');
         await userEvent.click(input);

--- a/website/src/components/SearchPage/fields/AutoCompleteField.spec.tsx
+++ b/website/src/components/SearchPage/fields/AutoCompleteField.spec.tsx
@@ -52,8 +52,12 @@ describe('AutoCompleteField', () => {
         render(
             <AutoCompleteField
                 field={field}
-                lapisUrl={lapisUrl}
-                lapsiSearchParameters={lapisSearchParameters}
+                optionsProvider={{
+                    type: 'generic',
+                    lapisUrl,
+                    lapisSearchParameters,
+                    fieldName: field.name,
+                }}
                 setSomeFieldValues={setSomeFieldValues}
             />,
         );
@@ -84,8 +88,12 @@ describe('AutoCompleteField', () => {
         render(
             <AutoCompleteField
                 field={field}
-                lapisUrl={lapisUrl}
-                lapsiSearchParameters={lapisSearchParameters}
+                optionsProvider={{
+                    type: 'generic',
+                    lapisUrl,
+                    lapisSearchParameters,
+                    fieldName: field.name,
+                }}
                 setSomeFieldValues={setSomeFieldValues}
             />,
         );
@@ -110,8 +118,12 @@ describe('AutoCompleteField', () => {
         render(
             <AutoCompleteField
                 field={field}
-                lapisUrl={lapisUrl}
-                lapsiSearchParameters={lapisSearchParameters}
+                optionsProvider={{
+                    type: 'generic',
+                    lapisUrl,
+                    lapisSearchParameters,
+                    fieldName: field.name,
+                }}
                 setSomeFieldValues={setSomeFieldValues}
             />,
         );
@@ -132,8 +144,12 @@ describe('AutoCompleteField', () => {
         render(
             <AutoCompleteField
                 field={field}
-                lapisUrl={lapisUrl}
-                lapsiSearchParameters={lapisSearchParameters}
+                optionsProvider={{
+                    type: 'generic',
+                    lapisUrl,
+                    lapisSearchParameters,
+                    fieldName: field.name,
+                }}
                 setSomeFieldValues={setSomeFieldValues}
             />,
         );
@@ -159,8 +175,12 @@ describe('AutoCompleteField', () => {
         render(
             <AutoCompleteField
                 field={field}
-                lapisUrl={lapisUrl}
-                lapsiSearchParameters={lapisSearchParameters}
+                optionsProvider={{
+                    type: 'generic',
+                    lapisUrl,
+                    lapisSearchParameters,
+                    fieldName: field.name,
+                }}
                 setSomeFieldValues={setSomeFieldValues}
             />,
         );
@@ -189,8 +209,12 @@ describe('AutoCompleteField', () => {
         render(
             <AutoCompleteField
                 field={field}
-                lapisUrl={lapisUrl}
-                lapsiSearchParameters={lapisSearchParameters}
+                optionsProvider={{
+                    type: 'generic',
+                    lapisUrl,
+                    lapisSearchParameters,
+                    fieldName: field.name,
+                }}
                 setSomeFieldValues={setSomeFieldValues}
                 fieldValue='Option 1'
             />,

--- a/website/src/components/SearchPage/fields/AutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/AutoCompleteField.tsx
@@ -5,7 +5,6 @@ import { createOptionsProviderHook, type OptionsProvider } from './AutoCompleteO
 import { TextField } from './TextField.tsx';
 import { getClientLogger } from '../../../clientLogger.ts';
 import useClientFlag from '../../../hooks/isClient.ts';
-import { lapisClientHooks } from '../../../services/serviceHooks.ts';
 import { type GroupedMetadataFilter, type MetadataFilter, type SetSomeFieldValues } from '../../../types/config.ts';
 import { formatNumberWithDefaultLocale } from '../../../utils/formatNumber.tsx';
 

--- a/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
+++ b/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
@@ -80,11 +80,19 @@ const createLineageOptionsHook = (lapisUrl: string, fieldName: string): Autocomp
             },
             {},
         );
-        // TODO properly convert the data into options
-        const options: Option[] = [
-            { option: data?.substring(0, 5) ?? 'foo', count: 1 },
-            { option: data?.substring(5, 10) ?? 'bar', count: 2 },
-        ];
+
+        const options: Option[] = [];
+
+        // TODO - what about the counts? duplicates?
+        if (data) {
+            Object.entries(data.data).forEach(([lineageName, lineageEntry]) => {
+                options.push({ option: lineageName, count: -1 });
+                if (lineageEntry.aliases) {
+                    lineageEntry.aliases.forEach((alias) => options.push({ option: alias, count: -1 }));
+                }
+            });
+        }
+
         return {
             options,
             isLoading,

--- a/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
+++ b/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
@@ -153,7 +153,7 @@ const createLineageOptionsHook = (
         return {
             options,
             isLoading: aggregateIsLoading || defIsLoading,
-            error: new AggregateError([aggregateError, defError]),
+            error: new AggregateError([aggregateError, defError].filter(Boolean)),
             load: () => mutate(lapisParams),
         };
     };

--- a/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
+++ b/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
@@ -72,24 +72,27 @@ const createGenericOptionsHook = (
 
 const createLineageOptionsHook = (lapisUrl: string, fieldName: string): AutocompleteOptionsHook => {
     return function hook() {
-        const { data, isLoading, error } = lapisClientHooks(lapisUrl).zodiosHooks.useLineageDefinition({
-            params: {
-                column: fieldName
-            }
-        }, {})
+        const { data, isLoading, error } = lapisClientHooks(lapisUrl).zodiosHooks.useLineageDefinition(
+            {
+                params: {
+                    column: fieldName,
+                },
+            },
+            {},
+        );
         // TODO properly convert the data into options
         const options: Option[] = [
-            {option: data?.substring(0, 5) ?? 'foo', count: 1},
-            {option: data?.substring(5, 10) ?? 'bar', count: 2}
-        ]
+            { option: data?.substring(0, 5) ?? 'foo', count: 1 },
+            { option: data?.substring(5, 10) ?? 'bar', count: 2 },
+        ];
         return {
             options,
             isLoading,
             error,
-            load: () => {}  // TODO - is it correct to just have a no-op here?
+            load: () => {}, // TODO - is it correct to just have a no-op here?
         };
-    }
-}
+    };
+};
 
 export const createOptionsProviderHook = (optionsProvider: OptionsProvider): AutocompleteOptionsHook => {
     switch (optionsProvider.type) {
@@ -104,12 +107,8 @@ export const createOptionsProviderHook = (optionsProvider: OptionsProvider): Aut
             );
         }
         case 'lineage':
-            return useCallback(
-                createLineageOptionsHook(
-                    optionsProvider.lapisUrl,
-                    optionsProvider.fieldName
-                ),
-                [optionsProvider]
-            )
+            return useCallback(createLineageOptionsHook(optionsProvider.lapisUrl, optionsProvider.fieldName), [
+                optionsProvider,
+            ]);
     }
 };

--- a/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
+++ b/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
@@ -126,7 +126,7 @@ function aggregateCounts(
                 (children.get(currentElement) ?? []).forEach((child) => toVisit.push(child));
             }
             const count = Array.from(descendants)
-                .map((descendant) => counts.get(descendant) ?? 0)
+                .map((descendant) => canonicalCounts.get(descendant) ?? 0)
                 .reduce((acc, num) => acc + num, 0);
             resolvedCounts.set(lineage, count);
         }

--- a/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
+++ b/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
@@ -1,0 +1,115 @@
+import { useCallback } from 'react';
+
+import { lapisClientHooks } from '../../../services/serviceHooks.ts';
+
+export type Option = {
+    option: string;
+    count: number | undefined;
+};
+
+/* Fetch options as all possible unique values for `fieldName` */
+type GenericOptionsProvider = {
+    type: 'generic';
+    lapisUrl: string;
+    lapisSearchParameters: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any -- TODO(#3451)
+    fieldName: string;
+};
+
+/* Fetch options from the lineage definition for `fieldName` */
+type LineageOptionsProvider = {
+    type: 'lineage';
+    lapisUrl: string;
+    fieldName: string;
+};
+
+/* Defines where how the options in the dropdown of the AutocompleteField are fetched. */
+export type OptionsProvider = GenericOptionsProvider | LineageOptionsProvider;
+
+export type AutocompleteOptionsHook = () => {
+    options: Option[];
+    isLoading: boolean;
+    error: Error | null;
+    load: () => void;
+};
+
+const createGenericOptionsHook = (
+    lapisUrl: string,
+    fieldName: string,
+    lapisSearchParameters: Record<string, any>, // eslint-disable-line @typescript-eslint/no-explicit-any -- TODO(#3451) use a proper type
+): AutocompleteOptionsHook => {
+    const otherFields = { ...lapisSearchParameters };
+    delete otherFields[fieldName];
+
+    Object.keys(otherFields).forEach((key) => {
+        if (otherFields[key] === '') {
+            delete otherFields[key];
+        }
+    });
+
+    const lapisParams = { fields: [fieldName], ...otherFields };
+
+    return function hook() {
+        const { data, isLoading, error, mutate } = lapisClientHooks(lapisUrl).zodiosHooks.useAggregated({}, {});
+
+        const options: Option[] = (data?.data ?? [])
+            .filter(
+                (it) =>
+                    typeof it[fieldName] === 'string' ||
+                    typeof it[fieldName] === 'boolean' ||
+                    typeof it[fieldName] === 'number',
+            )
+            .map((it) => ({ option: it[fieldName]!.toString(), count: it.count }))
+            .sort((a, b) => (a.option.toLowerCase() < b.option.toLowerCase() ? -1 : 1));
+
+        return {
+            options,
+            isLoading,
+            error,
+            load: () => mutate(lapisParams),
+        };
+    };
+};
+
+const createLineageOptionsHook = (lapisUrl: string, fieldName: string): AutocompleteOptionsHook => {
+    return function hook() {
+        const { data, isLoading, error } = lapisClientHooks(lapisUrl).zodiosHooks.useLineageDefinition({
+            params: {
+                column: fieldName
+            }
+        }, {})
+        // TODO properly convert the data into options
+        const options: Option[] = [
+            {option: data?.substring(0, 5) ?? 'foo', count: 1},
+            {option: data?.substring(5, 10) ?? 'bar', count: 2}
+        ]
+        return {
+            options,
+            isLoading,
+            error,
+            load: () => {}  // TODO - is it correct to just have a no-op here?
+        };
+    }
+}
+
+export const createOptionsProviderHook = (optionsProvider: OptionsProvider): AutocompleteOptionsHook => {
+    switch (optionsProvider.type) {
+        case 'generic': {
+            return useCallback(
+                createGenericOptionsHook(
+                    optionsProvider.lapisUrl,
+                    optionsProvider.fieldName,
+                    optionsProvider.lapisSearchParameters,
+                ),
+                [optionsProvider],
+            );
+        }
+        case 'lineage':
+            return useCallback(
+                createLineageOptionsHook(
+                    optionsProvider.lapisUrl,
+                    optionsProvider.fieldName
+                ),
+                [optionsProvider]
+            )
+    }
+};

--- a/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
+++ b/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
@@ -72,7 +72,11 @@ const createGenericOptionsHook = (
 
 const createLineageOptionsHook = (lapisUrl: string, fieldName: string): AutocompleteOptionsHook => {
     return function hook() {
-        const { data, isLoading, error } = lapisClientHooks(lapisUrl).zodiosHooks.useLineageDefinition(
+        const {
+            data: lineageDefinition,
+            isLoading,
+            error,
+        } = lapisClientHooks(lapisUrl).zodiosHooks.useLineageDefinition(
             {
                 params: {
                     column: fieldName,
@@ -81,23 +85,27 @@ const createLineageOptionsHook = (lapisUrl: string, fieldName: string): Autocomp
             {},
         );
 
-        const options: Option[] = [];
+        const lineages: string[] = [];
 
-        // TODO - what about the counts? duplicates?
-        if (data) {
-            Object.entries(data.data).forEach(([lineageName, lineageEntry]) => {
-                options.push({ option: lineageName, count: -1 });
+        if (lineageDefinition) {
+            Object.entries(lineageDefinition).forEach(([lineageName, lineageEntry]) => {
+                lineages.push(lineageName);
                 if (lineageEntry.aliases) {
-                    lineageEntry.aliases.forEach((alias) => options.push({ option: alias, count: -1 }));
+                    lineageEntry.aliases.forEach((alias) => lineages.push(alias));
                 }
             });
         }
+
+        const options: Option[] = new Array(...new Set(lineages)).map((lineage) => ({
+            option: lineage,
+            count: undefined,
+        }));
 
         return {
             options,
             isLoading,
             error,
-            load: () => {}, // TODO - is it correct to just have a no-op here?
+            load: () => {},
         };
     };
 };

--- a/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
+++ b/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
@@ -110,6 +110,7 @@ const createLineageOptionsHook = (
 
         const counts = new Map<string, number>();
 
+        // set initial counts
         if (data?.data) {
             data.data
                 .filter(
@@ -124,11 +125,25 @@ const createLineageOptionsHook = (
         const options: Option[] = [];
 
         if (lineageDefinition) {
-            Object.entries(lineageDefinition).forEach(([lineageName, lineageEntry]) => {
-                const count: number | undefined = counts.get(lineageName);
+            // sum up counts for all aliases
+            Object.entries(lineageDefinition).forEach(([lineageName, { aliases }]) => {
+                if (aliases) {
+                    aliases.forEach((alias) => {
+                        const aliasCount = counts.get(alias) ?? 0;
+                        const lineageCount = counts.get(lineageName) ?? 0;
+                        counts.set(lineageName, lineageCount + aliasCount);
+                        counts.delete(alias);
+                    });
+                }
+            });
+
+            // generate options
+            Object.entries(lineageDefinition).forEach(([lineageName, { aliases }]) => {
+                let count: number | undefined = counts.get(lineageName);
+                if (count === 0) count = undefined;
                 options.push({ option: lineageName, count });
-                if (lineageEntry.aliases) {
-                    lineageEntry.aliases.forEach((alias) => options.push({ option: alias, count }));
+                if (aliases) {
+                    aliases.forEach((alias) => options.push({ option: alias, count }));
                 }
             });
         }

--- a/website/src/components/SearchPage/fields/LineageField.spec.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.spec.tsx
@@ -26,7 +26,6 @@ describe('LineageField', () => {
     const field: MetadataFilter = { name: 'lineage', label: 'My Lineage', type: 'string' };
     const setSomeFieldValues = vi.fn();
     const lapisUrl = 'https://example.com/api';
-    const lapisSearchParameters = { lineage: 'A.1' };
 
     beforeEach(() => {
         setSomeFieldValues.mockClear();
@@ -51,7 +50,6 @@ describe('LineageField', () => {
                 fieldValue='initialValue'
                 setSomeFieldValues={setSomeFieldValues}
                 lapisUrl={lapisUrl}
-                lapisSearchParameters={lapisSearchParameters}
             />,
         );
 
@@ -67,7 +65,6 @@ describe('LineageField', () => {
                 fieldValue='A.1'
                 setSomeFieldValues={setSomeFieldValues}
                 lapisUrl={lapisUrl}
-                lapisSearchParameters={lapisSearchParameters}
             />,
         );
 
@@ -85,7 +82,6 @@ describe('LineageField', () => {
                 fieldValue='A.1'
                 setSomeFieldValues={setSomeFieldValues}
                 lapisUrl={lapisUrl}
-                lapisSearchParameters={lapisSearchParameters}
             />,
         );
 
@@ -110,7 +106,6 @@ describe('LineageField', () => {
                 fieldValue='value*'
                 setSomeFieldValues={setSomeFieldValues}
                 lapisUrl={lapisUrl}
-                lapisSearchParameters={lapisSearchParameters}
             />,
         );
 

--- a/website/src/components/SearchPage/fields/LineageField.spec.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.spec.tsx
@@ -20,6 +20,7 @@ const mockUseLineageDefinition = vi.fn();
 lapisClientHooks.mockReturnValue({
     zodiosHooks: {
         useLineageDefinition: mockUseLineageDefinition,
+        useAggregated: mockUseAggregated
     },
 });
 
@@ -118,7 +119,7 @@ describe('LineageField', () => {
 
         const options = await screen.findAllByRole('option');
         expect(options.length).toBe(6);
-        await userEvent.click(options[3]);
+        await userEvent.click(options[2]);
 
         expect(setSomeFieldValues).toHaveBeenCalledWith(['lineage', 'A.1.1']);
 

--- a/website/src/components/SearchPage/fields/LineageField.spec.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.spec.tsx
@@ -104,7 +104,7 @@ describe('LineageField', () => {
         expect(setSomeFieldValues).toHaveBeenCalledWith(['lineage', 'A.1*']);
     });
 
-    it('aggregates counts for aliases correctly', async() => {
+    it('aggregates counts for aliases correctly', async () => {
         render(
             <LineageField
                 field={field}

--- a/website/src/components/SearchPage/fields/LineageField.spec.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.spec.tsx
@@ -119,6 +119,7 @@ describe('LineageField', () => {
 
         const options = await screen.findAllByRole('option');
         expect(options.length).toBe(6);
+        expect(options[2].textContent).toBe('A.1.1(35)'); // count for A.1.1 and B together
         await userEvent.click(options[2]);
 
         expect(setSomeFieldValues).toHaveBeenCalledWith(['lineage', 'A.1.1']);

--- a/website/src/components/SearchPage/fields/LineageField.spec.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.spec.tsx
@@ -13,12 +13,12 @@ vi.mock('../../../clientLogger.ts', () => ({
     }),
 }));
 
-const mockUseAggregated = vi.fn();
+const mockUseLineageDefinition = vi.fn();
 // @ts-expect-error because mockReturnValue is not defined in the type definition
 // eslint-disable-next-line @typescript-eslint/no-unsafe-call
 lapisClientHooks.mockReturnValue({
     zodiosHooks: {
-        useAggregated: mockUseAggregated,
+        useLineageDefinition: mockUseLineageDefinition,
     },
 });
 
@@ -30,7 +30,8 @@ describe('LineageField', () => {
     beforeEach(() => {
         setSomeFieldValues.mockClear();
 
-        mockUseAggregated.mockReturnValue({
+        mockUseLineageDefinition.mockReturnValue({
+            // TODO - what exactly should be returned here?
             data: {
                 data: [
                     { lineage: 'A.1', count: 10 },
@@ -60,12 +61,7 @@ describe('LineageField', () => {
 
     it('updates query when sublineages checkbox is toggled', () => {
         render(
-            <LineageField
-                field={field}
-                fieldValue='A.1'
-                setSomeFieldValues={setSomeFieldValues}
-                lapisUrl={lapisUrl}
-            />,
+            <LineageField field={field} fieldValue='A.1' setSomeFieldValues={setSomeFieldValues} lapisUrl={lapisUrl} />,
         );
 
         const checkbox = screen.getByRole('checkbox');
@@ -77,12 +73,7 @@ describe('LineageField', () => {
 
     it('handles input changes and calls setSomeFieldValues', async () => {
         render(
-            <LineageField
-                field={field}
-                fieldValue='A.1'
-                setSomeFieldValues={setSomeFieldValues}
-                lapisUrl={lapisUrl}
-            />,
+            <LineageField field={field} fieldValue='A.1' setSomeFieldValues={setSomeFieldValues} lapisUrl={lapisUrl} />,
         );
 
         await userEvent.click(screen.getByLabelText('My Lineage'));

--- a/website/src/components/SearchPage/fields/LineageField.spec.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.spec.tsx
@@ -31,12 +31,22 @@ describe('LineageField', () => {
         setSomeFieldValues.mockClear();
 
         mockUseLineageDefinition.mockReturnValue({
-            // TODO - what exactly should be returned here?
             data: {
-                data: [
-                    { lineage: 'A.1', count: 10 },
-                    { lineage: 'A.1.1', count: 20 },
-                ],
+                /* eslint-disable @typescript-eslint/naming-convention */
+                data: {
+                    'A': {},
+                    'A.1': {
+                        parents: ['A'],
+                    },
+                    'A.1.1': {
+                        parents: ['A.1'],
+                        aliases: ['B'],
+                    },
+                    'A.2': {
+                        parents: ['A'],
+                    },
+                },
+                /* eslint-enable @typescript-eslint/naming-convention */
             },
             isLoading: false,
             error: null,

--- a/website/src/components/SearchPage/fields/LineageField.spec.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.spec.tsx
@@ -104,7 +104,7 @@ describe('LineageField', () => {
         expect(setSomeFieldValues).toHaveBeenCalledWith(['lineage', 'A.1*']);
     });
 
-    it('handles input changes and calls setSomeFieldValues', async () => {
+    it('aggregates counts for aliases correctly', async() => {
         render(
             <LineageField
                 field={field}
@@ -119,7 +119,25 @@ describe('LineageField', () => {
 
         const options = await screen.findAllByRole('option');
         expect(options.length).toBe(6);
-        expect(options[2].textContent).toBe('A.1.1(35)'); // count for A.1.1 and B together
+        // A.1.1 and B are aliases -> should have same, aggregated count
+        expect(options[2].textContent).toBe('A.1.1(35)');
+        expect(options[4].textContent).toBe('B(35)');
+    });
+
+    it('handles input changes and calls setSomeFieldValues', async () => {
+        render(
+            <LineageField
+                field={field}
+                fieldValue='A.1'
+                setSomeFieldValues={setSomeFieldValues}
+                lapisUrl={lapisUrl}
+                lapisSearchParameters={lapisSearchParameters}
+            />,
+        );
+
+        await userEvent.click(screen.getByLabelText('My Lineage'));
+
+        const options = await screen.findAllByRole('option');
         await userEvent.click(options[2]);
 
         expect(setSomeFieldValues).toHaveBeenCalledWith(['lineage', 'A.1.1']);

--- a/website/src/components/SearchPage/fields/LineageField.spec.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.spec.tsx
@@ -31,23 +31,21 @@ describe('LineageField', () => {
         setSomeFieldValues.mockClear();
 
         mockUseLineageDefinition.mockReturnValue({
+            /* eslint-disable @typescript-eslint/naming-convention */
             data: {
-                /* eslint-disable @typescript-eslint/naming-convention */
-                data: {
-                    'A': {},
-                    'A.1': {
-                        parents: ['A'],
-                    },
-                    'A.1.1': {
-                        parents: ['A.1'],
-                        aliases: ['B'],
-                    },
-                    'A.2': {
-                        parents: ['A'],
-                    },
+                'A': {},
+                'A.1': {
+                    parents: ['A'],
                 },
-                /* eslint-enable @typescript-eslint/naming-convention */
+                'A.1.1': {
+                    parents: ['A.1'],
+                    aliases: ['B'],
+                },
+                'A.2': {
+                    parents: ['A'],
+                },
             },
+            /* eslint-enable @typescript-eslint/naming-convention */
             isLoading: false,
             error: null,
             mutate: vi.fn(),
@@ -89,7 +87,8 @@ describe('LineageField', () => {
         await userEvent.click(screen.getByLabelText('My Lineage'));
 
         const options = await screen.findAllByRole('option');
-        await userEvent.click(options[1]);
+        expect(options.length).toBe(5);
+        await userEvent.click(options[2]);
 
         expect(setSomeFieldValues).toHaveBeenCalledWith(['lineage', 'A.1.1']);
 

--- a/website/src/components/SearchPage/fields/LineageField.spec.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.spec.tsx
@@ -20,7 +20,7 @@ const mockUseLineageDefinition = vi.fn();
 lapisClientHooks.mockReturnValue({
     zodiosHooks: {
         useLineageDefinition: mockUseLineageDefinition,
-        useAggregated: mockUseAggregated
+        useAggregated: mockUseAggregated,
     },
 });
 

--- a/website/src/components/SearchPage/fields/LineageField.spec.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.spec.tsx
@@ -122,9 +122,36 @@ describe('LineageField', () => {
 
         const options = await screen.findAllByRole('option');
         expect(options.length).toBe(6);
+        expect(options[0].textContent).toBe('A');
+        expect(options[1].textContent).toBe('A.1(10)');
         // A.1.1 and B are aliases -> should have same, aggregated count
         expect(options[2].textContent).toBe('A.1.1(35)');
         expect(options[4].textContent).toBe('B(35)');
+    });
+
+    it('aggregates counts for sublineages correctly', async () => {
+        render(
+            <LineageField
+                field={field}
+                fieldValue='A.1'
+                setSomeFieldValues={setSomeFieldValues}
+                lapisUrl={lapisUrl}
+                lapisSearchParameters={lapisSearchParameters}
+            />,
+        );
+
+        const checkbox = screen.getByRole('checkbox');
+        fireEvent.click(checkbox);
+
+        await userEvent.click(screen.getByLabelText('My Lineage'));
+
+        const options = await screen.findAllByRole('option');
+        expect(options.length).toBe(6);
+        expect.soft(options[0].textContent).toBe('A(53)');
+        expect.soft(options[1].textContent).toBe('A.1(45)');
+        expect.soft(options[2].textContent).toBe('A.1.1(35)');
+        expect.soft(options[3].textContent).toBe('A.2(8)');
+        expect.soft(options[4].textContent).toBe('B(35)');
     });
 
     it('handles input changes and calls setSomeFieldValues', async () => {

--- a/website/src/components/SearchPage/fields/LineageField.spec.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.spec.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import { LineageField } from './LineageField';
@@ -84,6 +85,8 @@ describe('LineageField', () => {
         expect(screen.getByText('My Lineage')).toBeInTheDocument();
         const checkbox = screen.getByRole('checkbox');
         expect(checkbox).not.toBeChecked();
+        const textbox = screen.getByRole('textbox');
+        expect(textbox).toHaveValue('initialValue');
     });
 
     it('updates query when sublineages checkbox is toggled', () => {
@@ -166,5 +169,36 @@ describe('LineageField', () => {
         fireEvent.click(checkbox);
 
         expect(setSomeFieldValues).toHaveBeenCalledWith(['lineage', 'value']);
+    });
+
+    it('clears the whole input field when the fieldValue is updated externally', () => {
+        const Wrapper = () => {
+            const [value, setValue] = useState('A.1*');
+
+            return (
+                <>
+                    <LineageField
+                        field={field}
+                        fieldValue={value}
+                        setSomeFieldValues={setSomeFieldValues}
+                        lapisUrl={lapisUrl}
+                        lapisSearchParameters={lapisSearchParameters}
+                    />
+                    <button onClick={() => setValue('')}>reset</button>
+                </>
+            );
+        };
+
+        render(<Wrapper />);
+
+        const checkbox = screen.getByRole('checkbox');
+        expect(checkbox).toBeChecked();
+        const textbox = screen.getByRole('textbox');
+        expect(textbox).toHaveValue('A.1');
+
+        fireEvent.click(screen.getByText('reset'));
+
+        expect(checkbox).not.toBeChecked();
+        expect(textbox).toHaveValue('');
     });
 });

--- a/website/src/components/SearchPage/fields/LineageField.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type FC } from 'react';
 
-import { AutoCompleteField, createLapisAutocompleteOptionsHook } from './AutoCompleteField';
+import { AutoCompleteField } from './AutoCompleteField';
 import type { MetadataFilter, SetSomeFieldValues } from '../../../types/config';
 
 interface LineageFieldProps {
@@ -28,13 +28,12 @@ export const LineageField: FC<LineageFieldProps> = ({
         setSomeFieldValues([field.name, queryText]);
     }, [includeSublineages, inputText, fieldValue]);
 
-    const hook = createLapisAutocompleteOptionsHook(lapisUrl, field.name, lapisSearchParameters);
-
     return (
         <div key={field.name} className='flex flex-col border p-3 mb-3 rounded-md border-gray-300'>
             <AutoCompleteField
                 field={field}
-                hook={hook}
+                lapisUrl={lapisUrl}
+                lapsiSearchParameters={lapisSearchParameters}
                 setSomeFieldValues={([_, value]) => {
                     setInputText(value as string);
                 }}

--- a/website/src/components/SearchPage/fields/LineageField.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.tsx
@@ -18,15 +18,29 @@ export const LineageField: FC<LineageFieldProps> = ({
     lapisUrl,
     lapisSearchParameters,
 }) => {
-    const [includeSublineages, setIncludeSubLineages] = useState(fieldValue.endsWith('*'));
-    const [inputText, setInputText] = useState(fieldValue.endsWith('*') ? fieldValue.slice(0, -1) : fieldValue);
+    const [includeSublineages, _setIncludeSubLineages] = useState(fieldValue.endsWith('*'));
+    const [inputText, _setInputText] = useState(fieldValue.endsWith('*') ? fieldValue.slice(0, -1) : fieldValue);
 
     useEffect(() => {
+        _setInputText(fieldValue.endsWith('*') ? fieldValue.slice(0, -1) : fieldValue);
+        _setIncludeSubLineages(fieldValue.endsWith('*'));
+    }, [fieldValue]);
+
+    function queryText(includeSublineages: boolean, inputText: string) {
         let queryText = includeSublineages ? `${inputText}*` : inputText;
         if (queryText === '*') queryText = '';
-        if (queryText === fieldValue) return;
-        setSomeFieldValues([field.name, queryText]);
-    }, [includeSublineages, inputText, fieldValue]);
+        return queryText;
+    }
+
+    function setIncludeSubLineages(newValue: boolean) {
+        _setIncludeSubLineages(newValue);
+        setSomeFieldValues([field.name, queryText(newValue, inputText)]);
+    }
+
+    function setInputText(newValue: string) {
+        _setInputText(newValue);
+        setSomeFieldValues([field.name, queryText(includeSublineages, newValue)]);
+    }
 
     return (
         <div key={field.name} className='flex flex-col border p-3 mb-3 rounded-md border-gray-300'>

--- a/website/src/components/SearchPage/fields/LineageField.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.tsx
@@ -5,7 +5,6 @@ import type { MetadataFilter, SetSomeFieldValues } from '../../../types/config';
 
 interface LineageFieldProps {
     lapisUrl: string;
-    lapisSearchParameters: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any -- TODO(#3451) use a proper type
     field: MetadataFilter;
     fieldValue: string;
     setSomeFieldValues: SetSomeFieldValues;
@@ -15,8 +14,7 @@ export const LineageField: FC<LineageFieldProps> = ({
     field,
     fieldValue,
     setSomeFieldValues,
-    lapisUrl,
-    lapisSearchParameters,
+    lapisUrl
 }) => {
     const [includeSublineages, setIncludeSubLineages] = useState(fieldValue.endsWith('*'));
     const [inputText, setInputText] = useState(fieldValue.endsWith('*') ? fieldValue.slice(0, -1) : fieldValue);
@@ -33,9 +31,8 @@ export const LineageField: FC<LineageFieldProps> = ({
             <AutoCompleteField
                 field={field}
                 optionsProvider={{
-                    type: 'generic', // TODO use 'lineage' here
+                    type: 'lineage',
                     lapisUrl,
-                    lapisSearchParameters,
                     fieldName: field.name,
                 }}
                 setSomeFieldValues={([_, value]) => {

--- a/website/src/components/SearchPage/fields/LineageField.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type FC } from 'react';
 
-import { AutoCompleteField } from './AutoCompleteField';
+import { AutoCompleteField, createLapisAutocompleteOptionsHook } from './AutoCompleteField';
 import type { MetadataFilter, SetSomeFieldValues } from '../../../types/config';
 
 interface LineageFieldProps {
@@ -28,16 +28,17 @@ export const LineageField: FC<LineageFieldProps> = ({
         setSomeFieldValues([field.name, queryText]);
     }, [includeSublineages, inputText, fieldValue]);
 
+    const hook = createLapisAutocompleteOptionsHook(lapisUrl, field.name, lapisSearchParameters);
+
     return (
         <div key={field.name} className='flex flex-col border p-3 mb-3 rounded-md border-gray-300'>
             <AutoCompleteField
                 field={field}
-                lapisUrl={lapisUrl}
+                hook={hook}
                 setSomeFieldValues={([_, value]) => {
                     setInputText(value as string);
                 }}
                 fieldValue={inputText}
-                lapisSearchParameters={lapisSearchParameters}
             />
             <div className='flex flex-row justify-end'>
                 <label>

--- a/website/src/components/SearchPage/fields/LineageField.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.tsx
@@ -5,12 +5,19 @@ import type { MetadataFilter, SetSomeFieldValues } from '../../../types/config';
 
 interface LineageFieldProps {
     lapisUrl: string;
+    lapisSearchParameters: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any -- TODO(#3451)
     field: MetadataFilter;
     fieldValue: string;
     setSomeFieldValues: SetSomeFieldValues;
 }
 
-export const LineageField: FC<LineageFieldProps> = ({ field, fieldValue, setSomeFieldValues, lapisUrl }) => {
+export const LineageField: FC<LineageFieldProps> = ({
+    field,
+    fieldValue,
+    setSomeFieldValues,
+    lapisUrl,
+    lapisSearchParameters,
+}) => {
     const [includeSublineages, setIncludeSubLineages] = useState(fieldValue.endsWith('*'));
     const [inputText, setInputText] = useState(fieldValue.endsWith('*') ? fieldValue.slice(0, -1) : fieldValue);
 
@@ -28,6 +35,7 @@ export const LineageField: FC<LineageFieldProps> = ({ field, fieldValue, setSome
                 optionsProvider={{
                     type: 'lineage',
                     lapisUrl,
+                    lapisSearchParameters,
                     fieldName: field.name,
                 }}
                 setSomeFieldValues={([_, value]) => {

--- a/website/src/components/SearchPage/fields/LineageField.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.tsx
@@ -10,12 +10,7 @@ interface LineageFieldProps {
     setSomeFieldValues: SetSomeFieldValues;
 }
 
-export const LineageField: FC<LineageFieldProps> = ({
-    field,
-    fieldValue,
-    setSomeFieldValues,
-    lapisUrl
-}) => {
+export const LineageField: FC<LineageFieldProps> = ({ field, fieldValue, setSomeFieldValues, lapisUrl }) => {
     const [includeSublineages, setIncludeSubLineages] = useState(fieldValue.endsWith('*'));
     const [inputText, setInputText] = useState(fieldValue.endsWith('*') ? fieldValue.slice(0, -1) : fieldValue);
 

--- a/website/src/components/SearchPage/fields/LineageField.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.tsx
@@ -51,6 +51,7 @@ export const LineageField: FC<LineageFieldProps> = ({
                     lapisUrl,
                     lapisSearchParameters,
                     fieldName: field.name,
+                    includeSublineages,
                 }}
                 setSomeFieldValues={([_, value]) => {
                     setInputText(value as string);

--- a/website/src/components/SearchPage/fields/LineageField.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.tsx
@@ -32,8 +32,12 @@ export const LineageField: FC<LineageFieldProps> = ({
         <div key={field.name} className='flex flex-col border p-3 mb-3 rounded-md border-gray-300'>
             <AutoCompleteField
                 field={field}
-                lapisUrl={lapisUrl}
-                lapsiSearchParameters={lapisSearchParameters}
+                optionsProvider={{
+                    type: 'generic', // TODO use 'lineage' here
+                    lapisUrl,
+                    lapisSearchParameters,
+                    fieldName: field.name,
+                }}
                 setSomeFieldValues={([_, value]) => {
                     setInputText(value as string);
                 }}

--- a/website/src/services/lapisApi.ts
+++ b/website/src/services/lapisApi.ts
@@ -174,6 +174,14 @@ const alignedAminoAcidSequencesEndpoint = makeEndpoint({
     response: z.string(),
 });
 
+const lineageDefinitionEndpoint = makeEndpoint({
+    method: 'get',
+    path: withSample('/lineageDefinition/:column'),
+    alias: 'lineageDefinition',
+    immutable: true,
+    response: z.string()
+});
+
 export const lapisApi = makeApi([
     detailsEndpoint,
     aggregatedEndpoint,
@@ -186,4 +194,5 @@ export const lapisApi = makeApi([
     unalignedNucleotideSequencesEndpoint,
     unalignedNucleotideSequencesMultiSegmentEndpoint,
     alignedAminoAcidSequencesEndpoint,
+    lineageDefinitionEndpoint
 ]);

--- a/website/src/services/lapisApi.ts
+++ b/website/src/services/lapisApi.ts
@@ -179,7 +179,7 @@ const lineageDefinitionEndpoint = makeEndpoint({
     path: withSample('/lineageDefinition/:column'),
     alias: 'lineageDefinition',
     immutable: true,
-    response: z.string()
+    response: z.string(),
 });
 
 export const lapisApi = makeApi([
@@ -194,5 +194,5 @@ export const lapisApi = makeApi([
     unalignedNucleotideSequencesEndpoint,
     unalignedNucleotideSequencesMultiSegmentEndpoint,
     alignedAminoAcidSequencesEndpoint,
-    lineageDefinitionEndpoint
+    lineageDefinitionEndpoint,
 ]);

--- a/website/src/services/lapisApi.ts
+++ b/website/src/services/lapisApi.ts
@@ -6,7 +6,7 @@ import {
     detailsResponse,
     insertionsResponse,
     lapisBaseRequest,
-    lineageDefinitionResponse,
+    lineageDefinition,
     mutationsRequest,
     mutationsResponse,
     sequenceRequest,
@@ -180,7 +180,7 @@ const lineageDefinitionEndpoint = makeEndpoint({
     path: withSample('/lineageDefinition/:column'),
     alias: 'lineageDefinition',
     immutable: true,
-    response: lineageDefinitionResponse,
+    response: lineageDefinition,
 });
 
 export const lapisApi = makeApi([

--- a/website/src/services/lapisApi.ts
+++ b/website/src/services/lapisApi.ts
@@ -6,6 +6,7 @@ import {
     detailsResponse,
     insertionsResponse,
     lapisBaseRequest,
+    lineageDefinitionResponse,
     mutationsRequest,
     mutationsResponse,
     sequenceRequest,
@@ -179,7 +180,7 @@ const lineageDefinitionEndpoint = makeEndpoint({
     path: withSample('/lineageDefinition/:column'),
     alias: 'lineageDefinition',
     immutable: true,
-    response: z.string(),
+    response: lineageDefinitionResponse,
 });
 
 export const lapisApi = makeApi([

--- a/website/src/types/lapis.ts
+++ b/website/src/types/lapis.ts
@@ -69,6 +69,7 @@ const lineageDefinitionEntry = z.object({
     aliases: z.array(z.string()).optional(),
 });
 export const lineageDefinition = z.record(z.string(), lineageDefinitionEntry);
+export type LineageDefinition = z.infer<typeof lineageDefinition>;
 
 function makeLapisResponse<T extends ZodTypeAny>(data: T) {
     return z.object({

--- a/website/src/types/lapis.ts
+++ b/website/src/types/lapis.ts
@@ -64,6 +64,13 @@ const aggregatedItem = z
     .catchall(z.union([z.string(), z.number(), z.boolean(), z.null()]));
 export const aggregatedResponse = makeLapisResponse(z.array(aggregatedItem));
 
+const lineageDefinitionEntry = z.object({
+    parents: z.array(z.string()).optional(),
+    aliases: z.array(z.string()).optional(),
+});
+const lineageDefinition = z.record(lineageDefinitionEntry);
+export const lineageDefinitionResponse = makeLapisResponse(lineageDefinition);
+
 function makeLapisResponse<T extends ZodTypeAny>(data: T) {
     return z.object({
         data,

--- a/website/src/types/lapis.ts
+++ b/website/src/types/lapis.ts
@@ -68,8 +68,7 @@ const lineageDefinitionEntry = z.object({
     parents: z.array(z.string()).optional(),
     aliases: z.array(z.string()).optional(),
 });
-const lineageDefinition = z.record(lineageDefinitionEntry);
-export const lineageDefinitionResponse = makeLapisResponse(lineageDefinition);
+export const lineageDefinition = z.record(z.string(), lineageDefinitionEntry);
 
 function makeLapisResponse<T extends ZodTypeAny>(data: T) {
     return z.object({


### PR DESCRIPTION
resolves #3506 

preview URL: https://lineage-search2.loculus.org

### Summary
Lineage search now pulls all lineages and aliases from LAPIS. Previously, it only displayed lineages/aliases that were also present in the data already. LAPIS is still queried to get counts for lineages. a lineage and its aliases are listed seperately, but have the same (joint) count (i.e. if A1 and B are aliases and there are 2 seqs with A1 and 1 with B, both will be listed with count 3).

Also a bugfix was included where removing the value didn't reset the text field.

#### Automated test
- New test to check that things are aggregated correctly.
- New test to check that externally resetting the value resets the text field as well.
- Minor test improvements

#### Manual testing
I created a bunch of sequences and checked that the aliases etc are all there, as well as the counts being aggregated. I selected an alias and everything belonging to any of the aliases was shown.

### Screenshot

See below, B is an alias for A.1.1

<img width="1367" alt="image" src="https://github.com/user-attachments/assets/7f93b9ef-fb9b-44a3-b6c8-d071709137d5" />


**Video showcasing count aggregation**

https://github.com/user-attachments/assets/b3644d22-2c68-4adc-b695-22d83c1a2058

### PR Checklist
- ~~All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by appropriate, automated tests. (there were already tests)
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
