### PR TITLE
file sharing: more backend testing

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/api/FileTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/FileTypes.kt
@@ -21,3 +21,10 @@ data class FileIdAndUrl(
 data class FileIdAndName(val fileId: FileId, val name: String)
 
 data class FileIdAndNameAndUrl(val fileId: FileId, val name: String, val url: String)
+
+/**
+ * Strip the URL from the object.
+ */
+fun FileIdAndNameAndUrl.toFileIdAndName(): FileIdAndName {
+    return FileIdAndName(fileId, name)
+}

--- a/backend/src/main/kotlin/org/loculus/backend/api/FileTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/FileTypes.kt
@@ -25,6 +25,4 @@ data class FileIdAndNameAndUrl(val fileId: FileId, val name: String, val url: St
 /**
  * Strip the URL from the object.
  */
-fun FileIdAndNameAndUrl.toFileIdAndName(): FileIdAndName {
-    return FileIdAndName(fileId, name)
-}
+fun FileIdAndNameAndUrl.toFileIdAndName(): FileIdAndName = FileIdAndName(fileId, name)

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/S3Service.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/S3Service.kt
@@ -51,6 +51,10 @@ class S3Service(private val s3Config: S3Config) {
         return "${config.endpoint}/${config.bucket}/${getFileName(fileId)}"
     }
 
+    /**
+     * Sets the 'public=true' tag on the given file ID.
+     * The bucket should have a policy that files with this tag are publicly accessible.
+     */
     fun setFileToPublic(fileId: FileId) {
         val config = getS3BucketConfig()
         getInternalClient().setObjectTags(

--- a/backend/src/test/kotlin/org/loculus/backend/controller/EndpointTestExtension.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/EndpointTestExtension.kt
@@ -262,7 +262,7 @@ private fun createBucket(container: MinIOContainer, region: String, bucket: Stri
         {
           "Effect":"Allow",
           "Principal":"*",
-          "Action":["s3:GetObject"],
+          "Action":"s3:GetObject",
           "Resource":["arn:aws:s3:::$bucket/*"],
           "Condition":{
             "StringEquals":{

--- a/backend/src/test/kotlin/org/loculus/backend/controller/EndpointTestExtension.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/EndpointTestExtension.kt
@@ -2,6 +2,7 @@ package org.loculus.backend.controller
 
 import io.minio.MakeBucketArgs
 import io.minio.MinioClient
+import io.minio.SetBucketPolicyArgs
 import mu.KotlinLogging
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtendWith
@@ -254,4 +255,24 @@ private fun createBucket(container: MinIOContainer, region: String, bucket: Stri
             .bucket(bucket)
             .build(),
     )
+    val policy = """
+    {
+      "Version":"2012-10-17",
+      "Statement":[
+        {
+          "Effect":"Allow",
+          "Principal":"*",
+          "Action":["s3:GetObject"],
+          "Resource":["arn:aws:s3:::$bucket/*"],
+          "Condition":{
+            "StringEquals":{
+              "s3:ExistingObjectTag/public":"true"
+            }
+          }
+        }
+      ]
+    }
+    """.trimIndent()
+
+    minioClient.setBucketPolicy(SetBucketPolicyArgs.builder().bucket(bucket).region(region).config(policy).build())
 }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/files/FilesClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/files/FilesClient.kt
@@ -1,6 +1,7 @@
 package org.loculus.backend.controller.files
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.loculus.backend.api.FileIdAndUrl
 import org.loculus.backend.controller.jwtForDefaultUser
 import org.loculus.backend.controller.withAuth
 import org.loculus.backend.service.files.FileId
@@ -26,4 +27,12 @@ fun ResultActions.andGetFileIds(): List<FileId> = andReturn()
     .let {
         val responseJson = jacksonObjectMapper().readTree(it)
         responseJson.map { UUID.fromString(it.get("fileId").textValue()) }
+    }
+
+fun ResultActions.andGetFileIdsAndUrls(): List<FileIdAndUrl> = andReturn()
+    .response
+    .contentAsString
+    .let {
+        val responseJson = jacksonObjectMapper().readTree(it)
+        responseJson.map { FileIdAndUrl(UUID.fromString(it.get("fileId").textValue()), it.get("url").textValue()) }
     }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ApproveProcessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ApproveProcessedDataEndpointTest.kt
@@ -423,10 +423,6 @@ class ApproveProcessedDataEndpointTest(
 
     @Test
     fun `WHEN entries with extra files are approved THEN the files become public`() {
-        // prep data to processed
-        // approve
-        // check file etc -> should be accessible (200, not 403)
-
         convenienceClient.submitDefaultFiles(includeFileMapping = true)
         val unprocessedData = convenienceClient.extractUnprocessedData()
         val submittableData: List<SubmittedProcessedData> = unprocessedData.map {
@@ -455,8 +451,7 @@ class ApproveProcessedDataEndpointTest(
             .build()
 
         val response = client.send(request, HttpResponse.BodyHandlers.ofString())
-        println(response.body())
-        // TODO, should be code 200 - issue: bucket doesn't have required policy configured yet.
+        assertThat(response.statusCode(), `is`(200))
     }
 }
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ApproveProcessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ApproveProcessedDataEndpointTest.kt
@@ -1,7 +1,6 @@
 package org.loculus.backend.controller.submission
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.node.TextNode
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.hasSize
@@ -21,7 +20,6 @@ import org.loculus.backend.api.Status.PROCESSED
 import org.loculus.backend.api.SubmittedProcessedData
 import org.loculus.backend.config.BackendSpringProperty
 import org.loculus.backend.controller.ALTERNATIVE_DEFAULT_USER_NAME
-import org.loculus.backend.controller.DEFAULT_GROUP
 import org.loculus.backend.controller.DEFAULT_ORGANISM
 import org.loculus.backend.controller.DEFAULT_USER_NAME
 import org.loculus.backend.controller.EndpointTest
@@ -30,12 +28,9 @@ import org.loculus.backend.controller.S3_CONFIG
 import org.loculus.backend.controller.assertHasError
 import org.loculus.backend.controller.assertStatusIs
 import org.loculus.backend.controller.expectUnauthorizedResponse
-import org.loculus.backend.controller.files.andGetFileIds
 import org.loculus.backend.controller.generateJwtFor
 import org.loculus.backend.controller.getAccessionVersions
-import org.loculus.backend.controller.groupmanagement.andGetGroupId
 import org.loculus.backend.controller.jsonContainsAccessionVersionsInAnyOrder
-import org.loculus.backend.controller.jwtForDefaultUser
 import org.loculus.backend.controller.jwtForSuperUser
 import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles.NUMBER_OF_SEQUENCES
 import org.springframework.beans.factory.annotation.Autowired
@@ -438,18 +433,17 @@ class ApproveProcessedDataEndpointTest(
             SubmittedProcessedData(
                 accession = it.accession,
                 version = it.version,
-                data = foo(it.data)
+                data = foo(it.data),
             )
         }
-        convenienceClient.submitProcessedData(submittableData);
+        convenienceClient.submitProcessedData(submittableData)
 
         client.approveProcessedSequenceEntries(
             scope = ALL,
             jwt = jwtForSuperUser,
         )
 
-        val releasedData = convenienceClient.getReleasedData();
-
+        val releasedData = convenienceClient.getReleasedData()
 
         val tree = objectMapper.readTree(releasedData[0].metadata["fileField"]!!.asText())
 
@@ -467,6 +461,8 @@ class ApproveProcessedDataEndpointTest(
 }
 
 fun foo(data: OriginalDataWithFileUrls<GeneticSequence>): ProcessedData<GeneticSequence> {
-    val f: FileColumnNameMap = data.files!!.map { it.key to it.value.map { x -> FileIdAndName(x.fileId, x.name) } }.toMap();
-    return defaultProcessedData.copy(files = f);
+    val f: FileColumnNameMap = data.files!!.map {
+        it.key to it.value.map { x -> FileIdAndName(x.fileId, x.name) }
+    }.toMap()
+    return defaultProcessedData.copy(files = f)
 }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ApproveProcessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ApproveProcessedDataEndpointTest.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test
 import org.loculus.backend.api.AccessionVersion
 import org.loculus.backend.api.ApproveDataScope.ALL
 import org.loculus.backend.api.ApproveDataScope.WITHOUT_WARNINGS
-import org.loculus.backend.api.FileIdAndName
 import org.loculus.backend.api.Status.APPROVED_FOR_RELEASE
 import org.loculus.backend.api.Status.IN_PROCESSING
 import org.loculus.backend.api.Status.PROCESSED

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ExtractUnprocessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ExtractUnprocessedDataEndpointTest.kt
@@ -254,4 +254,6 @@ class ExtractUnprocessedDataEndpointTest(
             ),
         )
     }
+
+    // TODO Add test that also GETs the presigned URLs and makes sure that they work
 }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ExtractUnprocessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ExtractUnprocessedDataEndpointTest.kt
@@ -42,6 +42,10 @@ import org.springframework.http.HttpHeaders.ETAG
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 
 @EndpointTest(
     properties = [
@@ -255,5 +259,23 @@ class ExtractUnprocessedDataEndpointTest(
         )
     }
 
-    // TODO Add test that also GETs the presigned URLs and makes sure that they work
+    @Test
+    fun `GIVEN returns file mapping THEN the URLs are valid`() {
+        convenienceClient.submitDefaultFiles(includeFileMapping = true)
+
+        val result = client.extractUnprocessedData(
+            numberOfSequenceEntries = DefaultFiles.NUMBER_OF_SEQUENCES,
+        )
+        val responseBody = result.expectNdjsonAndGetContent<UnprocessedData>()
+        val url = responseBody.first().data.files!!["fileField"]!!.first().url
+
+        val client = HttpClient.newHttpClient()
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .build()
+
+        val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+        assertThat(response.statusCode(), `is`(200))
+        assertThat(response.body(), `is`("Hello, world!"))
+    }
 }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
@@ -112,9 +112,15 @@ class SubmissionConvenienceClient(
         username: String = DEFAULT_USER_NAME,
         groupId: Int? = null,
         dataUseTerms: DataUseTerms = DataUseTerms.Open,
-        includeFileMapping: Boolean = false
+        includeFileMapping: Boolean = false,
     ): List<AccessionVersionInterface> {
-        submitDefaultFiles(organism = organism, username = username, groupId = groupId, dataUseTerms = dataUseTerms, includeFileMapping = includeFileMapping)
+        submitDefaultFiles(
+            organism = organism,
+            username = username,
+            groupId = groupId,
+            dataUseTerms = dataUseTerms,
+            includeFileMapping = includeFileMapping,
+        )
         return extractUnprocessedData(organism = organism).getAccessionVersions()
     }
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
@@ -83,7 +83,6 @@ class SubmissionConvenienceClient(
 
         var fileMapping: SubmissionIdFilesMap? = null
         if (includeFileMapping) {
-
             val fileIdsAndUrls = filesClient.requestUploads(
                 groupIdToSubmitFor,
                 DefaultFiles.submissionIds.size,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
@@ -112,8 +112,9 @@ class SubmissionConvenienceClient(
         username: String = DEFAULT_USER_NAME,
         groupId: Int? = null,
         dataUseTerms: DataUseTerms = DataUseTerms.Open,
+        includeFileMapping: Boolean = false
     ): List<AccessionVersionInterface> {
-        submitDefaultFiles(organism = organism, username = username, groupId = groupId, dataUseTerms = dataUseTerms)
+        submitDefaultFiles(organism = organism, username = username, groupId = groupId, dataUseTerms = dataUseTerms, includeFileMapping = includeFileMapping)
         return extractUnprocessedData(organism = organism).getAccessionVersions()
     }
 
@@ -159,17 +160,19 @@ class SubmissionConvenienceClient(
         return accessionVersions
     }
 
-    private fun prepareDefaultSequenceEntriesToAwaitingApproval(
+    public fun prepareDefaultSequenceEntriesToAwaitingApproval(
         organism: String = DEFAULT_ORGANISM,
         username: String = DEFAULT_USER_NAME,
         groupId: Int? = null,
         dataUseTerms: DataUseTerms = DataUseTerms.Open,
+        includeFileMapping: Boolean = false,
     ): List<AccessionVersionInterface> {
         val accessionVersions = prepareDefaultSequenceEntriesToInProcessing(
             organism = organism,
             username = username,
             groupId = groupId,
             dataUseTerms = dataUseTerms,
+            includeFileMapping = includeFileMapping,
         )
         submitProcessedData(
             *accessionVersions.map {

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
@@ -192,19 +192,17 @@ class SubmissionConvenienceClient(
         return accessionVersions
     }
 
-    public fun prepareDefaultSequenceEntriesToAwaitingApproval(
+    private fun prepareDefaultSequenceEntriesToAwaitingApproval(
         organism: String = DEFAULT_ORGANISM,
         username: String = DEFAULT_USER_NAME,
         groupId: Int? = null,
         dataUseTerms: DataUseTerms = DataUseTerms.Open,
-        includeFileMapping: Boolean = false,
     ): List<AccessionVersionInterface> {
         val accessionVersions = prepareDefaultSequenceEntriesToInProcessing(
             organism = organism,
             username = username,
             groupId = groupId,
             dataUseTerms = dataUseTerms,
-            includeFileMapping = includeFileMapping,
         )
         submitProcessedData(
             *accessionVersions.map {

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
@@ -31,7 +31,7 @@ import org.loculus.backend.controller.ORGANISM_WITHOUT_CONSENSUS_SEQUENCES
 import org.loculus.backend.controller.OTHER_ORGANISM
 import org.loculus.backend.controller.expectNdjsonAndGetContent
 import org.loculus.backend.controller.files.FilesClient
-import org.loculus.backend.controller.files.andGetFileIds
+import org.loculus.backend.controller.files.andGetFileIdsAndUrls
 import org.loculus.backend.controller.generateJwtFor
 import org.loculus.backend.controller.getAccessionVersions
 import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
@@ -43,6 +43,10 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 
 data class SubmissionResult(val submissionIdMappings: List<SubmissionIdMapping>, val groupId: Int)
 
@@ -79,9 +83,31 @@ class SubmissionConvenienceClient(
 
         var fileMapping: SubmissionIdFilesMap? = null
         if (includeFileMapping) {
-            val fileId = filesClient.requestUploads(groupIdToSubmitFor, jwt = jwt).andGetFileIds()[0]
-            fileMapping = DefaultFiles.submissionIds.associateWith {
-                mapOf("fileField" to listOf(FileIdAndName(fileId, "foo.txt")))
+            // TODO, this whole thing isn't really valid.
+            // We need to _UPLOAD_ a file, and also, we shouldn't reuse the same file across submission IDs
+
+            val fileIdsAndUrls = filesClient.requestUploads(
+                groupIdToSubmitFor,
+                DefaultFiles.submissionIds.size,
+                jwt = jwt,
+            ).andGetFileIdsAndUrls()
+
+            fileMapping = mutableMapOf()
+
+            val client = HttpClient.newBuilder().build()
+            val fileContent = "Hello, world!".toByteArray()
+
+            DefaultFiles.submissionIds.forEachIndexed { i, submissionId ->
+
+                val request = HttpRequest.newBuilder()
+                    .uri(URI.create(fileIdsAndUrls[i].url))
+                    .PUT(HttpRequest.BodyPublishers.ofByteArray(fileContent))
+                    .build()
+
+                client.send(request, HttpResponse.BodyHandlers.ofString())
+
+                fileMapping[submissionId] =
+                    mapOf("fileField" to listOf(FileIdAndName(fileIdsAndUrls[i].fileId, "hello.txt")))
             }
         }
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
@@ -83,8 +83,6 @@ class SubmissionConvenienceClient(
 
         var fileMapping: SubmissionIdFilesMap? = null
         if (includeFileMapping) {
-            // TODO, this whole thing isn't really valid.
-            // We need to _UPLOAD_ a file, and also, we shouldn't reuse the same file across submission IDs
 
             val fileIdsAndUrls = filesClient.requestUploads(
                 groupIdToSubmitFor,


### PR DESCRIPTION
resolves #3991

- Add public policy to testcontainer bucket, so tagged files get made public.
- Add a new test, that checks whether approved files are actually public.
- Add a new test that checks whether the presigned URLs returned by 'extract-...-data' are accessible.

🚀 Preview: Add `preview` label to enable