### PR TITLE
fix(k8s): remove LAPIS startup probe to not kill it on startup when SILO is down

### DIFF
--- a/kubernetes/loculus/templates/lapis-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-deployment.yaml
@@ -43,13 +43,6 @@ spec:
             - name: lapis-silo-database-config-processed
               mountPath: /workspace/reference_genomes.json
               subPath: reference_genomes.json
-          startupProbe:
-            httpGet:
-              path: /sample/info
-              port: 8080
-            periodSeconds: 10
-            failureThreshold: 5
-            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /sample/info


### PR DESCRIPTION
See https://loculus.slack.com/archives/C05G172HL6L/p1748782553503469 for further reasoning

Helps with #2701

🚀 Preview: https://lapis-startup.loculus.org