### PR TITLE
Revert "chore(deps-dev): bump daisyui from 4.12.23 to 5.0.6 in /website"

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -74,7 +74,7 @@
                 "@vitejs/plugin-react": "^4.3.4",
                 "astro-eslint-parser": "^1.2.1",
                 "cross-env": "^7.0.3",
-                "daisyui": "^5.0.6",
+                "daisyui": "^4.12.23",
                 "eslint": "^9.17.0",
                 "eslint-plugin-astro": "^1.3.1",
                 "eslint-plugin-import": "^2.31.0",
@@ -6478,6 +6478,17 @@
                 "uncrypto": "^0.1.3"
             }
         },
+        "node_modules/css-selector-tokenizer": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.8.0.tgz",
+            "integrity": "sha512-Jd6Ig3/pe62/qe5SBPTN8h8LeUg/pT4lLgtavPf7updwwHpvFzxvOQBHYj2LZDMjUnBzgvIUSjRcf6oT5HzHFg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "fastparse": "^1.1.2"
+            }
+        },
         "node_modules/css.escape": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -6503,14 +6514,34 @@
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
             "license": "MIT"
         },
-        "node_modules/daisyui": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.0.6.tgz",
-            "integrity": "sha512-/e/9Gw/2y9oawBJlWkJMSEhRXdmfOLvcPl+6q/x2rPEdIVOtebs1t3ex2vwySl9vCRs1GGNBKCiL+P60Ps/wUw==",
+        "node_modules/culori": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/culori/-/culori-3.3.0.tgz",
+            "integrity": "sha512-pHJg+jbuFsCjz9iclQBqyL3B2HLCBF71BwVNujUYEvCeQMvV97R59MNK3R2+jgJ3a1fcZgI9B3vYgz8lzr/BFQ==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            }
+        },
+        "node_modules/daisyui": {
+            "version": "4.12.23",
+            "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-4.12.23.tgz",
+            "integrity": "sha512-EM38duvxutJ5PD65lO/AFMpcw+9qEy6XAZrTpzp7WyaPeO/l+F/Qiq0ECHHmFNcFXh5aVoALY4MGrrxtCiaQCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "css-selector-tokenizer": "^0.8",
+                "culori": "^3",
+                "picocolors": "^1",
+                "postcss-js": "^4"
+            },
+            "engines": {
+                "node": ">=16.9.0"
+            },
             "funding": {
-                "url": "https://github.com/saadeghi/daisyui?sponsor=1"
+                "type": "opencollective",
+                "url": "https://opencollective.com/daisyui"
             }
         },
         "node_modules/damerau-levenshtein": {
@@ -8074,6 +8105,13 @@
                 }
             ],
             "license": "BSD-3-Clause"
+        },
+        "node_modules/fastparse": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+            "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/fastq": {
             "version": "1.18.0",

--- a/website/package.json
+++ b/website/package.json
@@ -87,7 +87,7 @@
         "@vitejs/plugin-react": "^4.3.4",
         "astro-eslint-parser": "^1.2.1",
         "cross-env": "^7.0.3",
-        "daisyui": "^5.0.6",
+        "daisyui": "^4.12.23",
         "eslint": "^9.17.0",
         "eslint-plugin-astro": "^1.3.1",
         "eslint-plugin-import": "^2.31.0",


### PR DESCRIPTION
Reverts loculus-project/loculus#3866

https://revert-3866-dependabot-np.loculus.org/ebola-sudan/search?

The formatting of the download modal is a bit messed up - this seems to be the cause:

Main:
<img width="1198" alt="image" src="https://github.com/user-attachments/assets/9ac4397a-c7d5-4d0f-aad6-c1b382abb964" />

Vs this PR:
<img width="1047" alt="image" src="https://github.com/user-attachments/assets/095354da-dae4-4e79-8f1a-0606160152a2" />


In due course we can merge bumping it whilst fixing the classes to give the original result (and we probably will want to check other forms carefully too)
