### PR TITLE
fix(website): improve seqset details layout on mobile

### DIFF
--- a/website/src/pages/seqsets/[seqSetId].[version].astro
+++ b/website/src/pages/seqsets/[seqSetId].[version].astro
@@ -59,8 +59,8 @@ const authorResponse = seqSet !== undefined ? await seqSetClient.getAuthor(seqSe
     <div class='flex flex-col justify-center max-w-7xl'>
         {
             seqSet !== undefined ? (
-                <div class='flex flex-row items-left'>
-                    <div class='w-1/5 flex flex-col justify-start items-center'>
+                <div class='flex flex-col md:flex-row items-left'>
+                    <div class='w-full md:w-1/5 flex flex-col justify-start items-center'>
                         {authorResponse?.isOk() ? (
                             <AuthorDetails
                                 displayFullDetails={false}
@@ -77,7 +77,7 @@ const authorResponse = seqSet !== undefined ? await seqSetClient.getAuthor(seqSe
                             />
                         )}
                     </div>
-                    <div class='w-4/5 pl-6'>
+                    <div class='w-full md:w-4/5 md:pl-6 mt-6 md:mt-0'>
                         {seqSetRecordsResponse.isOk() ? (
                             <SeqSetItemActions
                                 clientConfig={clientConfig}


### PR DESCRIPTION
relates to #4323

- adjust seqset details layout to look better on small screens

<img width="314" alt="image" src="https://github.com/user-attachments/assets/b40b7928-f1ef-4937-9caa-c32143deab30" />


Table still bad, but we can tackle that later


------
https://chatgpt.com/codex/tasks/task_e_68405ced89f0832580c2e76d3e34f35a

🚀 Preview: https://codex-improve-seqset-deta.loculus.org