### PR TITLE
fix(kubernetes): add preprocessing dockerTag to schema

### DIFF
--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -368,6 +368,12 @@
                 "type": "string",
                 "description": "Docker image for the preprocessing pipeline."
               },
+              "dockerTag": {
+                "groups": ["preprocessing"],
+                "docsIncludePrefix": false,
+                "type": "string",
+                "description": "Docker tag for the preprocessing pipeline."
+              },
               "replicas": {
                 "groups": ["preprocessing"],
                 "docsIncludePrefix": false,


### PR DESCRIPTION
The Helm chart supports the specification of a docker tag for the preprocessing pipeline:

https://github.com/loculus-project/loculus/blob/de7cb98029c992ae7d38874577b3d2047b68ddb9/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml#L11

However, the field is missing in the schema. This PR adds it.

### PR Checklist
- [x] All necessary documentation has been adapted.
- ~[ ] The implemented feature is covered by appropriate, automated tests.~ No additional tests needed.
- ~[ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~ No manual testing needed.

🚀 Preview: https://fix-schema-prepro-tag.loculus.org