### PR TITLE
feat(website): Rename restricted to restricted use in terms selector

### DIFF
--- a/website/src/components/DataUseTerms/DataUseTermsSelector.spec.tsx
+++ b/website/src/components/DataUseTerms/DataUseTermsSelector.spec.tsx
@@ -18,7 +18,6 @@ describe('DataUseTermsSelector', () => {
             />,
         );
 
-        // Restricted radio input
         const restrictedInput = screen.getByLabelText('Restricted use');
         fireEvent.click(restrictedInput);
 
@@ -27,7 +26,6 @@ describe('DataUseTermsSelector', () => {
             restrictedUntil: maxRestrictedUntil.toFormat('yyyy-MM-dd'),
         });
 
-        // Open radio input
         const openInput = screen.getByLabelText('Open');
         fireEvent.click(openInput);
 
@@ -107,15 +105,12 @@ describe('DataUseTermsSelector', () => {
             />,
         );
 
-        // Open the modal
         const changeDateButton = screen.getByText('Change date');
         fireEvent.click(changeDateButton);
 
-        // Select a date in the modal
         const dateButton = screen.getByText('14');
         fireEvent.click(dateButton);
 
-        // Submit the modal
         const submitButton = screen.getByText('Save');
         fireEvent.click(submitButton);
 

--- a/website/src/components/DataUseTerms/DataUseTermsSelector.spec.tsx
+++ b/website/src/components/DataUseTerms/DataUseTermsSelector.spec.tsx
@@ -19,7 +19,7 @@ describe('DataUseTermsSelector', () => {
         );
 
         // Restricted radio input
-        const restrictedInput = screen.getByLabelText('Restricted');
+        const restrictedInput = screen.getByLabelText('Restricted use');
         fireEvent.click(restrictedInput);
 
         expect(mockSetDataUseTerms).toHaveBeenCalledWith({

--- a/website/src/components/DataUseTerms/DataUseTermsSelector.spec.tsx
+++ b/website/src/components/DataUseTerms/DataUseTermsSelector.spec.tsx
@@ -132,7 +132,7 @@ describe('DataUseTermsSelector', () => {
         render(<DataUseTermsSelector maxRestrictedUntil={maxRestrictedUntil} setDataUseTerms={mockSetDataUseTerms} />);
 
         const openInput = screen.getByLabelText('Open');
-        const restrictedInput = screen.getByLabelText('Restricted');
+        const restrictedInput = screen.getByLabelText('Restricted use');
 
         expect(openInput).not.toBeChecked();
         expect(restrictedInput).not.toBeChecked();

--- a/website/src/components/DataUseTerms/DataUseTermsSelector.tsx
+++ b/website/src/components/DataUseTerms/DataUseTermsSelector.tsx
@@ -108,7 +108,7 @@ const DataUseTermsSelector: FC<DataUseTermsSelectorProps> = ({
                     className='ml-2 h-4 p-2 text-sm font-medium leading-6 text-gray-900'
                 >
                     <Locked className='h-4 w-4 inline-block mr-2 -mt-1' />
-                    Restricted
+                    Restricted use
                 </label>
                 <div className='text-xs pl-8 text-gray-500 mb-4'>
                     Data use will be restricted for a period of time. The sequences will be available but there will be


### PR DESCRIPTION
Previously this text said "Restricted", we should standardise to "Restricted Use" as much as possible since data remains accessible. Technically it was right before anyway since its the "Terms of use" but this wouldn't be super clear.

### Screenshot
<img width="983" alt="image" src="https://github.com/user-attachments/assets/2496020f-b8b6-4c9b-b835-040a6ce032ea" />


🚀 Preview: https://restricted-use.loculus.org