### PR TITLE
fix(website): Make the sandwich menu display the site name not 'Loculus'

### DIFF
--- a/website/src/components/Navigation/Navigation.astro
+++ b/website/src/components/Navigation/Navigation.astro
@@ -1,4 +1,7 @@
 ---
+
+import { getWebsiteConfig } from '../../config';
+
 import { SandwichMenu } from './SandwichMenu.tsx';
 import { cleanOrganism } from './cleanOrganism';
 import { navigationItems } from '../../routes/navigationItems';
@@ -13,6 +16,8 @@ const { implicitOrganism, gitHubMainUrl } = Astro.props;
 const { organism, knownOrganisms } = cleanOrganism(Astro.params.organism);
 const selectedOrganism =
     implicitOrganism !== undefined ? knownOrganisms.find((it) => it.key === implicitOrganism) : organism;
+const siteName = getWebsiteConfig().name;
+
 
 const isLoggedIn = Astro.locals.session?.isLoggedIn ?? false;
 
@@ -34,6 +39,7 @@ const topNavigationItems = navigationItems.top(selectedOrganism?.key, isLoggedIn
             top: '-2rem',
         }}
     >
-        <SandwichMenu topNavigationItems={topNavigationItems} gitHubMainUrl={gitHubMainUrl} client:load />
+        <SandwichMenu topNavigationItems={topNavigationItems} gitHubMainUrl={gitHubMainUrl}
+        siteName={siteName} client:load />
     </div>
 </div>

--- a/website/src/components/Navigation/Navigation.astro
+++ b/website/src/components/Navigation/Navigation.astro
@@ -1,9 +1,7 @@
 ---
-
-import { getWebsiteConfig } from '../../config';
-
 import { SandwichMenu } from './SandwichMenu.tsx';
 import { cleanOrganism } from './cleanOrganism';
+import { getWebsiteConfig } from '../../config';
 import { navigationItems } from '../../routes/navigationItems';
 import { getAuthUrl } from '../../utils/getAuthUrl';
 
@@ -17,7 +15,6 @@ const { organism, knownOrganisms } = cleanOrganism(Astro.params.organism);
 const selectedOrganism =
     implicitOrganism !== undefined ? knownOrganisms.find((it) => it.key === implicitOrganism) : organism;
 const siteName = getWebsiteConfig().name;
-
 
 const isLoggedIn = Astro.locals.session?.isLoggedIn ?? false;
 
@@ -39,7 +36,11 @@ const topNavigationItems = navigationItems.top(selectedOrganism?.key, isLoggedIn
             top: '-2rem',
         }}
     >
-        <SandwichMenu topNavigationItems={topNavigationItems} gitHubMainUrl={gitHubMainUrl}
-        siteName={siteName} client:load />
+        <SandwichMenu
+            topNavigationItems={topNavigationItems}
+            gitHubMainUrl={gitHubMainUrl}
+            siteName={siteName}
+            client:load
+        />
     </div>
 </div>

--- a/website/src/components/Navigation/SandwichMenu.tsx
+++ b/website/src/components/Navigation/SandwichMenu.tsx
@@ -1,4 +1,5 @@
 import type { FC } from 'react';
+
 import { getWebsiteConfig } from '../../config';
 import { useOffCanvas } from '../../hooks/useOffCanvas';
 import { navigationItems, type TopNavigationItems } from '../../routes/navigationItems';

--- a/website/src/components/Navigation/SandwichMenu.tsx
+++ b/website/src/components/Navigation/SandwichMenu.tsx
@@ -1,4 +1,5 @@
 import type { FC } from 'react';
+import { getWebsiteConfig } from '../config';
 
 import { useOffCanvas } from '../../hooks/useOffCanvas';
 import { navigationItems, type TopNavigationItems } from '../../routes/navigationItems';
