### PR TITLE
feat!(deployment): Standardize image config in Helm Chart

### DIFF
--- a/docs/src/content/docs/reference/helm-chart-config.mdx
+++ b/docs/src/content/docs/reference/helm-chart-config.mdx
@@ -103,3 +103,7 @@ For [our ingest pipeline](https://github.com/loculus-project/loculus/tree/main/i
 ### Gene (type)
 
 <SchemaDocs group='gene' fieldColumnClass='w-48' />
+
+### Image spec (type)
+
+<SchemaDocs group='image' fieldColumnClass='w-48' />

--- a/kubernetes/loculus/templates/lapis-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- include "loculus.configProcessor" (dict "name" "lapis-silo-database-config" "dockerTag" $dockerTag) | nindent 8 }}
       containers:
         - name: lapis
-          image: "{{ $.Values.images.lapis.repository }}:{{ $.Values.images.lapis.tag | default "latest" }}"
+          image: "{{ $.Values.images.lapis.repository }}:{{ $.Values.images.lapis.tag }}"
           imagePullPolicy: "{{ $.Values.images.lapis.pullPolicy }}"
           {{- include "loculus.resources" (list "lapis" $.Values $key) | nindent 10 }}
           ports:

--- a/kubernetes/loculus/templates/lapis-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- include "loculus.configProcessor" (dict "name" "lapis-silo-database-config" "dockerTag" $dockerTag) | nindent 8 }}
       containers:
         - name: lapis
-          image: {{ $.Values.images.lapis }}
+          image: {{ $.Values.images.lapis.repository }}{{ $.Values.images.lapis.tag }}
           {{- include "loculus.resources" (list "lapis" $.Values $key) | nindent 10 }}
           ports:
             - containerPort: 8080

--- a/kubernetes/loculus/templates/lapis-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-deployment.yaml
@@ -26,6 +26,7 @@ spec:
       containers:
         - name: lapis
           image: "{{ $.Values.images.lapis.repository }}:{{ $.Values.images.lapis.tag }}"
+          imagePullPolicy: "{{ $.Values.images.lapis.pullPolicy }}"
           {{- include "loculus.resources" (list "lapis" $.Values $key) | nindent 10 }}
           ports:
             - containerPort: 8080

--- a/kubernetes/loculus/templates/lapis-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- include "loculus.configProcessor" (dict "name" "lapis-silo-database-config" "dockerTag" $dockerTag) | nindent 8 }}
       containers:
         - name: lapis
-          image: {{ $.Values.images.lapis.repository }}{{ $.Values.images.lapis.tag }}
+          image: "{{ $.Values.images.lapis.repository }}:{{ $.Values.images.lapis.tag }}"
           {{- include "loculus.resources" (list "lapis" $.Values $key) | nindent 10 }}
           ports:
             - containerPort: 8080

--- a/kubernetes/loculus/templates/lapis-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- include "loculus.configProcessor" (dict "name" "lapis-silo-database-config" "dockerTag" $dockerTag) | nindent 8 }}
       containers:
         - name: lapis
-          image: "{{ $.Values.images.lapis.repository }}:{{ $.Values.images.lapis.tag }}"
+          image: "{{ $.Values.images.lapis.repository }}:{{ $.Values.images.lapis.tag | default "latest" }}"
           imagePullPolicy: "{{ $.Values.images.lapis.pullPolicy }}"
           {{- include "loculus.resources" (list "lapis" $.Values $key) | nindent 10 }}
           ports:

--- a/kubernetes/loculus/templates/loculus-backend.yaml
+++ b/kubernetes/loculus/templates/loculus-backend.yaml
@@ -25,7 +25,7 @@ spec:
 {{- include "loculus.configProcessor" (dict "name" "loculus-backend-config" "dockerTag" $dockerTag) | nindent 8 }}
       containers:
         - name: backend
-          image: "ghcr.io/loculus-project/backend:{{ $dockerTag }}"
+          image: "{{ if $.Values.images.backend }}{{ $.Values.images.backend.repository }}:{{ $.Values.images.backend.tag }}{{ else }}ghcr.io/loculus-project/backend:{{ $dockerTag }}{{ end }}"
           imagePullPolicy: Always
           {{- include "loculus.resources" (list "backend" $.Values) | nindent 10 }}
           livenessProbe:

