### PR TITLE
fix(k8s): adjust cpu&mem requests based on Prometheus stats

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1808,16 +1808,18 @@ resources:
   website:
     requests:
       memory: "200Mi"
+      cpu: "100m"
     limits:
       memory: "1Gi"
   docs:
     requests:
-      memory: "200Mi"
+      memory: "100Mi"
+      cpu: "10m"
     limits:
       memory: "1Gi"
   ena-submission:
     requests:
-      memory: "80Mi"
+      memory: "200Mi"
       cpu: "10m"
     limits:
       memory: "10Gi"
@@ -1829,48 +1831,51 @@ resources:
       memory: "10Gi"
   ingest:
     requests:
-      memory: "1Gi"
+      memory: "200Mi"
       cpu: "200m"
     limits:
-      cpu: "200m"
+      cpu: "1"
       memory: "10Gi"
   keycloak:
     requests:
-      memory: "500Mi"
-      cpu: "20m"
+      memory: "700Mi"
+      cpu: "40m"
     limits:
       memory: "3Gi"
   silo:
     requests:
-      memory: "100Mi"
-      cpu: "10m"
+      memory: "200Mi"
+      cpu: "20m"
     limits:
       memory: "10Gi"
   lapis:
     requests:
-      memory: "220Mi"
-      cpu: "30m"
+      memory: "500Mi"
+      cpu: "100m"
     limits:
       memory: "5Gi"
   silo-preprocessing:
     requests:
       memory: "20Mi"
+      cpu: "20m"
     limits:
       memory: "10Gi"
   backend:
     requests:
-      memory: "640Mi"
-      cpu: "250m"
+      memory: "700Mi"
+      cpu: "200m"
     limits:
-      memory: "3Gi" # Backend requires at least 635741K of memory
+      memory: "3Gi"
   preprocessing:
     requests:
-      memory: "20Mi"
+      memory: "300Mi"
+      cpu: "50m"
     limits:
       memory: "3Gi"
   minio:
     requests:
-      memory: "200Mi"
+      memory: "400Mi"
+      cpu: "10m"
     limits:
       memory: "1Gi"
 defaultResources:

--- a/kubernetes/loculus/values_preview_server.yaml
+++ b/kubernetes/loculus/values_preview_server.yaml
@@ -60,3 +60,84 @@ auth:
   identityProviders:
     orcid:
       clientId: "APP-P1P7N7T9YVBHQ4EH"
+resources:
+  website:
+    requests:
+      memory: "100Mi"
+      cpu: "20m"
+    limits:
+      memory: "500Mi"
+  docs:
+    requests:
+      memory: "25Mi"
+      cpu: "1m"
+    limits:
+      memory: "1Gi"
+  ena-submission:
+    requests:
+      memory: "120Mi"
+      cpu: "1m"
+    limits:
+      memory: "10Gi"
+  ena-submission-list-cronjob:
+    requests:
+      memory: "80Mi"
+      cpu: "10m"
+    limits:
+      memory: "10Gi"
+  ingest:
+    requests:
+      memory: "100Mi"
+      cpu: "50m"
+    limits:
+      cpu: "400m"
+      memory: "10Gi"
+  keycloak:
+    requests:
+      memory: "600Mi"
+      cpu: "30m"
+    limits:
+      memory: "3Gi"
+  silo:
+    requests:
+      memory: "200Mi"
+      cpu: "10m"
+    limits:
+      memory: "10Gi"
+  lapis:
+    requests:
+      memory: "350Mi"
+      cpu: "30m"
+    limits:
+      memory: "5Gi"
+  silo-preprocessing:
+    requests:
+      memory: "10Mi"
+      cpu: "5m"
+    limits:
+      memory: "10Gi"
+  backend:
+    requests:
+      memory: "500Mi"
+      cpu: "50m"
+    limits:
+      memory: "3Gi"
+  preprocessing:
+    requests:
+      memory: "200Mi"
+      cpu: "10m"
+    limits:
+      memory: "3Gi"
+  minio:
+    requests:
+      memory: "250Mi"
+      cpu: "2m"
+    limits:
+      memory: "1Gi"
+defaultResources:
+  requests:
+    memory: "200Mi"
+    cpu: "20m"
+  limits:
+    memory: "1Gi"
+    cpu: "20m"


### PR DESCRIPTION
I carefully went through all of our pods in Grafana/Prometheus to see how much in resources they actually require

Preview server sets typical usage, while the main values yaml has a bit of headspace to be more "production-ready" like

This should help us get more previews up.

### Testing

- Check that values are correct
- Check that preview works fine

🚀 Preview: https://reduce-cpu-requests.loculus.org