### PR TITLE
feat(website): limit max number of displayed autocomplete options

### DIFF
--- a/website/src/components/SearchPage/fields/AutoCompleteField.spec.tsx
+++ b/website/src/components/SearchPage/fields/AutoCompleteField.spec.tsx
@@ -228,4 +228,39 @@ describe('AutoCompleteField', () => {
 
         expect(setSomeFieldValues).toHaveBeenCalledWith(['testField', '']);
     });
+
+    it('shows at most a configured number of options', async () => {
+        const data = [];
+        for (let i = 0; i < 100; i++) {
+            data.push({ testField: `Option ${i}`, count: 10 });
+        }
+        mockUseAggregated.mockReturnValue({
+            data: {
+                data,
+            },
+            isLoading: false,
+            error: null,
+            mutate: vi.fn(),
+        });
+        render(
+            <AutoCompleteField
+                field={field}
+                optionsProvider={{
+                    type: 'generic',
+                    lapisUrl,
+                    lapisSearchParameters,
+                    fieldName: field.name,
+                }}
+                setSomeFieldValues={setSomeFieldValues}
+                fieldValue='Option 1'
+                maxDisplayedOptions={50}
+            />,
+        );
+
+        const input = screen.getByLabelText('Test Field');
+        await userEvent.click(input);
+
+        const options = await screen.findAllByRole('option');
+        expect(options).toHaveLength(50);
+    });
 });

--- a/website/src/components/SearchPage/fields/AutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/AutoCompleteField.tsx
@@ -28,6 +28,7 @@ type AutoCompleteFieldProps = {
     optionsProvider: OptionsProvider;
     setSomeFieldValues: SetSomeFieldValues;
     fieldValue?: string | number | null;
+    maxDisplayedOptions?: number;
 };
 
 export const AutoCompleteField = ({
@@ -35,6 +36,7 @@ export const AutoCompleteField = ({
     optionsProvider,
     setSomeFieldValues,
     fieldValue,
+    maxDisplayedOptions = 1000,
 }: AutoCompleteFieldProps) => {
     const buttonRef = useRef<HTMLButtonElement>(null);
     const isClient = useClientFlag();
@@ -49,13 +51,13 @@ export const AutoCompleteField = ({
         }
     }, [error]);
 
-    const filteredOptions = useMemo(
-        () =>
+    const filteredOptions = useMemo(() => {
+        const allMatchedOptions =
             query === ''
                 ? options
-                : options.filter((option) => option.option.toLowerCase().includes(query.toLowerCase())),
-        [options, query],
-    );
+                : options.filter((option) => option.option.toLowerCase().includes(query.toLowerCase()));
+        return allMatchedOptions.slice(0, maxDisplayedOptions);
+    }, [options, query]);
 
     return (
         <Combobox


### PR DESCRIPTION
The auto-completion of the search is crashing my browser tab if there are too many options. As a solution, this PR proposes to only show a limited number of options. I observed a problem in a field with ~8000 values while it worked well for ~700 values, so I chose a cutoff of 1000.

### PR Checklist
- ~[ ] All necessary documentation has been adapted.~
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
    - Up to 1000 options work well for me (if we observe that it is too much for some devices, we can further adjust)

🚀 Preview: Add `preview` label to enable