### PR TITLE
fix(website): fallback to `name` if `displayName` not available

### DIFF
--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -160,7 +160,7 @@ const SearchField = ({ field, lapisUrl, fieldValues, setSomeFieldValues, lapisSe
         } else {
             return (
                 <div key={field.name} className='flex flex-col border p-3 mb-3 rounded-md border-gray-300'>
-                    <h3 className='text-gray-500 text-sm mb-1'>{field.displayName}</h3>
+                    <h3 className='text-gray-500 text-sm mb-1'>{field.displayName ?? field.name}</h3>
 
                     {field.groupedFields.map((f) => (
                         <SearchField

--- a/website/src/components/SearchPage/fields/AutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/AutoCompleteField.tsx
@@ -71,7 +71,7 @@ export const AutoCompleteField = ({
                     displayValue={(value: string) => value}
                     onChange={(event) => setQuery(event.target.value)}
                     onFocus={load}
-                    placeholder={field.displayName}
+                    placeholder={field.displayName ?? field.name}
                     as={CustomInput}
                     disabled={!isClient}
                 />

--- a/website/src/components/SearchPage/fields/DateField.tsx
+++ b/website/src/components/SearchPage/fields/DateField.tsx
@@ -74,7 +74,7 @@ const CustomizedDatePicker: FC<CustomizedDatePickerProps> = ({
         <div>
             <div className='flex justify-between items-center'>
                 <label htmlFor={field.name} className='block text-sm w-16 my-3 text-right mr-2 text-gray-400'>
-                    {field.displayName}
+                    {field.displayName ?? field.name}
                 </label>
                 <DatePicker
                     value={dateValue}

--- a/website/src/components/SearchPage/fields/NormalTextField.tsx
+++ b/website/src/components/SearchPage/fields/NormalTextField.tsx
@@ -20,7 +20,7 @@ export const NormalTextField = forwardRef<HTMLInputElement, NormalFieldProps>((p
 
     return (
         <TextField
-            label={field.displayName}
+            label={field.displayName ?? field.name}
             type={field.type}
             fieldValue={fieldValue}
             onFocus={onFocus}


### PR DESCRIPTION
resolves #4273 at least for now - we should do some thinking about whether we use `sentenceCase` for these sorts of purposes or not (we currently inconsistently sometimes do and sometimes don't - but it would be great to merge this as the current state is bad!)

### Screenshot
<img width="334" alt="image" src="https://github.com/user-attachments/assets/eef7136a-8daa-4c9b-a828-f02109c2a176" />


🚀 Preview: https://namefallback.loculus.org