### PR TITLE
fix(website): show 403 page when group access denied

### DIFF
--- a/website/src/pages/403.astro
+++ b/website/src/pages/403.astro
@@ -1,0 +1,10 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title='Access Denied'>
+    <div class='bc'>
+        <h1 class='title'>Access denied</h1>
+        <p>You do not have permission to view this page.</p>
+    </div>
+</BaseLayout>

--- a/website/src/pages/[organism]/submission/[groupId]/released.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/released.astro
@@ -17,7 +17,7 @@ import { getGroupsAndCurrentGroup } from '../../../../utils/submissionPages';
 
 const groupsResult = await getGroupsAndCurrentGroup(Astro.params, Astro.locals.session);
 if (groupsResult.isErr()) {
-    return new Response(undefined, { status: groupsResult.error.status });
+    return Astro.rewrite(groupsResult.error.type === 'group_not_found' ? '/404' : '/403');
 }
 const { currentGroup: group } = groupsResult.value;
 


### PR DESCRIPTION
## Summary
- return explicit 403 or 404 pages on released sequences page
- add a dedicated 403 error page

## Testing
- `npm run test`
- `npm run check-types`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_683d6c69a5048325a50f703fe36613d8