### PR TITLE
feat(integration-test): Allow configuring integration test base url and ignoring https errors

### DIFF
--- a/integration-tests/playwright.config.ts
+++ b/integration-tests/playwright.config.ts
@@ -26,7 +26,9 @@ const config = {
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
         /* Base URL to use in actions like `await page.goto('/')`. */
-        baseURL: 'http://localhost:3000',
+        baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost:3000',
+        /* Ignore HTTPS errors when requested via environment variable. */
+        ignoreHTTPSErrors: process.env.PLAYWRIGHT_TEST_IGNORE_HTTPS_ERRORS === 'true',
 
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: process.env.CI ? 'on-first-retry' : 'on',


### PR DESCRIPTION
This makes it easier to run integration tests against previews. Behaviour is unchanged by default.

🚀 Preview: Add `preview` label to enable