### PR TITLE
fix(k8s): Don't fail silo-preprocessing when backend is (temporarily) unavailable

### DIFF
--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -93,7 +93,20 @@ download_data() {
     exit 0
   fi
   if [ $exit_code -ne 0 ]; then
-    echo "Curl command failed with exit code $exit_code, cleaning up and exiting."
+    case $exit_code in
+      6)
+        echo "Curl command failed with exit code $exit_code: Couldn't resolve host. Backend service may not be available."
+        ;;
+      7)
+        echo "Curl command failed with exit code $exit_code: Failed to connect to server. Backend service may be temporarily down."
+        ;;
+      28)
+        echo "Curl command failed with exit code $exit_code: Operation timeout. Backend service may be overloaded or slow to respond."
+        ;;
+      *)
+        echo "Curl command failed with exit code $exit_code, cleaning up and exiting."
+        ;;
+    esac
     rm -rf "$new_input_data_dir"
     exit $exit_code
   fi

--- a/kubernetes/loculus/silo_import_wrapper.sh
+++ b/kubernetes/loculus/silo_import_wrapper.sh
@@ -32,8 +32,13 @@ while true; do
         bash /silo_import_job.sh --last-etag=0 --backend-base-url="$BACKEND_BASE_URL"
         exit_code=$?
         if [ "$exit_code" -ne 0 ]; then
-            echo "Error: Hard refresh failed with exit code $exit_code"
-            exit $exit_code
+            # Check if this is a connection error (curl exit code 7) or similar network issue
+            if [ "$exit_code" -eq 7 ] || [ "$exit_code" -eq 6 ] || [ "$exit_code" -eq 28 ]; then
+                echo "Warning: Hard refresh failed due to network connectivity issue (exit code $exit_code). Backend may be temporarily unavailable. Will retry on next iteration."
+            else
+                echo "Error: Hard refresh failed with exit code $exit_code (non-network error)"
+                exit $exit_code
+            fi
         else
             echo "Hard refresh completed successfully"
             echo "$current_time" >"$last_hard_refresh_time_path"
@@ -43,8 +48,13 @@ while true; do
         bash /silo_import_job.sh --last-etag="$last_etag" --backend-base-url="$BACKEND_BASE_URL"
         exit_code=$?
         if [ "$exit_code" -ne 0 ]; then
-            echo "Error: Soft refresh failed with exit code $exit_code"
-            exit $exit_code
+            # Check if this is a connection error (curl exit code 7) or similar network issue
+            if [ "$exit_code" -eq 7 ] || [ "$exit_code" -eq 6 ] || [ "$exit_code" -eq 28 ]; then
+                echo "Warning: Soft refresh failed due to network connectivity issue (exit code $exit_code). Backend may be temporarily unavailable. Will retry on next iteration."
+            else
+                echo "Error: Soft refresh failed with exit code $exit_code (non-network error)"
+                exit $exit_code
+            fi
         else
             echo "Soft refresh completed successfully"
         fi


### PR DESCRIPTION
resolves #4245

Don't fail silo-preprocessing when backend is down. Otherwise backend down means SILO->LAPIS are all down.

### Testing

- Kill backend manually in argocd
- Verify that SILO preprocessing doesn't error when it fails to connect backend

silo-prepro is indeed fine if backend is down:

```
calling http://loculus-backend-service:8079/ebola-sudan/get-released-data?compression=zstd
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (7) Failed to connect to loculus-backend-service port 8079 after 1 ms: Couldn't connect to server
Release data request returned with http status code: 000
Curl command failed with exit code 7: Failed to connect to server. Backend service may be temporarily down.
Warning: Hard refresh failed due to network connectivity issue (exit code 7). Backend may be temporarily unavailable. Will retry on next iteration.
Sleeping for 30 seconds
Checking for new data in SILO
Last download of released data had etag: 0
Last hard refresh was at: 0
Current timestamp: 1748615902
Last hard refresh was more than 1 hour ago. Performing hard refresh.
-----------START OF NEW RUN---------------------
Script started 

...


calling http://loculus-backend-service:8079/ebola-sudan/get-released-data?compression=zstd
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (7) Failed to connect to loculus-backend-service port 8079 after 1 ms: Couldn't connect to server
Release data request returned with http status code: 000
Curl command failed with exit code 7: Failed to connect to server. Backend service may be temporarily down.
Warning: Soft refresh failed due to network connectivity issue (exit code 7). Backend may be temporarily unavailable. Will retry on next iteration.
Sleeping for 30 seconds
```

### PR Checklist
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

Written by Claude Sonnet 4 in VS Code agent mode but carefully checked by me.

🚀 Preview: Add `preview` label to enable