### PR TITLE
feat(integration-tests): add invalid login test

### DIFF
--- a/integration-tests/playwright.config.ts
+++ b/integration-tests/playwright.config.ts
@@ -24,7 +24,8 @@ export default defineConfig({
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
         /* Base URL to use in actions like `await page.goto('/')`. */
-        baseURL: 'http://localhost:3000',
+        baseURL: process.env.BASE_URL || 'http://localhost:3000',
+        ignoreHTTPSErrors: true,
 
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: process.env.CI ? 'on-first-retry' : 'on',

--- a/integration-tests/tests/pages/auth.page.ts
+++ b/integration-tests/tests/pages/auth.page.ts
@@ -46,6 +46,15 @@ export class AuthPage {
         await this.page.waitForSelector('text=Welcome to Loculus', { state: 'attached' });
     }
 
+    async loginExpectFailure(username: string, password: string) {
+        await this.page.goto('/');
+        await this.page.getByRole('link', { name: 'Login' }).click();
+        await this.page.getByLabel('Username').fill(username);
+        await this.page.getByLabel('Password', { exact: true }).fill(password);
+        await this.page.getByRole('button', { name: 'Sign in' }).click();
+        await this.page.waitForSelector('text=Invalid username or password.', { state: 'visible' });
+    }
+
     async logout() {
         await this.page.waitForLoadState('networkidle');
         await this.page.goto('/');

--- a/integration-tests/tests/specs/auth/invalid-login.spec.ts
+++ b/integration-tests/tests/specs/auth/invalid-login.spec.ts
@@ -1,0 +1,19 @@
+import { expect } from '@playwright/test';
+import { test } from '../../fixtures/auth.fixture';
+import { AuthPage } from '../../pages/auth.page';
+
+// Verify error message appears when logging in with invalid credentials
+
+test.describe('Login Failure', () => {
+    let authPage: AuthPage;
+
+    test.beforeEach(async ({ page }) => {
+        authPage = new AuthPage(page);
+    });
+
+    test('should display an error for invalid password', async ({ page, testAccount }) => {
+        await authPage.createAccount(testAccount);
+        await authPage.logout();
+        await authPage.loginExpectFailure(testAccount.username, 'wrong-password');
+    });
+});


### PR DESCRIPTION
## Summary
- allow specifying BASE_URL through environment variable and ignore TLS errors
- add helper `loginExpectFailure` to check login errors
- create `invalid-login.spec.ts` to assert wrong-password behavior

## Testing
- ❌ `NODE_TLS_REJECT_UNAUTHORIZED=0 BASE_URL=https://main.loculus.org npx playwright test --workers=2 tests/specs/auth/login.spec.ts tests/specs/auth/registration.spec.ts`
  - Playwright dependencies could not fully install in the environment

------
https://chatgpt.com/codex/tasks/task_e_683f63a40c20832589a6693d6076b867