### PR TITLE
chore(backend): fix gradle deprecation warning

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -98,8 +98,8 @@ tasks.named('test') {
     useJUnitPlatform()
     testLogging {
         events TestLogEvent.FAILED
-        exceptionFormat TestExceptionFormat.FULL
-        showExceptions true
+        exceptionFormat = TestExceptionFormat.FULL
+        showExceptions = true
     }
 }
 


### PR DESCRIPTION
This fixes the "Space-assignment syntax in Groovy DSL has been deprecated." warning.

<img width="702" alt="image" src="https://github.com/user-attachments/assets/f6d6fc2e-4917-4ad4-926a-dba09ae23340" />


### PR Checklist
~- [ ] All necessary documentation has been adapted.~
~- [ ] The implemented feature is covered by appropriate, automated tests.~
~- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~