--- a/kubernetes/loculus/templates/loculus-backend.yaml
+++ b/kubernetes/loculus/templates/loculus-backend.yaml
@@ -25,8 +25,8 @@ spec:
 {{- include "loculus.configProcessor" (dict "name" "loculus-backend-config" "dockerTag" $dockerTag) | nindent 8 }}
       containers:
         - name: backend
-          image: "{{ with $.Values.images.backend }}{{ .repository }}:{{ .tag }}{{ else }}ghcr.io/loculus-project/backend:{{ $dockerTag }}{{ end }}"
-          imagePullPolicy: "{{ with index $.Values.images "backend" }}{{ .pullPolicy | default "Always" }}{{ else }}Always{{ end }}"
+          image: "{{ $.Values.images.backend.repository }}:{{ $.Values.images.backend.tag | default $dockerTag }}"
+          imagePullPolicy: "{{ $.Values.images.backend.pullPolicy }}"
           {{- include "loculus.resources" (list "backend" $.Values) | nindent 10 }}
           livenessProbe:
             httpGet:

--- a/kubernetes/loculus/templates/loculus-backend.yaml
+++ b/kubernetes/loculus/templates/loculus-backend.yaml
@@ -25,8 +25,8 @@ spec:
 {{- include "loculus.configProcessor" (dict "name" "loculus-backend-config" "dockerTag" $dockerTag) | nindent 8 }}
       containers:
         - name: backend
-          image: "{{ if $.Values.images.backend }}{{ $.Values.images.backend.repository }}:{{ $.Values.images.backend.tag }}{{ else }}ghcr.io/loculus-project/backend:{{ $dockerTag }}{{ end }}"
-          imagePullPolicy: Always
+          image: "{{ with $.Values.images.backend }}{{ .repository }}:{{ .tag }}{{ else }}ghcr.io/loculus-project/backend:{{ $dockerTag }}{{ end }}"
+          imagePullPolicy: "{{ with index $.Values.images "backend" }}{{ .pullPolicy | default "Always" }}{{ else }}Always{{ end }}"
           {{- include "loculus.resources" (list "backend" $.Values) | nindent 10 }}
           livenessProbe:
             httpGet:

--- a/kubernetes/loculus/templates/loculus-website.yaml
+++ b/kubernetes/loculus/templates/loculus-website.yaml
@@ -25,8 +25,8 @@ spec:
 {{- include "loculus.configProcessor" (dict "name" "loculus-website-config" "dockerTag" $dockerTag) | nindent 8 }}
       containers:
         - name: website
-          image: "{{ if $.Values.images.website }}{{ $.Values.images.website.repository }}:{{ $.Values.images.website.tag }}{{ else }}ghcr.io/loculus-project/website:{{ $dockerTag }}{{ end }}"
-          imagePullPolicy: Always
+          image: "{{ with index $.Values.images "website" }}{{ .repository }}:{{ .tag }}{{ else }}ghcr.io/loculus-project/website:{{ $dockerTag }}{{ end }}"
+          imagePullPolicy: "{{ with index $.Values.images "website" }}{{ .pullPolicy | default "Always" }}{{ else }}Always{{ end }}"
           {{- include "loculus.resources" (list "website" .Values) | nindent 10 }}
           ports:
             - containerPort: 3000

--- a/kubernetes/loculus/templates/loculus-website.yaml
+++ b/kubernetes/loculus/templates/loculus-website.yaml
@@ -25,8 +25,8 @@ spec:
 {{- include "loculus.configProcessor" (dict "name" "loculus-website-config" "dockerTag" $dockerTag) | nindent 8 }}
       containers:
         - name: website
-          image: "{{ with index $.Values.images "website" }}{{ .repository }}:{{ .tag }}{{ else }}ghcr.io/loculus-project/website:{{ $dockerTag }}{{ end }}"
-          imagePullPolicy: "{{ with index $.Values.images "website" }}{{ .pullPolicy | default "Always" }}{{ else }}Always{{ end }}"
+          image: "{{ $.Values.images.website.repository }}:{{ $.Values.images.website.tag | default $dockerTag }}"
+          imagePullPolicy: "{{ $.Values.images.website.pullPolicy }}"
           {{- include "loculus.resources" (list "website" .Values) | nindent 10 }}
           ports:
             - containerPort: 3000

