### PR TITLE
style(website): de-emphasize seqset author display

### DIFF
--- a/website/src/components/SeqSetCitations/AuthorDetails.tsx
+++ b/website/src/components/SeqSetCitations/AuthorDetails.tsx
@@ -32,11 +32,9 @@ export const AuthorDetails: FC<Props> = ({
     };
 
     const renderPartialDetails = () => (
-        <div className='flex flex-col items-center justify-center'>
-            <AccountCircleIcon fontSize={60} />
-            <div className='flex flex-col items-left justify-center'>
-                <div className='text-60'>{renderName()}</div>
-            </div>
+        <div className='flex flex-row items-center text-sm text-gray-500'>
+            <AccountCircleIcon fontSize={20} className='mr-1' />
+            <span>{renderName()}</span>
         </div>
     );
 


### PR DESCRIPTION
relates to #4270

Dramatically reduces the salience of the "seqset author" on the seqset page

We can amend this further but its pretty clearly an improvement over current state

<img width="1281" alt="image" src="https://github.com/user-attachments/assets/d663dd17-58a3-4711-8390-33a168f19cb6" />


------
https://chatgpt.com/codex/tasks/task_e_68401e2254d4832580913f6a41fafe4b

🚀 Preview: Add `preview` label to enable