### PR TITLE
feat(website): show why download button is disabled when query is too long

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/DownloadButton.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadButton.tsx
@@ -51,10 +51,12 @@ export const DownloadButton: FC<DownloadButtonProps> = ({
         downloadUrl,
         handleClick,
         isGetRequest,
+        message,
     }: {
         downloadUrl: string;
         handleClick: MouseEventHandler<HTMLAnchorElement> | undefined;
         isGetRequest: boolean;
+        message?: string;
     } = useMemo(() => {
         if (downloadOption === undefined || disabled) {
             return {
@@ -82,6 +84,7 @@ export const DownloadButton: FC<DownloadButtonProps> = ({
                 downloadUrl: '#',
                 handleClick: undefined,
                 isGetRequest: false,
+                message: "Sorry, we don't yet support downloading files with custom FASTA headers for long queries.",
             };
         }
 
@@ -100,14 +103,16 @@ export const DownloadButton: FC<DownloadButtonProps> = ({
 
     return (
         <div className='flex items-center'>
-            <a
-                className={`btn loculusColor ${disabled || handleClick === undefined ? 'btn-disabled' : ''} text-white`}
-                href={downloadUrl}
-                onClick={handleClick}
-                data-testid='start-download'
-            >
-                Download
-            </a>
+            <div className={message && 'tooltip tooltip-open tooltip-right tooltip-info'} data-tip={message}>
+                <a
+                    className={`btn loculusColor ${disabled || handleClick === undefined ? 'btn-disabled' : ''} text-white`}
+                    href={downloadUrl}
+                    onClick={handleClick}
+                    data-testid='start-download'
+                >
+                    Download
+                </a>
+            </div>
             {isGetRequest && !disabled && <CopyUrlButton url={downloadUrl} />}
         </div>
     );


### PR DESCRIPTION



<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
Follow-up to #3814 (https://github.com/loculus-project/loculus/pull/3814#discussion_r1987624964). Adds a little message that shows why the download button is disabled when we would need POST request to download sequences with rich fasta headers. The endpoint that handles the custom rich fasta header downloads doesn't support post requests yet.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->
![image](https://github.com/user-attachments/assets/e2087ebf-8af0-42b1-969c-727a52166548)

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by appropriate, automated tests.~~
~~- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~~
