### PR TITLE
fix(backend): don't emit files twice in released data

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -173,6 +173,39 @@ data class ProcessedData<SequenceType>(
     val files: FileCategoryFilesMap?,
 )
 
+data class ReleasedData(
+    @Schema(
+        example = """{"date": "2020-01-01", "country": "Germany", "age": 42, "qc": 0.95}""",
+        description = "Key value pairs of metadata, correctly typed",
+    )
+    val metadata: MetadataMap,
+    @Schema(
+        example = """{"segment1": "ACTG", "segment2": "GTCA"}""",
+        description = "The key is the segment name, the value is the nucleotide sequence",
+    )
+    val unalignedNucleotideSequences: Map<SegmentName, GeneticSequence?>,
+    @Schema(
+        example = """{"segment1": "ACTG", "segment2": "GTCA"}""",
+        description = "The key is the segment name, the value is the aligned nucleotide sequence",
+    )
+    val alignedNucleotideSequences: Map<SegmentName, GeneticSequence?>,
+    @Schema(
+        example = """{"segment1": ["123:GTCA", "345:AAAA"], "segment2": ["123:GTCA", "345:AAAA"]}""",
+        description = "The key is the segment name, the value is a list of nucleotide insertions",
+    )
+    val nucleotideInsertions: Map<SegmentName, List<Insertion>>,
+    @Schema(
+        example = """{"gene1": "NRNR", "gene2": "NRNR"}""",
+        description = "The key is the gene name, the value is the amino acid sequence",
+    )
+    val alignedAminoAcidSequences: Map<GeneName, GeneticSequence?>,
+    @Schema(
+        example = """{"gene1": ["123:RRN", "345:NNN"], "gene2": ["123:NNR", "345:RN"]}""",
+        description = "The key is the gene name, the value is a list of amino acid insertions",
+    )
+    val aminoAcidInsertions: Map<GeneName, List<Insertion>>,
+)
+
 data class ExternalSubmittedData(
     override val accession: Accession,
     override val version: Version,

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -10,10 +10,9 @@ import mu.KotlinLogging
 import org.loculus.backend.api.DataUseTerms
 import org.loculus.backend.api.FileCategoryFilesMap
 import org.loculus.backend.api.FileIdAndNameAndReadUrl
-import org.loculus.backend.api.GeneticSequence
 import org.loculus.backend.api.MetadataMap
 import org.loculus.backend.api.Organism
-import org.loculus.backend.api.ProcessedData
+import org.loculus.backend.api.ReleasedData
 import org.loculus.backend.api.VersionStatus
 import org.loculus.backend.api.addUrls
 import org.loculus.backend.config.BackendConfig
@@ -64,7 +63,7 @@ open class ReleasedDataModel(
     private val objectMapper: ObjectMapper,
 ) {
     @Transactional(readOnly = true)
-    open fun getReleasedData(organism: Organism): Sequence<ProcessedData<GeneticSequence>> {
+    open fun getReleasedData(organism: Organism): Sequence<ReleasedData> {
         log.info { "Fetching released submissions from database for organism $organism" }
 
         val latestVersions = submissionDatabaseService.getLatestVersions(organism)
@@ -113,7 +112,7 @@ open class ReleasedDataModel(
         latestVersions: Map<Accession, Version>,
         latestRevocationVersions: Map<Accession, Version>,
         earliestReleaseDateFinder: EarliestReleaseDateFinder?,
-    ): ProcessedData<GeneticSequence> {
+    ): ReleasedData {
         val versionStatus = computeVersionStatus(rawProcessedData, latestVersions, latestRevocationVersions)
 
         val currentDataUseTerms = computeDataUseTerm(rawProcessedData)
@@ -195,14 +194,13 @@ open class ReleasedDataModel(
                 },
             )
 
-        return ProcessedData(
+        return ReleasedData(
             metadata = metadata,
             unalignedNucleotideSequences = rawProcessedData.processedData.unalignedNucleotideSequences,
             alignedNucleotideSequences = rawProcessedData.processedData.alignedNucleotideSequences,
             nucleotideInsertions = rawProcessedData.processedData.nucleotideInsertions,
             aminoAcidInsertions = rawProcessedData.processedData.aminoAcidInsertions,
             alignedAminoAcidSequences = rawProcessedData.processedData.alignedAminoAcidSequences,
-            files = rawProcessedData.processedData.files,
         )
     }
 


### PR DESCRIPTION
We were outputting the whole `ProcessedData`, with additionally computed metadata, in `/get-released-data`, the `files` were emitted as a top-level field. This was not desired as SILO (only) takes the file mapping as a (stringified) metadata field. This PR removes the redundant `files` field.

### PR Checklist
- ~[ ] All necessary documentation has been adapted.~
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
    - Called `/get-released-data` manually
