### PR TITLE
fix(backend): prevent duplicate open data use terms

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsPreconditionValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsPreconditionValidator.kt
@@ -36,7 +36,7 @@ class DataUseTermsPreconditionValidator(private val dateProvider: DateProvider) 
                     DataUseTermsType.fromString(it[DataUseTermsTable.dataUseTermsTypeColumn]) == DataUseTermsType.OPEN
                 }
             ) {
-                throw UnprocessableEntityException("Data use terms are already OPEN.")
+                throw UnprocessableEntityException("The data use terms have already been set to 'Open' - this should appear in the next several minutes.")
             }
         }
 

--- a/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsPreconditionValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsPreconditionValidator.kt
@@ -31,6 +31,15 @@ class DataUseTermsPreconditionValidator(private val dateProvider: DateProvider) 
                 "$accessions and new data use terms $newDataUseTerms. Found $dataUseTerms."
         }
 
+        if (newDataUseTerms is DataUseTerms.Open) {
+            if (dataUseTerms.any {
+                    DataUseTermsType.fromString(it[DataUseTermsTable.dataUseTermsTypeColumn]) == DataUseTermsType.OPEN
+                }
+            ) {
+                throw UnprocessableEntityException("Data use terms are already OPEN.")
+            }
+        }
+
         if (newDataUseTerms is DataUseTerms.Restricted) {
             dataUseTerms.forEach {
                 val dataUseTermsType = DataUseTermsType.fromString(it[DataUseTermsTable.dataUseTermsTypeColumn])

--- a/backend/src/test/kotlin/org/loculus/backend/controller/datauseterms/DataUseTermsControllerTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/datauseterms/DataUseTermsControllerTest.kt
@@ -201,7 +201,7 @@ class DataUseTermsControllerTest(
                 newDataUseTerms = DataUseTerms.Open,
                 expectedStatus = status().isUnprocessableEntity,
                 expectedContentType = MediaType.APPLICATION_JSON_VALUE,
-                expectedDetailContains = "Data use terms are already OPEN.",
+                expectedDetailContains = "The data use terms have already been set to 'Open' - this should appear in the next several minutes.",
             ),
             DataUseTermsTestCase(
                 setupDataUseTerms = DataUseTerms.Restricted(dateMonthsFromNow(6)),

--- a/backend/src/test/kotlin/org/loculus/backend/controller/datauseterms/DataUseTermsControllerTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/datauseterms/DataUseTermsControllerTest.kt
@@ -146,7 +146,10 @@ class DataUseTermsControllerTest(
     @Test
     fun `WHEN superuser changes data use terms of an entry of other group THEN is successful`() {
         val accessions = submissionConvenienceClient
-            .submitDefaultFiles(username = DEFAULT_USER_NAME)
+            .submitDefaultFiles(
+                username = DEFAULT_USER_NAME,
+                dataUseTerms = DataUseTerms.Restricted(dateMonthsFromNow(6)),
+            )
             .submissionIdMappings
             .map { it.accession }
 
@@ -160,8 +163,8 @@ class DataUseTermsControllerTest(
             .andExpect(status().isNoContent)
 
         client.getDataUseTerms(accession = accessions.first())
-            .andExpect(jsonPath("\$[0].accession").value(accessions.first()))
-            .andExpect(jsonPath("\$[0].dataUseTerms.type").value(DataUseTermsType.OPEN.name))
+            .andExpect(jsonPath("\$[1].accession").value(accessions.first()))
+            .andExpect(jsonPath("\$[1].dataUseTerms.type").value(DataUseTermsType.OPEN.name))
     }
 
     companion object {
@@ -195,6 +198,13 @@ class DataUseTermsControllerTest(
         fun dataUseTermsTestCases(): List<DataUseTermsTestCase> = listOf(
             DataUseTermsTestCase(
                 setupDataUseTerms = DataUseTerms.Open,
+                newDataUseTerms = DataUseTerms.Open,
+                expectedStatus = status().isUnprocessableEntity,
+                expectedContentType = MediaType.APPLICATION_JSON_VALUE,
+                expectedDetailContains = "Data use terms are already OPEN.",
+            ),
+            DataUseTermsTestCase(
+                setupDataUseTerms = DataUseTerms.Restricted(dateMonthsFromNow(6)),
                 newDataUseTerms = DataUseTerms.Open,
                 expectedStatus = status().isNoContent,
                 expectedContentType = null,


### PR DESCRIPTION
## Summary
- throw error on OPEN to OPEN data use term updates
- update superuser test to use Restricted → Open
- add Restricted → Open case to parameterized tests

## Testing
- `./gradlew ktlintFormat`
- `USE_NONDOCKER_INFRA=true ./gradlew test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68405189bc8c83259123e71e8cce72cd

🚀 Preview: Add `preview` label to enable