### PR TITLE
feat(deployment): make localhost configurable

### DIFF
--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -463,7 +463,7 @@ fields:
 {{- else if eq $.Values.environment "server" }}
   {{- $lapisUrlTemplate = printf "https://lapis%s%s/%s" $.Values.subdomainSeparator $.Values.host "%organism%" }}
 {{- else }}
-  {{- $lapisUrlTemplate = "http://localhost:8080/%organism%" }}
+  {{- $lapisUrlTemplate = printf "http://%s:8080/%%organism%%" $.Values.localHost }}
 {{- end }}
 {{- $externalLapisUrlConfig := dict "lapisUrlTemplate" $lapisUrlTemplate "config" $.Values }}
             "backendUrl": "{{ include "loculus.backendUrl" . }}",

--- a/kubernetes/loculus/templates/_urls.tpl
+++ b/kubernetes/loculus/templates/_urls.tpl
@@ -5,7 +5,7 @@
   {{- else if eq $.Values.environment "server" -}}
     {{- (printf "https://backend%s%s" $.Values.subdomainSeparator $.Values.host) -}}
   {{- else -}}
-    {{- "http://localhost:8079" -}}
+    {{- printf "http://%s:8079" $.Values.localHost -}}
   {{- end -}}
 {{- end -}}
 
@@ -16,7 +16,7 @@
   {{- else if eq $.Values.environment "server" -}}
     {{- (printf "https://%s" $.Values.host) -}}
   {{- else -}}
-    {{- "http://localhost:3000" -}}
+    {{- printf "http://%s:3000" $.Values.localHost -}}
   {{- end -}}
 {{- end -}}
 
@@ -25,7 +25,7 @@
     {{- if eq $.Values.environment "server" -}}
         {{- (printf "https://s3%s%s" $.Values.subdomainSeparator $.Values.host) -}}
     {{- else -}}
-        {{- "http://localhost:8084" -}}
+        {{- printf "http://%s:8084" $.Values.localHost -}}
     {{- end -}}
   {{- else -}}
     {{- $.Values.s3.bucket.endpoint }}
@@ -47,14 +47,14 @@
   {{- else if eq $.Values.environment "server" -}}
     {{- (printf "https://authentication%s%s" $.Values.subdomainSeparator $.Values.host) -}}
   {{- else -}}
-    {{- "http://localhost:8083" -}}
+    {{- printf "http://%s:8083" $.Values.localHost -}}
   {{- end -}}
 {{- end -}}
 
 {{/* generates internal LAPIS urls from given config object */}}
 {{ define "loculus.generateInternalLapisUrls" }}
   {{ range $key, $_ := (.Values.organisms | default .Values.defaultOrganisms) }}
-    "{{ $key }}": "{{ if not $.Values.disableWebsite }}http://{{ template "loculus.lapisServiceName" $key }}:8080{{ else -}}http://localhost:8080/{{ $key }}{{ end }}"
+    "{{ $key }}": "{{ if not $.Values.disableWebsite }}http://{{ template "loculus.lapisServiceName" $key }}:8080{{ else -}}http://{{ $.Values.localHost }}:8080/{{ $key }}{{ end }}"
   {{ end }}
 {{ end }}
 

--- a/kubernetes/loculus/templates/ena-submission-config.yaml
+++ b/kubernetes/loculus/templates/ena-submission-config.yaml
@@ -1,8 +1,8 @@
 {{- if not .Values.disableEnaSubmission }}
 {{- $testconfig := .Values.testconfig | default false }}
 {{- $enaDepositionHost := $testconfig | ternary "127.0.0.1" "0.0.0.0" }}
