### PR TITLE
feat(backend): allow prepro to upload files for groups

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/auth/AuthenticatedUser.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/auth/AuthenticatedUser.kt
@@ -1,6 +1,7 @@
 package org.loculus.backend.auth
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.loculus.backend.auth.Roles.PREPROCESSING_PIPELINE
 import org.loculus.backend.auth.Roles.SUPER_USER
 import org.springframework.core.MethodParameter
 import org.springframework.security.authentication.AnonymousAuthenticationToken
@@ -27,6 +28,9 @@ class AuthenticatedUser(private val source: JwtAuthenticationToken) : User() {
 
     val isSuperUser: Boolean
         get() = source.authorities.any { it.authority == SUPER_USER }
+
+    val isPreprocessingPipeline: Boolean
+        get() = source.authorities.any { it.authority == PREPROCESSING_PIPELINE }
 }
 
 class AnonymousUser : User()

--- a/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
@@ -10,8 +10,8 @@ import org.loculus.backend.auth.AuthenticatedUser
 import org.loculus.backend.auth.HiddenParam
 import org.loculus.backend.auth.User
 import org.loculus.backend.service.files.FilesDatabaseService
+import org.loculus.backend.service.files.FilesPreconditionValidator
 import org.loculus.backend.service.files.S3Service
-import org.loculus.backend.service.groupmanagement.GroupManagementPreconditionValidator
 import org.loculus.backend.service.submission.AccessionPreconditionValidator
 import org.loculus.backend.service.submission.SubmissionDatabaseService
 import org.loculus.backend.utils.Accession
@@ -32,7 +32,7 @@ import java.net.URI
 class FilesController(
     private val filesDatabaseService: FilesDatabaseService,
     private val s3Service: S3Service,
-    private val groupManagementPreconditionValidator: GroupManagementPreconditionValidator,
+    private val filesPreconditionValidator: FilesPreconditionValidator,
     private val submissionDatabaseService: SubmissionDatabaseService,
     private val accessionPreconditionValidator: AccessionPreconditionValidator,
 ) {
@@ -90,10 +90,7 @@ class FilesController(
         @RequestParam
         numberFiles: Int = 1,
     ): List<FileIdAndWriteUrl> {
-        groupManagementPreconditionValidator.validateUserIsAllowedToModifyGroup(
-            groupId,
-            authenticatedUser,
-        )
+        filesPreconditionValidator.validateUserIsAllowedToUploadFileForGroup(groupId, authenticatedUser)
         val response = mutableListOf<FileIdAndWriteUrl>()
         repeat(numberFiles) {
             val fileId = filesDatabaseService.createFileEntry(authenticatedUser.username, groupId)

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/FilesPreconditionValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/FilesPreconditionValidator.kt
@@ -1,0 +1,23 @@
+package org.loculus.backend.service.files
+
+import org.loculus.backend.auth.AuthenticatedUser
+import org.loculus.backend.service.groupmanagement.GroupManagementPreconditionValidator
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class FilesPreconditionValidator(
+    private val groupManagementPreconditionValidator: GroupManagementPreconditionValidator,
+) {
+    /**
+     * Only users that can modify the group, can upload files for it.
+     * But the preprocessing pipeline can also upload files for a group.
+     */
+    @Transactional(readOnly = true)
+    fun validateUserIsAllowedToUploadFileForGroup(groupId: Int, authenticatedUser: AuthenticatedUser) {
+        if (authenticatedUser.isPreprocessingPipeline) {
+            return
+        }
+        groupManagementPreconditionValidator.validateUserIsAllowedToModifyGroup(groupId, authenticatedUser)
+    }
+}

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/FilesPreconditionValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/FilesPreconditionValidator.kt
@@ -10,8 +10,8 @@ class FilesPreconditionValidator(
     private val groupManagementPreconditionValidator: GroupManagementPreconditionValidator,
 ) {
     /**
-     * Only users that can modify the group, can upload files for it.
-     * But the preprocessing pipeline can also upload files for a group.
+     * Users who can modify the group and the preprocessing pipeline can 
+     * upload files for a group.
      */
     @Transactional(readOnly = true)
     fun validateUserIsAllowedToUploadFileForGroup(groupId: Int, authenticatedUser: AuthenticatedUser) {

--- a/backend/src/test/kotlin/org/loculus/backend/controller/files/RequestUploadEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/files/RequestUploadEndpointTest.kt
@@ -15,6 +15,7 @@ import org.loculus.backend.controller.S3_CONFIG
 import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
 import org.loculus.backend.controller.groupmanagement.andGetGroupId
 import org.loculus.backend.controller.jwtForAlternativeUser
+import org.loculus.backend.controller.jwtForProcessingPipeline
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
@@ -98,5 +99,12 @@ class RequestUploadEndpointTest(
         val groupId = groupManagementClient.createNewGroup(jwt = jwtForAlternativeUser).andGetGroupId()
         client.requestUploads(groupId = groupId, numberFiles = 1)
             .andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `GIVEN a preprocessing pipeline request with groupId of a different group THEN returns ok`() {
+        val groupId = groupManagementClient.createNewGroup(jwt = jwtForAlternativeUser).andGetGroupId()
+        client.requestUploads(groupId = groupId, numberFiles = 1, jwtForProcessingPipeline)
+            .andExpect(status().isOk)
     }
 }


### PR DESCRIPTION
resolves #4062

Requesting file uploads now works for the preprocessing pipeline.

A test was added as well.

No manual testing was done (but changes are pretty trivial).

### PR Checklist
- ~~All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by appropriate, automated tests.

🚀 Preview: Add `preview` label to enable