### PR TITLE
fix(website): Fix spacing around version selector

### DIFF
--- a/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.tsx
@@ -20,7 +20,7 @@ export const SequenceEntryHistoryMenu: React.FC<Props> = ({
     const selectedVersion = sequenceEntryHistory.find((version) => version.accessionVersion === accessionVersion);
     return (
         <>
-            <div className='dropdown dropdown-hover hidden sm:inline-block'>
+            <div className='dropdown dropdown-hover hidden sm:inline-block mr-2'>
                 <label tabIndex={0} className='btn btn-sm btn-outline py-1'>
                     <span className='text-sm'>
                         {selectedVersion === undefined ? 'All versions' : `Version ${selectedVersion.version}`}
@@ -64,7 +64,7 @@ export const SequenceEntryHistoryMenu: React.FC<Props> = ({
                     </li>
                 </ul>
             </div>
-            <div className='sm:hidden inline-block'>
+            <div className='sm:hidden inline-block mr-2'>
                 <a href={routes.versionPage(accessionVersion)} className='text-xl'>
                     <IcBaselineHistory />
                 </a>


### PR DESCRIPTION
resolves #4115

<img width="279" alt="image" src="https://github.com/user-attachments/assets/87aecca5-6cab-41d1-bca8-d0ef11492f65" />


## Summary
- add margin to the version selector so it's not flush against adjacent controls


🚀 Preview: https://codex-adjust-spacing-betw.loculus.org