### PR TITLE
fix(integration-tests): add missing await that otherwise causes spurious test failures

### DIFF
--- a/integration-tests/tests/pages/submission.page.ts
+++ b/integration-tests/tests/pages/submission.page.ts
@@ -32,7 +32,7 @@ class SubmissionPage {
 
 export class SingleSequenceSubmissionPage extends SubmissionPage {
     async navigateToSubmissionPage(organism: string = 'Ebola Sudan') {
-        super.navigateToSubmissionPage(organism);
+        await super.navigateToSubmissionPage(organism);
         await this.page.getByRole('link', { name: 'Submit single sequence' }).click();
     }
 


### PR DESCRIPTION
Lack of await caused weird failures in "afterHooks" which made no sense to me until @anna-parker and I stumbled over this together looking through the Playwright UI and tests.

@fhennig remember to sprinkle `await` liberally - linters will readily tell when the `await` is not needed. They often don't tell you when `await`s are missing.