### PR TITLE
chore: Fix typos using codespell

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
@@ -25,7 +25,7 @@ data class FileSharing(val outputFileUrlType: FileUrlType = FileUrlType.WEBSITE)
 
 /**
  * The types URLs that can be output for a file.
- * We can either link direclty to the file in S3, or link to the proxy endpoint on
+ * We can either link directly to the file in S3, or link to the proxy endpoint on
  * the website.
  */
 enum class FileUrlType {

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
@@ -376,7 +376,7 @@ class GetReleasedDataEndpointTest(
     }
 
     /**
-     * This test ist relevant for EarliestReleaseDateFinder which relies on this particular ordering to be returned.
+     * This test is relevant for EarliestReleaseDateFinder which relies on this particular ordering to be returned.
      */
     @Test
     fun `GIVEN multiple accessions with multiple versions THEN results are ordered by accession and version`() {

--- a/docs/src/content/docs/for-administrators/configuring-extra-files.md
+++ b/docs/src/content/docs/for-administrators/configuring-extra-files.md
@@ -69,7 +69,7 @@ my-organism:
 
 The example above configures the `raw_reads` file category.
 
-If a user submits these files, they will be passed along to the processing pipeline as well, and the pipeline can read them, pass them through as ouput files, or generate additional fields or process them in any other way.
+If a user submits these files, they will be passed along to the processing pipeline as well, and the pipeline can read them, pass them through as output files, or generate additional fields or process them in any other way.
 
 ## Configuring output files
 

--- a/docs/src/content/docs/for-users/search-sequences.md
+++ b/docs/src/content/docs/for-users/search-sequences.md
@@ -38,4 +38,4 @@ Dates like the collection date of a sequence can't always be exactly given as a 
 
 ![Comparison of strict and not strict range overlap.](/images/strict_not_strict.drawio.svg)
 
-The graphic above illustrates this, in Loculus these two modes are called "strict" and "not strict". Strict means, that the range of the date of the sequences must wholy be contained in the search range. Not strict means that a partial overlap is sufficient.
+The graphic above illustrates this, in Loculus these two modes are called "strict" and "not strict". Strict means, that the range of the date of the sequences must wholly be contained in the search range. Not strict means that a partial overlap is sufficient.

--- a/integration-tests/tests/specs/features/revise-sequence.spec.ts
+++ b/integration-tests/tests/specs/features/revise-sequence.spec.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test';
 import { SearchPage } from '../../pages/search.page';
 import { ReviewPage } from '../../pages/review.page';
 
-test('revising sequence data works: segement can be deleted; segment can be edited', async ({
+test('revising sequence data works: segment can be deleted; segment can be edited', async ({
     pageWithReleasedSequence: page,
 }) => {
     test.setTimeout(60000);

--- a/website/src/components/SearchPage/fields/DateRangeField.tsx
+++ b/website/src/components/SearchPage/fields/DateRangeField.tsx
@@ -12,7 +12,7 @@ export type DateRangeFieldProps = {
 
 /**
  * Whether to use strict mode or not is defined based on the fields that are given.
- * `true` is returned if an ambiguous combiation of fields is defined.
+ * `true` is returned if an ambiguous combination of fields is defined.
  */
 function isStrictMode(
     lowerFromDefined: boolean,

--- a/website/src/components/Submission/FileUpload/ColumnMapping.ts
+++ b/website/src/components/Submission/FileUpload/ColumnMapping.ts
@@ -90,13 +90,13 @@ export class ColumnMapping {
         const inputRows: string[][] = parsed.data;
         const headersInFile = inputRows.splice(0, 1)[0];
         const headers: string[] = [];
-        const indicies: number[] = [];
+        const indices: number[] = [];
         this.entries().forEach(([sourceCol, targetCol]) => {
             if (targetCol === null) return;
             headers.push(targetCol);
-            indicies.push(headersInFile.findIndex((sourceHeader) => sourceHeader === sourceCol));
+            indices.push(headersInFile.findIndex((sourceHeader) => sourceHeader === sourceCol));
         });
-        const newRows = inputRows.map((row) => indicies.map((i) => row[i]));
+        const newRows = inputRows.map((row) => indices.map((i) => row[i]));
         const newFileContent = Papa.unparse([headers, ...newRows], { delimiter: '\t', newline: '\n' });
         return new File([newFileContent], 'remapped.tsv');
     }

--- a/website/src/components/Submission/FormOrUploadWrapper.tsx
+++ b/website/src/components/Submission/FormOrUploadWrapper.tsx
@@ -12,7 +12,7 @@ import { EditableSequences, SequencesForm } from '../Edit/SequencesForm';
 export type InputMode = 'form' | 'bulk';
 
 /**
- * A wrapper type for a metadata file (TSV) and sequenc file (FASTA) which together
+ * A wrapper type for a metadata file (TSV) and sequence file (FASTA) which together
  * make up the sequence data.
  * The sequenceFile is optional, because Loculus also can be configured to not require
  * submission of consensus sequences. If consensus sequences are enabled, the file should be

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -29,7 +29,7 @@ export const customDisplay = z.object({
 
 /**
  * RangeOverlapSearch to configure on two fields that together allow to query
- * For an overlap of a search range and a targer range
+ * For an overlap of a search range and a target range
  */
 export const rangeOverlapSearch = z.object({
     /**


### PR DESCRIPTION
Ran `codespell --write-changes -i 2` and reviewed typo fixes to be correct.