### PR TITLE
feat(website): Use iso format `yyyy-MM-dd` in date search UI instead of `dd/MM/yyyy`

### DIFF
--- a/website/src/components/SearchPage/fields/DateField.spec.tsx
+++ b/website/src/components/SearchPage/fields/DateField.spec.tsx
@@ -6,6 +6,12 @@ import { TimestampField } from './DateField';
 
 const setSomeFieldValues = vi.fn();
 
+const date = new Date(Date.UTC(2025, 2, 17, 0, 0, 0)); // March 17, 2025, at midnight UTC
+const dateDisplayString = date.toISOString().split('T')[0];
+const dateDisplayStringWithoutDelims = dateDisplayString.replace(/\D/g, '');
+const timestampDayStart = Math.floor(date.getTime() / 1000);
+const timestampDayEnd = timestampDayStart + 24 * 60 * 60 - 1; // End of the day in UTC (23:59:59)
+
 describe('TimestampField', () => {
     beforeEach(() => {
         setSomeFieldValues.mockReset();
@@ -18,7 +24,7 @@ describe('TimestampField', () => {
                     name: 'releasedAtTimestampFrom',
                     type: 'timestamp',
                 }}
-                fieldValue={'1742169600'}
+                fieldValue={timestampDayStart.toString()}
                 setSomeFieldValues={setSomeFieldValues}
             />,
         );
@@ -26,7 +32,7 @@ describe('TimestampField', () => {
         const input = screen.getByRole('textbox');
         expect(input).toBeInTheDocument();
 
-        expect(input).toHaveValue('17/03/2025');
+        expect(input).toHaveValue(dateDisplayString);
     });
 
     test('"From" field sets date correctly', async () => {
@@ -42,9 +48,9 @@ describe('TimestampField', () => {
         );
 
         const input = screen.getByRole('textbox');
-        await userEvent.type(input, '17032025');
-        expect(input).toHaveValue('17/03/2025');
-        expect(setSomeFieldValues).lastCalledWith(['releasedAtTimestampFrom', '1742169600']);
+        await userEvent.type(input, dateDisplayStringWithoutDelims);
+        expect(input).toHaveValue(dateDisplayString);
+        expect(setSomeFieldValues).lastCalledWith(['releasedAtTimestampFrom', timestampDayStart.toString()]);
     });
 
     test('"To" field renders date correctly', () => {
@@ -54,7 +60,7 @@ describe('TimestampField', () => {
                     name: 'releasedAtTimestampTo',
                     type: 'timestamp',
                 }}
-                fieldValue={'1742255999'}
+                fieldValue={timestampDayEnd}
                 setSomeFieldValues={setSomeFieldValues}
             />,
         );
@@ -62,7 +68,7 @@ describe('TimestampField', () => {
         const input = screen.getByRole('textbox');
         expect(input).toBeInTheDocument();
 
-        expect(input).toHaveValue('17/03/2025');
+        expect(input).toHaveValue(dateDisplayString);
     });
 
     test('"To" field sets date correctly', async () => {
@@ -78,8 +84,8 @@ describe('TimestampField', () => {
         );
 
         const input = screen.getByRole('textbox');
-        await userEvent.type(input, '17032025');
-        expect(input).toHaveValue('17/03/2025');
-        expect(setSomeFieldValues).lastCalledWith(['releasedAtTimestampTo', '1742255999']);
+        await userEvent.type(input, dateDisplayStringWithoutDelims);
+        expect(input).toHaveValue(dateDisplayString);
+        expect(setSomeFieldValues).lastCalledWith(['releasedAtTimestampTo', timestampDayEnd.toString()]);
     });
 });

--- a/website/src/components/SearchPage/fields/DateField.tsx
+++ b/website/src/components/SearchPage/fields/DateField.tsx
@@ -148,7 +148,7 @@ const CustomizedDatePicker: FC<CustomizedDatePickerProps> = ({
                     id={field.name}
                     name={field.name}
                     key={field.name}
-                    format={'dd/MM/yyyy'}
+                    format={'yyyy-MM-dd'}
                     isoWeek={true}
                     oneTap={true}
                     onChange={(date) => {

--- a/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
+++ b/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
@@ -143,14 +143,17 @@ describe('DateRangeField', () => {
         expect(fromInput).not.toBeNull();
         expect(toInput).not.toBeNull();
 
+        const lowerString = '2002-02-02';
+        const upperString = '2003-03-03';
+
         await userEvent.type(fromInput!, '{backspace}');
-        await userEvent.type(fromInput!, '02022002');
+        await userEvent.type(fromInput!, lowerString.replace(/-/g, ''));
         await userEvent.type(toInput!, '{backspace}');
-        await userEvent.type(toInput!, '03032003');
+        await userEvent.type(toInput!, upperString.replace(/-/g, ''));
 
         expect(setSomeFieldValues).toHaveBeenLastCalledWith(
-            ['collectionDateRangeLowerFrom', '2002-02-02'],
-            ['collectionDateRangeUpperTo', '2003-03-03'],
+            ['collectionDateRangeLowerFrom', lowerString],
+            ['collectionDateRangeUpperTo', upperString],
             ['collectionDateRangeUpperFrom', null],
             ['collectionDateRangeLowerTo', null],
         );


### PR DESCRIPTION
resolves #

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://year-first.loculus.org