### PR TITLE
chore(preprocessing): disable dummy errors for files

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1485,9 +1485,6 @@ defaultOrganisms:
         image: ghcr.io/loculus-project/preprocessing-dummy
         args:
           - "--watch"
-          - "--withWarnings"
-          - "--withErrors"
-          - "--randomWarnError"
           - "--disableConsensusSequences"
     referenceGenomes:
       nucleotideSequences: []


### PR DESCRIPTION
The randomly occurring errors and warnings thrown by the dummy pipeline are annoying and not useful for developing the file sharing feature.

🚀 Preview: https://fs-disable-dummy-errors.loculus.org