### PR TITLE
fix(ci): use actual existing tag v4 for setup-node, not non-existing v4.4

### DIFF
--- a/.github/workflows/format-website-on-dispatch.yml
+++ b/.github/workflows/format-website-on-dispatch.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
       - name: Set up Node.js
-        uses: actions/setup-node@v4.4
+        uses: actions/setup-node@v4
         with:
           node-version-file: ./website/.nvmrc
       - name: Cache .npm


### PR DESCRIPTION
See https://github.com/loculus-project/loculus/pull/4577#discussion_r2180240161

Looks like 4.4 itself isn't a tag, it's either 4.4.0 or 4 that's accepted. We use 4 everywhere so for consistency let's go to that.

🚀 Preview: Add `preview` label to enable