### PR TITLE
feat(website): add SeqSet integration tests

### DIFF
--- a/integration-tests/tests/pages/seqset.page.ts
+++ b/integration-tests/tests/pages/seqset.page.ts
@@ -1,0 +1,35 @@
+import { Page } from '@playwright/test';
+
+export class SeqSetPage {
+    constructor(private page: Page) {}
+
+    async gotoList() {
+        await this.page.goto('/seqsets');
+    }
+
+    async gotoDetail(seqSetName: string) {
+        await this.gotoList();
+        await this.page.getByTestId(seqSetName).first().click();
+        await this.page.waitForLoadState();
+    }
+
+    async createSeqSet(seqSetName: string) {
+        await this.gotoList();
+        await this.page.getByTestId('AddIcon').waitFor();
+        await this.page.getByTestId('AddIcon').click();
+        await this.page.getByLabel('SeqSet name').fill(seqSetName);
+        await this.page.getByLabel('SeqSet description').fill('Test seqSet description');
+        await this.page.getByLabel('Focal accessions').fill('LOC_00000AE, LOC_000001Y');
+        await this.page.getByLabel('Background accessions').fill('LOC_000003U, LOC_000004S');
+        await this.page.getByRole('button', { name: 'Save' }).click();
+        await this.page.waitForLoadState();
+    }
+
+    async deleteSeqSet(seqSetName: string) {
+        await this.gotoList();
+        await this.page.getByText(seqSetName).first().click();
+        await this.page.getByRole('button', { name: 'Delete' }).click();
+        await this.page.getByRole('button', { name: 'Confirm' }).click();
+        await this.page.waitForLoadState();
+    }
+}

--- a/integration-tests/tests/specs/features/seqset/seqset.spec.ts
+++ b/integration-tests/tests/specs/features/seqset/seqset.spec.ts
@@ -1,0 +1,65 @@
+import { expect } from '@playwright/test';
+import { test } from '../../../fixtures/group.fixture';
+import { SeqSetPage } from '../../../pages/seqset.page';
+import { v4 as uuidv4 } from 'uuid';
+
+const generateName = () => `seqSet_${uuidv4().slice(0, 8)}`;
+
+test.describe('SeqSet operations', () => {
+    test('create seqSet appears in list', async ({ pageWithGroup }) => {
+        const seqSetPage = new SeqSetPage(pageWithGroup);
+        const name = generateName();
+        try {
+            await seqSetPage.createSeqSet(name);
+            await expect(pageWithGroup.getByRole('heading', { name })).toBeVisible();
+        } finally {
+            await seqSetPage.deleteSeqSet(name);
+        }
+    });
+
+    test('view details, export, edit and delete seqSet', async ({ pageWithGroup }) => {
+        const seqSetPage = new SeqSetPage(pageWithGroup);
+        const name = generateName();
+        const updatedName = `${name}_updated`;
+
+        try {
+            await seqSetPage.createSeqSet(name);
+            await seqSetPage.gotoDetail(name);
+
+            // export JSON
+            await pageWithGroup.getByRole('button', { name: 'Export' }).click();
+            await pageWithGroup.getByTestId('json-radio').click();
+            const [jsonDownload] = await Promise.all([
+                pageWithGroup.waitForEvent('download'),
+                pageWithGroup.getByRole('button', { name: 'Download' }).click(),
+            ]);
+            expect(jsonDownload.suggestedFilename()).toBe(`${name}.json`);
+
+            // export TSV
+            await seqSetPage.gotoDetail(name);
+            await pageWithGroup.getByRole('button', { name: 'Export' }).click();
+            await pageWithGroup.getByTestId('tsv-radio').click();
+            const [tsvDownload] = await Promise.all([
+                pageWithGroup.waitForEvent('download'),
+                pageWithGroup.getByRole('button', { name: 'Download' }).click(),
+            ]);
+            expect(tsvDownload.suggestedFilename()).toBe(`${name}.tsv`);
+
+            // edit name
+            await seqSetPage.gotoDetail(name);
+            await pageWithGroup.getByRole('button', { name: 'Edit' }).click();
+            await pageWithGroup.locator('#seqSet-name').fill(updatedName);
+            await pageWithGroup.getByRole('button', { name: 'Save' }).click();
+            await expect(
+                pageWithGroup.getByText(updatedName).locator('visible=true'),
+            ).toBeVisible();
+
+            // delete
+            await seqSetPage.deleteSeqSet(updatedName);
+        } finally {
+            // cleanup in case deletion failed
+            await seqSetPage.deleteSeqSet(updatedName).catch(() => {});
+            await seqSetPage.deleteSeqSet(name).catch(() => {});
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- add SeqSet page object for integration tests
- add integration tests covering SeqSet creation, export, editing and deletion

## Testing
- `npm run format`
- `npm run test` *(fails: request to https://registry.npmjs.org/playwright failed, reason: connect EHOSTUNREACH)*

🚀 Preview: Add `preview` label to enable