### PR TITLE
Reformat prepro

### DIFF
--- a/.github/workflows/preprocessing-tests.yaml
+++ b/.github/workflows/preprocessing-tests.yaml
@@ -31,5 +31,9 @@ jobs:
           pytest
         shell: micromamba-shell {0}
         working-directory: preprocessing/nextclade/
+      - name: Install mypy
+        run: |
+          python -m pip install --upgrade pip
+          pip install mypy
       - name: Run mypy (checks type hints)
         run: mypy .

--- a/.github/workflows/preprocessing-tests.yaml
+++ b/.github/workflows/preprocessing-tests.yaml
@@ -36,4 +36,4 @@ jobs:
           python -m pip install --upgrade pip
           pip install mypy
       - name: Run mypy (checks type hints)
-        run: mypy --config-file preprocessing/nextclade/mypy.ini preprocessing/nextclade
+        run: mypy --config-file preprocessing/nextclade/.mypy.ini preprocessing/nextclade

--- a/.github/workflows/preprocessing-tests.yaml
+++ b/.github/workflows/preprocessing-tests.yaml
@@ -36,4 +36,4 @@ jobs:
           python -m pip install --upgrade pip
           pip install mypy
       - name: Run mypy (checks type hints)
-        run: mypy .
+        run: mypy --config-file preprocessing/nextclade/mypy.ini preprocessing/nextclade

--- a/.github/workflows/preprocessing-tests.yaml
+++ b/.github/workflows/preprocessing-tests.yaml
@@ -36,6 +36,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install mypy
       - name: Install missing mypy type stubs
-        run: mypy --install-types --non-interactive
+        run: mypy --config-file preprocessing/nextclade/.mypy.ini preprocessing/nextclade --install-types --non-interactive
       - name: Run mypy (checks type hints)
         run: mypy --config-file preprocessing/nextclade/.mypy.ini preprocessing/nextclade

--- a/.github/workflows/preprocessing-tests.yaml
+++ b/.github/workflows/preprocessing-tests.yaml
@@ -35,5 +35,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install mypy
+      - name: Install missing mypy type stubs
+        run: mypy --install-types --non-interactive
       - name: Run mypy (checks type hints)
         run: mypy --config-file preprocessing/nextclade/.mypy.ini preprocessing/nextclade

--- a/.github/workflows/preprocessing-tests.yaml
+++ b/.github/workflows/preprocessing-tests.yaml
@@ -31,3 +31,5 @@ jobs:
           pytest
         shell: micromamba-shell {0}
         working-directory: preprocessing/nextclade/
+      - name: Run mypy (checks type hints)
+        run: mypy .

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1234,6 +1234,7 @@ defaultOrganisms:
         version: 1
         configFile:
           <<: *preprocessingConfigFile
+          require_nextclade_sort_match: True
           genes: [NP, VP35, VP40, GP, sGP, ssGP, VP30, VP24, L]
           nextclade_dataset_name: nextstrain/ebola/sudan
           nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/ebola/data_output
@@ -1241,6 +1242,7 @@ defaultOrganisms:
         version: 2
         configFile:
           <<: *preprocessingConfigFile
+          require_nextclade_sort_match: True
           genes: [NP, VP35, VP40, GP, sGP, ssGP, VP30, VP24, L]
           nextclade_dataset_name: nextstrain/ebola/sudan
           nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/ebola/data_output

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1233,8 +1233,7 @@ defaultOrganisms:
       - <<: *preprocessing
         version: 1
         configFile:
-          <<: *preprocessingConfigFile
-          require_nextclade_sort_match: True
+          <<: *preprocessingConfigFile      
           genes: [NP, VP35, VP40, GP, sGP, ssGP, VP30, VP24, L]
           nextclade_dataset_name: nextstrain/ebola/sudan
           nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/ebola/data_output
@@ -1242,7 +1241,6 @@ defaultOrganisms:
         version: 2
         configFile:
           <<: *preprocessingConfigFile
