### PR TITLE
feat(deployment): timestamp pods on deployment to force restart of all pods on every deployment

### DIFF
--- a/kubernetes/loculus/templates/docs-preview.yaml
+++ b/kubernetes/loculus/templates/docs-preview.yaml
@@ -8,7 +8,6 @@ metadata:
   name: loculus-docs
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
-    timestamp: {{ now | quote }}
 spec:
   replicas: 1
   selector:
@@ -17,6 +16,8 @@ spec:
       component: docs
   template:
     metadata:
+      annotations:
+        timestamp: {{ now | quote }}
       labels:
         app: loculus
         component: docs

--- a/kubernetes/loculus/templates/docs-preview.yaml
+++ b/kubernetes/loculus/templates/docs-preview.yaml
@@ -8,6 +8,7 @@ metadata:
   name: loculus-docs
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
+    timestamp: {{ now | quote }}
 spec:
   replicas: 1
   selector:

--- a/kubernetes/loculus/templates/ena-submission-deployment.yaml
+++ b/kubernetes/loculus/templates/ena-submission-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   name: loculus-ena-submission
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
+    timestamp: {{ now | quote }}
 spec:
   replicas: 1
   selector:

--- a/kubernetes/loculus/templates/ena-submission-deployment.yaml
+++ b/kubernetes/loculus/templates/ena-submission-deployment.yaml
@@ -7,7 +7,6 @@ metadata:
   name: loculus-ena-submission
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
-    timestamp: {{ now | quote }}
 spec:
   replicas: 1
   selector:
@@ -16,6 +15,8 @@ spec:
       component: loculus-ena-submission
   template:
     metadata:
+      annotations:
+        timestamp: {{ now | quote }}
       labels:
         app: loculus
         component: loculus-ena-submission

--- a/kubernetes/loculus/templates/ingest-deployment.yaml
+++ b/kubernetes/loculus/templates/ingest-deployment.yaml
@@ -9,7 +9,6 @@ metadata:
   name: loculus-ingest-deployment-{{ $key }}
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
-    timestamp: {{ now | quote }}
 spec:
   replicas: 1
   strategy:
@@ -20,6 +19,8 @@ spec:
       component: loculus-ingest-deployment-{{ $key }}
   template:
     metadata:
+      annotations:
+        timestamp: {{ now | quote }}
       labels:
         app: loculus
         component: loculus-ingest-deployment-{{ $key }}

--- a/kubernetes/loculus/templates/ingest-deployment.yaml
+++ b/kubernetes/loculus/templates/ingest-deployment.yaml
@@ -9,6 +9,7 @@ metadata:
   name: loculus-ingest-deployment-{{ $key }}
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
+    timestamp: {{ now | quote }}
 spec:
   replicas: 1
   strategy:

--- a/kubernetes/loculus/templates/keycloak-database-standin.yaml
+++ b/kubernetes/loculus/templates/keycloak-database-standin.yaml
@@ -6,7 +6,6 @@ metadata:
   name: loculus-keycloak-database
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
-    timestamp: {{ now | quote }}
 spec:
   replicas: 1
   selector:
@@ -17,6 +16,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        timestamp: {{ now | quote }}
       labels:
         app: loculus
         component: keycloak-database

--- a/kubernetes/loculus/templates/keycloak-database-standin.yaml
+++ b/kubernetes/loculus/templates/keycloak-database-standin.yaml
@@ -6,6 +6,7 @@ metadata:
   name: loculus-keycloak-database
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
+    timestamp: {{ now | quote }}
 spec:
   replicas: 1
   selector:

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: loculus-keycloak
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
+    timestamp: {{ now | quote }}
 spec:
   replicas: 1
   selector:

--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: loculus-keycloak
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
-    timestamp: {{ now | quote }}
 spec:
   replicas: 1
   selector:
@@ -15,6 +14,8 @@ spec:
       component: keycloak
   template:
     metadata:
+      annotations:
+        timestamp: {{ now | quote }}
       labels:
         app: loculus
         component: keycloak

--- a/kubernetes/loculus/templates/lapis-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-deployment.yaml
@@ -7,6 +7,7 @@ kind: Deployment
 metadata:
   name: loculus-lapis-{{ $key }}
   annotations:
+    timestamp: {{ now | quote }}
 spec:
   replicas: {{ $.Values.replicas.lapis | default 1 }}
   selector:

--- a/kubernetes/loculus/templates/lapis-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-deployment.yaml
@@ -7,7 +7,6 @@ kind: Deployment
 metadata:
   name: loculus-lapis-{{ $key }}
   annotations:
-    timestamp: {{ now | quote }}
 spec:
   replicas: {{ $.Values.replicas.lapis | default 1 }}
   selector:
