### PR TITLE
feat(int-tests): speed up read-only dependent tests by using pre-existing sequences

### DIFF
--- a/integration-tests/tests/fixtures/group.fixture.ts
+++ b/integration-tests/tests/fixtures/group.fixture.ts
@@ -13,6 +13,16 @@ interface TestGroup {
     country: string;
 }
 
+export const readonlyGroup = {
+    name: 'readonly-group',
+    email: 'readonly-group@example.com',
+    institution: 'Readonly Institute',
+    addressLine1: '123 Readonly Street',
+    city: 'Readonly City',
+    zipCode: '12345',
+    country: 'USA',
+};
+
 export const createTestGroup = (name = `test_group_${uuidv4().slice(0, 8)}`): TestGroup => ({
     name,
     email: `test_${uuidv4().slice(0, 8)}@test.com`,

--- a/integration-tests/tests/fixtures/user.fixture.ts
+++ b/integration-tests/tests/fixtures/user.fixture.ts
@@ -1,0 +1,8 @@
+export const readonlyUser = {
+    firstName: 'Playwright',
+    lastName: 'Setup',
+    email: 'playwright-readonly-setup-user@example.com',
+    organization: 'Test Institute',
+    password: 'a-very-secure-password-for-testing',
+    username: 'playwright-readonly-setup-user',
+};

--- a/integration-tests/tests/pages/group.page.ts
+++ b/integration-tests/tests/pages/group.page.ts
@@ -70,6 +70,31 @@ export class GroupPage {
         await expect(this.page.getByRole('heading', { name: groupData.name })).toBeVisible();
     }
 
+    async getOrCreateGroup(groupData: GroupData): Promise<string> {
+        await this.page.goto('/');
+        await this.page.getByRole('link', { name: 'My account' }).click();
+        const groupLink = this.page
+            .locator('li')
+            .filter({ hasText: groupData.name })
+            .getByRole('link');
+
+        let groupId: string | null | undefined;
+
+        if (await groupLink.isVisible()) {
+            const href = await groupLink.getAttribute('href');
+            groupId = href?.split('/').pop();
+        } else {
+            await this.createGroup(groupData);
+            const url = this.page.url();
+            groupId = url.split('/').pop();
+        }
+
+        if (!groupId) {
+            throw new Error(`Could not determine group ID for group: ${groupData.name}`);
+        }
+        return groupId;
+    }
+
     async goToGroupEditPage() {
         const editButton = this.page.getByRole('link', { name: 'Edit group' });
         await editButton.waitFor({ state: 'visible' });

--- a/integration-tests/tests/pages/submission.page.ts
+++ b/integration-tests/tests/pages/submission.page.ts
@@ -13,7 +13,7 @@ class SubmissionPage {
     }
 
     async navigateToSubmissionPage(organism: string = 'Ebola Sudan') {
-        await this.page.getByRole('link', { name: 'Submit' }).click();
+        await this.page.getByRole('link', { name: 'Submit', exact: true }).click();
         await this.page.getByRole('link', { name: organism }).click();
         await this.page.getByRole('link', { name: 'Submit Upload new sequences.' }).click();
     }

--- a/integration-tests/tests/pages/submission.page.ts
+++ b/integration-tests/tests/pages/submission.page.ts
@@ -15,7 +15,7 @@ class SubmissionPage {
     async navigateToSubmissionPage(organism: string = 'Ebola Sudan') {
         await this.page.getByRole('link', { name: 'Submit', exact: true }).click();
 
-        // Dependign on current state (organism selected or not), we need to switch
+        // Depending on current state (organism selected or not), we need to switch
         const organismSwitchLink = this.page.getByRole('link', { name: organism });
         const organismLocator = this.page.locator('label').filter({ hasText: organism });
 
@@ -121,7 +121,6 @@ export class SingleSequenceSubmissionPage extends SubmissionPage {
         sequenceData: Record<string, string>,
     ): Promise<ReviewPage> {
         await this.navigateToSubmissionPage();
-        // Switch to group the url if a groupId is provided
         if (groupId) {
             const currentUrl = this.page.url();
             const newUrl = currentUrl.replace(/submission\/\d+/, `submission/${groupId}`);

--- a/integration-tests/tests/readonly.setup.ts
+++ b/integration-tests/tests/readonly.setup.ts
@@ -1,18 +1,18 @@
 import { expect, test as setup } from '@playwright/test';
 import { AuthPage } from './pages/auth.page';
 import { GroupPage } from './pages/group.page';
-import { createTestGroup } from './fixtures/group.fixture';
+import { readonlyGroup } from './fixtures/group.fixture';
 import { SingleSequenceSubmissionPage } from './pages/submission.page';
 import { readonlyUser } from './fixtures/user.fixture';
 
-setup('Initialize a single ebola sequence as base data', async ({ page, baseURL }) => {
+setup('Initialize a single ebola sequence as base data', async ({ page }) => {
     setup.setTimeout(90000);
     const authPage = new AuthPage(page);
     await authPage.tryLoginOrRegister(readonlyUser);
 
-    // If we've reached here, it means we're logged in but the data is missing.
     const groupPage = new GroupPage(page);
-    await groupPage.createGroup(createTestGroup());
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const groupId = await groupPage.getOrCreateGroup(readonlyGroup);
 
     const submissionPage = new SingleSequenceSubmissionPage(page);
     const reviewPage = await submissionPage.completeSubmission(
@@ -48,7 +48,7 @@ setup('Initialize a single ebola sequence as base data', async ({ page, baseURL 
         .poll(
             async () => {
                 await page.reload();
-                return page.getByRole('link', { name: /LOC_/ }).isVisible();
+                return page.getByRole('link', { name: /LOC_/ }).first().isVisible();
             },
             {
                 message: 'Link with name /LOC_/ never became visible.',

--- a/integration-tests/tests/readonly.setup.ts
+++ b/integration-tests/tests/readonly.setup.ts
@@ -19,10 +19,8 @@ setup('Initialize a single ebola sequence as base data', async ({ page, baseURL 
         baseURL,
     ).toString();
     await page.goto(releasedSequencesUrl);
-    // Wait for page to load by asserting on presence of group name
-    await expect(page.getByRole('button', { name: readonlyGroup.name })).toBeVisible({
-        timeout: 5000,
-    });
+    // Wait for page to load by asserting on presence of the group name
+    await expect(page.getByText(readonlyGroup.name).first()).toBeVisible();
 
     const sequenceCount = await page.getByRole('link', { name: /LOC_/ }).count();
 

--- a/integration-tests/tests/readonly.setup.ts
+++ b/integration-tests/tests/readonly.setup.ts
@@ -3,22 +3,14 @@ import { AuthPage } from './pages/auth.page';
 import { GroupPage } from './pages/group.page';
 import { createTestGroup } from './fixtures/group.fixture';
 import { SingleSequenceSubmissionPage } from './pages/submission.page';
-import { v4 as uuidv4 } from 'uuid';
+import { readonlyUser } from './fixtures/user.fixture';
 
-setup('Initialize a single ebola sequence as base data', async ({ page }) => {
+setup('Initialize a single ebola sequence as base data', async ({ page, baseURL }) => {
     setup.setTimeout(90000);
     const authPage = new AuthPage(page);
-    const username = uuidv4().substring(0, 8);
-    const password = uuidv4().substring(0, 8);
-    await authPage.createAccount({
-        firstName: 'Foo',
-        lastName: 'Bar',
-        email: `${username}@foo.org`,
-        organization: 'Foo University',
-        password,
-        username,
-    });
+    await authPage.tryLoginOrRegister(readonlyUser);
 
+    // If we've reached here, it means we're logged in but the data is missing.
     const groupPage = new GroupPage(page);
     await groupPage.createGroup(createTestGroup());
 

--- a/integration-tests/tests/readonly.setup.ts
+++ b/integration-tests/tests/readonly.setup.ts
@@ -5,22 +5,39 @@ import { readonlyGroup } from './fixtures/group.fixture';
 import { SingleSequenceSubmissionPage } from './pages/submission.page';
 import { readonlyUser } from './fixtures/user.fixture';
 
-setup('Initialize a single ebola sequence as base data', async ({ page }) => {
-    setup.setTimeout(90000);
+setup('Initialize a single ebola sequence as base data', async ({ page, baseURL }) => {
+    setup.setTimeout(90_000);
     const authPage = new AuthPage(page);
     await authPage.tryLoginOrRegister(readonlyUser);
 
     const groupPage = new GroupPage(page);
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const groupId = await groupPage.getOrCreateGroup(readonlyGroup);
+
+    // Navigate directly to the group's released sequences page to check for data.
+    const releasedSequencesUrl = new URL(
+        `/ebola-sudan/submission/${groupId}/released`,
+        baseURL,
+    ).toString();
+    await page.goto(releasedSequencesUrl);
+    // Wait for page to load by asserting on presence of group name
+    await expect(page.getByRole('button', { name: readonlyGroup.name })).toBeVisible({
+        timeout: 5000,
+    });
+
+    const sequenceCount = await page.getByRole('link', { name: /LOC_/ }).count();
+
+    if (sequenceCount > 0) {
+        return; // Data exists, so we're done.
+    }
 
     const submissionPage = new SingleSequenceSubmissionPage(page);
     const reviewPage = await submissionPage.completeSubmission(
         {
-            submissionId: 'foobar',
+            submissionId: 'foobar-readonly',
             collectionCountry: 'France',
             collectionDate: '2021-05-12',
             authorAffiliations: 'Patho Institute, Paris',
+            groupId: groupId,
         },
         {
             main:
@@ -44,6 +61,7 @@ setup('Initialize a single ebola sequence as base data', async ({ page }) => {
     await reviewPage.waitForZeroProcessing();
     await reviewPage.releaseValidSequences();
     await page.getByRole('link', { name: 'released sequences' }).click();
+    // Reloading is required as the page does not automatically update with new data
     await expect
         .poll(
             async () => {


### PR DESCRIPTION
When doing Playwright debugging locally, it was annoying that for dependent tests, there would be new sequence creation every time one runs a test. This took 15+ seconds.

This PR now checks for existence of a sequence and skips submission of sequence if there already is a sequence in a group. This takes only ~2 seconds allowing faster iteration on dependent tests.

🚀 Preview: Add `preview` label to enable