### PR TITLE
fix(website): avoid get-data-to-edit for revocations

### DIFF
--- a/website/src/components/ReviewPage/ReviewCard.tsx
+++ b/website/src/components/ReviewPage/ReviewCard.tsx
@@ -516,10 +516,7 @@ function useGetMetadataAndAnnotations(
             params: { organism, accession, version },
         },
         {
-            enabled:
-                status !== receivedStatus &&
-                status !== inProcessingStatus &&
-                !isRevocation,
+            enabled: status !== receivedStatus && status !== inProcessingStatus && !isRevocation,
         },
     );
 }


### PR DESCRIPTION
Resolves #4551

## Summary
- stop using `get-data-to-edit` query when displaying a revocation entry

## Testing 

I checked we no longer see an error in the console and that other entries still appear normally

<img width="1201" alt="image" src="https://github.com/user-attachments/assets/bc623cb0-c7ac-423f-a7b7-4355aa5bd121" />



------
https://chatgpt.com/codex/tasks/task_e_6862a8e1ffe48325bfb6dae71bcc9f43

🚀 Preview: https://codex-remove-get-data-to.loculus.org