### PR TITLE
test(integration): add sequence TSV download test

### DIFF
--- a/integration-tests/tests/specs/features/sequence-tsv-download.dependent.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-tsv-download.dependent.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test';
+import { SearchPage } from '../../pages/search.page';
+const fs = require('fs');
+
+test('Download metadata TSV for a single sequence', async ({ page }) => {
+    const searchPage = new SearchPage(page);
+    await searchPage.ebolaSudan();
+
+    const loculusId = await searchPage.waitForLoculusId();
+    expect(loculusId).toBeTruthy();
+
+    await page.goto(`/seq/${loculusId}`);
+    await expect(page.getByRole('heading', { name: loculusId })).toBeVisible();
+
+    await page.getByText('Download', { exact: true }).click();
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('link', { name: 'Download metadata TSV' }).click();
+    const download = await downloadPromise;
+
+    const downloadPath = await download.path();
+    expect(downloadPath).toBeTruthy();
+
+    const fileContent = fs.readFileSync(downloadPath, 'utf8');
+    const fields = fileContent.split('\n')[0].split('\t');
+    expect(fields.length).toBeGreaterThan(5);
+});

--- a/integration-tests/tests/specs/features/sequence-tsv-download.dependent.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-tsv-download.dependent.spec.ts
@@ -25,5 +25,5 @@ test('Download metadata TSV for a single sequence', async ({ page }) => {
     const fields = lines[0].split('\t');
     expect(fields.length).toBeGreaterThan(5);
     const values = lines[1].split('\t');
-    expect(values.length).toBeGreaterThan(5);    
+    expect(values.length).toBeGreaterThan(5);
 });

--- a/integration-tests/tests/specs/features/sequence-tsv-download.dependent.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-tsv-download.dependent.spec.ts
@@ -21,6 +21,9 @@ test('Download metadata TSV for a single sequence', async ({ page }) => {
     expect(downloadPath).toBeTruthy();
 
     const fileContent = fs.readFileSync(downloadPath, 'utf8');
-    const fields = fileContent.split('\n')[0].split('\t');
+    const lines = fileContent.split('\n');
+    const fields = lines[0].split('\t');
     expect(fields.length).toBeGreaterThan(5);
+    const values = lines[1].split('\t');
+    expect(values.length).toBeGreaterThan(5);    
 });


### PR DESCRIPTION
Resolves https://github.com/loculus-project/loculus/issues/4225

## Summary
- add a Playwright integration test that verifies the 'Download metadata TSV' button for individual sequences


🚀 Preview: Add `preview` label to enable