### PR TITLE
fix(website): reset sequence preview state when switching

### DIFF
--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -334,6 +334,7 @@ export const InnerSearchFullUI = ({
                 setFieldSelected={setAColumnVisibility}
             />
             <SeqPreviewModal
+                key={previewedSeqId ?? 'seq-modal'}
                 seqId={previewedSeqId ?? ''}
                 accessToken={accessToken}
                 isOpen={Boolean(previewedSeqId)}


### PR DESCRIPTION
## Summary
- ensure Sequence Preview modal resets when selecting a new sequence

Resolves https://github.com/loculus-project/loculus/issues/4236

I couldn't see the issue in the preview

🚀 Preview: https://codex-fix-sequence-detail.loculus.org