### PR TITLE
chore(deployment): remove reloader

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -156,7 +156,6 @@ def handle_cluster():
             shell=True,
         )
     install_secret_generator()
-    install_reloader()
     while not is_traefik_running():
         print("Waiting for Traefik to start...")
         time.sleep(5)
@@ -448,37 +447,6 @@ def install_secret_generator():
         "resources.limits.memory=400Mi",
         "--set",
         "resources.requests.memory=200Mi",
-    ]
-    run_command(helm_install_command)
-
-
-def install_reloader():
-    add_helm_repo_command = [
-        "helm",
-        "repo",
-        "add",
-        "stakater",
-        "https://stakater.github.io/stakater-charts",
-    ]
-    run_command(add_helm_repo_command)
-    print("Stakater added to repositories.")
-
-    update_helm_repo_command = ["helm", "repo", "update"]
-    run_command(update_helm_repo_command)
-    print("Helm repositories updated.")
-
-    secret_generator_chart = "stakater/reloader"
-    print("Installing Reloader...")
-    helm_install_command = [
-        "helm",
-        "upgrade",
-        "--install",
-        "reloader",
-        secret_generator_chart,
-        "--set",
-        "reloader.deployment.resources.limits.memory=200Mi",
-        "--set",
-        "reloader.deployment.resources.requests.memory=100Mi",
     ]
     run_command(helm_install_command)
 

--- a/kubernetes/loculus/templates/docs-preview.yaml
+++ b/kubernetes/loculus/templates/docs-preview.yaml
@@ -8,7 +8,6 @@ metadata:
   name: loculus-docs
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
-    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   selector:

--- a/kubernetes/loculus/templates/ena-submission-deployment.yaml
+++ b/kubernetes/loculus/templates/ena-submission-deployment.yaml
@@ -7,7 +7,6 @@ metadata:
   name: loculus-ena-submission
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
-    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   selector:

--- a/kubernetes/loculus/templates/ingest-deployment.yaml
+++ b/kubernetes/loculus/templates/ingest-deployment.yaml
@@ -9,7 +9,6 @@ metadata:
   name: loculus-ingest-deployment-{{ $key }}
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
-    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   strategy:

--- a/kubernetes/loculus/templates/keycloak-database-standin.yaml
+++ b/kubernetes/loculus/templates/keycloak-database-standin.yaml
@@ -6,7 +6,6 @@ metadata:
   name: loculus-keycloak-database
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
-    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   selector:

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: loculus-keycloak
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
-    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   selector:

--- a/kubernetes/loculus/templates/lapis-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-deployment.yaml
@@ -7,7 +7,6 @@ kind: Deployment
 metadata:
   name: loculus-lapis-{{ $key }}
   annotations:
-    reloader.stakater.com/auto: "true"
 spec:
   replicas: {{ $.Values.replicas.lapis | default 1 }}
   selector:

--- a/kubernetes/loculus/templates/loculus-backend.yaml
+++ b/kubernetes/loculus/templates/loculus-backend.yaml
@@ -7,7 +7,6 @@ metadata:
   name: loculus-backend
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
-    reloader.stakater.com/auto: "true"
 spec:
   replicas: {{$.Values.replicas.backend}}
   selector:

--- a/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
@@ -17,7 +17,6 @@ metadata:
   name: loculus-preprocessing-{{ $organism }}-v{{ $processingConfig.version }}-{{ $processingIndex }}
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
-    reloader.stakater.com/auto: "true"
 spec:
   replicas: {{ $replicas }}
   selector:

--- a/kubernetes/loculus/templates/loculus-website.yaml
+++ b/kubernetes/loculus/templates/loculus-website.yaml
@@ -7,7 +7,6 @@ metadata:
   name: loculus-website
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
-    reloader.stakater.com/auto: "true"
 spec:
   replicas: {{$.Values.replicas.website}}
   selector:

--- a/kubernetes/loculus/templates/silo-deployment.yaml
+++ b/kubernetes/loculus/templates/silo-deployment.yaml
@@ -11,7 +11,6 @@ metadata:
   annotations:
     # Force replace when run a) with dev db and b) without persistence to ensure silo prepro fails loudly
     argocd.argoproj.io/sync-options: Replace=true{{ if (and (not $.Values.developmentDatabasePersistence) $.Values.runDevelopmentMainDatabase) }},Force=true{{ end }}
-    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
1. Removed the reloader.stakater.com/auto: "true" annotation from
  all Kubernetes deployment files:
    - loculus-backend.yaml
    - loculus-website.yaml
    - silo-deployment.yaml
    - lapis-deployment.yaml
    - keycloak-deployment.yaml
    - ingest-deployment.yaml
    - ena-submission-deployment.yaml
    - docs-preview.yaml
    - keycloak-database-standin.yaml
    - loculus-preprocessing-deployment.yaml
  2. Removed the reloader installation code from deploy.py:
    - Removed install_reloader() function call from handle_cluster()
  function
    - Deleted the entire install_reloader() function

🚀 Preview: https://remove-reloader.loculus.org