### PR TITLE
Refactor forms to reduce duplication

### DIFF
--- a/website/src/components/Submission/RevisionForm.tsx
+++ b/website/src/components/Submission/RevisionForm.tsx
@@ -1,8 +1,6 @@
 import { type FC } from 'react';
-import { toast } from 'react-toastify';
 
-import { DataUploadForm } from './DataUploadForm.tsx';
-import { routes } from '../../routes/routes.ts';
+import { UploadFormWrapper } from './UploadFormWrapper.tsx';
 import { type Group } from '../../types/backend.ts';
 import type { InputField } from '../../types/config.ts';
 import type { SubmissionDataTypes } from '../../types/config.ts';
@@ -20,34 +18,6 @@ type RevisionFormProps = {
     dataUseTermsEnabled: boolean;
 };
 
-export const RevisionForm: FC<RevisionFormProps> = ({
-    accessToken,
-    organism,
-    clientConfig,
-    group,
-    referenceGenomeSequenceNames,
-    metadataTemplateFields,
-    submissionDataTypes,
-    dataUseTermsEnabled,
-}) => {
-    return (
-        <div className='flex flex-col items-center'>
-            <DataUploadForm
-                accessToken={accessToken}
-                organism={organism}
-                referenceGenomeSequenceNames={referenceGenomeSequenceNames}
-                metadataTemplateFields={metadataTemplateFields}
-                clientConfig={clientConfig}
-                action='revise'
-                inputMode='bulk'
-                onError={(message) => toast.error(message, { position: 'top-center', autoClose: false })}
-                group={group}
-                onSuccess={() => {
-                    window.location.href = routes.userSequenceReviewPage(organism, group.groupId);
-                }}
-                submissionDataTypes={submissionDataTypes}
-                dataUseTermsEnabled={dataUseTermsEnabled}
-            />
-        </div>
-    );
-};
+export const RevisionForm: FC<RevisionFormProps> = (props) => (
+    <UploadFormWrapper {...props} action='revise' inputMode='bulk' />
+);

--- a/website/src/components/Submission/SubmissionForm.tsx
+++ b/website/src/components/Submission/SubmissionForm.tsx
@@ -1,9 +1,7 @@
 import { type FC } from 'react';
-import { toast } from 'react-toastify';
 
-import { DataUploadForm } from './DataUploadForm.tsx';
 import type { InputMode } from './FormOrUploadWrapper.tsx';
-import { routes } from '../../routes/routes.ts';
+import { UploadFormWrapper } from './UploadFormWrapper.tsx';
 import { type Group } from '../../types/backend.ts';
 import type { InputField } from '../../types/config.ts';
 import type { SubmissionDataTypes } from '../../types/config.ts';
@@ -22,35 +20,6 @@ type SubmissionFormProps = {
     dataUseTermsEnabled: boolean;
 };
 
-export const SubmissionForm: FC<SubmissionFormProps> = ({
-    accessToken,
-    organism,
-    clientConfig,
-    group,
-    inputMode,
-    referenceGenomeSequenceNames,
-    metadataTemplateFields,
-    submissionDataTypes,
-    dataUseTermsEnabled,
-}) => {
-    return (
-        <div className='flex flex-col items-center'>
-            <DataUploadForm
-                accessToken={accessToken}
-                organism={organism}
-                referenceGenomeSequenceNames={referenceGenomeSequenceNames}
-                metadataTemplateFields={metadataTemplateFields}
-                clientConfig={clientConfig}
-                action='submit'
-                inputMode={inputMode}
-                onError={(message) => toast.error(message, { position: 'top-center', autoClose: false })}
-                group={group}
-                onSuccess={() => {
-                    window.location.href = routes.userSequenceReviewPage(organism, group.groupId);
-                }}
-                submissionDataTypes={submissionDataTypes}
-                dataUseTermsEnabled={dataUseTermsEnabled}
-            />
-        </div>
-    );
-};
+export const SubmissionForm: FC<SubmissionFormProps> = (props) => (
+    <UploadFormWrapper {...props} action='submit' inputMode={props.inputMode} />
+);

--- a/website/src/components/Submission/UploadFormWrapper.tsx
+++ b/website/src/components/Submission/UploadFormWrapper.tsx
@@ -1,0 +1,56 @@
+import { type FC } from 'react';
+import { toast } from 'react-toastify';
+
+import { DataUploadForm, type UploadAction } from './DataUploadForm.tsx';
+import type { InputMode } from './FormOrUploadWrapper.tsx';
+import { routes } from '../../routes/routes.ts';
+import { type Group } from '../../types/backend.ts';
+import type { InputField } from '../../types/config.ts';
+import type { SubmissionDataTypes } from '../../types/config.ts';
+import type { ReferenceGenomesSequenceNames } from '../../types/referencesGenomes';
+import type { ClientConfig } from '../../types/runtimeConfig.ts';
+
+export type UploadFormWrapperProps = {
+    action: UploadAction;
+    inputMode: InputMode;
+    accessToken: string;
+    organism: string;
+    clientConfig: ClientConfig;
+    group: Group;
+    referenceGenomeSequenceNames: ReferenceGenomesSequenceNames;
+    metadataTemplateFields: Map<string, InputField[]>;
+    submissionDataTypes: SubmissionDataTypes;
+    dataUseTermsEnabled: boolean;
+};
+
+export const UploadFormWrapper: FC<UploadFormWrapperProps> = ({
+    action,
+    inputMode,
+    accessToken,
+    organism,
+    clientConfig,
+    group,
+    referenceGenomeSequenceNames,
+    metadataTemplateFields,
+    submissionDataTypes,
+    dataUseTermsEnabled,
+}) => (
+    <div className='flex flex-col items-center'>
+        <DataUploadForm
+            accessToken={accessToken}
+            organism={organism}
+            referenceGenomeSequenceNames={referenceGenomeSequenceNames}
+            metadataTemplateFields={metadataTemplateFields}
+            clientConfig={clientConfig}
+            action={action}
+            inputMode={inputMode}
+            onError={(message) => toast.error(message, { position: 'top-center', autoClose: false })}
+            group={group}
+            onSuccess={() => {
+                window.location.href = routes.userSequenceReviewPage(organism, group.groupId);
+            }}
+            submissionDataTypes={submissionDataTypes}
+            dataUseTermsEnabled={dataUseTermsEnabled}
+        />
+    </div>
+);


### PR DESCRIPTION
## Summary
- extract common behavior of SubmissionForm and RevisionForm into UploadFormWrapper
- use UploadFormWrapper from both forms

## Testing
- `npm run format`
- `npm run check-types`
- `npm run test` *(fails: ECONNREFUSED, tests run in watch mode)*

🚀 Preview: Add `preview` label to enable