--- a/kubernetes/loculus/templates/loculus-website.yaml
+++ b/kubernetes/loculus/templates/loculus-website.yaml
@@ -25,7 +25,7 @@ spec:
 {{- include "loculus.configProcessor" (dict "name" "loculus-website-config" "dockerTag" $dockerTag) | nindent 8 }}
       containers:
         - name: website
-          image: "{{ if $.Values.customWebsiteImage }}{{ $.Values.customWebsiteImage }}{{ else }}ghcr.io/loculus-project/website:{{ $dockerTag }}{{ end }}"
+          image: "{{ if $.Values.images.website }}{{ $.Values.images.website.repository }}:{{ $.Values.images.website.tag }}{{ else }}ghcr.io/loculus-project/website:{{ $dockerTag }}{{ end }}"
           imagePullPolicy: Always
           {{- include "loculus.resources" (list "website" .Values) | nindent 10 }}
           ports:

--- a/kubernetes/loculus/templates/silo-deployment.yaml
+++ b/kubernetes/loculus/templates/silo-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         {{- include "loculus.configProcessor" (dict "name" "lapis-silo-database-config" "dockerTag" $dockerTag) | nindent 8 }}
       containers:
         - name: silo
-          image: "{{ $.Values.images.lapisSilo.repository }}:{{ $.Values.images.lapisSilo.tag | default "latest" }}"
+          image: "{{ $.Values.images.lapisSilo.repository }}:{{ $.Values.images.lapisSilo.tag }}"
           imagePullPolicy: "{{ $.Values.images.lapisSilo.pullPolicy }}"
           {{- include "loculus.resources" (list "silo" $.Values $key) | nindent 10 }}
           ports:

--- a/kubernetes/loculus/templates/silo-deployment.yaml
+++ b/kubernetes/loculus/templates/silo-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         {{- include "loculus.configProcessor" (dict "name" "lapis-silo-database-config" "dockerTag" $dockerTag) | nindent 8 }}
       containers:
         - name: silo
-          image: {{ $.Values.images.lapisSilo.repository }}{{ $.Values.images.lapisSilo.tag }}
+          image: "{{ $.Values.images.lapisSilo.repository }}:{{ $.Values.images.lapisSilo.tag }}"
           {{- include "loculus.resources" (list "silo" $.Values $key) | nindent 10 }}
           ports:
             - containerPort: 8081
@@ -43,7 +43,7 @@ spec:
             - name: lapis-silo-shared-data
               mountPath: /data
         - name: silo-preprocessing
-          image: {{ $.Values.images.lapisSilo.repository }}{{ $.Values.images.lapisSilo.tag }}
+          image: "{{ $.Values.images.lapisSilo.repository }}:{{ $.Values.images.lapisSilo.tag }}"
           imagePullPolicy: IfNotPresent
           {{- include "loculus.resources" (list "silo-preprocessing" $.Values) | nindent 10 }}
           command:

--- a/kubernetes/loculus/templates/silo-deployment.yaml
+++ b/kubernetes/loculus/templates/silo-deployment.yaml
@@ -30,6 +30,7 @@ spec:
       containers:
         - name: silo
           image: "{{ $.Values.images.lapisSilo.repository }}:{{ $.Values.images.lapisSilo.tag }}"
+          imagePullPolicy: "{{ $.Values.images.lapisSilo.pullPolicy }}"
           {{- include "loculus.resources" (list "silo" $.Values $key) | nindent 10 }}
           ports:
             - containerPort: 8081
@@ -44,7 +45,7 @@ spec:
               mountPath: /data
         - name: silo-preprocessing
           image: "{{ $.Values.images.lapisSilo.repository }}:{{ $.Values.images.lapisSilo.tag }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: "{{ $.Values.images.lapisSilo.pullPolicy }}"
           {{- include "loculus.resources" (list "silo-preprocessing" $.Values) | nindent 10 }}
           command:
             - sh

--- a/kubernetes/loculus/templates/silo-deployment.yaml
+++ b/kubernetes/loculus/templates/silo-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         {{- include "loculus.configProcessor" (dict "name" "lapis-silo-database-config" "dockerTag" $dockerTag) | nindent 8 }}
       containers:
         - name: silo
-          image: {{ $.Values.images.lapisSilo }}
+          image: {{ $.Values.images.lapisSilo.repository }}{{ $.Values.images.lapisSilo.tag }}
           {{- include "loculus.resources" (list "silo" $.Values $key) | nindent 10 }}
           ports:
             - containerPort: 8081
