### PR TITLE
feat(ingest): notify on potential suppression

### DIFF
--- a/ingest/scripts/compare_hashes.py
+++ b/ingest/scripts/compare_hashes.py
@@ -184,7 +184,7 @@ def main(
         config.debug_hashes = True
 
     submitted: dict = json.load(open(old_hashes, encoding="utf-8"))
-    ingested_insdc_accessions = get_approved_submitted_accessions(submitted)
+    ingested_insdc_accessions_not_yet_reingested = get_approved_submitted_accessions(submitted)
 
     update_manager = SequenceUpdateManager(
         submit=[],
@@ -213,7 +213,7 @@ def main(
             process_hashes(
                 insdc_accession_base, fasta_id, record["hash"], submitted, update_manager
             )
-            ingested_insdc_accessions.discard(insdc_accession_base)
+            ingested_insdc_accessions_not_yet_reingested.discard(insdc_accession_base)
             continue
 
         insdc_keys = [f"insdcAccessionBase_{segment}" for segment in config.nucleotide_sequences]
@@ -232,7 +232,7 @@ def main(
             ]
         )
         insdc_accessions = [record[key] for key in insdc_keys if record.get(key)]
-        ingested_insdc_accessions.difference_update(insdc_accessions)
+        ingested_insdc_accessions_not_yet_reingested.difference_update(insdc_accessions)
         hash_float, update_manager.sampled_out = sample_out_hashed_records(
             insdc_accession_base, subsample_fraction, update_manager.sampled_out, fasta_id
         )
@@ -283,10 +283,11 @@ def main(
         else:
             logger.info(f"{text}: {len(value)}")
 
-    if len(ingested_insdc_accessions) > 0:
+    if len(ingested_insdc_accessions_not_yet_reingested) > 0:
         warning = (
-            f"{len(ingested_insdc_accessions)} previously ingested INSDC accessions not found in "
-            f"re-ingested metadata - {', '.join(ingested_insdc_accessions)}."
+            f"{len(ingested_insdc_accessions_not_yet_reingested)} previously ingested INSDC "
+            "accessions not found in re-ingested metadata - "
+            f"{', '.join(ingested_insdc_accessions_not_yet_reingested)}."
             " This might be due to these sequences being suppressed in the INSDC database."
             " Please check the INSDC database for these accessions."
             " If this is the case, please revoke these accessions in Loculus."

--- a/ingest/scripts/compare_hashes.py
+++ b/ingest/scripts/compare_hashes.py
@@ -185,8 +185,8 @@ def main(
         config.debug_hashes = True
 
     submitted: dict = json.load(open(old_hashes, encoding="utf-8"))
-    ingested_insdc_accessions = get_approved_submitted_accessions(submitted)
-    reingested_insdc_accessions = set()
+    already_ingested_accessions = get_approved_submitted_accessions(submitted)
+    current_ingested_accessions = set()
 
     update_manager = SequenceUpdateManager(
         submit=[],
@@ -215,7 +215,7 @@ def main(
             process_hashes(
                 insdc_accession_base, fasta_id, record["hash"], submitted, update_manager
             )
-            reingested_insdc_accessions.add(insdc_accession_base)
+            current_ingested_accessions.add(insdc_accession_base)
             continue
 
         insdc_keys = [f"insdcAccessionBase_{segment}" for segment in config.nucleotide_sequences]
@@ -234,7 +234,7 @@ def main(
             ]
         )
         insdc_accessions = [record[key] for key in insdc_keys if record.get(key)]
-        reingested_insdc_accessions.update(set(insdc_accessions))
+        current_ingested_accessions.update(set(insdc_accessions))
         hash_float, update_manager.sampled_out = sample_out_hashed_records(
             insdc_accession_base, subsample_fraction, update_manager.sampled_out, fasta_id
         )
@@ -285,7 +285,7 @@ def main(
         else:
             logger.info(f"{text}: {len(value)}")
 
-    potentially_suppressed = ingested_insdc_accessions - reingested_insdc_accessions
+    potentially_suppressed = already_ingested_accessions - current_ingested_accessions
     if len(potentially_suppressed) > 0:
         warning = (
             f"{len(potentially_suppressed)} previously ingested INSDC accessions not found in "

--- a/ingest/scripts/compare_hashes.py
+++ b/ingest/scripts/compare_hashes.py
@@ -91,7 +91,7 @@ def process_hashes(
           hash: efg
           status: HAS_ERRORS
           submitter: curator
-        jointAccession: insdc_accession.seg1/insdc_accession.seg2
+          jointAccession: insdc_accession.seg1/insdc_accession.seg2
     """
     if ingested_insdc_accession not in submitted:
         update_manager.submit.append(fasta_id)
@@ -127,6 +127,16 @@ def process_hashes(
     else:
         update_manager.noop[fasta_id] = corresponding_loculus_accession
     return update_manager
+
+
+def get_approved_submitted_accessions(data):
+    approved = set()
+    for insdc_accession, info in data.items():
+        versions = info.get("versions", [])
+        sorted_versions = sorted(versions, key=lambda x: x["version"])
+        if sorted_versions and sorted_versions[-1].get("status") == "APPROVED_FOR_RELEASE":
+            approved.add(insdc_accession)
+    return approved
 
 
 @click.command()
@@ -174,7 +184,7 @@ def main(
         config.debug_hashes = True
 
     submitted: dict = json.load(open(old_hashes, encoding="utf-8"))
-    ingested_insdc_accessions = set(submitted.keys())
+    ingested_insdc_accessions = get_approved_submitted_accessions(submitted)
 
     update_manager = SequenceUpdateManager(
         submit=[],

--- a/ingest/scripts/compare_hashes.py
+++ b/ingest/scripts/compare_hashes.py
@@ -256,7 +256,7 @@ def main(
                     "jointAccession"
                 ]
                 # TODO: Figure out how to check for curation when regrouping - maybe just notify
-        logger.warn(
+        logger.warning(
             "Grouping has changed. Ingest would like to group INSDC samples:"
             f"{insdc_accession_base}, however these were previously grouped as {old_accessions}"
         )

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1190,7 +1190,7 @@ defaultOrganismConfig: &defaultOrganismConfig
   ingest: &ingest
     image: ghcr.io/loculus-project/ingest
     configFile: &ingestConfigFile
-      taxon_id: 186538
+      taxon_id: 3052462
   enaDeposition:
     configFile:
       taxon_id: 186540

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1190,7 +1190,7 @@ defaultOrganismConfig: &defaultOrganismConfig
   ingest: &ingest
     image: ghcr.io/loculus-project/ingest
     configFile: &ingestConfigFile
-      taxon_id: 3052462
+      taxon_id: 3052460
   enaDeposition:
     configFile:
       taxon_id: 186540

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1190,7 +1190,7 @@ defaultOrganismConfig: &defaultOrganismConfig
   ingest: &ingest
     image: ghcr.io/loculus-project/ingest
     configFile: &ingestConfigFile
-      taxon_id: 3052460
+      taxon_id: 186538
   enaDeposition:
     configFile:
       taxon_id: 186540


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/2885

Send a notification on slack if re-ingested sequences do not include insdc-accessions that were previously ingested (and are not in a blocked, error, revoked state).

### Screenshot

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
Test:
1. ingest from ebola zaire and set db to persistent
2. switch to ingest from ebola sudan
3. ensure receive notification:
![image](https://github.com/user-attachments/assets/0eb6a9b4-d6d4-4378-90c1-d1b79ec10533)
admittedly its not very easy to search this message - but I assume we will generally not receive a notification of 3k sequences that are missing and I would need to give ingest the slack token to upload files
4. revoke some sequences (e.g. ebola zaire: OK572988.1), re-ingest ensure not notified about these sequences 
![image](https://github.com/user-attachments/assets/09e6895c-cb71-49e7-a939-b274d7df1e28)

=> I am now reverting the persistent DB changes to stop us getting notifications every 30min on slack.

🚀 Preview: https://notify-on-suppression.loculus.org