### PR TITLE
feat(deployment): add scalable replica settings

### DIFF
--- a/kubernetes/loculus/templates/lapis-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-deployment.yaml
@@ -1,5 +1,8 @@
 {{- $dockerTag := include "loculus.dockerTag" .Values }}
 
+{{- $replicas := $.Values.replicas.lapis }}
+{{- $min := $replicas.min | default 1 }}
+{{- $max := $replicas.max | default $min }}
 {{- range $key, $organism := (.Values.organisms | default .Values.defaultOrganisms) }}
 ---
 apiVersion: apps/v1
@@ -8,7 +11,9 @@ metadata:
   name: loculus-lapis-{{ $key }}
   annotations:
 spec:
-  replicas: {{ $.Values.replicas.lapis | default 1 }}
+  {{- if eq $min $max }}
+  replicas: {{ $min }}
+  {{- end }}
   selector:
     matchLabels:
       app: loculus
@@ -68,4 +73,26 @@ spec:
             timeoutSeconds: 5
       volumes:
         {{- include "loculus.configVolume" (dict "name" "lapis-silo-database-config" "configmap" (printf "lapis-silo-database-config-%s" $key)) | nindent 8 }}
+{{- if ne $min $max }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: loculus-lapis-{{ $key }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: loculus-lapis-{{ $key }}
+  minReplicas: {{ $min }}
+  maxReplicas: {{ $max }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
 {{- end }}
+{{- end }}
+

--- a/kubernetes/loculus/templates/loculus-backend.yaml
+++ b/kubernetes/loculus/templates/loculus-backend.yaml
@@ -7,8 +7,13 @@ metadata:
   name: loculus-backend
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
+{{- $replicas := $.Values.replicas.backend }}
+{{- $min := $replicas.min | default 1 }}
+{{- $max := $replicas.max | default $min }}
 spec:
-  replicas: {{$.Values.replicas.backend}}
+  {{- if eq $min $max }}
+  replicas: {{ $min }}
+  {{- end }}
   selector:
     matchLabels:
       app: loculus
@@ -149,4 +154,25 @@ spec:
               mountPath: /config
       volumes:
 {{ include "loculus.configVolume" (dict "name" "loculus-backend-config") | nindent 8 }}
+{{- if ne $min $max }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: loculus-backend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: loculus-backend
+  minReplicas: {{ $min }}
+  maxReplicas: {{ $max }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+{{- end }}
 {{- end }}

--- a/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
@@ -9,7 +9,9 @@
 {{- range $organism, $organismConfig := (.Values.organisms | default .Values.defaultOrganisms) }}
 {{- range $processingIndex, $processingConfig := $organismConfig.preprocessing }}
 {{- $thisDockerTag := $processingConfig.dockerTag | default $dockerTag }}
-{{- $replicas := $processingConfig.replicas | default 1 }}
+{{- $replicasCfg := $processingConfig.replicas }}
+{{- $min := ($replicasCfg.min | default (toInt $replicasCfg)) | default 1 }}
+{{- $max := ($replicasCfg.max | default $min) }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -18,7 +20,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
 spec:
-  replicas: {{ $replicas }}
+  {{- if eq $min $max }}
+  replicas: {{ $min }}
+  {{- end }}
   selector:
     matchLabels:
       app: loculus
@@ -61,6 +65,27 @@ spec:
           configMap:
             name: loculus-preprocessing-config-{{ $organism }}-v{{ $processingConfig.version }}-{{ $processingIndex }}
       {{- end }}
+{{- if ne $min $max }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: loculus-preprocessing-{{ $organism }}-v{{ $processingConfig.version }}-{{ $processingIndex }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: loculus-preprocessing-{{ $organism }}-v{{ $processingConfig.version }}-{{ $processingIndex }}
+  minReplicas: {{ $min }}
+  maxReplicas: {{ $max }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/kubernetes/loculus/templates/loculus-website.yaml
+++ b/kubernetes/loculus/templates/loculus-website.yaml
@@ -7,8 +7,13 @@ metadata:
   name: loculus-website
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
+{{- $replicas := $.Values.replicas.website }}
+{{- $min := $replicas.min | default 1 }}
+{{- $max := $replicas.max | default $min }}
 spec:
-  replicas: {{$.Values.replicas.website}}
+  {{- if eq $min $max }}
+  replicas: {{ $min }}
+  {{- end }}
   selector:
     matchLabels:
       app: loculus
@@ -50,4 +55,25 @@ spec:
         - name: custom-website-sealed-secret
       volumes:
 {{ include "loculus.configVolume" (dict "name" "loculus-website-config") | nindent 8 }}
+{{- if ne $min $max }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: loculus-website
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: loculus-website
+  minReplicas: {{ $min }}
+  maxReplicas: {{ $max }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+{{- end }}
 {{- end }}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -454,8 +454,13 @@
               "replicas": {
                 "groups": ["preprocessing"],
                 "docsIncludePrefix": false,
-                "type": "number",
-                "description": "How many replicas of the prepreprocessing pipeline to run."
+                "type": "object",
+                "description": "Scaling settings for the preprocessing pipeline.",
+                "properties": {
+                  "min": {"type": "integer", "default": 1},
+                  "max": {"type": "integer", "default": 1}
+                },
+                "additionalProperties": false
               },
               "args": {
                 "groups": ["preprocessing"],
@@ -1255,19 +1260,31 @@
       "type": "object",
       "properties": {
         "website": {
-          "type": "integer",
-          "description": "Number of replicas for the website deployment",
-          "default": 1
+          "type": "object",
+          "description": "Scaling settings for the website deployment",
+          "properties": {
+            "min": {"type": "integer", "default": 1},
+            "max": {"type": "integer", "default": 1}
+          },
+          "additionalProperties": false
         },
         "backend": {
-          "type": "integer",
-          "description": "Number of replicas for the backend deployment",
-          "default": 1
+          "type": "object",
+          "description": "Scaling settings for the backend deployment",
+          "properties": {
+            "min": {"type": "integer", "default": 1},
+            "max": {"type": "integer", "default": 1}
+          },
+          "additionalProperties": false
         },
         "lapis": {
-          "type": "integer",
-          "description": "Number of replicas for the LAPIS deployment",
-          "default": 1
+          "type": "object",
+          "description": "Scaling settings for the LAPIS deployment",
+          "properties": {
+            "min": {"type": "integer", "default": 1},
+            "max": {"type": "integer", "default": 1}
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1191,7 +1191,9 @@ defaultOrganismConfig: &defaultOrganismConfig
       image: ghcr.io/loculus-project/preprocessing-nextclade
       args:
         - "prepro"
-      replicas: 2
+      replicas:
+        min: 2
+        max: 2
       configFile: &preprocessingConfigFile
         log_level: DEBUG
         genes: []
@@ -1799,9 +1801,15 @@ enaDeposition:
   enaIsBroker: False
 subdomainSeparator: "-"
 replicas:
-  website: 1
-  backend: 1
-  lapis: 1
+  website:
+    min: 1
+    max: 1
+  backend:
+    min: 1
+    max: 1
+  lapis:
+    min: 1
+    max: 1
 gitHubEditLink: "https://github.com/loculus-project/loculus/edit/main/monorepo/website/"
 gitHubMainUrl: https://github.com/loculus-project/loculus
 resources:


### PR DESCRIPTION
## Summary
- support min/max replica values in values.yaml
- document replica min/max structure in values.schema.json
- use fixed replicas when min == max and create an HPA when min != max for backend, website, lapis and preprocessing deployments
- keep the LAPIS autoscaler inside the range loop
- only create backend and website HPAs when they aren't disabled

## Testing
- `ruff check .` *(fails: Found 3131 errors)*