### PR TITLE
feat(website): add icons to Tools and Download buttons

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/DowloadDialogButton.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DowloadDialogButton.tsx
@@ -1,4 +1,5 @@
 import type { FC } from 'react';
+import MaterialSymbolsLightDownload from '~icons/material-symbols-light/download';
 
 import { type SequenceFilter } from './SequenceFilters';
 import { formatNumberWithDefaultLocale } from '../../../utils/formatNumber';
@@ -26,7 +27,8 @@ export const DownloadDialogButton: FC<DownloadDialogButtonProps> = ({ onClick, s
         buttonWidthClass = 'w-[15rem]'; // this width is fine for up to two digit numbers
     }
     return (
-        <button className={buttonWidthClass + ' outlineButton'} onClick={onClick}>
+        <button className={buttonWidthClass + ' outlineButton flex items-center justify-center'} onClick={onClick}>
+            <MaterialSymbolsLightDownload className='inline-block mr-1' aria-hidden='true' />
             {buttonText}
         </button>
     );

--- a/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
@@ -8,6 +8,7 @@ import { processTemplate, matchPlaceholders } from '../../../utils/templateProce
 import BasicModal from '../../common/Modal';
 import DashiconsExternal from '~icons/dashicons/external';
 import IwwaArrowDown from '~icons/iwwa/arrow-down';
+import MaterialSymbolsLightHandymanOutline from '~icons/material-symbols-light/handyman-outline';
 
 const DATA_TYPES = ['unalignedNucleotideSequences', 'metadata', 'alignedNucleotideSequences'] as const;
 type DataType = (typeof DATA_TYPES)[number];
@@ -120,7 +121,10 @@ export const LinkOutMenu: FC<LinkOutMenuProps> = ({
                     className='outlineButton flex items-center min-w-[100px] justify-between h-full'
                     onClick={() => setIsOpen(!isOpen)}
                 >
-                    <span>Tools</span>
+                    <span className='flex items-center'>
+                        <MaterialSymbolsLightHandymanOutline className='h-5 w-5 mr-1' aria-hidden='true' />
+                        Tools
+                    </span>
                     <IwwaArrowDown className='ml-2 h-5 w-5' aria-hidden='true' />
                 </MenuButton>
 


### PR DESCRIPTION
## Summary
- add icon imports for Download and Tools buttons
- display Material Symbols icons on the Tools dropdown and download dialog button

## Testing
- `npm run format`
- `npm run test -- --run` *(fails: Test run cancelled)*
- `npm run check-types`

------
https://chatgpt.com/codex/tasks/task_e_6846f5029bac832590ab9761c30d3acd