### PR TITLE
fix(backend,ingest): handle revoked sequences in /get-original-metadata, they have null metadata

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -269,7 +269,7 @@ data class AccessionVersionOriginalMetadata(
     override val accession: Accession,
     override val version: Version,
     val submitter: String,
-    val originalMetadata: Map<String, String?>,
+    val originalMetadata: Map<String, String?>?,
 ) : AccessionVersionInterface
 
 enum class Status {

--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -269,6 +269,7 @@ data class AccessionVersionOriginalMetadata(
     override val accession: Accession,
     override val version: Version,
     val submitter: String,
+    val isRevocation: Boolean,
     val originalMetadata: Map<String, String?>?,
 ) : AccessionVersionInterface
 

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -1059,6 +1059,7 @@ class SubmissionDatabaseService(
         fields: List<String>?,
     ): Sequence<AccessionVersionOriginalMetadata> {
         val originalMetadata = SequenceEntriesView.originalDataColumn
+            // It's actually <Map<String, String>?> but exposed does not support nullable types here
             .extract<Map<String, String>>("metadata")
             .alias("original_metadata")
 
@@ -1080,7 +1081,9 @@ class SubmissionDatabaseService(
             .fetchSize(streamBatchSize)
             .asSequence()
             .map {
-                val metadata = it[originalMetadata]
+                // Revoked sequences have no original metdadata, hence null can happen
+                @Suppress("USELESS_ELVIS")
+                val metadata = it[originalMetadata] ?: emptyMap()
                 val selectedMetadata = fields?.associateWith { field -> metadata[field] }
                     ?: metadata
                 AccessionVersionOriginalMetadata(

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -1069,6 +1069,7 @@ class SubmissionDatabaseService(
                 SequenceEntriesView.accessionColumn,
                 SequenceEntriesView.versionColumn,
                 SequenceEntriesView.submitterColumn,
+                SequenceEntriesView.isRevocationColumn,
             )
             .where(
                 originalMetadataFilter(
@@ -1090,6 +1091,7 @@ class SubmissionDatabaseService(
                     it[SequenceEntriesView.accessionColumn],
                     it[SequenceEntriesView.versionColumn],
                     it[SequenceEntriesView.submitterColumn],
+                    it[SequenceEntriesView.isRevocationColumn],
                     selectedMetadata,
                 )
             }

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -1083,8 +1083,8 @@ class SubmissionDatabaseService(
             .map {
                 // Revoked sequences have no original metdadata, hence null can happen
                 @Suppress("USELESS_ELVIS")
-                val metadata = it[originalMetadata] ?: emptyMap()
-                val selectedMetadata = fields?.associateWith { field -> metadata[field] }
+                val metadata = it[originalMetadata] ?: null
+                val selectedMetadata = fields?.associateWith { field -> metadata?.get(field) }
                     ?: metadata
                 AccessionVersionOriginalMetadata(
                     it[SequenceEntriesView.accessionColumn],

--- a/ingest/README.md
+++ b/ingest/README.md
@@ -121,7 +121,7 @@ source ~/.zshrc
 Then activate the loculus-ingest environment
 
 ```bash
-micromamba create -f environment.yml --platform osx-64 --rc-file .mambarc
+micromamba create -f environment.yml --rc-file .mambarc
 micromamba activate loculus-ingest
 ```
 

--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -542,7 +542,6 @@ def get_submitted(config: Config):
     for loculus_accession, insdc_accessions in loculus_to_insdc_accession_map.items():
         if loculus_accession in revocation_dict:
             for insdc_accession in insdc_accessions:
-                logger.info(f"revocation dict {revocation_dict}")
                 for version in revocation_dict[loculus_accession]:
                     submitted_dict[insdc_accession]["versions"].append(
                         {

--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -638,7 +638,7 @@ def submit_to_loculus(
     if mode == "get-submitted":
         logger.info("Getting submitted sequences")
         response = get_submitted(config)
-        Path(output).write_text(json.dumps(response, indent=4, sort_keys=True), encoding="utf-8")
+        Path(output).write_text(json.dumps(response, indent=4, sort_keys=False), encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/ingest/scripts/compare_hashes.py
+++ b/ingest/scripts/compare_hashes.py
@@ -259,7 +259,11 @@ def main(
     for value, path, text in outputs:
         with open(path, "w", encoding="utf-8") as file:
             json.dump(value, file)
-        logger.info(f"{text}: {len(value)}")
+        if text == "Blocked sequences":
+            for status, accessions in value.items():
+                logger.info(f"Blocked sequences - {status}: {len(accessions)}")
+        else:
+            logger.info(f"{text}: {len(value)}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
resolves #4036 

co-authored by @anna-parker

Fix backend to deal with `null` original metadata.

Now we get this for revoked sequences in `/get-original-metadata` (we add the `isRevocation` field to the output):

```
{"accession":"LOC_000M2HN","version":2,"submitter":"superuser","originalMetadata":null, "isRevocation": True}
```

Ingest also works: we remove the key sort and additionally handle revocations separately (as they do not contain the INSDC accession in the originalMetadata as it is empty) 

We now emit isRevocation in `/get-original-metadata` to allow ingest to handle revocations properly.

### Testing

- Unit test added that reproduces the bug and no longer does so with the fix
- Manual in preview: Revoke a sequence, rerun ingest without problems
- Manual in preview: Revoke two sequences, rerun ingest without problems (Anya noticed this failed and she fixed it)

### Ideas for future

- Nice to have: Integration test for reingest with a revoked sequence

### PR Checklist
- ~[ ] All necessary documentation has been adapted.~
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://fix-null-metadata.loculus.org