### PR TITLE
chore: remove comments from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,5 @@
 resolves #
 
-preview URL: <branchname>.loculus.org
-
 ### Summary
 
 ### Screenshot

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 resolves #
 
-preview URL:
+preview URL: <branchname>.loculus.org
 
 ### Summary
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,12 @@
-<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
 resolves #
 
-<!-- Add "preview" label in almost all cases to have testable deployment. Then lookup the deployment URL in argocd and paste it here (if you don't know how to look up the URL, ask here: https://loculus.slack.com/archives/C06JCAZLG14), it's something like `{REPLACE}.loculus.org` -->
 preview URL:
 
 ### Summary
-<!-- Add a few sentences describing the main changes introduced in this PR -->
 
 ### Screenshot
-<!-- When applicable, add a screenshot showing the main effect this PR has, even if "trivial": e.g. changed layout, changed button text, different logging in backend. This helps others quickly grasping what you did even if they are not familiar with the code base. -->
 
 ### PR Checklist
-<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
 - [ ] All necessary documentation has been adapted.
 - [ ] The implemented feature is covered by appropriate, automated tests.
 - [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,5 @@
 resolves #
 
-### Summary
-
 ### Screenshot
 
 ### PR Checklist


### PR DESCRIPTION
We now have Squash merges defaulting to include PR description, which yields something like https://github.com/loculus-project/loculus/commit/1b944de935fe6b5b3dd9cd9895528d1de0f689b2 

<img width="545" alt="image" src="https://github.com/user-attachments/assets/3315e2f1-088a-45a7-889b-2b387725dea8" />

which is very saturated with comments from the PR template. Obviously we had these for a reason but they could be something we describe in Nuclino or docs instead. My preference would be to remove them, as here, but I expect some may disagree. Just an idea.