### PR TITLE
fix(backend): prevent open sequence being set to Open

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsPreconditionValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsPreconditionValidator.kt
@@ -36,7 +36,10 @@ class DataUseTermsPreconditionValidator(private val dateProvider: DateProvider) 
                     DataUseTermsType.fromString(it[DataUseTermsTable.dataUseTermsTypeColumn]) == DataUseTermsType.OPEN
                 }
             ) {
-                throw UnprocessableEntityException("The data use terms have already been set to 'Open':" + " this will take efect in the next several minutes.")
+                throw UnprocessableEntityException(
+                    "The data use terms have already been set to 'Open':" +
+                        " this will take efect in the next several minutes.",
+                )
             }
         }
 

--- a/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsPreconditionValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsPreconditionValidator.kt
@@ -37,7 +37,7 @@ class DataUseTermsPreconditionValidator(private val dateProvider: DateProvider) 
                 }
             ) {
                 throw UnprocessableEntityException(
-                    "The data use terms have already been set to 'Open':" +
+                    "The data use terms have already been set to 'Open'-" +
                         " this will take effect in the next several minutes.",
                 )
             }

--- a/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsPreconditionValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsPreconditionValidator.kt
@@ -36,7 +36,7 @@ class DataUseTermsPreconditionValidator(private val dateProvider: DateProvider) 
                     DataUseTermsType.fromString(it[DataUseTermsTable.dataUseTermsTypeColumn]) == DataUseTermsType.OPEN
                 }
             ) {
-                throw UnprocessableEntityException("The data use terms have already been set to 'Open' - this should appear in the next several minutes.")
+                throw UnprocessableEntityException("The data use terms have already been set to 'Open':" + "this will take efect in the next several minutes.")
             }
         }
 

--- a/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsPreconditionValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsPreconditionValidator.kt
@@ -36,7 +36,7 @@ class DataUseTermsPreconditionValidator(private val dateProvider: DateProvider) 
                     DataUseTermsType.fromString(it[DataUseTermsTable.dataUseTermsTypeColumn]) == DataUseTermsType.OPEN
                 }
             ) {
-                throw UnprocessableEntityException("Data use terms are already OPEN.")
+                throw UnprocessableEntityException("The data use terms have already been set to 'Open' - this should appear in the next several minutes.")
             }
         }
 

--- a/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsPreconditionValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsPreconditionValidator.kt
@@ -36,7 +36,7 @@ class DataUseTermsPreconditionValidator(private val dateProvider: DateProvider) 
                     DataUseTermsType.fromString(it[DataUseTermsTable.dataUseTermsTypeColumn]) == DataUseTermsType.OPEN
                 }
             ) {
-                throw UnprocessableEntityException("The data use terms have already been set to 'Open':" + "this will take efect in the next several minutes.")
+                throw UnprocessableEntityException("The data use terms have already been set to 'Open':" + " this will take efect in the next several minutes.")
             }
         }
 

--- a/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsPreconditionValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsPreconditionValidator.kt
@@ -31,6 +31,15 @@ class DataUseTermsPreconditionValidator(private val dateProvider: DateProvider) 
                 "$accessions and new data use terms $newDataUseTerms. Found $dataUseTerms."
         }
 
+        if (newDataUseTerms is DataUseTerms.Open) {
+            if (dataUseTerms.any {
+                    DataUseTermsType.fromString(it[DataUseTermsTable.dataUseTermsTypeColumn]) == DataUseTermsType.OPEN
+                }
+            ) {
+                throw UnprocessableEntityException("Data use terms are already OPEN.")
+            }
+        }
+
         if (newDataUseTerms is DataUseTerms.Restricted) {
             dataUseTerms.forEach {
                 val dataUseTermsType = DataUseTermsType.fromString(it[DataUseTermsTable.dataUseTermsTypeColumn])

--- a/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsPreconditionValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsPreconditionValidator.kt
@@ -38,7 +38,7 @@ class DataUseTermsPreconditionValidator(private val dateProvider: DateProvider) 
             ) {
                 throw UnprocessableEntityException(
                     "The data use terms have already been set to 'Open':" +
-                        " this will take efect in the next several minutes.",
+                        " this will take effect in the next several minutes.",
                 )
             }
         }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/datauseterms/DataUseTermsControllerTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/datauseterms/DataUseTermsControllerTest.kt