@@ -43,7 +43,7 @@ spec:
             - name: lapis-silo-shared-data
               mountPath: /data
         - name: silo-preprocessing
-          image: {{ $.Values.images.lapisSilo }}
+          image: {{ $.Values.images.lapisSilo.repository }}{{ $.Values.images.lapisSilo.tag }}
           imagePullPolicy: IfNotPresent
           {{- include "loculus.resources" (list "silo-preprocessing" $.Values) | nindent 10 }}
           command:

--- a/kubernetes/loculus/templates/silo-deployment.yaml
+++ b/kubernetes/loculus/templates/silo-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         {{- include "loculus.configProcessor" (dict "name" "lapis-silo-database-config" "dockerTag" $dockerTag) | nindent 8 }}
       containers:
         - name: silo
-          image: "{{ $.Values.images.lapisSilo.repository }}:{{ $.Values.images.lapisSilo.tag }}"
+          image: "{{ $.Values.images.lapisSilo.repository }}:{{ $.Values.images.lapisSilo.tag | default "latest" }}"
           imagePullPolicy: "{{ $.Values.images.lapisSilo.pullPolicy }}"
           {{- include "loculus.resources" (list "silo" $.Values $key) | nindent 10 }}
           ports:

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1119,7 +1119,7 @@
           "tag": { "type": "string" },
           "pullPolicy": { "type": "string" }
         },
-        "required": ["repository", "tag"],
+        "required": ["repository", "pullPolicy"],
         "additionalProperties": false
       }
     },

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -604,7 +604,17 @@
           }
         }
       }
-    } 
+    },
+    "imageSpec": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string" }
+      },
+      "required": ["repository", "pullPolicy"],
+      "additionalProperties": false
+    }
   },
   "type": "object",
   "additionalProperties": false,
@@ -1112,16 +1122,13 @@
     },
     "images": {
       "type": "object",
-      "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "repository": { "type": "string" },
-          "tag": { "type": "string" },
-          "pullPolicy": { "type": "string" }
-        },
-        "required": ["repository", "pullPolicy"],
-        "additionalProperties": false
-      }
+      "properties": {
+        "lapis": { "$ref": "#/definitions/imageSpec" },
+        "lapisSilo": { "$ref": "#/definitions/imageSpec" },
+        "website": { "$ref": "#/definitions/imageSpec" },
+        "backend": { "$ref": "#/definitions/imageSpec" }
+      },
+      "additionalProperties": false
     },
     "registrationTermsMessage": {
       "type": "string",

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1117,19 +1117,15 @@
     },
     "images": {
       "type": "object",
-      "properties": {
-        "lapisSilo": {
-          "type": "string",
-          "description": "TODO",
-          "default": "ghcr.io/genspectrum/lapis-silo:0.5.2"
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "repository": { "type": "string" },
+          "tag": { "type": "string" }
         },
-        "lapis": {
-          "type": "string",
-          "description": "TODO",
-          "default": "ghcr.io/genspectrum/lapis:0.3.13"
-        }
-      },
-      "additionalProperties": false
+        "required": ["repository", "tag"],
+        "additionalProperties": false
+      }
     },
     "registrationTermsMessage": {
       "type": "string",

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1116,7 +1116,8 @@
         "type": "object",
         "properties": {
           "repository": { "type": "string" },
-          "tag": { "type": "string" }
+          "tag": { "type": "string" },
+          "pullPolicy": { "type": "string" }
         },
         "required": ["repository", "tag"],
         "additionalProperties": false

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -978,11 +978,6 @@
       "default": false,
       "description": "If true, disables ENA (European Nucleotide Archive) submission service."
     },
