### PR TITLE
fix(deposition): fix all `CreationResult(results=` typos, allow setting user/pass in .env file

### DIFF
--- a/ena-submission/README.md
+++ b/ena-submission/README.md
@@ -198,6 +198,11 @@ python scripts/deposition_dry_run.py --log-level=DEBUG --data-to-submit=results/
 ```
 
 You can also run the integration tests locally, these will submit sequences to ENA dev. Be careful when modifying these tests to always set `test=true`. 
+#### Integration tests
+
+You can also run the integration tests locally, these will submit sequences to ENA dev. Be careful when modifying these tests to always set `test=true`.
+
+You also need to set the environment variables `ENA_USERNAME` and `ENA_PASSWORD` to your ENA test account credentials. You can use the `.env` file in the root of this repository to set these variables.
 
 ```sh
 docker run --name test-postgres -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=unsecure -e POSTGRES_DB=loculus -p 5432:5432 -d postgres

--- a/ena-submission/environment.yml
+++ b/ena-submission/environment.yml
@@ -19,3 +19,6 @@ dependencies:
   - xmltodict
   - biopython
   - pytz
+  - types-pytz
+  - types-psycopg2
+  - python-dotenv

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -61,6 +61,8 @@ def get_ena_config(
     ena_submission_url_default: str,
     ena_reports_service_url_default: str,
 ) -> ENAConfig:
+    import dotenv
+    dotenv.load_dotenv()
     ena_submission_username = os.getenv("ENA_USERNAME")
     if not ena_submission_username:
         ena_submission_username = ena_submission_username_default
@@ -187,16 +189,18 @@ def create_ena_project(config: ENAConfig, project_set: ProjectSet) -> CreationRe
     > {output}
     """
     errors = []
-    warnings = []
+    warnings: list[str] = []
 
     try:
         xml = get_project_xml(project_set)
+        logger.debug(f"Posting Project creation XML to ENA with alias {project_set.project[0].alias}")
+        # Actual HTTP request to ENA happens here
         response = post_webin(config, xml)
     except requests.exceptions.RequestException as e:
         error_message = f"Request failed with exception: {e}."
         logger.error(error_message)
         errors.append(error_message)
-        return CreationResult(results=None, errors=errors, warnings=warnings)
+        return CreationResult(result=None, errors=errors, warnings=warnings)
 
     if not response.ok:
         error_message = (
@@ -259,7 +263,7 @@ def create_ena_sample(
         error_message = f"Request failed with exception: {e}."
         logger.error(error_message)
         errors.append(error_message)
-        return CreationResult(results=None, errors=errors, warnings=warnings)
+        return CreationResult(result=None, errors=errors, warnings=warnings)
 
     if not response.ok:
         error_message = (


### PR DESCRIPTION
I used find/replace to replace the remaining CreationResult kwarg typos (there were 2 left)

Also, allow using `.env` file to keep username/password for deposition (more convenient than env variables that need to be explicitly set).

🚀 Preview: Add `preview` label to enable