### PR TITLE
fix: Edit form does not incorrectly drop sequence data anymore.

### DIFF
--- a/website/src/components/Edit/SequencesForm.spec.tsx
+++ b/website/src/components/Edit/SequencesForm.spec.tsx
@@ -3,19 +3,36 @@ import { describe, expect, test } from 'vitest';
 import { EditableSequences } from './SequencesForm';
 import { defaultReviewData } from '../../../vitest.setup';
 
-describe('InputForm', () => {
+describe('SequencesForm', () => {
     test('Empty editable sequences (with names only) produces `undefined`', () => {
         const emptyEditableSequences = EditableSequences.fromSequenceNames(['foo', 'bar']);
         expect(emptyEditableSequences.getSequenceFasta('subId')).toBeUndefined();
     });
 
-    test('GIVEN only a single segment has data THEN the fasta has only that segment', async () => {
+    test('GIVEN a multi-segmented organism and only a single segment has data THEN the fasta has only that segment', async () => {
         let editableSequences = EditableSequences.fromSequenceNames(['foo', 'bar']);
         editableSequences = editableSequences.update({ key: 'foo', value: 'ATCG' });
         const fasta = editableSequences.getSequenceFasta('subId');
         expect(fasta).not.toBeUndefined();
         const fastaText = await fasta!.text();
-        expect(fastaText).toBe('>subId_foo\nATCG');
+        expect.soft(fastaText).toBe('>subId_foo\nATCG');
+
+        const sequenceRecord = Object.entries(editableSequences.getSequenceRecord());
+        expect(sequenceRecord.length).toBe(1);
+        expect(sequenceRecord[0]).toStrictEqual(['foo', 'ATCG']);
+    });
+
+    test('GIVEN a single-segmented organism with segment data THEN the fasta header does not contain the segment name', async () => {
+        let editableSequences = EditableSequences.fromSequenceNames(['foo']);
+        editableSequences = editableSequences.update({ key: 'foo', value: 'ATCG' });
+        const fasta = editableSequences.getSequenceFasta('subId');
+        expect(fasta).not.toBeUndefined();
+        const fastaText = await fasta!.text();
+        expect.soft(fastaText).toBe('>subId\nATCG');
+
+        const sequenceRecord = Object.entries(editableSequences.getSequenceRecord());
+        expect(sequenceRecord.length).toBe(1);
+        expect(sequenceRecord[0]).toStrictEqual(['foo', 'ATCG']);
     });
 
     test('GIVEN initial data with an empty segment THEN the fasta does not contain the empty segment', async () => {
@@ -27,6 +44,23 @@ describe('InputForm', () => {
         const fasta = editableSequences.getSequenceFasta('subId');
         expect(fasta).not.toBeUndefined();
         const fastaText = await fasta!.text();
-        expect(fastaText).toBe('>subId_originalSequenceName\nATCG');
+        expect.soft(fastaText).toBe('>subId_originalSequenceName\nATCG');
+
+        const sequenceRecord = Object.entries(editableSequences.getSequenceRecord());
+        expect(sequenceRecord.length).toBe(1);
+        expect(sequenceRecord[0]).toStrictEqual(['originalSequenceName', 'ATCG']);
+    });
+
+    test('GIVEN initial segment data that is then deleted as an edit THEN the edit record does not contain the segment key', async () => {
+        let editableSequences = EditableSequences.fromInitialData(defaultReviewData, [
+            'originalSequenceName',
+            'anotherSequenceName',
+        ]);
+        editableSequences = editableSequences.update({ key: 'originalSequenceName', value: '' });
+        const fasta = editableSequences.getSequenceFasta('subId');
+        expect(fasta).toBeUndefined();
+
+        const sequenceRecord = Object.entries(editableSequences.getSequenceRecord());
+        expect(sequenceRecord.length).toBe(0);
     });
 });

--- a/website/src/components/Edit/SequencesForm.spec.tsx
+++ b/website/src/components/Edit/SequencesForm.spec.tsx
@@ -51,7 +51,7 @@ describe('SequencesForm', () => {
         expect(sequenceRecord[0]).toStrictEqual(['originalSequenceName', 'ATCG']);
     });
 
-    test('GIVEN initial segment data that is then deleted as an edit THEN the edit record does not contain the segment key', async () => {
+    test('GIVEN initial segment data that is then deleted as an edit THEN the edit record does not contain the segment key', () => {
         let editableSequences = EditableSequences.fromInitialData(defaultReviewData, [
             'originalSequenceName',
             'anotherSequenceName',

--- a/website/src/components/Submission/FileUpload/fileProcessing.ts
+++ b/website/src/components/Submission/FileUpload/fileProcessing.ts
@@ -91,6 +91,9 @@ export const PLAIN_SEGMENT_KIND: FileKind = {
             .filter((l) => !l.startsWith('>'))
             .map((l) => l.trim())
             .join('');
+        if (segmentData.length === 0) {
+            return err(new Error('Uploaded file does not contain segment data.'));
+        }
         return ok({
             inner: () => {
                 const blob = new Blob([segmentData], { type: 'text/plain' });


### PR DESCRIPTION
resolves #3798 

preview URL: https://fix-submission.loculus.org

### Summary
- The data given to the `submit-edit-data` endpoint now does not contain empty strings anymore for sequences that weren't submitted.
- I added some more tests to cover better that component. - Including a test that reproduced the issue.
- I did manual testing to check that the error doesn't show anymore.

### Screenshot


https://github.com/user-attachments/assets/cc307f36-5cfb-4a5c-aaad-33ed700b193f



### PR Checklist
- ~~All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
