### PR TITLE
chore(ci): remove powershell from init-shells as it's unused and triggers warning

### DIFF
--- a/.github/workflows/ena-submission-unit-tests.yaml
+++ b/.github/workflows/ena-submission-unit-tests.yaml
@@ -26,7 +26,6 @@ jobs:
             micromamba-version: 'latest'
             init-shell: >-
                 bash
-                powershell
             cache-environment: true
             post-cleanup: 'all'
       - name: Run tests

--- a/.github/workflows/ena-submission-workflow-tests.yml
+++ b/.github/workflows/ena-submission-workflow-tests.yml
@@ -53,7 +53,6 @@ jobs:
             micromamba-version: 'latest'
             init-shell: >-
                 bash
-                powershell
             cache-environment: true
             post-cleanup: 'all'
       - name: Run tests


### PR DESCRIPTION
<img width="1214" alt="Google Chrome 2025-06-30 15 50 14" src="https://github.com/user-attachments/assets/2e2e6858-22e7-445c-acf4-dd69f0b73cbf" />

<img width="1148" alt="Google Chrome 2025-06-30 15 50 19" src="https://github.com/user-attachments/assets/877120f3-e255-4c8f-9401-b781fe05aa1b" />

Failure is unrelated:
<img width="1002" alt="image" src="https://github.com/user-attachments/assets/1f2eb5a8-b926-4a68-8088-fe0ba4375908" />


🚀 Preview: Add `preview` label to enable