### PR TITLE
fix(website): Check for empty LAPIS responses and raise error

### DIFF
--- a/website/src/utils/createDownloadAPIRoute.ts
+++ b/website/src/utils/createDownloadAPIRoute.ts
@@ -134,7 +134,21 @@ const getSequenceData = async (
     const organisms = getConfiguredOrganisms();
     const promises = organisms.map(({ key }) =>
         getSequenceDataWithOrganism(accessionVersion, key, fileSuffix, undefinedVersionRedirectUrl, getter).then(
-            (result) => (result.isOk() ? ok(result.value) : Promise.reject(new Error(result.error.detail))),
+            (result) => {
+                if (result.isOk()) {
+                    if (result.value.type === ResultType.REDIRECT) {
+                        return ok(result.value);
+                    } else {
+                        if (result.value.data.trim().split('\n').length > 1) {
+                            return ok(result.value);
+                        } else {
+                            return Promise.reject(new Error('Result is empty - expected data.'));
+                        }
+                    }
+                } else {
+                    return Promise.reject(new Error(result.error.detail));
+                }
+            },
         ),
     );
 


### PR DESCRIPTION
resolves #4223 

LAPIS resonds with an `OK` response also for empty data, and that caused issues. Now we're checking if at least one data row is returned, and otherwise an error is raised (making the Promise rejected).

Note on redirects: for URLs without a version, a redirect is returned, so that is just passed through as OK - we "kick the can down to road"

### Manual testing

I tested that I can DL sequence data on seqs where I couldn't (reliably) before. I also tested a link without a version part and that worked too. This is the URL I used during my tests: https://main.loculus.org/seq/LOC_00004U7.1 (but with localhost)

### PR Checklist
- ~~All necessary documentation has been adapted.~~ (n/A)
- ~~The implemented feature is covered by appropriate, automated tests.~~ (postponed: #4225)
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://seq-dl-fix.loculus.org