### PR TITLE
feat(website): only show "Loading..." text after 500ms of loading

### DIFF
--- a/website/src/components/SearchPage/SeqPreviewModal.tsx
+++ b/website/src/components/SearchPage/SeqPreviewModal.tsx
@@ -106,8 +106,8 @@ export const SeqPreviewModal: React.FC<SeqPreviewModalProps> = ({
                         sequenceFlaggingConfig={data.isRevocation ? undefined : sequenceFlaggingConfig}
                     />
                 </div>
-            ) : (
-                isLoading ? null : <div>Failed to load sequence data</div>
+            ) : isLoading ? null : (
+                <div>Failed to load sequence data</div>
             )}
         </div>
     );

--- a/website/src/components/SearchPage/SeqPreviewModal.tsx
+++ b/website/src/components/SearchPage/SeqPreviewModal.tsx
@@ -50,6 +50,19 @@ export const SeqPreviewModal: React.FC<SeqPreviewModalProps> = ({
     const [isLoading, setIsLoading] = useState(true);
     const [data, setData] = useState<DetailsJson | null>(null);
     const [isError, setIsError] = useState(false);
+    const [showLoading, setShowLoading] = useState(false);
+
+    useEffect(() => {
+        let loadingTimeout: ReturnType<typeof setTimeout> | null = null;
+        if (isLoading) {
+            loadingTimeout = setTimeout(() => setShowLoading(true), 500);
+        } else {
+            setShowLoading(false);
+        }
+        return () => {
+            if (loadingTimeout) clearTimeout(loadingTimeout);
+        };
+    }, [isLoading]);
 
     useEffect(() => {
         if (seqId) {
@@ -81,7 +94,7 @@ export const SeqPreviewModal: React.FC<SeqPreviewModalProps> = ({
                 />
             )}
 
-            {isLoading ? (
+            {showLoading ? (
                 <div>Loading...</div>
             ) : data !== null && !isError ? (
                 <div className='px-6'>
@@ -94,7 +107,7 @@ export const SeqPreviewModal: React.FC<SeqPreviewModalProps> = ({
                     />
                 </div>
             ) : (
-                <div>Failed to load sequence data</div>
+                isLoading ? null : <div>Failed to load sequence data</div>
             )}
         </div>
     );


### PR DESCRIPTION
Reduce flicker, only show loading if it's actually taking a while to load.

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

Mostly written by GPT-4.1 in VS Code in Agent mode

🚀 Preview: https://delay-loading.loculus.org