### PR TITLE
Convert useQueryAsState to TypeScript

### DIFF
--- a/website/src/components/SearchPage/useQueryAsState.spec.ts
+++ b/website/src/components/SearchPage/useQueryAsState.spec.ts
@@ -1,8 +1,7 @@
-/* eslint-disable @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
 import { renderHook, act } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import useQueryAsState from './useQueryAsState';
+import useQueryAsState from './useQueryAsState.ts';
 
 describe('useQueryAsState', () => {
     let replaceStateMock: ReturnType<typeof vi.spyOn>;

--- a/website/src/components/SearchPage/useQueryAsState.ts
+++ b/website/src/components/SearchPage/useQueryAsState.ts
@@ -1,22 +1,25 @@
 import { useState, useEffect } from 'react';
 
+export interface QueryState {
+    [key: string]: string;
+}
+
+export type UseQueryAsStateReturn<T extends QueryState> = [T, React.Dispatch<React.SetStateAction<T>>];
+
 const MAX_URL_LENGTH = 2000; // Set a maximum URL length threshold
 
-export default function useQueryAsState(defaultDict) {
-    const [valueDict, setValueDict] = useState(defaultDict);
+export default function useQueryAsState<T extends QueryState>(defaultDict: T): UseQueryAsStateReturn<T> {
+    const [valueDict, setValueDict] = useState<T>(defaultDict);
     const [useUrlStorage, setUseUrlStorage] = useState(true);
 
     useEffect(() => {
         const urlParams = new URLSearchParams(window.location.search);
-        const newDict = {};
+        const newDict: Record<string, string> = {};
         for (const [key, value] of urlParams) {
             newDict[key] = value;
         }
-       
-        setValueDict( // only change if actually different
-        (prev) =>
-            JSON.stringify(prev) === JSON.stringify(newDict) ? prev : newDict
-        );
+
+        setValueDict((prev) => (JSON.stringify(prev) === JSON.stringify(newDict) ? prev : (newDict as T)));
     }, []);
 
     useEffect(() => {
@@ -25,13 +28,19 @@ export default function useQueryAsState(defaultDict) {
             for (const [key, value] of Object.entries(valueDict)) {
                 urlParams.set(key, value);
             }
-            let newUrl = window.location.protocol + "//" + window.location.host + window.location.pathname + "?" + urlParams.toString();
+            let newUrl =
+                window.location.protocol +
+                '//' +
+                window.location.host +
+                window.location.pathname +
+                '?' +
+                urlParams.toString();
 
             // Avoid '*' at the end because some systems do not recognize it as part of the link
-            if (newUrl.endsWith("*")) {
-                newUrl = newUrl.concat("&");
+            if (newUrl.endsWith('*')) {
+                newUrl = newUrl.concat('&');
             }
-            
+
             if (newUrl.length > MAX_URL_LENGTH) {
                 setUseUrlStorage(false);
                 window.history.replaceState({ path: window.location.pathname }, '', window.location.pathname);


### PR DESCRIPTION
## Summary
- extract `QueryState` type from `useQueryAsState`
- use `QueryState` throughout `SearchFullUI`

## Testing
- `npm run format`
- `npm run check-types`
- `npm run test` *(watch mode)*

🚀 Preview: Add `preview` label to enable