### PR TITLE
feat(website): warn when link out exceeds recommended sequences

### DIFF
--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -184,8 +184,11 @@ organisms:
         {{- range $linkOut := .linkOuts }}
         - name: {{ quote $linkOut.name }}
           url: {{ quote $linkOut.url }}
+          {{- if $linkOut.maxNumberOfRecommendedEntries }}
+          maxNumberOfRecommendedEntries: {{ $linkOut.maxNumberOfRecommendedEntries }}
+          {{- end }}
         {{- end }}
-      {{ end }}
+      {{- end }}
       loadSequencesAutomatically: {{ .loadSequencesAutomatically | default false }}
       {{ if .richFastaHeaderFields}}
       richFastaHeaderFields: {{ toJson .richFastaHeaderFields }}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -361,6 +361,10 @@
                   "url": {
                     "type": "string",
                     "description": "URL template with placeholders. Example: 'https://tool.example.com/?data={{[unalignedNucleotideSequences+rich|fasta]}}'"
+                  },
+                  "maxNumberOfRecommendedEntries": {
+                    "type": "integer",
+                    "description": "Optional maximum number of recommended entries for the tool beyond which a warning will be shown.'"
                   }
                 },
                 "required": ["name", "url"]

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -48,6 +48,7 @@ defaultOrganismConfig: &defaultOrganismConfig
     image: "/images/organisms/ebolasudan_small.jpg"
     linkOuts:
       - name: "Nextclade"
+        maxNumberOfRecommendedEntries: 5
         url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences+rich|fasta]}}&dataset-name=nextstrain/ebola/sudan&dataset-server=https://raw.githubusercontent.com/nextstrain/nextclade_data/ebola/data_output"
     earliestReleaseDate:
       enabled: true

--- a/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.spec.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.spec.tsx
@@ -48,6 +48,7 @@ describe('LinkOutMenu with enabled data use terms', () => {
             <LinkOutMenu
                 downloadUrlGenerator={realDownloadUrlGenerator}
                 sequenceFilter={mockSequenceFilter}
+                sequenceCount={1}
                 linkOuts={linkOuts}
                 dataUseTermsEnabled={true}
             />,
@@ -67,6 +68,7 @@ describe('LinkOutMenu with enabled data use terms', () => {
             <LinkOutMenu
                 downloadUrlGenerator={realDownloadUrlGenerator}
                 sequenceFilter={mockSequenceFilter}
+                sequenceCount={1}
                 linkOuts={linkOuts}
                 dataUseTermsEnabled={true}
             />,
@@ -92,6 +94,7 @@ describe('LinkOutMenu with enabled data use terms', () => {
             <LinkOutMenu
                 downloadUrlGenerator={realDownloadUrlGenerator}
                 sequenceFilter={mockSequenceFilter}
+                sequenceCount={1}
                 linkOuts={linkOuts}
                 dataUseTermsEnabled={true}
             />,
@@ -117,6 +120,7 @@ describe('LinkOutMenu with enabled data use terms', () => {
             <LinkOutMenu
                 downloadUrlGenerator={realDownloadUrlGenerator}
                 sequenceFilter={mockSequenceFilter}
+                sequenceCount={1}
                 linkOuts={[{ name: 'Basic', url: 'http://example.com/tool?data=[unalignedNucleotideSequences]' }]}
                 dataUseTermsEnabled={true}
             />,
@@ -137,6 +141,7 @@ describe('LinkOutMenu with disabled data use terms', () => {
             <LinkOutMenu
                 downloadUrlGenerator={realDownloadUrlGenerator}
                 sequenceFilter={mockSequenceFilter}
+                sequenceCount={1}
                 linkOuts={linkOuts}
                 dataUseTermsEnabled={false}
             />,

--- a/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
@@ -15,11 +15,13 @@ type DataType = (typeof DATA_TYPES)[number];
 type LinkOut = {
     name: string;
     url: string;
+    maxNumberOfRecommendedEntries?: number;
 };
 
 type LinkOutMenuProps = {
     downloadUrlGenerator: DownloadUrlGenerator;
     sequenceFilter: SequenceFilter;
+    sequenceCount?: number;
     linkOuts: LinkOut[];
     dataUseTermsEnabled: boolean;
 };
@@ -27,6 +29,7 @@ type LinkOutMenuProps = {
 export const LinkOutMenu: FC<LinkOutMenuProps> = ({
     downloadUrlGenerator,
     sequenceFilter,
+    sequenceCount,
     linkOuts,
     dataUseTermsEnabled,
 }) => {
@@ -36,6 +39,18 @@ export const LinkOutMenu: FC<LinkOutMenuProps> = ({
 
     const handleLinkClick = (linkOut: LinkOut) => {
         currentLinkOut.current = linkOut;
+        if (
+            linkOut.maxNumberOfRecommendedEntries !== undefined &&
+            sequenceCount !== undefined &&
+            sequenceCount > linkOut.maxNumberOfRecommendedEntries
+        ) {
+            const proceed = confirm(
+                `Warning: This tool is recommended for at most ${linkOut.maxNumberOfRecommendedEntries} sequences. You are attempting to use ${sequenceCount}. Continue?`,
+            );
+            if (!proceed) {
+                return;
+            }
+        }
         if (dataUseTermsEnabled) {
             setDataUseTermsModalVisible(true);
         } else {

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -296,6 +296,7 @@ export const InnerSearchFullUI = ({
     }, [lapisSearchParameters, schema.tableColumns, schema.primaryKey, pageSize, page, orderByField, orderDirection]);
 
     const totalSequences = aggregatedHook.data?.data[0].count ?? undefined;
+    const linkOutSequenceCount = downloadFilter.sequenceCount() ?? totalSequences;
 
     const [oldData, setOldData] = useState<TableSequenceData[] | null>(null);
     const [oldCount, setOldCount] = useState<number | null>(null);
@@ -458,6 +459,7 @@ export const InnerSearchFullUI = ({
                                 <LinkOutMenu
                                     downloadUrlGenerator={downloadUrlGenerator}
                                     sequenceFilter={downloadFilter}
+                                    sequenceCount={linkOutSequenceCount}
                                     linkOuts={linkOuts}
                                     dataUseTermsEnabled={dataUseTermsEnabled}
                                 />

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -108,6 +108,7 @@ export type GroupedMetadataFilter = {
 export const linkOut = z.object({
     name: z.string(),
     url: z.string(),
+    maxNumberOfRecommendedEntries: z.number().int().positive().optional(),
 });
 
 export type LinkOut = z.infer<typeof linkOut>;


### PR DESCRIPTION
Resolves #4215 for now. It's not perfect but we can come back to the whole linkOut modal when we have sequence numbers for the number of open and restricted sequences.

🚀 Preview: https://codex-add-warning-for-exc.loculus.org