### PR TITLE
Fix Autocomplete dropdown scroll lock

### DIFF
--- a/website/src/components/Edit/InputField.tsx
+++ b/website/src/components/Edit/InputField.tsx
@@ -44,7 +44,10 @@ export const InputField: FC<InputFieldProps> = ({ row, onChange, colorClassName,
                             }  ${row.value === row.initialValue && colorClassName} h-8`}
                             autoComplete='none'
                         />
-                        <ComboboxOptions className='absolute border empty:invisible z-20 w-full py-1 mt-1 overflow-auto text-base bg-white rounded-md shadow-lg max-h-60 ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm min-h-32'>
+                        <ComboboxOptions
+                            modal={false}
+                            className='absolute border empty:invisible z-20 w-full py-1 mt-1 overflow-auto text-base bg-white rounded-md shadow-lg max-h-60 ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm min-h-32'
+                        >
                             {filteredOptions.map((option) => (
                                 <ComboboxOption
                                     key={option.name}

--- a/website/src/components/SearchPage/fields/AutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/AutoCompleteField.tsx
@@ -101,6 +101,7 @@ export const AutoCompleteField = ({
                 </ComboboxButton>
 
                 <ComboboxOptions
+                    modal={false}
                     className='absolute z-20 w-full py-1 mt-1 overflow-auto text-base bg-white rounded-md shadow-lg max-h-60 ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm
           min-h-32
           '

--- a/website/src/components/SearchPage/fields/MutationField.tsx
+++ b/website/src/components/SearchPage/fields/MutationField.tsx
@@ -116,7 +116,10 @@ export const MutationField: FC<MutationFieldProps> = ({ referenceGenomesSequence
                         leaveFrom='opacity-100'
                         leaveTo='opacity-0'
                     >
-                        <ComboboxOptions className='absolute w-full z-20 py-1 mt-1 overflow-auto text-base bg-white rounded-md shadow-lg max-h-60 ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm'>
+                        <ComboboxOptions
+                            modal={false}
+                            className='absolute w-full z-20 py-1 mt-1 overflow-auto text-base bg-white rounded-md shadow-lg max-h-60 ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm'
+                        >
                             {options.map((option, index) => (
                                 <ComboboxOption
                                     key={index}


### PR DESCRIPTION
## Summary
- add `modal={false}` to ComboboxOptions in input, mutation and generic autocomplete fields so page scrolling works when dropdown is open

## Testing
- `npm run test`
- `npm run check-types`
- `npm run format`
