### PR TITLE
fix(website): Fix processTemplate multiple placeholder replacement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ temp/
 
 logs/
 __pycache__/
+website/agents.md

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@ temp/
 
 logs/
 __pycache__/
-website/agents.md

--- a/website/src/utils/templateProcessor.spec.ts
+++ b/website/src/utils/templateProcessor.spec.ts
@@ -156,6 +156,16 @@ describe('processTemplate', () => {
         expect(result).toBe('https://example.com/users/123');
     });
 
+    it('replaces all occurrences of a placeholder', () => {
+        const template = 'https://example.com/[id]/edit/[id]';
+        const placeholdersAndValues = {
+            id: '42',
+        };
+
+        const result = processTemplate(template, placeholdersAndValues);
+        expect(result).toBe('https://example.com/42/edit/42');
+    });
+
     it('replaces empty values with empty strings', () => {
         const template = 'https://example.com/[path]/[id]';
         const placeholdersAndValues = {

--- a/website/src/utils/templateProcessor.ts
+++ b/website/src/utils/templateProcessor.ts
@@ -64,7 +64,7 @@ export function processTemplate(template: string, placeholdersAndValues: Record<
     // Replace special placeholders with their values
     let result = template;
     Object.entries(placeholdersAndValues).forEach(([key, value]) => {
-        result = result.replace(`[${key}]`, value || '');
+        result = result.replaceAll(`[${key}]`, value || '');
     });
 
     // Process all {{ }} expressions recursively


### PR DESCRIPTION
In the code that constructs URLs for linkOuts I forgot to consider the case that a placeholder might appear twice - this fixes that

## Summary
- ensure all occurrences of each placeholder get replaced in templates using `replaceAll`
- test multiple placeholders of the same name

🚀 Preview: Add `preview` label to enable