### PR TITLE
chore(docs): typo fixes in file sharing docs

### DIFF
--- a/docs/src/content/docs/for-administrators/configuring-extra-files.md
+++ b/docs/src/content/docs/for-administrators/configuring-extra-files.md
@@ -111,5 +111,5 @@ my-organism:
 ```
 
 :::note
-The name (`rawReads` in the example above) must to not be a name that is also used by a metadata field!
+The name (`rawReads` in the example above) must not be a name that is also used by a metadata field!
 :::


### PR DESCRIPTION
A few typo fixes to the file sharing docs