### PR TITLE
fix(deployment): change lapis livenessProbe to readinessProbe and use a liveness probe based on health endpoint

### DIFF
--- a/kubernetes/loculus/templates/lapis-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-deployment.yaml
@@ -56,6 +56,14 @@ spec:
             periodSeconds: 10
             failureThreshold: 2
             timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 
+            timeoutSeconds: 5
       volumes:
         {{- include "loculus.configVolume" (dict "name" "lapis-silo-database-config" "configmap" (printf "lapis-silo-database-config-%s" $key)) | nindent 8 }}
 {{- end }}

--- a/kubernetes/loculus/templates/lapis-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
             timeoutSeconds: 5
-          livenessProbe:
+          readinessProbe:
             httpGet:
               path: /sample/info
               port: 8080


### PR DESCRIPTION
Before this when SILO saturated all LAPIS pods would be restarted