### PR TITLE
fix(website): replace brittle timeout hack by changing tooltip triggers

### DIFF
--- a/website/src/components/Submission/FileUpload/ColumnMappingModal.tsx
+++ b/website/src/components/Submission/FileUpload/ColumnMappingModal.tsx
@@ -26,15 +26,7 @@ export const ColumnMappingModal: FC<ColumnMappingModalProps> = ({
     const [isOpen, setIsOpen] = useState(false);
 
     const openDialog = () => setIsOpen(true);
-    const closeDialog = () => {
-        setIsOpen(false);
-        // This is used to not have the Tooltip on the open-button pop up again.
-        setTimeout(() => {
-            if (document.activeElement === null) return;
-            (document.activeElement as HTMLElement).blur();
-        }, 10);
-    };
-
+    const closeDialog = () => setIsOpen(false);
     const [currentMapping, setCurrentMapping] = useState<ColumnMapping | null>(null);
     const [inputColumns, setInputColumns] = useState<string[] | null>(null);
 
@@ -100,7 +92,14 @@ export const ColumnMappingModal: FC<ColumnMappingModalProps> = ({
             >
                 {openModalButtonText}
             </button>
-            <Tooltip id='columnMapping' place='bottom' globalCloseEvents={{ scroll: true, clickOutsideAnchor: true }}>
+            <Tooltip
+                id='columnMapping'
+                place='bottom'
+                globalCloseEvents={{ scroll: true, clickOutsideAnchor: true }}
+                // Don't open on focus, as otherwise closing the dialog will reopen tooltip
+                openEvents={{ mouseenter: true, focus: false }}
+                closeEvents={{ mouseleave: true, blur: true }}
+            >
                 If your metadata file does not use the defined field names, this allow you
                 <br />
                 to map columns in your file to the fields expected by the database.


### PR DESCRIPTION
Resolves #4501

Using timeout caused tests to occasionally crash locally. The original implementation was a hack to avoid tooltip from reopening after modal is closed (it returns because focus returns to button with tooltip).

One shouldn't use timeout without cleaning up the timeout in case of component unmount.

As few people will use keyboard navigation, we can just not trigger the tooltip on focus.

resolves #

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable