### PR TITLE
chore(k8s): align revoke-regroup cronjob names

### DIFF
--- a/kubernetes/loculus/templates/ingest-deployment.yaml
+++ b/kubernetes/loculus/templates/ingest-deployment.yaml
@@ -87,7 +87,7 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: loculus-revoke-and-regroup-cronjob-{{ $key }}
+  name: loculus-ingest-revoke-and-regroup-cronjob-{{ $key }}
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
 spec:
@@ -102,7 +102,7 @@ spec:
         metadata:
           labels:
             app: loculus
-            component: loculus-ingest-cronjob-{{ $key }}
+            component: loculus-ingest-revoke-and-regroup-cronjob-{{ $key }}
         spec:
           {{- include "possiblePriorityClassName" $ | nindent 6 }}
           restartPolicy: Never


### PR DESCRIPTION
Job and template metadata were out of sync.
Now they are both the same as they usually are and also more informative
about what's actually happening.
We no longer do ingest via cronjob, only revoke, hence good to be
specific

resolves #

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable