### PR TITLE
fix(backend): reject empty FASTA segments

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
@@ -109,7 +109,7 @@ class SubmitModel(
         batchSize: Int = 1000,
     ): List<SubmissionIdMapping> = try {
         log.info {
-            "Processing submission (type: ${submissionParams.uploadType.name})  with uploadId $uploadId"
+            "Processing submission (type: ${submissionParams.uploadType.name}) with uploadId $uploadId"
         }
 
         submissionIdFilesMappingPreconditionValidator

--- a/backend/src/main/kotlin/org/loculus/backend/utils/FastaReader.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/FastaReader.kt
@@ -1,5 +1,6 @@
 package org.loculus.backend.utils
 
+import org.loculus.backend.controller.UnprocessableEntityException
 import java.io.BufferedReader
 import java.io.InputStream
 import java.io.InputStreamReader
@@ -50,6 +51,9 @@ class FastaReader(inputStream: InputStream) :
         nextEntry = if (sampleName == null) {
             null
         } else {
+            if (sequence.isEmpty()) {
+                throw UnprocessableEntityException("No sequence data given for sample $sampleName.")
+            }
             FastaEntry(sampleName, sequence.toString())
         }
     }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
@@ -163,7 +163,7 @@ class SubmitEndpointTest(
     }
 
     @Test
-    fun `  GIVEN fasta data with unknown segment THEN data is not accepted`() {
+    fun `GIVEN fasta data with unknown segment THEN data is not accepted`() {
         submissionControllerClient.submit(
             SubmitFiles.metadataFileWith(
                 content = """
@@ -187,6 +187,36 @@ class SubmitEndpointTest(
                     "\$.detail",
                 ).value(
                     "The FASTA header commonHeader_nonExistingSegmentName ends with the segment name nonExistingSegmentName, which is not valid. Valid segment names: notOnlySegment, secondSegment",
+                ),
+            )
+    }
+
+    @Test
+    fun `GIVEN fasta data with empty segment THEN data is not accepted`() {
+        submissionControllerClient.submit(
+            SubmitFiles.metadataFileWith(
+                content = """
+                        submissionId	firstColumn
+                        commonHeader	someValue
+                """.trimIndent(),
+            ),
+            SubmitFiles.sequenceFileWith(
+                content = """
+                        >commonHeader_notOnlySegment
+                        AC
+                        >commonHeader_secondSegment
+                """.trimIndent(),
+            ),
+            organism = OTHER_ORGANISM,
+            groupId = groupId,
+        )
+            .andExpect(status().isUnprocessableEntity())
+            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(
+                jsonPath(
+                    "\$.detail",
+                ).value(
+                    "No sequence data given for sample commonHeader_secondSegment.",
                 ),
             )
     }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
@@ -222,6 +222,37 @@ class SubmitEndpointTest(
     }
 
     @Test
+    fun `GIVEN fasta data with whitespace-only segment THEN data is not accepted`() {
+        submissionControllerClient.submit(
+            SubmitFiles.metadataFileWith(
+                content = """
+                        submissionId	firstColumn
+                        commonHeader	someValue
+                """.trimIndent(),
+            ),
+            SubmitFiles.sequenceFileWith(
+                content = """
+                        >commonHeader_notOnlySegment
+                        AC
+                        >commonHeader_secondSegment
+                          
+                """.trimIndent(),
+            ),
+            organism = OTHER_ORGANISM,
+            groupId = groupId,
+        )
+            .andExpect(status().isUnprocessableEntity())
+            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(
+                jsonPath(
+                    "\$.detail",
+                ).value(
+                    "No sequence data given for sample commonHeader_secondSegment.",
+                ),
+            )
+    }
+
+    @Test
     fun `GIVEN submission with file mapping THEN returns an error`() {
         submissionControllerClient.submit(
             DefaultFiles.metadataFile,

--- a/docs/src/content/docs/reference/fasta-format.md
+++ b/docs/src/content/docs/reference/fasta-format.md
@@ -27,3 +27,5 @@ GTGTTCTCTTGAGTGTTGGCAAAATGGAAAACAAAATCGAGGTGAACAACAAAGATGAGATGAACAAATGGTTTGAGGAG
 ```
 
 Here, three segments are given named `L`, `M` and `S`, and the ID for the whole sequence is `test_NIHPAK`.
+
+A segment cannot be empty.


### PR DESCRIPTION
resolves #3800 

The FASTA reader was modified to raise an error if a segment doesn't have data.

### Manual testing

I've uploaded CCHF example file with one segment data but removed, and I got an error (as expected).

### Screenshot

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/802ec9fb-0e22-4ab7-accd-591a0822254b" />


### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://fix-empty-segment-err.loculus.org