### PR TITLE
chore(backend): fix Kotlin lint about redundant else clause

### DIFF
--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
@@ -483,8 +483,6 @@ class SubmissionConvenienceClient(
             groupId = groupId,
             dataUseTerms = dataUseTerms,
         )
-
-        else -> throw Exception("Test issue: No data preparation defined for status $status")
     }
 
     fun getReleasedData(organism: String = DEFAULT_ORGANISM) =


### PR DESCRIPTION
Fixes lint:

```
 > Task :compileTestKotlin
  w: file:///home/runner/work/loculus/loculus/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt:487:9 'when' is exhaustive so 'else' is redundant here.
  
```

🚀 Preview: Add `preview` label to enable