### PR TITLE
ui: use 'primary' color for submission form controls

### DIFF
--- a/website/src/components/DataUseTerms/DataUseTermsSelector.tsx
+++ b/website/src/components/DataUseTerms/DataUseTermsSelector.tsx
@@ -79,7 +79,7 @@ const DataUseTermsSelector: FC<DataUseTermsSelectorProps> = ({
                     onChange={() => setSelectedOption(openDataUseTermsOption)}
                     type='radio'
                     checked={selectedOption === openDataUseTermsOption}
-                    className='h-4 w-4 p-2 border-gray-300 text-iteal-600 focus:ring-iteal-600 inline-block'
+                    className='h-4 w-4 p-2 border-gray-300 text-primary-600 focus:ring-primary-600 inline-block'
                 />
                 <label htmlFor='data-use-open' className='ml-2 h-4 p-2 text-sm font-medium leading-6 text-gray-900'>
                     <Unlocked className='h-4 w-4 inline-block mr-2 -mt-1' />
@@ -101,7 +101,7 @@ const DataUseTermsSelector: FC<DataUseTermsSelectorProps> = ({
                     onChange={() => setSelectedOption(restrictedDataUseTermsOption)}
                     type='radio'
                     checked={selectedOption === restrictedDataUseTermsOption}
-                    className='h-4 w-4 border-gray-300 text-iteal-600 focus:ring-iteal-600 inline-block'
+                    className='h-4 w-4 border-gray-300 text-primary-600 focus:ring-primary-600 inline-block'
                 />
                 <label
                     htmlFor='data-use-restricted'

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -310,7 +310,7 @@ const Acknowledgement = ({
                             <input
                                 type='checkbox'
                                 name='confirmation-no-pii'
-                                className='mr-3 ml-1 h-5 w-5 rounded border-gray-300 text-blue focus:ring-blue'
+                                className='mr-3 ml-1 h-5 w-5 rounded border-gray-300 text-primary-600 focus:ring-primary-600'
                                 checked={confirmedNoPII}
                                 onChange={() => setConfirmedNoPII(!confirmedNoPII)}
                             />
@@ -326,7 +326,7 @@ const Acknowledgement = ({
                             <input
                                 type='checkbox'
                                 name='confirmation-INSDC-upload-terms'
-                                className='mr-3 ml-1 h-5 w-5 rounded border-gray-300 text-blue focus:ring-blue'
+                                className='mr-3 ml-1 h-5 w-5 rounded border-gray-300 text-primary-600 focus:ring-primary-600'
                                 checked={agreedToINSDCUploadTerms}
                                 onChange={() => setAgreedToINSDCUploadTerms(!agreedToINSDCUploadTerms)}
                             />


### PR DESCRIPTION
### Summary
- use `primary-600` color for the data use terms selector and the acknowledgement checkboxes

### Screenshot

<img width="920" alt="image" src="https://github.com/user-attachments/assets/efca245c-f184-4c1f-a6de-31bb6b65f99c" />