### PR TITLE
feat(website): truncate review cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ temp/
 
 logs/
 __pycache__/
+website/agents.md

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@ temp/
 
 logs/
 __pycache__/
-website/agents.md

--- a/website/src/components/ReviewPage/ReviewCard.tsx
+++ b/website/src/components/ReviewPage/ReviewCard.tsx
@@ -1,4 +1,4 @@
-import { type FC, useState } from 'react';
+import { type FC, useState, useRef, useEffect } from 'react';
 
 import { SequencesDialog } from './SequencesDialog.tsx';
 import { backendClientHooks } from '../../services/serviceHooks.ts';
@@ -403,19 +403,31 @@ const KeyValueComponent: FC<KeyValueComponentProps> = ({
     const textTooltipId = 'text-tooltip-' + keyName + accessionVersion;
     const noteTooltipId = 'note-tooltip-' + keyName + accessionVersion;
 
+    const textRef = useRef<HTMLSpanElement>(null);
+    const [isTruncated, setIsTruncated] = useState(false);
+
+    useEffect(() => {
+        if (textRef.current) {
+            setIsTruncated(textRef.current.scrollWidth > textRef.current.clientWidth);
+        }
+    }, [value]);
+
+    const showTooltip = primaryMessages !== undefined || isTruncated;
+    const tooltipContent =
+        primaryMessages !== undefined ? primaryMessages.map((annotation) => annotation.message).join(', ') : value;
+
     return (
         <div className={`flex flex-col m-2 `}>
             <span className={keyStyle ?? 'text-gray-500 uppercase text-xs'}>{keyName}</span>
             <span className={`text-base ${extraStyle}`}>
-                <span className={textColor} data-tooltip-id={textTooltipId}>
+                <span
+                    ref={textRef}
+                    className={`${textColor} truncate max-w-xs inline-block`}
+                    data-tooltip-id={showTooltip ? textTooltipId : undefined}
+                >
                     {value}
                 </span>
-                {primaryMessages !== undefined && (
-                    <CustomTooltip
-                        id={textTooltipId}
-                        content={primaryMessages.map((annotation) => annotation.message).join(', ')}
-                    />
-                )}
+                {showTooltip && <CustomTooltip id={textTooltipId} content={tooltipContent} />}
                 {secondaryMessages !== undefined && (
                     <>
                         <Note className='text-yellow-500 inline-block' data-tooltip-id={noteTooltipId} />


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/1400

- truncate long metadata values in ReviewCard
- show tooltip when text is truncated

<img width="1418" alt="image" src="https://github.com/user-attachments/assets/2ce5fbea-e044-483e-b5a8-c5c07dacba36" />

<img width="1420" alt="image" src="https://github.com/user-attachments/assets/57661409-3460-4cff-a8c1-9d58e493929d" />

🚀 Preview: Add `preview` label to enable