### PR TITLE
feat(website): Visualize that a file upload component has data in it already if empty

### DIFF
--- a/integration-tests/playwright.config.ts
+++ b/integration-tests/playwright.config.ts
@@ -33,13 +33,19 @@ export default defineConfig({
     /* Configure projects for major browsers */
     projects: [
         {
+            name: 'readonly setup',
+            testMatch: /readonly\.setup\.ts/,
+        },
+        {
             name: 'chromium',
             use: { ...devices['Desktop Chrome'] },
+            dependencies: ['readonly setup'],
         },
 
         {
             name: 'firefox',
             use: { ...devices['Desktop Firefox'] },
+            dependencies: ['readonly setup'],
         },
     ],
 });

--- a/integration-tests/tests/fixtures/group.fixture.ts
+++ b/integration-tests/tests/fixtures/group.fixture.ts
@@ -13,7 +13,7 @@ interface TestGroup {
     country: string;
 }
 
-const createTestGroup = (name = `test_group_${uuidv4().slice(0, 8)}`): TestGroup => ({
+export const createTestGroup = (name = `test_group_${uuidv4().slice(0, 8)}`): TestGroup => ({
     name,
     email: `test_${uuidv4().slice(0, 8)}@test.com`,
     institution: 'Test Institution',

--- a/integration-tests/tests/fixtures/sequence.fixture.ts
+++ b/integration-tests/tests/fixtures/sequence.fixture.ts
@@ -2,7 +2,6 @@ import { test as groupTest } from './group.fixture';
 import { Page } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 import { SingleSequenceSubmissionPage } from '../pages/singlesubmission.page';
-import { ReviewPage } from '../pages/review.page';
 
 type SequenceFixtures = {
     pageWithReleasedSequence: Page;
@@ -32,11 +31,11 @@ export const test = groupTest.extend<SequenceFixtures>({
             const reviewPage = await submissionPage.submitSequence();
 
             await reviewPage.releaseValidSequences();
-
-            await pageWithGroup.waitForTimeout(35000);
-            await pageWithGroup.reload();
-
             await pageWithGroup.getByRole('link', { name: 'Released Sequences' }).click();
+            while (!(await pageWithGroup.getByRole('link', { name: /LOC_/ }).isVisible())) {
+                await pageWithGroup.reload();
+                await pageWithGroup.waitForTimeout(2000);
+            }
 
             await use(pageWithGroup);
         },

--- a/integration-tests/tests/pages/review.page.ts
+++ b/integration-tests/tests/pages/review.page.ts
@@ -8,11 +8,15 @@ export class ReviewPage {
         this.page.locator('div:has(> div > h2:text("Processed Sequences"))').first();
     private sequencesDialogCloseButton = () =>
         this.sequencesDialog().getByRole('button', { name: '✕' });
-    private sequenceViewerContent = () => this.page.getByTestId('fixed-length-text-viewer');
+    public sequenceViewerContent = () => this.page.getByTestId('fixed-length-text-viewer');
     private sequenceTabs = () => this.page.locator('.tab');
 
     constructor(page: Page) {
         this.page = page;
+    }
+
+    async waitForZeroProcessing() {
+        await expect(this.page.locator('body')).toContainText('0 awaiting processing', { timeout: 33000 });
     }
 
     async navigateToReviewPage() {
@@ -28,7 +32,7 @@ export class ReviewPage {
 
     async viewSequences() {
         const button = this.viewSequencesButton();
-        await expect(button).toBeVisible({ timeout: 30000 });
+        await expect(button).toBeVisible({ timeout: 15000 });
         await button.click();
         await expect(this.sequencesDialog()).toBeVisible();
         return this.sequencesDialog();

--- a/integration-tests/tests/pages/review.page.ts
+++ b/integration-tests/tests/pages/review.page.ts
@@ -16,7 +16,9 @@ export class ReviewPage {
     }
 
     async waitForZeroProcessing() {
-        await expect(this.page.locator('body')).toContainText('0 awaiting processing', { timeout: 33000 });
+        await expect(this.page.locator('body')).toContainText('0 awaiting processing', {
+            timeout: 33000,
+        });
     }
 
     async navigateToReviewPage() {

--- a/integration-tests/tests/pages/search.page.ts
+++ b/integration-tests/tests/pages/search.page.ts
@@ -12,6 +12,10 @@ export class SearchPage {
         await this.navigateToVirus('Ebola Sudan');
     }
 
+    async cchf() {
+        await this.navigateToVirus('Crimean-Congo Hemorrhagic Fever Virus');
+    }
+
     async select(fieldLabel: string, option: string) {
         await this.page.locator('label').filter({ hasText: fieldLabel }).click();
         await this.page.getByRole('option', { name: new RegExp(option) }).click();

--- a/integration-tests/tests/readonly.setup.ts
+++ b/integration-tests/tests/readonly.setup.ts
@@ -1,0 +1,58 @@
+import { expect, test as setup } from '@playwright/test';
+import { AuthPage } from './pages/auth.page';
+import { GroupPage } from './pages/group.page';
+import { createTestGroup } from './fixtures/group.fixture';
+import { SingleSequenceSubmissionPage } from './pages/singlesubmission.page';
+import { v4 as uuidv4 } from 'uuid';
+
+setup('Initialize a single ebola sequence as base data', async ({ page }) => {
+    setup.setTimeout(90000);
+    const authPage = new AuthPage(page);
+    const username = uuidv4().substring(0, 8);
+    const password = uuidv4().substring(0, 8);
+    await authPage.createAccount({
+        firstName: 'Foo',
+        lastName: 'Bar',
+        email: `${username}@foo.org`,
+        organization: 'Foo University',
+        password,
+        username,
+    });
+
+    const groupPage = new GroupPage(page);
+    await groupPage.createGroup(createTestGroup());
+
+    const submissionPage = new SingleSequenceSubmissionPage(page);
+    const reviewPage = await submissionPage.completeSubmission(
+        {
+            submissionId: 'foobar',
+            collectionCountry: 'France',
+            collectionDate: '2021-05-12',
+            authorAffiliations: 'Patho Institute, Paris',
+        },
+        {
+            main:
+                'nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnntgtgtgcgaataactatga' +
+                'ggaagattaataattttcctnctcattgaaatttatatcggnaatttaaattgaaattgt' +
+                'tactgtaatcatacctggtttgntttcagagccatatcaccaagatagagaacaacctag' +
+                'gtctccggagggggcaagggcatcagtgtgctcagttgaaaatcccttgtcaacatctag' +
+                'gccttatcacatcacaagttccgccttaaactctgcagggtgatccaacaaccttaatag' +
+                'caacattattgttaaaggacagcattagttcacagtcaaacaagcaagattgagaattaa' +
+                'ctttgattttgaacctgaacacccagaggactggagactcaacaaccctaaagcctaggg' +
+                'taaaacattagaaatagtttaaagacaaattgctcggaatcacaaaattccgagtatgga' +
+                'ttctcgtcctcagaaagtctggatgacgccgagtctcactgaatctgacatggattacca' +
+                'caagatcttgacagcaggtctgtccgttcaacaggggattgttcggcaaagagtcatccc' +
+                'agtgtatcaagtaaacaatcttgaggaaatttgccaacttatcatacaggcctttgaagc' +
+                'tggtgttgattttcaagagagtgcggacagtttccttctcatgctttgtcttcatcatgc' +
+                'gtaccaaggagattacaaacttttcttggaaagtggcgcagtcaagt',
+        },
+    );
+
+    await reviewPage.waitForZeroProcessing();
+    await reviewPage.releaseValidSequences();
+    await page.getByRole('link', { name: 'released sequences' }).click();
+    while (!(await page.getByRole('link', { name: /LOC_/ }).isVisible())) {
+        await page.reload();
+        await page.waitForTimeout(2000);
+    }
+});

--- a/integration-tests/tests/specs/features/download.spec.ts
+++ b/integration-tests/tests/specs/features/download.spec.ts
@@ -1,17 +1,10 @@
-import { test } from '../../fixtures/sequence.fixture';
-import { expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { SearchPage } from '../../pages/search.page';
 const fs = require('fs');
 
-test('Download metadata and check number of cols', async ({ pageWithReleasedSequence: page }) => {
-    test.setTimeout(120000);
+test('Download metadata and check number of cols', async ({ page }) => {
     const searchPage = new SearchPage(page);
-
-    await page.goto('/');
-    await page.getByRole('link', { name: 'Crimean-Congo Hemorrhagic Fever Virus' }).click();
-
-    const loculusId = await searchPage.waitForLoculusId();
-    expect(loculusId).toBeTruthy();
+    await searchPage.ebolaSudan();
 
     await page.getByRole('button', { name: 'Download all entries' }).click();
     await page.getByLabel('I agree to the data use terms.').check();
@@ -42,14 +35,10 @@ test('Download metadata and check number of cols', async ({ pageWithReleasedSequ
     expect(fields).toHaveLength(9);
 });
 
-test('Download metadata with POST and check number of cols', async ({
-    pageWithReleasedSequence: page,
-}) => {
-    test.setTimeout(120000);
+test('Download metadata with POST and check number of cols', async ({ page }) => {
     await page.goto('/');
     const searchPage = new SearchPage(page);
-
-    await page.getByRole('link', { name: 'Crimean-Congo Hemorrhagic Fever Virus' }).click();
+    await searchPage.ebolaSudan();
 
     const loculusId = await searchPage.waitForLoculusId();
     expect(loculusId).toBeTruthy();

--- a/integration-tests/tests/specs/features/download.spec.ts
+++ b/integration-tests/tests/specs/features/download.spec.ts
@@ -1,4 +1,3 @@
-import { approxMaxAcceptableUrlLength } from '../../../../website/src/routes/routes';
 import { test } from '../../fixtures/sequence.fixture';
 import { expect } from '@playwright/test';
 import { SearchPage } from '../../pages/search.page';

--- a/integration-tests/tests/specs/features/revise-sequence.spec.ts
+++ b/integration-tests/tests/specs/features/revise-sequence.spec.ts
@@ -3,21 +3,23 @@ import { expect } from '@playwright/test';
 import { SearchPage } from '../../pages/search.page';
 import { ReviewPage } from '../../pages/review.page';
 
-test('revising sequence data works: segement can be deleted; segment can be edited', async ({ pageWithReleasedSequence: page }) => {
+test('revising sequence data works: segement can be deleted; segment can be edited', async ({
+    pageWithReleasedSequence: page,
+}) => {
     test.setTimeout(60000);
     const searchPage = new SearchPage(page);
 
     await searchPage.cchf();
 
     await page.getByRole('link', { name: 'Submit' }).click();
-    await page.getByRole('link', { name: 'View View your group\'s' }).click();
+    await page.getByRole('link', { name: "View View your group's" }).click();
 
     const loculusId = await searchPage.waitForLoculusId();
     expect(loculusId).toBeTruthy();
 
     await searchPage.clickOnSequence(0);
 
-    await page.getByRole('link', { name: 'Revise this sequence' }).click({ timeout: 15000});
+    await page.getByRole('link', { name: 'Revise this sequence' }).click({ timeout: 15000 });
     await expect(page.getByRole('heading', { name: 'Create new revision from' })).toBeVisible();
 
     await page.getByTestId('discard_L_segment_file').click();
@@ -26,9 +28,9 @@ test('revising sequence data works: segement can be deleted; segment can be edit
         name: 'update_S.txt',
         mimeType: 'text/plain',
         buffer: Buffer.from('AAAAA'),
-    })
-    
-    await page.getByRole('button',  { name: 'Submit' }).click();
+    });
+
+    await page.getByRole('button', { name: 'Submit' }).click();
     await page.getByRole('button', { name: 'Confirm' }).click();
 
     const reviewPage = new ReviewPage(page);
@@ -36,10 +38,10 @@ test('revising sequence data works: segement can be deleted; segment can be edit
     await reviewPage.waitForZeroProcessing();
 
     await reviewPage.viewSequences();
-    await expect(reviewPage.sequenceViewerContent()).not.toBeVisible();  // L was deleted
+    await expect(reviewPage.sequenceViewerContent()).not.toBeVisible(); // L was deleted
 
     const tabs = await reviewPage.getAvailableSequenceTabs();
-    await reviewPage.switchSequenceTab(tabs[2]);  // S tab
+    await reviewPage.switchSequenceTab(tabs[2]); // S tab
 
     expect(await reviewPage.getSequenceContent()).toBe('AAAAA');
 

--- a/integration-tests/tests/specs/features/revise-sequence.spec.ts
+++ b/integration-tests/tests/specs/features/revise-sequence.spec.ts
@@ -1,0 +1,47 @@
+import { test } from '../../fixtures/sequence.fixture';
+import { expect } from '@playwright/test';
+import { SearchPage } from '../../pages/search.page';
+import { ReviewPage } from '../../pages/review.page';
+
+test('revising sequence data works: segement can be deleted; segment can be edited', async ({ pageWithReleasedSequence: page }) => {
+    test.setTimeout(60000);
+    const searchPage = new SearchPage(page);
+
+    await searchPage.cchf();
+
+    await page.getByRole('link', { name: 'Submit' }).click();
+    await page.getByRole('link', { name: 'View View your group\'s' }).click();
+
+    const loculusId = await searchPage.waitForLoculusId();
+    expect(loculusId).toBeTruthy();
+
+    await searchPage.clickOnSequence(0);
+
+    await page.getByRole('link', { name: 'Revise this sequence' }).click({ timeout: 15000});
+    await expect(page.getByRole('heading', { name: 'Create new revision from' })).toBeVisible();
+
+    await page.getByTestId('discard_L_segment_file').click();
+    await page.getByTestId('discard_S_segment_file').click();
+    await page.getByTestId('S_segment_file').setInputFiles({
+        name: 'update_S.txt',
+        mimeType: 'text/plain',
+        buffer: Buffer.from('AAAAA'),
+    })
+    
+    await page.getByRole('button',  { name: 'Submit' }).click();
+    await page.getByRole('button', { name: 'Confirm' }).click();
+
+    const reviewPage = new ReviewPage(page);
+
+    await reviewPage.waitForZeroProcessing();
+
+    await reviewPage.viewSequences();
+    await expect(reviewPage.sequenceViewerContent()).not.toBeVisible();  // L was deleted
+
+    const tabs = await reviewPage.getAvailableSequenceTabs();
+    await reviewPage.switchSequenceTab(tabs[2]);  // S tab
+
+    expect(await reviewPage.getSequenceContent()).toBe('AAAAA');
+
+    await reviewPage.closeSequencesDialog();
+});

--- a/integration-tests/tests/specs/features/search.spec.ts
+++ b/integration-tests/tests/specs/features/search.spec.ts
@@ -12,8 +12,7 @@ test.describe('Search', () => {
         await searchPage.ebolaSudan();
 
         await searchPage.select('Collection country', 'France');
-        await expect(page.getByText('Collection Country:France')).toBeVisible();
-
+        await expect(page.getByText('Collection country:France')).toBeVisible();
         await searchPage.enterMutation('A23T');
         await expect(page.getByText('nucleotideMutations:A23T')).toBeVisible();
 

--- a/integration-tests/tests/specs/features/search.spec.ts
+++ b/integration-tests/tests/specs/features/search.spec.ts
@@ -1,49 +1,39 @@
 import { expect } from '@playwright/test';
 import { SearchPage } from '../../pages/search.page';
-import { test } from '../../fixtures/group.fixture';
+import { test } from '../../fixtures/sequence.fixture';
 import { SingleSequenceSubmissionPage } from '../../pages/singlesubmission.page';
 
 test.describe('Search', () => {
     let searchPage: SearchPage;
 
-    test.beforeEach(async ({ page }) => {
-        searchPage = new SearchPage(page);
+    test.beforeEach(async ({ pageWithReleasedSequence, page }) => {
+        searchPage = new SearchPage(pageWithReleasedSequence);
     });
 
     test('test that search form resets when the reset button is clicked', async ({ page }) => {
-        await searchPage.ebolaSudan();
-        await searchPage.enterMutation('A23T');
-        await expect(page.getByText('nucleotideMutations:A23T')).toBeVisible();
+        await searchPage.cchf();
+
+        await searchPage.select("Collection country", "France");
+        await expect(page.getByText('Collection Country:France')).toBeVisible();
+
+        await searchPage.enterMutation('L:23T');
+        await expect(page.getByText('nucleotideMutations:L:23T')).toBeVisible();
+
         await searchPage.resetSearchForm();
         expect(new URL(page.url()).searchParams.size).toBe(0);
     });
 
     test('test that filter can be removed by clicking the X', async ({ page, pageWithGroup }) => {
-        test.setTimeout(60000);
-        const submissionPage = new SingleSequenceSubmissionPage(pageWithGroup);
-        const reviewPage = await submissionPage.completeSubmission(
-            {
-                submissionId: 'TEST-ID-123',
-                collectionCountry: 'Canada',
-                collectionDate: '2023-10-15',
-                authorAffiliations: 'Research Lab, University',
-            },
-            {
-                main: 'ATTGATCTCATCATTTACCAATTGGAGACCGTTTAACTAGTCAATCCCCCATTTGGGGGCATTCCTAAAGTGTTGCAAAGGTATGTGGGTCGTATTGCTTTGCCTTTTCCTAACCTGGCTCCTCCTACAATTCTAACCTGCTTGATAAGTGTGATTACCTGAGTAATAGACTAATTTCGTCCTGGTAATTAGCATTTTCTAGTAAAACCAATACTATCTCAAGTCCTAAGAGGAGGTGAGAAGAGGGTCTCGAGGTATCCCTCCAGTCCACAAAATCTAGCTAATTTTAGCTGAGTGGACTGATTACTCTCATCACACGCTAACTACTAAGGGTTTACCTGAGAGCCTACAACATGGATAAACGGGTGAGAGGTTCATGGGCCCTGGGAGGACAATCTGAAGTTGATCTTGACTACCACAAAATATTAACAGCCGGGCTTTCGGTCCAACAAGGGATTGTGCGACAAAGAGTCATCCCGGTATATGTTGTGAGTGATCTTGAGGGTATTTGTCAACATATCATTCAGGCCTTTGAAGCAGGCGTAGATTTCCAAGATAATGCTGACAGCTTCCTTTTACTTTTATGTTTACATCATGCTTACCAAGGAGATCATAGGCTCTTCCTCAAAAGTGATGCAGTTCAATACTTAGAGGGCCATGGTTTCAGGTTTGAGGTCCGAGAAAAGGAGAATGTGCACCGTCTGGATGAATTGTTGCCCAATGTCACCGGTGGAAAAAATCTTAGGAGAACATTGGCTGCAATGCCTGAAGAGGAGACAACAGAAGCTAACGCTGGTCAGTTTTTATCCTTTGCCAGTTTGTTTCTACCCAAACTTGTCGTTGGGGAGAAAGCGTGTCTGGAAAAAGTACAAAGGCAGATTCAGGTCCATGCAGAACAAGGGCTCATTCAATATCCAACTTCCTGGCAATCAGTTGGACACATGATGGTGATCTTCCGTTTGATGAGAACAAACTTTTTAATCAAGTTCCTACTAATACATCAGGGGATGCACATGG',
-            },
-        );
-        await reviewPage.releaseValidSequences();
-        await searchPage.ebolaSudan();
-        await searchPage.select('Collection country', 'Canada');
-        await expect(page.getByText('Collection country:Canada')).toBeVisible();
+        await searchPage.cchf();
+        await searchPage.select('Collection country', 'France');
+        await expect(page.getByText('Collection country:France')).toBeVisible();
         await page.getByLabel('remove filter').click();
-        await expect(page.getByText('Collection country:Canada')).not.toBeVisible();
+        await expect(page.getByText('Collection country:France')).not.toBeVisible();
         await expect(page.getByLabel('Collection country')).toBeEmpty();
         expect(new URL(page.url()).searchParams.size).toBe(0);
     });
 
     test('test that mutation filter can be removed by clicking the X', async ({ page }) => {
-        test.setTimeout(60000);
         await searchPage.ebolaSudan();
         await searchPage.enterMutation('A23T');
         await expect(page.getByText('nucleotideMutations:A23T')).toBeVisible();

--- a/integration-tests/tests/specs/features/search.spec.ts
+++ b/integration-tests/tests/specs/features/search.spec.ts
@@ -1,19 +1,18 @@
 import { expect } from '@playwright/test';
 import { SearchPage } from '../../pages/search.page';
 import { test } from '../../fixtures/sequence.fixture';
-import { SingleSequenceSubmissionPage } from '../../pages/singlesubmission.page';
 
 test.describe('Search', () => {
     let searchPage: SearchPage;
 
-    test.beforeEach(async ({ pageWithReleasedSequence, page }) => {
+    test.beforeAll(async ({ pageWithReleasedSequence }) => {
         searchPage = new SearchPage(pageWithReleasedSequence);
     });
 
     test('test that search form resets when the reset button is clicked', async ({ page }) => {
         await searchPage.cchf();
 
-        await searchPage.select("Collection country", "France");
+        await searchPage.select('Collection country', 'France');
         await expect(page.getByText('Collection Country:France')).toBeVisible();
 
         await searchPage.enterMutation('L:23T');

--- a/integration-tests/tests/specs/features/search.spec.ts
+++ b/integration-tests/tests/specs/features/search.spec.ts
@@ -5,7 +5,7 @@ import { test } from '../../fixtures/sequence.fixture';
 test.describe('Search', () => {
     let searchPage: SearchPage;
 
-    test.beforeAll(async ({ pageWithReleasedSequence }) => {
+    test.beforeEach(async ({ pageWithReleasedSequence }) => {
         searchPage = new SearchPage(pageWithReleasedSequence);
     });
 

--- a/integration-tests/tests/specs/features/search.spec.ts
+++ b/integration-tests/tests/specs/features/search.spec.ts
@@ -1,29 +1,28 @@
-import { expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { SearchPage } from '../../pages/search.page';
-import { test } from '../../fixtures/sequence.fixture';
 
 test.describe('Search', () => {
     let searchPage: SearchPage;
 
-    test.beforeEach(async ({ pageWithReleasedSequence }) => {
-        searchPage = new SearchPage(pageWithReleasedSequence);
+    test.beforeEach(async ({ page }) => {
+        searchPage = new SearchPage(page);
     });
 
     test('test that search form resets when the reset button is clicked', async ({ page }) => {
-        await searchPage.cchf();
+        await searchPage.ebolaSudan();
 
         await searchPage.select('Collection country', 'France');
         await expect(page.getByText('Collection Country:France')).toBeVisible();
 
-        await searchPage.enterMutation('L:23T');
-        await expect(page.getByText('nucleotideMutations:L:23T')).toBeVisible();
+        await searchPage.enterMutation('A23T');
+        await expect(page.getByText('nucleotideMutations:A23T')).toBeVisible();
 
         await searchPage.resetSearchForm();
         expect(new URL(page.url()).searchParams.size).toBe(0);
     });
 
-    test('test that filter can be removed by clicking the X', async ({ page, pageWithGroup }) => {
-        await searchPage.cchf();
+    test('test that filter can be removed by clicking the X', async ({ page }) => {
+        await searchPage.ebolaSudan();
         await searchPage.select('Collection country', 'France');
         await expect(page.getByText('Collection country:France')).toBeVisible();
         await page.getByLabel('remove filter').click();

--- a/integration-tests/tests/specs/features/search.spec.ts
+++ b/integration-tests/tests/specs/features/search.spec.ts
@@ -12,8 +12,6 @@ test.describe('Search', () => {
 
     test('test that search form resets when the reset button is clicked', async ({ page }) => {
         await searchPage.ebolaSudan();
-        await searchPage.select('Collection country', 'Canada');
-        await expect(page.getByText('Collection country:Canada')).toBeVisible();
         await searchPage.enterMutation('A23T');
         await expect(page.getByText('nucleotideMutations:A23T')).toBeVisible();
         await searchPage.resetSearchForm();

--- a/integration-tests/tests/specs/features/sequence-preview-url.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-preview-url.spec.ts
@@ -1,87 +1,87 @@
 import { expect } from '@playwright/test';
-import { test } from '../../fixtures/auth.fixture';
+import { test } from '../../fixtures/sequence.fixture';
 import { SearchPage } from '../../pages/search.page';
 
 test.describe('Sequence Preview URL Parameters', () => {
-  let searchPage: SearchPage;
+    let searchPage: SearchPage;
 
-  test.beforeEach(async ({ page }) => {
-    searchPage = new SearchPage(page);
-  });
+    test.beforeAll(async ({ pageWithReleasedSequence }) => {
+        searchPage = new SearchPage(pageWithReleasedSequence);
+    });
 
-  test('should store the previewed sequence ID in the URL', async ({ page }) => {
-    await searchPage.ebolaSudan();
-    
-    let urlParams = await searchPage.getUrlParams();
-    expect(urlParams.has('selectedSeq')).toBe(false);
-    
-    await searchPage.clickOnSequence(0);
-    
-    await expect(page.locator('[data-testid="sequence-preview-modal"]')).toBeVisible();
-    
-    urlParams = await searchPage.getUrlParams();
-    expect(urlParams.has('selectedSeq')).toBe(true);
-    expect(urlParams.get('selectedSeq')).not.toBeNull();
-    const selectedSeqId = urlParams.get('selectedSeq');
-    
-    await (await searchPage.closePreviewButton()).click();
-    
-    urlParams = await searchPage.getUrlParams();
-    expect(urlParams.has('selectedSeq')).toBe(false);
-    
-    const currentUrl = new URL(page.url());
-    currentUrl.searchParams.set('selectedSeq', selectedSeqId);
-    await page.goto(currentUrl.toString());
-    
-    await expect(page.locator('[data-testid="sequence-preview-modal"]')).toBeVisible();
-  });
+    test('should store the previewed sequence ID in the URL', async ({ page }) => {
+        await searchPage.cchf();
 
-  test('should store half-screen state in the URL', async ({ page }) => {
-    await searchPage.ebolaSudan();
-    
-    await searchPage.clickOnSequence(0);
-    
-    await expect(page.locator('[data-testid="sequence-preview-modal"]')).toBeVisible();
-    
-    await (await searchPage.toggleHalfScreenButton()).click();
-    
-    let urlParams = await searchPage.getUrlParams();
-    expect(urlParams.has('halfScreen')).toBe(true);
-    expect(urlParams.get('halfScreen')).toBe('true');
-    
-    await expect(page.locator('[data-testid="half-screen-preview"]')).toBeVisible();
-    
-    await (await searchPage.toggleHalfScreenButton()).click();
-    
-    urlParams = await searchPage.getUrlParams();
-    expect(urlParams.has('halfScreen')).toBe(false);
-    
-    await expect(page.locator('[data-testid="sequence-preview-modal"]')).toBeVisible();
-  });
+        let urlParams = await searchPage.getUrlParams();
+        expect(urlParams.has('selectedSeq')).toBe(false);
 
-  test('should restore state from URL parameters on page load', async ({ page }) => {
-    await searchPage.ebolaSudan();
-    
-    await searchPage.clickOnSequence(0);
-    await expect(page.locator('[data-testid="sequence-preview-modal"]')).toBeVisible();
-    
-    const urlParams = await searchPage.getUrlParams();
-    const selectedSeqId = urlParams.get('selectedSeq');
-    
-    await (await searchPage.toggleHalfScreenButton()).click();
-    
-    await (await searchPage.closePreviewButton()).click();
-    
-    const currentUrl = new URL(page.url());
-    currentUrl.searchParams.set('selectedSeq', selectedSeqId);
-    currentUrl.searchParams.set('halfScreen', 'true');
-    await page.goto(currentUrl.toString());
-    
-    await expect(page.locator('[data-testid="half-screen-preview"]')).toBeVisible();
-    
-    await page.goto('/');
-    await page.goBack();
-    
-    await expect(page.locator('[data-testid="half-screen-preview"]')).toBeVisible();
-  });
+        await searchPage.clickOnSequence(0);
+
+        await expect(page.locator('[data-testid="sequence-preview-modal"]')).toBeVisible();
+
+        urlParams = await searchPage.getUrlParams();
+        expect(urlParams.has('selectedSeq')).toBe(true);
+        expect(urlParams.get('selectedSeq')).not.toBeNull();
+        const selectedSeqId = urlParams.get('selectedSeq');
+
+        await (await searchPage.closePreviewButton()).click();
+
+        urlParams = await searchPage.getUrlParams();
+        expect(urlParams.has('selectedSeq')).toBe(false);
+
+        const currentUrl = new URL(page.url());
+        currentUrl.searchParams.set('selectedSeq', selectedSeqId);
+        await page.goto(currentUrl.toString());
+
+        await expect(page.locator('[data-testid="sequence-preview-modal"]')).toBeVisible();
+    });
+
+    test('should store half-screen state in the URL', async ({ page }) => {
+        await searchPage.cchf();
+
+        await searchPage.clickOnSequence(0);
+
+        await expect(page.locator('[data-testid="sequence-preview-modal"]')).toBeVisible();
+
+        await (await searchPage.toggleHalfScreenButton()).click();
+
+        let urlParams = await searchPage.getUrlParams();
+        expect(urlParams.has('halfScreen')).toBe(true);
+        expect(urlParams.get('halfScreen')).toBe('true');
+
+        await expect(page.locator('[data-testid="half-screen-preview"]')).toBeVisible();
+
+        await (await searchPage.toggleHalfScreenButton()).click();
+
+        urlParams = await searchPage.getUrlParams();
+        expect(urlParams.has('halfScreen')).toBe(false);
+
+        await expect(page.locator('[data-testid="sequence-preview-modal"]')).toBeVisible();
+    });
+
+    test('should restore state from URL parameters on page load', async ({ page }) => {
+        await searchPage.cchf();
+
+        await searchPage.clickOnSequence(0);
+        await expect(page.locator('[data-testid="sequence-preview-modal"]')).toBeVisible();
+
+        const urlParams = await searchPage.getUrlParams();
+        const selectedSeqId = urlParams.get('selectedSeq');
+
+        await (await searchPage.toggleHalfScreenButton()).click();
+
+        await (await searchPage.closePreviewButton()).click();
+
+        const currentUrl = new URL(page.url());
+        currentUrl.searchParams.set('selectedSeq', selectedSeqId);
+        currentUrl.searchParams.set('halfScreen', 'true');
+        await page.goto(currentUrl.toString());
+
+        await expect(page.locator('[data-testid="half-screen-preview"]')).toBeVisible();
+
+        await page.goto('/');
+        await page.goBack();
+
+        await expect(page.locator('[data-testid="half-screen-preview"]')).toBeVisible();
+    });
 });

--- a/integration-tests/tests/specs/features/sequence-preview-url.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-preview-url.spec.ts
@@ -1,17 +1,15 @@
-import { expect } from '@playwright/test';
-import { test } from '../../fixtures/sequence.fixture';
+import { expect, test } from '@playwright/test';
 import { SearchPage } from '../../pages/search.page';
 
 test.describe('Sequence Preview URL Parameters', () => {
-
     let searchPage: SearchPage;
 
-    test.beforeEach(async ({ pageWithReleasedSequence }) => {
-        searchPage = new SearchPage(pageWithReleasedSequence);
+    test.beforeEach(async ({ page }) => {
+        searchPage = new SearchPage(page);
     });
 
     test('should store the previewed sequence ID in the URL', async ({ page }) => {
-        await searchPage.cchf();
+        await searchPage.ebolaSudan();
 
         let urlParams = await searchPage.getUrlParams();
         expect(urlParams.has('selectedSeq')).toBe(false);
@@ -38,7 +36,7 @@ test.describe('Sequence Preview URL Parameters', () => {
     });
 
     test('should store half-screen state in the URL', async ({ page }) => {
-        await searchPage.cchf();
+        await searchPage.ebolaSudan();
 
         await searchPage.clickOnSequence(0);
 
@@ -61,7 +59,7 @@ test.describe('Sequence Preview URL Parameters', () => {
     });
 
     test('should restore state from URL parameters on page load', async ({ page }) => {
-        await searchPage.cchf();
+        await searchPage.ebolaSudan();
 
         await searchPage.clickOnSequence(0);
         await expect(page.locator('[data-testid="sequence-preview-modal"]')).toBeVisible();

--- a/integration-tests/tests/specs/features/sequence-preview-url.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-preview-url.spec.ts
@@ -3,9 +3,10 @@ import { test } from '../../fixtures/sequence.fixture';
 import { SearchPage } from '../../pages/search.page';
 
 test.describe('Sequence Preview URL Parameters', () => {
+
     let searchPage: SearchPage;
 
-    test.beforeAll(async ({ pageWithReleasedSequence }) => {
+    test.beforeEach(async ({ pageWithReleasedSequence }) => {
         searchPage = new SearchPage(pageWithReleasedSequence);
     });
 

--- a/integration-tests/tests/specs/features/sequence-view.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-view.spec.ts
@@ -34,6 +34,7 @@ test.describe('Sequence view in review card', () => {
 
         const reviewPage = new ReviewPage(page);
 
+        await reviewPage.waitForZeroProcessing();
         await reviewPage.viewSequences();
 
         const dialogTitle = page.getByText('Processed Sequences', { exact: true });

--- a/integration-tests/tests/specs/features/sequence-view.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-view.spec.ts
@@ -30,8 +30,6 @@ test.describe('Sequence view in review card', () => {
             page.getByRole('heading', { name: 'Review current submissions' }),
         ).toBeVisible();
 
-        await page.waitForTimeout(60000);
-
         const reviewPage = new ReviewPage(page);
 
         await reviewPage.waitForZeroProcessing();

--- a/integration-tests/tests/specs/features/submission-flow.spec.ts
+++ b/integration-tests/tests/specs/features/submission-flow.spec.ts
@@ -43,8 +43,10 @@ test.describe('Submission flow', () => {
         await page.getByRole('button', { name: 'Release', exact: true }).click();
         await page.getByRole('link', { name: 'Released Sequences' }).click();
 
-        await page.waitForTimeout(35000);
-        await page.reload();
+        while (!(await page.getByRole('cell', { name: 'Pakistan' }).isVisible())) {
+            await page.reload();
+            await page.waitForTimeout(2000);
+        }
 
         await page.getByRole('cell', { name: 'Pakistan' }).click();
         await page.waitForSelector('text="test_NIHPAK-19"');
@@ -79,8 +81,10 @@ test.describe('Submission flow', () => {
         await page.getByRole('button', { name: 'Release', exact: true }).click();
         await page.getByRole('link', { name: 'Released Sequences' }).click();
 
-        await page.waitForTimeout(35000);
-        await page.reload();
+        while (!(await page.getByRole('cell', { name: 'Colombia' }).isVisible())) {
+            await page.reload();
+            await page.waitForTimeout(2000);
+        }
 
         await page.getByRole('cell', { name: 'Colombia' }).click();
         await page.waitForSelector('text="Research Lab, University of Example"');

--- a/website/src/components/Edit/EditPage.spec.tsx
+++ b/website/src/components/Edit/EditPage.spec.tsx
@@ -42,6 +42,7 @@ function renderEditPage({
             <EditPage
                 organism={testOrganism}
                 dataToEdit={editedData}
+                segmentNames={['originalSequenceName']}
                 clientConfig={clientConfig}
                 accessToken={testAccessToken}
                 groupedInputFields={groupedInputFields}

--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -25,6 +25,7 @@ type EditPageProps = {
     organism: string;
     clientConfig: ClientConfig;
     dataToEdit: SequenceEntryToEdit;
+    segmentNames: string[];
     accessToken: string;
     groupedInputFields: Map<string, InputField[]>;
     submissionDataTypes: SubmissionDataTypes;
@@ -35,13 +36,16 @@ const logger = getClientLogger('EditPage');
 const InnerEditPage: FC<EditPageProps> = ({
     organism,
     dataToEdit,
+    segmentNames,
     clientConfig,
     accessToken,
     groupedInputFields,
     submissionDataTypes,
 }) => {
     const [editableMetadata, setEditableMetadata] = useState(EditableMetadata.fromInitialData(dataToEdit));
-    const [editableSequences, setEditableSequences] = useState(EditableSequences.fromInitialData(dataToEdit));
+    const [editableSequences, setEditableSequences] = useState(
+        EditableSequences.fromInitialData(dataToEdit, segmentNames),
+    );
 
     const isCreatingRevision = dataToEdit.status === approvedForReleaseStatus;
 

--- a/website/src/components/Edit/InputForm.spec.tsx
+++ b/website/src/components/Edit/InputForm.spec.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import { EditableSequences } from './InputForm';
+import { defaultReviewData } from '../../../vitest.setup';
 
 describe('InputForm', () => {
     test('Empty editable sequences produces `undefined`', () => {
@@ -20,5 +21,17 @@ describe('InputForm', () => {
         expect(fasta).not.toBeUndefined();
         const fastaText = await fasta!.text();
         expect(fastaText).toBe('>subId_foo\nATCG');
+    });
+
+    test('GIVEN initial data with an empty segment THEN the fasta does not contain the empty segment', async () => {
+        let editableSequences = EditableSequences.fromInitialData(defaultReviewData, [
+            'originalSequenceName',
+            'anotherSequenceName',
+        ]);
+        editableSequences = editableSequences.update({ key: 'originalSequenceName', value: 'ATCG' });
+        const fasta = editableSequences.getSequenceFasta('subId');
+        expect(fasta).not.toBeUndefined();
+        const fastaText = await fasta!.text();
+        expect(fastaText).toBe('>subId_originalSequenceName\nATCG');
     });
 });

--- a/website/src/components/Edit/InputForm.spec.tsx
+++ b/website/src/components/Edit/InputForm.spec.tsx
@@ -4,11 +4,6 @@ import { EditableSequences } from './InputForm';
 import { defaultReviewData } from '../../../vitest.setup';
 
 describe('InputForm', () => {
-    test('Empty editable sequences produces `undefined`', () => {
-        const emptyEditableSequences = EditableSequences.empty();
-        expect(emptyEditableSequences.getSequenceFasta('subId')).toBeUndefined();
-    });
-
     test('Empty editable sequences (with names only) produces `undefined`', () => {
         const emptyEditableSequences = EditableSequences.fromSequenceNames(['foo', 'bar']);
         expect(emptyEditableSequences.getSequenceFasta('subId')).toBeUndefined();

--- a/website/src/components/Edit/InputForm.tsx
+++ b/website/src/components/Edit/InputForm.tsx
@@ -275,7 +275,7 @@ export const SequencesForm: FC<SequenceFormProps> = ({ editableSequences, setEdi
                             small={true}
                             initialValue={
                                 field.initialValue.length > 0
-                                    ? new VirtualFile(field.initialValue, 'existing_data.txt')
+                                    ? new VirtualFile(field.initialValue, 'Existing data')
                                     : undefined
                             }
                             showUndo={true}

--- a/website/src/components/Edit/InputForm.tsx
+++ b/website/src/components/Edit/InputForm.tsx
@@ -278,6 +278,7 @@ export const SequencesForm: FC<SequenceFormProps> = ({ editableSequences, setEdi
                                     ? new VirtualFile(field.initialValue, 'existing_data.txt')
                                     : undefined
                             }
+                            showUndo={true}
                         />
                     </div>
                 ))}

--- a/website/src/components/Edit/InputForm.tsx
+++ b/website/src/components/Edit/InputForm.tsx
@@ -203,12 +203,6 @@ export class EditableSequences {
         );
     }
 
-    reset(key: string): EditableSequences {
-        return new EditableSequences(
-            this.rows.map((prevRow) => (prevRow.key === key ? { ...prevRow, value: prevRow.initialValue } : prevRow)),
-        );
-    }
-
     getSequenceFasta(submissionId: string): File | undefined {
         // if no values are set at all, return undefined
         if (!this.rows.some((row) => row.value !== '')) return undefined;
@@ -255,19 +249,16 @@ export const SequencesForm: FC<SequenceFormProps> = ({ editableSequences, setEdi
                             setFile={async (file) => {
                                 const text = file ? await file.text() : '';
                                 setEditableSequences((editableSequences) =>
-                                    file
-                                        ? editableSequences.update({
-                                              key: field.key,
-                                              value: text,
-                                          })
-                                        : editableSequences.reset(field.key),
+                                    editableSequences.update({
+                                        key: field.key,
+                                        value: text,
+                                    }),
                                 );
                             }}
                             name={`${field.key}_segment_file`}
                             ariaLabel={`${field.key} Segment File`}
                             fileKind={PLAIN_SEGMENT_KIND}
                             small={true}
-                            emptyHasData={field.value.length > 0}
                         />
                     </div>
                 ))}

--- a/website/src/components/Edit/InputForm.tsx
+++ b/website/src/components/Edit/InputForm.tsx
@@ -8,7 +8,7 @@ import { ACCESSION_FIELD, SUBMISSION_ID_FIELD } from '../../settings.ts';
 import type { ProcessingAnnotationSourceType, SequenceEntryToEdit } from '../../types/backend.ts';
 import type { InputField } from '../../types/config';
 import { FileUploadComponent } from '../Submission/FileUpload/FileUploadComponent.tsx';
-import { PLAIN_SEGMENT_KIND } from '../Submission/FileUpload/fileProcessing.ts';
+import { PLAIN_SEGMENT_KIND, VirtualFile } from '../Submission/FileUpload/fileProcessing.ts';
 
 type SubtitleProps = {
     title: string;
@@ -273,6 +273,11 @@ export const SequencesForm: FC<SequenceFormProps> = ({ editableSequences, setEdi
                             ariaLabel={`${field.key} Segment File`}
                             fileKind={PLAIN_SEGMENT_KIND}
                             small={true}
+                            initialValue={
+                                field.initialValue.length > 0
+                                    ? new VirtualFile(field.initialValue, 'existing_data.txt')
+                                    : undefined
+                            }
                         />
                     </div>
                 ))}

--- a/website/src/components/Edit/InputForm.tsx
+++ b/website/src/components/Edit/InputForm.tsx
@@ -203,6 +203,12 @@ export class EditableSequences {
         );
     }
 
+    reset(key: string): EditableSequences {
+        return new EditableSequences(
+            this.rows.map((prevRow) => (prevRow.key === key ? { ...prevRow, value: prevRow.initialValue } : prevRow)),
+        );
+    }
+
     getSequenceFasta(submissionId: string): File | undefined {
         // if no values are set at all, return undefined
         if (!this.rows.some((row) => row.value !== '')) return undefined;
@@ -249,16 +255,19 @@ export const SequencesForm: FC<SequenceFormProps> = ({ editableSequences, setEdi
                             setFile={async (file) => {
                                 const text = file ? await file.text() : '';
                                 setEditableSequences((editableSequences) =>
-                                    editableSequences.update({
-                                        key: field.key,
-                                        value: text,
-                                    }),
+                                    file
+                                        ? editableSequences.update({
+                                              key: field.key,
+                                              value: text,
+                                          })
+                                        : editableSequences.reset(field.key),
                                 );
                             }}
                             name={`${field.key}_segment_file`}
                             ariaLabel={`${field.key} Segment File`}
                             fileKind={PLAIN_SEGMENT_KIND}
                             small={true}
+                            emptyHasData={field.value.length > 0}
                         />
                     </div>
                 ))}

--- a/website/src/components/Edit/InputForm.tsx
+++ b/website/src/components/Edit/InputForm.tsx
@@ -178,6 +178,10 @@ export class EditableSequences {
         }));
     }
 
+    /**
+     * @param initialData The sequence entry to edit, from which the initial sequence data is taken.
+     * @param segmentNames All segment names for the organism of the sequence. This is used to include empty segments.
+     */
     static fromInitialData(initialData: SequenceEntryToEdit, segmentNames: string[]): EditableSequences {
         const emptyRows = this.emptyRows(segmentNames);
         const existingDataRows = Object.entries(initialData.originalData.unalignedNucleotideSequences).map(
@@ -201,14 +205,17 @@ export class EditableSequences {
         return new EditableSequences(mergedRows);
     }
 
+    /**
+     * Create an empty {@link EditableSequences} object from segment names.
+     * Each segment will be empty initially.
+     */
     static fromSequenceNames(segmentNames: string[]): EditableSequences {
         return new EditableSequences(this.emptyRows(segmentNames));
     }
 
-    static empty(): EditableSequences {
-        return new EditableSequences([]);
-    }
-
+    /**
+     * Create a new {@link EditableSequences} object with the given row value updated.
+     */
     update(editedRow: KeyValuePair & {}): EditableSequences {
         return new EditableSequences(
             this.rows.map((prevRow) =>

--- a/website/src/components/Edit/SequencesForm.spec.tsx
+++ b/website/src/components/Edit/SequencesForm.spec.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
-import { defaultReviewData } from '../../../vitest.setup';
+
 import { EditableSequences } from './SequencesForm';
+import { defaultReviewData } from '../../../vitest.setup';
 
 describe('InputForm', () => {
     test('Empty editable sequences (with names only) produces `undefined`', () => {

--- a/website/src/components/Edit/SequencesForm.tsx
+++ b/website/src/components/Edit/SequencesForm.tsx
@@ -3,38 +3,59 @@ import { type Dispatch, type FC, type SetStateAction } from 'react';
 import type { KeyValuePair, Row } from './InputField';
 import { mapErrorsAndWarnings, type SequenceEntryToEdit } from '../../types/backend.ts';
 import { FileUploadComponent } from '../Submission/FileUpload/FileUploadComponent.tsx';
-import { PLAIN_SEGMENT_KIND } from '../Submission/FileUpload/fileProcessing.ts';
+import { PLAIN_SEGMENT_KIND, VirtualFile } from '../Submission/FileUpload/fileProcessing.ts';
 
 export class EditableSequences {
     private constructor(public readonly rows: Row[]) {}
 
-    static fromInitialData(initialData: SequenceEntryToEdit): EditableSequences {
-        return new EditableSequences(
-            Object.entries(initialData.originalData.unalignedNucleotideSequences).map(([key, value]) => ({
+    private static emptyRows(names: string[]): Row[] {
+        return names.map((name) => ({
+            key: name,
+            initialValue: '',
+            value: '',
+            errors: [],
+            warnings: [],
+        }));
+    }
+
+    /**
+     * @param initialData The sequence entry to edit, from which the initial sequence data is taken.
+     * @param segmentNames All segment names for the organism of the sequence. This is used to include empty segments.
+     */
+    static fromInitialData(initialData: SequenceEntryToEdit, segmentNames: string[]): EditableSequences {
+        const emptyRows = this.emptyRows(segmentNames);
+        const existingDataRows = Object.entries(initialData.originalData.unalignedNucleotideSequences).map(
+            ([key, value]) => ({
                 key,
                 initialValue: value.toString(),
                 value: value.toString(),
                 ...mapErrorsAndWarnings(initialData, key, 'NucleotideSequence'),
-            })),
+            }),
         );
+        const mergedRows: Row[] = [];
+        // merge in this way to retain the order of segment names as they were given.
+        emptyRows.forEach((row) => {
+            const existingRow = existingDataRows.find((r) => r.key === row.key);
+            if (existingRow) {
+                mergedRows.push(existingRow);
+            } else {
+                mergedRows.push(row);
+            }
+        });
+        return new EditableSequences(mergedRows);
     }
 
+    /**
+     * Create an empty {@link EditableSequences} object from segment names.
+     * Each segment will be empty initially.
+     */
     static fromSequenceNames(segmentNames: string[]): EditableSequences {
-        return new EditableSequences(
-            segmentNames.map((name) => ({
-                key: name,
-                initialValue: '',
-                value: '',
-                errors: [],
-                warnings: [],
-            })),
-        );
+        return new EditableSequences(this.emptyRows(segmentNames));
     }
 
-    static empty(): EditableSequences {
-        return new EditableSequences([]);
-    }
-
+    /**
+     * Create a new {@link EditableSequences} object with the given row value updated.
+     */
     update(editedRow: KeyValuePair & {}): EditableSequences {
         return new EditableSequences(
             this.rows.map((prevRow) =>
@@ -99,6 +120,12 @@ export const SequencesForm: FC<SequenceFormProps> = ({ editableSequences, setEdi
                             ariaLabel={`${field.key} Segment File`}
                             fileKind={PLAIN_SEGMENT_KIND}
                             small={true}
+                            initialValue={
+                                field.initialValue.length > 0
+                                    ? new VirtualFile(field.initialValue, 'Existing data')
+                                    : undefined
+                            }
+                            showUndo={true}
                         />
                     </div>
                 ))}

--- a/website/src/components/Submission/FileUpload/FileUploadComponent.spec.tsx
+++ b/website/src/components/Submission/FileUpload/FileUploadComponent.spec.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FileUploadComponent } from './FileUploadComponent';
+import { PLAIN_SEGMENT_KIND, VirtualFile } from './fileProcessing';
+
+const mockSetFile = vi.fn();
+
+describe('FileUploadComponent', () => {
+    it('renders upload button and allows file selection', async () => {
+        render(
+            <FileUploadComponent
+                setFile={mockSetFile}
+                name='testFile'
+                ariaLabel='Upload test file'
+                fileKind={PLAIN_SEGMENT_KIND}
+            />,
+        );
+
+        const uploadButton = screen.getByText(/Upload/);
+        expect(uploadButton).toBeInTheDocument();
+
+        const fileInput = screen.getByTestId('testFile');
+        const file = new File(['file content'], 'test.txt', { type: 'text/plain' });
+
+        await userEvent.upload(fileInput, file);
+
+        expect(mockSetFile).toHaveBeenCalled();
+    });
+
+    it('displays the uploaded file name and allows discarding and undoing discard', async () => {
+        const initialFile = new VirtualFile('content', 'initial.txt');
+        render(
+            <FileUploadComponent
+                setFile={mockSetFile}
+                name='test'
+                ariaLabel='Upload test file'
+                fileKind={PLAIN_SEGMENT_KIND}
+                initialValue={initialFile}
+                showUndo={true}
+            />,
+        );
+
+        expect(screen.getByText('initial.txt')).toBeInTheDocument();
+
+        const discardButton = screen.getByTestId('discard_test');
+        await userEvent.click(discardButton);
+
+        expect(mockSetFile).toHaveBeenCalledWith(undefined);
+        expect(screen.queryByText('initial.txt')).not.toBeInTheDocument();
+        mockSetFile.mockReset();
+
+        const undoButton = screen.getByTestId('undo_test');
+        await userEvent.click(undoButton);
+
+        expect(mockSetFile).toHaveBeenCalledWith(initialFile);
+        expect(screen.getByText('initial.txt')).toBeInTheDocument();
+    });
+});

--- a/website/src/components/Submission/FileUpload/FileUploadComponent.spec.tsx
+++ b/website/src/components/Submission/FileUpload/FileUploadComponent.spec.tsx
@@ -43,6 +43,7 @@ describe('FileUploadComponent', () => {
         );
 
         expect(screen.getByText('initial.txt')).toBeInTheDocument();
+        expect(screen.queryByTestId('undo_test')).not.toBeInTheDocument();
 
         const discardButton = screen.getByTestId('discard_test');
         await userEvent.click(discardButton);
@@ -56,5 +57,31 @@ describe('FileUploadComponent', () => {
 
         expect(mockSetFile).toHaveBeenCalledWith(initialFile);
         expect(screen.getByText('initial.txt')).toBeInTheDocument();
+
+        expect(screen.queryByTestId('undo_test')).not.toBeInTheDocument();
+    });
+
+    it('does not show undo button if it is disabled', async () => {
+        const initialFile = new VirtualFile('content', 'initial.txt');
+        render(
+            <FileUploadComponent
+                setFile={mockSetFile}
+                name='test'
+                ariaLabel='Upload test file'
+                fileKind={PLAIN_SEGMENT_KIND}
+                initialValue={initialFile}
+                showUndo={false}
+            />,
+        );
+
+        expect(screen.getByText('initial.txt')).toBeInTheDocument();
+        expect(screen.queryByTestId('undo_test')).not.toBeInTheDocument();
+
+        const discardButton = screen.getByTestId('discard_test');
+        await userEvent.click(discardButton);
+
+        expect(mockSetFile).toHaveBeenCalledWith(undefined);
+        expect(screen.queryByText('initial.txt')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('undo_test')).not.toBeInTheDocument();
     });
 });

--- a/website/src/components/Submission/FileUpload/FileUploadComponent.spec.tsx
+++ b/website/src/components/Submission/FileUpload/FileUploadComponent.spec.tsx
@@ -29,6 +29,34 @@ describe('FileUploadComponent', () => {
         expect(mockSetFile).toHaveBeenCalled();
     });
 
+    it('resets file to `undefined` when undo button is clicked after a file was selected', async () => {
+        render(
+            <FileUploadComponent
+                setFile={mockSetFile}
+                name='testFile'
+                ariaLabel='Upload test file'
+                fileKind={PLAIN_SEGMENT_KIND}
+                showUndo={true}
+            />,
+        );
+
+        const uploadButton = screen.getByText(/Upload/);
+        expect(uploadButton).toBeInTheDocument();
+
+        const fileInput = screen.getByTestId('testFile');
+        const file = new File(['file content'], 'test.txt', { type: 'text/plain' });
+
+        await userEvent.upload(fileInput, file);
+
+        expect(mockSetFile).toHaveBeenCalled();
+        const undoButton = screen.getByTestId('undo_testFile');
+        expect(undoButton).toBeInTheDocument();
+
+        await userEvent.click(undoButton);
+
+        expect(mockSetFile).lastCalledWith(undefined);
+    });
+
     it('displays the uploaded file name and allows discarding and undoing discard', async () => {
         const initialFile = new VirtualFile('content', 'initial.txt');
         render(

--- a/website/src/components/Submission/FileUpload/FileUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/FileUploadComponent.tsx
@@ -10,14 +10,12 @@ export const FileUploadComponent = ({
     ariaLabel,
     fileKind,
     small = false,
-    emptyHasData = false,
 }: {
     setFile: (file: ProcessedFile | undefined) => Promise<void> | void;
     name: string;
     ariaLabel: string;
     fileKind: FileKind;
     small?: boolean;
-    emptyHasData?: boolean;
 }) => {
     const [myFile, rawSetMyFile] = useState<ProcessedFile | undefined>(undefined);
     const [isDragOver, setIsDragOver] = useState(false);
@@ -88,22 +86,18 @@ export const FileUploadComponent = ({
     }, [myFile, setMyFile]);
     return (
         <div
-            className={`flex flex-col items-center justify-center ${small ? 'h-24' : 'h-40'} w-full rounded-lg border ${myFile ? 'border-hidden' : 'border-dashed border-gray-900/25'} ${isDragOver && !myFile ? 'bg-green-100' : ''}`}
+            className={`flex flex-col ${small ? 'h-24' : 'h-40'} w-full rounded-lg border ${myFile ? 'border-hidden' : 'border-dashed border-gray-900/25'} ${isDragOver && !myFile ? 'bg-green-100' : ''}`}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}
         >
-            <div className={`mx-auto`}>
-                {emptyHasData && !myFile ? (
-                    <div className='text-sm text-gray-500 mb-1'>[existing data]</div>
-                ) : small ? (
-                    <fileKind.icon className='h-8 w-8 text-gray-300' aria-hidden='true' />
-                ) : (
-                    <fileKind.icon className='h-12 w-12 text-gray-300' aria-hidden='true' />
-                )}
-            </div>
+            {small ? (
+                <fileKind.icon className='mx-auto mt-2 mb-0 h-8 w-8 text-gray-300' aria-hidden='true' />
+            ) : (
+                <fileKind.icon className='mx-auto mt-4 mb-0 h-12 w-12 text-gray-300' aria-hidden='true' />
+            )}
             {!myFile ? (
-                <div className={`flex flex-col items-center justify-center ${small ? 'py-0' : 'py-2'} px-4`}>
+                <div className={`flex flex-col items-center justify-center flex-1 py-2 px-4`}>
                     <div>
                         <label className='inline relative cursor-pointer rounded-md bg-white font-semibold text-primary-600 focus-within:outline-none focus-within:ring-2 focus-within:ring-primary-600 focus-within:ring-offset-2 hover:text-primary-500'>
                             <span

--- a/website/src/components/Submission/FileUpload/FileUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/FileUploadComponent.tsx
@@ -10,14 +10,16 @@ export const FileUploadComponent = ({
     ariaLabel,
     fileKind,
     small = false,
+    initialValue = undefined,
 }: {
     setFile: (file: ProcessedFile | undefined) => Promise<void> | void;
     name: string;
     ariaLabel: string;
     fileKind: FileKind;
     small?: boolean;
+    initialValue?: ProcessedFile;
 }) => {
-    const [myFile, rawSetMyFile] = useState<ProcessedFile | undefined>(undefined);
+    const [myFile, rawSetMyFile] = useState<ProcessedFile | undefined>(initialValue);
     const [isDragOver, setIsDragOver] = useState(false);
     const isClient = useClientFlag();
 

--- a/website/src/components/Submission/FileUpload/FileUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/FileUploadComponent.tsx
@@ -3,6 +3,7 @@ import { toast } from 'react-toastify';
 
 import type { FileKind, ProcessedFile } from './fileProcessing.ts';
 import useClientFlag from '../../../hooks/isClient.ts';
+import UndoTwoToneIcon from '~icons/ic/twotone-undo';
 
 export const FileUploadComponent = ({
     setFile,
@@ -11,6 +12,7 @@ export const FileUploadComponent = ({
     fileKind,
     small = false,
     initialValue = undefined,
+    showUndo = false,
 }: {
     setFile: (file: ProcessedFile | undefined) => Promise<void> | void;
     name: string;
@@ -18,10 +20,13 @@ export const FileUploadComponent = ({
     fileKind: FileKind;
     small?: boolean;
     initialValue?: ProcessedFile;
+    showUndo?: boolean;
 }) => {
     const [myFile, rawSetMyFile] = useState<ProcessedFile | undefined>(initialValue);
     const [isDragOver, setIsDragOver] = useState(false);
     const isClient = useClientFlag();
+
+    const [isEdited, setIsEdited] = useState(false);
 
     const setMyFile = useCallback(
         async (file: File | null) => {
@@ -43,9 +48,27 @@ export const FileUploadComponent = ({
             }
             await setFile(processedFile);
             rawSetMyFile(processedFile);
+            // update edited state
+            if (processedFile === undefined && initialValue !== undefined) {
+                setIsEdited(true);
+            } else if (processedFile !== undefined && initialValue === undefined) {
+                setIsEdited(true);
+            } else if (processedFile === undefined && initialValue === undefined) {
+                setIsEdited(false);
+            } else {
+                const initialText = await initialValue!.text();
+                const currentText = await processedFile!.text();
+                setIsEdited(initialText !== currentText);
+            }
         },
         [setFile, rawSetMyFile],
     );
+    const reset = async () => {
+        await setFile(initialValue);
+        rawSetMyFile(initialValue);
+        setIsEdited(false);
+    };
+
     const fileInputRef = useRef<HTMLInputElement>(null);
     const handleUpload = () => {
         document.getElementById(name)?.click();
@@ -88,7 +111,7 @@ export const FileUploadComponent = ({
     }, [myFile, setMyFile]);
     return (
         <div
-            className={`flex flex-col ${small ? 'h-24' : 'h-40'} w-full rounded-lg border ${myFile ? 'border-hidden' : 'border-dashed border-gray-900/25'} ${isDragOver && !myFile ? 'bg-green-100' : ''}`}
+            className={`flex flex-col ${small ? 'h-24' : 'h-40'} w-full rounded-lg border ${myFile ? 'border-hidden' : 'border-dashed border-gray-900/25'} ${isDragOver && !myFile ? 'bg-green-100' : ''} relative`}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}
@@ -101,7 +124,7 @@ export const FileUploadComponent = ({
             {!myFile ? (
                 <div className={`flex flex-col items-center justify-center flex-1 py-2 px-4`}>
                     <div>
-                        <label className='inline relative cursor-pointer rounded-md bg-white font-semibold text-primary-600 focus-within:outline-none focus-within:ring-2 focus-within:ring-primary-600 focus-within:ring-offset-2 hover:text-primary-500'>
+                        <label className='inline cursor-pointer rounded-md bg-white font-semibold text-primary-600 focus-within:outline-none focus-within:ring-2 focus-within:ring-primary-600 focus-within:ring-offset-2 hover:text-primary-500'>
                             <span
                                 onClick={(e) => {
                                     e.preventDefault();
@@ -141,6 +164,15 @@ export const FileUploadComponent = ({
                         className='text-xs break-words text-gray-700 py-1.5 px-4 border border-gray-300 rounded-md hover:bg-gray-50'
                     >
                         Discard file
+                    </button>
+                </div>
+            )}
+            {showUndo && isEdited && (
+                <div className='absolute top-1 right-2'>
+                    <button className='bg-transparent' onClick={() => void reset()}>
+                        <div className='tooltip tooltip-info whitespace-pre-line' data-tip='Revert to initial data'>
+                            <UndoTwoToneIcon color='action' />
+                        </div>
                     </button>
                 </div>
             )}

--- a/website/src/components/Submission/FileUpload/FileUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/FileUploadComponent.tsx
@@ -169,7 +169,12 @@ export const FileUploadComponent = ({
             )}
             {showUndo && isEdited && (
                 <div className='absolute top-1 right-2'>
-                    <button className='bg-transparent' onClick={() => void reset()}>
+                    <button
+                        className='bg-transparent'
+                        onClick={() => void reset()}
+                        aria-label={`Undo ${name}`}
+                        data-testid={`undo_${name}`}
+                    >
                         <div className='tooltip tooltip-info whitespace-pre-line' data-tip='Revert to initial data'>
                             <UndoTwoToneIcon color='action' />
                         </div>

--- a/website/src/components/Submission/FileUpload/FileUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/FileUploadComponent.tsx
@@ -10,12 +10,14 @@ export const FileUploadComponent = ({
     ariaLabel,
     fileKind,
     small = false,
+    emptyHasData = false,
 }: {
     setFile: (file: ProcessedFile | undefined) => Promise<void> | void;
     name: string;
     ariaLabel: string;
     fileKind: FileKind;
     small?: boolean;
+    emptyHasData?: boolean;
 }) => {
     const [myFile, rawSetMyFile] = useState<ProcessedFile | undefined>(undefined);
     const [isDragOver, setIsDragOver] = useState(false);
@@ -86,18 +88,22 @@ export const FileUploadComponent = ({
     }, [myFile, setMyFile]);
     return (
         <div
-            className={`flex flex-col ${small ? 'h-24' : 'h-40'} w-full rounded-lg border ${myFile ? 'border-hidden' : 'border-dashed border-gray-900/25'} ${isDragOver && !myFile ? 'bg-green-100' : ''}`}
+            className={`flex flex-col items-center justify-center ${small ? 'h-24' : 'h-40'} w-full rounded-lg border ${myFile ? 'border-hidden' : 'border-dashed border-gray-900/25'} ${isDragOver && !myFile ? 'bg-green-100' : ''}`}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}
         >
-            {small ? (
-                <fileKind.icon className='mx-auto mt-2 mb-0 h-8 w-8 text-gray-300' aria-hidden='true' />
-            ) : (
-                <fileKind.icon className='mx-auto mt-4 mb-0 h-12 w-12 text-gray-300' aria-hidden='true' />
-            )}
+            <div className={`mx-auto`}>
+                {emptyHasData && !myFile ? (
+                    <div className='text-sm text-gray-500 mb-1'>[existing data]</div>
+                ) : small ? (
+                    <fileKind.icon className='h-8 w-8 text-gray-300' aria-hidden='true' />
+                ) : (
+                    <fileKind.icon className='h-12 w-12 text-gray-300' aria-hidden='true' />
+                )}
+            </div>
             {!myFile ? (
-                <div className={`flex flex-col items-center justify-center flex-1 py-2 px-4`}>
+                <div className={`flex flex-col items-center justify-center ${small ? 'py-0' : 'py-2'} px-4`}>
                     <div>
                         <label className='inline relative cursor-pointer rounded-md bg-white font-semibold text-primary-600 focus-within:outline-none focus-within:ring-2 focus-within:ring-primary-600 focus-within:ring-offset-2 hover:text-primary-500'>
                             <span

--- a/website/src/components/Submission/FileUpload/fileProcessing.ts
+++ b/website/src/components/Submission/FileUpload/fileProcessing.ts
@@ -138,6 +138,13 @@ export class RawFile implements ProcessedFile {
     }
 }
 
+export class VirtualFile extends RawFile {
+    constructor(content: string, fileName: string = 'virtual.txt') {
+        const blob = new Blob([content]);
+        super(new File([blob], fileName));
+    }
+}
+
 type SupportedInBrowserCompressionKind = 'zst' | 'gz' | 'zip';
 const isSupportedInBrowserCompressionKind = (s: string): s is SupportedInBrowserCompressionKind =>
     ['zst', 'gz', 'zip'].includes(s);

--- a/website/src/pages/[organism]/submission/edit/[accession]/[version].astro
+++ b/website/src/pages/[organism]/submission/edit/[accession]/[version].astro
@@ -5,6 +5,7 @@ import { getGroupedInputFields, getRuntimeConfig, getSchema } from '../../../../
 import BaseLayout from '../../../../../layouts/BaseLayout.astro';
 import { BackendClient } from '../../../../../services/backendClient';
 import { getAccessToken } from '../../../../../utils/getAccessToken';
+import { getReferenceGenomesSequenceNames } from '../../../../../utils/search';
 
 const version = Astro.params.version!;
 const accession = Astro.params.accession!;
@@ -24,6 +25,7 @@ const accessToken = getAccessToken(Astro.locals.session)!;
 
 const clientConfig = getRuntimeConfig().public;
 const schema = getSchema(organism);
+const segmentNames = getReferenceGenomesSequenceNames(organism).nucleotideSequences;
 
 const dataToEdit = await BackendClient.create().getDataToEdit(organism, accessToken, accession, version);
 ---
@@ -36,6 +38,7 @@ const dataToEdit = await BackendClient.create().getDataToEdit(organism, accessTo
                     organism={organism}
                     accessToken={accessToken}
                     dataToEdit={dataToEdit}
+                    segmentNames={segmentNames}
                     clientConfig={clientConfig}
                     groupedInputFields={groupedInputFields}
                     submissionDataTypes={schema.submissionDataTypes}


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #3850

<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
preview URL:

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->
- Allow defining 'initial data' for the file upload component. it is displayed as a file.
- add the 'undo' functionality to the file upload component so you can revert to the initial data.
- bugfix: empty segments now show an upload control on the edit form of a sequence.

#### Testing
- Added automated tests for the FileUploadComponent to check that it correctly discards and undos.
- Manually checked that it's possible to discard sequence data in the edit form.
- Add integration test to check that discarded or modified sequence data is submitted correctly in the edit form.

### Screenshot

https://github.com/user-attachments/assets/1fb2a998-38ed-4675-958a-1029fdea360f

### PR Checklist
- ~~All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
