### PR TITLE
refactor(backend): use AWS SDK instead of MinIO client

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation "org.hibernate.validator:hibernate-validator:9.0.0.Final"
     implementation "org.keycloak:keycloak-admin-client:26.0.5"
     implementation("io.minio:minio:8.5.17")
-    implementation("software.amazon.awssdk:aws-sdk-java:2.31.58")
+    implementation("software.amazon.awssdk:s3:2.31.58")
 
     implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server"
     implementation "org.springframework.boot:spring-boot-starter-security"

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation "org.hibernate.validator:hibernate-validator:9.0.0.Final"
     implementation "org.keycloak:keycloak-admin-client:26.0.5"
     implementation("io.minio:minio:8.5.17")
+    implementation("software.amazon.awssdk:aws-sdk-java:2.31.58")
 
     implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server"
     implementation "org.springframework.boot:spring-boot-starter-security"

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.daemon.jvmargs=-Xmx1g

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,1 +1,0 @@
-kotlin.daemon.jvmargs=-Xmx1g

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/S3Service.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/S3Service.kt
@@ -107,31 +107,23 @@ class S3Service(private val s3Config: S3Config) {
     private fun createClient(bucketConfig: S3BucketConfig): S3Client = S3Client.builder()
         .endpointOverride(URI.create(bucketConfig.internalEndpoint ?: bucketConfig.endpoint))
         .region(Region.of(bucketConfig.region))
-        .credentialsProvider(
-            StaticCredentialsProvider.create(
-                AwsBasicCredentials.create(bucketConfig.accessKey, bucketConfig.secretKey),
-            ),
-        )
-        .serviceConfiguration(
-            S3Configuration.builder()
-                .pathStyleAccessEnabled(true)
-                .build(),
-        )
+        .credentialsProvider(createCredentialProvider(bucketConfig))
+        .serviceConfiguration(createServiceConfiguration())
         .build()
 
     private fun createPresigner(bucketConfig: S3BucketConfig): S3Presigner = S3Presigner.builder()
         .endpointOverride(URI.create(bucketConfig.endpoint))
         .region(Region.of(bucketConfig.region))
-        .credentialsProvider(
-            StaticCredentialsProvider.create(
-                AwsBasicCredentials.create(bucketConfig.accessKey, bucketConfig.secretKey),
-            ),
-        )
-        .serviceConfiguration(
-            S3Configuration.builder()
-                .pathStyleAccessEnabled(true)
-                .build(),
-        )
+        .credentialsProvider(createCredentialProvider(bucketConfig))
+        .serviceConfiguration(createServiceConfiguration())
+        .build()
+
+    private fun createCredentialProvider(bucketConfig: S3BucketConfig) = StaticCredentialsProvider.create(
+        AwsBasicCredentials.create(bucketConfig.accessKey, bucketConfig.secretKey),
+    )
+
+    private fun createServiceConfiguration() = S3Configuration.builder()
+        .pathStyleAccessEnabled(true)
         .build()
 
     private fun getFileIdPath(fileId: FileId): String = "files/$fileId"


### PR DESCRIPTION
Unfortunately, the MinIO S3 client library doesn't support multipart uploads (#4378). Therefore, this PR switches to using AWS' SDK.

### PR Checklist
- ~[ ] All necessary documentation has been adapted.~
- ~[ ] The implemented feature is covered by appropriate, automated tests.~ – It's a pure refactoring, the existing feature is well covered by tests.
- ~[ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~

🚀 Preview: Add `preview` label to enable