### PR TITLE
fix(website): Fix the format of the reference dialog

### DIFF
--- a/website/src/components/SequenceDetailsPage/ReferenceSequenceLinkButton.tsx
+++ b/website/src/components/SequenceDetailsPage/ReferenceSequenceLinkButton.tsx
@@ -10,7 +10,7 @@ export const ReferenceLink = ({ accession }: { accession: string }) => {
         <a
             href={'https://www.ncbi.nlm.nih.gov/nuccore/__value__'.replace('__value__', accession.toString())}
             target='_blank'
-            className='underline  hover:text-primary-500'
+            className='underline text-primary-600 hover:text-primary-500'
         >
             {accession}
         </a>
@@ -75,23 +75,29 @@ const ReferenceSequenceLinkButton: React.FC<Props> = ({ reference }) => {
                                                     sequence
                                                     {reference.length > 1 ? 's: ' : ': '}
                                                 </div>
-                                                <span>
-                                                    {reference.map(
-                                                        (currElement, index) =>
-                                                            currElement.insdcAccessionFull !== undefined && (
-                                                                <div key={index} className='text-primary-700 ml-5 flex'>
-                                                                    {isMultiSegmented && (
-                                                                        <div className='w-10 text-left mr-2'>
-                                                                            {currElement.name}:
-                                                                        </div>
-                                                                    )}
-                                                                    <ReferenceLink
-                                                                        accession={currElement.insdcAccessionFull}
-                                                                    />
-                                                                </div>
-                                                            ),
-                                                    )}
-                                                </span>
+                                                <table className='ml-5 mt-2'>
+                                                    <tbody>
+                                                        {reference.map(
+                                                            (currElement, index) =>
+                                                                currElement.insdcAccessionFull !== undefined && (
+                                                                    <tr key={index}>
+                                                                        {isMultiSegmented && (
+                                                                            <td className='px-2 font-medium'>
+                                                                                {currElement.name}:
+                                                                            </td>
+                                                                        )}
+                                                                        <td className='px-2'>
+                                                                            <ReferenceLink
+                                                                                accession={
+                                                                                    currElement.insdcAccessionFull
+                                                                                }
+                                                                            />
+                                                                        </td>
+                                                                    </tr>
+                                                                ),
+                                                        )}
+                                                    </tbody>
+                                                </table>
                                             </div>
                                         )}
                                     </div>


### PR DESCRIPTION
resolves #3780 

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
I've changed the display of the table-like rows to use a table instead of fixed-width divs, so the cells expand if the labels get long.

### Screenshot
<img width="702" alt="image" src="https://github.com/user-attachments/assets/b5e5f3c3-ae41-4709-863a-83aa6d3d3ff5" />


### PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by appropriate, automated tests.~~
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?) -> I have tested it locally, manually added longer sequence names (see the screenshot)
