### PR TITLE
fix(website): Fix group edit error message

### DIFF
--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -1,0 +1,7 @@
+## The environment
+
+You do not have internet access but packages should have already been installed with `npm ci`.
+
+## Checklist before committing code
+
+Run `npm run test`, `npm run check-types`, `npm run format`.

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -1,7 +1,0 @@
-## The environment
-
-You do not have internet access but packages should have already been installed with `npm ci`.
-
-## Checklist before committing code
-
-Run `npm run test`, `npm run check-types`, `npm run format`.

--- a/website/src/hooks/useGroupOperations.ts
+++ b/website/src/hooks/useGroupOperations.ts
@@ -152,7 +152,7 @@ function callEditGroup(accessToken: string, zodios: ZodiosInstance<typeof groupM
                 group: groupResult,
             } as EditGroupSuccess;
         } catch (error) {
-            const message = `Failed to create group: ${stringifyMaybeAxiosError(error)}`;
+            const message = `Failed to edit group: ${stringifyMaybeAxiosError(error)}`;
             return {
                 succeeded: false,
                 errorMessage: message,


### PR DESCRIPTION
Fix minor bug in group edit error message (copy/paste bug identified by codex)

## Summary
- fix error message shown when group editing fails

🚀 Preview: Add `preview` label to enable