### PR TITLE
chore(integration-tests): Use Test ID for component.

### DIFF
--- a/integration-tests/tests/pages/review.page.ts
+++ b/integration-tests/tests/pages/review.page.ts
@@ -20,9 +20,10 @@ export class ReviewPage {
     }
 
     async waitForZeroProcessing() {
-        await expect(this.page.locator('body')).toContainText('0 awaiting processing', {
-            timeout: 33000,
-        });
+        await expect(this.page.locator('[data-testid="review-page-control-panel"]')).toContainText(
+            '0 awaiting processing',
+            { timeout: 33000 },
+        );
     }
 
     async navigateToReviewPage() {

--- a/website/src/components/ReviewPage/ReviewPage.tsx
+++ b/website/src/components/ReviewPage/ReviewPage.tsx
@@ -184,7 +184,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({
 
     const controlPanel = (
         <div className='flex flex-col'>
-            <div className='text-gray-600 mr-3'>
+            <div className='text-gray-600 mr-3' data-testid='review-page-control-panel'>
                 {unprocessedCount > 0 && (
                     <span className='loading loading-spinner loading-sm mr-2 relative top-1'> </span>
                 )}


### PR DESCRIPTION
The previous implementation of `waitForZeroProcessing` always checked the whole body. In case of a test failure, this produced a very large diff, which didn't load very well in the playwright report.

Now a test ID is used, and the diff is a reasonable size.
