### PR TITLE
Fix autocomplete closing

### DIFF
--- a/website/src/components/SearchPage/fields/AutoCompleteField.spec.tsx
+++ b/website/src/components/SearchPage/fields/AutoCompleteField.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
@@ -227,5 +227,42 @@ describe('AutoCompleteField', () => {
         await userEvent.click(clearButton);
 
         expect(setSomeFieldValues).toHaveBeenCalledWith(['testField', '']);
+    });
+
+    it('closes suggestion list when input loses focus', async () => {
+        mockUseAggregated.mockReturnValue({
+            data: {
+                data: [
+                    { testField: 'Option 1', count: 10 },
+                    { testField: 'Option 2', count: 20 },
+                ],
+            },
+            isLoading: false,
+            error: null,
+            mutate: vi.fn(),
+        });
+
+        render(
+            <AutoCompleteField
+                field={field}
+                optionsProvider={{
+                    type: 'generic',
+                    lapisUrl,
+                    lapisSearchParameters,
+                    fieldName: field.name,
+                }}
+                setSomeFieldValues={setSomeFieldValues}
+            />,
+        );
+
+        const input = screen.getByLabelText('Test Field');
+        await userEvent.click(input);
+
+        const options = await screen.findAllByRole('option');
+        expect(options).toHaveLength(2);
+
+        fireEvent.blur(input);
+
+        await waitFor(() => expect(screen.queryByRole('option')).not.toBeInTheDocument());
     });
 });

--- a/website/src/components/SearchPage/fields/AutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/AutoCompleteField.tsx
@@ -14,6 +14,7 @@ const CustomInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputEl
         fieldValue={props.value}
         onChange={props.onChange}
         onFocus={props.onFocus}
+        onBlur={props.onBlur}
         disabled={props.disabled}
         autoComplete='off'
         placeholder={props.placeholder ?? ''}


### PR DESCRIPTION
## Summary
- ensure Combobox `onBlur` is propagated in AutoCompleteField
- add test verifying option list closes on blur

This would resolve https://github.com/loculus-project/loculus/issues/2285 although I'm not 100% sure it's definitely better

🚀 Preview: Add `preview` label to enable