### PR TITLE
fix(workflow): disable add preview url for PRs opened by dependabot

### DIFF
--- a/.github/workflows/add-preview-url.yml
+++ b/.github/workflows/add-preview-url.yml
@@ -14,6 +14,13 @@ jobs:
           github-token: ${{ secrets.LOCULUS_BOT_WRITE_PRS }}
           script: |
             const pr = context.payload.pull_request;
+
+            // Skip if PR author is Dependabot for security reasons
+            if (pr.user.login === 'dependabot[bot]') {
+              console.log("Skipping Dependabot PR.");
+              return;
+            }
+
             const branchName = pr.head.ref;
             const hasPreviewLabel = pr.labels.some(label => label.name === 'preview');
             

--- a/.github/workflows/add-preview-url.yml
+++ b/.github/workflows/add-preview-url.yml
@@ -15,7 +15,7 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
 
-            // Skip if PR author is Dependabot for security reasons
+            // Skip if PR author is Dependabot as Dependabot cannot access github-token
             if (pr.user.login === 'dependabot[bot]') {
               console.log("Skipping Dependabot PR.");
               return;


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/3987

### Screenshot

### PR Checklist
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
- tested that this works by rebasing a dependabot PR on this branch: https://github.com/loculus-project/loculus/pull/3956 (PR passes this check, fails others

🚀 Preview: Add `preview` label to enable