-          require_nextclade_sort_match: True
           genes: [NP, VP35, VP40, GP, sGP, ssGP, VP30, VP24, L]
           nextclade_dataset_name: nextstrain/ebola/sudan
           nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/ebola/data_output

--- a/preprocessing/nextclade/.mypy.ini
+++ b/preprocessing/nextclade/.mypy.ini
@@ -18,3 +18,6 @@ ignore_missing_imports = True
 
 [mypy-yaml.*]
 ignore_missing_imports = True
+
+[mypy-pytest.*]
+ignore_missing_imports = True

--- a/preprocessing/nextclade/.mypy.ini
+++ b/preprocessing/nextclade/.mypy.ini
@@ -9,3 +9,12 @@ ignore_missing_imports = True
 
 [mypy-dpath.*]
 ignore_missing_imports = True
+
+[mypy-pandas.*]
+ignore_missing_imports = True
+
+[mypy-requests.*]
+ignore_missing_imports = True
+
+[mypy-yaml.*]
+ignore_missing_imports = True

--- a/preprocessing/nextclade/README.md
+++ b/preprocessing/nextclade/README.md
@@ -65,6 +65,7 @@ docker run -it --platform=linux/amd64 --network host --rm nextclade_processing p
 ## Development
 
 - Install Ruff to lint/format
+- Enable type checking. In VSCode this can be done by opening the `User Settings` (Command+shift+P on mac), navigating to `python > analysis: type checking mode` and setting this to `basic`.
 
 When deployed on kubernetes the preprocessing pipeline reads in config files which are created by `loculus/kubernetes/loculus/templates/loculus-preprocessing-config.yaml`. When run locally the pipeline uses only the default values defined in `preprocessing/nextclade/src/loculus_preprocessing/config.py`. When running the preprocessing pipeline locally it makes sense to create a local config file using the command:
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/backend.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/backend.py
@@ -86,13 +86,16 @@ def parse_ndjson(ndjson_data: str) -> Sequence[UnprocessedEntry]:
             error_msg = f"Failed to parse JSON: {json_str_processed}"
             raise ValueError(error_msg) from e
         unaligned_nucleotide_sequences = json_object["data"]["unalignedNucleotideSequences"]
