### PR TITLE
feat(config): clean up old failed/succeeded cronjobs

### DIFF
--- a/kubernetes/loculus/templates/ena-submission-deployment.yaml
+++ b/kubernetes/loculus/templates/ena-submission-deployment.yaml
@@ -119,6 +119,8 @@ spec:
   schedule: "0 0 * * *" # get submission list daily at midnight
   startingDeadlineSeconds: 60
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       activeDeadlineSeconds: {{ $.Values.getSubmissionListLimitSeconds }}

--- a/kubernetes/loculus/templates/ingest-deployment.yaml
+++ b/kubernetes/loculus/templates/ingest-deployment.yaml
@@ -109,6 +109,8 @@ spec:
   suspend: true
   startingDeadlineSeconds: 60
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       activeDeadlineSeconds: {{ $.Values.ingestLimitSeconds }}


### PR DESCRIPTION
I asked chatgpt how to ensure we don't store the logs of all failed/succeeded cronjobs and this was the result
