### PR TITLE
fix(deployment): Don't timestamp keycloak so it doesn't restart every 24 hrs (or on rollouts most likely)

### DIFF
--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -14,8 +14,6 @@ spec:
       component: keycloak
   template:
     metadata:
-      annotations:
-        timestamp: {{ now | quote }}
       labels:
         app: loculus
         component: keycloak


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/2604 which we fear this is likely logging everyone out every 24 hrs (including sometimes while using the site). The tradeoff is during dev you might now need to restart keycloak manually. But let's fix this for now and come up with a better solution later if we need to.

🚀 Preview: https://keycloaktimestamp.loculus.org