### PR TITLE
fix(k8s): give backend and LAPIS 3min to become live with startup probe

### DIFF
--- a/kubernetes/loculus/templates/lapis-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-deployment.yaml
@@ -43,11 +43,16 @@ spec:
             - name: lapis-silo-database-config-processed
               mountPath: /workspace/reference_genomes.json
               subPath: reference_genomes.json
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 5
+            failureThreshold: 36 # 3 minutes to start
           readinessProbe:
             httpGet:
               path: /sample/info
               port: 8080
-            initialDelaySeconds: 30
             periodSeconds: 10
             failureThreshold: 3
             timeoutSeconds: 5
@@ -55,7 +60,6 @@ spec:
             httpGet:
               path: /actuator/health
               port: 8080
-            initialDelaySeconds: 30
             periodSeconds: 10
             failureThreshold: 3
             timeoutSeconds: 5

--- a/kubernetes/loculus/templates/loculus-backend.yaml
+++ b/kubernetes/loculus/templates/loculus-backend.yaml
@@ -29,11 +29,16 @@ spec:
           image: "{{ $.Values.images.backend.repository }}:{{ $.Values.images.backend.tag | default $dockerTag }}"
           imagePullPolicy: "{{ $.Values.images.backend.pullPolicy }}"
           {{- include "loculus.resources" (list "backend" $.Values) | nindent 10 }}
+          startupProbe:
+            httpGet:
+              path: "/actuator/health/liveness"
+              port: 8079
+            periodSeconds: 5
+            failureThreshold: 36 # 3 minutes to start
           livenessProbe:
             httpGet:
               path: "/actuator/health/liveness"
               port: 8079
-            initialDelaySeconds: 90
             periodSeconds: 10
           readinessProbe:
             httpGet:

--- a/kubernetes/loculus/values_preview_server.yaml
+++ b/kubernetes/loculus/values_preview_server.yaml
@@ -119,7 +119,7 @@ resources:
   backend:
     requests:
       memory: "500Mi"
-      cpu: "50m"
+      cpu: "100m"
     limits:
       memory: "3Gi"
   preprocessing:


### PR DESCRIPTION
When the cluster is CPU throttling the backend/lapis startup, it can take quite some time to become live - longer than 90 seconds, causing it to get killed. Java has ridiculously long startup CPU requirements unfortunately.

Adding a startup probe to give them more time (3min)

🚀 Preview: https://backend-startup.loculus.org