-        trimmed_unaligned_nucleotide_sequences = {key: trim_ns(value) if value else None for key, value in unaligned_nucleotide_sequences.items()}
+        trimmed_unaligned_nucleotide_sequences = {
+            key: trim_ns(value) if value else None
+            for key, value in unaligned_nucleotide_sequences.items()
+        }
         unprocessed_data = UnprocessedData(
             submitter=json_object["submitter"],
             metadata=json_object["data"]["metadata"],
             unalignedNucleotideSequences=trimmed_unaligned_nucleotide_sequences
             if unaligned_nucleotide_sequences
-            else None,
+            else {},
         )
         entry = UnprocessedEntry(
             accessionVersion=f"{json_object['accession']}.{json_object['version']}",

--- a/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
@@ -7,11 +7,12 @@ GeneName = str
 SegmentName = str
 NucleotideSequence = str
 AminoAcidSequence = str
+GenericSequence = AminoAcidSequence | NucleotideSequence
 NucleotideInsertion = str
 AminoAcidInsertion = str
 FunctionName = str  # Name of function present in processing_functions
 ArgName = str  # Name of argument present in processing_functions
-ArgValue = str  # Name of argument present in processing_functions
+ArgValue = list[str] | str | bool | None  # Name of argument value present in processing_functions
 InputField = str  # Name of field in input data, either inputMetadata or NextcladeMetadata
 ProcessedMetadataValue = str | int | float | bool | None
 ProcessedMetadata = dict[str, ProcessedMetadataValue]
@@ -36,8 +37,8 @@ class AnnotationSource:
 
 @dataclass(frozen=True)
 class ProcessingAnnotation:
-    unprocessedFields: tuple[AnnotationSource, ...]  # noqa: N815
-    processedFields: tuple[AnnotationSource, ...]  # noqa: N815
+    unprocessedFields: list[AnnotationSource]  # noqa: N815
+    processedFields: list[AnnotationSource]  # noqa: N815
     message: str
 
     def __post_init__(self):
@@ -52,7 +53,7 @@ class ProcessingAnnotation:
 class UnprocessedData:
     submitter: str
     metadata: InputMetadata
-    unalignedNucleotideSequences: dict[str, NucleotideSequence]  # noqa: N815
+    unalignedNucleotideSequences: dict[SegmentName, NucleotideSequence | None]  # noqa: N815
 
 
 @dataclass
@@ -62,7 +63,7 @@ class UnprocessedEntry:
 
 
 FunctionInputs = dict[ArgName, InputField]
-FunctionArgs = dict[ArgName, ArgValue] | None
+FunctionArgs = dict[ArgName, ArgValue]
 
 
 @dataclass

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -135,12 +135,15 @@ def run_sort(
     (default is nextclade_dataset_name)
     """
     nextclade_dataset_name = get_nextclade_dataset_name(config, segment)
+    if not config.accepted_dataset_matches and not nextclade_dataset_name:
+        logger.warning("No nextclade dataset name or accepted dataset match list found in config")
+        return alerts
     nextclade_dataset_server = get_nextclade_dataset_server(config, segment)
 
     if config.minimizer_url:
         minimizer_file = dataset_dir + "/minimizer/minimizer.json"
 
-    accepted_dataset_names = config.accepted_dataset_matches or [nextclade_dataset_name]
+    accepted_dataset_names = config.accepted_dataset_matches or [nextclade_dataset_name]  # type: ignore
 
     result_file = result_file_dir + "/sort_output.tsv"
     command = [

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -41,10 +41,15 @@ def standardize_option(option):
     return " ".join(option.lower().split())
 
 
-def invalid_value_annotation(input_datum, output_field, input_fields, value_type) -> ProcessingAnnotation:
+def invalid_value_annotation(
+    input_datum, output_field, input_fields, value_type
+) -> ProcessingAnnotation:
     return ProcessingAnnotation(
         processedFields=[AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)],
-        unprocessedFields=[AnnotationSource(name=field, type=AnnotationSourceType.METADATA) for field in input_fields],
+        unprocessedFields=[
+            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
+            for field in input_fields
+        ],
         message=f"Invalid {value_type} value: {input_datum} for field {output_field}.",
     )
 
@@ -125,7 +130,7 @@ class ProcessingFunctions:
                         message=(
                             f"Internal Error: Function {function_name} did not return "
                             f"ProcessingResult with input {input_data} and args {args}, "
-                            "please contact the administrator."
+                            f"please contact the administrator."
                         ),
                     )
                 ],
@@ -163,7 +168,7 @@ class ProcessingFunctions:
         input_data: InputMetadata,
         output_field: str,
         input_fields: list[str],
-        args: FunctionArgs = None,  # args is essential - even if Pylance says it's not used
+        args: FunctionArgs,  # args is essential - even if Pylance says it's not used
     ) -> ProcessingResult:
         """Check that date is complete YYYY-MM-DD
         If not according to format return error
@@ -199,8 +204,7 @@ class ProcessingFunctions:
             return ProcessingResult(datum=date, warnings=warnings, errors=errors)
         except ValueError as e:
             error_message = (
-                f"Date is {date} which is not in the required format YYYY-MM-DD. "
-                f"Parsing error: {e}"
+                f"Date is {date} which is not in the required format YYYY-MM-DD. Parsing error: {e}"
             )
             return ProcessingResult(
                 datum=None,
@@ -224,14 +228,14 @@ class ProcessingFunctions:
         input_data: InputMetadata,
         output_field: str,
         input_fields: list[str],
-        args: FunctionArgs = None,  # args is essential - even if Pylance says it's not used
+        args: FunctionArgs,  # args is essential - even if Pylance says it's not used
     ) -> ProcessingResult:
         """Parse date string (`input.date`) formatted as one of YYYY | YYYY-MM | YYYY-MM-DD into a range using upper bound (`input.releaseDate`)
         Return value determined FunctionArgs:
         fieldType: "dateRangeString" | "dateRangeLower" | "dateRangeUpper"
         Default fieldType is "dateRangeString"
         """
-        if args is None:
+        if not args:
             args = {"fieldType": "dateRangeString"}
 
         logger.debug(f"input_data: {input_data}")
@@ -324,7 +328,7 @@ class ProcessingFunctions:
                     )
                 )
 
