### PR TITLE
fix(website): fix select all/none in FieldSelectorModal

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/FieldSelector/FieldSelectorModal.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/FieldSelector/FieldSelectorModal.tsx
@@ -28,16 +28,18 @@ export const FieldSelectorModal: FC<FieldSelectorProps> = ({
     const [selectedFields, setSelectedFields] = useState<Set<string>>(getInitialSelectedFields());
 
     const handleFieldSelection = (fieldName: string, selected: boolean) => {
-        const newSelectedFields = new Set(selectedFields);
+        setSelectedFields((prevSelectedFields) => {
+            const newSelectedFields = new Set(prevSelectedFields);
 
-        if (selected) {
-            newSelectedFields.add(fieldName);
-        } else {
-            newSelectedFields.delete(fieldName);
-        }
+            if (selected) {
+                newSelectedFields.add(fieldName);
+            } else {
+                newSelectedFields.delete(fieldName);
+            }
 
-        setSelectedFields(newSelectedFields);
-        onSave(Array.from(newSelectedFields));
+            onSave(Array.from(newSelectedFields));
+            return newSelectedFields;
+        });
     };
 
     const fieldItems: FieldItem[] = metadata.map((field) => ({


### PR DESCRIPTION
resolves #4116 

The select all/none buttons were not working in the download panel. This is fixed now.

### PR Checklist
- ~[ ] All necessary documentation has been adapted.~
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
    - Confirmed in preview that the buttons are working.

🚀 Preview: https://fix-select-all-none.loculus.org