### PR TITLE
feat(backend): document 307 redirect for file downloads

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
@@ -49,7 +49,7 @@ class FilesController(
         description = "Temporary redirect to S3 download URL",
         headers = [Header(name = HttpHeaders.LOCATION, description = "S3 download URL")],
     )
-    @ApiResponse(responseCode = "403", description = "Authentication needed or not authorized")
+    @ApiResponse(responseCode = "403", description = "Authentication needed or not authorized. Non-public files require authentication and authorization.")
     @ApiResponse(responseCode = "404", description = "File does not exist")
     @GetMapping("/get/{accession}/{version}/{fileCategory}/{fileName}")
     fun getFileDownloadUrl(

--- a/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
@@ -2,6 +2,8 @@ package org.loculus.backend.controller
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.headers.Header
+import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import org.apache.http.HttpStatus
 import org.loculus.backend.api.AccessionVersion
@@ -15,6 +17,7 @@ import org.loculus.backend.service.files.S3Service
 import org.loculus.backend.service.submission.AccessionPreconditionValidator
 import org.loculus.backend.service.submission.SubmissionDatabaseService
 import org.loculus.backend.utils.Accession
+import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
@@ -37,6 +40,17 @@ class FilesController(
     private val accessionPreconditionValidator: AccessionPreconditionValidator,
 ) {
 
+    @Operation(
+        summary = "Get file",
+        description = "Returns a 307 redirect to a pre-signed S3 download URL",
+    )
+    @ApiResponse(
+        responseCode = "307",
+        description = "Temporary redirect to S3 download URL",
+        headers = [Header(name = HttpHeaders.LOCATION, description = "S3 download URL")],
+    )
+    @ApiResponse(responseCode = "403", description = "Authentication needed or not authorized")
+    @ApiResponse(responseCode = "404", description = "File not found")
     @GetMapping("/get/{accession}/{version}/{fileCategory}/{fileName}")
     fun getFileDownloadUrl(
         @HiddenParam user: User,

--- a/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
@@ -50,7 +50,7 @@ class FilesController(
         headers = [Header(name = HttpHeaders.LOCATION, description = "S3 download URL")],
     )
     @ApiResponse(responseCode = "403", description = "Authentication needed or not authorized")
-    @ApiResponse(responseCode = "404", description = "File not found")
+    @ApiResponse(responseCode = "404", description = "File does not exist")
     @GetMapping("/get/{accession}/{version}/{fileCategory}/{fileName}")
     fun getFileDownloadUrl(
         @HiddenParam user: User,

--- a/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
@@ -41,7 +41,7 @@ class FilesController(
 ) {
 
     @Operation(
-        summary = "Get file",
+        summary = "Download file via S3 redirect",
         description = "Returns a 307 redirect to a pre-signed S3 download URL",
     )
     @ApiResponse(


### PR DESCRIPTION
resolves #4600

https://backend-codex-update-swagger-for.loculus.org/swagger-ui/index.html#/files-controller/getFileDownloadUrl

## Summary
- annotate `FilesController.getFileDownloadUrl` with OpenAPI
- clarify that the endpoint returns a 307 redirect

<img width="1542" alt="Google Chrome 2025-07-03 21 03 02" src="https://github.com/user-attachments/assets/5e67333f-f2e3-4012-a09b-d7ae494bdacb" />

<img width="1473" alt="Google Chrome 2025-07-03 21 03 14" src="https://github.com/user-attachments/assets/8a4a3594-716a-4ace-bb74-24a02039b57b" />


## Testing
- `./gradlew ktlintFormat`
- `USE_NONDOCKER_INFRA=true ./gradlew test --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6866b3aeaf7c83258ad9a2c5885ba829

🚀 Preview: Add `preview` label to enable