### PR TITLE
fix!(prepro): trim lower case Ns from unaligned, not just upper case

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1061,7 +1061,7 @@ def format_stop_codon(result: str | None) -> str | None:
 
 def trim_ns(sequence: str) -> str:
     """
-    Trims 'N' characters from the start and end of a nucleotide sequence.
+    Trims 'N' and 'n' characters from the start and end of a nucleotide sequence.
 
     Args:
         sequence (str): The nucleotide sequence to process.
@@ -1069,4 +1069,4 @@ def trim_ns(sequence: str) -> str:
     Returns:
         str: The trimmed sequence.
     """
-    return sequence.lstrip("N").rstrip("N")
+    return sequence.strip("Nn")


### PR DESCRIPTION
We should trigger a full reprocessing in case there were untrimmed `n`s