### PR TITLE
feat(integration-tests): use setup project to submit some data to speed up tests

### DIFF
--- a/integration-tests/playwright.config.ts
+++ b/integration-tests/playwright.config.ts
@@ -33,13 +33,19 @@ export default defineConfig({
     /* Configure projects for major browsers */
     projects: [
         {
+            name: 'readonly setup',
+            testMatch: /readonly\.setup\.ts/,
+        },
+        {
             name: 'chromium',
             use: { ...devices['Desktop Chrome'] },
+            dependencies: ['readonly setup'],
         },
 
         {
             name: 'firefox',
             use: { ...devices['Desktop Firefox'] },
+            dependencies: ['readonly setup'],
         },
     ],
 });

--- a/integration-tests/tests/fixtures/group.fixture.ts
+++ b/integration-tests/tests/fixtures/group.fixture.ts
@@ -13,7 +13,7 @@ interface TestGroup {
     country: string;
 }
 
-const createTestGroup = (name = `test_group_${uuidv4().slice(0, 8)}`): TestGroup => ({
+export const createTestGroup = (name = `test_group_${uuidv4().slice(0, 8)}`): TestGroup => ({
     name,
     email: `test_${uuidv4().slice(0, 8)}@test.com`,
     institution: 'Test Institution',

--- a/integration-tests/tests/fixtures/sequence.fixture.ts
+++ b/integration-tests/tests/fixtures/sequence.fixture.ts
@@ -2,7 +2,6 @@ import { test as groupTest } from './group.fixture';
 import { Page } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 import { SingleSequenceSubmissionPage } from '../pages/singlesubmission.page';
-import { ReviewPage } from '../pages/review.page';
 
 type SequenceFixtures = {
     pageWithReleasedSequence: Page;

--- a/integration-tests/tests/fixtures/sequence.fixture.ts
+++ b/integration-tests/tests/fixtures/sequence.fixture.ts
@@ -31,11 +31,11 @@ export const test = groupTest.extend<SequenceFixtures>({
             const reviewPage = await submissionPage.submitSequence();
 
             await reviewPage.releaseValidSequences();
-
-            await pageWithGroup.waitForTimeout(35000);
-            await pageWithGroup.reload();
-
             await pageWithGroup.getByRole('link', { name: 'Released Sequences' }).click();
+            while (!(await pageWithGroup.getByRole('link', { name: /LOC_/ }).isVisible())) {
+                await pageWithGroup.reload();
+                await pageWithGroup.waitForTimeout(2000);
+            }
 
             await use(pageWithGroup);
         },

--- a/integration-tests/tests/pages/auth.page.ts
+++ b/integration-tests/tests/pages/auth.page.ts
@@ -35,7 +35,6 @@ export class AuthPage {
 
         await this.page.getByLabel('I agree').check();
         await this.page.getByRole('button', { name: 'Register' }).click();
-        await this.page.waitForTimeout(3000);
     }
 
     async login(username: string, password: string) {

--- a/integration-tests/tests/pages/auth.page.ts
+++ b/integration-tests/tests/pages/auth.page.ts
@@ -35,6 +35,7 @@ export class AuthPage {
 
         await this.page.getByLabel('I agree').check();
         await this.page.getByRole('button', { name: 'Register' }).click();
+        await this.page.waitForTimeout(3000);
     }
 
     async login(username: string, password: string) {

--- a/integration-tests/tests/readonly.setup.ts
+++ b/integration-tests/tests/readonly.setup.ts
@@ -1,0 +1,54 @@
+import { test as setup } from '@playwright/test';
+import { AuthPage } from './pages/auth.page';
+import { GroupPage } from './pages/group.page';
+import { createTestGroup } from './fixtures/group.fixture';
+import { SingleSequenceSubmissionPage } from './pages/singlesubmission.page';
+import { v4 as uuidv4 } from 'uuid';
+
+setup('init some stuff', async ({ page }) => {
+    setup.setTimeout(90000);
+    const authPage = new AuthPage(page);
+    await authPage.navigateToRegister();
+    const username = uuidv4().substring(0, 8);
+    const password = uuidv4().substring(0, 8);
+    await authPage.createAccount({
+        firstName: 'Foo',
+        lastName: 'Bar',
+        email: `${username}@foo.org`,
+        organization: 'Foo University',
+        password,
+        username,
+    });
+
+    const groupPage = new GroupPage(page);
+    await groupPage.navigateToCreateGroupPage();
+    await groupPage.createGroup(createTestGroup());
+
+    const submissionPage = new SingleSequenceSubmissionPage(page);
+    const reviewPage = await submissionPage.completeSubmission({
+        submissionId: 'foobar',
+        collectionCountry: 'France',
+        collectionDate: '2021-05-12',
+        authorAffiliations: 'Patho Institute, Paris'
+    }, {
+        main: 'nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnntgtgtgcgaataactatga' +
+        'ggaagattaataattttcctnctcattgaaatttatatcggnaatttaaattgaaattgt' +
+        'tactgtaatcatacctggtttgntttcagagccatatcaccaagatagagaacaacctag' +
+        'gtctccggagggggcaagggcatcagtgtgctcagttgaaaatcccttgtcaacatctag' +
+        'gccttatcacatcacaagttccgccttaaactctgcagggtgatccaacaaccttaatag' +
+        'caacattattgttaaaggacagcattagttcacagtcaaacaagcaagattgagaattaa' +
+        'ctttgattttgaacctgaacacccagaggactggagactcaacaaccctaaagcctaggg' +
+        'taaaacattagaaatagtttaaagacaaattgctcggaatcacaaaattccgagtatgga' +
+        'ttctcgtcctcagaaagtctggatgacgccgagtctcactgaatctgacatggattacca' +
+        'caagatcttgacagcaggtctgtccgttcaacaggggattgttcggcaaagagtcatccc' +
+        'agtgtatcaagtaaacaatcttgaggaaatttgccaacttatcatacaggcctttgaagc' +
+        'tggtgttgattttcaagagagtgcggacagtttccttctcatgctttgtcttcatcatgc' +
+        'gtaccaaggagattacaaacttttcttggaaagtggcgcagtcaagt'
+    })
+
+    await reviewPage.waitForZeroProcessing();
+    await reviewPage.releaseValidSequences();
+
+    // wait for backend to load the sequence
+    await page.waitForTimeout(35000);
+});

--- a/integration-tests/tests/readonly.setup.ts
+++ b/integration-tests/tests/readonly.setup.ts
@@ -1,11 +1,11 @@
-import { test as setup } from '@playwright/test';
+import { expect, test as setup } from '@playwright/test';
 import { AuthPage } from './pages/auth.page';
 import { GroupPage } from './pages/group.page';
 import { createTestGroup } from './fixtures/group.fixture';
 import { SingleSequenceSubmissionPage } from './pages/singlesubmission.page';
 import { v4 as uuidv4 } from 'uuid';
 
-setup('init some stuff', async ({ page }) => {
+setup('Initialize a single ebola sequence as base data', async ({ page }) => {
     setup.setTimeout(90000);
     const authPage = new AuthPage(page);
     await authPage.navigateToRegister();
@@ -25,30 +25,36 @@ setup('init some stuff', async ({ page }) => {
     await groupPage.createGroup(createTestGroup());
 
     const submissionPage = new SingleSequenceSubmissionPage(page);
-    const reviewPage = await submissionPage.completeSubmission({
-        submissionId: 'foobar',
-        collectionCountry: 'France',
-        collectionDate: '2021-05-12',
-        authorAffiliations: 'Patho Institute, Paris'
-    }, {
-        main: 'nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnntgtgtgcgaataactatga' +
-        'ggaagattaataattttcctnctcattgaaatttatatcggnaatttaaattgaaattgt' +
-        'tactgtaatcatacctggtttgntttcagagccatatcaccaagatagagaacaacctag' +
-        'gtctccggagggggcaagggcatcagtgtgctcagttgaaaatcccttgtcaacatctag' +
-        'gccttatcacatcacaagttccgccttaaactctgcagggtgatccaacaaccttaatag' +
-        'caacattattgttaaaggacagcattagttcacagtcaaacaagcaagattgagaattaa' +
-        'ctttgattttgaacctgaacacccagaggactggagactcaacaaccctaaagcctaggg' +
-        'taaaacattagaaatagtttaaagacaaattgctcggaatcacaaaattccgagtatgga' +
-        'ttctcgtcctcagaaagtctggatgacgccgagtctcactgaatctgacatggattacca' +
-        'caagatcttgacagcaggtctgtccgttcaacaggggattgttcggcaaagagtcatccc' +
-        'agtgtatcaagtaaacaatcttgaggaaatttgccaacttatcatacaggcctttgaagc' +
-        'tggtgttgattttcaagagagtgcggacagtttccttctcatgctttgtcttcatcatgc' +
-        'gtaccaaggagattacaaacttttcttggaaagtggcgcagtcaagt'
-    })
+    const reviewPage = await submissionPage.completeSubmission(
+        {
+            submissionId: 'foobar',
+            collectionCountry: 'France',
+            collectionDate: '2021-05-12',
+            authorAffiliations: 'Patho Institute, Paris',
+        },
+        {
+            main:
+                'nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnntgtgtgcgaataactatga' +
+                'ggaagattaataattttcctnctcattgaaatttatatcggnaatttaaattgaaattgt' +
+                'tactgtaatcatacctggtttgntttcagagccatatcaccaagatagagaacaacctag' +
+                'gtctccggagggggcaagggcatcagtgtgctcagttgaaaatcccttgtcaacatctag' +
+                'gccttatcacatcacaagttccgccttaaactctgcagggtgatccaacaaccttaatag' +
+                'caacattattgttaaaggacagcattagttcacagtcaaacaagcaagattgagaattaa' +
+                'ctttgattttgaacctgaacacccagaggactggagactcaacaaccctaaagcctaggg' +
+                'taaaacattagaaatagtttaaagacaaattgctcggaatcacaaaattccgagtatgga' +
+                'ttctcgtcctcagaaagtctggatgacgccgagtctcactgaatctgacatggattacca' +
+                'caagatcttgacagcaggtctgtccgttcaacaggggattgttcggcaaagagtcatccc' +
+                'agtgtatcaagtaaacaatcttgaggaaatttgccaacttatcatacaggcctttgaagc' +
+                'tggtgttgattttcaagagagtgcggacagtttccttctcatgctttgtcttcatcatgc' +
+                'gtaccaaggagattacaaacttttcttggaaagtggcgcagtcaagt',
+        },
+    );
 
     await reviewPage.waitForZeroProcessing();
     await reviewPage.releaseValidSequences();
-
-    // wait for backend to load the sequence
-    await page.waitForTimeout(35000);
+    await page.getByRole('link', { name: 'released sequences' }).click();
+    while (!(await page.getByRole('link', { name: /LOC_/ }).isVisible())) {
+        await page.reload();
+        await page.waitForTimeout(2000);
+    }
 });

--- a/integration-tests/tests/readonly.setup.ts
+++ b/integration-tests/tests/readonly.setup.ts
@@ -8,7 +8,6 @@ import { v4 as uuidv4 } from 'uuid';
 setup('Initialize a single ebola sequence as base data', async ({ page }) => {
     setup.setTimeout(90000);
     const authPage = new AuthPage(page);
-    await authPage.navigateToRegister();
     const username = uuidv4().substring(0, 8);
     const password = uuidv4().substring(0, 8);
     await authPage.createAccount({

--- a/integration-tests/tests/readonly.setup.ts
+++ b/integration-tests/tests/readonly.setup.ts
@@ -21,7 +21,6 @@ setup('Initialize a single ebola sequence as base data', async ({ page }) => {
     });
 
     const groupPage = new GroupPage(page);
-    await groupPage.navigateToCreateGroupPage();
     await groupPage.createGroup(createTestGroup());
 
     const submissionPage = new SingleSequenceSubmissionPage(page);

--- a/integration-tests/tests/specs/features/download.spec.ts
+++ b/integration-tests/tests/specs/features/download.spec.ts
@@ -3,7 +3,6 @@ import { SearchPage } from '../../pages/search.page';
 const fs = require('fs');
 
 test('Download metadata and check number of cols', async ({ page }) => {
-    test.setTimeout(30000);
     const searchPage = new SearchPage(page);
     await searchPage.ebolaSudan();
 
@@ -36,14 +35,11 @@ test('Download metadata and check number of cols', async ({ page }) => {
     expect(fields).toHaveLength(9);
 });
 
-test('Download metadata with POST and check number of cols', async ({
-    page,
-}) => {
-    test.setTimeout(30000);
+test('Download metadata with POST and check number of cols', async ({ page }) => {
     await page.goto('/');
     const searchPage = new SearchPage(page);
     await searchPage.ebolaSudan();
-    
+
     const loculusId = await searchPage.waitForLoculusId();
     expect(loculusId).toBeTruthy();
 

--- a/integration-tests/tests/specs/features/download.spec.ts
+++ b/integration-tests/tests/specs/features/download.spec.ts
@@ -1,17 +1,11 @@
-import { test } from '../../fixtures/sequence.fixture';
-import { expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { SearchPage } from '../../pages/search.page';
 const fs = require('fs');
 
-test('Download metadata and check number of cols', async ({ pageWithReleasedSequence: page }) => {
-    test.setTimeout(120000);
+test('Download metadata and check number of cols', async ({ page }) => {
+    test.setTimeout(30000);
     const searchPage = new SearchPage(page);
-
-    await page.goto('/');
-    await page.getByRole('link', { name: 'Crimean-Congo Hemorrhagic Fever Virus' }).click();
-
-    const loculusId = await searchPage.waitForLoculusId();
-    expect(loculusId).toBeTruthy();
+    await searchPage.ebolaSudan();
 
     await page.getByRole('button', { name: 'Download all entries' }).click();
     await page.getByLabel('I agree to the data use terms.').check();
@@ -43,14 +37,13 @@ test('Download metadata and check number of cols', async ({ pageWithReleasedSequ
 });
 
 test('Download metadata with POST and check number of cols', async ({
-    pageWithReleasedSequence: page,
+    page,
 }) => {
-    test.setTimeout(120000);
+    test.setTimeout(30000);
     await page.goto('/');
     const searchPage = new SearchPage(page);
-
-    await page.getByRole('link', { name: 'Crimean-Congo Hemorrhagic Fever Virus' }).click();
-
+    await searchPage.ebolaSudan();
+    
     const loculusId = await searchPage.waitForLoculusId();
     expect(loculusId).toBeTruthy();
 

--- a/integration-tests/tests/specs/features/search.spec.ts
+++ b/integration-tests/tests/specs/features/search.spec.ts
@@ -1,12 +1,11 @@
-import { expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { SearchPage } from '../../pages/search.page';
-import { test } from '../../fixtures/sequence.fixture';
 
 test.describe('Search', () => {
     let searchPage: SearchPage;
 
-    test.beforeEach(async ({ pageWithReleasedSequence }) => {
-        searchPage = new SearchPage(pageWithReleasedSequence);
+    test.beforeEach(async ({ page }) => {
+        searchPage = new SearchPage(page);
     });
 
     test('test that search form resets when the reset button is clicked', async ({ page }) => {
@@ -22,7 +21,7 @@ test.describe('Search', () => {
         expect(new URL(page.url()).searchParams.size).toBe(0);
     });
 
-    test('test that filter can be removed by clicking the X', async ({ page, pageWithGroup }) => {
+    test('test that filter can be removed by clicking the X', async ({ page }) => {
         await searchPage.ebolaSudan();
         await searchPage.select('Collection country', 'France');
         await expect(page.getByText('Collection country:France')).toBeVisible();

--- a/integration-tests/tests/specs/features/search.spec.ts
+++ b/integration-tests/tests/specs/features/search.spec.ts
@@ -10,20 +10,20 @@ test.describe('Search', () => {
     });
 
     test('test that search form resets when the reset button is clicked', async ({ page }) => {
-        await searchPage.cchf();
+        await searchPage.ebolaSudan();
 
         await searchPage.select('Collection country', 'France');
         await expect(page.getByText('Collection Country:France')).toBeVisible();
 
-        await searchPage.enterMutation('L:23T');
-        await expect(page.getByText('nucleotideMutations:L:23T')).toBeVisible();
+        await searchPage.enterMutation('A23T');
+        await expect(page.getByText('nucleotideMutations:A23T')).toBeVisible();
 
         await searchPage.resetSearchForm();
         expect(new URL(page.url()).searchParams.size).toBe(0);
     });
 
     test('test that filter can be removed by clicking the X', async ({ page, pageWithGroup }) => {
-        await searchPage.cchf();
+        await searchPage.ebolaSudan();
         await searchPage.select('Collection country', 'France');
         await expect(page.getByText('Collection country:France')).toBeVisible();
         await page.getByLabel('remove filter').click();

--- a/integration-tests/tests/specs/features/sequence-preview-url.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-preview-url.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from '@playwright/test';
 import { SearchPage } from '../../pages/search.page';
 
 test.describe('Sequence Preview URL Parameters', () => {
-
     let searchPage: SearchPage;
 
     test.beforeEach(async ({ page }) => {

--- a/integration-tests/tests/specs/features/sequence-preview-url.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-preview-url.spec.ts
@@ -1,17 +1,16 @@
-import { expect } from '@playwright/test';
-import { test } from '../../fixtures/sequence.fixture';
+import { expect, test } from '@playwright/test';
 import { SearchPage } from '../../pages/search.page';
 
 test.describe('Sequence Preview URL Parameters', () => {
 
     let searchPage: SearchPage;
 
-    test.beforeEach(async ({ pageWithReleasedSequence }) => {
-        searchPage = new SearchPage(pageWithReleasedSequence);
+    test.beforeEach(async ({ page }) => {
+        searchPage = new SearchPage(page);
     });
 
     test('should store the previewed sequence ID in the URL', async ({ page }) => {
-        await searchPage.cchf();
+        await searchPage.ebolaSudan();
 
         let urlParams = await searchPage.getUrlParams();
         expect(urlParams.has('selectedSeq')).toBe(false);
@@ -38,7 +37,7 @@ test.describe('Sequence Preview URL Parameters', () => {
     });
 
     test('should store half-screen state in the URL', async ({ page }) => {
-        await searchPage.cchf();
+        await searchPage.ebolaSudan();
 
         await searchPage.clickOnSequence(0);
 
@@ -61,7 +60,7 @@ test.describe('Sequence Preview URL Parameters', () => {
     });
 
     test('should restore state from URL parameters on page load', async ({ page }) => {
-        await searchPage.cchf();
+        await searchPage.ebolaSudan();
 
         await searchPage.clickOnSequence(0);
         await expect(page.locator('[data-testid="sequence-preview-modal"]')).toBeVisible();

--- a/integration-tests/tests/specs/features/sequence-view.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-view.spec.ts
@@ -30,8 +30,6 @@ test.describe('Sequence view in review card', () => {
             page.getByRole('heading', { name: 'Review current submissions' }),
         ).toBeVisible();
 
-        await page.waitForTimeout(60000);
-
         const reviewPage = new ReviewPage(page);
 
         await reviewPage.waitForZeroProcessing();

--- a/integration-tests/tests/specs/features/submission-flow.spec.ts
+++ b/integration-tests/tests/specs/features/submission-flow.spec.ts
@@ -43,8 +43,10 @@ test.describe('Submission flow', () => {
         await page.getByRole('button', { name: 'Release', exact: true }).click();
         await page.getByRole('link', { name: 'Released Sequences' }).click();
 
-        await page.waitForTimeout(35000);
-        await page.reload();
+        while (!(await page.getByRole('cell', { name: 'Pakistan' }).isVisible())) {
+            await page.reload();
+            await page.waitForTimeout(2000);
+        }
 
         await page.getByRole('cell', { name: 'Pakistan' }).click();
         await page.waitForSelector('text="test_NIHPAK-19"');
@@ -79,8 +81,10 @@ test.describe('Submission flow', () => {
         await page.getByRole('button', { name: 'Release', exact: true }).click();
         await page.getByRole('link', { name: 'Released Sequences' }).click();
 
-        await page.waitForTimeout(35000);
-        await page.reload();
+        while (!(await page.getByRole('cell', { name: 'Colombia' }).isVisible())) {
+            await page.reload();
+            await page.waitForTimeout(2000);
+        }
 
         await page.getByRole('cell', { name: 'Colombia' }).click();
         await page.waitForSelector('text="Research Lab, University of Example"');


### PR DESCRIPTION
A lot of tests do not edit the data, and creating a new group and submitting a sequence for each test slows down the tests a lot.

I added a base project dependency that submits a single sequence of ebola sudan to use in other tests.

I know this breaks the isolation of the tests, but I'd argue the test speed up is well worth it.

I also replaced a bunch of hard-coded timeouts with loops or waits for elements.

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR -->

### Screenshot
<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)
