### PR TITLE
fix(website): remove truncateColumnDisplayTo

### DIFF
--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -262,9 +262,6 @@ organisms:
   {{- if .hideOnSequenceDetailsPage }}
   hideOnSequenceDetailsPage: {{ .hideOnSequenceDetailsPage }}
   {{- end }}
-  {{- if .truncateColumnDisplayTo }}
-  truncateColumnDisplayTo: {{ .truncateColumnDisplayTo }}
-  {{- end }}
   {{- if .columnWidth }}
   columnWidth: {{ .columnWidth }}
   {{- end }}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -68,11 +68,6 @@
           "type": "number",
           "description": "The minimum column width for this field on the search table."
         },
-        "truncateColumnDisplayTo": {
-          "groups": ["metadata"],
-          "type": "number",
-          "description": "The number of characters to truncate the column content to."
-        },
         "order": {
           "groups": ["metadata"],
           "type": "number",

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -545,7 +545,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         enableSubstringSearch: true
         order: 40
         includeInDownloadsByDefault: true
-        truncateColumnDisplayTo: 25
         ingest: ncbiSubmitterNames
         preprocessing:
           function: check_authors
@@ -556,7 +555,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Author affiliations
         desired: true
         enableSubstringSearch: true
-        truncateColumnDisplayTo: 15
         header: Authors
         ingest: ncbiSubmitterAffiliation
         includeInDownloadsByDefault: true

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -48,7 +48,6 @@ export const metadata = z.object({
     notSearchable: z.boolean().optional(),
     hideInSearchResultsTable: z.boolean().optional(),
     customDisplay: customDisplay.optional(),
-    truncateColumnDisplayTo: z.number().optional(),
     initiallyVisible: z.boolean().optional(),
     hideOnSequenceDetailsPage: z.boolean().optional(),
     header: z.string().optional(),


### PR DESCRIPTION
## Summary
- drop `truncateColumnDisplayTo` metadata option
- rely solely on CSS truncation for search results
- remove references from kubernetes config files

## Testing
- `npm run format`
- `npm run check-types`
- `npm run test` *(fails: connect ECONNREFUSED)*