### PR TITLE
refactor(website): get rid of zodios in the backend client

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -8,7 +8,7 @@ import { Banner } from '../components/common/Banner';
 import { getWebsiteConfig } from '../config';
 import 'react-toastify/dist/ReactToastify.css';
 import { navigationItems } from '../routes/navigationItems';
-import { BackendClient } from '../services/backendClient';
+import { createBackendClient } from '../services/backendClientFactory';
 
 const websiteConfig = getWebsiteConfig();
 const { name: websiteName, logo, bannerMessage, additionalHeadHTML, gitHubMainUrl } = websiteConfig;
@@ -21,7 +21,7 @@ interface Props {
 
 const { title, implicitOrganism, noHorizontalPadding } = Astro.props;
 
-const backendIsInDebugMode = await BackendClient.create().isInDebugMode();
+const backendIsInDebugMode = await createBackendClient().isInDebugMode();
 
 const lastTimeBannerWasClosed = Astro.cookies.get('lastTimeBannerWasClosed')?.value;
 ---

--- a/website/src/pages/[organism]/submission/[groupId]/index.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/index.astro
@@ -20,6 +20,8 @@ async function getSequenceCounts(organism: string, groupId: number) {
     try {
         const response = await backendClient.getSequences(accessToken, organism, {
             groupIdsFilter: groupId.toString(),
+            // We only need the counts, so we can set the page and size to 0
+            // to avoid fetching the actual sequences (slow part of the endpoint)
             page: 0,
             size: 0,
         });

--- a/website/src/pages/[organism]/submission/[groupId]/index.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/index.astro
@@ -1,8 +1,7 @@
 ---
 import SubmissionPageWrapper from '../../../../components/Submission/SubmissionPageWrapper.astro';
 import { routes } from '../../../../routes/routes';
-import { BackendClient } from '../../../../services/backendClient';
-import { createAuthorizationHeader } from '../../../../utils/createAuthorizationHeader';
+import { createBackendClient } from '../../../../services/backendClientFactory';
 import { getAccessToken } from '../../../../utils/getAccessToken';
 import { getGroupsAndCurrentGroup } from '../../../../utils/submissionPages';
 import F7Arrow2Circlepath from '~icons/f7/arrow-2-circlepath';
@@ -17,20 +16,13 @@ const accessToken = getAccessToken(session)!;
 const groupsResult = await getGroupsAndCurrentGroup(Astro.params, Astro.locals.session);
 
 async function getSequenceCounts(organism: string, groupId: number) {
-    const backendClient = BackendClient.create();
+    const backendClient = createBackendClient();
     try {
-        const response = await backendClient.call('getSequences', {
-            params: { organism },
-            headers: createAuthorizationHeader(accessToken),
-            queries: {
-                groupIdsFilter: groupId.toString(),
-                // We only need the counts, so we can set the page and size to 0
-                // to avoid fetching the actual sequences (slow part of the endpoint)
-                page: 0,
-                size: 0,
-            },
+        const response = await backendClient.getSequences(accessToken, organism, {
+            groupIdsFilter: groupId.toString(),
+            page: 0,
+            size: 0,
         });
-
         if (response.isErr()) {
             throw new Error('Failed to fetch sequences');
         }

--- a/website/src/pages/[organism]/submission/edit/[accession]/[version].astro
+++ b/website/src/pages/[organism]/submission/edit/[accession]/[version].astro
@@ -8,7 +8,7 @@ import {
     getSchema,
 } from '../../../../../config';
 import BaseLayout from '../../../../../layouts/BaseLayout.astro';
-import { BackendClient } from '../../../../../services/backendClient';
+import { createBackendClient } from '../../../../../services/backendClientFactory';
 import { getAccessToken } from '../../../../../utils/getAccessToken';
 
 const version = Astro.params.version!;
@@ -31,7 +31,7 @@ const clientConfig = getRuntimeConfig().public;
 const schema = getSchema(organism);
 const segmentNames = getReferenceGenomesSequenceNames(organism).nucleotideSequences;
 
-const dataToEdit = await BackendClient.create().getDataToEdit(organism, accessToken, accession, version);
+const dataToEdit = await createBackendClient().getDataToEdit(organism, accessToken, accession, version);
 ---
 
 <BaseLayout title={`Edit ${accession}.${version}`}>

--- a/website/src/pages/seq/[accessionVersion]/getSequenceDetailsTableData.ts
+++ b/website/src/pages/seq/[accessionVersion]/getSequenceDetailsTableData.ts
@@ -4,7 +4,7 @@ import { getTableData } from '../../../components/SequenceDetailsPage/getTableDa
 import { type TableDataEntry } from '../../../components/SequenceDetailsPage/types.ts';
 import { getSchema } from '../../../config.ts';
 import { routes } from '../../../routes/routes.ts';
-import { BackendClient } from '../../../services/backendClient.ts';
+import { createBackendClient } from '../../../services/backendClientFactory.ts';
 import { LapisClient } from '../../../services/lapisClient.ts';
 import type { DataUseTermsHistoryEntry, ProblemDetail } from '../../../types/backend.ts';
 import type { SequenceEntryHistory } from '../../../types/lapis.ts';
@@ -38,7 +38,7 @@ export const getSequenceDetailsTableData = async (
     const { accession, version } = parseAccessionVersionFromString(accessionVersion);
 
     const lapisClient = LapisClient.createForOrganism(organism);
-    const backendClient = BackendClient.create();
+    const backendClient = createBackendClient();
 
     if (version === undefined) {
         const latestVersionResult = await lapisClient.getLatestAccessionVersion(accession);
@@ -53,9 +53,7 @@ export const getSequenceDetailsTableData = async (
     const [tableDataResult, sequenceEntryHistoryResult, dataUseHistoryResult] = await Promise.all([
         getTableData(accessionVersion, schema, lapisClient),
         lapisClient.getAllSequenceEntryHistoryForAccession(accession),
-        backendClient.call('getDataUseTermsHistory', {
-            params: { accession },
-        }),
+        backendClient.getDataUseTermsHistory(accession),
     ]);
 
     return Result.combine([tableDataResult, sequenceEntryHistoryResult, dataUseHistoryResult]).map(

--- a/website/src/services/backendApi.ts
+++ b/website/src/services/backendApi.ts
@@ -10,7 +10,6 @@ import {
     dataUseTermsHistoryEntry,
     editedSequenceEntryData,
     getSequencesResponse,
-    info,
     problemDetail,
     revocationRequest,
     sequenceEntryToEdit,
@@ -248,13 +247,6 @@ const setDataUseTerms = makeEndpoint({
     ],
 });
 
-const infoEndpoint = makeEndpoint({
-    method: 'get',
-    path: '/',
-    alias: 'info',
-    response: info,
-});
-
 export const backendApi = makeApi([
     submitEndpoint,
     reviseEndpoint,
@@ -268,5 +260,4 @@ export const backendApi = makeApi([
     submitProcessedDataEndpoint,
     getDataUseTermsHistoryEndpoint,
     setDataUseTerms,
-    infoEndpoint,
 ]);

--- a/website/src/services/backendClient.ts
+++ b/website/src/services/backendClient.ts
@@ -1,28 +1,154 @@
-import { backendApi } from './backendApi.ts';
-import { ZodiosWrapperClient } from './zodiosWrapperClient.ts';
-import { getRuntimeConfig } from '../config.ts';
-import { getInstanceLogger } from '../logger.ts';
+import axios, { AxiosError, type Method } from 'axios';
+import { err, ok, Result } from 'neverthrow';
+import { z, ZodSchema } from 'zod';
+
+import { getInstanceLogger, type InstanceLogger } from '../logger.ts';
+import {
+    dataUseTermsHistoryEntry,
+    getSequencesResponse,
+    info,
+    sequenceEntryToEdit,
+    type ProblemDetail,
+} from '../types/backend.ts';
 import { createAuthorizationHeader } from '../utils/createAuthorizationHeader.ts';
 
 const myLogger = getInstanceLogger('BackendClient');
 
-export class BackendClient extends ZodiosWrapperClient<typeof backendApi> {
-    public static create(backendUrl: string = getRuntimeConfig().serverSide.backendUrl, logger = myLogger) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return new BackendClient(backendUrl, backendApi, (axiosError) => axiosError.data, logger, 'backend');
-    }
+type GetSequencesParameters = {
+    groupIdsFilter?: string | undefined;
+    statusesFilter?: string | undefined;
+    processingResultFilter?: string | undefined;
+    page?: number | undefined;
+    size?: number | undefined;
+};
+
+export class BackendClient {
+    constructor(
+        private readonly url: string,
+        private readonly logger: InstanceLogger = myLogger,
+    ) {}
 
     public getDataToEdit(organism: string, token: string, accession: string, version: string | number) {
-        return this.call('getDataToEdit', {
-            params: { accession, version, organism },
-            headers: createAuthorizationHeader(token),
-        });
+        return this.request(
+            `/${organism}/get-data-to-edit/${accession}/${version}`,
+            'GET',
+            sequenceEntryToEdit,
+            createAuthorizationHeader(token),
+            undefined,
+            undefined,
+        );
+    }
+
+    public getDataUseTermsHistory(accession: string) {
+        return this.request(
+            `/data-use-terms/${accession}`,
+            'GET',
+            z.array(dataUseTermsHistoryEntry),
+            undefined,
+            undefined,
+            undefined,
+        );
+    }
+
+    /*
+
+    const getSequencesEndpoint = makeEndpoint({
+    method: 'get',
+    path: withOrganismPathSegment('/get-sequences'),
+    alias: 'getSequences',
+    parameters: [
+        authorizationHeader,
+        {
+            name: 'groupIdsFilter',
+            type: 'Query',
+            schema: z.string().optional(), // comma separated list of group ids (numbers)
+        },
+        {
+            name: 'statusesFilter',
+            type: 'Query',
+            schema: z.string().optional(),
+        },
+        {
+            name: 'processingResultFilter',
+            type: 'Query',
+            schema: z.string().optional(),
+        },
+        {
+            name: 'page', // 0-indexed
+            type: 'Query',
+            schema: z.number().optional(),
+        },
+        {
+            name: 'size',
+            type: 'Query',
+            schema: z.number().optional(),
+        },
+    ],
+    response: getSequencesResponse,
+    errors: [notAuthorizedError, { status: 404, schema: problemDetail }],
+});
+
+    */
+
+    public getSequences(token: string, organism: string, params: GetSequencesParameters) {
+        return this.request(
+            `/${organism}/get-sequences`,
+            'GET',
+            getSequencesResponse,
+            createAuthorizationHeader(token),
+            undefined,
+            params,
+        );
     }
 
     public async isInDebugMode() {
-        return (await this.call('info')).match(
+        const infoResponse = await this.request('/', 'GET', info, undefined, undefined, undefined);
+        return infoResponse.match(
             (info) => info.isInDebugMode,
             () => false,
         );
+    }
+
+    private async request<T>(
+        endpoint: string,
+        method: Method,
+        responseSchema: ZodSchema<T>,
+        headers: Record<string, string> | undefined,
+        request: unknown,
+        params: unknown,
+    ): Promise<Result<T, ProblemDetail>> {
+        try {
+            const response = await axios.request({
+                url: `${this.url}${endpoint}`,
+                method,
+                headers,
+                params,
+                data: request,
+            });
+
+            const responseDataResult = responseSchema.safeParse(response.data);
+            if (responseDataResult.success) {
+                return ok(responseDataResult.data);
+            }
+            return err({
+                type: 'about:blank',
+                title: 'bad response',
+                status: 0,
+                detail: `Failed to parse backend response: ${responseDataResult.error.toString()}`,
+                instance: '/sample/details',
+            });
+        } catch (e) {
+            const axiosError = e as AxiosError;
+
+            // return err(this.createProblemDetail(axiosError, endpoint));
+
+            return err({
+                type: 'about:blank',
+                title: 'bad response',
+                status: 0,
+                detail: `Failed to parse backend response: ${axiosError.cause?.message}`,
+                instance: '/sample/details',
+            });
+        }
     }
 }

--- a/website/src/services/backendClient.ts
+++ b/website/src/services/backendClient.ts
@@ -8,7 +8,6 @@ import {
     getSequencesResponse,
     info,
     sequenceEntryToEdit,
-    unprocessedData,
     type ProblemDetail,
 } from '../types/backend.ts';
 import { createAuthorizationHeader } from '../utils/createAuthorizationHeader.ts';
@@ -48,43 +47,6 @@ export class BackendClient {
             undefined,
             undefined,
             undefined,
-        );
-    }
-
-    public extractUnprocessedData(
-        token: string,
-        organism: string,
-        numberOfSequenceEntries: number,
-        pipelineVersion: number,
-    ) {
-        return this.request(
-            `/${organism}/extract-unprocessed-data`,
-            'POST',
-            z.union([z.string(), unprocessedData]),
-            createAuthorizationHeader(token),
-            undefined,
-            {
-                numberOfSequenceEntries,
-                pipelineVersion,
-            },
-        );
-    }
-
-    public submitProcessedData(token: string, organism: string, pipelineVersion: number, body: string) {
-        return this.request(
-            `/${organism}/submit-processed-data`,
-            'POST',
-            z.never(),
-            {
-                ...createAuthorizationHeader(token),
-                /* eslint-disable @typescript-eslint/naming-convention -- header names are not camel case */
-                'Content-Type': 'application/x-ndjson',
-                /* eslint-enable @typescript-eslint/naming-convention */
-            },
-            body,
-            {
-                pipelineVersion,
-            },
         );
     }
 

--- a/website/src/services/backendClient.ts
+++ b/website/src/services/backendClient.ts
@@ -8,6 +8,7 @@ import {
     getSequencesResponse,
     info,
     sequenceEntryToEdit,
+    unprocessedData,
     type ProblemDetail,
 } from '../types/backend.ts';
 import { createAuthorizationHeader } from '../utils/createAuthorizationHeader.ts';
@@ -50,45 +51,42 @@ export class BackendClient {
         );
     }
 
-    /*
+    public extractUnprocessedData(
+        token: string,
+        organism: string,
+        numberOfSequenceEntries: number,
+        pipelineVersion: number,
+    ) {
+        return this.request(
+            `/${organism}/extract-unprocessed-data`,
+            'POST',
+            z.union([z.string(), unprocessedData]),
+            createAuthorizationHeader(token),
+            undefined,
+            {
+                numberOfSequenceEntries,
+                pipelineVersion,
+            },
+        );
+    }
 
-    const getSequencesEndpoint = makeEndpoint({
-    method: 'get',
-    path: withOrganismPathSegment('/get-sequences'),
-    alias: 'getSequences',
-    parameters: [
-        authorizationHeader,
-        {
-            name: 'groupIdsFilter',
-            type: 'Query',
-            schema: z.string().optional(), // comma separated list of group ids (numbers)
-        },
-        {
-            name: 'statusesFilter',
-            type: 'Query',
-            schema: z.string().optional(),
-        },
-        {
-            name: 'processingResultFilter',
-            type: 'Query',
-            schema: z.string().optional(),
-        },
-        {
-            name: 'page', // 0-indexed
-            type: 'Query',
-            schema: z.number().optional(),
-        },
-        {
-            name: 'size',
-            type: 'Query',
-            schema: z.number().optional(),
-        },
-    ],
-    response: getSequencesResponse,
-    errors: [notAuthorizedError, { status: 404, schema: problemDetail }],
-});
-
-    */
+    public submitProcessedData(token: string, organism: string, pipelineVersion: number, body: string) {
+        return this.request(
+            `/${organism}/submit-processed-data`,
+            'POST',
+            z.never(),
+            {
+                ...createAuthorizationHeader(token),
+                /* eslint-disable @typescript-eslint/naming-convention -- header names are not camel case */
+                'Content-Type': 'application/x-ndjson',
+                /* eslint-enable @typescript-eslint/naming-convention */
+            },
+            body,
+            {
+                pipelineVersion,
+            },
+        );
+    }
 
     public getSequences(token: string, organism: string, params: GetSequencesParameters) {
         return this.request(

--- a/website/src/services/backendClient.ts
+++ b/website/src/services/backendClient.ts
@@ -21,7 +21,6 @@ type GetSequencesParameters = {
     page?: number | undefined;
     size?: number | undefined;
 };
-
 export class BackendClient {
     constructor(
         private readonly url: string,
@@ -94,20 +93,16 @@ export class BackendClient {
                 type: 'about:blank',
                 title: 'bad response',
                 status: 0,
-                detail: `Failed to parse backend response: ${responseDataResult.error.toString()}`,
-                instance: '/sample/details',
+                detail: `Failed to parse backend response: ${responseDataResult.error.toString()}`
             });
         } catch (e) {
             const axiosError = e as AxiosError;
-
-            // return err(this.createProblemDetail(axiosError, endpoint));
-
+ 
             return err({
                 type: 'about:blank',
                 title: 'bad response',
                 status: 0,
-                detail: `Failed to parse backend response: ${axiosError.cause?.message}`,
-                instance: '/sample/details',
+                detail: `Failed to make request: ${axiosError.cause?.message}`,
             });
         }
     }

--- a/website/src/services/backendClient.ts
+++ b/website/src/services/backendClient.ts
@@ -93,11 +93,11 @@ export class BackendClient {
                 type: 'about:blank',
                 title: 'bad response',
                 status: 0,
-                detail: `Failed to parse backend response: ${responseDataResult.error.toString()}`
+                detail: `Failed to parse backend response: ${responseDataResult.error.toString()}`,
             });
         } catch (e) {
             const axiosError = e as AxiosError;
- 
+
             return err({
                 type: 'about:blank',
                 title: 'bad response',

--- a/website/src/services/backendClientFactory.ts
+++ b/website/src/services/backendClientFactory.ts
@@ -1,6 +1,10 @@
 import { getRuntimeConfig } from '../config';
 import { BackendClient } from './backendClient';
 
+/**
+ * Create a new {@link BackendClient} by using {@link getRuntimeConfig}
+ * to configure the client.
+ */
 export function createBackendClient(): BackendClient {
     return new BackendClient(getRuntimeConfig().serverSide.backendUrl);
 }

--- a/website/src/services/backendClientFactory.ts
+++ b/website/src/services/backendClientFactory.ts
@@ -1,0 +1,6 @@
+import { getRuntimeConfig } from '../config';
+import { BackendClient } from './backendClient';
+
+export function createBackendClient(): BackendClient {
+    return new BackendClient(getRuntimeConfig().serverSide.backendUrl);
+}

--- a/website/tests/backendAuth.spec.ts
+++ b/website/tests/backendAuth.spec.ts
@@ -1,4 +1,5 @@
 import { backendClient, dummyOrganism, expect, test } from './e2e.fixture.ts';
+import { createAuthorizationHeader } from '../src/utils/createAuthorizationHeader.ts';
 
 const tokenSignedWithDifferentKey =
     'eyJhbGciOiJSUzI1NiJ9.eyJleHAiOjE3MDE0MjMyNzAsImlhdCI6MTcwMTMzNjg3MCwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdFVzZXIifQ' +
@@ -9,7 +10,14 @@ const tokenSignedWithDifferentKey =
 
 test.describe('The backend', () => {
     test('should reject a call with a token that was not signed by Keycloak', async () => {
-        const response = await backendClient.getDataToEdit(dummyOrganism.key, tokenSignedWithDifferentKey, '1', 1);
+        const response = await backendClient.call('getDataToEdit', {
+            params: {
+                accession: '1',
+                version: 1,
+                organism: dummyOrganism.key,
+            },
+            headers: createAuthorizationHeader(tokenSignedWithDifferentKey),
+        });
         expect(response._unsafeUnwrapErr().detail).toContain('Invalid signature');
     });
 });

--- a/website/tests/backendAuth.spec.ts
+++ b/website/tests/backendAuth.spec.ts
@@ -1,5 +1,4 @@
 import { backendClient, dummyOrganism, expect, test } from './e2e.fixture.ts';
-import { createAuthorizationHeader } from '../src/utils/createAuthorizationHeader.ts';
 
 const tokenSignedWithDifferentKey =
     'eyJhbGciOiJSUzI1NiJ9.eyJleHAiOjE3MDE0MjMyNzAsImlhdCI6MTcwMTMzNjg3MCwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdFVzZXIifQ' +
@@ -10,14 +9,7 @@ const tokenSignedWithDifferentKey =
 
 test.describe('The backend', () => {
     test('should reject a call with a token that was not signed by Keycloak', async () => {
-        const response = await backendClient.call('getDataToEdit', {
-            params: {
-                accession: '1',
-                version: 1,
-                organism: dummyOrganism.key,
-            },
-            headers: createAuthorizationHeader(tokenSignedWithDifferentKey),
-        });
+        const response = await backendClient.getDataToEdit(dummyOrganism.key, tokenSignedWithDifferentKey, '1', 1);
         expect(response._unsafeUnwrapErr().detail).toContain('Invalid signature');
     });
 });

--- a/website/tests/e2e.fixture.ts
+++ b/website/tests/e2e.fixture.ts
@@ -69,7 +69,7 @@ export const e2eLogger = winston.createLogger({
     transports: [new winston.transports.Console()],
 });
 
-export const backendClient = BackendClient.create(backendUrl, e2eLogger);
+export const backendClient = new BackendClient(backendUrl, e2eLogger);
 export const groupManagementClient = GroupManagementClient.create(backendUrl, e2eLogger);
 
 export const testSequenceEntryData = {

--- a/website/tests/e2e.fixture.ts
+++ b/website/tests/e2e.fixture.ts
@@ -8,18 +8,20 @@ import winston from 'winston';
 
 import { EditPage } from './pages/edit/edit.page';
 import { NavigationFixture } from './pages/navigation.fixture';
+import type { InstanceLogger } from '../src/logger.ts';
 import { ReviewPage } from './pages/review/review.page.ts';
 import { RevisePage } from './pages/revise/revise.page';
 import { SearchPage } from './pages/search/search.page';
 import { SeqSetPage } from './pages/seqsets/seqset.page';
 import { SequencePage } from './pages/sequences/sequences.page';
 import { SubmitPage } from './pages/submission/submit.page';
+import { backendApi } from '../src/services/backendApi.ts';
 import { GroupPage } from './pages/user/group/group.page.ts';
 import { UserPage } from './pages/user/userPage/userPage.ts';
 import { throwOnConsole } from './util/throwOnConsole.ts';
 import { ACCESS_TOKEN_COOKIE, REFRESH_TOKEN_COOKIE } from '../src/middleware/authMiddleware';
-import { BackendClient } from '../src/services/backendClient';
 import { GroupManagementClient } from '../src/services/groupManagementClient.ts';
+import { ZodiosWrapperClient } from '../src/services/zodiosWrapperClient.ts';
 import { type DataUseTerms, type NewGroup, openDataUseTermsOption } from '../src/types/backend.ts';
 import { getClientMetadata } from '../src/utils/clientMetadata.ts';
 import { realmPath } from '../src/utils/realmPath.ts';
@@ -69,7 +71,14 @@ export const e2eLogger = winston.createLogger({
     transports: [new winston.transports.Console()],
 });
 
-export const backendClient = new BackendClient(backendUrl, e2eLogger);
+class BackendClient extends ZodiosWrapperClient<typeof backendApi> {
+    public static create(backendUrl: string, logger: InstanceLogger) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return new BackendClient(backendUrl, backendApi, (axiosError) => axiosError.data, logger, 'backend');
+    }
+}
+
+export const backendClient = BackendClient.create(backendUrl, e2eLogger);
 export const groupManagementClient = GroupManagementClient.create(backendUrl, e2eLogger);
 
 export const testSequenceEntryData = {

--- a/website/tests/e2e.fixture.ts
+++ b/website/tests/e2e.fixture.ts
@@ -71,7 +71,7 @@ export const e2eLogger = winston.createLogger({
     transports: [new winston.transports.Console()],
 });
 
-class BackendClient extends ZodiosWrapperClient<typeof backendApi> {
+export class BackendClient extends ZodiosWrapperClient<typeof backendApi> {
     public static create(backendUrl: string, logger: InstanceLogger) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return new BackendClient(backendUrl, backendApi, (axiosError) => axiosError.data, logger, 'backend');

--- a/website/tests/util/preprocessingPipeline.ts
+++ b/website/tests/util/preprocessingPipeline.ts
@@ -56,13 +56,12 @@ async function submit(preprocessingOptions: PreprocessingOptions[]) {
 
     const jwt = await getJwtTokenForPreprocessingPipeline();
 
-    const response = await BackendClient.create(backendUrl, e2eLogger).call('submitProcessedData', body, {
-        params: { organism: dummyOrganism.key },
-        queries: { pipelineVersion: 1 },
-        /* eslint-disable @typescript-eslint/naming-convention -- header names are not camel case */
-        headers: { 'Content-Type': 'application/x-ndjson', 'Authorization': `Bearer ${jwt}` },
-        /* eslint-enable @typescript-eslint/naming-convention */
-    });
+    const response = await new BackendClient(backendUrl, e2eLogger).submitProcessedData(
+        jwt,
+        dummyOrganism.key,
+        1,
+        body,
+    );
 
     if (response.isErr()) {
         throw handleError(response.error);
@@ -81,11 +80,12 @@ async function getJwtTokenForPreprocessingPipeline(
 async function query(numberOfSequenceEntries: number): Promise<UnprocessedData[]> {
     const jwt = await getJwtTokenForPreprocessingPipeline();
 
-    const response = await BackendClient.create(backendUrl, e2eLogger).call('extractUnprocessedData', undefined, {
-        params: { organism: dummyOrganism.key },
-        queries: { numberOfSequenceEntries, pipelineVersion: 1 },
-        headers: { Authorization: `Bearer ${jwt}` }, // eslint-disable-line @typescript-eslint/naming-convention -- header names are not camel case
-    });
+    const response = await new BackendClient(backendUrl, e2eLogger).extractUnprocessedData(
+        jwt,
+        dummyOrganism.key,
+        numberOfSequenceEntries,
+        1,
+    );
 
     return response.match(
         (unprocessedDataAsNdjson) => {


### PR DESCRIPTION
Removes the zodios dependency from the `BackendClient`. Also makes the `BackendClient` usable in react by not having the `config.ts` import in it anymore.


### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.

🚀 Preview: https://backend-client.loculus.org