@@ -201,7 +201,7 @@ class DataUseTermsControllerTest(
                 newDataUseTerms = DataUseTerms.Open,
                 expectedStatus = status().isUnprocessableEntity,
                 expectedContentType = MediaType.APPLICATION_JSON_VALUE,
-                expectedDetailContains = "The data use terms have already been set to 'Open' - this should appear in the next several minutes.",
+                expectedDetailContains = "The data use terms have already been set to 'Open'",
             ),
             DataUseTermsTestCase(
                 setupDataUseTerms = DataUseTerms.Restricted(dateMonthsFromNow(6)),

--- a/backend/src/test/kotlin/org/loculus/backend/controller/datauseterms/DataUseTermsControllerTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/datauseterms/DataUseTermsControllerTest.kt
@@ -201,7 +201,7 @@ class DataUseTermsControllerTest(
                 newDataUseTerms = DataUseTerms.Open,
                 expectedStatus = status().isUnprocessableEntity,
                 expectedContentType = MediaType.APPLICATION_JSON_VALUE,
-                expectedDetailContains = "Data use terms are already OPEN.",
+                expectedDetailContains = "The data use terms have already been set to 'Open' - this should appear in the next several minutes.",
             ),
             DataUseTermsTestCase(
                 setupDataUseTerms = DataUseTerms.Restricted(dateMonthsFromNow(6)),

--- a/backend/src/test/kotlin/org/loculus/backend/controller/datauseterms/DataUseTermsControllerTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/datauseterms/DataUseTermsControllerTest.kt
@@ -146,7 +146,10 @@ class DataUseTermsControllerTest(
     @Test
     fun `WHEN superuser changes data use terms of an entry of other group THEN is successful`() {
         val accessions = submissionConvenienceClient
-            .submitDefaultFiles(username = DEFAULT_USER_NAME)
+            .submitDefaultFiles(
+                username = DEFAULT_USER_NAME,
+                dataUseTerms = DataUseTerms.Restricted(dateMonthsFromNow(6)),
+            )
             .submissionIdMappings
             .map { it.accession }
 
@@ -160,8 +163,8 @@ class DataUseTermsControllerTest(
             .andExpect(status().isNoContent)
 
         client.getDataUseTerms(accession = accessions.first())
-            .andExpect(jsonPath("\$[0].accession").value(accessions.first()))
-            .andExpect(jsonPath("\$[0].dataUseTerms.type").value(DataUseTermsType.OPEN.name))
+            .andExpect(jsonPath("\$[1].accession").value(accessions.first()))
+            .andExpect(jsonPath("\$[1].dataUseTerms.type").value(DataUseTermsType.OPEN.name))
     }
 
     companion object {
@@ -195,6 +198,13 @@ class DataUseTermsControllerTest(
         fun dataUseTermsTestCases(): List<DataUseTermsTestCase> = listOf(
             DataUseTermsTestCase(
                 setupDataUseTerms = DataUseTerms.Open,
+                newDataUseTerms = DataUseTerms.Open,
+                expectedStatus = status().isUnprocessableEntity,
+                expectedContentType = MediaType.APPLICATION_JSON_VALUE,
+                expectedDetailContains = "Data use terms are already OPEN.",
+            ),
+            DataUseTermsTestCase(
+                setupDataUseTerms = DataUseTerms.Restricted(dateMonthsFromNow(6)),
                 newDataUseTerms = DataUseTerms.Open,
                 expectedStatus = status().isNoContent,
                 expectedContentType = null,


### PR DESCRIPTION
resolves #4272

This (codex) revealed various test cases which didn't make a lot of sense!


When you first do it you get this:

<img width="360" alt="image" src="https://github.com/user-attachments/assets/cbdfb185-3824-4e56-bdbc-12d93ecfe4b9" />

(that was already the case)

now when you try again you get this (minus the typo which I will have fixed by the time you read this)

<img width="439" alt="image" src="https://github.com/user-attachments/assets/c08180e0-a577-4218-82d3-1fd65b33757f" />

🚀 Preview: Add `preview` label to enable