### PR TITLE
test(integration): add seqset creation test

### DIFF
--- a/integration-tests/tests/pages/seqset.page.ts
+++ b/integration-tests/tests/pages/seqset.page.ts
@@ -1,0 +1,21 @@
+import { Page } from '@playwright/test';
+
+export class SeqSetPage {
+    constructor(private page: Page) {}
+
+    async navigateToList() {
+        await this.page.goto('/seqsets');
+    }
+
+    async createSeqSet(name: string, description: string, accessions: string) {
+        await this.navigateToList();
+        await this.page.getByTestId('AddIcon').click();
+        const nameInput = this.page.getByLabel('SeqSet name');
+        await nameInput.waitFor({ state: 'visible' });
+        await nameInput.fill(name);
+        await this.page.getByLabel('SeqSet description').fill(description);
+        await this.page.getByLabel(/Focal accessions/).fill(accessions);
+        await this.page.getByRole('button', { name: 'Save' }).click();
+        await this.page.waitForURL(/\/seqsets\//);
+    }
+}

--- a/integration-tests/tests/specs/features/create-seqset.dependent.spec.ts
+++ b/integration-tests/tests/specs/features/create-seqset.dependent.spec.ts
@@ -1,0 +1,21 @@
+import { expect } from '@playwright/test';
+import { test } from '../../fixtures/group.fixture';
+import { SearchPage } from '../../pages/search.page';
+import { SeqSetPage } from '../../pages/seqset.page';
+
+// This test relies on the sequence created in readonly.setup.ts
+
+test('create a seqset from an available sequence', async ({ pageWithGroup }) => {
+    const searchPage = new SearchPage(pageWithGroup);
+    await searchPage.ebolaSudan();
+
+    const accession = await searchPage.waitForLoculusId();
+    expect(accession).toBeTruthy();
+
+    const seqSetPage = new SeqSetPage(pageWithGroup);
+    const seqSetName = `Test SeqSet ${Date.now()}`;
+
+    await seqSetPage.createSeqSet(seqSetName, 'created in test', accession!);
+
+    await expect(pageWithGroup.getByRole('heading', { name: seqSetName })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add page object for SeqSet interactions in integration tests
- add dependent integration test that creates a seqset from a released sequence

## Testing
- `npm run format`
- `NODE_TLS_REJECT_UNAUTHORIZED=0 BASE_URL=https://main.loculus.org npx playwright test --workers=1 tests/specs/features/create-seqset.dependent.spec.ts` *(fails: Slow test file; 2 did not run)*

------
https://chatgpt.com/codex/tasks/task_e_683f8d662d0883259173c951eda6dcb8

🚀 Preview: Add `preview` label to enable