### PR TITLE
Revert "chore(deps): bump @astrojs/starlight-tailwind from 3.0.1 to 4.0.1 in /docs"

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@astrojs/check": "^0.9.4",
                 "@astrojs/starlight": "^0.34.2",
-                "@astrojs/starlight-tailwind": "^4.0.1",
+                "@astrojs/starlight-tailwind": "^3.0.1",
                 "@astrojs/tailwind": "^6.0.2",
                 "astro": "^5.7.10",
                 "prettier": "^3.5.3",
@@ -249,13 +249,14 @@
             }
         },
         "node_modules/@astrojs/starlight-tailwind": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/starlight-tailwind/-/starlight-tailwind-4.0.1.tgz",
-            "integrity": "sha512-AOOEWTGqJ7fG66U04xTmZQZ40oZnUYe4Qljpr+No88ozKywtsD1DiXOrGTeHCnZu0hRtMbRtBGB1fZsf0L62iw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/starlight-tailwind/-/starlight-tailwind-3.0.1.tgz",
+            "integrity": "sha512-9gPBaglNYuD3gLSF+4RvmbO3DxMMMby/AYFuwZkS+BLo67WQWyBIdYtmof814Gi750qSnt0sCvhqFAURqbA1Cw==",
             "license": "MIT",
             "peerDependencies": {
-                "@astrojs/starlight": ">=0.34.0",
-                "tailwindcss": "^4.0.0"
+                "@astrojs/starlight": ">=0.30.0",
+                "@astrojs/tailwind": "^5.1.3 || ^6.0.0",
+                "tailwindcss": "^3.3.3"
             }
         },
         "node_modules/@astrojs/starlight/node_modules/hastscript": {
@@ -8961,9 +8962,9 @@
             }
         },
         "@astrojs/starlight-tailwind": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/starlight-tailwind/-/starlight-tailwind-4.0.1.tgz",
-            "integrity": "sha512-AOOEWTGqJ7fG66U04xTmZQZ40oZnUYe4Qljpr+No88ozKywtsD1DiXOrGTeHCnZu0hRtMbRtBGB1fZsf0L62iw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/starlight-tailwind/-/starlight-tailwind-3.0.1.tgz",
+            "integrity": "sha512-9gPBaglNYuD3gLSF+4RvmbO3DxMMMby/AYFuwZkS+BLo67WQWyBIdYtmof814Gi750qSnt0sCvhqFAURqbA1Cw==",
             "requires": {}
         },
         "@astrojs/tailwind": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "@astrojs/check": "^0.9.4",
         "@astrojs/starlight": "^0.34.2",
-        "@astrojs/starlight-tailwind": "^4.0.1",
+        "@astrojs/starlight-tailwind": "^3.0.1",
         "@astrojs/tailwind": "^6.0.2",
         "astro": "^5.7.10",
         "prettier": "^3.5.3",


### PR DESCRIPTION
Reverts loculus-project/loculus#4013 which breaks CI for docs: https://github.com/loculus-project/loculus/actions/runs/14888052688/job/41813084241