### PR TITLE
feat(k8s): configurable silo/kecyloak replicas and add optional podDisruptionBudget

### DIFF
--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
 spec:
-  replicas: 1
+  replicas: {{ $.Values.replicas.keycloak | default 1 }}1
   selector:
     matchLabels:
       app: loculus

--- a/kubernetes/loculus/templates/pod-disruption-budgets.yaml
+++ b/kubernetes/loculus/templates/pod-disruption-budgets.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.podDisruptionBudgets.enabled }}
+{{- if not .Values.disableBackend }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: loculus-backend-pdb
+spec:
+  minAvailable: {{ .Values.podDisruptionBudgets.backend.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      app: loculus
+      component: backend
+{{- end }}
+{{- if not .Values.disableWebsite }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: loculus-website-pdb
+spec:
+  minAvailable: {{ .Values.podDisruptionBudgets.website.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      app: loculus
+      component: website
+{{- end }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak-pdb
+spec:
+  minAvailable: {{ .Values.podDisruptionBudgets.keycloak.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      app: loculus
+      component: keycloak
+{{- range $key, $organism := .Values.organisms }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: loculus-silo-{{ $key }}-pdb
+spec:
+  minAvailable: {{ $.Values.podDisruptionBudgets.silo.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      app: loculus
+      component: silo-{{ $key }}
+{{- end }}
+{{- range $key, $organism := .Values.organisms }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: loculus-lapis-{{ $key }}-pdb
+spec:
+  minAvailable: {{ $.Values.podDisruptionBudgets.lapis.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      app: loculus
+      component: lapis-{{ $key }}
+{{- end }}
+{{- end }}

--- a/kubernetes/loculus/templates/silo-deployment.yaml
+++ b/kubernetes/loculus/templates/silo-deployment.yaml
@@ -12,7 +12,7 @@ metadata:
     # Force replace when run a) with dev db and b) without persistence to ensure silo prepro fails loudly
     argocd.argoproj.io/sync-options: Replace=true{{ if (and (not $.Values.developmentDatabasePersistence) $.Values.runDevelopmentMainDatabase) }},Force=true{{ end }}
 spec:
-  replicas: 1
+  replicas: {{ $.Values.replicas.silo | default 1 }}
   selector:
     matchLabels:
       app: loculus

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1807,6 +1807,8 @@ replicas:
   website: 1
   backend: 1
   lapis: 1
+  silo: 1
+  keycloak: 1
 gitHubEditLink: "https://github.com/loculus-project/loculus/edit/main/monorepo/website/"
 gitHubMainUrl: https://github.com/loculus-project/loculus
 resources:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1809,6 +1809,18 @@ replicas:
   lapis: 1
   silo: 1
   keycloak: 1
+podDisruptionBudgets:
+  enabled: false
+  backend:
+    minAvailable: 1
+  website:
+    minAvailable: 1
+  keycloak:
+    minAvailable: 1
+  silo:
+    minAvailable: 1
+  lapis:
+    minAvailable: 1
 gitHubEditLink: "https://github.com/loculus-project/loculus/edit/main/monorepo/website/"
 gitHubMainUrl: https://github.com/loculus-project/loculus
 resources:


### PR DESCRIPTION
- **feat(k8s): allow setting replicas for silo and keycloak**
- **Taking stuff from https://github.com/loculus-project/loculus/pull/4299**

resolves #

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)
