### PR TITLE
fix(website): trim remote banner message

### DIFF
--- a/website/src/services/bannerMessageService.ts
+++ b/website/src/services/bannerMessageService.ts
@@ -24,7 +24,7 @@ export async function getRemoteBannerMessage(): Promise<string | null> {
                 responseType: 'text',
                 timeout: REQUEST_TIMEOUT_MS,
             });
-            cachedMessage = typeof response.data === 'string' ? response.data : '';
+            cachedMessage = typeof response.data === 'string' ? response.data.trim() : '';
         } catch (e) {
             logger.error(`Failed to fetch banner message from ${bannerMessageURL}: ${(e as Error).message}`);
             cachedMessage = '';


### PR DESCRIPTION
## Summary
- trim whitespace from remote banner message when fetched (the main point is that a file with simply `\n` will become empty)

------
https://chatgpt.com/codex/tasks/task_e_6848924a255483259b084d96d46ddccc