### PR TITLE
feat(website): Improve sequence details dropdown a little

### DIFF
--- a/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.spec.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.spec.tsx
@@ -31,7 +31,7 @@ describe('SequenceEntryHistoryMenu', () => {
 
     const historyRevoke: SequenceEntryHistory = [
         { ...baseEntry, accessionVersion: 'BAR.1', versionStatus: 'REVISED', isRevocation: false, version: 1 },
-        { ...baseEntry, accessionVersion: 'BAR.2', versionStatus: 'LATEST_VERSION', isRevocation: true, version: 2 }, 
+        { ...baseEntry, accessionVersion: 'BAR.2', versionStatus: 'LATEST_VERSION', isRevocation: true, version: 2 },
     ];
 
     test('revoked version is labeled correctly', async () => {

--- a/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.spec.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.spec.tsx
@@ -35,7 +35,7 @@ describe('SequenceEntryHistoryMenu', () => {
     ];
 
     test('revoked version is labeled correctly', async () => {
-        render(<SequenceEntryHistoryMenu sequenceEntryHistory={historyRevoke} accessionVersion='FOO.2' />);
+        render(<SequenceEntryHistoryMenu sequenceEntryHistory={historyRevoke} accessionVersion='BAR.2' />);
         const button = screen.getByText('Version 2');
         await userEvent.hover(button);
 

--- a/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.spec.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.spec.tsx
@@ -36,7 +36,7 @@ describe('SequenceEntryHistoryMenu', () => {
 
     test('revoked version is labeled correctly', async () => {
         render(<SequenceEntryHistoryMenu sequenceEntryHistory={historyRevoke} accessionVersion='FOO.2' />);
-        const button = screen.getByText('All versions');
+        const button = screen.getByText('Version 2');
         await userEvent.hover(button);
 
         expect(screen.getByRole('link', { name: 'BAR.1 Previous version' })).toBeVisible();

--- a/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.spec.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.spec.tsx
@@ -31,7 +31,7 @@ describe('SequenceEntryHistoryMenu', () => {
 
     const historyRevoke: SequenceEntryHistory = [
         { ...baseEntry, accessionVersion: 'BAR.1', versionStatus: 'REVISED', isRevocation: false, version: 1 },
-        { ...baseEntry, accessionVersion: 'BAR.2', versionStatus: 'LATEST_VERSION', isRevocation: true, version: 2 },
+        { ...baseEntry, accessionVersion: 'BAR.2', versionStatus: 'LATEST_VERSION', isRevocation: true, version: 2 }, 
     ];
 
     test('revoked version is labeled correctly', async () => {

--- a/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.spec.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.spec.tsx
@@ -30,8 +30,8 @@ describe('SequenceEntryHistoryMenu', () => {
     });
 
     const historyRevoke: SequenceEntryHistory = [
-        { ...baseEntry, accessionVersion: 'BAR.1', versionStatus: 'REVISED', isRevocation: false },
-        { ...baseEntry, accessionVersion: 'BAR.2', versionStatus: 'LATEST_VERSION', isRevocation: true },
+        { ...baseEntry, accessionVersion: 'BAR.1', versionStatus: 'REVISED', isRevocation: false, version: 1 },
+        { ...baseEntry, accessionVersion: 'BAR.2', versionStatus: 'LATEST_VERSION', isRevocation: true, version: 2 },
     ];
 
     test('revoked version is labeled correctly', async () => {

--- a/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.tsx
@@ -17,13 +17,13 @@ export const SequenceEntryHistoryMenu: React.FC<Props> = ({
     accessionVersion,
     setPreviewedSeqId,
 }) => {
-    const selectedVersion=sequenceEntryHistory.find((version) => version.accessionVersion === accessionVersion);
+    const selectedVersion = sequenceEntryHistory.find((version) => version.accessionVersion === accessionVersion);
     return (
         <>
             <div className='dropdown dropdown-hover hidden sm:inline-block'>
                 <label tabIndex={0} className='btn btn-sm btn-outline py-1'>
                     <span className='text-sm'>
-                        {selectedVersion === undefined ? "All versions" : `Version ${selectedVersion.version}`}
+                        {selectedVersion === undefined ? 'All versions' : `Version ${selectedVersion.version}`}
                     </span>
                     <Arrow />
                 </label>

--- a/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.tsx
@@ -17,13 +17,13 @@ export const SequenceEntryHistoryMenu: React.FC<Props> = ({
     accessionVersion,
     setPreviewedSeqId,
 }) => {
+    const selectedVersion=sequenceEntryHistory.find((version) => version.accessionVersion === accessionVersion);
     return (
         <>
             <div className='dropdown dropdown-hover hidden sm:inline-block'>
                 <label tabIndex={0} className='btn btn-sm btn-outline py-1'>
                     <span className='text-sm'>
-                        Version{' '}
-                        {sequenceEntryHistory.find((version) => version.accessionVersion === accessionVersion).version}
+                        {selectedVersion === undefined ? "All versions" : "Version "+selectedVersion.version}
                     </span>
                     <Arrow />
                 </label>

--- a/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.tsx
@@ -23,7 +23,7 @@ export const SequenceEntryHistoryMenu: React.FC<Props> = ({
             <div className='dropdown dropdown-hover hidden sm:inline-block'>
                 <label tabIndex={0} className='btn btn-sm btn-outline py-1'>
                     <span className='text-sm'>
-                        {selectedVersion === undefined ? "All versions" : "Version "+selectedVersion.version}
+                        {selectedVersion === undefined ? "All versions" : `Version ${selectedVersion.version}`}
                     </span>
                     <Arrow />
                 </label>

--- a/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.tsx
@@ -21,9 +21,10 @@ export const SequenceEntryHistoryMenu: React.FC<Props> = ({
         <>
             <div className='dropdown dropdown-hover hidden sm:inline-block'>
                 <label tabIndex={0} className='btn btn-sm btn-outline py-1'>
-                    <a href={routes.versionPage(accessionVersion)} className='text-sm'>
-                        All versions
-                    </a>
+                    <span className='text-sm'>
+                        Version{' '}
+                        {sequenceEntryHistory.find((version) => version.accessionVersion === accessionVersion).version}
+                    </span>
                     <Arrow />
                 </label>
                 <ul
@@ -56,6 +57,11 @@ export const SequenceEntryHistoryMenu: React.FC<Props> = ({
                             </li>
                         );
                     })}
+                    <li className='border-t mt-1 pt-1'>
+                        <a href={routes.versionPage(accessionVersion)} className='hover:no-underline'>
+                            All versions
+                        </a>
+                    </li>
                 </ul>
             </div>
             <div className='sm:hidden inline-block'>

--- a/website/tests/pages/sequences/sequences.page.ts
+++ b/website/tests/pages/sequences/sequences.page.ts
@@ -21,7 +21,7 @@ export class SequencePage {
         this.specificProteinTab = this.page.getByRole('button', { name: 'Aligned amino acid sequences' });
         this.geneDropdown = this.page.locator('select');
         this.versionLink = this.page.getByRole('button', {
-            name: `Version 1`,
+            name: /Version \d+/,
         });
         this.allVersions = this.page.getByRole('link', {
             name: `All versions`,

--- a/website/tests/pages/sequences/sequences.page.ts
+++ b/website/tests/pages/sequences/sequences.page.ts
@@ -19,7 +19,10 @@ export class SequencePage {
         this.loadButton = this.page.getByRole('button', { name: 'Load sequences' });
         this.specificProteinTab = this.page.getByRole('button', { name: 'Aligned amino acid sequences' });
         this.geneDropdown = this.page.locator('select');
-        this.allVersions = this.page.getByRole('link', {
+        this.versionLink = this.page.getByRole('link', {
+            name: `Version 1`,
+        });
+        this.versionLink = this.page.getByRole('link', {
             name: `All versions`,
         });
         throwOnConsole(page);
@@ -33,8 +36,13 @@ export class SequencePage {
     }
 
     public async gotoAllVersions() {
+        await expect(this.versionLink).toBeVisible();
+        await this.versionLink.click();
         await expect(this.allVersions).toBeVisible();
+
         await this.allVersions.click();
+
+
     }
 
     public async loadSequences() {

--- a/website/tests/pages/sequences/sequences.page.ts
+++ b/website/tests/pages/sequences/sequences.page.ts
@@ -20,8 +20,7 @@ export class SequencePage {
         this.loadButton = this.page.getByRole('button', { name: 'Load sequences' });
         this.specificProteinTab = this.page.getByRole('button', { name: 'Aligned amino acid sequences' });
         this.geneDropdown = this.page.locator('select');
-        this.versionLink = this.page.getByText( /Version \d+/
-        );
+        this.versionLink = this.page.getByText(/Version \d+/);
         this.allVersions = this.page.getByRole('link', {
             name: `All versions`,
         });
@@ -41,8 +40,6 @@ export class SequencePage {
         await expect(this.allVersions).toBeVisible();
 
         await this.allVersions.click();
-
-
     }
 
     public async loadSequences() {

--- a/website/tests/pages/sequences/sequences.page.ts
+++ b/website/tests/pages/sequences/sequences.page.ts
@@ -20,9 +20,8 @@ export class SequencePage {
         this.loadButton = this.page.getByRole('button', { name: 'Load sequences' });
         this.specificProteinTab = this.page.getByRole('button', { name: 'Aligned amino acid sequences' });
         this.geneDropdown = this.page.locator('select');
-        this.versionLink = this.page.getByRole('button', {
-            name: /Version \d+/,
-        });
+        this.versionLink = this.page.getByText( /Version \d+/
+        );
         this.allVersions = this.page.getByRole('link', {
             name: `All versions`,
         });

--- a/website/tests/pages/sequences/sequences.page.ts
+++ b/website/tests/pages/sequences/sequences.page.ts
@@ -12,6 +12,7 @@ export class SequencePage {
 
     private readonly loadButton: Locator;
     private readonly allVersions: Locator;
+    private readonly versionLink: Locator;
     private readonly specificProteinTab: Locator;
     private readonly geneDropdown: Locator;
 
@@ -22,7 +23,7 @@ export class SequencePage {
         this.versionLink = this.page.getByRole('link', {
             name: `Version 1`,
         });
-        this.versionLink = this.page.getByRole('link', {
+        this.allVersions = this.page.getByRole('link', {
             name: `All versions`,
         });
         throwOnConsole(page);

--- a/website/tests/pages/sequences/sequences.page.ts
+++ b/website/tests/pages/sequences/sequences.page.ts
@@ -20,7 +20,7 @@ export class SequencePage {
         this.loadButton = this.page.getByRole('button', { name: 'Load sequences' });
         this.specificProteinTab = this.page.getByRole('button', { name: 'Aligned amino acid sequences' });
         this.geneDropdown = this.page.locator('select');
-        this.versionLink = this.page.getByRole('link', {
+        this.versionLink = this.page.getByRole('button', {
             name: `Version 1`,
         });
         this.allVersions = this.page.getByRole('link', {


### PR DESCRIPTION
Removes somewhat confusing behaviour of a dropdown that is actually a button, with a more conventional dropdown that displays the current selected version.


<img width="370" alt="image" src="https://github.com/user-attachments/assets/194f79ad-ab3f-4e81-8b8c-cdf304d4996d" />


<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: http://dropdown.loculus.org

