### PR TITLE
chore(website): small improvements to DisabledUntilHydrated element

### DIFF
--- a/website/src/components/DisabledUntilHydrated.tsx
+++ b/website/src/components/DisabledUntilHydrated.tsx
@@ -1,9 +1,9 @@
-import { cloneElement, type FC, type ReactElement } from 'react';
+import { Children, cloneElement, type FC, type ReactElement } from 'react';
 
 import useClientFlag from '../hooks/isClient';
 
 interface DisabledUntilHydratedProps {
-    children: ReactElement;
+    children: ReactElement<{ disabled?: boolean }>;
     alsoDisabledIf?: boolean;
 }
 
@@ -12,7 +12,17 @@ interface DisabledUntilHydratedProps {
  */
 const DisabledUntilHydrated: FC<DisabledUntilHydratedProps> = ({ children, alsoDisabledIf = false }) => {
     const isClient = useClientFlag();
-    return cloneElement(children, { disabled: !isClient || alsoDisabledIf });
+
+    // Ensure that there is exactly one child element
+    const child = Children.only(children);
+    // Error if we're overriding a `disabled` prop
+    if (child.props.disabled !== undefined) {
+        throw new Error(
+            'DisabledUntilHydrated: child element should not set its own `disabled` prop—it will be overridden.',
+        );
+    }
+
+    return cloneElement(child, { disabled: !isClient || alsoDisabledIf });
 };
 
 export default DisabledUntilHydrated;


### PR DESCRIPTION
- Ensure it gets only one child
- Throw if it would override a disabled (ideally this would be done by TS but it seems complicated)

### Screenshot

Example lint we get now:

<img width="1113" alt="image" src="https://github.com/user-attachments/assets/9d7768da-1180-4281-a3d3-6ec70d7f3673" />

And if disabled is set on child:
<img width="795" alt="image" src="https://github.com/user-attachments/assets/9ee114e8-0d18-45c9-8c9a-d83b8c2a8475" />


### PR Checklist
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable