### PR TITLE
fix(ci): pin helm version in setup-helm action to avoid old fallback

### DIFF
--- a/.github/workflows/e2e-k3d.yml
+++ b/.github/workflows/e2e-k3d.yml
@@ -47,6 +47,8 @@ jobs:
           curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
           k3d version
       - uses: azure/setup-helm@v4
+        with:
+          version: v3.18.3
       - name: Create k3d cluster
         run: |
           ./deploy.py --verbose cluster

--- a/.github/workflows/helm-schema-lint.yaml
+++ b/.github/workflows/helm-schema-lint.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
-          version: latest
+          version: v3.18.3
 
       - name: Run Helm lint on values files
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,6 +45,8 @@ jobs:
           curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
           k3d version
       - uses: azure/setup-helm@v4
+        with:
+          version: v3.18.3
       - name: Create k3d cluster
         run: |
           ./deploy.py --verbose cluster --bind-all

--- a/.github/workflows/website-playwright-dev-test.yml
+++ b/.github/workflows/website-playwright-dev-test.yml
@@ -27,6 +27,8 @@ jobs:
           - os: ${{ github.ref != 'refs/heads/main' && 'macos-latest' }}
     steps:
       - uses: azure/setup-helm@v4
+        with:
+          version: v3.18.3
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'


### PR DESCRIPTION
The azure/setup-helm action falls back to an old default version (3.13.3) when fetching the latest fails.

Pinning version to a concrete recent version (3.18.3) avoids this fallback and causes easier to debug failures.

It's recommended in the action's README:

> If something goes wrong with fetching the latest version the action will use the hardcoded default stable version (currently v3.13.3). If you rely on a certain version higher than the default, you should explicitly use that version instead of latest.

The undesired fallback behavior happened here: https://github.com/loculus-project/loculus/actions/runs/15763535878/job/44435288826#step:6:10

🚀 Preview: Add `preview` label to enable