### PR TITLE
fix(k8s): Match bare LAPIS urls without trailin slash as well

### DIFF
--- a/kubernetes/loculus/templates/lapis-ingress.yaml
+++ b/kubernetes/loculus/templates/lapis-ingress.yaml
@@ -35,6 +35,13 @@ spec:
             name: {{ template "loculus.lapisServiceName" $key }}
             port:
               number: 8080
+      - path: /{{ $key }} # Fallback for bare LAPIS url to avoid 404 (#3360)
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "loculus.lapisServiceName" $key }}
+            port:
+              number: 8080
       {{- end }}
   {{- if eq $.Values.environment "server" }}
   tls:


### PR DESCRIPTION
Resolves #3360

We could alternatively do canonicalisation of trailing/non-trailing slashes
But this would involve deeper changes. The change here has minimal risks and fixes the bug efficiently.

resolves #

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)
