### PR TITLE
docs: fix config example in tutorial

### DIFF
--- a/docs/src/content/docs/for-administrators/setup-with-k3d-and-nginx.mdx
+++ b/docs/src/content/docs/for-administrators/setup-with-k3d-and-nginx.mdx
@@ -108,8 +108,6 @@ auth:
   verifyEmail: false
   resetPasswordAllowed: false
   registrationAllowed: true
-  smtp: null
-  identityProviders: null
 
 disableIngest: true
 disableEnaSubmission: true


### PR DESCRIPTION
The schema doesn't allow setting `auth.smtp` and `auth.identityProviders` to `null`.

### PR Checklist
- ~[ ] All necessary documentation has been adapted.~
- ~[ ] The implemented feature is covered by appropriate, automated tests.~
- ~[ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~

🚀 Preview: Add `preview` label to enable