-            if datum.date_range_lower > datetime.now(tz=pytz.utc):
+            if datum.date_range_lower and datum.date_range_lower > datetime.now(tz=pytz.utc):
                 logger.debug(
                     f"Lower range of date: {datum.date_range_lower} > {datetime.now(tz=pytz.utc)}"
                 )
@@ -341,7 +345,7 @@ class ProcessingFunctions:
                     )
                 )
 
-            if release_date and (datum.date_range_lower > release_date):
+            if release_date and datum.date_range_lower and (datum.date_range_lower > release_date):
                 logger.debug(f"Lower range of date: {parsed_date} > release_date: {release_date}")
                 errors.append(
                     ProcessingAnnotation(
@@ -363,7 +367,10 @@ class ProcessingFunctions:
                 case "dateRangeString":
                     return_value = datum.date_range_string
                 case "dateRangeLower":
-                    return_value = datum.date_range_lower.strftime("%Y-%m-%d")
+                    if datum.date_range_lower is None:
+                        return_value = None
+                    else:
+                        return_value = datum.date_range_lower.strftime("%Y-%m-%d")
                     warnings = errors = []
                 case "dateRangeUpper":
                     return_value = datum.date_range_upper.strftime("%Y-%m-%d")
@@ -384,9 +391,9 @@ class ProcessingFunctions:
                         AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
                     ],
                     unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                        AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
+                        for field in input_fields
+                    ],
                     message=f"Metadata field {output_field}: Date {input_date_str} could not be parsed.",
                 )
             ],
@@ -397,7 +404,7 @@ class ProcessingFunctions:
         input_data: InputMetadata,
         output_field,
         input_fields: list[str],
-        args: FunctionArgs = None,  # args is essential - even if Pylance says it's not used
+        args: FunctionArgs,  # args is essential - even if Pylance says it's not used
     ) -> ProcessingResult:
         """Parse date string. If it's incomplete, add 01-01, if no year, return null and error
         input_data:
@@ -490,8 +497,7 @@ class ProcessingFunctions:
                                 for field in input_fields
                             ],
                             message=(
-                                f"Metadata field {output_field}:'{date_str}'"
-                                "is after release date."
+                                f"Metadata field {output_field}:'{date_str}'is after release date."
                             ),
                         )
                     )
@@ -523,7 +529,7 @@ class ProcessingFunctions:
         input_data: InputMetadata,
         output_field: str,
         input_fields: list[str],
-        args: FunctionArgs = None,  # args is essential - even if Pylance says it's not used
+        args: FunctionArgs,  # args is essential - even if Pylance says it's not used
     ) -> ProcessingResult:
         """Parse a timestamp string, e.g. 2022-11-01T00:00:00Z and return a YYYY-MM-DD string"""
         timestamp = input_data["timestamp"]
@@ -547,8 +553,7 @@ class ProcessingFunctions:
             )
         except ValueError as e:
             error_message = (
-                f"Timestamp is {timestamp} which is not in parseable YYYY-MM-DD. "
-                f"Parsing error: {e}"
+                f"Timestamp is {timestamp} which is not in parseable YYYY-MM-DD. Parsing error: {e}"
             )
             return ProcessingResult(
                 datum=None,
@@ -572,7 +577,7 @@ class ProcessingFunctions:
         input_data: InputMetadata,
         output_field: str,
         input_fields: list[str],
-        args: FunctionArgs = None,
+        args: FunctionArgs,
     ) -> ProcessingResult:
         """Concatenates input fields with accession_version using the "/" separator in the order
         specified by the order argument.
