### PR TITLE
feat(deployment): Add `submissionId`, `groupName` to default metadata downloads

### DIFF
--- a/integration-tests/tests/specs/features/search/download.dependent.spec.ts
+++ b/integration-tests/tests/specs/features/search/download.dependent.spec.ts
@@ -72,5 +72,5 @@ test('Download metadata with POST and check number of cols', async ({ page }) =>
     const firstLine = lines[0];
     const fields = firstLine.split('\t');
 
-    expect(fields).toHaveLength(9);
+    expect(fields).toHaveLength(11);
 });

--- a/integration-tests/tests/specs/features/search/download.dependent.spec.ts
+++ b/integration-tests/tests/specs/features/search/download.dependent.spec.ts
@@ -32,7 +32,7 @@ test('Download metadata and check number of cols', async ({ page }) => {
     const firstLine = lines[0];
     const fields = firstLine.split('\t');
 
-    expect(fields).toHaveLength(9);
+    expect(fields).toHaveLength(11);
 });
 
 test('Download metadata with POST and check number of cols', async ({ page }) => {

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -79,7 +79,6 @@ fields:
     autocomplete: true
     displayName: Date released (exact)
     columnWidth: 100
-    includeInDownloadsByDefault: true
   {{- if $.Values.dataUseTerms.enabled }}
   - name: dataUseTerms
     type: string

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -26,6 +26,7 @@ fields:
     type: string
     header: Submission details
     enableSubstringSearch: true
+    includeInDownloadsByDefault: true
   - name: isRevocation
     displayName: Is revocation
     type: boolean
@@ -43,6 +44,7 @@ fields:
     autocomplete: true
     header: Submission details
     displayName: Submitting group
+    includeInDownloadsByDefault: true
     customDisplay:
       type: submittingGroup
       displayGroup: group
@@ -77,6 +79,7 @@ fields:
     autocomplete: true
     displayName: Date released (exact)
     columnWidth: 100
+    includeInDownloadsByDefault: true
   {{- if $.Values.dataUseTerms.enabled }}
   - name: dataUseTerms
     type: string


### PR DESCRIPTION
These feel like things we should have available by default in downloads - `submissionId` in particular because submitters will need it to link accessions to submissions, e.g. for revision.

In due course we should allow customising this stuff by deployers, but that's a bigger job

🚀 Preview: https://add-default-download.loculus.org