### PR TITLE
ci(integration-tests): run different browser tests in different containers

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,6 +22,12 @@ jobs:
       checks: read
       actions: read # Required by workflow-telemetry-action
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        browser:
+          - chromium
+          - firefox
     timeout-minutes: 45
     env:
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -74,6 +80,8 @@ jobs:
       - name: Sleep for 10 secs
         run: sleep 10
       - name: Run Integration test
+        env:
+          BROWSER: ${{ matrix.browser }}
         run: |
           set -o pipefail
           cd integration-tests && npx playwright test --workers=4 2>&1 | tee output.txt
@@ -85,7 +93,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.browser }}
           path: integration-tests/playwright-report/
           retention-days: 30
       - name: List running pods
@@ -104,5 +112,5 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: kubernetes-logs
+          name: kubernetes-logs-${{ matrix.browser }}
           path: kubernetes_logs/

--- a/integration-tests/playwright.config.ts
+++ b/integration-tests/playwright.config.ts
@@ -66,9 +66,9 @@ const config = {
 };
 
 if (browser) {
-  config.projects = config.projects.filter((p) => 
-    p.name.startsWith(browser) || p.name === 'readonly setup'
-  );
+    config.projects = config.projects.filter(
+        (p) => p.name.startsWith(browser) || p.name === 'readonly setup',
+    );
 }
 
 export default defineConfig(config);

--- a/integration-tests/playwright.config.ts
+++ b/integration-tests/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const browser = process.env.BROWSER;
+
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
@@ -11,7 +13,7 @@ import { defineConfig, devices } from '@playwright/test';
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
-export default defineConfig({
+const config = {
     testDir: './tests',
     /* Run tests in files in parallel */
     fullyParallel: true,
@@ -61,4 +63,10 @@ export default defineConfig({
             testMatch: /^(?!.*\.dependent\.spec\.ts$).*\.spec\.ts$/,
         },
     ],
-});
+};
+
+if (browser) {
+    config.projects = config.projects.filter((p) => p.name.startsWith(browser));
+}
+
+export default defineConfig(config);

--- a/integration-tests/playwright.config.ts
+++ b/integration-tests/playwright.config.ts
@@ -66,7 +66,9 @@ const config = {
 };
 
 if (browser) {
-    config.projects = config.projects.filter((p) => p.name.startsWith(browser));
+  config.projects = config.projects.filter((p) => 
+    p.name.startsWith(browser) || p.name === 'readonly setup'
+  );
 }
 
 export default defineConfig(config);


### PR DESCRIPTION
This drops the "run integration tests" step of the integration tests from about 4 mins 40 to 2 mins 30.
(And when tests fail it should drop from potentially 8 to 4)

Seems worth it? 

------
https://chatgpt.com/codex/tasks/task_e_6841a367f36c8325ac445bab0c072522

🚀 Preview: Add `preview` label to enable