### PR TITLE
feat(backend): accept file mapping in /submit and /revise endpoints

### DIFF
--- a/.github/scripts/wait_for_pods_to_be_ready.py
+++ b/.github/scripts/wait_for_pods_to_be_ready.py
@@ -12,14 +12,17 @@ def main(timeout=480):
     while True:
         pods = get_pods()
 
-        if time.time() > end_time:
-            print("Aborting, timeout reached")
-            exit(1)
 
         try:
-            if all_pods_are_ready(pods):
+            not_ready_pods = not_ready_pod_names(pods)
+            if len(not_ready_pod_names) == 0:
                 print("All pods are up and running!")
                 break
+
+            if time.time() > end_time:
+                print("Aborting, timeout reached.")
+                print_debug_info(not_ready_pods)
+                exit(1)
         except KeyError as e:
             print("KeyError:", e, "continuing...")
 
@@ -33,7 +36,14 @@ def get_pods():
     return json.loads(result.stdout)["items"]
 
 
-def all_pods_are_ready(pods):
+def print_debug_info(pod_names):
+    print("\nFetching events for more details...\n")
+    for pod_name in pod_names:
+        subprocess.run(["kubectl", "get", "events", "--field-selector involvedObject.name=" + pod_name, "--sort-by=.metadata.creationTimestamp"], text=True)
+
+
+def not_ready_pod_names(pods):
+    names = []
     for pod in pods:
         if "silo-import-cronjob" in pod["metadata"]["name"]:
             continue
@@ -41,8 +51,8 @@ def all_pods_are_ready(pods):
         if pod["status"]["phase"] == "Succeeded":
             continue
         if has_container_that_is_not_ready(pod):
-            return False
-    return True
+            names.append(pod["metadata"]["name"])
+    return names
 
 
 def has_container_that_is_not_ready(pod):

--- a/.github/workflows/e2e-k3d.yml
+++ b/.github/workflows/e2e-k3d.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       ALL_BROWSERS: ${{ github.ref == 'refs/heads/main' || github.event.inputs.all_browsers && 'true' || 'false' }}
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
-      wait_timeout: ${{ github.ref == 'refs/heads/main' && 900 || 240 }}
+      wait_timeout: ${{ github.ref == 'refs/heads/main' && 900 || 600 }}
     steps:
       - name: Shorten sha
         run: echo "sha=${sha::7}" >> $GITHUB_ENV

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 45
     env:
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
-      wait_timeout: ${{ github.ref == 'refs/heads/main' && 900 || 300 }}
+      wait_timeout: ${{ github.ref == 'refs/heads/main' && 900 || 600 }}
     steps:
       - name: Shorten sha
         run: echo "sha=${sha::7}" >> $GITHUB_ENV

--- a/backend/docs/db/schema.sql
+++ b/backend/docs/db/schema.sql
@@ -355,7 +355,8 @@ CREATE TABLE public.metadata_upload_aux_table (
     submitter text NOT NULL,
     group_id integer,
     uploaded_at timestamp without time zone NOT NULL,
-    metadata jsonb NOT NULL
+    metadata jsonb NOT NULL,
+    files jsonb
 );
 
 

--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -265,6 +265,10 @@ data class OriginalData<SequenceType>(
         description = "The key is the segment name, the value is the nucleotide sequence",
     )
     val unalignedNucleotideSequences: Map<SegmentName, SequenceType?>,
+    @Schema(
+        description = "TODO",
+    )
+    val files: FileColumnNameMap? = null,
 )
 
 data class AccessionVersionOriginalMetadata(

--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.loculus.backend.model.SubmissionId
+import org.loculus.backend.service.files.FileId
 import org.loculus.backend.utils.Accession
 import org.loculus.backend.utils.Version
 import org.springframework.core.convert.converter.Converter
@@ -343,3 +345,9 @@ class CompressionFormatConverter : Converter<String, CompressionFormat> {
     }
         ?: throw IllegalArgumentException("Unknown compression: $source")
 }
+
+typealias SubmissionIdFilesMap = Map<SubmissionId, FileColumnNameMap>
+
+typealias FileColumnNameMap = Map<String, List<FileIdAndName>>
+
+data class FileIdAndName(val fileId: FileId, val name: String)

