### PR TITLE
fix(kubernetes): make the "empty lineage definition file" valid YAML

### DIFF
--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -159,7 +159,7 @@ download_lineage_definitions() {
 
   if [[ -z "$pipelineVersion" ]]; then
     echo "No pipeline version found. Writing empty lineage definition file."
-    touch $lineage_definition_file
+    echo "{}" > $lineage_definition_file
   elif [[ $(echo "$pipelineVersion" | wc -l) -eq 1 ]]; then
     echo "Single pipeline version: $pipelineVersion"
 


### PR DESCRIPTION
<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL: https://validemptylineagedefiniti.loculus.org/

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

An empty file is not a valid lineage definition, because that must be a YAML object on top level.

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by appropriate, automated tests.~~
~~- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~~