@@ -16,6 +15,8 @@ spec:
       component: lapis-{{ $key }}
   template:
     metadata:
+      annotations:
+        timestamp: {{ now | quote }}
       labels:
         app: loculus
         component: lapis-{{ $key }}

--- a/kubernetes/loculus/templates/loculus-backend.yaml
+++ b/kubernetes/loculus/templates/loculus-backend.yaml
@@ -7,6 +7,7 @@ metadata:
   name: loculus-backend
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
+    timestamp: {{ now | quote }}
 spec:
   replicas: {{$.Values.replicas.backend}}
   selector:

--- a/kubernetes/loculus/templates/loculus-backend.yaml
+++ b/kubernetes/loculus/templates/loculus-backend.yaml
@@ -7,7 +7,6 @@ metadata:
   name: loculus-backend
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
-    timestamp: {{ now | quote }}
 spec:
   replicas: {{$.Values.replicas.backend}}
   selector:
@@ -16,6 +15,8 @@ spec:
       component: backend
   template:
     metadata:
+      annotations:
+        timestamp: {{ now | quote }}
       labels:
         app: loculus
         component: backend

--- a/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
@@ -17,6 +17,7 @@ metadata:
   name: loculus-preprocessing-{{ $organism }}-v{{ $processingConfig.version }}-{{ $processingIndex }}
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
+    timestamp: {{ now | quote }}
 spec:
   replicas: {{ $replicas }}
   selector:

--- a/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
@@ -17,7 +17,6 @@ metadata:
   name: loculus-preprocessing-{{ $organism }}-v{{ $processingConfig.version }}-{{ $processingIndex }}
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
-    timestamp: {{ now | quote }}
 spec:
   replicas: {{ $replicas }}
   selector:
@@ -26,6 +25,8 @@ spec:
       component: loculus-preprocessing-{{ $organism }}-v{{ $processingConfig.version }}-{{ $processingIndex }}
   template:
     metadata:
+      annotations:
+        timestamp: {{ now | quote }}
       labels:
         app: loculus
         component: loculus-preprocessing-{{ $organism }}-v{{ $processingConfig.version }}-{{ $processingIndex }}

--- a/kubernetes/loculus/templates/loculus-website.yaml
+++ b/kubernetes/loculus/templates/loculus-website.yaml
@@ -7,7 +7,6 @@ metadata:
   name: loculus-website
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
-    timestamp: {{ now | quote }}
 spec:
   replicas: {{$.Values.replicas.website}}
   selector:
@@ -16,6 +15,8 @@ spec:
       component: website
   template:
     metadata:
+      annotations:
+        timestamp: {{ now | quote }}
       labels:
         app: loculus
         component: website

--- a/kubernetes/loculus/templates/loculus-website.yaml
+++ b/kubernetes/loculus/templates/loculus-website.yaml
@@ -7,6 +7,7 @@ metadata:
   name: loculus-website
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
+    timestamp: {{ now | quote }}
 spec:
   replicas: {{$.Values.replicas.website}}
   selector:

--- a/kubernetes/loculus/templates/silo-deployment.yaml
+++ b/kubernetes/loculus/templates/silo-deployment.yaml
@@ -11,7 +11,6 @@ metadata:
   annotations:
     # Force replace when run a) with dev db and b) without persistence to ensure silo prepro fails loudly
     argocd.argoproj.io/sync-options: Replace=true{{ if (and (not $.Values.developmentDatabasePersistence) $.Values.runDevelopmentMainDatabase) }},Force=true{{ end }}
-    timestamp: {{ now | quote }}
 spec:
   replicas: 1
   selector:
@@ -20,6 +19,8 @@ spec:
       component: silo-{{ $key }}
   template:
     metadata:
+      annotations:
+        timestamp: {{ now | quote }}
       labels:
         app: loculus
         component: silo-{{ $key }}

--- a/kubernetes/loculus/templates/silo-deployment.yaml
+++ b/kubernetes/loculus/templates/silo-deployment.yaml
@@ -11,6 +11,7 @@ metadata:
   annotations:
     # Force replace when run a) with dev db and b) without persistence to ensure silo prepro fails loudly
     argocd.argoproj.io/sync-options: Replace=true{{ if (and (not $.Values.developmentDatabasePersistence) $.Values.runDevelopmentMainDatabase) }},Force=true{{ end }}
+    timestamp: {{ now | quote }}
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
resolves #3170

This adds timestamp annotations to all pods that basically describe the time on which helm was run to make a deployment. The effect of this should be that all pods have to restart when a new deployment is made, because this value will change. This should ensure that config-only updates are still made.

Testing:
- Tested that the product still works
- Tested that I can see the annotations in the pod

In terms of whether it fixes the issue - it should but IMO we can wait and see

🚀 Preview: https://timetamp-now.loculus.org