### PR TITLE
feat(website): switch date format in date picker fields from dd/MM/yyyy to yyyy-MM-dd

### DIFF
--- a/integration-tests/tests/specs/features/search/active-filters.dependent.spec.ts
+++ b/integration-tests/tests/specs/features/search/active-filters.dependent.spec.ts
@@ -40,7 +40,7 @@ test.describe('Search', () => {
     test('test that date range filter can be removed by clicking the X', async ({ page }) => {
         await searchPage.ebolaSudan();
 
-        await page.getByPlaceholder('dd/MM/yyyy').first().click();
+        await page.getByPlaceholder('yyyy-mm-dd').first().click();
         await page.getByTestId('calendar').getByText('20', { exact: true }).click();
         await expect(page.getByText('Collection date - From:')).toBeVisible();
 
@@ -49,7 +49,7 @@ test.describe('Search', () => {
             .filter({ hasText: /Collection date - From:/ })
             .getByLabel('remove filter')
             .click();
-        await expect(page.getByPlaceholder('dd/MM/yyyy').first()).toBeEmpty();
+        await expect(page.getByPlaceholder('yyyy-mm-dd').first()).toBeEmpty();
         expect(new URL(page.url()).searchParams.size).toBe(0);
     });
 });

--- a/website/src/components/SearchPage/fields/DateField.spec.tsx
+++ b/website/src/components/SearchPage/fields/DateField.spec.tsx
@@ -26,7 +26,7 @@ describe('TimestampField', () => {
         const input = screen.getByRole('textbox');
         expect(input).toBeInTheDocument();
 
-        expect(input).toHaveValue('17/03/2025');
+        expect(input).toHaveValue('2025-03-17');
     });
 
     test('"From" field sets date correctly', async () => {
@@ -42,8 +42,8 @@ describe('TimestampField', () => {
         );
 
         const input = screen.getByRole('textbox');
-        await userEvent.type(input, '17032025');
-        expect(input).toHaveValue('17/03/2025');
+        await userEvent.type(input, '20250317');
+        expect(input).toHaveValue('2025-03-17');
         expect(setSomeFieldValues).lastCalledWith(['releasedAtTimestampFrom', '1742169600']);
     });
 
@@ -62,7 +62,7 @@ describe('TimestampField', () => {
         const input = screen.getByRole('textbox');
         expect(input).toBeInTheDocument();
 
-        expect(input).toHaveValue('17/03/2025');
+        expect(input).toHaveValue('2025-03-17');
     });
 
     test('"To" field sets date correctly', async () => {
@@ -78,8 +78,8 @@ describe('TimestampField', () => {
         );
 
         const input = screen.getByRole('textbox');
-        await userEvent.type(input, '17032025');
-        expect(input).toHaveValue('17/03/2025');
+        await userEvent.type(input, '20250317');
+        expect(input).toHaveValue('2025-03-17');
         expect(setSomeFieldValues).lastCalledWith(['releasedAtTimestampTo', '1742255999']);
     });
 });

--- a/website/src/components/SearchPage/fields/DateField.tsx
+++ b/website/src/components/SearchPage/fields/DateField.tsx
@@ -182,7 +182,7 @@ const CustomizedDatePicker: FC<CustomizedDatePickerProps> = ({
                     {field.displayName ?? field.name}
                 </label>
                 <DatePicker
-                    format='dd/MM/yyyy'
+                    format='yyyy-MM-dd'
                     defaultValue={defaultDate}
                     id={field.name}
                     name={field.name}

--- a/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
+++ b/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
@@ -141,13 +141,13 @@ describe('DateRangeField', () => {
         const fromInput = screen.getByText('From').closest('div')?.querySelector('input');
         const toInput = screen.getByText('To').closest('div')?.querySelector('input');
 
-        expect(fromInput).toHaveValue('01/01/2024');
-        expect(toInput).toHaveValue('31/12/2024');
+        expect(fromInput).toHaveValue('2024-01-01');
+        expect(toInput).toHaveValue('2024-12-31');
 
         await userEvent.type(fromInput!, '{backspace}');
-        await userEvent.type(fromInput!, '23041987');
+        await userEvent.type(fromInput!, '19870423');
         await userEvent.type(toInput!, '{backspace}');
-        await userEvent.type(toInput!, '13102014');
+        await userEvent.type(toInput!, '20141013');
 
         expect(setSomeFieldValues).toHaveBeenLastCalledWith(
             ['collectionDateRangeLowerFrom', '1987-04-23'],
@@ -194,8 +194,8 @@ describe('DateRangeField', () => {
         const getToInput = () => screen.getByText('To').closest('div')?.querySelector('input');
         const button = screen.getByText('Update Dates');
 
-        expect(getFromInput()).toHaveValue('01/01/2024');
-        expect(getToInput()).toHaveValue('31/12/2024');
+        expect(fromInput()).toHaveValue('2024-01-01');
+        expect(toInput()).toHaveValue('2024-12-31');
 
         await user.click(button);
 

--- a/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
+++ b/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
@@ -194,8 +194,8 @@ describe('DateRangeField', () => {
         const getToInput = () => screen.getByText('To').closest('div')?.querySelector('input');
         const button = screen.getByText('Update Dates');
 
-        expect(fromInput()).toHaveValue('2024-01-01');
-        expect(toInput()).toHaveValue('2024-12-31');
+        expect(getFromInput()).toHaveValue('2024-01-01');
+        expect(getToInput()).toHaveValue('2024-12-31');
 
         await user.click(button);
 


### PR DESCRIPTION
Switch date picker date format from `dd/mm/yyyy` to `yyyy-mm-dd`.

### Screenshot

<img width="804" alt="image" src="https://github.com/user-attachments/assets/c1e8907c-8464-431e-b3b3-4ea24a94b39c" />

### Manual testing

- Type dates in both date range and timestamp fields and verify they behave as expected

### PR Checklist
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://year-first-2.loculus.org