### PR TITLE
fix(integration-tests): Fix a test that broke due to month changing

### DIFF
--- a/integration-tests/tests/specs/features/search/active-filters.spec.ts
+++ b/integration-tests/tests/specs/features/search/active-filters.spec.ts
@@ -41,7 +41,7 @@ test.describe('Search', () => {
         await searchPage.ebolaSudan();
 
         await page.getByPlaceholder('dd/MM/yyyy').first().click();
-        await page.getByTestId('calendar').getByText('11', { exact: true }).click();
+        await page.getByTestId('calendar').getByText('20', { exact: true }).click();
         await expect(page.getByText('Collection date - From:')).toBeVisible();
 
         await page.locator('div').filter({ hasText: /Collection date - From:/ }).getByLabel('remove filter').click();


### PR DESCRIPTION
Clicking "11" wasn't unique anymore (Apr 11 and May 11). With clicking "20" this shouldn't happen anymore.