### PR TITLE
chore(ingest): log basic details about NCBI dataset files

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -150,6 +150,9 @@ rule format_ncbi_dataset_report:
             --config-file {input.config} \
             --input {input.dataset_report} \
             --output {output.ncbi_dataset_tsv}
+        echo "Processed metadata file lines: $(wc -l < {output.ncbi_dataset_tsv})"
+        echo "Hash of output: $(md5sum {output.ncbi_dataset_tsv})"
+        echo "Hash of sorted output: $(md5sum <(sort {output.ncbi_dataset_tsv}))"
         """
 
 
@@ -163,6 +166,9 @@ rule format_ncbi_dataset_sequences:
         seqkit seq -w0 -i \
             {input.dataset_sequences} \
             > {output.ncbi_dataset_sequences}
+        echo "Stats of NCBI dataset sequences: $(seqkit stats {output.ncbi_dataset_sequences})"
+        echo "seqkit hash of NCBI dataset sequences: $(seqkit sum -a -s {output.ncbi_dataset_sequences})"
+        echo "Plain hash of NCBI dataset sequences: $(md5sum {output.ncbi_dataset_sequences})"
         """
 
 


### PR DESCRIPTION
When investigating why Pathoplexus got some Genbank sequences only a week after their release,
I noticed some logs about the content of NCBI datasets downloads could be helpful for debugging in the future.
None of the changes cause any change in behaviour, it's just a few extra log lines.

### Screenshot

<img width="1200" alt="image" src="https://github.com/user-attachments/assets/b20b2e45-178b-4bfa-8268-dff6b9398704" />

### Testing

- [x] Preview ingest works and contains the new log lines.

🚀 Preview: https://ingest-ncbi-logs.loculus.org