### PR TITLE
feat(website): Add dialog to view processed files in 'review' window (before approving)

### DIFF
--- a/integration-tests/tests/pages/review.page.ts
+++ b/integration-tests/tests/pages/review.page.ts
@@ -3,6 +3,10 @@ import { Page, expect } from '@playwright/test';
 export class ReviewPage {
     private page: Page;
 
+    private viewFilesButton = () => this.page.getByTestId(/view-files/).first();
+    private filesDialog = () => this.page.locator('div:has(> div > h2:text("Files"))').first();
+    private filesDialogCloseButton = () => this.filesDialog().getByRole('button', { name: '✕' });
+
     private viewSequencesButton = () => this.page.getByTestId(/view-sequences-/).first();
     private sequencesDialog = () =>
         this.page.locator('div:has(> div > h2:text("Processed Sequences"))').first();
@@ -40,9 +44,22 @@ export class ReviewPage {
         return this.sequencesDialog();
     }
 
+    async viewFiles() {
+        const button = this.viewFilesButton();
+        await expect(button).toBeVisible({ timeout: 15000 });
+        await button.click();
+        await expect(this.filesDialog()).toBeVisible();
+        return this.filesDialog();
+    }
+
     async closeSequencesDialog() {
         await this.sequencesDialogCloseButton().click();
         await expect(this.sequencesDialog()).not.toBeVisible();
+    }
+
+    async closeFilesDialog() {
+        await this.filesDialogCloseButton().click();
+        await expect(this.filesDialog()).not.toBeVisible();
     }
 
     async switchSequenceTab(tabName: string) {

--- a/integration-tests/tests/specs/features/file-sharing.spec.ts
+++ b/integration-tests/tests/specs/features/file-sharing.spec.ts
@@ -31,6 +31,14 @@ test('submit a single sequence with two files', async ({ pageWithGroup, page }) 
     const reviewPage = await submissionPage.submitSequence();
     await reviewPage.waitForZeroProcessing();
 
+    // check that files can be seen after processing
+    const filesDialog = await reviewPage.viewFiles();
+    expect(filesDialog.getByText('hello.txt')).toBeVisible();
+    await checkFileContent(page, 'hello.txt', 'Hello');
+    expect(filesDialog.getByText('world.txt')).toBeVisible();
+    await checkFileContent(page, 'world.txt', 'World');
+    await reviewPage.closeFilesDialog();
+
     await reviewPage.releaseValidSequences();
 
     await page.getByRole('link', { name: 'released sequences' }).click();

--- a/integration-tests/tests/specs/features/file-sharing.spec.ts
+++ b/integration-tests/tests/specs/features/file-sharing.spec.ts
@@ -33,9 +33,9 @@ test('submit a single sequence with two files', async ({ pageWithGroup, page }) 
 
     // check that files can be seen after processing
     const filesDialog = await reviewPage.viewFiles();
-    expect(filesDialog.getByText('hello.txt')).toBeVisible();
+    await expect(filesDialog.getByText('hello.txt')).toBeVisible();
     await checkFileContent(page, 'hello.txt', 'Hello');
-    expect(filesDialog.getByText('world.txt')).toBeVisible();
+    await expect(filesDialog.getByText('world.txt')).toBeVisible();
     await checkFileContent(page, 'world.txt', 'World');
     await reviewPage.closeFilesDialog();
 

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -216,6 +216,9 @@ organisms:
           definition: "Reason for revising sequences or other general comments concerning a specific version"
           example: "Fixed an issue in previous version where low-coverage nucleotides were erroneously filled with reference sequence"
           desired: true
+      {{ if .files }}
+      files: {{ .files | toYaml | nindent 8 }}
+      {{ end }}
       metadata:
         {{- $args := dict "metadata" (concat $commonMetadata .metadata) "nucleotideSequences" $nucleotideSequences}}
         {{ $metadata := include "loculus.generateWebsiteMetadata" $args | fromYaml }}

--- a/website/src/components/ReviewPage/FilesDialog.tsx
+++ b/website/src/components/ReviewPage/FilesDialog.tsx
@@ -1,38 +1,75 @@
 import { type FC } from 'react';
+import { type SequenceEntryToEdit } from '../../types/backend.ts';
 
 type FilesDialogProps = {
     isOpen: boolean;
     onClose: () => void;
+    dataToView: SequenceEntryToEdit | undefined;
 };
 
-const exampleFiles = [
-    { name: 'Example 1', url: 'https://example.com/file1.txt' },
-    { name: 'Example 2', url: 'https://example.com/file2.txt' },
-    { name: 'Example 3', url: 'https://example.com/file3.txt' },
-];
+export const FilesDialog: FC<FilesDialogProps> = ({ isOpen, onClose, dataToView }) => {
+    if (!isOpen || !dataToView) return null;
 
-export const FilesDialog: FC<FilesDialogProps> = ({ isOpen, onClose }) => {
-    if (!isOpen) return null;
+    const originalFilesByCategory = dataToView.originalData.files;
+    const processedFilesByCategory = dataToView.processedData.files;
 
     return (
         <div className='fixed inset-0 flex items-center justify-center z-50 overflow-auto bg-black bg-opacity-30'>
             <div className='bg-white rounded-lg p-6 max-w-xl mx-3 w-full max-h-[90vh] flex flex-col'>
                 <div className='flex justify-between items-center mb-4'>
                     <h2 className='text-xl font-semibold'>Files</h2>
-                    <button className='text-gray-500 hover:text-gray-700' onClick={onClose}>
-                        ✕
-                    </button>
+                    <button className='text-gray-500 hover:text-gray-700' onClick={onClose}>✕</button>
                 </div>
 
-                <ul className='list-disc pl-5 space-y-2'>
-                    {exampleFiles.map(({ name, url }) => (
-                        <li key={url}>
-                            <a href={url} className='text-blue-600 hover:underline' target='_blank' rel='noopener noreferrer'>
-                                {name}
-                            </a>
-                        </li>
-                    ))}
-                </ul>
+                <div className='overflow-auto space-y-6'>
+
+                    <div>
+                        <h3 className='text-lg font-semibold mb-2'>Original Files</h3>
+                        {Object.entries(originalFilesByCategory).map(([key, files]) => (
+                            <div key={key} className='mb-4'>
+                                <h4 className='font-medium'>{key}</h4>
+                                <ul className='list-disc pl-5 space-y-1'>
+                                    {files.map(file => (
+                                        <li key={file.fileId}>
+                                            <a
+                                                href={`/seq/${dataToView.accession}.${dataToView.version}/${key}/${file.name}`}
+                                                className='text-blue-600 hover:underline'
+                                                target='_blank'
+                                                rel='noopener noreferrer'
+                                            >
+                                                {file.name}
+                                            </a>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        ))}
+                    </div>
+
+                    <div>
+                        <h3 className='text-lg font-semibold mb-2'>Processed Files</h3>
+                        {Object.entries(processedFilesByCategory).map(([key, files]) => (
+                            <div key={key} className='mb-4'>
+                                <h4 className='font-medium'>{key}</h4>
+                                <ul className='list-disc pl-5 space-y-1'>
+                                    {files.map(file => (
+                                        <li key={file.fileId}>
+                                            <a
+                                                href={`/seq/${dataToView.accession}.${dataToView.version}/${key}/${file.name}`}
+                                                className='text-blue-600 hover:underline'
+                                                target='_blank'
+                                                rel='noopener noreferrer'
+                                            >
+                                                {file.name}
+                                            </a>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        ))}
+                    </div>
+
+                </div>
             </div>
         </div>
     );

--- a/website/src/components/ReviewPage/FilesDialog.tsx
+++ b/website/src/components/ReviewPage/FilesDialog.tsx
@@ -22,7 +22,7 @@ export const FilesDialog: FC<FilesDialogProps> = ({ isOpen, onClose, dataToView 
                 </div>
 
                 <div>
-                    {Object.entries(dataToView.processedData.files).map(([category, files]) => (
+                    {Object.entries(dataToView.processedData.files ?? []).map(([category, files]) => (
                         <div key={category} className='mb-4'>
                             <h3 className='font-medium'>{category}</h3>
                             <ul className='list-disc pl-5 space-y-1'>

--- a/website/src/components/ReviewPage/FilesDialog.tsx
+++ b/website/src/components/ReviewPage/FilesDialog.tsx
@@ -24,52 +24,26 @@ export const FilesDialog: FC<FilesDialogProps> = ({ isOpen, onClose, dataToView 
                     </button>
                 </div>
 
-                <div className='overflow-auto space-y-6'>
-                    <div>
-                        <h3 className='text-lg font-semibold mb-2'>Original Files</h3>
-                        {Object.entries(originalFilesByCategory).map(([key, files]) => (
-                            <div key={key} className='mb-4'>
-                                <h4 className='font-medium'>{key}</h4>
-                                <ul className='list-disc pl-5 space-y-1'>
-                                    {files.map((file) => (
-                                        <li key={file.fileId}>
-                                            <a
-                                                href={`/seq/${dataToView.accession}.${dataToView.version}/${key}/${file.name}`}
-                                                className='text-blue-600 hover:underline'
-                                                target='_blank'
-                                                rel='noopener noreferrer'
-                                            >
-                                                {file.name}
-                                            </a>
-                                        </li>
-                                    ))}
-                                </ul>
-                            </div>
-                        ))}
-                    </div>
-
-                    <div>
-                        <h3 className='text-lg font-semibold mb-2'>Processed Files</h3>
-                        {Object.entries(processedFilesByCategory).map(([key, files]) => (
-                            <div key={key} className='mb-4'>
-                                <h4 className='font-medium'>{key}</h4>
-                                <ul className='list-disc pl-5 space-y-1'>
-                                    {files.map((file) => (
-                                        <li key={file.fileId}>
-                                            <a
-                                                href={`/seq/${dataToView.accession}.${dataToView.version}/${key}/${file.name}`}
-                                                className='text-blue-600 hover:underline'
-                                                target='_blank'
-                                                rel='noopener noreferrer'
-                                            >
-                                                {file.name}
-                                            </a>
-                                        </li>
-                                    ))}
-                                </ul>
-                            </div>
-                        ))}
-                    </div>
+                <div>
+                    {Object.entries(processedFilesByCategory).map(([key, files]) => (
+                        <div key={key} className='mb-4'>
+                            <h3 className='font-medium'>{key}</h3>
+                            <ul className='list-disc pl-5 space-y-1'>
+                                {files.map((file) => (
+                                    <li key={file.fileId}>
+                                        <a
+                                            href={`/seq/${dataToView.accession}.${dataToView.version}/${key}/${file.name}`}
+                                            className='text-blue-600 hover:underline'
+                                            target='_blank'
+                                            rel='noopener noreferrer'
+                                        >
+                                            {file.name}
+                                        </a>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    ))}
                 </div>
             </div>
         </div>

--- a/website/src/components/ReviewPage/FilesDialog.tsx
+++ b/website/src/components/ReviewPage/FilesDialog.tsx
@@ -30,7 +30,7 @@ export const FilesDialog: FC<FilesDialogProps> = ({ isOpen, onClose, dataToView 
                                     <li key={file.fileId}>
                                         <a
                                             href={`/seq/${dataToView.accession}.${dataToView.version}/${category}/${file.name}`}
-                                            className='text-blue-600 hover:underline'
+                                            className='text-primary-600 hover:underline'
                                             target='_blank'
                                             rel='noopener noreferrer'
                                         >

--- a/website/src/components/ReviewPage/FilesDialog.tsx
+++ b/website/src/components/ReviewPage/FilesDialog.tsx
@@ -1,4 +1,5 @@
 import { type FC } from 'react';
+
 import { type SequenceEntryToEdit } from '../../types/backend.ts';
 
 type FilesDialogProps = {
@@ -18,18 +19,19 @@ export const FilesDialog: FC<FilesDialogProps> = ({ isOpen, onClose, dataToView 
             <div className='bg-white rounded-lg p-6 max-w-xl mx-3 w-full max-h-[90vh] flex flex-col'>
                 <div className='flex justify-between items-center mb-4'>
                     <h2 className='text-xl font-semibold'>Files</h2>
-                    <button className='text-gray-500 hover:text-gray-700' onClick={onClose}>✕</button>
+                    <button className='text-gray-500 hover:text-gray-700' onClick={onClose}>
+                        ✕
+                    </button>
                 </div>
 
                 <div className='overflow-auto space-y-6'>
-
                     <div>
                         <h3 className='text-lg font-semibold mb-2'>Original Files</h3>
                         {Object.entries(originalFilesByCategory).map(([key, files]) => (
                             <div key={key} className='mb-4'>
                                 <h4 className='font-medium'>{key}</h4>
                                 <ul className='list-disc pl-5 space-y-1'>
-                                    {files.map(file => (
+                                    {files.map((file) => (
                                         <li key={file.fileId}>
                                             <a
                                                 href={`/seq/${dataToView.accession}.${dataToView.version}/${key}/${file.name}`}
@@ -52,7 +54,7 @@ export const FilesDialog: FC<FilesDialogProps> = ({ isOpen, onClose, dataToView 
                             <div key={key} className='mb-4'>
                                 <h4 className='font-medium'>{key}</h4>
                                 <ul className='list-disc pl-5 space-y-1'>
-                                    {files.map(file => (
+                                    {files.map((file) => (
                                         <li key={file.fileId}>
                                             <a
                                                 href={`/seq/${dataToView.accession}.${dataToView.version}/${key}/${file.name}`}
@@ -68,7 +70,6 @@ export const FilesDialog: FC<FilesDialogProps> = ({ isOpen, onClose, dataToView 
                             </div>
                         ))}
                     </div>
-
                 </div>
             </div>
         </div>

--- a/website/src/components/ReviewPage/FilesDialog.tsx
+++ b/website/src/components/ReviewPage/FilesDialog.tsx
@@ -1,0 +1,39 @@
+import { type FC } from 'react';
+
+type FilesDialogProps = {
+    isOpen: boolean;
+    onClose: () => void;
+};
+
+const exampleFiles = [
+    { name: 'Example 1', url: 'https://example.com/file1.txt' },
+    { name: 'Example 2', url: 'https://example.com/file2.txt' },
+    { name: 'Example 3', url: 'https://example.com/file3.txt' },
+];
+
+export const FilesDialog: FC<FilesDialogProps> = ({ isOpen, onClose }) => {
+    if (!isOpen) return null;
+
+    return (
+        <div className='fixed inset-0 flex items-center justify-center z-50 overflow-auto bg-black bg-opacity-30'>
+            <div className='bg-white rounded-lg p-6 max-w-xl mx-3 w-full max-h-[90vh] flex flex-col'>
+                <div className='flex justify-between items-center mb-4'>
+                    <h2 className='text-xl font-semibold'>Files</h2>
+                    <button className='text-gray-500 hover:text-gray-700' onClick={onClose}>
+                        ✕
+                    </button>
+                </div>
+
+                <ul className='list-disc pl-5 space-y-2'>
+                    {exampleFiles.map(({ name, url }) => (
+                        <li key={url}>
+                            <a href={url} className='text-blue-600 hover:underline' target='_blank' rel='noopener noreferrer'>
+                                {name}
+                            </a>
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </div>
+    );
+};

--- a/website/src/components/ReviewPage/FilesDialog.tsx
+++ b/website/src/components/ReviewPage/FilesDialog.tsx
@@ -11,9 +11,6 @@ type FilesDialogProps = {
 export const FilesDialog: FC<FilesDialogProps> = ({ isOpen, onClose, dataToView }) => {
     if (!isOpen || !dataToView) return null;
 
-    const originalFilesByCategory = dataToView.originalData.files;
-    const processedFilesByCategory = dataToView.processedData.files;
-
     return (
         <div className='fixed inset-0 flex items-center justify-center z-50 overflow-auto bg-black bg-opacity-30'>
             <div className='bg-white rounded-lg p-6 max-w-xl mx-3 w-full max-h-[90vh] flex flex-col'>
@@ -25,14 +22,14 @@ export const FilesDialog: FC<FilesDialogProps> = ({ isOpen, onClose, dataToView 
                 </div>
 
                 <div>
-                    {Object.entries(processedFilesByCategory).map(([key, files]) => (
-                        <div key={key} className='mb-4'>
-                            <h3 className='font-medium'>{key}</h3>
+                    {Object.entries(dataToView.processedData.files).map(([category, files]) => (
+                        <div key={category} className='mb-4'>
+                            <h3 className='font-medium'>{category}</h3>
                             <ul className='list-disc pl-5 space-y-1'>
                                 {files.map((file) => (
                                     <li key={file.fileId}>
                                         <a
-                                            href={`/seq/${dataToView.accession}.${dataToView.version}/${key}/${file.name}`}
+                                            href={`/seq/${dataToView.accession}.${dataToView.version}/${category}/${file.name}`}
                                             className='text-blue-600 hover:underline'
                                             target='_blank'
                                             rel='noopener noreferrer'

--- a/website/src/components/ReviewPage/FilesDialog.tsx
+++ b/website/src/components/ReviewPage/FilesDialog.tsx
@@ -31,8 +31,6 @@ export const FilesDialog: FC<FilesDialogProps> = ({ isOpen, onClose, dataToView 
                                         <a
                                             href={`/seq/${dataToView.accession}.${dataToView.version}/${category}/${file.name}`}
                                             className='text-primary-600 hover:underline'
-                                            target='_blank'
-                                            rel='noopener noreferrer'
                                         >
                                             {file.name}
                                         </a>

--- a/website/src/components/ReviewPage/FilesDialog.tsx
+++ b/website/src/components/ReviewPage/FilesDialog.tsx
@@ -22,7 +22,7 @@ export const FilesDialog: FC<FilesDialogProps> = ({ isOpen, onClose, dataToView 
                 </div>
 
                 <div>
-                    {Object.entries(dataToView.processedData.files ?? []).map(([category, files]) => (
+                    {Object.entries(dataToView.processedData.files ?? {}).map(([category, files]) => (
                         <div key={category} className='mb-4'>
                             <h3 className='font-medium'>{category}</h3>
                             <ul className='list-disc pl-5 space-y-1'>

--- a/website/src/components/ReviewPage/ReviewCard.tsx
+++ b/website/src/components/ReviewPage/ReviewCard.tsx
@@ -117,6 +117,7 @@ export const ReviewCard: FC<ReviewCardProps> = ({
             <FilesDialog
                 isOpen={isFilesDialogOpen}
                 onClose={() => setFilesDialogOpen(false)}
+                dataToView={data}
             />
         </div>
     );

--- a/website/src/components/ReviewPage/ReviewCard.tsx
+++ b/website/src/components/ReviewPage/ReviewCard.tsx
@@ -28,8 +28,8 @@ import QuestionMark from '~icons/fluent/tag-question-mark-24-filled';
 import Locked from '~icons/fluent-emoji-high-contrast/locked';
 import Unlocked from '~icons/fluent-emoji-high-contrast/unlocked';
 import EmptyCircle from '~icons/grommet-icons/empty-circle';
+import Files from '~icons/lucide/files';
 import RiDna from '~icons/mdi/dna';
-import Files from '~icons/mdi/files';
 import TickOutline from '~icons/mdi/tick-outline';
 import WpfPaperPlane from '~icons/wpf/paper-plane';
 

--- a/website/src/components/ReviewPage/ReviewCard.tsx
+++ b/website/src/components/ReviewPage/ReviewCard.tsx
@@ -59,6 +59,7 @@ export const ReviewCard: FC<ReviewCardProps> = ({
     const [isSequencesDialogOpen, setSequencesDialogOpen] = useState(false);
     const [isFilesDialogOpen, setFilesDialogOpen] = useState(false);
     const { isLoading, data } = useGetMetadataAndAnnotations(organism, clientConfig, accessToken, sequenceEntryStatus);
+    const hasFiles = Object.entries(data?.processedData.files ?? {}).length > 0;
 
     const notProcessed = sequenceEntryStatus.status !== processedStatus;
 
@@ -98,6 +99,7 @@ export const ReviewCard: FC<ReviewCardProps> = ({
                     viewSequences={data && !notProcessed ? () => setSequencesDialogOpen(true) : undefined}
                     viewFiles={data && !notProcessed ? () => setFilesDialogOpen(true) : undefined}
                     filesEnabled={filesEnabled}
+                    hasFiles={hasFiles}
                 />
             </div>
 
@@ -130,6 +132,7 @@ type ButtonBarProps = {
     viewSequences?: () => void;
     viewFiles?: () => void;
     filesEnabled: boolean;
+    hasFiles: boolean;
 };
 
 const ButtonBar: FC<ButtonBarProps> = ({
@@ -140,6 +143,7 @@ const ButtonBar: FC<ButtonBarProps> = ({
     viewSequences,
     viewFiles,
     filesEnabled,
+    hasFiles,
 }) => {
     const buttonBarClass = (disabled: boolean) =>
         `${disabled ? 'text-gray-300' : 'text-gray-500 hover:text-gray-900 hover:cursor-pointer'} inline-block text-xl`;
@@ -154,36 +158,35 @@ const ButtonBar: FC<ButtonBarProps> = ({
                 {filesEnabled && viewFiles && (
                     <>
                         <button
-                            className={buttonBarClass(notProcessed)}
+                            className={buttonBarClass(!hasFiles)}
                             onClick={viewFiles}
                             data-tooltip-id={'view-files-tooltip' + sequenceEntryStatus.accession}
                             data-testid={`view-files-${sequenceEntryStatus.accession}`}
                             key={'view-files-button-' + sequenceEntryStatus.accession}
-                            disabled={notProcessed}
+                            disabled={!hasFiles}
                         >
                             <Files />
                         </button>
                         <CustomTooltip
                             id={'view-files-tooltip' + sequenceEntryStatus.accession}
-                            content={notProcessed ? 'Processing...' : 'View files'}
+                            content={hasFiles ? 'View files' : 'No files for this entry'}
                         />
                     </>
                 )}
                 {viewSequences && (
                     <>
                         <button
-                            className={buttonBarClass(notProcessed)}
+                            className={buttonBarClass(false)}
                             onClick={viewSequences}
                             data-tooltip-id={'view-sequences-tooltip' + sequenceEntryStatus.accession}
                             data-testid={`view-sequences-${sequenceEntryStatus.accession}`}
                             key={'view-sequences-button-' + sequenceEntryStatus.accession}
-                            disabled={notProcessed}
                         >
                             <RiDna />
                         </button>
                         <CustomTooltip
                             id={'view-sequences-tooltip' + sequenceEntryStatus.accession}
-                            content={notProcessed ? 'Processing...' : 'View processed sequences'}
+                            content={'View processed sequences'}
                         />
                     </>
                 )}

--- a/website/src/components/ReviewPage/ReviewCard.tsx
+++ b/website/src/components/ReviewPage/ReviewCard.tsx
@@ -42,6 +42,7 @@ type ReviewCardProps = {
     clientConfig: ClientConfig;
     organism: string;
     accessToken: string;
+    filesEnabled: boolean;
 };
 
 export const ReviewCard: FC<ReviewCardProps> = ({
@@ -53,6 +54,7 @@ export const ReviewCard: FC<ReviewCardProps> = ({
     clientConfig,
     organism,
     accessToken,
+    filesEnabled,
 }) => {
     const [isSequencesDialogOpen, setSequencesDialogOpen] = useState(false);
     const [isFilesDialogOpen, setFilesDialogOpen] = useState(false);
@@ -95,6 +97,7 @@ export const ReviewCard: FC<ReviewCardProps> = ({
                     editAccessionVersion={editAccessionVersion}
                     viewSequences={data && !notProcessed ? () => setSequencesDialogOpen(true) : undefined}
                     viewFiles={data && !notProcessed ? () => setFilesDialogOpen(true) : undefined}
+                    filesEnabled={filesEnabled}
                 />
             </div>
 
@@ -126,6 +129,7 @@ type ButtonBarProps = {
     editAccessionVersion: () => void;
     viewSequences?: () => void;
     viewFiles?: () => void;
+    filesEnabled: boolean;
 };
 
 const ButtonBar: FC<ButtonBarProps> = ({
@@ -135,6 +139,7 @@ const ButtonBar: FC<ButtonBarProps> = ({
     editAccessionVersion,
     viewSequences,
     viewFiles,
+    filesEnabled,
 }) => {
     const buttonBarClass = (disabled: boolean) =>
         `${disabled ? 'text-gray-300' : 'text-gray-500 hover:text-gray-900 hover:cursor-pointer'} inline-block text-xl`;
@@ -146,7 +151,7 @@ const ButtonBar: FC<ButtonBarProps> = ({
     return (
         <div className='flex mb-auto pt-3.5 items-center'>
             <div className='flex space-x-4'>
-                {viewFiles && (
+                {filesEnabled && viewFiles && (
                     <>
                         <button
                             className={buttonBarClass(notProcessed)}

--- a/website/src/components/ReviewPage/ReviewCard.tsx
+++ b/website/src/components/ReviewPage/ReviewCard.tsx
@@ -160,7 +160,7 @@ const ButtonBar: FC<ButtonBarProps> = ({
                         </button>
                         <CustomTooltip
                             id={'view-files-tooltip' + sequenceEntryStatus.accession}
-                            content={notProcessed ? 'Processing...' : 'View files for sequence'}
+                            content={notProcessed ? 'Processing...' : 'View files'}
                         />
                     </>
                 )}

--- a/website/src/components/ReviewPage/ReviewCard.tsx
+++ b/website/src/components/ReviewPage/ReviewCard.tsx
@@ -1,5 +1,6 @@
 import { type FC, useState, useRef, useEffect } from 'react';
 
+import { FilesDialog } from './FilesDialog.tsx';
 import { SequencesDialog } from './SequencesDialog.tsx';
 import { backendClientHooks } from '../../services/serviceHooks.ts';
 import {
@@ -31,7 +32,6 @@ import RiDna from '~icons/mdi/dna';
 import Files from '~icons/mdi/files';
 import TickOutline from '~icons/mdi/tick-outline';
 import WpfPaperPlane from '~icons/wpf/paper-plane';
-import { FilesDialog } from './FilesDialog.tsx';
 
 type ReviewCardProps = {
     sequenceEntryStatus: SequenceEntryStatus;
@@ -114,11 +114,7 @@ export const ReviewCard: FC<ReviewCardProps> = ({
                 onClose={() => setSequencesDialogOpen(false)}
                 dataToView={data}
             />
-            <FilesDialog
-                isOpen={isFilesDialogOpen}
-                onClose={() => setFilesDialogOpen(false)}
-                dataToView={data}
-            />
+            <FilesDialog isOpen={isFilesDialogOpen} onClose={() => setFilesDialogOpen(false)} dataToView={data} />
         </div>
     );
 };
@@ -138,12 +134,10 @@ const ButtonBar: FC<ButtonBarProps> = ({
     deleteAccessionVersion,
     editAccessionVersion,
     viewSequences,
-    viewFiles
+    viewFiles,
 }) => {
     const buttonBarClass = (disabled: boolean) =>
-        `${
-            disabled ? 'text-gray-300' : 'text-gray-500 hover:text-gray-900 hover:cursor-pointer'
-        } inline-block text-xl`;
+        `${disabled ? 'text-gray-300' : 'text-gray-500 hover:text-gray-900 hover:cursor-pointer'} inline-block text-xl`;
     const approvable =
         sequenceEntryStatus.status === processedStatus &&
         !(sequenceEntryStatus.processingResult === errorsProcessingResult);

--- a/website/src/components/ReviewPage/ReviewCard.tsx
+++ b/website/src/components/ReviewPage/ReviewCard.tsx
@@ -28,8 +28,10 @@ import Locked from '~icons/fluent-emoji-high-contrast/locked';
 import Unlocked from '~icons/fluent-emoji-high-contrast/unlocked';
 import EmptyCircle from '~icons/grommet-icons/empty-circle';
 import RiDna from '~icons/mdi/dna';
+import Files from '~icons/mdi/files';
 import TickOutline from '~icons/mdi/tick-outline';
 import WpfPaperPlane from '~icons/wpf/paper-plane';
+import { FilesDialog } from './FilesDialog.tsx';
 
 type ReviewCardProps = {
     sequenceEntryStatus: SequenceEntryStatus;
@@ -53,6 +55,7 @@ export const ReviewCard: FC<ReviewCardProps> = ({
     accessToken,
 }) => {
     const [isSequencesDialogOpen, setSequencesDialogOpen] = useState(false);
+    const [isFilesDialogOpen, setFilesDialogOpen] = useState(false);
     const { isLoading, data } = useGetMetadataAndAnnotations(organism, clientConfig, accessToken, sequenceEntryStatus);
 
     const notProcessed = sequenceEntryStatus.status !== processedStatus;
@@ -91,6 +94,7 @@ export const ReviewCard: FC<ReviewCardProps> = ({
                     deleteAccessionVersion={deleteAccessionVersion}
                     editAccessionVersion={editAccessionVersion}
                     viewSequences={data && !notProcessed ? () => setSequencesDialogOpen(true) : undefined}
+                    viewFiles={data && !notProcessed ? () => setFilesDialogOpen(true) : undefined}
                 />
             </div>
 
@@ -110,6 +114,10 @@ export const ReviewCard: FC<ReviewCardProps> = ({
                 onClose={() => setSequencesDialogOpen(false)}
                 dataToView={data}
             />
+            <FilesDialog
+                isOpen={isFilesDialogOpen}
+                onClose={() => setFilesDialogOpen(false)}
+            />
         </div>
     );
 };
@@ -120,6 +128,7 @@ type ButtonBarProps = {
     deleteAccessionVersion: () => void;
     editAccessionVersion: () => void;
     viewSequences?: () => void;
+    viewFiles?: () => void;
 };
 
 const ButtonBar: FC<ButtonBarProps> = ({
@@ -128,11 +137,12 @@ const ButtonBar: FC<ButtonBarProps> = ({
     deleteAccessionVersion,
     editAccessionVersion,
     viewSequences,
+    viewFiles
 }) => {
     const buttonBarClass = (disabled: boolean) =>
         `${
             disabled ? 'text-gray-300' : 'text-gray-500 hover:text-gray-900 hover:cursor-pointer'
-        } pl-3 inline-block mr-2 mb-2 text-xl`;
+        } inline-block text-xl`;
     const approvable =
         sequenceEntryStatus.status === processedStatus &&
         !(sequenceEntryStatus.processingResult === errorsProcessingResult);
@@ -140,7 +150,25 @@ const ButtonBar: FC<ButtonBarProps> = ({
 
     return (
         <div className='flex mb-auto pt-3.5 items-center'>
-            <div className='flex space-x-1'>
+            <div className='flex space-x-4'>
+                {viewFiles && (
+                    <>
+                        <button
+                            className={buttonBarClass(notProcessed)}
+                            onClick={viewFiles}
+                            data-tooltip-id={'view-files-tooltip' + sequenceEntryStatus.accession}
+                            data-testid={`view-files-${sequenceEntryStatus.accession}`}
+                            key={'view-files-button-' + sequenceEntryStatus.accession}
+                            disabled={notProcessed}
+                        >
+                            <Files />
+                        </button>
+                        <CustomTooltip
+                            id={'view-files-tooltip' + sequenceEntryStatus.accession}
+                            content={notProcessed ? 'Processing...' : 'View files for sequence'}
+                        />
+                    </>
+                )}
                 {viewSequences && (
                     <>
                         <button

--- a/website/src/components/ReviewPage/ReviewPage.spec.tsx
+++ b/website/src/components/ReviewPage/ReviewPage.spec.tsx
@@ -29,6 +29,7 @@ function renderReviewPage() {
             metadataDisplayNames={new Map()}
             accessToken={testAccessToken}
             clientConfig={testConfig.public}
+            filesEnabled={false}
         />,
     );
 }

--- a/website/src/components/ReviewPage/ReviewPage.tsx
+++ b/website/src/components/ReviewPage/ReviewPage.tsx
@@ -42,6 +42,7 @@ type ReviewPageProps = {
     group: Group;
     accessToken: string;
     metadataDisplayNames: Map<string, string>;
+    filesEnabled: boolean;
 };
 
 const pageSizeOptions = [10, 20, 50, 100] as const;
@@ -73,7 +74,14 @@ const NumberAndVisibility = ({
     );
 };
 
-const InnerReviewPage: FC<ReviewPageProps> = ({ clientConfig, organism, group, accessToken, metadataDisplayNames }) => {
+const InnerReviewPage: FC<ReviewPageProps> = ({
+    clientConfig,
+    organism,
+    group,
+    accessToken,
+    metadataDisplayNames,
+    filesEnabled,
+}) => {
     const [pageQuery, setPageQuery] = useState<PageQuery>({ pageOneIndexed: 1, size: pageSizeOptions[2] });
 
     const hooks = useSubmissionOperations(organism, group, clientConfig, accessToken, toast.error, pageQuery);
@@ -372,6 +380,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({ clientConfig, organism, group, a
                             clientConfig={clientConfig}
                             organism={organism}
                             accessToken={accessToken}
+                            filesEnabled={filesEnabled}
                         />
                     </div>
                 );

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -15,7 +15,7 @@ import {
     type Group,
     openDataUseTermsOption,
     restrictedDataUseTermsOption,
-    type FileMapping,
+    type SubmissionIdFileMapping,
 } from '../../types/backend.ts';
 import type { FileCategory, InputField } from '../../types/config.ts';
 import type { SubmissionDataTypes } from '../../types/config.ts';
@@ -65,7 +65,7 @@ const InnerDataUploadForm = ({
 
     const { submit, revise, isLoading } = useSubmitFiles(accessToken, organism, clientConfig, onSuccess, onError);
     const [fileFactory, setFileFactory] = useState<FileFactory | undefined>(undefined);
-    const [fileMapping, setFileMapping] = useState<FileMapping | undefined>(undefined);
+    const [fileMapping, setFileMapping] = useState<SubmissionIdFileMapping | undefined>(undefined);
     const [dataUseTermsType, setDataUseTermsType] = useState<DataUseTermsOption>(openDataUseTermsOption);
     const [restrictedUntil, setRestrictedUntil] = useState<DateTime>(dateTimeInMonths(6));
 
@@ -274,7 +274,7 @@ const ExtraFilesUpload = ({
     inputMode: InputMode;
     group: Group;
     fileCategories: FileCategory[];
-    setFileMapping: Dispatch<SetStateAction<FileMapping | undefined>>;
+    setFileMapping: Dispatch<SetStateAction<SubmissionIdFileMapping | undefined>>;
     onError: (message: string) => void;
 }) => {
     return (

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -15,7 +15,7 @@ import {
     type Group,
     openDataUseTermsOption,
     restrictedDataUseTermsOption,
-    type SubmissionIdFileMapping,
+    type FilesBySubmissionId,
 } from '../../types/backend.ts';
 import type { FileCategory, InputField } from '../../types/config.ts';
 import type { SubmissionDataTypes } from '../../types/config.ts';
@@ -65,7 +65,7 @@ const InnerDataUploadForm = ({
 
     const { submit, revise, isLoading } = useSubmitFiles(accessToken, organism, clientConfig, onSuccess, onError);
     const [fileFactory, setFileFactory] = useState<FileFactory | undefined>(undefined);
-    const [fileMapping, setFileMapping] = useState<SubmissionIdFileMapping | undefined>(undefined);
+    const [fileMapping, setFileMapping] = useState<FilesBySubmissionId | undefined>(undefined);
     const [dataUseTermsType, setDataUseTermsType] = useState<DataUseTermsOption>(openDataUseTermsOption);
     const [restrictedUntil, setRestrictedUntil] = useState<DateTime>(dateTimeInMonths(6));
 
@@ -274,7 +274,7 @@ const ExtraFilesUpload = ({
     inputMode: InputMode;
     group: Group;
     fileCategories: FileCategory[];
-    setFileMapping: Dispatch<SetStateAction<SubmissionIdFileMapping | undefined>>;
+    setFileMapping: Dispatch<SetStateAction<FilesBySubmissionId | undefined>>;
     onError: (message: string) => void;
 }) => {
     return (

--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
@@ -4,7 +4,7 @@ import { toast } from 'react-toastify';
 
 import useClientFlag from '../../../hooks/isClient';
 import { BackendClient } from '../../../services/backendClient';
-import type { FileMapping, Group } from '../../../types/backend';
+import type { SubmissionIdFileMapping, Group } from '../../../types/backend';
 import type { ClientConfig } from '../../../types/runtimeConfig';
 import type { InputMode } from '../FormOrUploadWrapper';
 import LucideFile from '~icons/lucide/file';
@@ -71,7 +71,7 @@ type FolderUploadComponentProps = {
     accessToken: string;
     clientConfig: ClientConfig;
     group: Group;
-    setFileMapping: Dispatch<SetStateAction<FileMapping | undefined>>;
+    setFileMapping: Dispatch<SetStateAction<SubmissionIdFileMapping | undefined>>;
     onError: (message: string) => void;
 };
 

--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
@@ -4,7 +4,7 @@ import { toast } from 'react-toastify';
 
 import useClientFlag from '../../../hooks/isClient';
 import { BackendClient } from '../../../services/backendClient';
-import type { SubmissionIdFileMapping, Group } from '../../../types/backend';
+import type { FilesBySubmissionId, Group } from '../../../types/backend';
 import type { ClientConfig } from '../../../types/runtimeConfig';
 import type { InputMode } from '../FormOrUploadWrapper';
 import LucideFile from '~icons/lucide/file';
@@ -71,7 +71,7 @@ type FolderUploadComponentProps = {
     accessToken: string;
     clientConfig: ClientConfig;
     group: Group;
-    setFileMapping: Dispatch<SetStateAction<SubmissionIdFileMapping | undefined>>;
+    setFileMapping: Dispatch<SetStateAction<FilesBySubmissionId | undefined>>;
     onError: (message: string) => void;
 };
 

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -121,6 +121,10 @@ function getConfig(organism: string): InstanceConfig {
     return websiteConfig.organisms[organism];
 }
 
+export function outputFilesEnabled(organism: string): boolean {
+    return (getConfig(organism).schema.files ?? []).length > 0;
+}
+
 export function getSchema(organism: string): Schema {
     return getConfig(organism).schema;
 }

--- a/website/src/pages/[organism]/submission/[groupId]/review.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/review.astro
@@ -1,7 +1,7 @@
 ---
 import { ReviewPage } from '../../../../components/ReviewPage/ReviewPage';
 import SubmissionPageWrapper from '../../../../components/Submission/SubmissionPageWrapper.astro';
-import { getMetadataDisplayNames, getRuntimeConfig } from '../../../../config';
+import { getMetadataDisplayNames, getRuntimeConfig, outputFilesEnabled } from '../../../../config';
 import { type ClientConfig } from '../../../../types/runtimeConfig';
 import { getAccessToken } from '../../../../utils/getAccessToken';
 import { getGroupsAndCurrentGroup } from '../../../../utils/submissionPages';
@@ -10,6 +10,7 @@ const organism = Astro.params.organism!;
 const groupsResult = await getGroupsAndCurrentGroup(Astro.params, Astro.locals.session);
 
 const clientConfig: ClientConfig = getRuntimeConfig().public;
+const filesEnabled = outputFilesEnabled(organism);
 const metadataDisplayNames: Map<string, string> = getMetadataDisplayNames(organism);
 ---
 
@@ -23,6 +24,7 @@ const metadataDisplayNames: Map<string, string> = getMetadataDisplayNames(organi
                     group={group}
                     accessToken={getAccessToken(Astro.locals.session)!}
                     metadataDisplayNames={metadataDisplayNames}
+                    filesEnabled={filesEnabled}
                     client:load
                 />
             ),

--- a/website/src/pages/seq/[accessionVersion]/[fileCategory]/[fileName].ts
+++ b/website/src/pages/seq/[accessionVersion]/[fileCategory]/[fileName].ts
@@ -32,9 +32,8 @@ export const GET: APIRoute = async ({ params, locals }) => {
             headers: { Location: s3Url },
         });
     } else if (response.ok) {
-        return new Response(await response.text(), { status: response.status });
+        return new Response(response.body, { status: response.status });
     } else {
-        const text = await response.text();
-        return new Response(text, { status: response.status });
+        return new Response(response.body, { status: response.status });
     }
 };

--- a/website/src/pages/seq/[accessionVersion]/[fileCategory]/[fileName].ts
+++ b/website/src/pages/seq/[accessionVersion]/[fileCategory]/[fileName].ts
@@ -2,19 +2,16 @@ import type { APIRoute } from 'astro';
 
 import { getRuntimeConfig } from '../../../../config';
 import { parseAccessionVersionFromString } from '../../../../utils/extractAccessionVersion';
+import { getAccessToken } from '../../../../utils/getAccessToken';
 
-export const GET: APIRoute = async ({ params, cookies }) => {
+export const GET: APIRoute = async ({ params, locals }) => {
     const runtimeConfig = getRuntimeConfig();
     const { accessionVersion, fileCategory, fileName } = params;
     const { accession, version } = parseAccessionVersionFromString(accessionVersion!);
 
     const backendUrl = `${runtimeConfig.public.backendUrl}/files/get/${accession}/${version}/${encodeURIComponent(fileCategory!)}/${encodeURIComponent(fileName!)}`;
 
-    const accessToken = cookies.get('access_token')?.value;
-
-    if (!accessToken) {
-        return new Response('Unauthorized: access_token cookie missing', { status: 401 });
-    }
+    const accessToken = getAccessToken(locals.session)!;
 
     const response = await fetch(backendUrl, {
         redirect: 'manual',

--- a/website/src/pages/seq/[accessionVersion]/[fileCategory]/[fileName].ts
+++ b/website/src/pages/seq/[accessionVersion]/[fileCategory]/[fileName].ts
@@ -3,25 +3,14 @@ import type { APIRoute } from 'astro';
 import { getRuntimeConfig } from '../../../../config';
 import { parseAccessionVersionFromString } from '../../../../utils/extractAccessionVersion';
 
-function getCookieValue(cookieHeader: string | null, cookieName: string): string | null {
-    if (!cookieHeader) return null;
-    const cookies = cookieHeader.split(';').map((c) => c.trim());
-    for (const cookie of cookies) {
-        const [name, ...rest] = cookie.split('=');
-        if (name === cookieName) return rest.join('=');
-    }
-    return null;
-}
-
-export const GET: APIRoute = async ({ params, request }) => {
+export const GET: APIRoute = async ({ params, cookies }) => {
     const runtimeConfig = getRuntimeConfig();
     const { accessionVersion, fileCategory, fileName } = params;
     const { accession, version } = parseAccessionVersionFromString(accessionVersion!);
 
     const backendUrl = `${runtimeConfig.public.backendUrl}/files/get/${accession}/${version}/${encodeURIComponent(fileCategory!)}/${encodeURIComponent(fileName!)}`;
 
-    const cookieHeader = request.headers.get('cookie');
-    const accessToken = getCookieValue(cookieHeader, 'access_token');
+    const accessToken = cookies.get('access_token')?.value;
 
     if (!accessToken) {
         return new Response('Unauthorized: access_token cookie missing', { status: 401 });

--- a/website/src/pages/seq/[accessionVersion]/[fileCategory]/[fileName].ts
+++ b/website/src/pages/seq/[accessionVersion]/[fileCategory]/[fileName].ts
@@ -3,17 +3,52 @@ import type { APIRoute } from 'astro';
 import { getRuntimeConfig } from '../../../../config';
 import { parseAccessionVersionFromString } from '../../../../utils/extractAccessionVersion';
 
-export const GET: APIRoute = ({ params }) => {
+function getCookieValue(cookieHeader: string | null, cookieName: string): string | null {
+    if (!cookieHeader) return null;
+    const cookies = cookieHeader.split(';').map((c) => c.trim());
+    for (const cookie of cookies) {
+        const [name, ...rest] = cookie.split('=');
+        if (name === cookieName) return rest.join('=');
+    }
+    return null;
+}
+
+export const GET: APIRoute = async ({ params, request }) => {
     const runtimeConfig = getRuntimeConfig();
     const { accessionVersion, fileCategory, fileName } = params;
     const { accession, version } = parseAccessionVersionFromString(accessionVersion!);
 
-    const redirectUrl = `${runtimeConfig.public.backendUrl}/files/get/${accession}/${version}/${encodeURIComponent(fileCategory!)}/${encodeURIComponent(fileName!)}`;
-    return new Response(null, {
-        status: 302,
+    const backendUrl = `${runtimeConfig.public.backendUrl}/files/get/${accession}/${version}/${encodeURIComponent(fileCategory!)}/${encodeURIComponent(fileName!)}`;
+
+    const cookieHeader = request.headers.get('cookie');
+    const accessToken = getCookieValue(cookieHeader, 'access_token');
+
+    if (!accessToken) {
+        return new Response('Unauthorized: access_token cookie missing', { status: 401 });
+    }
+
+    const response = await fetch(backendUrl, {
+        redirect: 'manual',
         headers: {
             // eslint-disable-next-line @typescript-eslint/naming-convention
-            Location: redirectUrl,
+            Authorization: `Bearer ${accessToken}`,
         },
     });
+
+    if (response.status === 307 || response.status === 302) {
+        const s3Url = response.headers.get('Location');
+        if (!s3Url) {
+            return new Response('Backend redirect missing Location header', { status: 500 });
+        }
+        return new Response(null, {
+            status: response.status,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            headers: { Location: s3Url },
+        });
+    } else if (response.ok) {
+        return new Response(await response.text(), { status: response.status });
+    } else {
+        const text = await response.text();
+        return new Response(text, { status: response.status });
+    }
 };

--- a/website/src/types/backend.ts
+++ b/website/src/types/backend.ts
@@ -213,10 +213,14 @@ export const sequenceEntryToEdit = accessionVersion.merge(
         originalData: z.object({
             metadata: unprocessedMetadataRecord,
             unalignedNucleotideSequences: z.record(z.string()),
-            files: z.record(z.array(z.object({
-                fileId: z.string(),
-                name: z.string()
-            }))),
+            files: z.record(
+                z.array(
+                    z.object({
+                        fileId: z.string(),
+                        name: z.string(),
+                    }),
+                ),
+            ),
         }),
         processedData: z.object({
             metadata: metadataRecord,
@@ -225,10 +229,14 @@ export const sequenceEntryToEdit = accessionVersion.merge(
             nucleotideInsertions: z.record(z.array(z.string())),
             alignedAminoAcidSequences: z.record(z.string().nullable()),
             aminoAcidInsertions: z.record(z.array(z.string())),
-            files: z.record(z.array(z.object({
-                fileId: z.string(),
-                name: z.string()
-            }))),
+            files: z.record(
+                z.array(
+                    z.object({
+                        fileId: z.string(),
+                        name: z.string(),
+                    }),
+                ),
+            ),
         }),
     }),
 );

--- a/website/src/types/backend.ts
+++ b/website/src/types/backend.ts
@@ -203,6 +203,19 @@ export const unprocessedData = accessionVersion.merge(
 );
 export type UnprocessedData = z.infer<typeof unprocessedData>;
 
+// The struct to store the files per category for one submission
+const categoryFileMapping = z.record(
+    z.array(
+        z.object({
+            fileId: z.string(),
+            name: z.string(),
+        }),
+    ),
+);
+
+export const submissionIdFileMapping = z.record(categoryFileMapping);
+export type SubmissionIdFileMapping = z.infer<typeof submissionIdFileMapping>;
+
 export const sequenceEntryToEdit = accessionVersion.merge(
     z.object({
         status: sequenceEntryStatusNames,
@@ -213,14 +226,7 @@ export const sequenceEntryToEdit = accessionVersion.merge(
         originalData: z.object({
             metadata: unprocessedMetadataRecord,
             unalignedNucleotideSequences: z.record(z.string()),
-            files: z.record(
-                z.array(
-                    z.object({
-                        fileId: z.string(),
-                        name: z.string(),
-                    }),
-                ),
-            ),
+            files: categoryFileMapping,
         }),
         processedData: z.object({
             metadata: metadataRecord,
@@ -229,14 +235,7 @@ export const sequenceEntryToEdit = accessionVersion.merge(
             nucleotideInsertions: z.record(z.array(z.string())),
             alignedAminoAcidSequences: z.record(z.string().nullable()),
             aminoAcidInsertions: z.record(z.array(z.string())),
-            files: z.record(
-                z.array(
-                    z.object({
-                        fileId: z.string(),
-                        name: z.string(),
-                    }),
-                ),
-            ),
+            files: categoryFileMapping,
         }),
     }),
 );
@@ -260,24 +259,10 @@ export const mapErrorsAndWarnings = (
         .map((warning) => warning.message),
 });
 
-export const fileMapping = z.record(
-    // submission ID
-    z.record(
-        // file field
-        z.array(
-            z.object({
-                fileId: z.string().uuid(),
-                name: z.string(),
-            }),
-        ),
-    ),
-);
-export type FileMapping = z.infer<typeof fileMapping>;
-
 export const uploadFiles = z.object({
     metadataFile: z.instanceof(File),
     sequenceFile: z.instanceof(File).optional(),
-    fileMapping: fileMapping.optional(),
+    fileMapping: submissionIdFileMapping.optional(),
 });
 
 export const submitFiles = uploadFiles.merge(

--- a/website/src/types/backend.ts
+++ b/website/src/types/backend.ts
@@ -226,7 +226,7 @@ export const sequenceEntryToEdit = accessionVersion.merge(
         originalData: z.object({
             metadata: unprocessedMetadataRecord,
             unalignedNucleotideSequences: z.record(z.string()),
-            files: categoryFileMapping,
+            files: categoryFileMapping.nullable(),
         }),
         processedData: z.object({
             metadata: metadataRecord,
@@ -235,7 +235,7 @@ export const sequenceEntryToEdit = accessionVersion.merge(
             nucleotideInsertions: z.record(z.array(z.string())),
             alignedAminoAcidSequences: z.record(z.string().nullable()),
             aminoAcidInsertions: z.record(z.array(z.string())),
-            files: categoryFileMapping,
+            files: categoryFileMapping.nullable(),
         }),
     }),
 );

--- a/website/src/types/backend.ts
+++ b/website/src/types/backend.ts
@@ -213,6 +213,10 @@ export const sequenceEntryToEdit = accessionVersion.merge(
         originalData: z.object({
             metadata: unprocessedMetadataRecord,
             unalignedNucleotideSequences: z.record(z.string()),
+            files: z.record(z.array(z.object({
+                fileId: z.string(),
+                name: z.string()
+            }))),
         }),
         processedData: z.object({
             metadata: metadataRecord,
@@ -221,6 +225,10 @@ export const sequenceEntryToEdit = accessionVersion.merge(
             nucleotideInsertions: z.record(z.array(z.string())),
             alignedAminoAcidSequences: z.record(z.string().nullable()),
             aminoAcidInsertions: z.record(z.array(z.string())),
+            files: z.record(z.array(z.object({
+                fileId: z.string(),
+                name: z.string()
+            }))),
         }),
     }),
 );

--- a/website/src/types/backend.ts
+++ b/website/src/types/backend.ts
@@ -203,8 +203,7 @@ export const unprocessedData = accessionVersion.merge(
 );
 export type UnprocessedData = z.infer<typeof unprocessedData>;
 
-// The struct to store the files per category for one submission
-const categoryFileMapping = z.record(
+const filesByCategory = z.record(
     z.array(
         z.object({
             fileId: z.string(),
@@ -213,8 +212,8 @@ const categoryFileMapping = z.record(
     ),
 );
 
-export const submissionIdFileMapping = z.record(categoryFileMapping);
-export type SubmissionIdFileMapping = z.infer<typeof submissionIdFileMapping>;
+export const filesBySubmissionId = z.record(filesByCategory);
+export type FilesBySubmissionId = z.infer<typeof filesBySubmissionId>;
 
 export const sequenceEntryToEdit = accessionVersion.merge(
     z.object({
@@ -226,7 +225,7 @@ export const sequenceEntryToEdit = accessionVersion.merge(
         originalData: z.object({
             metadata: unprocessedMetadataRecord,
             unalignedNucleotideSequences: z.record(z.string()),
-            files: categoryFileMapping.nullable(),
+            files: filesByCategory.nullable(),
         }),
         processedData: z.object({
             metadata: metadataRecord,
@@ -235,7 +234,7 @@ export const sequenceEntryToEdit = accessionVersion.merge(
             nucleotideInsertions: z.record(z.array(z.string())),
             alignedAminoAcidSequences: z.record(z.string().nullable()),
             aminoAcidInsertions: z.record(z.array(z.string())),
-            files: categoryFileMapping.nullable(),
+            files: filesByCategory.nullable(),
         }),
     }),
 );
@@ -262,7 +261,7 @@ export const mapErrorsAndWarnings = (
 export const uploadFiles = z.object({
     metadataFile: z.instanceof(File),
     sequenceFile: z.instanceof(File).optional(),
-    fileMapping: submissionIdFileMapping.optional(),
+    fileMapping: filesBySubmissionId.optional(),
 });
 
 export const submitFiles = uploadFiles.merge(

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -131,6 +131,7 @@ export type SubmissionDataTypes = z.infer<typeof submissionDataTypesSchema>;
 export const schema = z.object({
     organismName: z.string(),
     image: z.string().optional(),
+    files: z.array(fileCategory).optional(),
     metadata: z.array(metadata),
     metadataTemplate: z.array(z.string()).optional(),
     inputFields: z.array(inputField),

--- a/website/vitest.setup.ts
+++ b/website/vitest.setup.ts
@@ -8,6 +8,7 @@ import { setupServer } from 'msw/node';
 import ResizeObserver from 'resize-observer-polyfill';
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest';
 
+// eslint-disable-next-line  @typescript-eslint/no-unsafe-call
 mockAnimationsApi();
 
 import {

--- a/website/vitest.setup.ts
+++ b/website/vitest.setup.ts
@@ -8,7 +8,6 @@ import { setupServer } from 'msw/node';
 import ResizeObserver from 'resize-observer-polyfill';
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest';
 
-// eslint-disable-next-line  @typescript-eslint/no-unsafe-call
 mockAnimationsApi();
 
 import {
@@ -96,6 +95,7 @@ export const defaultReviewData: SequenceEntryToEdit = {
         unalignedNucleotideSequences: {
             originalSequenceName: 'originalUnalignedNucleotideSequencesValue',
         },
+        files: null,
     },
     processedData: {
         metadata: {
@@ -117,6 +117,7 @@ export const defaultReviewData: SequenceEntryToEdit = {
         aminoAcidInsertions: {
             processedInsertionGeneName: ['aminoAcidInsertion1', 'aminoAcidInsertion2'],
         },
+        files: null,
     },
     submissionId: 'defaultSubmitter',
 };


### PR DESCRIPTION
resolves #3968 

Adds a button similar to the 'view sequences' button to view files that opens a dialog with the file links.

The /seq/...filename.txt route is refactored to directly return a redirect to S3, instead of a redirect to the backend (which could then redirect to S3), so one network hop is saved.

### Manual testing

I've made a submission with files, waited for them to process, and then downloaded them through the dialog. works! See also the video below.

### Screenshot

https://github.com/user-attachments/assets/4af8f542-823f-4e4f-8d2f-0be38b5d3480

### PR Checklist
- ~~All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://review-files.loculus.org