### PR TITLE
fix(website): prevent text selection from triggering row click

### DIFF
--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -133,7 +133,7 @@ export const Table: FC<TableProps> = ({
         // Only treat as a row click if the user didn't change the selection
         const current = selection?.toString() ?? '';
         if (current && current !== mouseDownSelection.current) {
-        selection?.removeAllRanges();
+        //selection?.removeAllRanges();
         if (window.getSelection()?.toString()) {
             return;
         }

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -134,10 +134,9 @@ export const Table: FC<TableProps> = ({
         const sel = window.getSelection();
         const current = sel?.toString() ?? '';
         if (current && current !== mouseDownSelection.current) {
-        //selection?.removeAllRanges();
-        
+            //selection?.removeAllRanges();
+
             return;
-       
         }
 
         const detectMob = () => {

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -131,12 +131,13 @@ export const Table: FC<TableProps> = ({
 
     const handleRowClick = (e: React.MouseEvent<HTMLTableRowElement>, seqId: string) => {
         // Only treat as a row click if the user didn't change the selection
-        const current = selection?.toString() ?? '';
+        const sel = window.getSelection();
+        const current = sel?.toString() ?? '';
         if (current && current !== mouseDownSelection.current) {
         //selection?.removeAllRanges();
-        if (window.getSelection()?.toString()) {
+        
             return;
-        }
+       
         }
 
         const detectMob = () => {

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -123,6 +123,11 @@ export const Table: FC<TableProps> = ({
     };
 
     const handleRowClick = (e: React.MouseEvent<HTMLTableRowElement>, seqId: string) => {
+        // Don't treat the click as a row click if the user is selecting text
+        if (window.getSelection()?.toString()) {
+            return;
+        }
+
         const detectMob = () => {
             const toMatch = [/Android/i, /webOS/i, /iPhone/i, /iPod/i, /BlackBerry/i, /Windows Phone/i];
 

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -123,7 +123,7 @@ export const Table: FC<TableProps> = ({
     };
 
     const handleRowClick = (e: React.MouseEvent<HTMLTableRowElement>, seqId: string) => {
-        // Don't treat the click as a row click if the user is selecting text
+        // Don't treat the click as a row click if the user is just selecting text
         if (window.getSelection()?.toString()) {
             return;
         }

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -137,6 +137,7 @@ export const Table: FC<TableProps> = ({
         if (window.getSelection()?.toString()) {
             return;
         }
+        }
 
         const detectMob = () => {
             const toMatch = [/Android/i, /webOS/i, /iPhone/i, /iPod/i, /BlackBerry/i, /Windows Phone/i];

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -122,10 +122,18 @@ export const Table: FC<TableProps> = ({
         }
     };
 
+    const mouseDownSelection = useRef('');
+
+    const handleRowMouseDown = () => {
+        const sel = window.getSelection();
+        mouseDownSelection.current = sel?.toString() ?? '';
+    };
+
     const handleRowClick = (e: React.MouseEvent<HTMLTableRowElement>, seqId: string) => {
-        const selection = window.getSelection();
-        if (selection?.toString()) {
-            selection.removeAllRanges();
+        // Only treat as a row click if the user didn't change the selection
+        const current = selection?.toString() ?? '';
+        if (current && current !== mouseDownSelection.current) {
+        selection?.removeAllRanges();
         if (window.getSelection()?.toString()) {
             return;
         }
@@ -216,6 +224,7 @@ export const Table: FC<TableProps> = ({
                                     className={`hover:bg-primary-100 border-b border-gray-200 ${
                                         row[primaryKey] === previewedSeqId ? 'bg-gray-200' : ''
                                     } cursor-pointer`}
+                                    onMouseDown={handleRowMouseDown}
                                     onClick={(e) => handleRowClick(e, row[primaryKey] as string)}
                                     onAuxClick={(e) => handleRowClick(e, row[primaryKey] as string)}
                                     data-testid='sequence-row'

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -123,7 +123,9 @@ export const Table: FC<TableProps> = ({
     };
 
     const handleRowClick = (e: React.MouseEvent<HTMLTableRowElement>, seqId: string) => {
-        // Don't treat the click as a row click if the user is just selecting text
+        const selection = window.getSelection();
+        if (selection?.toString()) {
+            selection.removeAllRanges();
         if (window.getSelection()?.toString()) {
             return;
         }

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -134,8 +134,6 @@ export const Table: FC<TableProps> = ({
         const sel = window.getSelection();
         const current = sel?.toString() ?? '';
         if (current && current !== mouseDownSelection.current) {
-            //selection?.removeAllRanges();
-
             return;
         }
 


### PR DESCRIPTION
resolves #4311
- avoid opening the sequence  when the user is just trying to select text in the search results table



------
https://chatgpt.com/codex/tasks/task_e_684024fd9cfc8325ac24d80868b61e15

🚀 Preview: https://codex-prevent-click-on-te.loculus.org