### PR TITLE
integration tests: increase CI worker count

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Run Integration test
         run: |
           set -o pipefail
-          cd integration-tests && npx playwright test --workers=8 2>&1 | tee output.txt
+          cd integration-tests && npx playwright test 2>&1 | tee output.txt
           EXIT_CODE=$?
           echo '```' >> $GITHUB_STEP_SUMMARY
           sed -n '/Running [0-9]\+ tests/,$p' output.txt >> $GITHUB_STEP_SUMMARY

--- a/integration-tests/playwright.config.ts
+++ b/integration-tests/playwright.config.ts
@@ -18,7 +18,9 @@ export default defineConfig({
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
     /* Retry on CI only */
-    retries: process.env.CI ? 2 : 0,
+    retries: process.env.CI ? 3 : 0,
+
+    workers: process.env.CI ? 8 : undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: 'html',
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -29,6 +31,9 @@ export default defineConfig({
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: process.env.CI ? 'on-first-retry' : 'on',
     },
+
+    timeout: 60 * 1000,
+
 
     /* Configure projects for major browsers */
     projects: [


### PR DESCRIPTION
testing 8 for now, and seeing if it's quick.
4 runs at about 11 minutes I think.

Maybe more workers doesn't even help, since it's all async anyways.