### PR TITLE
fix(backend): authenticated file access to unpublished files

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/auth/AuthenticatedUser.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/auth/AuthenticatedUser.kt
@@ -38,7 +38,7 @@ class AnonymousUser : User()
 @Component
 class UserConverter : HandlerMethodArgumentResolver {
     override fun supportsParameter(parameter: MethodParameter): Boolean =
-        AuthenticatedUser::class.java.isAssignableFrom(parameter.parameterType)
+        User::class.java.isAssignableFrom(parameter.parameterType)
 
     override fun resolveArgument(
         parameter: MethodParameter,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/files/FilesClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/files/FilesClient.kt
@@ -1,12 +1,16 @@
 package org.loculus.backend.controller.files
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.loculus.backend.api.FileCategory
 import org.loculus.backend.api.FileIdAndWriteUrl
 import org.loculus.backend.controller.jwtForDefaultUser
 import org.loculus.backend.controller.withAuth
 import org.loculus.backend.service.files.FileId
+import org.loculus.backend.utils.Accession
+import org.loculus.backend.utils.Version
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import java.util.*
 
@@ -17,6 +21,24 @@ class FilesClient(private val mockMvc: MockMvc) {
             .withAuth(jwt)
         groupId?.let { request.param("groupId", it.toString()) }
         numberFiles?.let { request.param("numberFiles", it.toString()) }
+        return mockMvc.perform(request)
+    }
+
+    fun getFile(
+        accession: Accession,
+        version: Version,
+        fileCategory: FileCategory,
+        fileName: String,
+        jwt: String? = null,
+    ): ResultActions {
+        val request = get(
+            "/files/get/{accession}/{version}/{category}/{filename}",
+            accession,
+            version,
+            fileCategory,
+            fileName,
+        )
+            .withAuth(jwt)
         return mockMvc.perform(request)
     }
 }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/files/GetFilesEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/files/GetFilesEndpointTest.kt
@@ -1,0 +1,66 @@
+package org.loculus.backend.controller.files
+
+import org.hamcrest.Matchers.containsString
+import org.junit.jupiter.api.Test
+import org.loculus.backend.api.FileIdAndName
+import org.loculus.backend.config.BackendSpringProperty
+import org.loculus.backend.controller.EndpointTest
+import org.loculus.backend.controller.S3_CONFIG
+import org.loculus.backend.controller.jwtForDefaultUser
+import org.loculus.backend.controller.submission.PreparedProcessedData
+import org.loculus.backend.controller.submission.SubmissionConvenienceClient
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@EndpointTest(
+    properties = ["${BackendSpringProperty.BACKEND_CONFIG_PATH}=$S3_CONFIG"],
+)
+class GetFilesEndpointTest(
+    @Autowired private val
+    submissionConvenienceClient: SubmissionConvenienceClient,
+    @Autowired private val filesClient: FilesClient,
+) {
+    @Test
+    fun `GIVEN an unpublished file WHEN requesting without auth THEN an error is raised`() {
+        submissionConvenienceClient.submitDefaultFiles(includeFileMapping = true)
+        val data = submissionConvenienceClient.extractUnprocessedData().first()
+        submissionConvenienceClient.submitProcessedData(
+            PreparedProcessedData.withFiles(
+                data.accession,
+                data.data.files!!.map {
+                    Pair(it.key, it.value.map { FileIdAndName(it.fileId, it.name) })
+                }.toMap(),
+            ),
+        )
+
+        filesClient.getFile(data.accession, data.version, "myFileCategory", "hello.txt")
+            .andExpect(status().isForbidden())
+            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(
+                jsonPath(
+                    "\$.detail",
+                    containsString("file is not public"),
+                ),
+            )
+    }
+
+    @Test
+    fun `GIVEN an unpublished file WHEN requesting with auth THEN the file is returned`() {
+        submissionConvenienceClient.submitDefaultFiles(includeFileMapping = true)
+        val data = submissionConvenienceClient.extractUnprocessedData().first()
+        submissionConvenienceClient.submitProcessedData(
+            PreparedProcessedData.withFiles(
+                data.accession,
+                data.data.files!!.map {
+                    Pair(it.key, it.value.map { FileIdAndName(it.fileId, it.name) })
+                }.toMap(),
+            ),
+        )
+
+        filesClient.getFile(data.accession, data.version, "myFileCategory", "hello.txt", jwt = jwtForDefaultUser)
+            .andExpect(status().is3xxRedirection())
+    }
+}


### PR DESCRIPTION
I found an issue, the authenticated access to unpublished files didn't work. I wrote a test for that: `GIVEN an unpublished file WHEN requesting with auth THEN the file is returned`, and implemented the fix.

This came up while working on https://github.com/loculus-project/loculus/issues/3968 and is relevant for implementing that.

🚀 Preview: Add `preview` label to enable