### PR TITLE
Add superuser dev dashboard

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/SecurityConfig.kt
@@ -63,6 +63,7 @@ class SecurityConfig {
 
     private val debugEndpoints = arrayOf(
         "/debug/*",
+        "/dev/*",
     )
 
     @Bean

--- a/backend/src/main/kotlin/org/loculus/backend/controller/DevDashboardController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/DevDashboardController.kt
@@ -1,0 +1,17 @@
+package org.loculus.backend.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import org.loculus.backend.service.submission.SubmissionDatabaseService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/dev")
+@SecurityRequirement(name = "bearerAuth")
+class DevDashboardController(private val submissionDatabaseService: SubmissionDatabaseService) {
+    @Operation(summary = "Get number of processed sequence entries per pipeline version and organism")
+    @GetMapping("/pipeline-stats")
+    fun getPipelineStats(): Map<String, Map<Long, Int>> = submissionDatabaseService.getPipelineVersionStats()
+}

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -831,6 +831,33 @@ class SubmissionDatabaseService(
         return ProcessingResult.entries.associateWith { processingResultCounts[it] ?: 0 }
     }
 
+    fun getPipelineVersionStats(): Map<String, Map<Long, Int>> {
+        val organismColumn = SequenceEntriesTable.organismColumn
+        val pipelineVersionColumn = SequenceEntriesPreprocessedDataTable.pipelineVersionColumn
+        val countColumn = Count(stringLiteral("*"))
+
+        val result = mutableMapOf<String, MutableMap<Long, Int>>()
+        val sql = """
+            SELECT se.organism, sep.pipeline_version, COUNT(*) as count
+            FROM sequence_entries_preprocessed_data sep
+            JOIN sequence_entries se ON se.accession = sep.accession AND se.version = sep.version
+            WHERE sep.processing_status = 'PROCESSED'
+            GROUP BY se.organism, sep.pipeline_version
+        """.trimIndent()
+        transaction {
+            exec(sql) { rs ->
+                while (rs.next()) {
+                    val organism = rs.getString("organism")
+                    val version = rs.getLong("pipeline_version")
+                    val count = rs.getInt("count")
+                    result.getOrPut(organism) { mutableMapOf() }[version] = count
+                }
+            }
+        }
+
+        return result
+    }
+
     fun revoke(
         accessions: List<Accession>,
         authenticatedUser: AuthenticatedUser,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/dev/PipelineStatsEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/dev/PipelineStatsEndpointTest.kt
@@ -1,0 +1,32 @@
+package org.loculus.backend.controller.dev
+
+import org.junit.jupiter.api.Test
+import org.loculus.backend.controller.EndpointTest
+import org.loculus.backend.controller.jwtForDefaultUser
+import org.loculus.backend.controller.jwtForSuperUser
+import org.loculus.backend.controller.withAuth
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@EndpointTest
+class PipelineStatsEndpointTest(@Autowired val mockMvc: MockMvc) {
+    @Test
+    fun `GIVEN no auth THEN unauthorized`() {
+        mockMvc.perform(get("/dev/pipeline-stats"))
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `WHEN non superuser THEN forbidden`() {
+        mockMvc.perform(get("/dev/pipeline-stats").withAuth(jwtForDefaultUser))
+            .andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `WHEN superuser THEN ok`() {
+        mockMvc.perform(get("/dev/pipeline-stats").withAuth(jwtForSuperUser))
+            .andExpect(status().isOk)
+    }
+}

--- a/website/src/pages/dev-dashboard.astro
+++ b/website/src/pages/dev-dashboard.astro
@@ -1,0 +1,24 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { createBackendClient } from '../services/backendClientFactory';
+import { getAccessToken } from '../utils/getAccessToken';
+
+const accessToken = getAccessToken(Astro.locals.session);
+let statsResult;
+if (accessToken !== undefined) {
+    statsResult = await createBackendClient().getPipelineStats(accessToken);
+}
+---
+
+<BaseLayout title='Dev Dashboard'>
+    {
+        accessToken === undefined ? (
+            <p>You must be logged in.</p>
+        ) : (
+            statsResult?.match(
+                (stats) => <pre>{JSON.stringify(stats, null, 2)}</pre>,
+                (error) => <pre>Error: {error.detail}</pre>,
+            )
+        )
+    }
+</BaseLayout>

--- a/website/src/services/backendClient.ts
+++ b/website/src/services/backendClient.ts
@@ -8,6 +8,7 @@ import {
     info,
     requestUploadResponse,
     sequenceEntryToEdit,
+    pipelineVersionStats,
     type ProblemDetail,
 } from '../types/backend.ts';
 import { createAuthorizationHeader } from '../utils/createAuthorizationHeader.ts';
@@ -81,6 +82,17 @@ export class BackendClient {
         return infoResponse.match(
             (info) => info.isInDebugMode,
             () => false,
+        );
+    }
+
+    public getPipelineStats(token: string) {
+        return this.request(
+            '/dev/pipeline-stats',
+            'GET',
+            pipelineVersionStats,
+            createAuthorizationHeader(token),
+            undefined,
+            undefined,
         );
     }
 

--- a/website/src/types/backend.ts
+++ b/website/src/types/backend.ts
@@ -338,3 +338,6 @@ export const requestUploadResponse = z.array(
     }),
 );
 export type RequestUploadResponse = z.infer<typeof requestUploadResponse>;
+
+export const pipelineVersionStats = z.record(z.record(z.number()));
+export type PipelineVersionStats = z.infer<typeof pipelineVersionStats>;


### PR DESCRIPTION
## Summary
- add `/dev/pipeline-stats` endpoint secured for superusers
- implement counting of processed entries per pipeline version
- expose dashboard page on website
- extend backend client and typings
- cover endpoint with tests

## Testing
- `./gradlew ktlintFormat`
- `USE_NONDOCKER_INFRA=true ./gradlew test --console=plain`
- `npm run format`
- `npm run test`
- `npm run check-types`
