### PR TITLE
fix(website): Make sequences-file check only happen when consensus sequences are enabled

### DIFF
--- a/website/src/components/Submission/FormOrUploadWrapper.tsx
+++ b/website/src/components/Submission/FormOrUploadWrapper.tsx
@@ -106,7 +106,7 @@ export const FormOrUploadWrapper: FC<FormOrUploadWrapperProps> = ({
                         }
 
                         const sFile = sequenceFile?.inner();
-                        if (sFile === undefined) {
+                        if (enableConsensusSequences && sFile === undefined) {
                             return { type: 'error', errorMessage: 'Please specify a sequences file.' };
                         }
 

--- a/website/src/components/Submission/SubmissionForm.spec.tsx
+++ b/website/src/components/Submission/SubmissionForm.spec.tsx
@@ -297,7 +297,7 @@ describe('SubmitForm', () => {
         mockRequest.backend.submit(200, testResponse);
         mockRequest.backend.getGroupsOfUser();
 
-        const { getByLabelText } = renderSubmissionForm({
+        const { getByLabelText, getByRole } = renderSubmissionForm({
             allowSubmissionOfConsensusSequences: false,
         });
 
@@ -308,6 +308,8 @@ describe('SubmitForm', () => {
         await userEvent.click(
             getByLabelText(/I confirm that the data submitted is not sensitive or human-identifiable/i),
         );
+
+        await userEvent.click(getByRole('button', { name: 'Submit sequences' }));
 
         await waitFor(() => {
             expect(toast.error).not.toHaveBeenCalled();


### PR DESCRIPTION
resolves #3972 

### Screenshot



https://github.com/user-attachments/assets/667dc925-f6dd-438e-bbd2-5cc8c3dc9f19


### PR Checklist
- ~~All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by appropriate, automated tests.

🚀 Preview: Add `preview` label to enable