### PR TITLE
feat: strip Ns right after reading from file to ensure all pipelines (incl. those without nextclade) strip Ns

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/backend.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/backend.py
@@ -84,10 +84,13 @@ def parse_ndjson(ndjson_data: str) -> Sequence[UnprocessedEntry]:
             error_msg = f"Failed to parse JSON: {json_str_processed}"
             raise ValueError(error_msg) from e
         unaligned_nucleotide_sequences = json_object["data"]["unalignedNucleotideSequences"]
+        trimmed_unaligned_nucleotide_sequences = {}
+        for key, value in unaligned_nucleotide_sequences.items():
+            trimmed_unaligned_nucleotide_sequences[key] = trim_ns(value) if value else None
         unprocessed_data = UnprocessedData(
             submitter=json_object["submitter"],
             metadata=json_object["data"]["metadata"],
-            unalignedNucleotideSequences=trim_ns(unaligned_nucleotide_sequences)
+            unalignedNucleotideSequences=trimmed_unaligned_nucleotide_sequences
             if unaligned_nucleotide_sequences
             else None,
         )

--- a/preprocessing/nextclade/src/loculus_preprocessing/backend.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/backend.py
@@ -12,7 +12,6 @@ from pathlib import Path
 import jwt
 import pytz
 import requests
-from preprocessing.nextclade.src.loculus_preprocessing.processing_functions import trim_ns
 
 from .config import Config
 from .datatypes import (
@@ -20,6 +19,7 @@ from .datatypes import (
     UnprocessedData,
     UnprocessedEntry,
 )
+from .processing_functions import trim_ns
 
 
 class JwtCache:

--- a/preprocessing/nextclade/src/loculus_preprocessing/backend.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/backend.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import jwt
 import pytz
 import requests
+from preprocessing.nextclade.src.loculus_preprocessing.processing_functions import trim_ns
 
 from .config import Config
 from .datatypes import (
@@ -82,14 +83,16 @@ def parse_ndjson(ndjson_data: str) -> Sequence[UnprocessedEntry]:
         except json.JSONDecodeError as e:
             error_msg = f"Failed to parse JSON: {json_str_processed}"
             raise ValueError(error_msg) from e
+        unaligned_nucleotide_sequences = json_object["data"]["unalignedNucleotideSequences"]
         unprocessed_data = UnprocessedData(
             submitter=json_object["submitter"],
             metadata=json_object["data"]["metadata"],
-            unalignedNucleotideSequences=json_object["data"]["unalignedNucleotideSequences"],
+            unalignedNucleotideSequences=trim_ns(unaligned_nucleotide_sequences)
+            if unaligned_nucleotide_sequences
+            else None,
         )
         entry = UnprocessedEntry(
-            accessionVersion=f"{json_object['accession']}.{
-                json_object['version']}",
+            accessionVersion=f"{json_object['accession']}.{json_object['version']}",
             data=unprocessed_data,
         )
         entries.append(entry)

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -40,7 +40,7 @@ from .datatypes import (
     UnprocessedData,
     UnprocessedEntry,
 )
-from .processing_functions import ProcessingFunctions, format_frameshift, format_stop_codon, trim_ns
+from .processing_functions import ProcessingFunctions, format_frameshift, format_stop_codon
 from .sequence_checks import errors_if_non_iupac
 
 logger = logging.getLogger(__name__)
@@ -192,7 +192,7 @@ def enrich_with_nextclade(  # noqa: C901, PLR0912, PLR0914, PLR0915
             elif len(unaligned_segment) == 1:
                 num_valid_segments += 1
                 unaligned_nucleotide_sequences[id][segment] = (
-                    trim_ns(entry.data.unalignedNucleotideSequences[unaligned_segment[0]])
+                    entry.data.unalignedNucleotideSequences[unaligned_segment[0]]
                 )
             else:
                 unaligned_nucleotide_sequences[id][segment] = None

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -984,7 +984,7 @@ def format_stop_codon(result: str) -> str:
     return ",".join(stop_codon_strings)
 
 
-def trim_ns(sequence: str | None) -> str:
+def trim_ns(sequence: str) -> str:
     """
     Trims 'N' characters from the start and end of a nucleotide sequence.
 
@@ -994,6 +994,4 @@ def trim_ns(sequence: str | None) -> str:
     Returns:
         str: The trimmed sequence.
     """
-    if sequence is None:
-        return ""
     return sequence.lstrip("N").rstrip("N")


### PR DESCRIPTION
resolves #

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://trim-ns-anya.loculus.org