### PR TITLE
feat(kubernetes): update LAPIS to 0.5.1 and enable advanced queries

### DIFF
--- a/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
+++ b/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
@@ -4,9 +4,6 @@
   {{- if .generateIndex }}
   generateIndex: {{ .generateIndex }}
   {{- end }}
-  {{- if .enableSubstringSearch }}
-  lapisAllowsRegexSearch: true
-  {{- end }}
   {{- if .lineageSystem }}
   generateIndex: true
   generateLineageIndex: true
@@ -42,4 +39,6 @@ schema:
   {{- end }}
   {{- end }}
   primaryKey: accessionVersion
+  features:
+    - name: generalizedAdvancedQuery
 {{- end }}

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1712,7 +1712,7 @@ images:
     pullPolicy: IfNotPresent
   lapis:
     repository: "ghcr.io/genspectrum/lapis"
-    tag: "0.4.5"
+    tag: "0.5.1"
     pullPolicy: IfNotPresent
   website:
     repository: "ghcr.io/loculus-project/website"


### PR DESCRIPTION
We recently added advanced queries in LAPIS. They are documented here: https://lapis.cov-spectrum.org/open/v2/docs/concepts/advanced-query

The config field `lapisAllowsRegexSearch` is not necessary anymore. All string fields can be queried with `<fieldName>.regex` now.

I left the `enableSubstringSearch` config field in Loculus though, because it's probably good to leave that for the UI, isn't it?

Changelog: 

## [0.5.1](https://github.com/GenSpectrum/LAPIS/compare/v0.5.0...v0.5.1) (2025-05-28)

### Bug Fixes

* **lapis:** advanced queries: make `.regex` case-insensitive ([#1198](https://github.com/GenSpectrum/LAPIS/issues/1198)) ([fd85fa5](https://github.com/GenSpectrum/LAPIS/commit/fd85fa5fbe8cb765c6a994214d10fb587cd36d10))

## [0.5.0](https://github.com/GenSpectrum/LAPIS/compare/v0.4.5...v0.5.0) (2025-05-22)

### ⚠ BREAKING CHANGES

* **lapis:** lapisAllowsRegexSearch on string metadata fields in the database config is not necessary anymore, regex search is always enabled for all string fields.

### Features

* **lapis:** add advanced queries feature ([#1144](https://github.com/GenSpectrum/LAPIS/issues/1144)) ([b8e8ca8](https://github.com/GenSpectrum/LAPIS/commit/b8e8ca8177e987e1dce4c4c7d0fcf298cfe02574))

### Manual testing

- Theo confirmed that he can still use regex searches
- Substring search still works: https://lapis051.loculus.org/ebola-sudan/search?visibility_authors=true&authors=Whitmer

### Screenshot

### PR Checklist
- [x] All necessary documentation has been adapted: No user visible changes
~~- [ ] The implemented feature is covered by appropriate, automated tests.~~
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://lapis051.loculus.org