### PR TITLE
feat(website): make LinkOuts usable without data use terms

### DIFF
--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -350,7 +350,7 @@
               "groups": ["schema"],
               "docsIncludePrefix": false,
               "type": "array",
-              "description": "[NB: This feature will currently only work correctly if data use terms are enabled]. An array of external tools that can be linked to from the search page. Each linkOut has a name and URL. The URL can contain placeholders in the format [dataType] or [dataType:segment] or [dataType+rich] or [dataType:segment+rich|format] which will be replaced with the corresponding data URLs. `rich` means display name faster headers. Valid dataTypes are: unalignedNucleotideSequences, metadata, and alignedNucleotideSequences. You can also use {{this}} notation to URL-encode the contents of the double brackets, and you can {{nest {{these}} }}.",
+              "description": "An array of external tools that can be linked to from the search page. Each linkOut has a name and URL. The URL can contain placeholders in the format [dataType] or [dataType:segment] or [dataType+rich] or [dataType:segment+rich|format] which will be replaced with the corresponding data URLs. `rich` means display name faster headers. Valid dataTypes are: unalignedNucleotideSequences, metadata, and alignedNucleotideSequences. You can also use {{this}} notation to URL-encode the contents of the double brackets, and you can {{nest {{these}} }}.",
               "items": {
                 "type": "object",
                 "properties": {

--- a/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.spec.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.spec.tsx
@@ -18,37 +18,38 @@ const realDownloadUrlGenerator = new DownloadUrlGenerator('test', 'http://testur
 
 const mockSequenceFilter = FieldFilterSet.empty();
 
-describe('LinkOutMenu', () => {
-    const linkOuts = [
-        {
-            name: 'Basic',
-            url: 'http://example.com/tool?data=[unalignedNucleotideSequences]',
-            description: 'Basic tool description',
-        },
-        { name: 'Format', url: 'http://example.com/tool?data=[unalignedNucleotideSequences|json]' },
-        { name: 'Segment', url: 'http://example.com/tool?data=[unalignedNucleotideSequences:S]' },
-        { name: 'SegmentFormat', url: 'http://example.com/tool?data=[unalignedNucleotideSequences:S|json]' },
-        { name: 'Rich', url: 'http://example.com/tool?data=[unalignedNucleotideSequences+rich]' },
-        { name: 'RichFormat', url: 'http://example.com/tool?data=[unalignedNucleotideSequences+rich|json]' },
-        { name: 'SegmentRich', url: 'http://example.com/tool?data=[unalignedNucleotideSequences:S+rich]' },
-        {
-            name: 'Complete',
-            url: 'http://example.com/tool?data=[unalignedNucleotideSequences:S+rich|json]',
-            description: 'Complete tool with all options',
-        },
-        {
-            name: 'Multiple',
-            url: 'http://example.com/tool?data1=[unalignedNucleotideSequences]&data2=[metadata|json]',
-        },
-        { name: 'Invalid', url: 'http://example.com/tool?data=[invalidType]&valid=[metadata]' },
-    ];
+const linkOuts = [
+    {
+        name: 'Basic',
+        url: 'http://example.com/tool?data=[unalignedNucleotideSequences]',
+        description: 'Basic tool description',
+    },
+    { name: 'Format', url: 'http://example.com/tool?data=[unalignedNucleotideSequences|json]' },
+    { name: 'Segment', url: 'http://example.com/tool?data=[unalignedNucleotideSequences:S]' },
+    { name: 'SegmentFormat', url: 'http://example.com/tool?data=[unalignedNucleotideSequences:S|json]' },
+    { name: 'Rich', url: 'http://example.com/tool?data=[unalignedNucleotideSequences+rich]' },
+    { name: 'RichFormat', url: 'http://example.com/tool?data=[unalignedNucleotideSequences+rich|json]' },
+    { name: 'SegmentRich', url: 'http://example.com/tool?data=[unalignedNucleotideSequences:S+rich]' },
+    {
+        name: 'Complete',
+        url: 'http://example.com/tool?data=[unalignedNucleotideSequences:S+rich|json]',
+        description: 'Complete tool with all options',
+    },
+    {
+        name: 'Multiple',
+        url: 'http://example.com/tool?data1=[unalignedNucleotideSequences]&data2=[metadata|json]',
+    },
+    { name: 'Invalid', url: 'http://example.com/tool?data=[invalidType]&valid=[metadata]' },
+];
 
+describe('LinkOutMenu with enabled data use terms', () => {
     test('opens modal when a tool is clicked', () => {
         render(
             <LinkOutMenu
                 downloadUrlGenerator={realDownloadUrlGenerator}
                 sequenceFilter={mockSequenceFilter}
                 linkOuts={linkOuts}
+                dataUseTermsEnabled={true}
             />,
         );
 
@@ -67,6 +68,7 @@ describe('LinkOutMenu', () => {
                 downloadUrlGenerator={realDownloadUrlGenerator}
                 sequenceFilter={mockSequenceFilter}
                 linkOuts={linkOuts}
+                dataUseTermsEnabled={true}
             />,
         );
 
@@ -91,6 +93,7 @@ describe('LinkOutMenu', () => {
                 downloadUrlGenerator={realDownloadUrlGenerator}
                 sequenceFilter={mockSequenceFilter}
                 linkOuts={linkOuts}
+                dataUseTermsEnabled={true}
             />,
         );
 
@@ -115,6 +118,7 @@ describe('LinkOutMenu', () => {
                 downloadUrlGenerator={realDownloadUrlGenerator}
                 sequenceFilter={mockSequenceFilter}
                 linkOuts={[{ name: 'Basic', url: 'http://example.com/tool?data=[unalignedNucleotideSequences]' }]}
+                dataUseTermsEnabled={true}
             />,
         );
 
@@ -124,5 +128,23 @@ describe('LinkOutMenu', () => {
 
         expect(window.open).toHaveBeenCalled();
         expect(vi.mocked(window.open).mock.calls[0][0]).not.toBeUndefined();
+    });
+});
+
+describe('LinkOutMenu with disabled data use terms', () => {
+    test('opens tool when it is clicked', () => {
+        render(
+            <LinkOutMenu
+                downloadUrlGenerator={realDownloadUrlGenerator}
+                sequenceFilter={mockSequenceFilter}
+                linkOuts={linkOuts}
+                dataUseTermsEnabled={false}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /Tools/ }));
+        fireEvent.click(screen.getByText('Basic'));
+
+        expect(window.open).toHaveBeenCalled();
     });
 });

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -459,6 +459,7 @@ export const InnerSearchFullUI = ({
                                     downloadUrlGenerator={downloadUrlGenerator}
                                     sequenceFilter={downloadFilter}
                                     linkOuts={linkOuts}
+                                    dataUseTermsEnabled={dataUseTermsEnabled}
                                 />
                             )}
                         </div>


### PR DESCRIPTION
resolves #4114

If DUTs are disabled when clicking on a LinkOut / Tool on the search page, no modal to select the data use terms will be shown. Instead, the tool will be opened directly.

To test manually, use a config with

```
dataUseTerms:
  enabled: false
```

### Screen recording

If data use terms are disabled:

https://github.com/user-attachments/assets/129bd696-8e52-4125-8db2-480013ac6a0c

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
    - See screen recording

🚀 Preview: https://link-out-without-dut.loculus.org