### PR TITLE
Make file links available in SILO

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -182,7 +182,7 @@ open class ReleasedDataModel(
                             TextNode(
                                 entry.value.map { fileEntry ->
                                     s3Service.createPublicUrl(fileEntry.fileId, 1)
-                                }.joinToString { ", " },
+                                }.joinToString(", "),
                             )
                     }.toMap()
                 },

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -181,7 +181,7 @@ open class ReleasedDataModel(
                         entry.key to
                             TextNode(
                                 entry.value.map { fileEntry ->
-                                    s3Service.createPublicUrl(fileEntry.fileId, 1)
+                                    s3Service.createPublicUrl(fileEntry.fileId, rawProcessedData.groupId)
                                 }.joinToString(" "),
                             )
                     }.toMap()

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -182,7 +182,7 @@ open class ReleasedDataModel(
                             TextNode(
                                 entry.value.map { fileEntry ->
                                     s3Service.createPublicUrl(fileEntry.fileId, 1)
-                                }.joinToString(", "),
+                                }.joinToString(" "),
                             )
                     }.toMap()
                 },

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -14,6 +14,7 @@ import org.loculus.backend.api.ProcessedData
 import org.loculus.backend.api.VersionStatus
 import org.loculus.backend.config.BackendConfig
 import org.loculus.backend.service.datauseterms.DATA_USE_TERMS_TABLE_NAME
+import org.loculus.backend.service.files.S3Service
 import org.loculus.backend.service.groupmanagement.GROUPS_TABLE_NAME
 import org.loculus.backend.service.submission.CURRENT_PROCESSING_PIPELINE_TABLE_NAME
 import org.loculus.backend.service.submission.EXTERNAL_METADATA_TABLE_NAME
@@ -52,6 +53,7 @@ open class ReleasedDataModel(
     private val submissionDatabaseService: SubmissionDatabaseService,
     private val backendConfig: BackendConfig,
     private val dateProvider: DateProvider,
+    private val s3Service: S3Service,
 ) {
     @Transactional(readOnly = true)
     open fun getReleasedData(organism: Organism): Sequence<ProcessedData<GeneticSequence>> {
@@ -171,9 +173,20 @@ open class ReleasedDataModel(
                         "dataUseTermsUrl" to TextNode(dataUseTermsUrl!!),
                     )
                 },
+            ) +
+            conditionalMetadata(
+                rawProcessedData.processedData.files != null,
+                {
+                    rawProcessedData.processedData.files!!.map { entry ->
+                        entry.key to
+                            TextNode(
+                                entry.value.map { fileEntry ->
+                                    s3Service.createPublicUrl(fileEntry.fileId, 1)
+                                }.joinToString { ", " },
+                            )
+                    }.toMap()
+                },
             )
-        // TODO add file fields here
-        // compute URLs based on S3 settings, groupID and fileID
 
         return ProcessedData(
             metadata = metadata,

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -172,6 +172,8 @@ open class ReleasedDataModel(
                     )
                 },
             )
+        // TODO add file fields here
+        // compute URLs based on S3 settings, groupID and fileID
 
         return ProcessedData(
             metadata = metadata,

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/S3Service.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/S3Service.kt
@@ -40,6 +40,11 @@ class S3Service(private val backendConfig: BackendConfig) {
         )
     }
 
+    fun createPublicUrl(fileId: FileId, groupId: Int): String {
+        val config = getS3BucketConfig()
+        return "${config.endpoint}/${config.bucket}/${getFileName(fileId, groupId)}"
+    }
+
     fun setFileToPublic(fileId: FileId, groupId: Int) {
         val config = getS3BucketConfig()
         getClient().setObjectTags(

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/S3Service.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/S3Service.kt
@@ -42,7 +42,7 @@ class S3Service(private val backendConfig: BackendConfig) {
 
     fun createPublicUrl(fileId: FileId, groupId: Int): String {
         val config = getS3BucketConfig()
-        return "${config.endpoint}/${config.bucket}/${getFileName(fileId, groupId)}"
+        return "https://${config.endpoint}/${config.bucket}/${getFileName(fileId, groupId)}"
     }
 
     fun setFileToPublic(fileId: FileId, groupId: Int) {

--- a/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
+++ b/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
@@ -35,6 +35,12 @@ schema:
       name: {{ .name }}
   {{- end }}
   {{- end }}
+  {{- if .files }}
+  {{- range .files }}
+    - type: string
+      name: {{ .name }}
+  {{- end }}
+  {{- end }}
   primaryKey: accessionVersion
 {{ if .silo}}
   {{- .silo | toYaml | nindent 2 }}


### PR DESCRIPTION
partially resolves #3932 

- Generate metadata field settings in SILO
- compute string fields in the `get-release-data` endpoint. Each "file field" is added as a field to metadata, and it contains the links to the files as public S3 links, separated by a space"

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://fs-silo.loculus.org