### PR TITLE
chore(ci): run ena integration tests on all ena-submission file changes

### DIFF
--- a/.github/workflows/ena-submission-workflow-tests.yml
+++ b/.github/workflows/ena-submission-workflow-tests.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-concurrency:
-  group: ci-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}-ena-submission-workflow-tests
-  cancel-in-progress: true
 jobs:
   Tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ena-submission-workflow-tests.yml
+++ b/.github/workflows/ena-submission-workflow-tests.yml
@@ -2,7 +2,7 @@ name: ena-submission-workflow-tests
 on:
   pull_request:
     paths:
-      - "ena-submission/scripts/test_ena_submission_integration.py"
+      - "ena-submission/**"
       - ".github/workflows/ena-submission-workflow-tests.yml"
   push:
     branches:

--- a/.github/workflows/ena-submission-workflow-tests.yml
+++ b/.github/workflows/ena-submission-workflow-tests.yml
@@ -67,7 +67,6 @@ jobs:
             environment-file: ena-submission/environment.yml
             micromamba-version: 'latest'
             cache-environment: true
-            cache-environment-key: micromamba-${{ hashFiles('ena-submission/environment.yml') }}
       - name: Run tests
         run: |
             pip install .

--- a/.github/workflows/ena-submission-workflow-tests.yml
+++ b/.github/workflows/ena-submission-workflow-tests.yml
@@ -34,27 +34,40 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
+      - name: Extract Flyway version
+        id: flyway_version
+        run: |
+          FLYWAY_VERSION=$(grep "^FROM flyway/flyway:" ./ena-submission/flyway/Dockerfile \
+            | sed -E 's/^FROM flyway\/flyway:([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          echo "version=$FLYWAY_VERSION" >> $GITHUB_OUTPUT
       - name: Install Flyway
         run: |
-          curl -L -o flyway.tar.gz "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/10.0.0/flyway-commandline-10.0.0-linux-x64.tar.gz"
+          FLYWAY_VERSION=${{ steps.flyway_version.outputs.version }}
+          curl -L -o flyway.tar.gz \
+            https://github.com/flyway/flyway/releases/download/flyway-$FLYWAY_VERSION/flyway-commandline-$FLYWAY_VERSION-linux-x64.tar.gz
           tar -xzf flyway.tar.gz
-          sudo mv flyway-10.0.0 /opt/flyway
+          sudo mv flyway-$FLYWAY_VERSION /opt/flyway
           echo "/opt/flyway" >> $GITHUB_PATH
       - name: Run Flyway
-        run: flyway -url=jdbc:postgresql://localhost:5432/loculus -schemas=ena_deposition_schema -user=postgres -password=unsecure -locations=filesystem:./ena-submission/flyway/sql migrate
+        run: | 
+          flyway -url=jdbc:postgresql://localhost:5432/loculus \
+            -schemas=ena_deposition_schema \
+            -user=postgres \
+            -password=unsecure \
+            -locations=filesystem:./ena-submission/flyway/sql \
+            migrate
       - name: Install WEBIN CLI
         run: |
           WEBIN_CLI_VERSION=$(cat ena-submission/.webinrc)
-          wget -q "https://github.com/enasequence/webin-cli/releases/download/${WEBIN_CLI_VERSION}/webin-cli-${WEBIN_CLI_VERSION}.jar" -O ena-submission/webin-cli.jar
+          wget -q "https://github.com/enasequence/webin-cli/releases/download/${WEBIN_CLI_VERSION}/webin-cli-${WEBIN_CLI_VERSION}.jar" \
+            -O ena-submission/webin-cli.jar
       - name: Set up micromamba
         uses: mamba-org/setup-micromamba@v2
         with: 
             environment-file: ena-submission/environment.yml
             micromamba-version: 'latest'
-            init-shell: >-
-                bash
             cache-environment: true
-            post-cleanup: 'all'
+            cache-environment-key: micromamba-${{ hashFiles('ena-submission/environment.yml') }}
       - name: Run tests
         run: |
             pip install .

--- a/ena-submission/flyway/Dockerfile
+++ b/ena-submission/flyway/Dockerfile
@@ -1,4 +1,6 @@
-FROM flyway/flyway:latest
+# The version number is also used in the ena-submission-workflow-tests.yml file to extract the Flyway version dynamically.
+# We thus require a specific major.minor.patch version here
+FROM flyway/flyway:11.10.0-alpine-mongo
 
 # Copy configuration and SQL files
 COPY conf /flyway/conf


### PR DESCRIPTION
The action was set to only run when the test file itself changed - we want it to run in general when there are relevant changes to the ena package as a whole.

🚀 Preview: Add `preview` label to enable