### PR TITLE
feat(website): some small improvements to organism card (rev 2)

### DIFF
--- a/website/src/components/IndexPage/OrganismCard.astro
+++ b/website/src/components/IndexPage/OrganismCard.astro
@@ -28,15 +28,15 @@ const { key, image, displayName, organismStatistics, numberDaysAgoStatistics } =
     <div class='my-4 mx-4 h-28 flex flex-col justify-between text-slate-900'>
         <h3 class='font-semibold mb-2'>{displayName}</h3>
         <p class='text-sm leading-7'>
-            <span class='font-semibold'>
+            <span class='font-bold'>
                 {formatNumberWithDefaultLocale(organismStatistics.totalSequences)}
-
-                sequences</span
-            >
+            </span>
+            sequences
             <br />
-            <span class='text-sm'>
-                +{formatNumberWithDefaultLocale(organismStatistics.recentSequences)}
-
+            <span class='text-slate-400 text-sm'>
+                <span class='text-slate-500'>
+                    +{formatNumberWithDefaultLocale(organismStatistics.recentSequences)}
+                </span>
                 in last {numberDaysAgoStatistics} days
             </span>
             <span class='hidden'

--- a/website/src/components/IndexPage/OrganismCard.astro
+++ b/website/src/components/IndexPage/OrganismCard.astro
@@ -16,21 +16,27 @@ const { key, image, displayName, organismStatistics, numberDaysAgoStatistics } =
 
 <a
     href={routes.organismStartPage(key)}
-    class='block rounded border box-border border-gray-300 m-2 w-56 hover:bg-gray-100 mx-auto sm:mx-0'
+    class='shadow-[0_3px_10px_rgb(0,0,0,0.1)]
+    block rounded-lg m-2 w-60
+    hover:brightness-115
+    hover:shadow-[0_3px_10px_rgb(0,0,0,0.2)]
+    hover:no-underline
+    transition-all duration-200 ease-in-out
+    mx-auto sm:mx-0'
 >
-    {image !== undefined && <img src={image} class='h-40 w-full object-cover rounded-t-[3px]' alt={displayName} />}
-    <div class='my-4 mx-4 h-28 flex flex-col justify-between'>
+    {image !== undefined && <img src={image} class='h-40 w-full object-cover rounded-t-[8px]' alt={displayName} />}
+    <div class='my-4 mx-4 h-28 flex flex-col justify-between text-slate-900'>
         <h3 class='font-semibold mb-2'>{displayName}</h3>
         <p class='text-sm leading-7'>
-            <span class='font-bold'>
+            <span class='font-semibold'>
                 {formatNumberWithDefaultLocale(organismStatistics.totalSequences)}
-            </span>
-            sequences
+
+                sequences</span
+            >
             <br />
-            <span class='text-slate-400 text-sm'>
-                <span class='text-slate-500'>
-                    +{formatNumberWithDefaultLocale(organismStatistics.recentSequences)}
-                </span>
+            <span class='text-sm'>
+                +{formatNumberWithDefaultLocale(organismStatistics.recentSequences)}
+
                 in last {numberDaysAgoStatistics} days
             </span>
             <span class='hidden'

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -22,7 +22,7 @@ const organismStatisticsMap = await getOrganismStatisticsMap(
 
         <div class='flex justify-center'>
             <div
-                class=`flex flex-wrap justify-center gap-x-4  gap-y-4 ${getConfiguredOrganisms().length ===5 ? "max-w-4xl" : ""}`
+                class=`flex flex-wrap justify-center gap-x-5  gap-y-4 ${getConfiguredOrganisms().length ===5 ? "max-w-4xl" : ""}`
             >
                 {
                     getConfiguredOrganisms().map(({ key, displayName, image }) => (


### PR DESCRIPTION
Adds a shadow to organism cards and redesigns them in various small ways. Uses Felix's original number formatting.

<img width="1220" alt="image" src="https://github.com/user-attachments/assets/65034ce4-9fed-41fa-8fa4-70ecb561d3d0" />


