### PR TITLE
chore(kubernetes): fix default of runDevelopmentS3 in schema

### DIFF
--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1028,7 +1028,7 @@
     "runDevelopmentS3": {
       "groups": ["db"],
       "type": "boolean",
-      "default": false,
+      "default": true,
       "description": "If true, runs a development MinIO S3 instance within the cluster."
     },
     "disableWebsite": {


### PR DESCRIPTION
The documentation of `runDevelopmentS3` in the schema is wrong: the default value is `true`:

https://github.com/loculus-project/loculus/blob/22e9404defbd503812006048cfa3c9fa9f19bc3c/kubernetes/loculus/values.yaml#L1786

(I think that we should set it to false but that's for a different ticket, see: https://github.com/loculus-project/loculus/issues/3070#issuecomment-2889997230)