### PR TITLE
feat(website): subtle zebra striping for search rows

### DIFF
--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -207,7 +207,11 @@ export const Table: FC<TableProps> = ({
                                 <tr
                                     key={index}
                                     className={`hover:bg-primary-100 border-b border-gray-200 ${
-                                        row[primaryKey] === previewedSeqId ? 'bg-gray-200' : ''
+                                        row[primaryKey] === previewedSeqId
+                                            ? 'bg-gray-200'
+                                            : index % 2 === 0
+                                              ? 'bg-gray-50'
+                                              : 'bg-white'
                                     } cursor-pointer`}
                                     onClick={(e) => handleRowClick(e, row[primaryKey] as string)}
                                     onAuxClick={(e) => handleRowClick(e, row[primaryKey] as string)}


### PR DESCRIPTION
## Summary
- add very light alternating row colours in the search table

## Testing
- `npm run format`
- `npm run check-types`
- `npm run test` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68408c17cadc8325b072e86e8e5d8bcd