### PR TITLE
Ignore node modules in website lint

### DIFF
--- a/website/eslint.config.js
+++ b/website/eslint.config.js
@@ -120,7 +120,7 @@ const disableFromReact = {
 
 export default tseslint.config(
     {
-        ignores: ['**/.astro/content.d.ts'],
+        ignores: ['**/.astro/content.d.ts', '**/node_modules/**'],
         files: ['**/*.ts', '**/*.tsx'],
         extends: [
             eslint.configs.recommended,


### PR DESCRIPTION
## Summary
- exclude node_modules from website lint config

🚀 Preview: Add `preview` label to enable