### PR TITLE
Fix duplicate DataUseTerms type

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/api/DataUseTerms.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/DataUseTerms.kt
@@ -57,6 +57,7 @@ enum class DataUseTermsType {
 )
 @JsonPropertyOrder(value = ["type", "restrictedUntil"])
 sealed interface DataUseTerms {
+    @get:JsonIgnore
     val type: DataUseTermsType
 
     @JsonTypeName("OPEN")


### PR DESCRIPTION
## Summary
- prevent duplicate `type` field in DataUseTerms by ignoring the interface property

## Testing
- `./gradlew ktlintCheck` *(fails: Could not resolve dependencies)*
- `./gradlew test --no-daemon --stacktrace` *(fails: build did not complete)*