### PR TITLE
fix(website): Render timestamp as YYYY-MM-DD instead of UNIX timestamp

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/SequenceFilters.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/SequenceFilters.tsx
@@ -113,12 +113,19 @@ export class FieldFilter implements SequenceFilter {
                 .filter(({ filterValue }) => filterValue.length > 0)
                 .map(({ name, filterValue }): [string, [string, string]] => [
                     name,
-                    [this.findSchemaLabel(name), this.filterValueDisplayString(filterValue)],
+                    [this.findSchemaLabel(name), this.filterValueDisplayString(name, filterValue)],
                 ]),
         );
     }
 
-    private filterValueDisplayString(value: any): string {
+    private filterValueDisplayString(fieldName: string, value: any): string {
+        const filterValueType = this.schema
+            .flatMap((metadataFilter) => (metadataFilter.grouped ? metadataFilter.groupedFields : metadataFilter))
+            .find((metadataFilter) => metadataFilter.name === fieldName)?.type;
+        if (filterValueType === 'timestamp') {
+            const date = new Date(Number(value) * 1000);
+            return date.toISOString().split('T')[0]; // Extract YYYY-MM-DD
+        }
         if (Array.isArray(value)) {
             let stringified = value.join(', ');
             if (stringified.length > 40) {

--- a/website/src/components/SearchPage/fields/DateField.spec.tsx
+++ b/website/src/components/SearchPage/fields/DateField.spec.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { TimestampField } from './DateField';
+
+const setSomeFieldValues = vi.fn();
+
+describe('TimestampField', () => {
+    beforeEach(() => {
+        setSomeFieldValues.mockReset();
+    });
+
+    test('"From" field renders date correctly', () => {
+        render(
+            <TimestampField
+                field={{
+                    name: 'releasedAtTimestampFrom',
+                    type: 'timestamp',
+                }}
+                fieldValue={'1742169600'}
+                setSomeFieldValues={setSomeFieldValues}
+            />,
+        );
+
+        const input = screen.getByRole('textbox');
+        expect(input).toBeInTheDocument();
+
+        expect(input).toHaveValue('17/03/2025');
+    });
+
+    test('"From" field sets date correctly', async () => {
+        render(
+            <TimestampField
+                field={{
+                    name: 'releasedAtTimestampFrom',
+                    type: 'timestamp',
+                }}
+                fieldValue={''}
+                setSomeFieldValues={setSomeFieldValues}
+            />,
+        );
+
+        const input = screen.getByRole('textbox');
+        await userEvent.type(input, '17032025');
+        expect(input).toHaveValue('17/03/2025');
+        expect(setSomeFieldValues).toHaveBeenCalledTimes(8);
+        expect(setSomeFieldValues).lastCalledWith(['releasedAtTimestampFrom', '1742169600']);
+    });
+
+    test('"To" field renders date correctly', () => {
+        render(
+            <TimestampField
+                field={{
+                    name: 'releasedAtTimestampTo',
+                    type: 'timestamp',
+                }}
+                fieldValue={'1742255999'}
+                setSomeFieldValues={setSomeFieldValues}
+            />,
+        );
+
+        const input = screen.getByRole('textbox');
+        expect(input).toBeInTheDocument();
+
+        expect(input).toHaveValue('17/03/2025');
+    });
+
+    test('"To" field sets date correctly', async () => {
+        render(
+            <TimestampField
+                field={{
+                    name: 'releasedAtTimestampTo',
+                    type: 'timestamp',
+                }}
+                fieldValue={''}
+                setSomeFieldValues={setSomeFieldValues}
+            />,
+        );
+
+        const input = screen.getByRole('textbox');
+        await userEvent.type(input, '17032025');
+        expect(input).toHaveValue('17/03/2025');
+        expect(setSomeFieldValues).toHaveBeenCalledTimes(8);
+        expect(setSomeFieldValues).lastCalledWith(['releasedAtTimestampTo', '1742255999']);
+    });
+});

--- a/website/src/components/SearchPage/fields/DateField.tsx
+++ b/website/src/components/SearchPage/fields/DateField.tsx
@@ -29,23 +29,36 @@ export const DateField: FC<Omit<CustomizedDatePickerProps, 'dateToValueConverter
 
 export const TimestampField: FC<Omit<CustomizedDatePickerProps, 'dateToValueConverter' | 'valueToDateConverter'>> = (
     props,
-) => (
-    <CustomizedDatePicker
-        {...props}
-        dateToValueConverter={(date) => {
-            const initialValue = date ? String(Math.floor(date.getTime() / 1000)) : '';
-            if (initialValue === 'NaN') {
-                return '';
-            } else {
-                return initialValue;
-            }
-        }}
-        valueToDateConverter={(value) => {
-            const timestamp = Math.max(parseInt(value, 10));
-            return isNaN(timestamp) ? undefined : new Date(timestamp * 1000);
-        }}
-    />
-);
+) => {
+    const isUpperBound = props.field.name.endsWith('To');
+
+    return (
+        <CustomizedDatePicker
+            {...props}
+            dateToValueConverter={(date) => {
+                if (date === null) {
+                    return '';
+                }
+                if (isUpperBound) {
+                    date.setHours(23, 59, 59, 999);
+                } else {
+                    date.setHours(0, 0, 0, 0);
+                }
+                const localSecondsInUtc = Math.floor(date.getTime() / 1000);
+                const utcSeconds = localSecondsInUtc - date.getTimezoneOffset() * 60;
+                if (isNaN(utcSeconds)) return '';
+                return String(utcSeconds);
+            }}
+            valueToDateConverter={(value) => {
+                const timestamp = Math.max(parseInt(value, 10));
+                if (isNaN(timestamp)) return undefined;
+                const tzOffset = new Date().getTimezoneOffset() * 60;
+                const date = new Date((timestamp + tzOffset) * 1000);
+                return date;
+            }}
+        />
+    );
+};
 
 const CustomizedDatePicker: FC<CustomizedDatePickerProps> = ({
     field,

--- a/website/src/components/common/ActiveFilters.spec.tsx
+++ b/website/src/components/common/ActiveFilters.spec.tsx
@@ -42,6 +42,21 @@ describe('ActiveFilters', () => {
 
             expect(mockRemoveFilter).toHaveBeenCalledWith('field1');
         });
+
+        it('renders UNIX timestamps as YYYY-MM-DD', () => {
+            render(
+                <ActiveFilters
+                    sequenceFilter={
+                        new FieldFilter({ releaseTimestamp: '1742288104' }, {}, [
+                            { name: 'releaseTimestamp', type: 'timestamp' },
+                        ])
+                    }
+                />,
+            );
+
+            expect(screen.queryByText('2025-03-18')).toBeInTheDocument();
+            expect(screen.queryByText('1742288104')).not.toBeInTheDocument();
+        });
     });
 
     describe('with selected sequences', () => {


### PR DESCRIPTION
resolves #3727 , resolves #1556

preview URL: https://timestamp-format.loculus.org

### Summary
- Render timestamp fields as YYYY-MM-DD
- Check whether a timestamp field is 'From' or 'To' (or neither) and set the HH:MM component to 23:59 for 'To'.

#### Testing
- Added unit test to the `ActiveFilters` component to check that the format is correct for timestamps.
- Added unit test for the `TimestampField` to check if the correct unix timestamp gets set.

### Screenshot

<img width="1013" alt="image" src="https://github.com/user-attachments/assets/ea808e2c-b0b3-43cc-a338-988dcb8b0acb" />

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by appropriate, automated tests.