@@ -582,16 +587,33 @@ class ProcessingFunctions:
 
         number_fields = len(input_data.keys()) + 1
 
-        accession_version = args["accession_version"]
+        if not isinstance(args["accession_version"], str):
+            return ProcessingResult(
+                datum=None,
+                warnings=[],
+                errors=[
+                    ProcessingAnnotation(
+                        processedFields=[
+                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
+                        ],
+                        unprocessedFields=[
+                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
+                            for field in input_fields
+                        ],
+                        message=(
+                            f"Internal Error: Function concatenate did not receive accession_version "
+                            f"ProcessingResult with input {input_data} and args {args}, "
+                            f"please contact the administrator."
+                        ),
+                    )
+                ],
+            )
+
+        accession_version: str = args["accession_version"]
         order = args["order"]
         type = args["type"]
 
-        # Check accessionVersion only exists once in the list:
-        if number_fields != len(order):
-            logging.error(
-                f"Concatenate: Expected {len(order)} fields, got {number_fields}. "
-                f"This is probably a configuration error. (accession_version: {accession_version})"
-            )
+        def add_errors():
             errors.append(
                 ProcessingAnnotation(
                     processedFields=[
@@ -605,28 +627,61 @@ class ProcessingFunctions:
                     "This may be a configuration error, please contact the administrator.",
                 )
             )
+
+        if not isinstance(order, list):
+            logging.error(
+                f"Concatenate: Expected order field to be a list. "
+                f"This is probably a configuration error. (accession_version: {accession_version})"
+            )
+            add_errors()
+            return ProcessingResult(
+                datum=None,
+                warnings=warnings,
+                errors=errors,
+            )
+        elif number_fields != len(order):
+            logging.error(
+                f"Concatenate: Expected {len(order)} fields, got {number_fields}. "
+                f"This is probably a configuration error. (accession_version: {accession_version})"
+            )
+            add_errors()
+            return ProcessingResult(
+                datum=None,
+                warnings=warnings,
+                errors=errors,
+            )
+        elif not isinstance(type, list):
+            logging.error(
+                f"Concatenate: Expected type field to be a list. "
+                f"This is probably a configuration error. (accession_version: {accession_version})"
+            )
+            add_errors()
             return ProcessingResult(
                 datum=None,
                 warnings=warnings,
                 errors=errors,
             )
 
-        formatted_input_data = []
+        formatted_input_data: list[str] = []
         try:
             for i in range(len(order)):
                 if type[i] == "date":
                     processed = ProcessingFunctions.parse_and_assert_past_date(
-                        {"date": input_data[order[i]]}, output_field, input_fields
+                        {"date": input_data[order[i]]}, output_field, input_fields, args
                     )
-                    formatted_input_data.append("" if processed.datum is None else processed.datum)
+                    formatted_input_data.append(
+                        "" if processed.datum is None else str(processed.datum)
+                    )
                 elif type[i] == "timestamp":
                     processed = ProcessingFunctions.parse_timestamp(
-                        {"timestamp": input_data[order[i]]}, output_field, input_fields
+                        {"timestamp": input_data[order[i]]}, output_field, input_fields, args
                     )
-                    formatted_input_data.append("" if processed.datum is None else processed.datum)
+                    formatted_input_data.append(
+                        "" if processed.datum is None else str(processed.datum)
+                    )
                 elif order[i] in input_data:
                     formatted_input_data.append(
-                        "" if input_data[order[i]] is None else input_data[order[i]]
+                        "" if input_data[order[i]] is None else str(input_data[order[i]])
                     )
                 else:
                     formatted_input_data.append(accession_version)
@@ -666,7 +721,7 @@ class ProcessingFunctions:
         input_data: InputMetadata,
         output_field: str,
         input_fields: list[str],
-        args: FunctionArgs = None,
+        args: FunctionArgs,
     ) -> ProcessingResult:
         authors = input_data["authors"]
 
