### PR TITLE
fix(website): Fix Keycloak account URL protocol handling

### DIFF
--- a/website/src/utils/urlForKeycloakAccountPage.spec.ts
+++ b/website/src/utils/urlForKeycloakAccountPage.spec.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from 'vitest';
-import { urlForKeycloakAccountPage } from './urlForKeycloakAccountPage';
 import type { BaseClient } from 'openid-client';
+import { describe, expect, test } from 'vitest';
+
+import { urlForKeycloakAccountPage } from './urlForKeycloakAccountPage';
 
 function createClient(url: string): BaseClient {
     return {

--- a/website/src/utils/urlForKeycloakAccountPage.spec.ts
+++ b/website/src/utils/urlForKeycloakAccountPage.spec.ts
@@ -7,7 +7,7 @@ function createClient(url: string): BaseClient {
     return {
         endSessionUrl: () => url,
     } as unknown as BaseClient;
-}
+} 
 
 describe('urlForKeycloakAccountPage', () => {
     test('uses https issuer', () => {

--- a/website/src/utils/urlForKeycloakAccountPage.spec.ts
+++ b/website/src/utils/urlForKeycloakAccountPage.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+import { urlForKeycloakAccountPage } from './urlForKeycloakAccountPage';
+import type { BaseClient } from 'openid-client';
+
+function createClient(url: string): BaseClient {
+    return {
+        endSessionUrl: () => url,
+    } as unknown as BaseClient;
+}
+
+describe('urlForKeycloakAccountPage', () => {
+    test('uses https issuer', () => {
+        const client = createClient('https://kc.example.com/realms/loculus/protocol/openid-connect/logout');
+        expect(urlForKeycloakAccountPage(client)).toBe('https://kc.example.com/realms/loculus/account');
+    });
+
+    test('uses http issuer', () => {
+        const client = createClient('http://kc.example.com/realms/loculus/protocol/openid-connect/logout');
+        expect(urlForKeycloakAccountPage(client)).toBe('http://kc.example.com/realms/loculus/account');
+    });
+});

--- a/website/src/utils/urlForKeycloakAccountPage.spec.ts
+++ b/website/src/utils/urlForKeycloakAccountPage.spec.ts
@@ -7,7 +7,7 @@ function createClient(url: string): BaseClient {
     return {
         endSessionUrl: () => url,
     } as unknown as BaseClient;
-} 
+}
 
 describe('urlForKeycloakAccountPage', () => {
     test('uses https issuer', () => {

--- a/website/src/utils/urlForKeycloakAccountPage.ts
+++ b/website/src/utils/urlForKeycloakAccountPage.ts
@@ -4,6 +4,6 @@ import { realmPath } from './realmPath.ts';
 
 export function urlForKeycloakAccountPage(client: BaseClient) {
     const endsessionUrl = client.endSessionUrl();
-    const host = new URL(endsessionUrl).host;
-    return `https://${host}${realmPath}/account`;
+    const url = new URL(endsessionUrl);
+    return `${url.protocol}//${url.host}${realmPath}/account`;
 }


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/3273 (which codex independently identified). Now we can link to Keycloak account info page even when we're hosting it on HTTP not HTTPS.


## Summary
- keep protocol from `endSessionUrl` when building Keycloak account link
- add unit tests for http and https issuers

🚀 Preview: Add `preview` label to enable