### PR TITLE
Fix orderBy typing in hooks

### DIFF
--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -285,7 +285,6 @@ export const InnerSearchFullUI = ({
                 type: orderDirection,
             },
         ];
-        // @ts-expect-error because the hooks don't accept OrderBy
         detailsHook.mutate({
             ...lapisSearchParameters,
             fields: [...columnsToShow, schema.primaryKey],

--- a/website/src/services/lapisClient.ts
+++ b/website/src/services/lapisClient.ts
@@ -106,7 +106,6 @@ export class LapisClient extends ZodiosWrapperClient<typeof lapisApi> {
     public async getAllSequenceEntryHistoryForAccession(
         accession: string,
     ): Promise<Result<SequenceEntryHistory, ProblemDetail>> {
-        // @ts-expect-error Bug in Zod: https://github.com/colinhacks/zod/issues/3136
         const request: LapisBaseRequest = {
             accession,
             fields: [

--- a/website/src/types/lapis.ts
+++ b/website/src/types/lapis.ts
@@ -19,7 +19,10 @@ export const lapisBaseRequest = z
         fields: z.array(z.string()).optional(),
         orderBy: z.array(orderBy).optional(),
     })
-    .catchall(z.union([z.string(), z.number(), z.null(), z.array(z.string())]));
+    // allow unknown metadata fields but don't reject orderBy arrays
+    .catchall(
+        z.union([z.string(), z.number(), z.null(), z.array(z.string()), z.array(orderBy)])
+    );
 export type LapisBaseRequest = z.infer<typeof lapisBaseRequest>;
 
 export const mutationsRequest = lapisBaseRequest.extend({ minProportion: z.number().optional() });

--- a/website/src/utils/serversideSearch.ts
+++ b/website/src/utils/serversideSearch.ts
@@ -38,7 +38,6 @@ export const performLapisSearchQueries = async (
     const client = LapisClient.createForOrganism(organism);
 
     const [detailsResult, aggregatedResult] = await Promise.all([
-        // @ts-expect-error because OrderBy typing does not accept this for unknown reasons
         client.call('details', {
             ...lapisSearchParameters,
             fields: [...columnsToShow, schema.primaryKey],


### PR DESCRIPTION
## Summary
- allow `orderBy` arrays through `lapisBaseRequest`
- remove outdated `@ts-expect-error` comments
- update calls that pass `orderBy`

## Testing
- `npx tsc --noEmit`