@@ -763,7 +818,7 @@ class ProcessingFunctions:
 
     @staticmethod
     def identity(  # noqa: C901, PLR0912
-        input_data: InputMetadata, output_field: str, input_fields: list[str], args: FunctionArgs = None
+        input_data: InputMetadata, output_field: str, input_fields: list[str], args: FunctionArgs
     ) -> ProcessingResult:
         """Identity function, takes input_data["input"] and returns it as output"""
         if "input" not in input_data:
@@ -796,13 +851,19 @@ class ProcessingFunctions:
                         output_datum = int(input_datum)
                     except ValueError:
                         output_datum = None
-                        errors.append(invalid_value_annotation(input_datum, output_field, input_fields, "int"))
+                        errors.append(
+                            invalid_value_annotation(input_datum, output_field, input_fields, "int")
+                        )
                 case "float":
                     try:
                         output_datum = float(input_datum)
                     except ValueError:
                         output_datum = None
-                        errors.append(invalid_value_annotation(input_datum, output_field, input_fields, "float"))
+                        errors.append(
+                            invalid_value_annotation(
+                                input_datum, output_field, input_fields, "float"
+                            )
+                        )
                 case "boolean":
                     if input_datum.lower() == "true":
                         output_datum = True
@@ -811,7 +872,9 @@ class ProcessingFunctions:
                     else:
                         output_datum = None
                         errors.append(
-                            invalid_value_annotation(input_datum, output_field, input_fields, "boolean")
+                            invalid_value_annotation(
+                                input_datum, output_field, input_fields, "boolean"
+                            )
                         )
                 case _:
                     output_datum = input_datum
@@ -821,10 +884,10 @@ class ProcessingFunctions:
 
     @staticmethod
     def process_options(
-        input_data: InputMetadata, output_field: str, input_fields: list[str], args: FunctionArgs = None
+        input_data: InputMetadata, output_field: str, input_fields: list[str], args: FunctionArgs
     ) -> ProcessingResult:
         """Checks that option is in options"""
-        if "options" not in args:
+        if "options" not in args or not isinstance(args["options"], list):
             return ProcessingResult(
                 datum=None,
                 warnings=[],
@@ -838,8 +901,8 @@ class ProcessingFunctions:
                             for field in input_fields
                         ],
                         message=(
-                            "Website configuration error: no options specified for field "
-                            f"{output_field}, please contact an administrator.",
+                            "Website configuration error: no options list specified for field "
+                            f"{output_field}, please contact an administrator."
                         ),
                     )
                 ],
@@ -897,7 +960,7 @@ class ProcessingFunctions:
         return ProcessingResult(datum=output_datum, warnings=[], errors=[])
 
 
-def format_frameshift(input: str) -> str:
+def format_frameshift(input: str | None) -> str | None:
     """
     In nextclade frameshifts have the json format:
     [{
@@ -936,6 +999,8 @@ def format_frameshift(input: str) -> str:
     * Makes the range [] have an inclusive start and inclusive end
     (the default in nextclade is exclusive end)
     """
+    if input is None:
+        return None
     if input == "[]":
         return ""
 
@@ -960,7 +1025,7 @@ def format_frameshift(input: str) -> str:
     return ",".join(frame_shift_strings)
 
 
-def format_stop_codon(result: str) -> str:
+def format_stop_codon(result: str | None) -> str | None:
     """
     In nextclade stop codons have the json format:
     [   {
@@ -973,13 +1038,15 @@ def format_stop_codon(result: str) -> str:
     * converts this to a comma-separated list of strings: cdsName:codon
     * Converts stop codon positions from index-0 to index-1 (this aligns with other metrics)
     """
+    if result is None:
+        return None
     if result == "[]":
         return ""
     result = result.replace("'", '"')
     stop_codons = json.loads(result)
     stop_codon_strings = []
     for stop_codon in stop_codons:
