### PR TITLE
feat(website): Add warning when last group member leaves

### DIFF
--- a/website/src/components/User/GroupPage.tsx
+++ b/website/src/components/User/GroupPage.tsx
@@ -104,8 +104,13 @@ const InnerGroupPage: FC<GroupPageProps> = ({
                             </a>
                             <button
                                 onClick={() => {
+                                    const isLastMember = (groupDetails.data?.users.length ?? 0) <= 1;
+                                    const lastMemberWarning =
+                                        'You are the last user in this group. Leaving will leave the group without any members, meaning that nobody is able to add future members.';
+                                    const dialogText = `${isLastMember ? `${lastMemberWarning} ` : ''}Are you sure you want to leave the ${groupName} group?`;
+
                                     displayConfirmationDialog({
-                                        dialogText: `Are you sure you want to leave the ${groupName} group?`,
+                                        dialogText,
 
                                         onConfirmation: async () => {
                                             await removeFromGroup(username);

--- a/website/src/components/User/GroupPage.tsx
+++ b/website/src/components/User/GroupPage.tsx
@@ -106,8 +106,8 @@ const InnerGroupPage: FC<GroupPageProps> = ({
                                 onClick={() => {
                                     const isLastMember = (groupDetails.data?.users.length ?? 0) <= 1;
                                     const lastMemberWarning =
-                                        'You are the last user in this group. Leaving will leave the group without any members, meaning that nobody is able to add future members.';
-                                    const dialogText = `${isLastMember ? `${lastMemberWarning} ` : ''}Are you sure you want to leave the ${groupName} group?`;
+                                        'You are the last user in this group. Leaving will leave the group without any members, meaning that nobody is able to add future members. ';
+                                    const dialogText = `${isLastMember ? lastMemberWarning : ''}Are you sure you want to leave the ${groupName} group?`;
 
                                     displayConfirmationDialog({
                                         dialogText,


### PR DESCRIPTION
Resolves https://github.com/loculus-project/loculus/issues/698

## Summary
- warn users when leaving a group if they are the last member

I tested this and it worked as expected (tested both for groups with >1 members and 1 member)

🚀 Preview: https://codex-add-warning-when-le.loculus.org