### PR TITLE
Format integration tests on format_me label

### DIFF
--- a/.github/workflows/format-integration-tests.yml
+++ b/.github/workflows/format-integration-tests.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   format:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'format_me'))
     runs-on: ubuntu-latest
     
     defaults:
@@ -31,3 +32,16 @@ jobs:
       
       - name: Check formatting
         run: npm run format:check
+
+      - name: Format Integration Tests
+        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'format_me'))
+        run: npm run format
+
+      - name: Commit and Push Changes
+        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'format_me'))
+        run: |
+          git config --global user.name 'Loculus bot'
+          git config --global user.email 'bot@loculus.org'
+          git add -A
+          git commit -m "Automated integration tests formatting" || echo "No changes to commit"
+          git push origin HEAD:${{ github.head_ref }}


### PR DESCRIPTION
Add condition to format integration tests when `format_me` label is present.

* Add condition to check if the `format_me` label is present in `.github/workflows/format-integration-tests.yml`.
* Add step to format the integration tests if the `format_me` label is present.
* Add step to commit and push the changes if the `format_me` label is present.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/loculus-project/loculus/pull/3966?shareId=feadc572-4434-4cda-9278-6ac6bdc4e006).