### PR TITLE
feat(website): add analytics tracking

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -23,6 +23,10 @@ export default defineConfig({
                         'src': 'https://plausible.io/js/script.js',
                     },
                 },
+                {
+                    tag: 'script',
+                    children: 'window.trackLoculusEvent=function(x){window.plausible&&window.plausible("linkout",{props:{link:x}});};',
+                },
             ],
             editLink: {
                 baseUrl: 'https://github.com/loculus-project/loculus/edit/main/docs/',

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -23,10 +23,6 @@ export default defineConfig({
                         'src': 'https://plausible.io/js/script.js',
                     },
                 },
-                {
-                    tag: 'script',
-                    children: 'window.trackLoculusEvent=function(x){window.plausible&&window.plausible("linkout",{props:{link:x}});};',
-                },
             ],
             editLink: {
                 baseUrl: 'https://github.com/loculus-project/loculus/edit/main/docs/',

--- a/kubernetes/loculus/values_preview_server.yaml
+++ b/kubernetes/loculus/values_preview_server.yaml
@@ -37,7 +37,7 @@ secrets:
 previewDocs: true
 robotsNoindexHeader: true
 disableEnaSubmission: false
-additionalHeadHTML: '<script defer data-domain="loculus.org" src="https://plausible.io/js/script.js"></script>'
+additionalHeadHTML: '<script defer data-domain="loculus.org" src="https://plausible.io/js/script.js"></script><script>window.trackLoculusEvent=function(x){window.plausible&&window.plausible("linkout",{props:{link:x}});}</script>'
 ingest:
   ncbiGatewayUrl: "https://ncbi-temp-proxy.api.taxonium.org/datasets/v2"
   mirrorBucket: "https://hel1.your-objectstorage.com/loculus-public/mirror/"

--- a/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
@@ -89,6 +89,9 @@ export const LinkOutMenu: FC<LinkOutMenuProps> = ({
     };
 
     const openUrl = (url: string) => {
+        if (typeof window !== 'undefined' && typeof window.trackLoculusEvent === 'function' && currentLinkOut.current) {
+            window.trackLoculusEvent(currentLinkOut.current.name);
+        }
         if (url.length > approxMaxAcceptableUrlLength) {
             alert(
                 `Warning: The generated URL for the tool is very long (${url.length} characters) and may not work in some browsers or servers. This may relate to your current search filter settings.`,

--- a/website/src/env.d.ts
+++ b/website/src/env.d.ts
@@ -22,3 +22,7 @@ declare namespace App {
         session?: Session;
     }
 }
+
+interface Window {
+    trackLoculusEvent?: (x: string) => void;
+}


### PR DESCRIPTION
## Summary
- extend docs head config to define a `trackLoculusEvent` helper
- insert the analytics helper next to the plausible script in Kubernetes preview values
- call `trackLoculusEvent` for each linkout in `LinkOutMenu`
- declare `trackLoculusEvent` on the `Window` interface

## Testing
- `npm run test` *(fails: AggregateError ECONNREFUSED)*
- `npm run check-types`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68405546051883259b6f9ee8c254408e

🚀 Preview: Add `preview` label to enable