### PR TITLE
chore!(deployment): Remove `dateToSortBy`, `partitionBy` as now deprecated in SILO (and the wrapper `silo` value)

### DIFF
--- a/docs/src/content/docs/for-administrators/setup-with-kubernetes.md
+++ b/docs/src/content/docs/for-administrators/setup-with-kubernetes.md
@@ -116,7 +116,6 @@ organisms:
         defaultOrder: descending
         defaultOrderBy: date
       silo:
-        dateToSortBy: date
         partitionBy: pangoLineage
     preprocessing:
       image: ghcr.io/loculus-project/preprocessing-dummy

--- a/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
+++ b/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
@@ -36,7 +36,4 @@ schema:
   {{- end }}
   {{- end }}
   primaryKey: accessionVersion
-{{ if .silo}}
-  {{- .silo | toYaml | nindent 2 }}
-{{ end }}
 {{- end }}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -355,11 +355,6 @@
               "description": "Configuration regarding the SILO database engine",
               "additionalProperties": false,
               "properties": {
-                "dateToSortBy": {
-                  "groups": ["schema"],
-                  "type": "string",
-                  "description": "Name of a field of type date. This might speed up date range searches on this field and improve sequence compression."
-                },
                 "partitionBy": {
                   "groups": ["schema"],
                   "type": "string"

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1174,7 +1174,6 @@ defaultOrganismConfig: &defaultOrganismConfig
       defaultOrderBy: sampleCollectionDate
       defaultOrder: descending
     silo:
-      dateToSortBy: sampleCollectionDateRangeUpper
     extraInputFields: []
   preprocessing:
     - &preprocessing
@@ -1383,7 +1382,6 @@ defaultOrganisms:
         defaultOrder: descending
         defaultOrderBy: date
       silo:
-        dateToSortBy: date
     preprocessing:
       - version: 2
         image: ghcr.io/loculus-project/preprocessing-dummy
@@ -1469,7 +1467,6 @@ defaultOrganisms:
         defaultOrder: descending
         defaultOrderBy: date
       silo:
-        dateToSortBy: date
     preprocessing:
       - version: 3
         image: ghcr.io/loculus-project/preprocessing-nextclade
@@ -1527,7 +1524,6 @@ defaultOrganisms:
         defaultOrder: descending
         defaultOrderBy: date
       silo:
-        dateToSortBy: date
     preprocessing:
       - version: 4
         image: ghcr.io/loculus-project/preprocessing-nextclade


### PR DESCRIPTION
These options will be deprecated when SILO is bumped to https://github.com/GenSpectrum/LAPIS-SILO/releases/tag/v0.6.0 so I thought we might as well remove the fluff while I remember.

Breaking!: ensure the `silo` section is removed from `values.yaml` to avoid helm lint errors

🚀 Preview: Add `preview` label to enable