### PR TITLE
fix(ingest): handle revocations correctly in call_loculus

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -269,6 +269,7 @@ data class AccessionVersionOriginalMetadata(
     override val accession: Accession,
     override val version: Version,
     val submitter: String,
+    val isRevocation: Boolean,
     val originalMetadata: Map<String, String?>?,
 ) : AccessionVersionInterface
 

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -1069,6 +1069,7 @@ class SubmissionDatabaseService(
                 SequenceEntriesView.accessionColumn,
                 SequenceEntriesView.versionColumn,
                 SequenceEntriesView.submitterColumn,
+                SequenceEntriesView.isRevocationColumn,
             )
             .where(
                 originalMetadataFilter(
@@ -1090,6 +1091,7 @@ class SubmissionDatabaseService(
                     it[SequenceEntriesView.accessionColumn],
                     it[SequenceEntriesView.versionColumn],
                     it[SequenceEntriesView.submitterColumn],
+                    it[SequenceEntriesView.isRevocationColumn],
                     selectedMetadata,
                 )
             }

--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -539,19 +539,20 @@ def get_submitted(config: Config):
                 }
             )
         # Ensure revocations added to correct INSDC accession
-        for loculus_accession in loculus_to_insdc_accession_map:
+        for loculus_accession, insdc_accessions in loculus_to_insdc_accession_map.items():
             if loculus_accession in revocation_dict:
-                logger.info(f"revocation dict {revocation_dict}")
-                for version in revocation_dict[loculus_accession]:
-                    submitted_dict[insdc_accession]["versions"].append(
-                        {
-                            "version": version,
-                            "hash": "",
-                            "status": "REVOKED",
-                            "jointAccession": joint_accession,
-                            "submitter": submitter,
-                        }
-                    )
+                for insdc_accession in insdc_accessions:
+                    logger.info(f"revocation dict {revocation_dict}")
+                    for version in revocation_dict[loculus_accession]:
+                        submitted_dict[insdc_accession]["versions"].append(
+                            {
+                                "version": version,
+                                "hash": "",
+                                "status": "REVOKED",
+                                "jointAccession": "",
+                                "submitter": "",
+                            }
+                        )
                 revocation_dict.pop(loculus_accession)
 
     if revocation_dict.keys():

--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -476,6 +476,7 @@ def get_submitted(config: Config):
 
     # Initialize the dictionary to store results
     submitted_dict: dict[str, dict[str, str | list]] = {}
+    loculus_to_insdc_accession_map: dict[str, list[str]] = {}
     revocation_dict: dict[
         str, list[str]
     ] = {}  # revocations do not have original data or INSDC accession
@@ -511,6 +512,7 @@ def get_submitted(config: Config):
             insdc_accessions = [original_metadata.get("insdcAccessionBase", "")]
             joint_accession = original_metadata.get("insdcAccessionBase", "")
 
+        loculus_to_insdc_accession_map[loculus_accession] = insdc_accessions
         for insdc_accession in insdc_accessions:
             if insdc_accession not in submitted_dict:
                 submitted_dict[insdc_accession] = {
@@ -536,7 +538,8 @@ def get_submitted(config: Config):
                     "submitter": submitter,
                 }
             )
-            # Ensure revocations added to correct INSDC accession
+        # Ensure revocations added to correct INSDC accession
+        for loculus_accession in loculus_to_insdc_accession_map:
             if loculus_accession in revocation_dict:
                 logger.info(f"revocation dict {revocation_dict}")
                 for version in revocation_dict[loculus_accession]:

--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -490,9 +490,9 @@ def get_submitted(config: Config):
         loculus_version = int(entry["version"])
         submitter = entry["submitter"]
         if entry["isRevocation"]:
-            revocation_dict[loculus_accession] = revocation_dict.get(loculus_accession, []).append(
-                loculus_version
-            )
+            revocation_dict[loculus_accession] = revocation_dict.setdefault(
+                loculus_accession, []
+            ).append(loculus_version)
             continue
         original_metadata: dict[str, str] = entry["originalMetadata"]
         hash_value = original_metadata.get("hash", "")

--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -440,7 +440,7 @@ def get_submitted(config: Config):
     else:
         insdc_key = ["insdcAccessionBase"]
 
