### PR TITLE
chore(int-tests): Give slow `pageWithACreatedUser` fixture dedicated time so short timeouts on test don't cause flakes

### DIFF
--- a/integration-tests/playwright.config.ts
+++ b/integration-tests/playwright.config.ts
@@ -31,7 +31,11 @@ const config = {
         ignoreHTTPSErrors: process.env.PLAYWRIGHT_TEST_IGNORE_HTTPS_ERRORS === 'true',
 
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-        trace: process.env.CI ? 'on-first-retry' : 'on',
+        trace: (process.env.CI ? 'on-first-retry' : 'on') as
+            | 'on'
+            | 'off'
+            | 'retain-on-failure'
+            | 'on-first-retry',
     },
 
     /* Configure projects for major browsers */

--- a/integration-tests/tests/fixtures/auth.fixture.ts
+++ b/integration-tests/tests/fixtures/auth.fixture.ts
@@ -22,10 +22,13 @@ export const test = base.extend<TestFixtures>({
         await use(testAccount);
     },
 
-    pageWithACreatedUser: async ({ page, testAccount }, use) => {
-        const authPage = new AuthPage(page);
-        await authPage.createAccount(testAccount);
-        await use(page);
-        await authPage.logout();
-    },
+    pageWithACreatedUser: [
+        async ({ page, testAccount }, use) => {
+            const authPage = new AuthPage(page);
+            await authPage.createAccount(testAccount);
+            await use(page);
+            await authPage.logout();
+        },
+        { timeout: 30_000 },
+    ],
 });

--- a/integration-tests/tests/specs/features/submission-flow.spec.ts
+++ b/integration-tests/tests/specs/features/submission-flow.spec.ts
@@ -7,7 +7,7 @@ test.describe('Submission flow', () => {
     test('submission page shows group creation button when not in a group', async ({
         pageWithACreatedUser,
     }) => {
-        test.setTimeout(10000);
+        test.setTimeout(30000);
         const page = pageWithACreatedUser;
         await page.getByRole('link', { name: 'Loculus' }).click();
         await page.getByRole('link', { name: 'Submit' }).click();


### PR DESCRIPTION
Should fix this type of flake: https://github.com/loculus-project/loculus/actions/runs/15878973039/job/44773849246#step:18:62

When a test gets a short timeout, that applies by default also to the fixtures. Some fixtures can take a while so this has caused flakes.