### PR TITLE
fix(website): fix handling of certain edgecases for the active filter display

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Run Integration test
         run: |
           set -o pipefail
-          cd integration-tests && npx playwright test 2>&1 | tee output.txt
+          cd integration-tests && npx playwright test --workers=4 2>&1 | tee output.txt
           EXIT_CODE=$?
           echo '```' >> $GITHUB_STEP_SUMMARY
           sed -n '/Running [0-9]\+ tests/,$p' output.txt >> $GITHUB_STEP_SUMMARY

--- a/integration-tests/tests/pages/search.page.ts
+++ b/integration-tests/tests/pages/search.page.ts
@@ -29,13 +29,13 @@ export class SearchPage {
     async enableSearchFields(...fieldLabels: string[]) {
         await this.page.getByRole('button', { name: 'Add Search Fields' }).click();
         for (const label of fieldLabels) {
-            await this.page.getByLabel(label).check();
+            await this.page.getByRole('checkbox', { name: label }).check();
         }
         await this.page.getByRole('button', { name: 'Close' }).click();
     }
 
     async fill(fieldLabel: string, value: string) {
-        const field = this.page.getByLabel(fieldLabel);
+        const field = this.page.getByRole('textbox', { name: fieldLabel });
         await field.fill(value);
         await field.press('Enter');
         await this.page.waitForTimeout(900); // how can we better ensure that the filter is applied?

--- a/integration-tests/tests/specs/features/search.spec.ts
+++ b/integration-tests/tests/specs/features/search.spec.ts
@@ -12,9 +12,9 @@ test.describe('Search', () => {
         await searchPage.ebolaSudan();
 
         await searchPage.select('Collection country', 'France');
-        await expect(page.getByText('Collection country:France')).toBeVisible();
         await searchPage.enterMutation('A23T');
-        await expect(page.getByText('nucleotideMutations:A23T')).toBeVisible();
+        await expect.soft(page.getByText('Collection country:France')).toBeVisible();
+        await expect.soft(page.getByText('mutation:A23T')).toBeVisible();
 
         await searchPage.resetSearchForm();
         expect(new URL(page.url()).searchParams.size).toBe(0);
@@ -33,9 +33,9 @@ test.describe('Search', () => {
     test('test that mutation filter can be removed by clicking the X', async ({ page }) => {
         await searchPage.ebolaSudan();
         await searchPage.enterMutation('A23T');
-        await expect(page.getByText('nucleotideMutations:A23T')).toBeVisible();
+        await expect(page.getByText('mutation:A23T')).toBeVisible();
         await page.getByLabel('remove filter').click();
-        await expect(page.getByText('nucleotideMutations:A23T')).not.toBeVisible();
+        await expect(page.getByText('mutation:A23T')).not.toBeVisible();
         expect(new URL(page.url()).searchParams.size).toBe(0);
     });
 

--- a/integration-tests/tests/specs/features/search/active-filters.spec.ts
+++ b/integration-tests/tests/specs/features/search/active-filters.spec.ts
@@ -37,7 +37,7 @@ test.describe('Search', () => {
         await expect(page.getByLabel('Author affiliations')).toBeEmpty();
     });
 
-    test.only('test that date range filter can be removed by clicking the X', async ({ page }) => {
+    test('test that date range filter can be removed by clicking the X', async ({ page }) => {
         await searchPage.ebolaSudan();
 
         await page.getByPlaceholder('dd/MM/yyyy').first().click();

--- a/integration-tests/tests/specs/features/search/active-filters.spec.ts
+++ b/integration-tests/tests/specs/features/search/active-filters.spec.ts
@@ -1,0 +1,52 @@
+import { expect } from "@playwright/test";
+import { test } from "../../../fixtures/auth.fixture";
+import { SearchPage } from "../../../pages/search.page";
+
+test.describe('Search', () => {
+    let searchPage: SearchPage;
+
+    test.beforeEach(async ({ page }) => {
+        searchPage = new SearchPage(page);
+    });
+
+    test('test that country filter can be removed by clicking the X', async ({ page }) => {
+        await searchPage.ebolaSudan();
+        await searchPage.select('Collection country', 'France');
+        await expect(page.getByText('Collection country:France')).toBeVisible();
+        await page.getByLabel('remove filter').click();
+        await expect(page.getByText('Collection country:France')).not.toBeVisible();
+        await expect(page.getByLabel('Collection country')).toBeEmpty();
+        expect(new URL(page.url()).searchParams.size).toBe(0);
+    });
+
+    test('test that mutation filter can be removed by clicking the X', async ({ page }) => {
+        await searchPage.ebolaSudan();
+        await searchPage.enterMutation('A23T');
+        await expect(page.getByText('mutation:A23T')).toBeVisible();
+        await page.getByLabel('remove filter').click();
+        await expect(page.getByText('mutation:A23T')).not.toBeVisible();
+        expect(new URL(page.url()).searchParams.size).toBe(0);
+    });
+
+    test('test that substring-search filter can be removed by clicking the X', async ({ page }) => {
+        await searchPage.ebolaSudan();
+        await searchPage.enableSearchFields('Author affiliations');
+        await searchPage.fill('Author affiliations', 'foo');
+        await expect(page.getByText('Author affiliations:foo')).toBeVisible();
+        await page.getByLabel('remove filter').click();
+        await expect(page.getByLabel('Author affiliations')).toBeEmpty();
+    });
+
+    test.only('test that date range filter can be removed by clicking the X', async ({ page }) => {
+        await searchPage.ebolaSudan();
+
+        await page.getByPlaceholder('dd/MM/yyyy').first().click();
+        await page.getByTestId('calendar').getByText('11', { exact: true }).click();
+        await page.getByRole('button', { name: 'OK' }).click();
+        await expect(page.getByText('Collection date - From:')).toBeVisible();
+
+        await page.locator('div').filter({ hasText: /Collection date - From:/ }).getByLabel('remove filter').click();
+        await expect(page.getByPlaceholder('dd/MM/yyyy').first()).toBeEmpty();
+        expect(new URL(page.url()).searchParams.size).toBe(0);
+    });
+});

--- a/integration-tests/tests/specs/features/search/active-filters.spec.ts
+++ b/integration-tests/tests/specs/features/search/active-filters.spec.ts
@@ -42,7 +42,6 @@ test.describe('Search', () => {
 
         await page.getByPlaceholder('dd/MM/yyyy').first().click();
         await page.getByTestId('calendar').getByText('11', { exact: true }).click();
-        await page.getByRole('button', { name: 'OK' }).click();
         await expect(page.getByText('Collection date - From:')).toBeVisible();
 
         await page.locator('div').filter({ hasText: /Collection date - From:/ }).getByLabel('remove filter').click();

--- a/integration-tests/tests/specs/features/search/download.spec.ts
+++ b/integration-tests/tests/specs/features/search/download.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { SearchPage } from '../../pages/search.page';
+import { SearchPage } from '../../../pages/search.page';
 const fs = require('fs');
 
 test('Download metadata and check number of cols', async ({ page }) => {

--- a/integration-tests/tests/specs/features/search/override-hidden-fields.ts
+++ b/integration-tests/tests/specs/features/search/override-hidden-fields.ts
@@ -1,8 +1,8 @@
 import { expect } from '@playwright/test';
-import { test } from '../../fixtures/group.fixture';
-import { ReviewPage } from '../../pages/review.page';
-import { SearchPage } from '../../pages/search.page';
-import { SingleSequenceSubmissionPage } from '../../pages/singlesubmission.page';
+import { test } from '../../../fixtures/group.fixture';
+import { ReviewPage } from '../../../pages/review.page';
+import { SearchPage } from '../../../pages/search.page';
+import { SingleSequenceSubmissionPage } from '../../../pages/singlesubmission.page';
 import { v4 as uuidv4 } from 'uuid';
 
 test('test', async ({ page, pageWithGroup }) => {

--- a/integration-tests/tests/specs/features/search/search.spec.ts
+++ b/integration-tests/tests/specs/features/search/search.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { SearchPage } from '../../pages/search.page';
+import { SearchPage } from '../../../pages/search.page';
 
 test.describe('Search', () => {
     let searchPage: SearchPage;
@@ -17,25 +17,6 @@ test.describe('Search', () => {
         await expect.soft(page.getByText('mutation:A23T')).toBeVisible();
 
         await searchPage.resetSearchForm();
-        expect(new URL(page.url()).searchParams.size).toBe(0);
-    });
-
-    test('test that filter can be removed by clicking the X', async ({ page }) => {
-        await searchPage.ebolaSudan();
-        await searchPage.select('Collection country', 'France');
-        await expect(page.getByText('Collection country:France')).toBeVisible();
-        await page.getByLabel('remove filter').click();
-        await expect(page.getByText('Collection country:France')).not.toBeVisible();
-        await expect(page.getByLabel('Collection country')).toBeEmpty();
-        expect(new URL(page.url()).searchParams.size).toBe(0);
-    });
-
-    test('test that mutation filter can be removed by clicking the X', async ({ page }) => {
-        await searchPage.ebolaSudan();
-        await searchPage.enterMutation('A23T');
-        await expect(page.getByText('mutation:A23T')).toBeVisible();
-        await page.getByLabel('remove filter').click();
-        await expect(page.getByText('mutation:A23T')).not.toBeVisible();
         expect(new URL(page.url()).searchParams.size).toBe(0);
     });
 

--- a/website/src/components/SearchPage/DownloadDialog/SequenceFilters.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/SequenceFilters.tsx
@@ -158,18 +158,18 @@ export class FieldFilterSet implements SequenceFilter {
         return result;
     }
 
+    private isHiddenFieldValue(fieldName: string, fieldValue: unknown) {
+        return (
+            Object.keys(this.hiddenFieldValues).includes(fieldName) && this.hiddenFieldValues[fieldName] === fieldValue
+        );
+    }
+
     public toDisplayStrings(): Map<string, [string, string]> {
-        const lapisSearchParameters = this.toApiParams(); // TODO we probably want to change this to this.fieldValues
         return new Map(
-            Object.entries(lapisSearchParameters)
-                .filter((vals) => vals[1] !== undefined && vals[1] !== '')
-                .filter(
-                    ([name, val]) =>
-                        !(Object.keys(this.hiddenFieldValues).includes(name) && this.hiddenFieldValues[name] === val),
-                )
-                .map(([name, filterValue]) => ({ name, filterValue: filterValue !== null ? filterValue : '' }))
-                .filter(({ filterValue }) => filterValue.length > 0)
-                .map(({ name, filterValue }): [string, [string, string]] => [
+            Object.entries(this.fieldValues)
+                // .filter(([, filterValue]) => filterValue !== null && filterValue !== '')
+                .filter(([name, filterValue]) => !this.isHiddenFieldValue(name, filterValue))
+                .map(([name, filterValue]): [string, [string, string]] => [
                     name,
                     [this.filterSchema.getLabel(name), this.filterValueDisplayString(name, filterValue)],
                 ]),
@@ -177,18 +177,15 @@ export class FieldFilterSet implements SequenceFilter {
     }
 
     private filterValueDisplayString(fieldName: string, value: any): string {
+        let result = value;
         if (this.filterSchema.getType(fieldName) === 'timestamp') {
             const date = new Date(Number(value) * 1000);
-            return date.toISOString().split('T')[0]; // Extract YYYY-MM-DD
+            result = date.toISOString().split('T')[0]; // Extract YYYY-MM-DD
         }
-        if (Array.isArray(value)) {
-            let stringified = value.join(', ');
-            if (stringified.length > 40) {
-                stringified = `${stringified.substring(0, 37)}...`;
-            }
-            return stringified;
+        if (result.length > 40) {
+            result = `${result.substring(0, 37)}...`;
         }
-        return value;
+        return result;
     }
 }
 /* eslint-enable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */

--- a/website/src/components/SearchPage/DownloadDialog/SequenceFilters.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/SequenceFilters.tsx
@@ -167,7 +167,6 @@ export class FieldFilterSet implements SequenceFilter {
     public toDisplayStrings(): Map<string, [string, string]> {
         return new Map(
             Object.entries(this.fieldValues)
-                // .filter(([, filterValue]) => filterValue !== null && filterValue !== '')
                 .filter(([name, filterValue]) => !this.isHiddenFieldValue(name, filterValue))
                 .map(([name, filterValue]): [string, [string, string]] => [
                     name,

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -21,7 +21,6 @@ import { type OrderBy } from '../../types/lapis.ts';
 import type { ReferenceGenomesSequenceNames } from '../../types/referencesGenomes.ts';
 import type { ClientConfig } from '../../types/runtimeConfig.ts';
 import { formatNumberWithDefaultLocale } from '../../utils/formatNumber.tsx';
-import { removeMutationQueries } from '../../utils/mutation.ts';
 import {
     getColumnVisibilitiesFromQuery,
     getFieldVisibilitiesFromQuery,
@@ -198,6 +197,14 @@ export const InnerSearchFullUI = ({
         [setState, setPage],
     );
 
+    const removeFilter = (metadataFilterName: string) => {
+        if (Object.keys(hiddenFieldValues).includes(metadataFilterName)) {
+            setSomeFieldValues([metadataFilterName, hiddenFieldValues[metadataFilterName]]);
+        } else {
+            setSomeFieldValues([metadataFilterName, null]);
+        }
+    };
+
     const setASearchVisibility = (fieldName: string, visible: boolean) => {
         setState((prev: any) => ({
             ...prev,
@@ -248,57 +255,6 @@ export const InnerSearchFullUI = ({
      * Some values are modified slightly or expanded based on field definitions.
      */
     const lapisSearchParameters = useMemo(() => tableFilter.toApiParams(), [tableFilter]);
-
-    const removeFilter = (key: string) => {
-        switch (key) {
-            case 'nucleotideMutations':
-                setSomeFieldValues([
-                    'mutation',
-                    removeMutationQueries(
-                        fieldValues.mutation!,
-                        referenceGenomesSequenceNames,
-                        'nucleotide',
-                        'substitutionOrDeletion',
-                    ),
-                ]);
-                break;
-            case 'aminoAcidMutations':
-                setSomeFieldValues([
-                    'mutation',
-                    removeMutationQueries(
-                        fieldValues.mutation!,
-                        referenceGenomesSequenceNames,
-                        'aminoAcid',
-                        'substitutionOrDeletion',
-                    ),
-                ]);
-                break;
-            case 'nucleotideInsertions':
-                setSomeFieldValues([
-                    'mutation',
-                    removeMutationQueries(
-                        fieldValues.mutation!,
-                        referenceGenomesSequenceNames,
-                        'nucleotide',
-                        'insertion',
-                    ),
-                ]);
-                break;
-            case 'aminoAcidInsertions':
-                setSomeFieldValues([
-                    'mutation',
-                    removeMutationQueries(
-                        fieldValues.mutation!,
-                        referenceGenomesSequenceNames,
-                        'aminoAcid',
-                        'insertion',
-                    ),
-                ]);
-                break;
-            default:
-                setSomeFieldValues([key, null]);
-        }
-    };
 
     const downloadFilter: SequenceFilter = sequencesSelected ? new SequenceEntrySelection(selectedSeqs) : tableFilter;
 

--- a/website/src/components/SearchPage/fields/DateField.spec.tsx
+++ b/website/src/components/SearchPage/fields/DateField.spec.tsx
@@ -44,7 +44,6 @@ describe('TimestampField', () => {
         const input = screen.getByRole('textbox');
         await userEvent.type(input, '17032025');
         expect(input).toHaveValue('17/03/2025');
-        expect(setSomeFieldValues).toHaveBeenCalledTimes(8);
         expect(setSomeFieldValues).lastCalledWith(['releasedAtTimestampFrom', '1742169600']);
     });
 
@@ -81,7 +80,6 @@ describe('TimestampField', () => {
         const input = screen.getByRole('textbox');
         await userEvent.type(input, '17032025');
         expect(input).toHaveValue('17/03/2025');
-        expect(setSomeFieldValues).toHaveBeenCalledTimes(8);
         expect(setSomeFieldValues).lastCalledWith(['releasedAtTimestampTo', '1742255999']);
     });
 });

--- a/website/src/components/SearchPage/fields/DateField.tsx
+++ b/website/src/components/SearchPage/fields/DateField.tsx
@@ -67,7 +67,7 @@ const CustomizedDatePicker: FC<CustomizedDatePickerProps> = ({
     valueToDateConverter,
     fieldValue,
 }) => {
-    const dateValue = fieldValue !== '' ? valueToDateConverter(fieldValue.toString()) : undefined;
+    const dateValue = fieldValue !== '' ? valueToDateConverter(fieldValue.toString()) : null;
     return (
         <div>
             <div className='flex justify-between items-center'>
@@ -77,7 +77,7 @@ const CustomizedDatePicker: FC<CustomizedDatePickerProps> = ({
                 <DatePicker
                     value={dateValue}
                     name={field.name}
-                    key={`${field.name}-${fieldValue}`}  // key set to force rerender when value changes
+                    key={field.name}
                     isoWeek={true}
                     oneTap={true}
                     onChange={(date) => {

--- a/website/src/components/SearchPage/fields/DateField.tsx
+++ b/website/src/components/SearchPage/fields/DateField.tsx
@@ -78,6 +78,7 @@ const CustomizedDatePicker: FC<CustomizedDatePickerProps> = ({
                     value={dateValue}
                     name={field.name}
                     key={field.name}
+                    isoWeek={true}
                     onChange={(date) => {
                         if (date) {
                             setSomeFieldValues([field.name, dateToValueConverter(date)]);

--- a/website/src/components/SearchPage/fields/DateField.tsx
+++ b/website/src/components/SearchPage/fields/DateField.tsx
@@ -20,10 +20,17 @@ export const DateField: FC<Omit<CustomizedDatePickerProps, 'dateToValueConverter
         {...props}
         dateToValueConverter={(date) => {
             if (!date) return '';
+            console.log(`foo: ${date}`);
             const isoDate = DateTime.fromJSDate(date).setZone('utc', { keepLocalTime: true }).toISODate();
+            console.log(`iso: ${isoDate}`);
             return isoDate ?? '';
         }}
-        valueToDateConverter={(value) => (value ? DateTime.fromISO(value, { zone: 'utc' }).toJSDate() : undefined)}
+        valueToDateConverter={(value) => {
+            console.log(`value: ${value}`);
+            console.log(`bla: ${DateTime.fromISO(value).setZone('local', { keepLocalTime: true })}`);
+            return (value ? DateTime.fromISO(value).setZone('local', { keepLocalTime: true }).toJSDate() : undefined);
+        }
+        }
     />
 );
 

--- a/website/src/components/SearchPage/fields/DateField.tsx
+++ b/website/src/components/SearchPage/fields/DateField.tsx
@@ -4,6 +4,7 @@ import { DatePicker } from 'rsuite';
 
 import 'rsuite/DatePicker/styles/index.css';
 import { type MetadataFilter, type SetSomeFieldValues } from '../../../types/config';
+import useClientFlag from '../../../hooks/isClient';
 
 type CustomizedDatePickerProps = {
     field: MetadataFilter;
@@ -67,6 +68,7 @@ const CustomizedDatePicker: FC<CustomizedDatePickerProps> = ({
     valueToDateConverter,
     fieldValue,
 }) => {
+    const isClient = useClientFlag();
     const dateValue = fieldValue !== '' ? valueToDateConverter(fieldValue.toString()) : null;
     return (
         <div>
@@ -79,6 +81,7 @@ const CustomizedDatePicker: FC<CustomizedDatePickerProps> = ({
                     name={field.name}
                     key={field.name}
                     isoWeek={true}
+                    oneTap={true}
                     onChange={(date) => {
                         if (date) {
                             setSomeFieldValues([field.name, dateToValueConverter(date)]);
@@ -89,6 +92,7 @@ const CustomizedDatePicker: FC<CustomizedDatePickerProps> = ({
                     onClean={() => {
                         setSomeFieldValues([field.name, '']);
                     }}
+                    disabled={!isClient}
                 />
             </div>
         </div>

--- a/website/src/components/SearchPage/fields/DateField.tsx
+++ b/website/src/components/SearchPage/fields/DateField.tsx
@@ -20,12 +20,10 @@ export const DateField: FC<Omit<CustomizedDatePickerProps, 'dateToValueConverter
         {...props}
         dateToValueConverter={(date) => {
             if (!date) return '';
-            const isoDate = DateTime.fromJSDate(date).toISO()?.split('T')[0];
+            const isoDate = DateTime.fromJSDate(date).toISODate();
             return isoDate ?? '';
         }}
-        valueToDateConverter={(value) => {
-            return value ? DateTime.fromISO(value).toJSDate() : undefined;
-        }}
+        valueToDateConverter={(value) => (value ? DateTime.fromISO(value).toJSDate() : undefined)}
     />
 );
 

--- a/website/src/components/SearchPage/fields/DateField.tsx
+++ b/website/src/components/SearchPage/fields/DateField.tsx
@@ -20,10 +20,10 @@ export const DateField: FC<Omit<CustomizedDatePickerProps, 'dateToValueConverter
         {...props}
         dateToValueConverter={(date) => {
             if (!date) return '';
-            const isoDate = DateTime.fromJSDate(date).toISODate();
+            const isoDate = DateTime.fromJSDate(date).setZone('utc', { keepLocalTime: true }).toISODate();
             return isoDate ?? '';
         }}
-        valueToDateConverter={(value) => (value ? DateTime.fromISO(value).toJSDate() : undefined)}
+        valueToDateConverter={(value) => (value ? DateTime.fromISO(value, { zone: 'utc' }).toJSDate() : undefined)}
     />
 );
 
@@ -78,8 +78,6 @@ const CustomizedDatePicker: FC<CustomizedDatePickerProps> = ({
                     value={dateValue}
                     name={field.name}
                     key={field.name}
-                    isoWeek={true}
-                    oneTap={true}
                     onChange={(date) => {
                         if (date) {
                             setSomeFieldValues([field.name, dateToValueConverter(date)]);

--- a/website/src/components/SearchPage/fields/DateField.tsx
+++ b/website/src/components/SearchPage/fields/DateField.tsx
@@ -20,17 +20,12 @@ export const DateField: FC<Omit<CustomizedDatePickerProps, 'dateToValueConverter
         {...props}
         dateToValueConverter={(date) => {
             if (!date) return '';
-            console.log(`foo: ${date}`);
-            const isoDate = DateTime.fromJSDate(date).setZone('utc', { keepLocalTime: true }).toISODate();
-            console.log(`iso: ${isoDate}`);
+            const isoDate = DateTime.fromJSDate(date).toISO()?.split('T')[0];
             return isoDate ?? '';
         }}
         valueToDateConverter={(value) => {
-            console.log(`value: ${value}`);
-            console.log(`bla: ${DateTime.fromISO(value).setZone('local', { keepLocalTime: true })}`);
-            return (value ? DateTime.fromISO(value).setZone('local', { keepLocalTime: true }).toJSDate() : undefined);
-        }
-        }
+            return value ? DateTime.fromISO(value).toJSDate() : undefined;
+        }}
     />
 );
 

--- a/website/src/components/SearchPage/fields/DateField.tsx
+++ b/website/src/components/SearchPage/fields/DateField.tsx
@@ -67,6 +67,7 @@ const CustomizedDatePicker: FC<CustomizedDatePickerProps> = ({
     valueToDateConverter,
     fieldValue,
 }) => {
+    const dateValue = fieldValue !== '' ? valueToDateConverter(fieldValue.toString()) : undefined;
     return (
         <div>
             <div className='flex justify-between items-center'>
@@ -74,9 +75,11 @@ const CustomizedDatePicker: FC<CustomizedDatePickerProps> = ({
                     {field.label}
                 </label>
                 <DatePicker
+                    value={dateValue}
                     name={field.name}
-                    defaultValue={fieldValue !== '' ? valueToDateConverter(fieldValue.toString()) : undefined}
-                    key={field.name}
+                    key={`${field.name}-${fieldValue}`}  // key set to force rerender when value changes
+                    isoWeek={true}
+                    oneTap={true}
                     onChange={(date) => {
                         if (date) {
                             setSomeFieldValues([field.name, dateToValueConverter(date)]);

--- a/website/src/components/SearchPage/fields/DateField.tsx
+++ b/website/src/components/SearchPage/fields/DateField.tsx
@@ -3,8 +3,8 @@ import type { FC } from 'react';
 import { DatePicker } from 'rsuite';
 
 import 'rsuite/DatePicker/styles/index.css';
-import { type MetadataFilter, type SetSomeFieldValues } from '../../../types/config';
 import useClientFlag from '../../../hooks/isClient';
+import { type MetadataFilter, type SetSomeFieldValues } from '../../../types/config';
 
 type CustomizedDatePickerProps = {
     field: MetadataFilter;

--- a/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
+++ b/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
@@ -130,6 +130,9 @@ describe('DateRangeField', () => {
     });
 
     it('updates query params if user types in new dates', async () => {
+        // this line fixes the test for me locally, but it makes no sense to me at all.
+        Settings.defaultZone = Settings.defaultZone.name;
+
         render(
             <DateRangeField
                 field={field}

--- a/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
+++ b/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
@@ -131,6 +131,9 @@ describe('DateRangeField', () => {
 
     it('updates query params if user types in new dates', async () => {
         // this line fixes the test for me locally, but it makes no sense to me at all.
+        // I have asked about this here: https://github.com/moment/luxon/issues/1691
+        // The tests run fine in the CI and there are also no issues in the browser. 
+        // I suspect it is nothing to worry about.
         Settings.defaultZone = Settings.defaultZone.name;
 
         render(

--- a/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
+++ b/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
@@ -132,7 +132,7 @@ describe('DateRangeField', () => {
     it('updates query params if user types in new dates', async () => {
         // this line fixes the test for me locally, but it makes no sense to me at all.
         // I have asked about this here: https://github.com/moment/luxon/issues/1691
-        // The tests run fine in the CI and there are also no issues in the browser. 
+        // The tests run fine in the CI and there are also no issues in the browser.
         // I suspect it is nothing to worry about.
         Settings.defaultZone = Settings.defaultZone.name;
 

--- a/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
+++ b/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import { DateRangeField } from './DateRangeField';
 import { type GroupedMetadataFilter, type FieldValues } from '../../../types/config';
+import { DateTime, Settings } from 'luxon';
 
 describe('DateRangeField', () => {
     function createRangeOverlapSearch(bound: 'lower' | 'upper') {
@@ -137,13 +138,17 @@ describe('DateRangeField', () => {
             />,
         );
 
+        Settings.defaultZone = 'Europe/berlin';
+
         const fromInput = screen.getByText('From').closest('div')?.querySelector('input');
         const toInput = screen.getByText('To').closest('div')?.querySelector('input');
 
         expect(fromInput).not.toBeNull();
         expect(toInput).not.toBeNull();
 
+        await userEvent.type(fromInput!, '{backspace}');
         await userEvent.type(fromInput!, '02022002');
+        await userEvent.type(toInput!, '{backspace}');
         await userEvent.type(toInput!, '03032003');
 
         expect(setSomeFieldValues).toHaveBeenLastCalledWith(

--- a/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
+++ b/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
@@ -1,10 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Settings } from 'luxon';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import { DateRangeField } from './DateRangeField';
 import { type GroupedMetadataFilter, type FieldValues } from '../../../types/config';
-import { DateTime, Settings } from 'luxon';
 
 describe('DateRangeField', () => {
     function createRangeOverlapSearch(bound: 'lower' | 'upper') {
@@ -137,8 +137,6 @@ describe('DateRangeField', () => {
                 setSomeFieldValues={setSomeFieldValues}
             />,
         );
-
-        Settings.defaultZone = 'Europe/berlin';
 
         const fromInput = screen.getByText('From').closest('div')?.querySelector('input');
         const toInput = screen.getByText('To').closest('div')?.querySelector('input');

--- a/website/src/components/SearchPage/fields/DateRangeField.tsx
+++ b/website/src/components/SearchPage/fields/DateRangeField.tsx
@@ -12,7 +12,7 @@ export type DateRangeFieldProps = {
 
 /**
  * Whether to use strict mode or not is defined based on the fields that are given.
- * `undefined` is returned if an ambiguous combiation of fields is defined.
+ * `true` is returned if an ambiguous combiation of fields is defined.
  */
 function isStrictMode(
     lowerFromDefined: boolean,
@@ -25,7 +25,7 @@ function isStrictMode(
     } else if ((lowerToDefined || upperFromDefined) && !lowerFromDefined && !upperToDefined) {
         return false;
     } else {
-        return true; // default to true if we the inputs don't make sense
+        return true; // default to true if the inputs don't make sense
     }
 }
 

--- a/website/src/components/SearchPage/fields/DateRangeField.tsx
+++ b/website/src/components/SearchPage/fields/DateRangeField.tsx
@@ -53,6 +53,19 @@ export const DateRangeField = ({ field, fieldValues, setSomeFieldValues }: DateR
     const [upperValue, setUpperValue] = useState(fieldValues[upperField.name] ?? '');
 
     useEffect(() => {
+        setStrictMode(
+            isStrictMode(
+                lowerFromField.name in fieldValues,
+                lowerToField.name in fieldValues,
+                upperFromField.name in fieldValues,
+                upperToField.name in fieldValues,
+            ),
+        );
+        setLowerValue(fieldValues[lowerField.name] ?? '');
+        setUpperValue(fieldValues[upperField.name] ?? '');
+    }, [field, fieldValues]);
+
+    useEffect(() => {
         if (strictMode) {
             setSomeFieldValues(
                 [lowerFromField.name, lowerValue],

--- a/website/src/components/SearchPage/fields/NormalTextField.tsx
+++ b/website/src/components/SearchPage/fields/NormalTextField.tsx
@@ -1,8 +1,8 @@
 import { forwardRef, type FocusEventHandler } from 'react';
 
 import { TextField } from './TextField';
-import type { MetadataFilter, SetSomeFieldValues } from '../../../types/config.ts';
 import useClientFlag from '../../../hooks/isClient.ts';
+import type { MetadataFilter, SetSomeFieldValues } from '../../../types/config.ts';
 
 export type NormalFieldProps = {
     field: MetadataFilter;

--- a/website/src/components/SearchPage/fields/NormalTextField.tsx
+++ b/website/src/components/SearchPage/fields/NormalTextField.tsx
@@ -2,6 +2,7 @@ import { forwardRef, type FocusEventHandler } from 'react';
 
 import { TextField } from './TextField';
 import type { MetadataFilter, SetSomeFieldValues } from '../../../types/config.ts';
+import useClientFlag from '../../../hooks/isClient.ts';
 
 export type NormalFieldProps = {
     field: MetadataFilter;
@@ -15,6 +16,7 @@ export type NormalFieldProps = {
 
 export const NormalTextField = forwardRef<HTMLInputElement, NormalFieldProps>((props, ref) => {
     const { field, setSomeFieldValues, multiline, onFocus, onBlur, fieldValue } = props;
+    const isClient = useClientFlag();
 
     return (
         <TextField
@@ -27,6 +29,7 @@ export const NormalTextField = forwardRef<HTMLInputElement, NormalFieldProps>((p
             autoComplete='off'
             multiline={multiline}
             ref={ref}
+            disabled={!isClient}
         />
     );
 });

--- a/website/src/components/common/ActiveFilters.spec.tsx
+++ b/website/src/components/common/ActiveFilters.spec.tsx
@@ -75,6 +75,27 @@ describe('ActiveFilters', () => {
             expect(screen.queryByText('2025-03-18')).toBeInTheDocument();
             expect(screen.queryByText('1742288104')).not.toBeInTheDocument();
         });
+
+        it('render substring-search fields correctly', () => {
+            render(
+                <ActiveFilters
+                    sequenceFilter={
+                        new FieldFilterSet(
+                            new MetadataFilterSchema([
+                                { name: 'authorAffiliations', type: 'string', substringSearch: true },
+                            ]),
+                            { authorAffiliations: 'foo' },
+                            {},
+                            { nucleotideSequences: [], genes: [], insdcAccessionFull: [] },
+                        )
+                    }
+                />,
+            );
+
+            screen.debug();
+            expect(screen.queryByText('authorAffiliations:')).toBeInTheDocument();
+            expect(screen.queryByText('authorAffiliations.regex:')).not.toBeInTheDocument();
+        });
     });
 
     describe('with selected sequences', () => {

--- a/website/src/components/common/ActiveFilters.tsx
+++ b/website/src/components/common/ActiveFilters.tsx
@@ -19,7 +19,11 @@ export const ActiveFilters: FC<ActiveFiltersProps> = ({ sequenceFilter, removeFi
                     className='border-primary-600 rounded-sm border border-l-primary-600 bg-gray-100 border-l-8 pl-3 py-1 text-sm flex flex-row'
                 >
                     <span className='text-primary-900 font-light pr-1'>{label}:</span>
-                    <span className='text-primary-900 font-semibold'>{value}</span>
+                    {value === '' ? (
+                        <span className='text-primary-900 italic'>unset</span>
+                    ) : (
+                        <span className='text-primary-900 font-semibold'>{value}</span>
+                    )}
                     {showXButton ? (
                         <button
                             aria-label='remove filter'

--- a/website/src/components/common/ActiveFilters.tsx
+++ b/website/src/components/common/ActiveFilters.tsx
@@ -20,7 +20,7 @@ export const ActiveFilters: FC<ActiveFiltersProps> = ({ sequenceFilter, removeFi
                 >
                     <span className='text-primary-900 font-light pr-1'>{label}:</span>
                     {value === '' ? (
-                        <span className='text-primary-900 italic'>unset</span>
+                        <span className='text-primary-900 italic'>any</span>
                     ) : (
                         <span className='text-primary-900 font-semibold'>{value}</span>
                     )}


### PR DESCRIPTION
resolves #3857 

preview URL: https://improve-filters.loculus.org

### Summary
- "Is revocation" and "version status" were previously not shown if unset, but also not shown if set (because it's a hidden default). Now the fields are shown when unset, and clicking the "x" button will reset it to the hidden field value.
- for substring-search-enabled fields, the active filter showed "<fieldname>.regex: (i?)<value>" because the lapisSearchParameters were used. This is now not the case anymore.
- A small 'regression': previously, mutations were shown split into "nucleotide" and "aminoacid" etc, but now this isn't done anymore.
- date fields
	- use Monday as the start of the week. 
	- use `oneTap` -> no more clicking "OK" to confirm a date selection.
- date range field now also suppors 'x'-ing in the active filters.
- increase integration test worker count from default (2) to 4.

#### Manual testing

I checked that the _Author affiliations_ field (which uses substring search) renders correctly in the active filters. I tested that that field, as well as dates, date ranges, mutations, all are possible to remove via the active filters panel.

#### Added tests
- added integration tests to check that the fields can be removed
- added unit tests for date range field

### Screenshot

#### Every field clears

https://github.com/user-attachments/assets/a711fb20-e88b-40b5-9def-b9d9cb044178

#### New handling of hidden fields

https://github.com/user-attachments/assets/8f0ed2e8-53df-464d-9b98-d155ac2e2278


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
