### PR TITLE
fix(website): disable 'View processed sequence' button when processing errors occur

### DIFF
--- a/website/src/components/ReviewPage/ReviewCard.tsx
+++ b/website/src/components/ReviewPage/ReviewCard.tsx
@@ -90,7 +90,11 @@ export const ReviewCard: FC<ReviewCardProps> = ({
                     approveAccessionVersion={approveAccessionVersion}
                     deleteAccessionVersion={deleteAccessionVersion}
                     editAccessionVersion={editAccessionVersion}
-                    viewSequences={data && !notProcessed ? () => setSequencesDialogOpen(true) : undefined}
+                    viewSequences={
+                        data && !notProcessed && sequenceEntryStatus.processingResult !== errorsProcessingResult
+                            ? () => setSequencesDialogOpen(true)
+                            : undefined
+                    }
                 />
             </div>
 
@@ -141,24 +145,28 @@ const ButtonBar: FC<ButtonBarProps> = ({
     return (
         <div className='flex mb-auto pt-3.5 items-center'>
             <div className='flex space-x-1'>
-                {viewSequences && (
-                    <>
-                        <button
-                            className={buttonBarClass(notProcessed)}
-                            onClick={viewSequences}
-                            data-tooltip-id={'view-sequences-tooltip' + sequenceEntryStatus.accession}
-                            data-testid={`view-sequences-${sequenceEntryStatus.accession}`}
-                            key={'view-sequences-button-' + sequenceEntryStatus.accession}
-                            disabled={notProcessed}
-                        >
-                            <RiDna />
-                        </button>
-                        <CustomTooltip
-                            id={'view-sequences-tooltip' + sequenceEntryStatus.accession}
-                            content={notProcessed ? 'Processing...' : 'View processed sequences'}
-                        />
-                    </>
-                )}
+                <>
+                    <button
+                        className={buttonBarClass(!viewSequences)}
+                        onClick={viewSequences}
+                        data-tooltip-id={'view-sequences-tooltip' + sequenceEntryStatus.accession}
+                        data-testid={`view-sequences-${sequenceEntryStatus.accession}`}
+                        key={'view-sequences-button-' + sequenceEntryStatus.accession}
+                        disabled={!viewSequences}
+                    >
+                        <RiDna />
+                    </button>
+                    <CustomTooltip
+                        id={'view-sequences-tooltip' + sequenceEntryStatus.accession}
+                        content={
+                            notProcessed
+                                ? 'Processing...'
+                                : sequenceEntryStatus.processingResult === errorsProcessingResult
+                                  ? 'No processed sequence available due to errors'
+                                  : 'View processed sequences'
+                        }
+                    />
+                </>
                 <div className='mx-3 h-5 mt-0.5 border-l border-gray-300'></div> {/* Vertical separator */}
                 <button
                     className={buttonBarClass(!approvable)}


### PR DESCRIPTION
## Summary
- Fixed the "View processed sequence" button to be disabled/greyed out when there are processing errors
- Updated tooltip to show "No processed sequence available due to errors" when button is disabled due to errors

## Problem
On the Review page, the "View processed sequence" button (DNA icon) appeared enabled even when there was an error during sequence processing and there was no actual processed sequence to view. This was confusing for users as clicking the button would show no sequences.

## Solution
The fix involves two changes:
1. Pass the `viewSequences` callback only when there's data, the sequence is processed, AND there are no errors
2. Update the button's disabled state to check if `viewSequences` callback exists (instead of just checking `notProcessed`)

Now the button is properly disabled when:
- The sequence is not yet processed (still processing or awaiting processing)
- The sequence has processing errors

Fixes #4171

## Test plan
- [ ] Submit a sequence that will have processing errors
- [ ] Go to the Review page
- [ ] Verify the "View processed sequence" button is disabled/greyed out
- [ ] Hover over the button and verify the tooltip shows "No processed sequence available due to errors"
- [ ] Submit a valid sequence without errors
- [ ] Verify the button is enabled for sequences without errors

🤖 Generated with [Claude Code](https://claude.ai/code)