### PR TITLE
fix(backend): validate processed files mapping against correct config

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
@@ -51,6 +51,7 @@ data class Schema(
     val externalMetadata: List<ExternalMetadata> = emptyList(),
     val earliestReleaseDate: EarliestReleaseDate = EarliestReleaseDate(false, emptyList()),
     val submissionDataTypes: SubmissionDataTypes = SubmissionDataTypes(),
+    val files: List<FileCategory> = emptyList(),
 )
 
 data class SubmissionDataTypes(

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -245,7 +245,7 @@ class SubmissionDatabaseService(
             submittedProcessedData.data.files?.let { fileMapping ->
                 fileMappingPreconditionValidator
                     .validateFilenamesAreUnique(fileMapping)
-                    .validateCategoriesMatchSchema(fileMapping, organism)
+                    .validateCategoriesMatchProcessedSchema(fileMapping, organism)
                     .validateFilesExist(fileMapping.fileIds)
             }
 
@@ -1034,7 +1034,7 @@ class SubmissionDatabaseService(
         editedSequenceEntryData.data.files?.let { fileMapping ->
             fileMappingPreconditionValidator
                 .validateFilenamesAreUnique(fileMapping)
-                .validateCategoriesMatchSchema(fileMapping, organism)
+                .validateCategoriesMatchSubmissionSchema(fileMapping, organism)
                 .validateFilesExist(fileMapping.fileIds)
         }
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ReviseEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ReviseEndpointTest.kt
@@ -352,7 +352,11 @@ class ReviseEndpointTest(
             .andExpect(
                 jsonPath(
                     "\$.detail",
-                ).value("The category unknownCategory is not part of the configured categories for dummyOrganism."),
+                ).value(
+                    containsString(
+                        "The category unknownCategory is not part of the configured categories for dummyOrganism.",
+                    ),
+                ),
             )
     }
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
@@ -196,7 +196,11 @@ class SubmitEndpointFileSharingTest(
             .andExpect(
                 jsonPath(
                     "\$.detail",
-                ).value("The category unknownCategory is not part of the configured categories for dummyOrganism."),
+                ).value(
+                    containsString(
+                        "The category unknownCategory is not part of the configured categories for dummyOrganism.",
+                    ),
+                ),
             )
     }
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
@@ -480,6 +480,9 @@ class SubmitProcessedDataEndpointTest(
                     "myFileCategory" to listOf(
                         FileIdAndName(fileIdAndUrl.fileId, "foo.txt"),
                     ),
+                    "myProcessedOnlyFileCategory" to listOf(
+                        FileIdAndName(fileIdAndUrl.fileId, "foo.txt"),
+                    ),
                 ),
             ),
         )

--- a/backend/src/test/resources/backend_config.json
+++ b/backend/src/test/resources/backend_config.json
@@ -196,6 +196,7 @@
                 "submissionDataTypes": {
                     "consensusSequences": false
                 },
+                "files": [],
                 "metadata": [
                     {
                         "name": "date",

--- a/backend/src/test/resources/backend_config_s3.json
+++ b/backend/src/test/resources/backend_config_s3.json
@@ -30,11 +30,16 @@
                     "files": {
                         "enabled": true,
                         "categories": [
-                            {"name":  "myFileCategory"},
-                            {"name":  "myOtherFileCategory"}
+                            {"name": "myFileCategory"},
+                            {"name": "myOtherFileCategory"}
                         ]
                     }
                 },
+                "files": [
+                    {"name": "myFileCategory"},
+                    {"name": "myOtherFileCategory"},
+                    {"name": "myProcessedOnlyFileCategory"}
+                ],
                 "metadata": [
                     {
                         "name": "date",

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -342,6 +342,10 @@ organisms:
       {{- $nucleotideSequences := .nucleotideSequences | default (list "main")}}
       organismName: {{ quote .organismName }}
       {{- include "loculus.submissionDataTypes" . | nindent 6 }}
+      {{- if .files }}
+      files:
+        {{ .files | toYaml | nindent 8 }}
+      {{- end }}
       metadata:
         {{- $args := dict "metadata" (include "loculus.patchMetadataSchema" . | fromYaml).metadata "nucleotideSequences" $nucleotideSequences}}
         {{ $metadata := include "loculus.generateBackendMetadata" $args | fromYaml }}


### PR DESCRIPTION
resolves #4381

The `<organism>.schema.files` is now passed on to the backend, which uses it to validate the file categories of submitted processed data.

### PR Checklist~
- ~[ ] All necessary documentation has been adapted.~
- [x] The implemented feature is covered by appropriate, automated tests.
- ~[ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~ Sufficiently covered by an automated test.

🚀 Preview: https://fix-file-category-validat.loculus.org