### PR TITLE
Pass pod priority to ENA submission cronjob

### DIFF
--- a/kubernetes/loculus/templates/ena-submission-deployment.yaml
+++ b/kubernetes/loculus/templates/ena-submission-deployment.yaml
@@ -131,6 +131,7 @@ spec:
           annotations:
             argocd.argoproj.io/sync-options: Replace=true
         spec:
+          {{- include "possiblePriorityClassName" . | nindent 10 }}
           restartPolicy: Never
           containers:
             - name: ena-submission


### PR DESCRIPTION
## Summary
- make the ENA submission cronjob use podPriorityClassName if provided

## Testing
- `helm` or `yamllint` not available
