### PR TITLE
fix(website): move download button to file upload component on edit page

### DIFF
--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -1,7 +1,6 @@
 import { type FC, useState } from 'react';
 import { toast } from 'react-toastify';
 
-import type { Row } from './InputField.tsx';
 import { EditableMetadata, MetadataForm, SubmissionIdRow, Subtitle } from './MetadataForm.tsx';
 import { EditableSequences, SequencesForm } from './SequencesForm.tsx';
 import { getClientLogger } from '../../clientLogger.ts';
@@ -108,7 +107,12 @@ const InnerEditPage: FC<EditPageProps> = ({
             </table>
             {submissionDataTypes.consensusSequences && (
                 <div className='mt-4 space-y-4'>
-                    <SequencesForm editableSequences={editableSequences} setEditableSequences={setEditableSequences} />
+                    <SequencesForm
+                        editableSequences={editableSequences}
+                        setEditableSequences={setEditableSequences}
+                        dataToEdit={dataToEdit}
+                        isLoading={isLoading}
+                    />
                 </div>
             )}
 
@@ -126,19 +130,6 @@ const InnerEditPage: FC<EditPageProps> = ({
                     {isLoading && <span className='loading loading-spinner loading-sm mr-2' />}
                     Submit
                 </button>
-
-                {submissionDataTypes.consensusSequences && (
-                    <button
-                        className='btn normal-case'
-                        onClick={() => generateAndDownloadFastaFile(editableSequences.rows, dataToEdit)}
-                        title={`Download the original, unaligned sequence${
-                            editableSequences.rows.length > 1 ? 's' : ''
-                        } as provided by the submitter`}
-                        disabled={isLoading}
-                    >
-                        Download Sequence{editableSequences.rows.length > 1 ? 's' : ''}
-                    </button>
-                )}
             </div>
         </>
     );
@@ -200,22 +191,4 @@ function useSubmitEdit(
             },
         },
     );
-}
-
-function generateAndDownloadFastaFile(editedSequences: Row[], editedData: SequenceEntryToEdit) {
-    const accessionVersion = getAccessionVersionString(editedData);
-    const fileContent =
-        editedSequences.length === 1
-            ? `>${accessionVersion}\n${editedSequences[0].value}`
-            : editedSequences.map((sequence) => `>${accessionVersion}_${sequence.key}\n${sequence.value}\n`).join('');
-
-    const blob = new Blob([fileContent], { type: 'text/plain' });
-    const url = URL.createObjectURL(blob);
-
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `${accessionVersion}.fasta`;
-    a.click();
-
-    URL.revokeObjectURL(url);
 }

