### PR TITLE
feat(website): improve edit data use terms button

### DIFF
--- a/website/src/components/DataUseTerms/EditDataUseTermsModal.tsx
+++ b/website/src/components/DataUseTerms/EditDataUseTermsModal.tsx
@@ -15,6 +15,7 @@ import {
 import type { Details } from '../../types/lapis';
 import type { ClientConfig } from '../../types/runtimeConfig';
 import { createAuthorizationHeader } from '../../utils/createAuthorizationHeader';
+import { formatNumberWithDefaultLocale } from '../../utils/formatNumber';
 import type { SequenceFilter } from '../SearchPage/DownloadDialog/SequenceFilters';
 import { ActiveFilters } from '../common/ActiveFilters';
 import { BaseDialog } from '../common/BaseDialog';
@@ -124,10 +125,18 @@ export const EditDataUseTermsModal: FC<EditDataUseTermsModalProps> = ({
         }
     }, [detailsHook.data, detailsHook.error, detailsHook.isLoading]);
 
+    const sequenceCount = sequenceFilter.sequenceCount();
+    let buttonText = 'Edit data use terms for all';
+    if (sequenceCount !== undefined) {
+        const formatted = formatNumberWithDefaultLocale(sequenceCount);
+        const plural = sequenceCount === 1 ? '' : 's';
+        buttonText = `Edit data use terms for ${formatted} sequence${plural}`;
+    }
+
     return (
         <>
-            <button className='mr-4 underline text-primary-700 hover:text-primary-500' onClick={openDialog}>
-                Edit data use terms
+            <button className='mr-4 outlineButton' onClick={openDialog}>
+                {buttonText}
             </button>
             <BaseDialog title='Edit data use terms' isOpen={isOpen} onClose={closeDialog}>
                 {state.type === 'loading' && 'loading'}


### PR DESCRIPTION
## Summary
- style the 'Edit data use terms' button like other outline buttons
- display the number of sequences being updated in the button text

## Testing
- `npm run format`
- `npm run check-types`
- `npm run test` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_683f422cf3248325a70b023967b52e90