-        stop_codon_string = f"{stop_codon["cdsName"]}:{stop_codon["codon"] + 1}"
+        stop_codon_string = f"{stop_codon['cdsName']}:{stop_codon['codon'] + 1}"
         stop_codon_strings.append(stop_codon_string)
     return ",".join(stop_codon_strings)
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -130,7 +130,7 @@ class ProcessingFunctions:
                         message=(
                             f"Internal Error: Function {function_name} did not return "
                             f"ProcessingResult with input {input_data} and args {args}, "
-                            f"please contact the administrator."
+                            "please contact the administrator."
                         ),
                     )
                 ],
@@ -603,7 +603,7 @@ class ProcessingFunctions:
                         message=(
                             f"Internal Error: Function concatenate did not receive accession_version "
                             f"ProcessingResult with input {input_data} and args {args}, "
-                            f"please contact the administrator."
+                            "please contact the administrator."
                         ),
                     )
                 ],

--- a/preprocessing/nextclade/src/loculus_preprocessing/sequence_checks.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/sequence_checks.py
@@ -26,7 +26,7 @@ UNALIGNED_NUCLEOTIDE_SYMBOLS = {
 
 
 def errors_if_non_iupac(
-    unaligned_nucleotide_sequences: dict[SegmentName, NucleotideSequence],
+    unaligned_nucleotide_sequences: dict[SegmentName, NucleotideSequence | None],
 ) -> list[ProcessingAnnotation]:
     errors: list[ProcessingAnnotation] = []
     for segment, sequence in unaligned_nucleotide_sequences.items():

--- a/preprocessing/nextclade/tests/factory_methods.py
+++ b/preprocessing/nextclade/tests/factory_methods.py
@@ -29,7 +29,7 @@ class ProcessingAnnotationTestCase:
 class UnprocessedEntryFactory:
     @staticmethod
     def create_unprocessed_entry(
-        metadata_dict: dict[str, str],
+        metadata_dict: dict[str, str | None],
         accession_id: str,
     ) -> UnprocessedEntry:
         return UnprocessedEntry(
@@ -61,7 +61,8 @@ class ProcessedEntryFactory:
             metadata_errors = []
         if metadata_warnings is None:
             metadata_warnings = []
-
+        if self.all_metadata_fields is None:
+            self.all_metadata_fields = []
         base_metadata_dict = dict.fromkeys(self.all_metadata_fields)
         base_metadata_dict.update(metadata_dict)
 

--- a/preprocessing/nextclade/tests/test_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_processing_functions.py
@@ -32,10 +32,10 @@ test_config_file = "tests/test_config.yaml"
 @dataclass
 class Case:
     name: str
-    metadata: dict[str, str]
+    metadata: dict[str, str | None]
     expected_metadata: dict[str, str]
     expected_errors: list[ProcessingAnnotationTestCase]
-    expected_warnings: list[ProcessingAnnotationTestCase] = None
+    expected_warnings: list[ProcessingAnnotationTestCase] | None = None
     accession_id: str = "000999"
 
     def create_test_case(self, factory_custom: ProcessedEntryFactory) -> ProcessingTestCase:


### PR DESCRIPTION
partially resolves https://github.com/loculus-project/loculus/issues/4189

### Screenshot
@corneliusroemer showed me how to enable type checking for python in VSCode - this PR cleans up prepro. It also adds a mypy type check to the cli to ensure that we do not regress again.

All changes are type related, main changes:
- ArgValue is now correctly typed as `ArgValue = list[str] | str | bool | None` and the type is checked before being used in functions
- `FunctionArgs` is now always a dictionary and never None (it was always used as a dict which caused type errors)
- In `ProcessingAnnotation` `unprocessedFields` and `processedFields` are now `list[AnnotationSource]` instead of tuples (they were typically used as lists)

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
- sign in as super user check that warnings and errors are being displayed correctly


🚀 Preview: https://reformat-prepro.loculus.org