### PR TITLE
fix(website): display authors as "FirstName LastName" in topmatter

### DIFF
--- a/website/src/components/SequenceDetailsPage/AuthorList.tsx
+++ b/website/src/components/SequenceDetailsPage/AuthorList.tsx
@@ -43,7 +43,11 @@ export const AuthorList: FC<AuthorsListProps> = ({ authors }) => {
                 {data.afterEllipsis.map((author, index) => (
                     <span key={index}>
                         {author}
-                        {index === data.afterEllipsis.length - 2 ? ' & ' : index !== data.afterEllipsis.length - 1 ? ', ' : ''}
+                        {index === data.afterEllipsis.length - 2
+                            ? ' & '
+                            : index !== data.afterEllipsis.length - 1
+                              ? ', '
+                              : ''}
                     </span>
                 ))}
             </>

--- a/website/src/components/SequenceDetailsPage/AuthorList.tsx
+++ b/website/src/components/SequenceDetailsPage/AuthorList.tsx
@@ -27,7 +27,7 @@ export const AuthorList: FC<AuthorsListProps> = ({ authors }) => {
         authorsElements = authors.map((author, index) => (
             <span key={index}>
                 {author}
-                {index !== authors.length - 1 ? '; ' : ''}
+                {index !== authors.length - 1 ? ', ' : ''}
             </span>
         ));
     } else {
@@ -36,14 +36,14 @@ export const AuthorList: FC<AuthorsListProps> = ({ authors }) => {
                 {data.beforeEllipsis.map((author, index) => (
                     <span key={index}>
                         {author}
-                        {'; '}
+                        {', '}
                     </span>
                 ))}
                 <span>...; </span>
                 {data.afterEllipsis.map((author, index) => (
                     <span key={index}>
                         {author}
-                        {index !== data.afterEllipsis.length - 1 ? '; ' : ''}
+                        {index !== data.afterEllipsis.length - 1 ? ', ' : ''}
                     </span>
                 ))}
             </>

--- a/website/src/components/SequenceDetailsPage/AuthorList.tsx
+++ b/website/src/components/SequenceDetailsPage/AuthorList.tsx
@@ -27,7 +27,7 @@ export const AuthorList: FC<AuthorsListProps> = ({ authors }) => {
         authorsElements = authors.map((author, index) => (
             <span key={index}>
                 {author}
-                {index !== authors.length - 1 ? ', ' : ''}
+                {index === authors.length - 2 ? ' & ' : index !== authors.length - 1 ? ', ' : ''}
             </span>
         ));
     } else {
@@ -43,7 +43,7 @@ export const AuthorList: FC<AuthorsListProps> = ({ authors }) => {
                 {data.afterEllipsis.map((author, index) => (
                     <span key={index}>
                         {author}
-                        {index !== data.afterEllipsis.length - 1 ? ', ' : ''}
+                        {index === data.afterEllipsis.length - 2 ? ' & ' : index !== data.afterEllipsis.length - 1 ? ', ' : ''}
                     </span>
                 ))}
             </>

--- a/website/src/components/SequenceDetailsPage/getDataTableData.spec.ts
+++ b/website/src/components/SequenceDetailsPage/getDataTableData.spec.ts
@@ -15,11 +15,7 @@ describe('getDataTableData', () => {
 
     test('should move authors to topmatter', () => {
         const data = getDataTableData(testTableDataEntries);
-        expect(data.topmatter.authors).toStrictEqual([
-            'First1 Last1',
-            'First2 Last2',
-            'First3 Last3',
-        ]);
+        expect(data.topmatter.authors).toStrictEqual(['First1 Last1', 'First2 Last2', 'First3 Last3']);
         expect(
             data.table
                 .flatMap((x) => x.rows)

--- a/website/src/components/SequenceDetailsPage/getDataTableData.spec.ts
+++ b/website/src/components/SequenceDetailsPage/getDataTableData.spec.ts
@@ -15,7 +15,11 @@ describe('getDataTableData', () => {
 
     test('should move authors to topmatter', () => {
         const data = getDataTableData(testTableDataEntries);
-        expect(data.topmatter.authors).toStrictEqual(['author 1', 'author 2', 'author 3']);
+        expect(data.topmatter.authors).toStrictEqual([
+            'First1 Last1',
+            'First2 Last2',
+            'First3 Last3',
+        ]);
         expect(
             data.table
                 .flatMap((x) => x.rows)
@@ -49,7 +53,7 @@ const testTableDataEntries: TableDataEntry[] = [
     {
         label: 'Authors',
         name: 'authors',
-        value: 'author 1; author 2; author 3',
+        value: 'Last1, First1; Last2, First2; Last3, First3',
         header: 'Header 2',
         type: { kind: 'metadata', metadataType: 'authors' },
     },

--- a/website/src/components/SequenceDetailsPage/getDataTableData.ts
+++ b/website/src/components/SequenceDetailsPage/getDataTableData.ts
@@ -12,9 +12,9 @@ export type DataTableData = {
 };
 
 function formatAuthorName(author: string): string {
-    const [last, first] = author.split(',').map((x) => x.trim());
-    if (first !== undefined && last !== undefined && first.length > 0 && last.length > 0) {
-        return `${first} ${last}`;
+    const parts = author.split(',').map((x) => x.trim());
+    if (parts.length >= 2 && parts[0].length > 0 && parts[1].length > 0) {
+        return `${parts[1]} ${parts[0]}`;
     }
     return author.trim();
 }

--- a/website/src/components/SequenceDetailsPage/getDataTableData.ts
+++ b/website/src/components/SequenceDetailsPage/getDataTableData.ts
@@ -10,6 +10,14 @@ export type DataTableData = {
         rows: TableDataEntry[];
     }[];
 };
+
+function formatAuthorName(author: string): string {
+    const [last, first] = author.split(',').map((x) => x.trim());
+    if (first !== undefined && last !== undefined && first.length > 0 && last.length > 0) {
+        return `${first} ${last}`;
+    }
+    return author.trim();
+}
 function grouping(listTableDataEntries: TableDataEntry[]): TableDataEntry[] {
     const result: TableDataEntry[] = [];
     const groupedEntries = new Map<string, TableDataEntry[]>();
@@ -71,7 +79,9 @@ export function getDataTableData(listTableDataEntries: TableDataEntry[]): DataTa
             result.topmatter.authors = entry.value
                 .toString()
                 .split(';')
-                .map((x) => x.trim());
+                .map((x) => x.trim())
+                .filter((x) => x.length > 0)
+                .map(formatAuthorName);
             continue;
         }
 

--- a/website/src/components/SequenceDetailsPage/getDataTableData.ts
+++ b/website/src/components/SequenceDetailsPage/getDataTableData.ts
@@ -79,8 +79,7 @@ export function getDataTableData(listTableDataEntries: TableDataEntry[]): DataTa
             result.topmatter.authors = entry.value
                 .toString()
                 .split(';')
-                .map((x) => x.trim())
-                .filter((x) => x.length > 0)
+                .filter((x) => x.trim().length > 0)
                 .map(formatAuthorName);
             continue;
         }


### PR DESCRIPTION
Relates to https://github.com/loculus-project/loculus/issues/4293

![image](https://github.com/user-attachments/assets/d7dd54fb-7824-4b98-a009-32ab50e42b75)


- display authors as `FirstName Lastname` in the topmatter, to avoid ugly semicolons
- uses "&" for last author
- other places remain as before, but that inconsistency makes sense: in a tabular form you do probably want to start with the surname
- @chaoran-chen suggested we at some point make the format customisable for Loculus. I have nothing against anyone doing that whenever they want, but I don't think it blocks us implementing something that works well for our current deployments.

I think we should consider if we think this looks better than what we have atm: I am a bit uncertain - I think it will look better with full first names, but with initials it's a bit meh.

------
https://chatgpt.com/codex/tasks/task_e_6840bdc93a9c83258b381f3c9af02094

🚀 Preview: https://codex-format-authors-as-f.loculus.org