-    "customWebsiteImage": {
-      "groups": ["services"],
-      "type": "string",
-      "description": "Optional custom Docker image for the website."
-    },
     "organisms": {
       "groups": ["organism-conf"],
       "type": "object",

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -608,9 +608,21 @@
     "imageSpec": {
       "type": "object",
       "properties": {
-        "repository": { "type": "string" },
-        "tag": { "type": "string" },
-        "pullPolicy": { "type": "string" }
+        "repository": {
+          "groups": ["image"],
+          "type": "string",
+          "description": "The repository to pull the image from. Example: ghcr.io/loculus-project/website"
+        },
+        "tag": {
+          "groups": ["image"],
+          "type": "string",
+          "description": "The tag to pull. Examples: latest, 0.5.7"
+        },
+        "pullPolicy": {
+          "groups": ["image"],
+          "type": "string",
+          "description": "The pull policy to use. Examples: IfNotPresent, Always."
+        }
       },
       "required": ["repository", "pullPolicy"],
       "additionalProperties": false
@@ -1121,7 +1133,9 @@
       "default": false
     },
     "images": {
+      "groups": ["general"],
       "type": "object",
+      "description": "Which docker images to use. You can specify an [image spec (type)](#image-spec-type) for `lapis`, `lapisSilo`, `website` and `backend.`",
       "properties": {
         "lapis": { "$ref": "#/definitions/imageSpec" },
         "lapisSilo": { "$ref": "#/definitions/imageSpec" },

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1639,6 +1639,12 @@ images:
     repository: "ghcr.io/genspectrum/lapis"
     tag: "0.4.1"
     pullPolicy: IfNotPresent
+  website:
+    repository: "ghcr.io/loculus-project/website"
+    pullPolicy: Always
+  backend:
+    repository: "ghcr.io/loculus-project/backend"
+    pullPolicy: Always
 secrets:
   smtp-password:
     type: raw

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1634,9 +1634,11 @@ images:
   lapisSilo:
     repository: "ghcr.io/genspectrum/lapis-silo"
     tag: "0.5.7"
+    pullPolicy: IfNotPresent
   lapis:
     repository: "ghcr.io/genspectrum/lapis"
     tag: "0.4.1"
+    pullPolicy: IfNotPresent
 secrets:
   smtp-password:
     type: raw

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1231,7 +1231,7 @@ defaultOrganisms:
           genes: [NP, VP35, VP40, GP, sGP, ssGP, VP30, VP24, L]
           nextclade_dataset_name: nextstrain/ebola/sudan
           nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/ebola/data_output
-      - <<: *preprocessing # test having 2 simultaneous versions
+      - <<: *preprocessing
         version: 2
         configFile:
           <<: *preprocessingConfigFile
@@ -1631,8 +1631,12 @@ bannerMessage: "This is a demonstration environment. It may contain non-accurate
 welcomeMessageHTML: null
 additionalHeadHTML: ""
 images:
-  lapisSilo: "ghcr.io/genspectrum/lapis-silo:0.5.7"
-  lapis: "ghcr.io/genspectrum/lapis:0.4.1"
+  lapisSilo:
+    repository: "ghcr.io/genspectrum/lapis-silo"
+    tag: "0.5.7"
+  lapis:
+    repository: "ghcr.io/genspectrum/lapis"
+    tag: "0.4.1"
 secrets:
   smtp-password:
     type: raw


### PR DESCRIPTION
**BREAKING** - Changes the way images are configured. If your `values.yaml` specified `images.lapisSilo`, `images.lapis` or `customWebsiteImage`, you need to change those settings to use the new format. Otherwise, nothing needs to be done.

resolves #3726

preview URL (docs): https://docs-helm-refactor-image-conf.loculus.org/reference/helm-chart-config/

### Summary
Images for `lapis`, `lapisSilo`, `website` and `backend` are now all configured under an `images` key:

```yaml
images:
  lapisSilo:
    repository: "ghcr.io/genspectrum/lapis-silo"
    tag: "0.5.7"
    pullPolicy: IfNotPresent
  lapis:
    repository: "ghcr.io/genspectrum/lapis"
    tag: "0.4.1"
    pullPolicy: IfNotPresent
  website:
    repository: "ghcr.io/loculus-project/website"
    pullPolicy: Always
  backend:
    repository: "ghcr.io/loculus-project/backend"
    pullPolicy: Always
```

The `customWebsiteImage` key is no longer valid, use `images.website` instead.

Docs were adapted.

### Screenshot of the docs
<img width="771" alt="image" src="https://github.com/user-attachments/assets/892fbb84-740a-4ce1-bc9f-cc5cbfaa7821" />

---

<img width="771" alt="image" src="https://github.com/user-attachments/assets/570d187b-b5ba-478e-af68-dee85a338b44" />



### PR Checklist
- [x] All necessary documentation has been adapted.
- ~~The implemented feature is covered by appropriate, automated tests.~~
- ~~Any manual testidng that has been done is documented (i.e. what exactly was tested?)~~
