### PR TITLE
wip: enable backend tests without Docker

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -92,7 +92,13 @@ task checkDocker {
 
 tasks.named('test') {
     // Docker is required to start the testing database with https://java.testcontainers.org/
-    dependsOn checkDocker
+    // When USE_LOCAL_SERVICES is set, local binaries are used instead and the docker check
+    // can be skipped.
+    if (!System.getenv().containsKey('USE_LOCAL_SERVICES')) {
+        dependsOn checkDocker
+    } else {
+        println 'Running tests with local services - skipping docker check'
+    }
     useJUnitPlatform()
     testLogging {
         events TestLogEvent.FAILED


### PR DESCRIPTION
## Summary
- support running backend tests without Docker by skipping the Docker check when `USE_LOCAL_SERVICES` is set
- extend `EndpointTestExtension` to start PostgreSQL and Minio either via Testcontainers or using local binaries located in `/workspace/depencies`
- implement simple local service managers for PostgreSQL and Minio

## Testing
- `./gradlew testClasses`

🚀 Preview: Add `preview` label to enable