-    fields = ["hash", *insdc_key]
+    fields = ["hash", "is_revocation", *insdc_key]
 
     params = {
         "fields": fields,

--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -490,9 +490,9 @@ def get_submitted(config: Config):
         loculus_version = int(entry["version"])
         submitter = entry["submitter"]
         if entry["isRevocation"]:
-            revocation_dict[loculus_accession] = revocation_dict.setdefault(
-                loculus_accession, []
-            ).append(loculus_version)
+            if loculus_accession not in revocation_dict:
+                revocation_dict[loculus_accession] = []
+            revocation_dict[loculus_accession].append(loculus_version)
             continue
         original_metadata: dict[str, str] = entry["originalMetadata"]
         hash_value = original_metadata.get("hash", "")

--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -489,7 +489,7 @@ def get_submitted(config: Config):
         loculus_accession = entry["accession"]
         loculus_version = int(entry["version"])
         submitter = entry["submitter"]
-        if entry["is_revocation"]:
+        if entry["isRevocation"]:
             revocation_dict[loculus_accession] = revocation_dict.get(loculus_accession, []).append(
                 loculus_version
             )

--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -538,22 +538,22 @@ def get_submitted(config: Config):
                     "submitter": submitter,
                 }
             )
-        # Ensure revocations added to correct INSDC accession
-        for loculus_accession, insdc_accessions in loculus_to_insdc_accession_map.items():
-            if loculus_accession in revocation_dict:
-                for insdc_accession in insdc_accessions:
-                    logger.info(f"revocation dict {revocation_dict}")
-                    for version in revocation_dict[loculus_accession]:
-                        submitted_dict[insdc_accession]["versions"].append(
-                            {
-                                "version": version,
-                                "hash": "",
-                                "status": "REVOKED",
-                                "jointAccession": "",
-                                "submitter": "",
-                            }
-                        )
-                revocation_dict.pop(loculus_accession)
+    # Ensure revocations added to correct INSDC accession
+    for loculus_accession, insdc_accessions in loculus_to_insdc_accession_map.items():
+        if loculus_accession in revocation_dict:
+            for insdc_accession in insdc_accessions:
+                logger.info(f"revocation dict {revocation_dict}")
+                for version in revocation_dict[loculus_accession]:
+                    submitted_dict[insdc_accession]["versions"].append(
+                        {
+                            "version": version,
+                            "hash": "",
+                            "status": "REVOKED",
+                            "jointAccession": "",
+                            "submitter": "",
+                        }
+                    )
+            revocation_dict.pop(loculus_accession)
 
     if revocation_dict.keys():
         logger.error(

--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -538,6 +538,7 @@ def get_submitted(config: Config):
             )
             # Ensure revocations added to correct INSDC accession
             if loculus_accession in revocation_dict:
+                logger.info(f"revocation dict {revocation_dict}")
                 for version in revocation_dict[loculus_accession]:
                     submitted_dict[insdc_accession]["versions"].append(
                         {

--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -440,7 +440,7 @@ def get_submitted(config: Config):
     else:
         insdc_key = ["insdcAccessionBase"]
 
-    fields = ["hash", "is_revocation", *insdc_key]
+    fields = ["hash", *insdc_key]
 
     params = {
         "fields": fields,

--- a/ingest/scripts/compare_hashes.py
+++ b/ingest/scripts/compare_hashes.py
@@ -259,7 +259,11 @@ def main(
     for value, path, text in outputs:
         with open(path, "w", encoding="utf-8") as file:
             json.dump(value, file)
-        logger.info(f"{text}: {len(value)}")
+        if text == "Blocked sequences":
+            for status, accessions in value.items():
+                logger.info(f"Blocked sequences - {status}: {len(accessions)}")
+        else:
+            logger.info(f"{text}: {len(value)}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/pull/4040#issuecomment-2823260215

### Screenshot

If we now revoke 2 sequences that were created by the insdc_ingest_user we get another error. Original metadata is empty for revocations and without this the call_loculus script maps the revoked sequences to insdc_accession=NULL. We throw an error if multiple sequences map to the same insdc_accession - it also good to make sure this are mapped correctly so we never try to revise a revoked sequence. 

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://original-metadata-endpoin.loculus.org