### PR TITLE
Deduplicate inherently coupled ena deposition related configs

### DIFF
--- a/kubernetes/loculus/templates/loculus-preprocessing-config.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-config.yaml
@@ -5,6 +5,9 @@
 {{- $nucleotideSequencesList := (eq $rawNucleotideSequences nil | ternary (list "main") $rawNucleotideSequences) }}
 {{- range $processingIndex, $processingConfig := $organismConfig.preprocessing }}
 {{- if $processingConfig.configFile }}
+{{- /* Use the enaDepositionConfig as the base config */}}
+{{- $enaDepositionConfig := dig "enaDeposition" "configFile" dict $organismConfig }}
+{{- $mergedConfigFile := merge $processingConfig.configFile $enaDepositionConfig }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -13,7 +16,7 @@ metadata:
 data:
   preprocessing-config.yaml: |
     organism: {{ $organism }}
-    {{- $processingConfig.configFile | toYaml | nindent 4 }}
+    {{- $mergedConfigFile | toYaml | nindent 4 }}
     {{- (dict "nucleotideSequences" $nucleotideSequencesList) | toYaml | nindent 4 }}
     processing_spec:
       {{- $args := dict "metadata" $metadata "nucleotideSequences" $nucleotideSequences }}

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1201,8 +1201,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         - "prepro"
       replicas: 2
       configFile: &preprocessingConfigFile
-        scientific_name: "Sudan ebolavirus"
-        molecule_type: "genomic RNA"
         log_level: DEBUG
         genes: []
         batch_size: 100
@@ -1309,8 +1307,6 @@ defaultOrganisms:
         version: 1
         configFile:
           <<: *preprocessingConfigFile
-          scientific_name: "West Nile virus"
-          molecule_type: "genomic RNA"
           nextclade_dataset_name: nextstrain/wnv/all-lineages
           nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/wnv/data_output
           genes: [capsid, prM, env, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
@@ -1678,8 +1674,6 @@ defaultOrganisms:
       - <<: *preprocessing
         configFile:
           <<: *preprocessingConfigFile
-          scientific_name: "Orthonairovirus haemorrhagiae"
-          molecule_type: "genomic RNA"
           log_level: DEBUG
           nextclade_dataset_name: nextstrain/cchfv/linked
           nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/cornelius-cchfv/data_output


### PR DESCRIPTION
It doesn't make sense to duplicate the scientific name. It's:
- Annoying for maintainers
- Prone to cause bugs
- The annotation file is inherently coupled to ENA deposition, that's the reason we're putting those annotations in there

Without this, we'd need to add 40 lines of yaml to our PPX production yaml: 10 organisms x 2 processing versions x 2 lines per version... that's just silly

🚀 Preview: Add `preview` label to enable