### PR TITLE
fix(website): avoid unnecessary url params

### DIFF
--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -233,10 +233,17 @@ export const InnerSearchFullUI = ({
     };
 
     const setAColumnVisibility = (fieldName: string, visible: boolean) => {
-        setState((prev: any) => ({
-            ...prev,
-            [`${COLUMN_VISIBILITY_PREFIX}${fieldName}`]: visible ? 'true' : 'false',
-        }));
+        setState((prev: any) => {
+            const newState = { ...prev };
+            const key = `${COLUMN_VISIBILITY_PREFIX}${fieldName}`;
+            const defaultVisible = schema.tableColumns.includes(fieldName);
+            if (visible === defaultVisible) {
+                delete newState[key];
+            } else {
+                newState[key] = visible ? 'true' : 'false';
+            }
+            return newState;
+        });
     };
 
     useEffect(() => {


### PR DESCRIPTION
Resolves #4319

- stop storing default column visibility states in the URL

I manually tested that I can hit "Select none" and get no columns displayed with the state stored appropriately in the URL - and that "Select all" also still works, and various things in between


------
https://chatgpt.com/codex/tasks/task_e_684053a648788325a903def53889b7b7

🚀 Preview: Add `preview` label to enable