### PR TITLE
feat(website): improve seqset add button

### DIFF
--- a/website/src/components/SeqSetCitations/SeqSetListActions.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetListActions.tsx
@@ -23,7 +23,7 @@ const SeqSetListActionsInner: FC<SeqSetListActionsProps> = ({ clientConfig, acce
                     onClick={() => setCreateModalVisible(true)}
                 >
                     <AddBoxIcon fontSize='large' />
-                    Add SeqSet
+                    Create SeqSet
                 </button>
             </div>
             <Modal isModalVisible={createModalVisible} setModalVisible={setCreateModalVisible}>

--- a/website/src/components/SeqSetCitations/SeqSetListActions.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetListActions.tsx
@@ -16,13 +16,14 @@ const SeqSetListActionsInner: FC<SeqSetListActionsProps> = ({ clientConfig, acce
 
     return (
         <>
-            <div className='pl-2'>
+            <div className='pl-2 ml-auto'>
                 <button
                     data-testid='AddIcon'
-                    className='btn btn-sm btn-circle btn-ghost'
+                    className='btn btn-sm loculusColor text-white flex items-center gap-1'
                     onClick={() => setCreateModalVisible(true)}
                 >
                     <AddBoxIcon fontSize='large' />
+                    Add SeqSet
                 </button>
             </div>
             <Modal isModalVisible={createModalVisible} setModalVisible={setCreateModalVisible}>

--- a/website/src/pages/seqsets/index.astro
+++ b/website/src/pages/seqsets/index.astro
@@ -58,7 +58,7 @@ const editAccountUrl = urlForKeycloakAccountPage(keycloakClient!) + '/#/personal
                         <hr />
                         <div class='flex justify-start'>
                             <div class='w-11/12'>
-                                <div class='flex justify-start items-center py-8'>
+                                <div class='flex justify-between items-center py-8'>
                                     <h1 class='text-2xl font-semibold'>SeqSets</h1>
                                     <SeqSetListActions
                                         clientConfig={clientConfig}


### PR DESCRIPTION
In my opinion the Add SeqSet button was too subtle, and generally out of the style of our typical buttons - I even found myself missing it. This addresses that:

<img width="782" alt="image" src="https://github.com/user-attachments/assets/e05bd0e5-d9b7-464e-94d7-7c1298bd423b" />


------
https://chatgpt.com/codex/tasks/task_e_683f8fd167188325a05dfa0a3d1ff74a

🚀 Preview: Add `preview` label to enable