@@ -12,6 +13,7 @@ type SandwichMenuProps = {
 
 export const SandwichMenu: FC<SandwichMenuProps> = ({ topNavigationItems, gitHubMainUrl }) => {
     const { isOpen, toggle: toggleMenu, close: closeMenu } = useOffCanvas();
+    const siteName = getWebsiteConfig().name;
 
     return (
         <div className='relative'>
@@ -37,7 +39,7 @@ export const SandwichMenu: FC<SandwichMenuProps> = ({ topNavigationItems, gitHub
                 <div className='font-bold p-5 flex flex-col justify-between min-h-screen max-h-screen overflow-y-auto'>
                     <div>
                         <div className='h-10'>
-                            <a href='/'>Loculus</a>
+                            <a href='/'>{siteName}</a>
                         </div>
                         <div className='flex-grow divide-y-2 divide-gray-300 divide-solid border-t-2 border-b-2 border-gray-300 border-solid '>
                             {topNavigationItems.map(({ text, path }) => (

--- a/website/src/components/Navigation/SandwichMenu.tsx
+++ b/website/src/components/Navigation/SandwichMenu.tsx
@@ -9,7 +9,7 @@ import { SandwichIcon } from '../SandwichIcon';
 type SandwichMenuProps = {
     topNavigationItems: TopNavigationItems;
     gitHubMainUrl: string | undefined;
-}; 
+};
 
 export const SandwichMenu: FC<SandwichMenuProps> = ({ topNavigationItems, gitHubMainUrl }) => {
     const { isOpen, toggle: toggleMenu, close: closeMenu } = useOffCanvas();

--- a/website/src/components/Navigation/SandwichMenu.tsx
+++ b/website/src/components/Navigation/SandwichMenu.tsx
@@ -11,6 +11,7 @@ type SandwichMenuProps = {
     siteName: string;
 };
 
+
 export const SandwichMenu: FC<SandwichMenuProps> = ({ topNavigationItems, gitHubMainUrl, siteName }) => {
     const { isOpen, toggle: toggleMenu, close: closeMenu } = useOffCanvas();
 

--- a/website/src/components/Navigation/SandwichMenu.tsx
+++ b/website/src/components/Navigation/SandwichMenu.tsx
@@ -11,7 +11,6 @@ type SandwichMenuProps = {
     siteName: string;
 };
 
-
 export const SandwichMenu: FC<SandwichMenuProps> = ({ topNavigationItems, gitHubMainUrl, siteName }) => {
     const { isOpen, toggle: toggleMenu, close: closeMenu } = useOffCanvas();
 

--- a/website/src/components/Navigation/SandwichMenu.tsx
+++ b/website/src/components/Navigation/SandwichMenu.tsx
@@ -1,6 +1,5 @@
 import type { FC } from 'react';
-import { getWebsiteConfig } from '../config';
-
+import { getWebsiteConfig } from '../../config';
 import { useOffCanvas } from '../../hooks/useOffCanvas';
 import { navigationItems, type TopNavigationItems } from '../../routes/navigationItems';
 import { OffCanvasOverlay } from '../OffCanvasOverlay';

--- a/website/src/components/Navigation/SandwichMenu.tsx
+++ b/website/src/components/Navigation/SandwichMenu.tsx
@@ -9,7 +9,7 @@ import { SandwichIcon } from '../SandwichIcon';
 type SandwichMenuProps = {
     topNavigationItems: TopNavigationItems;
     gitHubMainUrl: string | undefined;
-};
+}; 
 
 export const SandwichMenu: FC<SandwichMenuProps> = ({ topNavigationItems, gitHubMainUrl }) => {
     const { isOpen, toggle: toggleMenu, close: closeMenu } = useOffCanvas();

--- a/website/src/components/Navigation/SandwichMenu.tsx
+++ b/website/src/components/Navigation/SandwichMenu.tsx
@@ -1,6 +1,5 @@
 import type { FC } from 'react';
 
-import { getWebsiteConfig } from '../../config';
 import { useOffCanvas } from '../../hooks/useOffCanvas';
 import { navigationItems, type TopNavigationItems } from '../../routes/navigationItems';
 import { OffCanvasOverlay } from '../OffCanvasOverlay';
@@ -9,11 +8,11 @@ import { SandwichIcon } from '../SandwichIcon';
 type SandwichMenuProps = {
     topNavigationItems: TopNavigationItems;
     gitHubMainUrl: string | undefined;
+    siteName: string;
 };
 
-export const SandwichMenu: FC<SandwichMenuProps> = ({ topNavigationItems, gitHubMainUrl }) => {
+export const SandwichMenu: FC<SandwichMenuProps> = ({ topNavigationItems, gitHubMainUrl, siteName }) => {
     const { isOpen, toggle: toggleMenu, close: closeMenu } = useOffCanvas();
-    const siteName = getWebsiteConfig().name;
 
     return (
         <div className='relative'>


### PR DESCRIPTION
Update the sandwich menu to display the site name dynamically

* Import `getWebsiteConfig` from `../config` in `SandwichMenu.tsx`.
* Replace the hardcoded "Loculus" with the dynamically fetched site name from `getWebsiteConfig().name` in the `SandwichMenu` component.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/loculus-project/loculus/pull/4074?shareId=11cb7a4a-78e9-47de-a5fe-b6380f3099c4).

🚀 Preview: https://theosanderson-fix-sandwic.loculus.org