--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -352,9 +352,9 @@ class CompressionFormatConverter : Converter<String, CompressionFormat> {
 
 typealias SubmissionIdFilesMap = Map<SubmissionId, FileColumnNameMap>
 
-fun getAllFileIds(submissionIdFilesMap: SubmissionIdFilesMap): List<FileId> = submissionIdFilesMap.values.flatMap {
+fun SubmissionIdFilesMap.getAllFileIds(): Set<FileId> = this.values.flatMap {
     it.values
-}.flatten().map { it.fileId }
+}.flatten().map { it.fileId }.toSet()
 
 typealias FileColumnNameMap = Map<String, List<FileIdAndName>>
 

--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -350,10 +350,11 @@ class CompressionFormatConverter : Converter<String, CompressionFormat> {
         ?: throw IllegalArgumentException("Unknown compression: $source")
 }
 
-abstract class SubmissionIdFilesMap : Map<SubmissionId, FileColumnNameMap> {
+typealias SubmissionIdFilesMap = Map<SubmissionId, FileColumnNameMap>
 
-    fun getAllFileIds(): List<FileId> = this.values.flatMap { it.values }.flatten().map { it.fileId }
-}
+fun getAllFileIds(submissionIdFilesMap: SubmissionIdFilesMap): List<FileId> = submissionIdFilesMap.values.flatMap {
+    it.values
+}.flatten().map { it.fileId }
 
 typealias FileColumnNameMap = Map<String, List<FileIdAndName>>
 

--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -350,7 +350,10 @@ class CompressionFormatConverter : Converter<String, CompressionFormat> {
         ?: throw IllegalArgumentException("Unknown compression: $source")
 }
 
-typealias SubmissionIdFilesMap = Map<SubmissionId, FileColumnNameMap>
+abstract class SubmissionIdFilesMap : Map<SubmissionId, FileColumnNameMap> {
+
+    fun getAllFileIds(): List<FileId> = this.values.flatMap { it.values }.flatten().map { it.fileId }
+}
 
 typealias FileColumnNameMap = Map<String, List<FileIdAndName>>
 

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -34,6 +34,7 @@ import org.loculus.backend.api.SubmissionIdFilesMap
 import org.loculus.backend.api.SubmissionIdMapping
 import org.loculus.backend.api.SubmittedProcessedData
 import org.loculus.backend.api.UnprocessedData
+import org.loculus.backend.api.getAllFileIds
 import org.loculus.backend.auth.AuthenticatedUser
 import org.loculus.backend.auth.HiddenParam
 import org.loculus.backend.config.BackendConfig
@@ -159,7 +160,7 @@ open class SubmissionController(
             objectMapper.readValue(it, object : TypeReference<SubmissionIdFilesMap>() {})
         }
         fileMappingParsed?.let {
-            val usedFileIds = it.getAllFileIds()
+            val usedFileIds = getAllFileIds(it)
             val notExistingIds = filesDatabaseService.notExistingIds(usedFileIds)
             if (notExistingIds.isNotEmpty()) {
                 throw BadRequestException("The File IDs $notExistingIds do not exist.")

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -82,7 +82,7 @@ open class SubmissionController(
     private val iteratorStreamer: IteratorStreamer,
     private val requestIdContext: RequestIdContext,
     private val backendConfig: BackendConfig,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
 ) {
     @Operation(description = SUBMIT_DESCRIPTION)
     @ApiResponse(responseCode = "200", description = SUBMIT_RESPONSE_DESCRIPTION)

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -34,7 +34,6 @@ import org.loculus.backend.api.SubmissionIdFilesMap
 import org.loculus.backend.api.SubmissionIdMapping
 import org.loculus.backend.api.SubmittedProcessedData
 import org.loculus.backend.api.UnprocessedData
-import org.loculus.backend.api.getAllFileIds
 import org.loculus.backend.auth.AuthenticatedUser
 import org.loculus.backend.auth.HiddenParam
 import org.loculus.backend.config.BackendConfig
@@ -117,7 +116,9 @@ open class SubmissionController(
                 innerDataUseTermsType = dataUseTermsType
             }
         }
-        val fileMappingParsed = parseAndValidateFileMapping(fileMapping, groupId)
+        val fileMappingParsed = fileMapping?.let {
+            objectMapper.readValue(it, object : TypeReference<SubmissionIdFilesMap>() {})
+        }
         val params = SubmissionParams.OriginalSubmissionParams(
             organism,
             authenticatedUser,
@@ -144,7 +145,9 @@ open class SubmissionController(
         ) @RequestParam sequenceFile: MultipartFile?,
         @RequestPart fileMapping: String?,
     ): List<SubmissionIdMapping> {
-        val fileMappingParsed = parseAndValidateFileMapping(fileMapping, -1) // TODO what is the group ID here?
+        val fileMappingParsed = fileMapping?.let {
+            objectMapper.readValue(it, object : TypeReference<SubmissionIdFilesMap>() {})
+        }
         val params = SubmissionParams.RevisionSubmissionParams(
             organism,
             authenticatedUser,
@@ -153,29 +156,6 @@ open class SubmissionController(
             fileMappingParsed,
         )
         return submitModel.processSubmissions(UUID.randomUUID().toString(), params)
-    }
-
-    private fun parseAndValidateFileMapping(maybeFileMapping: String?, groupId: Int): SubmissionIdFilesMap? {
-        val fileMappingParsed = maybeFileMapping?.let {
-            objectMapper.readValue(it, object : TypeReference<SubmissionIdFilesMap>() {})
-        }
-        fileMappingParsed?.let {
-            val usedFileIds = getAllFileIds(it)
-            // Check if all given file IDs exist in the DB
-            val notExistingIds = filesDatabaseService.notExistingIds(usedFileIds)
-            if (notExistingIds.isNotEmpty()) {
-                throw BadRequestException("The File IDs $notExistingIds do not exist.")
-            }
-            // Check that all files belong to the given group
-            filesDatabaseService.getGroupIds(usedFileIds).forEach {
-                if (it.value != groupId) {
-                    throw BadRequestException(
-                        "The File ${it.key} belongs to group ${it.value} but should be long to group $groupId.",
-                    )
-                }
-            }
-        }
-        return fileMappingParsed
     }
 
     @Operation(description = EXTRACT_UNPROCESSED_DATA_DESCRIPTION)

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -159,6 +159,7 @@ open class SubmissionController(
         val fileMappingParsed = maybeFileMapping?.let {
             objectMapper.readValue(it, object : TypeReference<SubmissionIdFilesMap>() {})
         }
+        // Check if all given file IDs exist in the DB
         fileMappingParsed?.let {
             val usedFileIds = getAllFileIds(it)
             val notExistingIds = filesDatabaseService.notExistingIds(usedFileIds)

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -1,5 +1,7 @@
 package org.loculus.backend.controller
 
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.headers.Header
@@ -28,6 +30,7 @@ import org.loculus.backend.api.ProcessedData
 import org.loculus.backend.api.ProcessingResult
 import org.loculus.backend.api.SequenceEntryVersionToEdit
 import org.loculus.backend.api.Status
+import org.loculus.backend.api.SubmissionIdFilesMap
 import org.loculus.backend.api.SubmissionIdMapping
 import org.loculus.backend.api.SubmittedProcessedData
 import org.loculus.backend.api.UnprocessedData
@@ -58,11 +61,12 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody
-import java.util.UUID
+import java.util.*
 import io.swagger.v3.oas.annotations.parameters.RequestBody as SwaggerRequestBody
 
 private val log = KotlinLogging.logger { }
@@ -78,6 +82,7 @@ open class SubmissionController(
     private val iteratorStreamer: IteratorStreamer,
     private val requestIdContext: RequestIdContext,
     private val backendConfig: BackendConfig,
+    private val objectMapper: ObjectMapper,
 ) {
     @Operation(description = SUBMIT_DESCRIPTION)
     @ApiResponse(responseCode = "200", description = SUBMIT_RESPONSE_DESCRIPTION)
@@ -99,6 +104,7 @@ open class SubmissionController(
                 " It is the date when the sequence entries will become 'OPEN'." +
                 " Format: YYYY-MM-DD",
         ) @RequestParam restrictedUntil: String?,
+        @RequestPart fileMapping: String?,
     ): List<SubmissionIdMapping> {
         var innerDataUseTermsType = DataUseTermsType.OPEN
         if (backendConfig.dataUseTerms.enabled) {
@@ -108,12 +114,15 @@ open class SubmissionController(
                 innerDataUseTermsType = dataUseTermsType
             }
         }
-
+        val fileMappingParsed = fileMapping?.let {
+            objectMapper.readValue(fileMapping, object : TypeReference<SubmissionIdFilesMap>() {})
+        }
         val params = SubmissionParams.OriginalSubmissionParams(
             organism,
             authenticatedUser,
             metadataFile,
             sequenceFile,
+            fileMappingParsed,
             groupId,
             DataUseTerms.fromParameters(innerDataUseTermsType, restrictedUntil),
         )
@@ -132,12 +141,17 @@ open class SubmissionController(
         @Parameter(
             description = SEQUENCE_FILE_DESCRIPTION,
         ) @RequestParam sequenceFile: MultipartFile?,
+        @RequestPart fileMapping: String?,
     ): List<SubmissionIdMapping> {
+        val fileMappingParsed = fileMapping?.let {
+            objectMapper.readValue(fileMapping, object : TypeReference<SubmissionIdFilesMap>() {})
+        }
         val params = SubmissionParams.RevisionSubmissionParams(
             organism,
             authenticatedUser,
             metadataFile,
             sequenceFile,
+            fileMappingParsed,
         )
         return submitModel.processSubmissions(UUID.randomUUID().toString(), params)
     }

--- a/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
@@ -131,8 +131,8 @@ class SubmitModel(
             // TODO Not every submission needs to have a file, right? Otherwise we need to check that too
         }
 
-        // Check if all given file IDs exist in the DB
         submissionParams.files?.let {
+            log.debug { "Validating that all submitted file IDs exist." }
             val usedFileIds = getAllFileIds(it)
             val notExistingIds = filesDatabaseService.notExistingIds(usedFileIds)
             if (notExistingIds.isNotEmpty()) {
@@ -147,6 +147,9 @@ class SubmitModel(
                 submissionParams.organism,
                 submissionParams.authenticatedUser,
             )
+            log.debug {
+                "Validating that submitted files belong to the group that their associated submission belongs to."
+            }
             submissionParams.files?.let { submittedFiles ->
                 val fileGroups = filesDatabaseService.getGroupIds(getAllFileIds(submittedFiles))
                 val submisssionIdGroups = uploadDatabaseService.getSubmissionIdToGroupMapping(uploadId)
@@ -165,6 +168,9 @@ class SubmitModel(
                 }
             }
         } else if (submissionParams is SubmissionParams.OriginalSubmissionParams) {
+            log.debug {
+                "Validating that submitted files belong to the group that their associated submission belongs to."
+            }
             submissionParams.files?.let {
                 val usedFileIds = getAllFileIds(it)
                 filesDatabaseService.getGroupIds(usedFileIds).forEach {

--- a/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
@@ -365,8 +365,8 @@ class SubmitModel(
         val filesKeysNotInMetadata = filesKeysSet.subtract(metadataKeysSet)
         if (filesKeysNotInMetadata.isNotEmpty()) {
             throw UnprocessableEntityException(
-                "Sequence file contains ${filesKeysNotInMetadata.size} submissionIds that are not present " +
-                    "in the metadata file: " + filesKeysNotInMetadata.toList().joinToString(limit = 10),
+                "Upload contains ${filesKeysNotInMetadata.size} submissionIds that are not present in the metadata " +
+                    "file: " + filesKeysNotInMetadata.toList().joinToString(limit = 10),
             )
         }
     }

--- a/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
@@ -176,7 +176,7 @@ class SubmitModel(
                 filesDatabaseService.getGroupIds(usedFileIds).forEach {
                     if (it.value != submissionParams.groupId) {
                         throw BadRequestException(
-                            "The File ${it.key} belongs to group ${it.value} but should be long to group ${submissionParams.groupId}",
+                            "The File ${it.key} belongs to group ${it.value} but should belong to group ${submissionParams.groupId}",
                         )
                     }
                 }

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/FilesDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/FilesDatabaseService.kt
@@ -5,6 +5,7 @@ import org.loculus.backend.utils.DateProvider
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
+import kotlin.collections.HashSet
 
 @Service
 @Transactional
@@ -20,5 +21,19 @@ class FilesDatabaseService(private val dateProvider: DateProvider) {
             it[groupIdColumn] = groupId
         }
         return id
+    }
+
+    /**
+     * Takes a list of File IDs and returns the subset of file IDs that do not exist in the database.
+     * If the resulting Set is empty, all given File IDs exist.
+     */
+    fun notExistingIds(fileIds: List<FileId>): Set<FileId> {
+        val uniqueIds = HashSet(fileIds)
+        val uniqueCount = uniqueIds.size.toLong()
+        val existingIds = FilesTable.select(FilesTable.idColumn).where {
+            FilesTable.idColumn inList uniqueIds
+        }.map { it[FilesTable.idColumn] }
+        val nonExistingIds = uniqueIds.subtract(existingIds.toSet())
+        return nonExistingIds
     }
 }

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/FilesDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/FilesDatabaseService.kt
@@ -35,4 +35,9 @@ class FilesDatabaseService(private val dateProvider: DateProvider) {
         val nonExistingIds = uniqueIds.subtract(existingIds.toSet())
         return nonExistingIds
     }
+
+    fun getGroupIds(fileIds: List<FileId>): Map<FileId, Int> =
+        FilesTable.select(FilesTable.idColumn, FilesTable.groupIdColumn)
+            .where { FilesTable.idColumn inList fileIds }
+            .associate { Pair(it[FilesTable.idColumn], it[FilesTable.groupIdColumn]) }
 }

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/FilesDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/FilesDatabaseService.kt
@@ -5,7 +5,6 @@ import org.loculus.backend.utils.DateProvider
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
-import kotlin.collections.HashSet
 
 @Service
 @Transactional
@@ -23,20 +22,7 @@ class FilesDatabaseService(private val dateProvider: DateProvider) {
         return id
     }
 
-    /**
-     * Takes a list of File IDs and returns the subset of file IDs that do not exist in the database.
-     * If the resulting Set is empty, all given File IDs exist.
-     */
-    fun notExistingIds(fileIds: List<FileId>): Set<FileId> {
-        val uniqueIds = HashSet(fileIds)
-        val existingIds = FilesTable.select(FilesTable.idColumn).where {
-            FilesTable.idColumn inList uniqueIds
-        }.map { it[FilesTable.idColumn] }
-        val nonExistingIds = uniqueIds.subtract(existingIds.toSet())
-        return nonExistingIds
-    }
-
-    fun getGroupIds(fileIds: List<FileId>): Map<FileId, Int> =
+    fun getGroupIds(fileIds: Set<FileId>): Map<FileId, Int> =
         FilesTable.select(FilesTable.idColumn, FilesTable.groupIdColumn)
             .where { FilesTable.idColumn inList fileIds }
             .associate { Pair(it[FilesTable.idColumn], it[FilesTable.groupIdColumn]) }

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/FilesDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/FilesDatabaseService.kt
@@ -29,7 +29,6 @@ class FilesDatabaseService(private val dateProvider: DateProvider) {
      */
     fun notExistingIds(fileIds: List<FileId>): Set<FileId> {
         val uniqueIds = HashSet(fileIds)
-        val uniqueCount = uniqueIds.size.toLong()
         val existingIds = FilesTable.select(FilesTable.idColumn).where {
             FilesTable.idColumn inList uniqueIds
         }.map { it[FilesTable.idColumn] }

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/CompressionService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/CompressionService.kt
@@ -71,6 +71,7 @@ class CompressionService(private val backendConfig: BackendConfig) {
                         else -> decompressNucleotideSequence(compressedSequence, it.key, organism)
                     }
                 },
+            originalData.files,
         )
 
     fun compressSequencesInOriginalData(originalData: OriginalData<GeneticSequence>, organism: Organism) = OriginalData(
@@ -82,6 +83,7 @@ class CompressionService(private val backendConfig: BackendConfig) {
                     else -> compressNucleotideSequence(sequenceData, segmentName, organism)
                 }
             },
+        originalData.files,
     )
 
     fun decompressSequencesInProcessedData(processedData: ProcessedData<CompressedSequence>, organism: Organism) =

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/MetadataUploadAuxTable.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/MetadataUploadAuxTable.kt
@@ -2,6 +2,7 @@ package org.loculus.backend.service.submission
 
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.kotlin.datetime.datetime
+import org.loculus.backend.api.FileColumnNameMap
 import org.loculus.backend.service.jacksonSerializableJsonb
 
 const val METADATA_UPLOAD_AUX_TABLE_NAME = "metadata_upload_aux_table"
@@ -17,5 +18,7 @@ object MetadataUploadAuxTable : Table(METADATA_UPLOAD_AUX_TABLE_NAME) {
     val uploadedAtColumn = datetime("uploaded_at")
     val metadataColumn =
         jacksonSerializableJsonb<Map<String, String>>("metadata").nullable()
+    val filesColumn =
+        jacksonSerializableJsonb<FileColumnNameMap>("files").nullable()
     override val primaryKey = PrimaryKey(uploadIdColumn, submissionIdColumn)
 }

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
@@ -262,6 +262,11 @@ class UploadDatabaseService(
         }
     }
 
+    fun getSubmissionIdToGroupMapping(uploadId: String): Map<String, Int> = MetadataUploadAuxTable
+        .select(submissionIdColumn, groupIdColumn)
+        .where { uploadIdColumn eq uploadId }
+        .associate { Pair(it[submissionIdColumn], it[groupIdColumn]!!) }
+
     fun generateNewAccessionsForOriginalUpload(uploadId: String) {
         val submissionIds =
             MetadataUploadAuxTable

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
@@ -114,19 +114,17 @@ class UploadDatabaseService(
         }
     }
 
-    fun getUploadSubmissionIds(uploadId: String): Pair<List<SubmissionId>, List<SubmissionId>> = Pair(
-        MetadataUploadAuxTable
-            .selectAll()
-            .where { uploadIdColumn eq uploadId }
-            .map { it[submissionIdColumn] },
+    fun getMetadataUploadSubmissionIds(uploadId: String): List<SubmissionId> = MetadataUploadAuxTable
+        .selectAll()
+        .where { uploadIdColumn eq uploadId }
+        .map { it[submissionIdColumn] }
 
-        SequenceUploadAuxTable
-            .selectAll()
-            .where { sequenceUploadIdColumn eq uploadId }
-            .map {
-                it[sequenceSubmissionIdColumn]
-            },
-    )
+    fun getSequenceUploadSubmissionIds(uploadId: String): List<SubmissionId> = SequenceUploadAuxTable
+        .selectAll()
+        .where { sequenceUploadIdColumn eq uploadId }
+        .map {
+            it[sequenceSubmissionIdColumn]
+        }
 
     fun mapAndCopy(uploadId: String, submissionParams: SubmissionParams): List<SubmissionIdMapping> = transaction {
         log.debug {

--- a/backend/src/main/resources/db/migration/V1.11__file_sharing.sql
+++ b/backend/src/main/resources/db/migration/V1.11__file_sharing.sql
@@ -4,3 +4,6 @@ create table files (
     uploader text not null,
     group_id integer not null references groups_table(group_id)
 );
+
+alter table metadata_upload_aux_table
+add column files jsonb;

--- a/backend/src/test/kotlin/org/loculus/backend/controller/ExceptionHandlerTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/ExceptionHandlerTest.kt
@@ -53,6 +53,7 @@ class ExceptionHandlerTest(@Autowired val mockMvc: MockMvc) {
         any(),
         any(),
         any(),
+        any(),
     )
 
     @Test

--- a/backend/src/test/kotlin/org/loculus/backend/controller/files/FilesClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/files/FilesClient.kt
@@ -8,7 +8,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 
 class FilesClient(private val mockMvc: MockMvc) {
 
-    fun requestUploads(groupId: Int?, numberFiles: Int?, jwt: String = jwtForDefaultUser): ResultActions {
+    fun requestUploads(groupId: Int?, numberFiles: Int? = null, jwt: String = jwtForDefaultUser): ResultActions {
         val request = post("/files/request-upload")
             .withAuth(jwt)
         groupId?.let { request.param("groupId", it.toString()) }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetOriginalMetadataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetOriginalMetadataEndpointTest.kt
@@ -179,6 +179,7 @@ class GetOriginalMetadataEndpointTest(
             submittedOrganism = Organism("organism"),
             uploadedMetadataBatch = listOf(MetadataEntry("submission id", mapOf("key" to "value"))),
             uploadedAt = LocalDateTime(2024, 1, 1, 1, 1, 1),
+            null,
         )
 
         submissionControllerClient.getOriginalMetadata()

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
@@ -46,7 +46,16 @@ class SubmissionControllerClient(private val mockMvc: MockMvc, private val objec
                 sequencesFile?.let { file(sequencesFile) }
             }
             .file(metadataFile)
-            .apply { fileMapping?.let { file("fileMapping", objectMapper.writeValueAsBytes(fileMapping)) } }
+            .apply {
+                fileMapping?.let {
+                    MockMultipartFile(
+                        "fileMapping",
+                        "originalfile.txt",
+                        "application/json",
+                        objectMapper.writeValueAsBytes(fileMapping),
+                    )
+                }
+            }
             .param("groupId", groupId.toString())
             .param("dataUseTermsType", dataUseTerm.type.name)
             .param(

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
@@ -10,6 +10,7 @@ import org.loculus.backend.api.EditedSequenceEntryData
 import org.loculus.backend.api.ExternalSubmittedData
 import org.loculus.backend.api.ProcessingResult
 import org.loculus.backend.api.Status
+import org.loculus.backend.api.SubmissionIdFilesMap
 import org.loculus.backend.api.SubmittedProcessedData
 import org.loculus.backend.controller.DEFAULT_EXTERNAL_METADATA_UPDATER
 import org.loculus.backend.controller.DEFAULT_GROUP_NAME
@@ -38,12 +39,14 @@ class SubmissionControllerClient(private val mockMvc: MockMvc, private val objec
         groupId: Int,
         dataUseTerm: DataUseTerms = DataUseTerms.Open,
         jwt: String? = jwtForDefaultUser,
+        fileMapping: SubmissionIdFilesMap? = null,
     ): ResultActions = mockMvc.perform(
         multipart(addOrganismToPath("/submit", organism = organism))
             .apply {
                 sequencesFile?.let { file(sequencesFile) }
             }
             .file(metadataFile)
+            .apply { fileMapping?.let { file("fileMapping", objectMapper.writeValueAsBytes(fileMapping)) } }
             .param("groupId", groupId.toString())
             .param("dataUseTermsType", dataUseTerm.type.name)
             .param(

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
@@ -48,11 +48,13 @@ class SubmissionControllerClient(private val mockMvc: MockMvc, private val objec
             .file(metadataFile)
             .apply {
                 fileMapping?.let {
-                    MockMultipartFile(
-                        "fileMapping",
-                        "originalfile.txt",
-                        "application/json",
-                        objectMapper.writeValueAsBytes(fileMapping),
+                    file(
+                        MockMultipartFile(
+                            "fileMapping",
+                            "originalfile.txt",
+                            "application/json",
+                            objectMapper.writeValueAsBytes(fileMapping),
+                        ),
                     )
                 }
             }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
@@ -23,7 +23,7 @@ import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import java.util.UUID
+import java.util.*
 
 @EndpointTest(
     properties = ["${BackendSpringProperty.BACKEND_CONFIG_PATH}=$S3_CONFIG"],
@@ -87,13 +87,13 @@ class SubmitEndpointFileSharingTest(
                     ),
             ),
         )
-            .andExpect(status().isBadRequest())
+            .andExpect(status().isUnprocessableEntity())
             .andExpect(content().contentType(APPLICATION_JSON_VALUE))
             .andExpect(
                 jsonPath(
                     "\$.detail",
                 ).value(
-                    "Upload contains files for [foobar] but these submission IDs were not found in the metadata file.",
+                    "Upload contains 1 submissionIds that are not present in the metadata file: foobar",
                 ),
             )
     }
@@ -149,7 +149,7 @@ class SubmitEndpointFileSharingTest(
             .andExpect(
                 jsonPath(
                     "\$.detail",
-                ).value("The File $fileId belongs to group $otherGroupId but should belong to group $groupId"),
+                ).value("The File $fileId does not belong to group $groupId."),
             )
     }
 }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
@@ -85,6 +85,6 @@ class SubmitEndpointFileSharingTest(
             ),
         )
             .andExpect(status().isBadRequest())
-            // TODO maybe check for specific error response
+        // TODO maybe check for specific error response
     }
 }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
@@ -1,0 +1,61 @@
+package org.loculus.backend.controller.submission
+
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.loculus.backend.api.FileIdAndName
+import org.loculus.backend.config.BackendConfig
+import org.loculus.backend.config.BackendSpringProperty
+import org.loculus.backend.controller.DEFAULT_ORGANISM
+import org.loculus.backend.controller.EndpointTest
+import org.loculus.backend.controller.S3_CONFIG
+import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
+import org.loculus.backend.controller.groupmanagement.andGetGroupId
+import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles
+import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles.NUMBER_OF_SEQUENCES
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+
+@EndpointTest(
+    properties = ["${BackendSpringProperty.BACKEND_CONFIG_PATH}=$S3_CONFIG"],
+)
+class SubmitEndpointFileSharingTest(
+    @Autowired val submissionControllerClient: SubmissionControllerClient,
+    @Autowired val backendConfig: BackendConfig,
+    @Autowired val groupManagementClient: GroupManagementControllerClient,
+) {
+    var groupId: Int = 0
+
+    @BeforeEach
+    fun prepareNewGroup() {
+        groupId = groupManagementClient.createNewGroup().andGetGroupId()
+    }
+
+    @Test
+    fun `config has been read and S3 is enabled`() {
+        assertThat(backendConfig.s3.enabled, `is`(true))
+    }
+
+    @Test
+    fun `GIVEN TODO foo`() {
+        submissionControllerClient.submit(
+            DefaultFiles.metadataFile,
+            DefaultFiles.sequencesFile,
+            organism = DEFAULT_ORGANISM,
+            groupId = groupId,
+            fileMapping = mapOf("subId" to mapOf("fileField" to listOf(FileIdAndName(UUID.randomUUID(), "foo.txt")))),
+        )
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("\$.length()").value(NUMBER_OF_SEQUENCES))
+            .andExpect(jsonPath("\$[0].submissionId").value("custom0"))
+            .andExpect(jsonPath("\$[0].accession", containsString(backendConfig.accessionPrefix)))
+            .andExpect(jsonPath("\$[0].version").value(1))
+    }
+}

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
@@ -1,5 +1,6 @@
 package org.loculus.backend.controller.submission
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
@@ -11,6 +12,7 @@ import org.loculus.backend.config.BackendSpringProperty
 import org.loculus.backend.controller.DEFAULT_ORGANISM
 import org.loculus.backend.controller.EndpointTest
 import org.loculus.backend.controller.S3_CONFIG
+import org.loculus.backend.controller.files.FilesClient
 import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
 import org.loculus.backend.controller.groupmanagement.andGetGroupId
 import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles
@@ -27,6 +29,8 @@ import java.util.UUID
 )
 class SubmitEndpointFileSharingTest(
     @Autowired val submissionControllerClient: SubmissionControllerClient,
+    @Autowired val filesClient: FilesClient,
+    @Autowired val objectMapper: ObjectMapper,
     @Autowired val backendConfig: BackendConfig,
     @Autowired val groupManagementClient: GroupManagementControllerClient,
 ) {
@@ -44,12 +48,16 @@ class SubmitEndpointFileSharingTest(
 
     @Test
     fun `GIVEN TODO foo`() {
+        val responseString = filesClient.requestUploads(groupId).andReturn().response.contentAsString
+        val responseJson = objectMapper.readTree(responseString)
+        val fileId = UUID.fromString(responseJson[0]["fileId"].asText())
+
         submissionControllerClient.submit(
             DefaultFiles.metadataFile,
             DefaultFiles.sequencesFile,
             organism = DEFAULT_ORGANISM,
             groupId = groupId,
-            fileMapping = mapOf("subId" to mapOf("fileField" to listOf(FileIdAndName(UUID.randomUUID(), "foo.txt")))),
+            fileMapping = mapOf("subId" to mapOf("fileField" to listOf(FileIdAndName(fileId, "foo.txt")))),
         )
             .andExpect(status().isOk)
             .andExpect(content().contentType(APPLICATION_JSON_VALUE))
@@ -57,5 +65,26 @@ class SubmitEndpointFileSharingTest(
             .andExpect(jsonPath("\$[0].submissionId").value("custom0"))
             .andExpect(jsonPath("\$[0].accession", containsString(backendConfig.accessionPrefix)))
             .andExpect(jsonPath("\$[0].version").value(1))
+    }
+
+    @Test
+    fun `GIVEN a non-existing file ID is given in submit THEN the request is not valid`() {
+        val responseString = filesClient.requestUploads(groupId).andReturn().response.contentAsString
+        val responseJson = objectMapper.readTree(responseString)
+        val fileId = UUID.fromString(responseJson[0]["fileId"].asText())
+        val randomId = UUID.randomUUID()
+
+        submissionControllerClient.submit(
+            DefaultFiles.metadataFile,
+            DefaultFiles.sequencesFile,
+            organism = DEFAULT_ORGANISM,
+            groupId = groupId,
+            fileMapping = mapOf(
+                "subId" to
+                    mapOf("fileField" to listOf(FileIdAndName(fileId, "foo.txt"), FileIdAndName(randomId, "bar.txt"))),
+            ),
+        )
+            .andExpect(status().isBadRequest())
+        // TODO check for specific error response
     }
 }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
@@ -47,7 +47,7 @@ class SubmitEndpointFileSharingTest(
     }
 
     @Test
-    fun `GIVEN TODO foo`() {
+    fun `GIVEN a valid request with a valid File ID THEN the request is valid`() {
         val responseString = filesClient.requestUploads(groupId).andReturn().response.contentAsString
         val responseJson = objectMapper.readTree(responseString)
         val fileId = UUID.fromString(responseJson[0]["fileId"].asText())
@@ -85,6 +85,6 @@ class SubmitEndpointFileSharingTest(
             ),
         )
             .andExpect(status().isBadRequest())
-        // TODO check for specific error response
+            // TODO maybe check for specific error response
     }
 }

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1774,6 +1774,11 @@ secrets:
     data:
       username: "dummy"
       password: "dummy"
+  s3-bucket:
+    type: raw
+    data:
+      accessKey: "dummy"
+      secretKey: "dummy"
 runDevelopmentKeycloakDatabase: true
 runDevelopmentMainDatabase: true
 developmentDatabasePersistence: false


### PR DESCRIPTION
_This PR is targeting the `file-sharing` feature branch and not the main branch._

resolves #3906

To test this:

```bash
curl -X 'POST' \
  'http://localhost:8079/dummy-organism/submit?groupId=1&dataUseTermsType=OPEN' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <token>' \
  -H 'Content-Type: multipart/form-data' \
  -F 'metadataFile=@metadata.tsv;type=text/tab-separated-values' \
  -F 'sequenceFile=@sequences.fasta' \
  -F 'fileMapping={"seq1":{"dance_video":[{"fileId":"550e8400-e29b-41d4-a716-446655440000","name":"dance.mp4"}]}}'
```

### Remaining tasks

- [x] Implement validation that file ids exist 
- [x] Implement validation that file ids belong to the right group
- [x] Implement validation that file submission IDs match metadata submission IDs
- [x] Fix tests
- [x] Add tests for all the validation steps

🚀 Preview: https://fs-submit-api.loculus.org