### PR TITLE
chore(backend): use BOM to manage JUnit dependency

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -67,7 +67,8 @@ dependencies {
     testImplementation "com.ninja-squad:springmockk:4.0.2"
     testImplementation "org.testcontainers:postgresql:1.21.1"
     testImplementation "org.testcontainers:minio:1.21.1"
-    testImplementation "org.junit.platform:junit-platform-launcher:1.12.2"
+    testImplementation platform("org.junit:junit-bom:5.13.1")
+    testImplementation "org.junit.platform:junit-platform-launcher"
     ktlint("com.pinterest.ktlint:ktlint-cli:1.6.0") {
         attributes {
             attribute(Bundling.BUNDLING_ATTRIBUTE, getObjects().named(Bundling, Bundling.EXTERNAL))


### PR DESCRIPTION
In #4393, dependabot was not able to update a JUnit dependency. The issue is that we import JUnit dependencies through different paths: `org.junit.platform:junit-platform-launcher` is imported directly, while other packages are imported indirectly through other dependencies, and in case of #4393, this is causing conflicting packages to be imported. To solve this, we can use a BOM (Bill of Material) package to manage the versions.

For more information about the problem and the BOM-packages, [here](https://reflectoring.io/maven-bom/) is a good article.

🚀 Preview: Add `preview` label to enable