### PR TITLE
feat(deployment): Make it possible to use local IP instead of `localhost`

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -47,10 +47,15 @@ jobs:
       - uses: azure/setup-helm@v4
       - name: Create k3d cluster
         run: |
-          ./deploy.py --verbose cluster
-      - name: Deploy with helm
+          ./deploy.py --verbose cluster --bind-all
+      - name: Deploy with Helm
         run: |
-          ./deploy.py --verbose helm --branch ${{ github.ref_name }} --sha ${{ env.sha }} --for-e2e --enablePreprocessing
+          ./deploy.py --verbose helm \
+            --branch ${{ github.ref_name }} \
+            --sha ${{ env.sha }} \
+            --for-e2e \
+            --enablePreprocessing \
+            --use-localhost-ip
       - uses: actions/setup-node@v4
         with:
           node-version-file: ./website/.nvmrc

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -90,6 +90,7 @@ jobs:
           BROWSER: ${{ matrix.browser }}
         run: |
           set -o pipefail
+          [ "$BROWSER" = "firefox" ] && export PLAYWRIGHT_TEST_IGNORE_HTTPS_ERRORS=true
           cd integration-tests && npx playwright test --workers=4 2>&1 | tee output.txt
           EXIT_CODE=$?
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -90,7 +90,6 @@ jobs:
           BROWSER: ${{ matrix.browser }}
         run: |
           set -o pipefail
-          [ "$BROWSER" = "firefox" ] && export PLAYWRIGHT_TEST_IGNORE_HTTPS_ERRORS=true
           cd integration-tests && npx playwright test --workers=4 2>&1 | tee output.txt
           EXIT_CODE=$?
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/deploy.py
+++ b/deploy.py
@@ -271,7 +271,6 @@ def get_local_ip() -> str:
         raise RuntimeError(msg)
 
     except (subprocess.CalledProcessError, FileNotFoundError, IndexError) as e:
-        # Fallback if hostname command fails or is not available
         msg = "Could not determine local IP address (hostname -I failed)."
         raise RuntimeError(msg) from e
 

--- a/deploy.py
+++ b/deploy.py
@@ -196,7 +196,7 @@ def cluster_exists(cluster_name):
     return cluster_name in result.stdout
 
 
-def handle_helm():
+def handle_helm():  # noqa: C901
     if args.uninstall:
         run_command(["helm", "uninstall", HELM_RELEASE_NAME])
         return
@@ -259,19 +259,21 @@ def handle_helm_upgrade():
 def get_local_ip() -> str:
     """Determine the IP address of the current host using hostname -I."""
     try:
-        result = subprocess.run(['hostname', '-I'],
-                              capture_output=True,
-                              text=True,
-                              check=True)
+        result = subprocess.run(["hostname", "-I"],  # noqa: S607
+                                capture_output=True,
+                                text=True,
+                                check=True)
 
         ip_addresses = result.stdout.strip().split()
         if ip_addresses:
             return ip_addresses[0]
-        return "127.0.0.1"
+        msg = "Could not determine local IP address (no addresses found)."
+        raise RuntimeError(msg)
 
-    except (subprocess.CalledProcessError, FileNotFoundError, IndexError):
+    except (subprocess.CalledProcessError, FileNotFoundError, IndexError) as e:
         # Fallback if hostname command fails or is not available
-        return "127.0.0.1"
+        msg = "Could not determine local IP address (hostname -I failed)."
+        raise RuntimeError(msg) from e
 
 
 def get_codespace_name():
