### PR TITLE
chore: increase number of SILO workers

### DIFF
--- a/kubernetes/loculus/templates/silo-deployment.yaml
+++ b/kubernetes/loculus/templates/silo-deployment.yaml
@@ -35,6 +35,8 @@ spec:
             - containerPort: 8081
           args:
             - "api"
+            - "--api-threads-for-http-connections"
+            - "16"
           volumeMounts:
             - name: lapis-silo-shared-data
               mountPath: /data


### PR DESCRIPTION
Preview: https://silo-workers.loculus.org

SILO by default only processes 4 requests in parallel (while accepting 64 requests). This is very low, and if all workers are blocked (e.g., due to parallel downloads), the liveliness probe of LAPIS fails, causing Kubernetes to kill LAPIS. By increasing the number of workers, we allow more parallel downloads but also mitigate the problem of LAPIS being killed a bit (#3839 actually fixes it).