### PR TITLE
feat(deployment): add autoscaling for website and lapis

### DIFF
--- a/kubernetes/loculus/templates/lapis-hpa.yaml
+++ b/kubernetes/loculus/templates/lapis-hpa.yaml
@@ -1,0 +1,21 @@
+{{- range $key, $_ := (.Values.organisms | default .Values.defaultOrganisms) }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: loculus-lapis-{{ $key }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: loculus-lapis-{{ $key }}
+  minReplicas: {{ $.Values.autoscaling.lapis.minReplicas }}
+  maxReplicas: {{ $.Values.autoscaling.lapis.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $.Values.autoscaling.lapis.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/kubernetes/loculus/templates/loculus-website-hpa.yaml
+++ b/kubernetes/loculus/templates/loculus-website-hpa.yaml
@@ -1,0 +1,20 @@
+{{- if not .Values.disableWebsite }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: loculus-website
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: loculus-website
+  minReplicas: {{ .Values.autoscaling.website.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.website.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.website.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1272,6 +1272,30 @@
       },
       "additionalProperties": false
     },
+    "autoscaling": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "website": {
+          "type": "object",
+          "properties": {
+            "minReplicas": { "type": "integer", "default": 1 },
+            "maxReplicas": { "type": "integer", "default": 3 },
+            "targetCPUUtilizationPercentage": { "type": "integer", "default": 80 }
+          },
+          "additionalProperties": false
+        },
+        "lapis": {
+          "type": "object",
+          "properties": {
+            "minReplicas": { "type": "integer", "default": 1 },
+            "maxReplicas": { "type": "integer", "default": 3 },
+            "targetCPUUtilizationPercentage": { "type": "integer", "default": 80 }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
     "preprocessingTimeout": {
       "type": "integer",
       "description": "TODO",

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1802,6 +1802,15 @@ replicas:
   website: 1
   backend: 1
   lapis: 1
+autoscaling:
+  website:
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 80
+  lapis:
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 80
 gitHubEditLink: "https://github.com/loculus-project/loculus/edit/main/monorepo/website/"
 gitHubMainUrl: https://github.com/loculus-project/loculus
 resources:


### PR DESCRIPTION
## Summary
- add HorizontalPodAutoscalers for the website and LAPIS
- configure default autoscaling options
- document autoscaling values in schema

## Testing
- `git status --short`

🚀 Preview: Add `preview` label to enable