### PR TITLE
fix(website): display dashes for empty values

### DIFF
--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -25,6 +25,8 @@ function formatField(value: unknown, type: string): string {
         return formatNumberWithDefaultLocale(value);
     } else if (typeof value === 'boolean') {
         return value ? 'True' : 'False';
+    } else if (typeof value === 'string') {
+        return value === '' ? '-' : value;
     } else {
         // @ts-expect-error: TODO(#3451) add proper types
         return value;


### PR DESCRIPTION
## Summary
- treat empty strings as dashes when formatting table values

## Testing
- `npm run test -- --run`
- `npm run check-types`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6851b8e7b35c8325b5438d1618cbfdb3