### PR TITLE
fix(backend): file upload for revisions

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
@@ -131,12 +131,6 @@ class SubmitModel(
             val sequenceSubmissionIds = uploadDatabaseService.getSequenceUploadSubmissionIds(uploadId).toSet()
             validateSubmissionIdSetsForConsensusSequences(metadataSubmissionIds, sequenceSubmissionIds)
         }
-        submissionParams.files?.let { submittedFiles ->
-            val fileSubmissionIds = submittedFiles.keys
-            validateSubmissionIdSetsForFiles(metadataSubmissionIds, fileSubmissionIds)
-            // the check below reads the DB, so needs to be after 'insertDataIntoAux'
-            validateFileExistenceAndGroupOwnership(submittedFiles, submissionParams, uploadId)
-        }
 
         if (submissionParams is SubmissionParams.RevisionSubmissionParams) {
             log.info { "Associating uploaded sequence data with existing sequence entries with uploadId $uploadId" }
@@ -145,6 +139,12 @@ class SubmitModel(
                 submissionParams.organism,
                 submissionParams.authenticatedUser,
             )
+        }
+
+        submissionParams.files?.let { submittedFiles ->
+            val fileSubmissionIds = submittedFiles.keys
+            validateSubmissionIdSetsForFiles(metadataSubmissionIds, fileSubmissionIds)
+            validateFileExistenceAndGroupOwnership(submittedFiles, submissionParams, uploadId)
         }
 
         if (submissionParams is SubmissionParams.OriginalSubmissionParams) {

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ReviseEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ReviseEndpointTest.kt
@@ -29,9 +29,11 @@ import org.loculus.backend.controller.expectNdjsonAndGetContent
 import org.loculus.backend.controller.expectUnauthorizedResponse
 import org.loculus.backend.controller.files.FilesClient
 import org.loculus.backend.controller.files.andGetFileIds
+import org.loculus.backend.controller.files.andGetFileIdsAndUrls
 import org.loculus.backend.controller.generateJwtFor
 import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
 import org.loculus.backend.controller.groupmanagement.andGetGroupId
+import org.loculus.backend.controller.jwtForDefaultUser
 import org.loculus.backend.controller.jwtForSuperUser
 import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles
 import org.springframework.beans.factory.annotation.Autowired
@@ -264,6 +266,35 @@ class ReviseEndpointTest(
             .andExpect(jsonPath("\$[0].submissionId").value("custom0"))
             .andExpect(jsonPath("\$[0].accession").value(accessions.first()))
             .andExpect(jsonPath("\$[0].version").value(2))
+    }
+
+    @Test
+    fun `GIVEN valid file THEN is successful`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        val accessions = convenienceClient.prepareDataTo(
+            status = APPROVED_FOR_RELEASE,
+            groupId = groupId,
+        )
+            .map { it.accession }
+        val fileIdAndUrl = filesClient.requestUploads(
+            groupId = groupId,
+            jwt = jwtForDefaultUser,
+        ).andGetFileIdsAndUrls()[0]
+        convenienceClient.uploadFile(fileIdAndUrl.presignedWriteUrl, "Hello World!")
+
+        client.reviseSequenceEntries(
+            DefaultFiles.getRevisedMetadataFile(accessions),
+            DefaultFiles.sequencesFile,
+            fileMapping = mapOf(
+                "custom0" to
+                    mapOf(
+                        "myFileCategory" to listOf(
+                            FileIdAndName(fileIdAndUrl.fileId, "foo.txt"),
+                        ),
+                    ),
+            ),
+        )
+            .andExpect(status().isOk)
     }
 
     @Test


### PR DESCRIPTION
There was a bug that prevented files from being attached to revisions. We need to associate revision entries with the existing sequence entries and their groups before checking the group ownership of files. I added a test to verify that attaching a file mapping now works.

### PR Checklist
- ~[ ] All necessary documentation has been adapted.~
- [x] The implemented feature is covered by appropriate, automated tests.
- ~[ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~

🚀 Preview: https://fix-files-revisions.loculus.org