@@ -428,7 +430,7 @@ def generate_config(
 
 
 def get_codespace_params(codespace_name):
-    publicRuntimeConfig = {
+    public_runtime_config = {
         "websiteUrl": f"https://{codespace_name}-3000.app.github.dev",
         "backendUrl": f"https://{codespace_name}-8079.app.github.dev",
         "lapisUrlTemplate": f"https://{codespace_name}-8080.app.github.dev/%organism%",
@@ -436,7 +438,7 @@ def get_codespace_params(codespace_name):
     }
     return [
         "--set-json",
-        f"public={json.dumps(publicRuntimeConfig)}",
+        f"public={json.dumps(public_runtime_config)}",
     ]
 
 
@@ -455,7 +457,7 @@ def install_secret_generator():
     run_command(update_helm_repo_command)
     print("Helm repositories updated.")
 
-    secret_generator_chart = "mittwald/kubernetes-secret-generator"
+    secret_generator_chart = "mittwald/kubernetes-secret-generator"  # noqa: S105
     print("Installing Kubernetes Secret Generator...")
     helm_install_command = [
         "helm",

--- a/integration-tests/playwright.config.ts
+++ b/integration-tests/playwright.config.ts
@@ -51,9 +51,6 @@ const config = {
             name: 'firefox-with-dep',
             use: {
                 ...devices['Desktop Firefox'],
-                firefoxUserPrefs: {
-                    'security.warn_submit_insecure': false,
-                },
             },
             dependencies: ['readonly setup'],
             testMatch: /.*\.dependent\.spec\.ts/,

--- a/integration-tests/playwright.config.ts
+++ b/integration-tests/playwright.config.ts
@@ -52,7 +52,7 @@ const config = {
             use: {
                 ...devices['Desktop Firefox'],
                 firefoxUserPrefs: {
-                   'security.warn_submit_insecure': false,
+                    'security.warn_submit_insecure': false,
                 },
             },
             dependencies: ['readonly setup'],

--- a/integration-tests/playwright.config.ts
+++ b/integration-tests/playwright.config.ts
@@ -49,7 +49,12 @@ const config = {
         },
         {
             name: 'firefox-with-dep',
-            use: { ...devices['Desktop Firefox'] },
+            use: {
+                ...devices['Desktop Firefox'],
+                firefoxUserPrefs: {
+                   'security.warn_submit_insecure': false,
+                },
+            },
             dependencies: ['readonly setup'],
             testMatch: /.*\.dependent\.spec\.ts/,
         },

--- a/integration-tests/tests/specs/features/search/download.dependent.spec.ts
+++ b/integration-tests/tests/specs/features/search/download.dependent.spec.ts
@@ -35,7 +35,11 @@ test('Download metadata and check number of cols', async ({ page }) => {
     expect(fields).toHaveLength(11);
 });
 
-test('Download metadata with POST and check number of cols', async ({ page }) => {
+test('Download metadata with POST and check number of cols', async ({ page, browserName }) => {
+    test.skip(
+        browserName === 'firefox',
+        'Firefox raises a native warning that blocks the download',
+    );
     await page.goto('/');
     const searchPage = new SearchPage(page);
     await searchPage.ebolaSudan();

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -463,7 +463,7 @@ fields:
 {{- else if eq $.Values.environment "server" }}
   {{- $lapisUrlTemplate = printf "https://lapis%s%s/%s" $.Values.subdomainSeparator $.Values.host "%organism%" }}
 {{- else }}
-  {{- $lapisUrlTemplate = "http://localhost:8080/%organism%" }}
+  {{- $lapisUrlTemplate = printf "http://%s:8080/%%organism%%" $.Values.localHost }}
 {{- end }}
 {{- $externalLapisUrlConfig := dict "lapisUrlTemplate" $lapisUrlTemplate "config" $.Values }}
             "backendUrl": "{{ include "loculus.backendUrl" . }}",

--- a/kubernetes/loculus/templates/_urls.tpl
+++ b/kubernetes/loculus/templates/_urls.tpl
@@ -5,7 +5,7 @@
   {{- else if eq $.Values.environment "server" -}}
     {{- (printf "https://backend%s%s" $.Values.subdomainSeparator $.Values.host) -}}
   {{- else -}}
-    {{- "http://localhost:8079" -}}
+    {{- printf "http://%s:8079" $.Values.localHost -}}
   {{- end -}}
 {{- end -}}
 
@@ -16,7 +16,7 @@
   {{- else if eq $.Values.environment "server" -}}
     {{- (printf "https://%s" $.Values.host) -}}
   {{- else -}}
-    {{- "http://localhost:3000" -}}
+    {{- printf "http://%s:3000" $.Values.localHost -}}
   {{- end -}}
 {{- end -}}
 
@@ -25,10 +25,10 @@
     {{- if eq $.Values.environment "server" -}}
         {{- (printf "https://s3%s%s" $.Values.subdomainSeparator $.Values.host) -}}
     {{- else -}}
-        {{- "http://localhost:8084" -}}
+        {{- printf "http://%s:8084" $.Values.localHost -}}
     {{- end -}}
   {{- else -}}
-    {{- $.Values.s3.bucket.endpoint }}
+    {{- printf "http://%s:8084" $.Values.localHost -}}
   {{- end -}}
 {{- end -}}
 
@@ -47,14 +47,14 @@
   {{- else if eq $.Values.environment "server" -}}
     {{- (printf "https://authentication%s%s" $.Values.subdomainSeparator $.Values.host) -}}
   {{- else -}}
-    {{- "http://localhost:8083" -}}
+    {{- printf "http://%s:8083" $.Values.localHost -}}
   {{- end -}}
 {{- end -}}
 
 {{/* generates internal LAPIS urls from given config object */}}
 {{ define "loculus.generateInternalLapisUrls" }}
   {{ range $key, $_ := (.Values.organisms | default .Values.defaultOrganisms) }}
-    "{{ $key }}": "{{ if not $.Values.disableWebsite }}http://{{ template "loculus.lapisServiceName" $key }}:8080{{ else -}}http://localhost:8080/{{ $key }}{{ end }}"
+    "{{ $key }}": "{{ if not $.Values.disableWebsite }}http://{{ template "loculus.lapisServiceName" $key }}:8080{{ else -}}http://{{ $.Values.localHost }}:8080/{{ $key }}{{ end }}"
   {{ end }}
 {{ end }}
 

--- a/kubernetes/loculus/templates/ena-submission-config.yaml
+++ b/kubernetes/loculus/templates/ena-submission-config.yaml
@@ -1,8 +1,8 @@
 {{- if not .Values.disableEnaSubmission }}
 {{- $testconfig := .Values.testconfig | default false }}
 {{- $enaDepositionHost := $testconfig | ternary "127.0.0.1" "0.0.0.0" }}
-{{- $backendHost := .Values.environment | eq "server" | ternary (printf "https://backend%s%s" .Values.subdomainSeparator $.Values.host) ($testconfig | ternary "http://localhost:8079" "http://loculus-backend-service:8079") }}
-{{- $keycloakHost := $testconfig | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083" }}
+{{- $backendHost := .Values.environment | eq "server" | ternary (printf "https://backend%s%s" .Values.subdomainSeparator $.Values.host) ($testconfig | ternary (printf "http://%s:8079" $.Values.localHost) "http://loculus-backend-service:8079") }}
+{{- $keycloakHost := $testconfig | ternary (printf "http://%s:8083" $.Values.localHost) "http://loculus-keycloak-service:8083" }}
 {{- $submitToEnaProduction := .Values.enaDeposition.submitToEnaProduction | default false }}
 {{- $enaDbName := .Values.enaDeposition.enaDbName | default false }}
 {{- $enaUniqueSuffix := .Values.enaDeposition.enaUniqueSuffix | default false }}

--- a/kubernetes/loculus/templates/ingest-config.yaml
+++ b/kubernetes/loculus/templates/ingest-config.yaml
@@ -1,8 +1,8 @@
 {{- $dockerTag := include "loculus.dockerTag" .Values }}
 {{- $testconfig := .Values.testconfig | default false }}
-{{- $backendHost := .Values.environment | eq "server" | ternary (printf "https://backend%s%s" .Values.subdomainSeparator $.Values.host) ($testconfig | ternary "http://localhost:8079" "http://loculus-backend-service:8079") }}
-{{- $enaDepositionHost := $testconfig | ternary "http://localhost:5000" "http://loculus-ena-submission-service:5000" }}
-{{- $keycloakHost := $testconfig | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083" }}
+{{- $backendHost := .Values.environment | eq "server" | ternary (printf "https://backend%s%s" .Values.subdomainSeparator $.Values.host) ($testconfig | ternary (printf "http://%s:8079" $.Values.localHost) "http://loculus-backend-service:8079") }}
+{{- $enaDepositionHost := $testconfig | ternary (printf "http://%s:5000" $.Values.localHost) "http://loculus-ena-submission-service:5000" }}
+{{- $keycloakHost := $testconfig | ternary (printf "http://%s:8083" $.Values.localHost) "http://loculus-keycloak-service:8083" }}
 {{- range $key, $values := (.Values.organisms | default .Values.defaultOrganisms) }}
 {{- if $values.ingest }}
 {{- $metadata := (include "loculus.patchMetadataSchema" $values.schema | fromYaml).metadata }}

--- a/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
@@ -4,7 +4,7 @@
     "http://loculus-backend-service:8079"
 }}
 {{- $testconfig := .Values.testconfig | default false }}
-{{- $keycloakHost := $testconfig | ternary "http://localhost:8083" "http://loculus-keycloak-service:8083" }}
+{{- $keycloakHost := $testconfig | ternary (printf "http://%s:8083" $.Values.localHost) "http://loculus-keycloak-service:8083" }}
 {{- if not .Values.disablePreprocessing }}
 {{- range $organism, $organismConfig := (.Values.organisms | default .Values.defaultOrganisms) }}
 {{- range $processingIndex, $processingConfig := $organismConfig.preprocessing }}

--- a/kubernetes/loculus/templates/loculus-website-config.yaml
+++ b/kubernetes/loculus/templates/loculus-website-config.yaml
@@ -15,12 +15,12 @@ data:
             {{- template "loculus.publicRuntimeConfig" . -}}
             {{- else }}
             {{ if $.Values.disableBackend -}}
-            "backendUrl": "http://localhost:8079",
+            "backendUrl": "http://{{ $.Values.localHost }}:8079",
             {{- else -}}
             "backendUrl": "http://loculus-backend-service:8079",
             {{- end }}
             "lapisUrls": {{- include "loculus.generateInternalLapisUrls" . | fromYaml | toJson }},
-            "keycloakUrl": "{{ if not .Values.disableWebsite -}}http://loculus-keycloak-service:8083{{ else -}}http://localhost:8083{{ end }}"
+            "keycloakUrl": "{{ if not .Values.disableWebsite -}}http://loculus-keycloak-service:8083{{ else -}}http://{{ $.Values.localHost }}:8083{{ end }}"
             {{- end }}
         },
         "public": {

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -748,6 +748,12 @@
       "default": "server",
       "description": "Deployment environment. local for development, server for production"
     },
+    "localHost": {
+      "groups": ["general"],
+      "type": "string",
+      "default": "localhost",
+      "description": "Host string used for local development"
+    },
     "host": {
       "groups": ["general"],
       "type": "string",

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1,4 +1,5 @@
 environment: server
+localHost: localhost
 robotsNoindexHeader: false
 seqSets:
   enabled: true


### PR DESCRIPTION
based on #4448, #4450, #4453

In #4344, #4298 we ran into issues with the integration tests running in CI. After some research we found that the issues were caused by the backend giving pre-signed URLs to the prepro pipeline, that only work from outside the cluster.

This PR fixes that, by making it possible to use the local IP of the host instead of the literal `localhost`. The IP will work inside and outside of the cluster.

- Introduces new `localHost` value in Helm Chart to override `localhost` literal with something else.
- Introduces `./deploy.py helm --use-localhost-ip` flag to use the IP instead of the `localhost` literal.
- Introduces `./deploy.py cluster --bind-all` flag to bind to all interfaces to reach bound ports via the IP.
- Uses the new flags in integration tests CI.

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- ~~Any manual testing that has been done is documented (i.e. what exactly was tested?)~~

🚀 Preview: Add `preview` label to enable