--- a/website/src/components/Edit/SequencesForm.tsx
+++ b/website/src/components/Edit/SequencesForm.tsx
@@ -105,7 +105,7 @@ export const SequencesForm: FC<SequenceFormProps> = ({
 }) => {
     const singleSegment = editableSequences.rows.length === 1;
     return (
-        <div className='border border-gray-300 rounded-lg p-4'>
+        <>
             <h3 className='subtitle'>{`Nucleotide sequence${singleSegment ? '' : 's'}`}</h3>
             <div className='flex flex-col lg:flex-row gap-6'>
                 {editableSequences.rows.map((field) => (
@@ -159,6 +159,6 @@ export const SequencesForm: FC<SequenceFormProps> = ({
                     </div>
                 ))}
             </div>
-        </div>
+        </>
     );
 };

--- a/website/src/components/Edit/SequencesForm.tsx
+++ b/website/src/components/Edit/SequencesForm.tsx
@@ -94,11 +94,18 @@ export class EditableSequences {
 type SequenceFormProps = {
     editableSequences: EditableSequences;
     setEditableSequences: Dispatch<SetStateAction<EditableSequences>>;
+    dataToEdit?: SequenceEntryToEdit;
+    isLoading?: boolean;
 };
-export const SequencesForm: FC<SequenceFormProps> = ({ editableSequences, setEditableSequences }) => {
+export const SequencesForm: FC<SequenceFormProps> = ({
+    editableSequences,
+    setEditableSequences,
+    dataToEdit,
+    isLoading,
+}) => {
     const singleSegment = editableSequences.rows.length === 1;
     return (
-        <>
+        <div className='border border-gray-300 rounded-lg p-4'>
             <h3 className='subtitle'>{`Nucleotide sequence${singleSegment ? '' : 's'}`}</h3>
             <div className='flex flex-col lg:flex-row gap-6'>
                 {editableSequences.rows.map((field) => (
@@ -126,10 +133,32 @@ export const SequencesForm: FC<SequenceFormProps> = ({ editableSequences, setEdi
                                     : undefined
                             }
                             showUndo={true}
+                            onDownload={
+                                field.initialValue.length > 0 && dataToEdit
+                                    ? () => {
+                                          const accessionVersion = `${dataToEdit.accession}.${dataToEdit.version}`;
+                                          const fileName = singleSegment
+                                              ? `${accessionVersion}.fasta`
+                                              : `${accessionVersion}_${field.key}.fasta`;
+                                          const fileContent = `>${singleSegment ? accessionVersion : `${accessionVersion}_${field.key}`}\n${field.initialValue}`;
+
+                                          const blob = new Blob([fileContent], { type: 'text/plain' });
+                                          const url = URL.createObjectURL(blob);
+
+                                          const a = document.createElement('a');
+                                          a.href = url;
+                                          a.download = fileName;
+                                          a.click();
+
+                                          URL.revokeObjectURL(url);
+                                      }
+                                    : undefined
+                            }
+                            downloadDisabled={isLoading}
                         />
                     </div>
                 ))}
             </div>
-        </>
+        </div>
     );
 };

--- a/website/src/components/Edit/SequencesForm.tsx
+++ b/website/src/components/Edit/SequencesForm.tsx
@@ -5,6 +5,30 @@ import { mapErrorsAndWarnings, type SequenceEntryToEdit } from '../../types/back
 import { FileUploadComponent } from '../Submission/FileUpload/FileUploadComponent.tsx';
 import { PLAIN_SEGMENT_KIND, VirtualFile } from '../Submission/FileUpload/fileProcessing.ts';
 
+function generateAndDownloadFastaFile(
+    accessionVersion: string,
+    sequenceData: string,
+    segmentKey?: string,
+    isSingleSegment: boolean = false,
+) {
+    const fileName =
+        isSingleSegment || !segmentKey ? `${accessionVersion}.fasta` : `${accessionVersion}_${segmentKey}.fasta`;
+
+    const header = isSingleSegment || !segmentKey ? accessionVersion : `${accessionVersion}_${segmentKey}`;
+
+    const fileContent = `>${header}\n${sequenceData}`;
+
+    const blob = new Blob([fileContent], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = fileName;
+    a.click();
+
+    URL.revokeObjectURL(url);
+}
+
 export class EditableSequences {
     private constructor(public readonly rows: Row[]) {}
 
@@ -137,20 +161,12 @@ export const SequencesForm: FC<SequenceFormProps> = ({
                                 field.initialValue.length > 0 && dataToEdit
                                     ? () => {
                                           const accessionVersion = `${dataToEdit.accession}.${dataToEdit.version}`;
-                                          const fileName = singleSegment
-                                              ? `${accessionVersion}.fasta`
-                                              : `${accessionVersion}_${field.key}.fasta`;
-                                          const fileContent = `>${singleSegment ? accessionVersion : `${accessionVersion}_${field.key}`}\n${field.initialValue}`;
-
-                                          const blob = new Blob([fileContent], { type: 'text/plain' });
-                                          const url = URL.createObjectURL(blob);
-
-                                          const a = document.createElement('a');
-                                          a.href = url;
-                                          a.download = fileName;
-                                          a.click();
-
-                                          URL.revokeObjectURL(url);
+                                          generateAndDownloadFastaFile(
+                                              accessionVersion,
+                                              field.initialValue,
+                                              field.key,
+                                              singleSegment,
+                                          );
                                       }
                                     : undefined
                             }

--- a/website/src/components/Submission/FileUpload/FileUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/FileUploadComponent.tsx
@@ -200,7 +200,7 @@ export const FileUploadComponent = ({
                     >
                         <div className='tooltip tooltip-info whitespace-pre-line' data-tip='Download sequence'>
                             <IcBaselineDownload
-                                className={`${downloadDisabled ? 'text-gray-400' : 'text-gray-600 hover:text-gray-800'} transition-colors`}
+                                className={`${downloadDisabled ? 'text-gray-200' : 'text-gray-400 hover:text-gray-600'} transition-colors`}
                             />
                         </div>
                     </button>

--- a/website/src/components/Submission/FileUpload/FileUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/FileUploadComponent.tsx
@@ -3,6 +3,7 @@ import { toast } from 'react-toastify';
 
 import type { FileKind, ProcessedFile } from './fileProcessing.ts';
 import useClientFlag from '../../../hooks/isClient.ts';
+import IcBaselineDownload from '~icons/ic/baseline-download';
 import UndoTwoToneIcon from '~icons/ic/twotone-undo';
 
 export const FileUploadComponent = ({
@@ -13,6 +14,8 @@ export const FileUploadComponent = ({
     small = false,
     initialValue = undefined,
     showUndo = false,
+    onDownload = undefined,
+    downloadDisabled = false,
 }: {
     setFile: (file: ProcessedFile | undefined) => Promise<void> | void;
     name: string;
@@ -21,6 +24,8 @@ export const FileUploadComponent = ({
     small?: boolean;
     initialValue?: ProcessedFile;
     showUndo?: boolean;
+    onDownload?: () => void;
+    downloadDisabled?: boolean;
 }) => {
     const [myFile, rawSetMyFile] = useState<ProcessedFile | undefined>(initialValue);
     const [isDragOver, setIsDragOver] = useState(false);
@@ -180,6 +185,23 @@ export const FileUploadComponent = ({
                     >
                         <div className='tooltip tooltip-info whitespace-pre-line' data-tip='Revert to initial data'>
                             <UndoTwoToneIcon color='action' />
+                        </div>
+                    </button>
+                </div>
+            )}
+            {onDownload && myFile && (
+                <div className={`absolute top-1 ${showUndo && isEdited ? 'right-10' : 'right-2'}`}>
+                    <button
+                        className='bg-transparent'
+                        onClick={onDownload}
+                        disabled={downloadDisabled}
+                        aria-label={`Download ${name}`}
+                        data-testid={`download_${name}`}
+                    >
+                        <div className='tooltip tooltip-info whitespace-pre-line' data-tip='Download sequence'>
+                            <IcBaselineDownload
+                                className={`${downloadDisabled ? 'text-gray-400' : 'text-gray-600 hover:text-gray-800'} transition-colors`}
+                            />
                         </div>
                     </button>
                 </div>


### PR DESCRIPTION
## Summary
- Moves the download button from the bottom action buttons to be integrated within each file upload component


<img width="771" alt="image" src="https://github.com/user-attachments/assets/90706e5c-dd74-4961-9eeb-60ea80488120" />


## Motivation
Fixes #3877 

The download button was previously positioned at the bottom of the edit page next to the submit button, which was confusing for users as it felt like it was where a submit button would be. This change moves the download functionality to be part of each file upload component, and makes it download each segment's data separately.



🤖 Generated with [Claude Code](https://claude.ai/code)

🚀 Preview: https://fix-3877-move-download-bu.loculus.org