### PR TITLE
fix(website): remove lineage aliases from drop down

### DIFF
--- a/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
+++ b/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
@@ -80,7 +80,7 @@ const createGenericOptionsHook = (
  * @param lineageDefinition The lineage definition.
  * @param counts Counts as they occur for lineages or aliases, without any aggregation.
  * @param includeSublineages Whether to aggregate across descendants or not.
- * @returns Counts for all lineages and aliases.
+ * @returns Counts for all lineages; including only canonical lineage names.
  */
 function aggregateCounts(
     lineageDefinition: LineageDefinition,
@@ -133,14 +133,6 @@ function aggregateCounts(
         }
     } else {
         resolvedCounts = canonicalCounts;
-    }
-
-    // add counts for aliases back
-    for (const [alias, canonicalLineage] of canonicalNames.entries()) {
-        if (alias !== canonicalLineage) {
-            const canonicalCount = canonicalCounts.get(canonicalLineage)!;
-            resolvedCounts.set(alias, canonicalCount);
-        }
     }
 
     return resolvedCounts;
@@ -204,13 +196,10 @@ const createLineageOptionsHook = (
             const aggregatedCounts = aggregateCounts(lineageDefinition, unaggregatedCounts, includeSublineages);
 
             // generate options
-            Object.entries(lineageDefinition).forEach(([lineageName, { aliases }]) => {
+            Object.keys(lineageDefinition).forEach((lineageName) => {
                 let count: number | undefined = aggregatedCounts.get(lineageName);
                 if (count === 0) count = undefined;
                 options.push({ option: lineageName, count });
-                if (aliases) {
-                    aliases.forEach((alias) => options.push({ option: alias, count }));
-                }
             });
         }
 

--- a/website/src/components/SearchPage/fields/LineageField.spec.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.spec.tsx
@@ -41,13 +41,17 @@ describe('LineageField', () => {
                 'A.1': {
                     parents: ['A'],
                 },
-                'B': {
+                'A.1.1': {
                     parents: ['A.1'],
-                    aliases: ['A.1.1'],
+                    aliases: ['B'],
                 },
-                'C': {
+                'B.1': {
+                    parents: ['A.1.1'],
+                    aliases: ['A.1.1.1'],
+                },
+                'A.2': {
                     parents: ['A'],
-                    aliases: ['A.2'],
+                    aliases: ['C'],
                 },
             },
             /* eslint-enable @typescript-eslint/naming-convention */
@@ -60,8 +64,8 @@ describe('LineageField', () => {
             data: {
                 data: [
                     { lineage: 'A.1', count: 10 },
-                    { lineage: 'A.1.1', count: 20 },
-                    { lineage: 'B', count: 15 },
+                    { lineage: 'A.1.1.1', count: 20 },
+                    { lineage: 'B.1', count: 15 },
                     { lineage: 'A.2', count: 8 },
                 ],
             },
@@ -121,11 +125,11 @@ describe('LineageField', () => {
         await userEvent.click(screen.getByLabelText('My Lineage'));
 
         const options = await screen.findAllByRole('option');
-        expect(options.length).toBe(4);
+        expect(options.length).toBe(5);
         expect(options[0].textContent).toBe('A');
         expect(options[1].textContent).toBe('A.1(10)');
-        // A.1.1 and B are aliases -> B should have aggregated count
-        expect(options[2].textContent).toBe('B(35)');
+        // A.1.1.1 and B.1 are aliases -> B.1 should have aggregated count
+        expect(options[4].textContent).toBe('B.1(35)');
     });
 
     it('aggregates counts for sublineages correctly', async () => {
@@ -145,11 +149,11 @@ describe('LineageField', () => {
         await userEvent.click(screen.getByLabelText('My Lineage'));
 
         const options = await screen.findAllByRole('option');
-        expect(options.length).toBe(4);
+        expect(options.length).toBe(5);
         expect.soft(options[0].textContent).toBe('A(53)');
         expect.soft(options[1].textContent).toBe('A.1(45)');
-        expect.soft(options[2].textContent).toBe('B(35)');
-        expect.soft(options[3].textContent).toBe('C(8)');
+        expect.soft(options[2].textContent).toBe('A.1.1(35)');
+        expect.soft(options[3].textContent).toBe('A.2(8)');
     });
 
     it('handles input changes and calls setSomeFieldValues', async () => {
@@ -168,13 +172,13 @@ describe('LineageField', () => {
         const options = await screen.findAllByRole('option');
         await userEvent.click(options[2]);
 
-        expect(setSomeFieldValues).toHaveBeenCalledWith(['lineage', 'B']);
+        expect(setSomeFieldValues).toHaveBeenCalledWith(['lineage', 'A.1.1']);
 
         const checkbox = screen.getByRole('checkbox');
         fireEvent.click(checkbox);
         expect(checkbox).toBeChecked();
 
-        expect(setSomeFieldValues).toHaveBeenCalledWith(['lineage', 'B*']);
+        expect(setSomeFieldValues).toHaveBeenCalledWith(['lineage', 'A.1.1*']);
     });
 
     it('clears wildcard when sublineages is unchecked', () => {

--- a/website/src/components/SearchPage/fields/LineageField.spec.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.spec.tsx
@@ -41,13 +41,13 @@ describe('LineageField', () => {
                 'A.1': {
                     parents: ['A'],
                 },
-                'A.1.1': {
+                'B': {
                     parents: ['A.1'],
-                    aliases: ['B'],
+                    aliases: ['A.1.1'],
                 },
-                'A.2': {
+                'C': {
                     parents: ['A'],
-                    aliases: ['C'],
+                    aliases: ['A.2'],
                 },
             },
             /* eslint-enable @typescript-eslint/naming-convention */
@@ -121,12 +121,11 @@ describe('LineageField', () => {
         await userEvent.click(screen.getByLabelText('My Lineage'));
 
         const options = await screen.findAllByRole('option');
-        expect(options.length).toBe(6);
+        expect(options.length).toBe(4);
         expect(options[0].textContent).toBe('A');
         expect(options[1].textContent).toBe('A.1(10)');
-        // A.1.1 and B are aliases -> should have same, aggregated count
-        expect(options[2].textContent).toBe('A.1.1(35)');
-        expect(options[4].textContent).toBe('B(35)');
+        // A.1.1 and B are aliases -> B should have aggregated count
+        expect(options[2].textContent).toBe('B(35)');
     });
 
     it('aggregates counts for sublineages correctly', async () => {
@@ -146,12 +145,11 @@ describe('LineageField', () => {
         await userEvent.click(screen.getByLabelText('My Lineage'));
 
         const options = await screen.findAllByRole('option');
-        expect(options.length).toBe(6);
+        expect(options.length).toBe(4);
         expect.soft(options[0].textContent).toBe('A(53)');
         expect.soft(options[1].textContent).toBe('A.1(45)');
-        expect.soft(options[2].textContent).toBe('A.1.1(35)');
-        expect.soft(options[3].textContent).toBe('A.2(8)');
-        expect.soft(options[4].textContent).toBe('B(35)');
+        expect.soft(options[2].textContent).toBe('B(35)');
+        expect.soft(options[3].textContent).toBe('C(8)');
     });
 
     it('handles input changes and calls setSomeFieldValues', async () => {
@@ -170,13 +168,13 @@ describe('LineageField', () => {
         const options = await screen.findAllByRole('option');
         await userEvent.click(options[2]);
 
-        expect(setSomeFieldValues).toHaveBeenCalledWith(['lineage', 'A.1.1']);
+        expect(setSomeFieldValues).toHaveBeenCalledWith(['lineage', 'B']);
 
         const checkbox = screen.getByRole('checkbox');
         fireEvent.click(checkbox);
         expect(checkbox).toBeChecked();
 
-        expect(setSomeFieldValues).toHaveBeenCalledWith(['lineage', 'A.1.1*']);
+        expect(setSomeFieldValues).toHaveBeenCalledWith(['lineage', 'B*']);
     });
 
     it('clears wildcard when sublineages is unchecked', () => {


### PR DESCRIPTION
resolves #4534 

Removes the explicit adding of aliases to the options list. Component tests are adapted accordingly.

**manual testing** - Created 100 Test organism entries, checked the dropdown, only the canonical names are shown.

### Screenshot

<img width="410" alt="image" src="https://github.com/user-attachments/assets/bf790637-90ca-44f7-a165-268a0fb9d043" />

lineage file content:

```
A:
  aliases: []
  parents: []
A.1:
  aliases: []
  parents:
  - A
A.1.1:
  aliases:
  - B
  parents:
  - A.1
A.2:
  aliases: []
  parents:
  - A
```


### PR Checklist
- ~~All necessary documentation has been adapted.~~ (I can't think of anything to document here)
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://dont-show-lineage-aliases.loculus.org