### PR TITLE
fix(website): Fix separator used in processing authors so that Show more / Show less works correctly

### DIFF
--- a/website/src/components/SequenceDetailsPage/getDataTableData.ts
+++ b/website/src/components/SequenceDetailsPage/getDataTableData.ts
@@ -70,7 +70,7 @@ export function getDataTableData(listTableDataEntries: TableDataEntry[]): DataTa
         ) {
             result.topmatter.authors = entry.value
                 .toString()
-                .split(',')
+                .split(';')
                 .map((x) => x.trim());
             continue;
         }


### PR DESCRIPTION
We changed the separator but forgot to update this so at the moment we truncate to just the first name / initial of last author, not their full name.

<img width="1270" alt="image" src="https://github.com/user-attachments/assets/f1da7104-e6d1-4fa8-8a88-bf826ba0d01a" />
