### PR TITLE
chore(ci): remove retry from backend tests, no longer needed

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -34,13 +34,9 @@ jobs:
           distribution: "adopt"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-      - name: Execute Tests
-        uses: nick-fields/retry@v3
-        with:
-          command: cd ./backend && ./gradlew test
-          max_attempts: 3
-          timeout_minutes: 10
-          retry_wait_seconds: 1
+      - name: Run tests
+        run: ./gradlew test
+        working-directory: ./backend
       - name: Check Format And Lint
         run: ./gradlew ktlintCheck
         working-directory: ./backend


### PR DESCRIPTION
Backend tests are no longer flaky, so simplify setup

resolves #

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable