### PR TITLE
chore(kubernetes): update LAPIS to 0.4.5 and SILO to 0.6.0

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1706,11 +1706,11 @@ additionalHeadHTML: ""
 images:
   lapisSilo:
     repository: "ghcr.io/genspectrum/lapis-silo"
-    tag: "0.5.7"
+    tag: "0.6.0"
     pullPolicy: IfNotPresent
   lapis:
     repository: "ghcr.io/genspectrum/lapis"
-    tag: "0.4.1"
+    tag: "0.4.5"
     pullPolicy: IfNotPresent
   website:
     repository: "ghcr.io/loculus-project/website"


### PR DESCRIPTION
Thanks to @theosanderson's https://github.com/pathoplexus/pathoplexus/pull/445, this shouldn't be breaking for Pathoplexus.

# LAPIS Changelog

## [0.4.5](https://github.com/GenSpectrum/LAPIS/compare/v0.4.4...v0.4.5) (2025-05-15)




### Bug Fixes

* **lapis-docs:** correct invalid gene in example ([#1165](https://github.com/GenSpectrum/LAPIS/issues/1165)) ([42b79a2](https://github.com/GenSpectrum/LAPIS/commit/42b79a2548e0a68027e871d2bde03d60e7f790f0))
* **lapis-docs:** fix condition when to show the "variant queries are not available" banner ([#1186](https://github.com/GenSpectrum/LAPIS/issues/1186)) ([6fe60fe](https://github.com/GenSpectrum/LAPIS/commit/6fe60fe9f7bcb943d5d5e35cb8448ddebe93e1f5))

## [0.4.4](https://github.com/GenSpectrum/LAPIS/compare/v0.4.3...v0.4.4) (2025-04-22)


### Bug Fixes

* **lapis:** add missing `dataFormat` to amino acid mutation GET endpoint in Swagger UI ([#1160](https://github.com/GenSpectrum/LAPIS/issues/1160)) ([5c4dbe2](https://github.com/GenSpectrum/LAPIS/commit/5c4dbe2f58082522ca4f321c20bf0f6e2cce1849)), closes [#1159](https://github.com/GenSpectrum/LAPIS/issues/1159)

## [0.4.3](https://github.com/GenSpectrum/LAPIS/compare/v0.4.2...v0.4.3) (2025-04-15)


### Features

* **lapis:** add `fields` property to mutation endpoints ([#1149](https://github.com/GenSpectrum/LAPIS/issues/1149)) ([4d8df3a](https://github.com/GenSpectrum/LAPIS/commit/4d8df3a937fe9b66ec9d77e3ac4f4b75446c694d)), closes [#1092](https://github.com/GenSpectrum/LAPIS/issues/1092)

## [0.4.2](https://github.com/GenSpectrum/LAPIS/compare/v0.4.1...v0.4.2) (2025-03-31)


### Features

* **lapis:** return empty lineage definitions when SILO returns an empty file ([#1126](https://github.com/GenSpectrum/LAPIS/issues/1126)) ([64651ad](https://github.com/GenSpectrum/LAPIS/commit/64651aded37b441de7e90cf614671f0d5c1e9823))


### Bug Fixes

* **lapis-docs:** mention how arrays must be supplied in form urlencoded requests ([#1128](https://github.com/GenSpectrum/LAPIS/issues/1128)) ([4f24a76](https://github.com/GenSpectrum/LAPIS/commit/4f24a763e1ec2168a0f034276261c31e9eb48bfe)), closes [#1089](https://github.com/GenSpectrum/LAPIS/issues/1089)
* **lapis:** also return CSV header when there are no data ([#1138](https://github.com/GenSpectrum/LAPIS/issues/1138)) ([aba1320](https://github.com/GenSpectrum/LAPIS/commit/aba1320e740e28581420750125ec2299bf3d9948)), closes [#1090](https://github.com/GenSpectrum/LAPIS/issues/1090)


# SILO Changelog

## [0.6.0](https://github.com/GenSpectrum/LAPIS-SILO/compare/v0.5.9...v0.6.0) (2025-04-23)


### ⚠ BREAKING CHANGES

* the DatabaseConfig fields `dateToSortBy` and `partitionBy` have been deprecated and do no longer have any effect. The internal endpoint for more detailed database storage information has been removed.

### Features

* add `append` as a third silo execution mode for incremental preprocessing ([84c4ae3](https://github.com/GenSpectrum/LAPIS-SILO/commit/84c4ae3df0995a07ebec26c286bc8e17001ef60b)), closes [#368](https://github.com/GenSpectrum/LAPIS-SILO/issues/368)
* introduce a database schema that actually describes the schema of the database ([be71e08](https://github.com/GenSpectrum/LAPIS-SILO/commit/be71e08a5413b9bb3b2c9566cdaa54b246745a56))
* still enable `silo preprocessing` as a shorthand for initialize-then-append ([9a91d0e](https://github.com/GenSpectrum/LAPIS-SILO/commit/9a91d0e0512ecce904629cb940be78410eeba4b4))

## [0.5.9](https://github.com/GenSpectrum/LAPIS-SILO/compare/v0.5.8...v0.5.9) (2025-04-16)


### Bug Fixes

* return 503 response when no database has been loaded yet ([#742](https://github.com/GenSpectrum/LAPIS-SILO/issues/742)) ([79ebbaa](https://github.com/GenSpectrum/LAPIS-SILO/commit/79ebbaacd47c51e8466fd2253aaf4647d759ff3b)), closes [#723](https://github.com/GenSpectrum/LAPIS-SILO/issues/723)

## [0.5.8](https://github.com/GenSpectrum/LAPIS-SILO/compare/v0.5.7...v0.5.8) (2025-03-31)


### Bug Fixes

* the InsertionContains filter regex should match for the full string ([#735](https://github.com/GenSpectrum/LAPIS-SILO/issues/735)) ([4bb8320](https://github.com/GenSpectrum/LAPIS-SILO/commit/4bb832001ffa2a6c543607787c1dc59baa2614be))

🚀 Preview: https://update-lapis-silo.loculus.org