### PR TITLE
fix(integration-tests): enable override tests

### DIFF
--- a/integration-tests/tests/specs/features/search/override-hidden-fields.spec.ts
+++ b/integration-tests/tests/specs/features/search/override-hidden-fields.spec.ts
@@ -5,7 +5,7 @@ import { SearchPage } from '../../../pages/search.page';
 import { SingleSequenceSubmissionPage } from '../../../pages/submission.page';
 import { v4 as uuidv4 } from 'uuid';
 
-test.only('Override hidden fields', async ({ page, pageWithGroup }) => {
+test('Override hidden fields', async ({ page, pageWithGroup }) => {
     test.setTimeout(95_000);
     const uuid = uuidv4();
 


### PR DESCRIPTION
resolves #4543

The test was disabled by mistake. It also uncovered a 422 error on the review page for revocations, which is now also fixed.

🚀 Preview: Add `preview` label to enable