### PR TITLE
fix(website): Fix error message for invalid metadata file extension upload

### DIFF
--- a/website/src/components/Submission/FileUpload/fileProcessing.spec.ts
+++ b/website/src/components/Submission/FileUpload/fileProcessing.spec.ts
@@ -60,6 +60,15 @@ describe('fileProcessing', () => {
         expect(processingResult.isErr()).toBeTruthy();
     });
 
+    test('Unsupported metadata extension results in error with message', async () => {
+        const file = new File(['dummy'], 'unsupported.txt');
+        const processingResult = await METADATA_FILE_KIND.processRawFile(file);
+
+        expect(processingResult.isErr()).toBeTruthy();
+        const message = processingResult._unsafeUnwrapErr().message;
+        expect(message).toContain('Unsupported file extension');
+    });
+
     test('Plain segment file content is extracted correctly', async () => {
         const dummyFile = new File(['>fooid\nACTG\n\nACTG\nACTG\n'], 'example.fasta', { type: 'text/plain' });
         const result = await PLAIN_SEGMENT_KIND.processRawFile(dummyFile);

--- a/website/src/components/Submission/FileUpload/fileProcessing.ts
+++ b/website/src/components/Submission/FileUpload/fileProcessing.ts
@@ -49,7 +49,13 @@ export const METADATA_FILE_KIND: FileKind = {
             }
             return ok(excelFile);
         }
-        return err(new Error());
+        return err(
+            new Error(
+                `Unsupported file extension for metadata upload. Please use one of: ${METADATA_FILE_KIND.supportedExtensions.join(
+                    ', ',
+                )}.`,
+            ),
+        );
     },
 };
 


### PR DESCRIPTION
resolves #4151 

<img width="459" alt="image" src="https://github.com/user-attachments/assets/6a42deea-5160-4188-9a11-f3df2b68f287" />


## Summary
- show better error when uploading metadata files with unsupported extensions
- test unsupported metadata extension

🚀 Preview: https://codex-fix-empty-error-mes.loculus.org