-{{- $backendHost := .Values.environment | eq "server" | ternary (printf "https://backend%s%s" .Values.subdomainSeparator $.Values.host) ($testconfig | ternary "http://localhost:8079" "http://loculus-backend-service:8079") }}
-{{- $keycloakHost := $testconfig | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083" }}
+{{- $backendHost := .Values.environment | eq "server" | ternary (printf "https://backend%s%s" .Values.subdomainSeparator $.Values.host) ($testconfig | ternary (printf "http://%s:8079" $.Values.localHost) "http://loculus-backend-service:8079") }}
+{{- $keycloakHost := $testconfig | ternary (printf "http://%s:8083" $.Values.localHost) "http://loculus-keycloak-service:8083" }}
 {{- $submitToEnaProduction := .Values.enaDeposition.submitToEnaProduction | default false }}
 {{- $enaDbName := .Values.enaDeposition.enaDbName | default false }}
 {{- $enaUniqueSuffix := .Values.enaDeposition.enaUniqueSuffix | default false }}

--- a/kubernetes/loculus/templates/ingest-config.yaml
+++ b/kubernetes/loculus/templates/ingest-config.yaml
@@ -1,8 +1,8 @@
 {{- $dockerTag := include "loculus.dockerTag" .Values }}
 {{- $testconfig := .Values.testconfig | default false }}
-{{- $backendHost := .Values.environment | eq "server" | ternary (printf "https://backend%s%s" .Values.subdomainSeparator $.Values.host) ($testconfig | ternary "http://localhost:8079" "http://loculus-backend-service:8079") }}
-{{- $enaDepositionHost := $testconfig | ternary "http://localhost:5000" "http://loculus-ena-submission-service:5000" }}
-{{- $keycloakHost := $testconfig | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083" }}
+{{- $backendHost := .Values.environment | eq "server" | ternary (printf "https://backend%s%s" .Values.subdomainSeparator $.Values.host) ($testconfig | ternary (printf "http://%s:8079" $.Values.localHost) "http://loculus-backend-service:8079") }}
+{{- $enaDepositionHost := $testconfig | ternary (printf "http://%s:5000" $.Values.localHost) "http://loculus-ena-submission-service:5000" }}
+{{- $keycloakHost := $testconfig | ternary (printf "http://%s:8083" $.Values.localHost) "http://loculus-keycloak-service:8083" }}
 {{- range $key, $values := (.Values.organisms | default .Values.defaultOrganisms) }}
 {{- if $values.ingest }}
 {{- $metadata := (include "loculus.patchMetadataSchema" $values.schema | fromYaml).metadata }}

--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -259,7 +259,7 @@ data:
           "redirectUris": [
             "https://{{$.Values.host}}/*",
             "http://{{$.Values.host}}/*",
-            "http://localhost:3000/*"
+            "http://{{$.Values.localHost}}:3000/*"
           ]
         },
         {

--- a/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
@@ -4,7 +4,7 @@
     "http://loculus-backend-service:8079"
 }}
 {{- $testconfig := .Values.testconfig | default false }}
-{{- $keycloakHost := $testconfig | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083" }}
+{{- $keycloakHost := $testconfig | ternary (printf "http://%s:8083" $.Values.localHost) "http://loculus-keycloak-service:8083" }}
 {{- if not .Values.disablePreprocessing }}
 {{- range $organism, $organismConfig := (.Values.organisms | default .Values.defaultOrganisms) }}
 {{- range $processingIndex, $processingConfig := $organismConfig.preprocessing }}

--- a/kubernetes/loculus/templates/loculus-website-config.yaml
+++ b/kubernetes/loculus/templates/loculus-website-config.yaml
@@ -15,12 +15,12 @@ data:
             {{- template "loculus.publicRuntimeConfig" . -}}
             {{- else }}
             {{ if $.Values.disableBackend -}}
-            "backendUrl": "http://localhost:8079",
+            "backendUrl": "http://{{ $.Values.localHost }}:8079",
             {{- else -}}
             "backendUrl": "http://loculus-backend-service:8079",
             {{- end }}
             "lapisUrls": {{- include "loculus.generateInternalLapisUrls" . | fromYaml | toJson }},
-            "keycloakUrl": "{{ if not .Values.disableWebsite -}}http://loculus-keycloak-service:8083{{ else -}}http://localhost:8083{{ end }}"
+            "keycloakUrl": "{{ if not .Values.disableWebsite -}}http://loculus-keycloak-service:8083{{ else -}}http://{{ $.Values.localHost }}:8083{{ end }}"
             {{- end }}
         },
         "public": {

--- a/kubernetes/loculus/templates/minio-deployment.yaml
+++ b/kubernetes/loculus/templates/minio-deployment.yaml
@@ -69,7 +69,7 @@ spec:
                   - |
                     (
                       sleep 10
-                      mc alias set local http://localhost:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+                      mc alias set local http://{{ $.Values.localHost }}:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
                       mc mb -p local/{{ .Values.s3.bucket.bucket }}
                       echo "Bucket {{ .Values.s3.bucket.bucket }} ensured."
                       mc anonymous set-json /policy/policy.json local/{{ .Values.s3.bucket.bucket }}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -748,6 +748,12 @@
       "default": "server",
       "description": "Deployment environment. local for development, server for production"
     },
+    "localHost": {
+      "groups": ["general"],
+      "type": "string",
+      "default": "localhost",
+      "description": "Hostname for local development URLs"
+    },
     "host": {
       "groups": ["general"],
       "type": "string",

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1,4 +1,5 @@
 environment: server
+localHost: localhost
 robotsNoindexHeader: false
 seqSets:
   enabled: true


### PR DESCRIPTION
## Summary
- make localhost configurable with `localHost` chart value
- use `localHost` in all dev URLs

## Testing
- `grep -R "localhost" -n kubernetes | cat`

------
https://chatgpt.com/codex/tasks/task_e_6852902463ec8325b7986aa595bf414a

🚀 Preview: Add `preview` label to enable