### PR TITLE
fix(website): deflake tests by disabling buttons until react has hydrated and increasing timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ temp/
 
 logs/
 __pycache__/
+
+.astro/

--- a/integration-tests/tests/fixtures/auth.fixture.ts
+++ b/integration-tests/tests/fixtures/auth.fixture.ts
@@ -26,8 +26,11 @@ export const test = base.extend<TestFixtures>({
         async ({ page, testAccount }, use) => {
             const authPage = new AuthPage(page);
             await authPage.createAccount(testAccount);
-            await use(page);
-            await authPage.logout();
+            try {
+                await use(page);
+            } finally {
+                await authPage.logout();
+            }
         },
         { timeout: 30_000 },
     ],

--- a/integration-tests/tests/fixtures/sequence.fixture.ts
+++ b/integration-tests/tests/fixtures/sequence.fixture.ts
@@ -1,5 +1,5 @@
 import { test as groupTest } from './group.fixture';
-import { Page } from '@playwright/test';
+import { expect, Page } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 import { SingleSequenceSubmissionPage } from '../pages/submission.page';
 
@@ -32,10 +32,18 @@ export const test = groupTest.extend<SequenceFixtures>({
 
             await reviewPage.releaseValidSequences();
             await pageWithGroup.getByRole('link', { name: 'Released Sequences' }).click();
-            while (!(await pageWithGroup.getByRole('link', { name: /LOC_/ }).isVisible())) {
-                await pageWithGroup.reload();
-                await pageWithGroup.waitForTimeout(2000);
-            }
+            await expect
+                .poll(
+                    async () => {
+                        await pageWithGroup.reload();
+                        return pageWithGroup.getByRole('link', { name: /LOC_/ }).isVisible();
+                    },
+                    {
+                        message: 'Link with name /LOC_/ never became visible.',
+                        timeout: 60000,
+                    },
+                )
+                .toBe(true);
 
             await use(pageWithGroup);
         },

--- a/integration-tests/tests/pages/review.page.ts
+++ b/integration-tests/tests/pages/review.page.ts
@@ -22,7 +22,7 @@ export class ReviewPage {
     async waitForZeroProcessing() {
         await expect(this.page.locator('[data-testid="review-page-control-panel"]')).toContainText(
             '0 awaiting processing',
-            { timeout: 33000 },
+            { timeout: 60000 },
         );
     }
 

--- a/integration-tests/tests/readonly.setup.ts
+++ b/integration-tests/tests/readonly.setup.ts
@@ -1,4 +1,4 @@
-import { test as setup } from '@playwright/test';
+import { expect, test as setup } from '@playwright/test';
 import { AuthPage } from './pages/auth.page';
 import { GroupPage } from './pages/group.page';
 import { createTestGroup } from './fixtures/group.fixture';
@@ -52,8 +52,16 @@ setup('Initialize a single ebola sequence as base data', async ({ page }) => {
     await reviewPage.waitForZeroProcessing();
     await reviewPage.releaseValidSequences();
     await page.getByRole('link', { name: 'released sequences' }).click();
-    while (!(await page.getByRole('link', { name: /LOC_/ }).isVisible())) {
-        await page.reload();
-        await page.waitForTimeout(2000);
-    }
+    await expect
+        .poll(
+            async () => {
+                await page.reload();
+                return page.getByRole('link', { name: /LOC_/ }).isVisible();
+            },
+            {
+                message: 'Link with name /LOC_/ never became visible.',
+                timeout: 60000,
+            },
+        )
+        .toBe(true);
 });

--- a/integration-tests/tests/specs/features/submission-flow.spec.ts
+++ b/integration-tests/tests/specs/features/submission-flow.spec.ts
@@ -43,10 +43,18 @@ test.describe('Submission flow', () => {
         await page.getByRole('button', { name: 'Release', exact: true }).click();
         await page.getByRole('link', { name: 'Released Sequences' }).click();
 
-        while (!(await page.getByRole('cell', { name: 'Pakistan' }).isVisible())) {
-            await page.reload();
-            await page.waitForTimeout(2000);
-        }
+        await expect
+            .poll(
+                async () => {
+                    await page.reload();
+                    return page.getByRole('cell', { name: 'Pakistan' }).isVisible();
+                },
+                {
+                    message: 'Cell with name Pakistan never became visible.',
+                    timeout: 60000,
+                },
+            )
+            .toBe(true);
 
         await page.getByRole('cell', { name: 'Pakistan' }).click();
         await page.waitForSelector('text="test_NIHPAK-19"');

--- a/website/src/components/Edit/InputField.tsx
+++ b/website/src/components/Edit/InputField.tsx
@@ -31,7 +31,12 @@ export const InputField: FC<InputFieldProps> = ({ row, onChange, colorClassName,
     return (
         <>
             {options !== undefined ? (
-                <Combobox immediate value={row.value} onChange={(value) => onChange({ ...row, value: value ?? '' })}>
+                <Combobox
+                    immediate
+                    value={row.value}
+                    onChange={(value) => onChange({ ...row, value: value ?? '' })}
+                    disabled={!isClient}
+                >
                     <div className='relative inline'>
                         <ComboboxInput
                             id={row.key}

--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -84,11 +84,7 @@ export const SearchForm = ({
                     <div className='flex'>
                         <div className='flex items-center justify-between w-full mb-1 text-primary-700'>
                             <div className='flex items-center justify-between w-full mb-1 text-primary-700 text-sm'>
-                                <button
-                                    className='hover:underline'
-                                    onClick={toggleFieldSelector}
-                                    disabled={!isClient}
-                                >
+                                <button className='hover:underline' onClick={toggleFieldSelector} disabled={!isClient}>
                                     <StreamlineWrench className='inline-block' /> Add Search Fields
                                 </button>
                                 <button

--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -12,6 +12,7 @@ import { LineageField } from './fields/LineageField.tsx';
 import { MutationField } from './fields/MutationField.tsx';
 import { NormalTextField } from './fields/NormalTextField';
 import { searchFormHelpDocsUrl } from './searchFormHelpDocsUrl.ts';
+import useClientFlag from '../../hooks/isClient.ts';
 import { useOffCanvas } from '../../hooks/useOffCanvas.ts';
 import type { GroupedMetadataFilter, MetadataFilter, FieldValues, SetSomeFieldValues } from '../../types/config.ts';
 import { type ReferenceGenomesSequenceNames } from '../../types/referencesGenomes.ts';
@@ -50,6 +51,7 @@ export const SearchForm = ({
     showMutationSearch,
 }: SearchFormProps) => {
     const visibleFields = filterSchema.filters.filter((field) => searchVisibilities.get(field.name));
+    const isClient = useClientFlag();
 
     const [isFieldSelectorOpen, setIsFieldSelectorOpen] = useState(false);
     const { isOpen: isMobileOpen, close: closeOnMobile, toggle: toggleMobileOpen } = useOffCanvas();
@@ -82,7 +84,11 @@ export const SearchForm = ({
                     <div className='flex'>
                         <div className='flex items-center justify-between w-full mb-1 text-primary-700'>
                             <div className='flex items-center justify-between w-full mb-1 text-primary-700 text-sm'>
-                                <button className='hover:underline' onClick={toggleFieldSelector}>
+                                <button
+                                    className='hover:underline'
+                                    onClick={toggleFieldSelector}
+                                    disabled={!isClient}
+                                >
                                     <StreamlineWrench className='inline-block' /> Add Search Fields
                                 </button>
                                 <button

--- a/website/src/components/SearchPage/fields/MutationField.tsx
+++ b/website/src/components/SearchPage/fields/MutationField.tsx
@@ -2,6 +2,7 @@ import { Combobox, ComboboxInput, ComboboxOption, ComboboxOptions, Transition } 
 import { type FC, Fragment, useMemo, useState } from 'react';
 import * as React from 'react';
 
+import useClientFlag from '../../../hooks/isClient.ts';
 import type { ReferenceGenomesSequenceNames } from '../../../types/referencesGenomes.ts';
 import { parseMutationsString, type MutationQuery, parseMutationString } from '../../../utils/mutation.ts';
 import { serializeMutationQueries } from '../../../utils/mutation.ts';
@@ -17,6 +18,7 @@ export const MutationField: FC<MutationFieldProps> = ({ referenceGenomesSequence
     const [options, setOptions] = useState<MutationQuery[]>([]);
     const [inputValue, setInputValue] = useState('');
     const [hasFocus, setHasFocus] = useState(false);
+    const isClient = useClientFlag();
 
     const selectedOptions = useMemo(
         () => parseMutationsString(value, referenceGenomesSequenceNames),
@@ -52,7 +54,7 @@ export const MutationField: FC<MutationFieldProps> = ({ referenceGenomesSequence
 
     return (
         <div className='flex relative mb-2 flex-row w-full'>
-            <Combobox value={selectedOptions} onChange={handleOptionClick}>
+            <Combobox value={selectedOptions} onChange={handleOptionClick} disabled={!isClient}>
                 <div className='w-full relative mt-1'>
                     <div
                         className={`w-full flex flex-wrap items-center border border-gray-300 bg-white rounded-md shadow-sm text-left cursor-default focus-within:ring-1 focus-within:ring-blue-500 focus-within:border-blue-500 sm:text-sm


### PR DESCRIPTION
resolves #4513, resolves #4369, resolves #4498, resolves #4358


Using `PLAYWRIGHT_TEST_BASE_URL="https://test-tweaks2.loculus.org" npx playwright test --ui --workers 10` I debugged flaky tests locally, figuring out root causes of timeouts/lack of progress.

Main reasons for failure:
- Lack of marking React controlled inputs as disabled until React has hydrated the server side rendered HTML. This has been a common flakiness theme for a while. The solution is to use the `const isClient = useClientFlag()` hook and set `disabled={!isClient}`. The phenotype of this failure mode is playwright apparently getting stuck at a step after it clicked something. It did the click but React never listened, and hence didn't open a combobox option or modal or...
- Too short timeouts, sometimes things like processing just take time. We should not set short timeouts, there's no real benefit, costs are high. Usually tests pass so timeouts have no effect if they are on the long side.

🚀 Preview: https://test-tweaks2.loculus.org