### PR TITLE
fix(deployment): add missing value for liveness probe

### DIFF
--- a/kubernetes/loculus/templates/lapis-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-deployment.yaml
@@ -54,7 +54,7 @@ spec:
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 10
-            failureThreshold: 2
+            failureThreshold: 3
             timeoutSeconds: 5
           livenessProbe:
             httpGet:
@@ -62,7 +62,7 @@ spec:
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 10
-            failureThreshold: 
+            failureThreshold: 3
             timeoutSeconds: 5
       volumes:
         {{- include "loculus.configVolume" (dict "name" "lapis-silo-database-config" "configmap" (printf "lapis-silo-database-config-%s" $key)) | nindent 8 }}


### PR DESCRIPTION
Fixes #3843 - though behaviour should be the same

Set the `failureThreshold` property for the readiness and liveness probes in `kubernetes/loculus/templates/lapis-deployment.yaml`.

* Set `failureThreshold` to 3 for the readiness probe.
* Set `failureThreshold` to 3 for the liveness probe.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/loculus-project/loculus/pull/3844?shareId=4802f559-0c54-47b5-87e0-8c143d94ecdd).