### PR TITLE
chore(backend): Fix CSV parser deprecation warnings

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/utils/MetadataEntry.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/MetadataEntry.kt
@@ -12,9 +12,9 @@ import java.io.InputStreamReader
 data class MetadataEntry(val submissionId: SubmissionId, val metadata: Map<String, String>)
 
 fun metadataEntryStreamAsSequence(metadataInputStream: InputStream): Sequence<MetadataEntry> {
-    val csvParser = CSVParser(
+    val csvParser = CSVParser.parse(
         InputStreamReader(metadataInputStream),
-        CSVFormat.TDF.builder().setHeader().setSkipHeaderRecord(true).build(),
+        CSVFormat.TDF.builder().setHeader().setSkipHeaderRecord(true).get(),
     )
 
     if (!csvParser.headerNames.contains(HEADER_TO_CONNECT_METADATA_AND_SEQUENCES)) {
@@ -55,9 +55,9 @@ fun metadataEntryStreamAsSequence(metadataInputStream: InputStream): Sequence<Me
 data class RevisionEntry(val submissionId: SubmissionId, val accession: Accession, val metadata: Map<String, String>)
 
 fun revisionEntryStreamAsSequence(metadataInputStream: InputStream): Sequence<RevisionEntry> {
-    val csvParser = CSVParser(
+    val csvParser = CSVParser.parse(
         InputStreamReader(metadataInputStream),
-        CSVFormat.TDF.builder().setHeader().setSkipHeaderRecord(true).build(),
+        CSVFormat.TDF.builder().setHeader().setSkipHeaderRecord(true).get(),
     )
 
     if (!csvParser.headerNames.contains(HEADER_TO_CONNECT_METADATA_AND_SEQUENCES)) {


### PR DESCRIPTION
Generated by Google's Jules.

I replaced the deprecated CSVParser constructor with the static factory method CSVParser.parse(). I also replaced the deprecated CSVFormat.Builder.build() method with the get() method.

These changes address lint warnings related to the usage of deprecated commons-csv APIs.

resolves #

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable