### PR TITLE
chore(deployment): increase SILO API max queued

### DIFF
--- a/kubernetes/loculus/templates/silo-deployment.yaml
+++ b/kubernetes/loculus/templates/silo-deployment.yaml
@@ -37,6 +37,8 @@ spec:
             - "api"
             - "--api-threads-for-http-connections"
             - "16"
+            - "--api-max-queued-http-connections"
+            - "1000"
           volumeMounts:
             - name: lapis-silo-shared-data
               mountPath: /data


### PR DESCRIPTION
preview URL: https://silo-queue.loculus.org

### Summary

The default number of requests that SILO allows to queue is 64 which is quite low. This PR increases it to 1000. We can of course adapt further (or make it configurable) in the future if needed.

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by appropriate, automated tests.~~
- ~~[ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~~
