### PR TITLE
feat(backend): Detect missing tabs in metadata TSV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ temp/
 
 logs/
 __pycache__/
+website/agents.md

--- a/backend/src/main/kotlin/org/loculus/backend/utils/MetadataEntry.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/MetadataEntry.kt
@@ -12,8 +12,19 @@ import java.io.InputStreamReader
 data class MetadataEntry(val submissionId: SubmissionId, val metadata: Map<String, String>)
 
 fun metadataEntryStreamAsSequence(metadataInputStream: InputStream): Sequence<MetadataEntry> {
+    val bufferedInputStream = metadataInputStream.buffered()
+    bufferedInputStream.mark(8192)
+    val firstLine = bufferedInputStream.bufferedReader().readLine()
+    bufferedInputStream.reset()
+
+    if (firstLine != null && !firstLine.contains('\t') && firstLine.contains(' ')) {
+        throw UnprocessableEntityException(
+            "No tabs detected in first line of metadata file. Please ensure the file is tab-separated.",
+        )
+    }
+
     val csvParser = CSVParser(
-        InputStreamReader(metadataInputStream),
+        InputStreamReader(bufferedInputStream),
         CSVFormat.TDF.builder().setHeader().setSkipHeaderRecord(true).build(),
     )
 
@@ -55,8 +66,19 @@ fun metadataEntryStreamAsSequence(metadataInputStream: InputStream): Sequence<Me
 data class RevisionEntry(val submissionId: SubmissionId, val accession: Accession, val metadata: Map<String, String>)
 
 fun revisionEntryStreamAsSequence(metadataInputStream: InputStream): Sequence<RevisionEntry> {
+    val bufferedInputStream = metadataInputStream.buffered()
+    bufferedInputStream.mark(8192)
+    val firstLine = bufferedInputStream.bufferedReader().readLine()
+    bufferedInputStream.reset()
+
+    if (firstLine != null && !firstLine.contains('\t') && firstLine.contains(' ')) {
+        throw UnprocessableEntityException(
+            "No tabs detected in first line of metadata file. Please ensure the file is tab-separated.",
+        )
+    }
+
     val csvParser = CSVParser(
-        InputStreamReader(metadataInputStream),
+        InputStreamReader(bufferedInputStream),
         CSVFormat.TDF.builder().setHeader().setSkipHeaderRecord(true).build(),
     )
 

--- a/backend/src/main/kotlin/org/loculus/backend/utils/MetadataEntry.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/MetadataEntry.kt
@@ -17,7 +17,7 @@ fun metadataEntryStreamAsSequence(metadataInputStream: InputStream): Sequence<Me
     val firstLine = bufferedInputStream.bufferedReader().readLine()
     bufferedInputStream.reset()
 
-    if (firstLine != null && !firstLine.contains('\t') && firstLine.contains(' ')) {
+    if (firstLine != null && !firstLine.contains('\t') ) {
         throw UnprocessableEntityException(
             "No tabs detected in first line of metadata file. Please ensure the file is tab-separated.",
         )

--- a/backend/src/test/kotlin/org/loculus/backend/utils/MetadataEntryTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/utils/MetadataEntryTest.kt
@@ -38,4 +38,17 @@ class MetadataEntryTest {
         val inputStream = ByteArrayInputStream(str.toByteArray())
         assertThrows<UnprocessableEntityException> { metadataEntryStreamAsSequence(inputStream).toList() }
     }
+
+    @Test
+    fun `detects missing tabs`() {
+        val str = """
+            submissionId Country
+            foo bar
+        """.trimIndent()
+        val inputStream = ByteArrayInputStream(str.toByteArray())
+        val exception = assertThrows<UnprocessableEntityException> {
+            metadataEntryStreamAsSequence(inputStream).toList()
+        }
+        assert(exception.message!!.contains("No tabs detected"))
+    }
 }

--- a/backend/src/test/kotlin/org/loculus/backend/utils/RevisionEntryTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/utils/RevisionEntryTest.kt
@@ -1,0 +1,21 @@
+package org.loculus.backend.utils
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.loculus.backend.controller.UnprocessableEntityException
+import java.io.ByteArrayInputStream
+
+class RevisionEntryTest {
+    @Test
+    fun `detects missing tabs in revised metadata`() {
+        val str = """
+            accession submissionId Country
+            1 foo bar
+        """.trimIndent()
+        val inputStream = ByteArrayInputStream(str.toByteArray())
+        val exception = assertThrows<UnprocessableEntityException> {
+            revisionEntryStreamAsSequence(inputStream).toList()
+        }
+        assert(exception.message!!.contains("No tabs detected"))
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/loculus-project/loculus/issues/2598

## Summary
- raise a specific error in the backend when metadata files don't have tabs and so are not TSVs
- detect this case for regular and revision metadata
- add unit tests for both metadata types


🚀 Preview: https://codex-detect-metadata-tsv.loculus.org