### PR TITLE
feat(prepro): use submittedAt date as upperBound in parse_date_into_range instead of processing time

### DIFF
--- a/preprocessing/nextclade/environment.yml
+++ b/preprocessing/nextclade/environment.yml
@@ -15,3 +15,9 @@ dependencies:
   - pytz=2024.2
   - requests=2.32
   - pandas=2.2
+  - ruff
+  - types-PyYAML
+  - types-requests
+  - types-pytz
+  - types-python-dateutil
+  - pytest

--- a/preprocessing/nextclade/src/loculus_preprocessing/backend.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/backend.py
@@ -92,6 +92,7 @@ def parse_ndjson(ndjson_data: str) -> Sequence[UnprocessedEntry]:
         }
         unprocessed_data = UnprocessedData(
             submitter=json_object["submitter"],
+            submittedAt=json_object["submittedAt"],
             metadata=json_object["data"]["metadata"],
             unalignedNucleotideSequences=trimmed_unaligned_nucleotide_sequences
             if unaligned_nucleotide_sequences

--- a/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
@@ -52,6 +52,7 @@ class ProcessingAnnotation:
 @dataclass
 class UnprocessedData:
     submitter: str
+    submittedAt: str  # ISO 8601 date string  # noqa: N815
     metadata: InputMetadata
     unalignedNucleotideSequences: dict[SegmentName, NucleotideSequence | None]  # noqa: N815
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
@@ -52,7 +52,7 @@ class ProcessingAnnotation:
 @dataclass
 class UnprocessedData:
     submitter: str
-    submittedAt: str  # ISO 8601 date string  # noqa: N815
+    submittedAt: str  # timestamp  # noqa: N815
     metadata: InputMetadata
     unalignedNucleotideSequences: dict[SegmentName, NucleotideSequence | None]  # noqa: N815
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -269,6 +269,7 @@ def enrich_with_nextclade(  # noqa: C901, PLR0912, PLR0914, PLR0915
         id = entry.accessionVersion
         input_metadata[id] = entry.data.metadata
         input_metadata[id]["submitter"] = entry.data.submitter
+        input_metadata[id]["submittedAt"] = entry.data.submittedAt
         aligned_aminoacid_sequences[id] = {}
         unaligned_nucleotide_sequences[id] = {}
         aligned_nucleotide_sequences[id] = {}
@@ -621,6 +622,7 @@ def get_metadata(  # noqa: PLR0913, PLR0917
             input_fields.append(input_path)
         args = spec.args
         args["submitter"] = unprocessed.submitter
+        args["submittedAt"] = unprocessed.submittedAt
     else:
         for arg_name, input_path in spec.inputs.items():
             input_data[arg_name] = add_input_metadata(
@@ -629,6 +631,7 @@ def get_metadata(  # noqa: PLR0913, PLR0917
             input_fields.append(input_path)
         args = spec.args
         args["submitter"] = unprocessed.inputMetadata["submitter"]
+        args["submittedAt"] = unprocessed.inputMetadata["submittedAt"]
 
     if spec.function == "concatenate":
         spec_copy = copy.deepcopy(spec)

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -250,7 +250,7 @@ class ProcessingFunctions:
         except Exception:
             release_date = None
 
-        submitted_at_str = args.get("submittedAt", "") or ""
+        submitted_at_str = str(args.get("submittedAt", "")) or ""
         try:
             if not isinstance(submitted_at_str, str):
                 msg = f"Expected submittedAt to be a string, got {type(submitted_at_str)}"

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -255,7 +255,7 @@ class ProcessingFunctions:
             if not isinstance(submitted_at_str, str):
                 msg = f"Expected submittedAt to be a string, got {type(submitted_at_str)}"
                 raise ValueError(msg)
-            submitted_at = dateutil.parse(submitted_at_str).replace(tzinfo=pytz.utc)
+            submitted_at = dateutil.parse(submitted_at_str)
         except Exception:
             return ProcessingResult(
                 datum=None,

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -26,7 +26,7 @@ from .datatypes import (
 
 logger = logging.getLogger(__name__)
 
-options_cache = {}
+options_cache: dict[str, dict[str, str]] = {}
 
 
 def compute_options_cache(output_field: str, options_list: list[str]) -> dict[str, str]:
@@ -251,7 +251,7 @@ class ProcessingFunctions:
             release_date = None
 
         try:
-            submitted_at = datetime.fromtimestamp(float(args["submittedAt"]), tz=pytz.utc)
+            submitted_at = datetime.fromtimestamp(float(str(args["submittedAt"])), tz=pytz.utc)
         except Exception:
             return ProcessingResult(
                 datum=None,

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -250,9 +250,8 @@ class ProcessingFunctions:
         except Exception:
             release_date = None
 
-        submitted_at_str = str(args.get("submittedAt", "")) or ""
         try:
-            submitted_at = datetime.fromtimestamp(float(submitted_at_str), tz=pytz.utc)
+            submitted_at = datetime.fromtimestamp(float(args["submittedAt"]), tz=pytz.utc)
         except Exception:
             return ProcessingResult(
                 datum=None,

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -255,7 +255,7 @@ class ProcessingFunctions:
             if not isinstance(submitted_at_str, str):
                 msg = f"Expected submittedAt to be a string, got {type(submitted_at_str)}"
                 raise ValueError(msg)
-            submitted_at = dateutil.parse(submitted_at_str)
+            submitted_at = datetime.fromtimestamp(float(submitted_at_str), tz=pytz.utc)
         except Exception:
             return ProcessingResult(
                 datum=None,

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -252,9 +252,6 @@ class ProcessingFunctions:
 
         submitted_at_str = str(args.get("submittedAt", "")) or ""
         try:
-            if not isinstance(submitted_at_str, str):
-                msg = f"Expected submittedAt to be a string, got {type(submitted_at_str)}"
-                raise ValueError(msg)
             submitted_at = datetime.fromtimestamp(float(submitted_at_str), tz=pytz.utc)
         except Exception:
             return ProcessingResult(

--- a/preprocessing/nextclade/tests/factory_methods.py
+++ b/preprocessing/nextclade/tests/factory_methods.py
@@ -37,7 +37,9 @@ class UnprocessedEntryFactory:
             accessionVersion=f"LOC_{accession_id}.1",
             data=UnprocessedData(
                 submitter="test_submitter",
-                submittedAt="2023-10-01T00:00:00Z",
+                submittedAt=str(datetime.strptime("2021-12-15", "%Y-%m-%d")
+                .replace(tzinfo=pytz.utc)
+                .timestamp()),
                 metadata=metadata_dict,
                 unalignedNucleotideSequences={"main": ""},
             ),

--- a/preprocessing/nextclade/tests/factory_methods.py
+++ b/preprocessing/nextclade/tests/factory_methods.py
@@ -37,6 +37,7 @@ class UnprocessedEntryFactory:
             accessionVersion=f"LOC_{accession_id}.1",
             data=UnprocessedData(
                 submitter="test_submitter",
+                submittedAt="2023-10-01T00:00:00Z",
                 metadata=metadata_dict,
                 unalignedNucleotideSequences={"main": ""},
             ),

--- a/preprocessing/nextclade/tests/factory_methods.py
+++ b/preprocessing/nextclade/tests/factory_methods.py
@@ -1,4 +1,7 @@
 from dataclasses import dataclass
+from datetime import datetime
+
+import pytz
 
 from loculus_preprocessing.datatypes import (
     AnnotationSource,
@@ -37,9 +40,9 @@ class UnprocessedEntryFactory:
             accessionVersion=f"LOC_{accession_id}.1",
             data=UnprocessedData(
                 submitter="test_submitter",
-                submittedAt=str(datetime.strptime("2021-12-15", "%Y-%m-%d")
-                .replace(tzinfo=pytz.utc)
-                .timestamp()),
+                submittedAt=str(
+                    datetime.strptime("2021-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
+                ),
                 metadata=metadata_dict,
                 unalignedNucleotideSequences={"main": ""},
             ),
@@ -87,7 +90,8 @@ class ProcessedEntryFactory:
                         AnnotationSource(
                             name=field,
                             type=AnnotationSourceType.METADATA,
-                        ) for field in error.unprocessedFieldsName
+                        )
+                        for field in error.unprocessedFieldsName
                     ],
                     processedFields=[
                         AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
@@ -103,7 +107,8 @@ class ProcessedEntryFactory:
                         AnnotationSource(
                             name=field,
                             type=AnnotationSourceType.METADATA,
-                        ) for field in warning.unprocessedFieldsName
+                        )
+                        for field in warning.unprocessedFieldsName
                     ],
                     processedFields=[
                         AnnotationSource(name=field, type=AnnotationSourceType.METADATA)

--- a/preprocessing/nextclade/tests/test_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_processing_functions.py
@@ -505,9 +505,9 @@ def test_preprocessing_without_consensus_sequences():
         accessionVersion=f"LOC_01.1",
         data=UnprocessedData(
             submitter="test_submitter",
-            submittedAt=str(datetime.strptime("2021-12-15", "%Y-%m-%d")
-                .replace(tzinfo=pytz.utc)
-                .timestamp()),
+            submittedAt=str(
+                datetime.strptime("2021-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
+            ),
             metadata={
                 "ncbi_required_collection_date": "2024-01-01",
                 "name_required": sequence_name,
@@ -602,9 +602,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": str(datetime.strptime("2021-12-15", "%Y-%m-%d")
-                .replace(tzinfo=pytz.utc)
-                .timestamp()),
+                "submittedAt": str(
+                    datetime.strptime("2021-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
+                ),
             },
         ).datum
         == "2021-12"
@@ -616,9 +616,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeLower",
-                "submittedAt": str(datetime.strptime("2021-12-15", "%Y-%m-%d")
-                .replace(tzinfo=pytz.utc)
-                .timestamp()),
+                "submittedAt": str(
+                    datetime.strptime("2021-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
+                ),
             },
         ).datum
         == "2021-12-01"
@@ -630,9 +630,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": str(datetime.strptime("2022-12-15", "%Y-%m-%d")
-                .replace(tzinfo=pytz.utc)
-                .timestamp()),
+                "submittedAt": str(
+                    datetime.strptime("2022-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
+                ),
             },
         ).datum
         == "2021-12-31"
@@ -644,9 +644,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": str(datetime.strptime("2021-12-15", "%Y-%m-%d")
-                .replace(tzinfo=pytz.utc)
-                .timestamp()),
+                "submittedAt": str(
+                    datetime.strptime("2021-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
+                ),
             },
         ).datum
         == "2021-12-15"
@@ -658,9 +658,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": str(datetime.strptime("2021-03-15", "%Y-%m-%d")
-                .replace(tzinfo=pytz.utc)
-                .timestamp()),
+                "submittedAt": str(
+                    datetime.strptime("2021-03-15", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
+                ),
             },
         ).datum
         == "2021-02-28"
@@ -672,9 +672,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": str(datetime.strptime("2021-12-15", "%Y-%m-%d")
-                .replace(tzinfo=pytz.utc)
-                .timestamp()),
+                "submittedAt": str(
+                    datetime.strptime("2021-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
+                ),
             },
         ).datum
         == "2021-12-15"
@@ -686,9 +686,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": str(datetime.strptime("2022-01-15", "%Y-%m-%d")
-                .replace(tzinfo=pytz.utc)
-                .timestamp()),
+                "submittedAt": str(
+                    datetime.strptime("2022-01-15", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
+                ),
             },
         ).datum
         == "2021-12-31"
@@ -700,9 +700,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": str(datetime.strptime("2021-12-16", "%Y-%m-%d")
-                .replace(tzinfo=pytz.utc)
-                .timestamp()),
+                "submittedAt": str(
+                    datetime.strptime("2021-12-16", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
+                ),
             },
         ).datum
         == "2021-12-15"
@@ -714,9 +714,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": str(datetime.strptime("2021-12-16", "%Y-%m-%d")
-                .replace(tzinfo=pytz.utc)
-                .timestamp()),
+                "submittedAt": str(
+                    datetime.strptime("2021-12-16", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
+                ),
             },
         ).datum
         == "2021-12-15"
@@ -728,9 +728,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": str(datetime.strptime("2021-12-16", "%Y-%m-%d")
-                .replace(tzinfo=pytz.utc)
-                .timestamp()),
+                "submittedAt": str(
+                    datetime.strptime("2021-12-16", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
+                ),
             },
         ).datum
         is None
@@ -742,9 +742,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": str(datetime.strptime("2021-12-16", "%Y-%m-%d")
-                .replace(tzinfo=pytz.utc)
-                .timestamp()),
+                "submittedAt": str(
+                    datetime.strptime("2021-12-16", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
+                ),
             },
         ).datum
         is None
@@ -756,9 +756,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeLower",
-                "submittedAt": str(datetime.strptime("2021-12-16", "%Y-%m-%d")
-                .replace(tzinfo=pytz.utc)
-                .timestamp()),
+                "submittedAt": str(
+                    datetime.strptime("2021-12-16", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
+                ),
             },
         ).datum
         is None

--- a/preprocessing/nextclade/tests/test_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_processing_functions.py
@@ -32,6 +32,12 @@ from loculus_preprocessing.processing_functions import (
 test_config_file = "tests/test_config.yaml"
 
 
+def ts_from_ymd(year: int, month: int, day: int) -> str:
+    """Convert a year, month, and day into a UTC timestamp string."""
+    dt = datetime(year, month, day, tzinfo=pytz.UTC)
+    return str(dt.timestamp())
+
+
 @dataclass
 class Case:
     name: str
@@ -505,9 +511,7 @@ def test_preprocessing_without_consensus_sequences():
         accessionVersion=f"LOC_01.1",
         data=UnprocessedData(
             submitter="test_submitter",
-            submittedAt=str(
-                datetime.strptime("2021-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
-            ),
+            submittedAt=ts_from_ymd(2021, 12, 15),
             metadata={
                 "ncbi_required_collection_date": "2024-01-01",
                 "name_required": sequence_name,
@@ -602,9 +606,7 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": str(
-                    datetime.strptime("2021-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
-                ),
+                "submittedAt": ts_from_ymd(2021, 12, 15),
             },
         ).datum
         == "2021-12"
@@ -616,9 +618,7 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeLower",
-                "submittedAt": str(
-                    datetime.strptime("2021-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
-                ),
+                "submittedAt": ts_from_ymd(2021, 12, 15),
             },
         ).datum
         == "2021-12-01"
@@ -630,9 +630,7 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": str(
-                    datetime.strptime("2022-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
-                ),
+                "submittedAt": ts_from_ymd(2022, 12, 15),
             },
         ).datum
         == "2021-12-31"
@@ -644,9 +642,7 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": str(
-                    datetime.strptime("2021-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
-                ),
+                "submittedAt": ts_from_ymd(2021, 12, 15),
             },
         ).datum
         == "2021-12-15"
@@ -658,9 +654,7 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": str(
-                    datetime.strptime("2021-03-15", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
-                ),
+                "submittedAt": ts_from_ymd(2021, 3, 15),
             },
         ).datum
         == "2021-02-28"
@@ -672,9 +666,7 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": str(
-                    datetime.strptime("2021-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
-                ),
+                "submittedAt": ts_from_ymd(2021, 12, 15),
             },
         ).datum
         == "2021-12-15"
@@ -686,9 +678,7 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": str(
-                    datetime.strptime("2022-01-15", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
-                ),
+                "submittedAt": ts_from_ymd(2022, 1, 15),
             },
         ).datum
         == "2021-12-31"
@@ -700,9 +690,7 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": str(
-                    datetime.strptime("2021-12-16", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
-                ),
+                "submittedAt": ts_from_ymd(2021, 12, 16),
             },
         ).datum
         == "2021-12-15"
@@ -714,9 +702,7 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": str(
-                    datetime.strptime("2021-12-16", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
-                ),
+                "submittedAt": ts_from_ymd(2021, 12, 16),
             },
         ).datum
         == "2021-12-15"
@@ -728,9 +714,7 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": str(
-                    datetime.strptime("2021-12-16", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
-                ),
+                "submittedAt": ts_from_ymd(2021, 12, 16),
             },
         ).datum
         is None
@@ -742,9 +726,7 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": str(
-                    datetime.strptime("2021-12-16", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
-                ),
+                "submittedAt": ts_from_ymd(2021, 12, 16),
             },
         ).datum
         is None
@@ -756,9 +738,7 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeLower",
-                "submittedAt": str(
-                    datetime.strptime("2021-12-16", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
-                ),
+                "submittedAt": ts_from_ymd(2021, 12, 16),
             },
         ).datum
         is None

--- a/preprocessing/nextclade/tests/test_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_processing_functions.py
@@ -506,7 +506,7 @@ def test_preprocessing_without_consensus_sequences():
             submittedAt="2024-01-01T00:00:00Z",
             metadata={
                 "ncbi_required_collection_date": "2024-01-01",
-                "name_required": sequence_name
+                "name_required": sequence_name,
             },
             unalignedNucleotideSequences={},
         ),
@@ -593,31 +593,64 @@ def test_format_authors() -> None:
 def test_parse_date_into_range() -> None:
     assert (
         ProcessingFunctions.parse_date_into_range(
-            {"date": "2021-12"}, "field_name", ["field_name"], {"fieldType": "dateRangeString"}
+            {"date": "2021-12"},
+            "field_name",
+            ["field_name"],
+            {"fieldType": "dateRangeString", "submittedAt": "2021-12-15"},
         ).datum
         == "2021-12"
     ), "dateRangeString: 2021-12 should be returned as is."
     assert (
         ProcessingFunctions.parse_date_into_range(
-            {"date": "2021-12"}, "field_name", ["field_name"], {"fieldType": "dateRangeLower"}
+            {"date": "2021-12"},
+            "field_name",
+            ["field_name"],
+            {"fieldType": "dateRangeLower", "submittedAt": "2021-12-15"},
         ).datum
         == "2021-12-01"
     ), "dateRangeLower: 2021-12 should be returned as 2021-12-01."
     assert (
         ProcessingFunctions.parse_date_into_range(
-            {"date": "2021-12"}, "field_name", ["field_name"], {"fieldType": "dateRangeUpper"}
+            {"date": "2021-12"},
+            "field_name",
+            ["field_name"],
+            {"fieldType": "dateRangeUpper", "submittedAt": "2022-12-15"},
         ).datum
         == "2021-12-31"
     ), "dateRangeUpper: 2021-12 should be returned as 2021-12-31."
     assert (
         ProcessingFunctions.parse_date_into_range(
-            {"date": "2021-02"}, "field_name", ["field_name"], {"fieldType": "dateRangeUpper"}
+            {"date": "2021-12"},
+            "field_name",
+            ["field_name"],
+            {"fieldType": "dateRangeUpper", "submittedAt": "2021-12-15"},
+        ).datum
+        == "2021-12-15"
+    ), "dateRangeUpper: 2021-12 should be returned as submittedAt time: 2021-12-15."
+    assert (
+        ProcessingFunctions.parse_date_into_range(
+            {"date": "2021-02"},
+            "field_name",
+            ["field_name"],
+            {"fieldType": "dateRangeUpper", "submittedAt": "2021-02-15"},
         ).datum
         == "2021-02-28"
     ), "dateRangeUpper: 2021-02 should be returned as 2021-02-28."
     assert (
         ProcessingFunctions.parse_date_into_range(
-            {"date": "2021"}, "field_name", ["field_name"], {"fieldType": "dateRangeUpper"}
+            {"date": "2021"},
+            "field_name",
+            ["field_name"],
+            {"fieldType": "dateRangeUpper", "submittedAt": "2021-12-15"},
+        ).datum
+        == "2021-12-15"
+    ), "dateRangeUpper: 2021 should be returned as 2021-12-15."
+    assert (
+        ProcessingFunctions.parse_date_into_range(
+            {"date": "2021"},
+            "field_name",
+            ["field_name"],
+            {"fieldType": "dateRangeUpper", "submittedAt": "2022-01-15"},
         ).datum
         == "2021-12-31"
     ), "dateRangeUpper: 2021 should be returned as 2021-12-31."
@@ -626,7 +659,7 @@ def test_parse_date_into_range() -> None:
             {"date": "2021-12", "releaseDate": "2021-12-15"},
             "field_name",
             ["field_name"],
-            {"fieldType": "dateRangeUpper"},
+            {"fieldType": "dateRangeUpper", "submittedAt": "2021-12-16"},
         ).datum
         == "2021-12-15"
     ), "dateRangeUpper: 2021-12 with releaseDate 2021-12-15 should be returned as 2021-12-15."
@@ -635,19 +668,25 @@ def test_parse_date_into_range() -> None:
             {"date": "", "releaseDate": "2021-12-15"},
             "field_name",
             ["field_name"],
-            {"fieldType": "dateRangeUpper"},
+            {"fieldType": "dateRangeUpper", "submittedAt": "2021-12-16"},
         ).datum
         == "2021-12-15"
     ), "dateRangeUpper: empty date with releaseDate 2021-12-15 should be returned as 2021-12-15."
     assert (
         ProcessingFunctions.parse_date_into_range(
-            {"date": ""}, "field_name", ["field_name"], {"fieldType": "dateRangeString"}
+            {"date": ""},
+            "field_name",
+            ["field_name"],
+            {"fieldType": "dateRangeString", "submittedAt": "2021-12-16"},
         ).datum
         is None
     ), "dateRangeString: empty date should be returned as None."
     assert (
         ProcessingFunctions.parse_date_into_range(
-            {"date": "not.date"}, "field_name", ["field_name"], {"fieldType": "dateRangeString"}
+            {"date": "not.date"},
+            "field_name",
+            ["field_name"],
+            {"fieldType": "dateRangeString", "submittedAt": "2021-12-16"},
         ).datum
         is None
     ), "dateRangeString: invalid date should be returned as None."
@@ -656,7 +695,7 @@ def test_parse_date_into_range() -> None:
             {"date": "", "releaseDate": "2021-12-15"},
             "field_name",
             ["field_name"],
-            {"fieldType": "dateRangeLower"},
+            {"fieldType": "dateRangeLower", "submittedAt": "2021-12-16"},
         ).datum
         is None
     ), "dateRangeLower: empty date should be returned as None."

--- a/preprocessing/nextclade/tests/test_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_processing_functions.py
@@ -632,7 +632,7 @@ def test_parse_date_into_range() -> None:
             {"date": "2021-02"},
             "field_name",
             ["field_name"],
-            {"fieldType": "dateRangeUpper", "submittedAt": "2021-02-15"},
+            {"fieldType": "dateRangeUpper", "submittedAt": "2021-03-15"},
         ).datum
         == "2021-02-28"
     ), "dateRangeUpper: 2021-02 should be returned as 2021-02-28."

--- a/preprocessing/nextclade/tests/test_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_processing_functions.py
@@ -600,7 +600,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": datetime.strptime("2021-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+                "submittedAt": datetime.strptime("2021-12-15", "%Y-%m-%d")
+                .replace(tzinfo=pytz.utc)
+                .timestamp(),
             },
         ).datum
         == "2021-12"
@@ -612,7 +614,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeLower",
-                "submittedAt": datetime.strptime("2021-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+                "submittedAt": datetime.strptime("2021-12-15", "%Y-%m-%d")
+                .replace(tzinfo=pytz.utc)
+                .timestamp(),
             },
         ).datum
         == "2021-12-01"
@@ -624,7 +628,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": datetime.strptime("2022-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+                "submittedAt": datetime.strptime("2022-12-15", "%Y-%m-%d")
+                .replace(tzinfo=pytz.utc)
+                .timestamp(),
             },
         ).datum
         == "2021-12-31"
@@ -636,7 +642,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": datetime.strptime("2021-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+                "submittedAt": datetime.strptime("2021-12-15", "%Y-%m-%d")
+                .replace(tzinfo=pytz.utc)
+                .timestamp(),
             },
         ).datum
         == "2021-12-15"
@@ -648,7 +656,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": datetime.strptime("2021-03-15", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+                "submittedAt": datetime.strptime("2021-03-15", "%Y-%m-%d")
+                .replace(tzinfo=pytz.utc)
+                .timestamp(),
             },
         ).datum
         == "2021-02-28"
@@ -660,7 +670,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": datetime.strptime("2021-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+                "submittedAt": datetime.strptime("2021-12-15", "%Y-%m-%d")
+                .replace(tzinfo=pytz.utc)
+                .timestamp(),
             },
         ).datum
         == "2021-12-15"
@@ -672,7 +684,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": datetime.strptime("2022-01-15", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+                "submittedAt": datetime.strptime("2022-01-15", "%Y-%m-%d")
+                .replace(tzinfo=pytz.utc)
+                .timestamp(),
             },
         ).datum
         == "2021-12-31"
@@ -684,7 +698,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": datetime.strptime("2021-12-16", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+                "submittedAt": datetime.strptime("2021-12-16", "%Y-%m-%d")
+                .replace(tzinfo=pytz.utc)
+                .timestamp(),
             },
         ).datum
         == "2021-12-15"
@@ -696,7 +712,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": datetime.strptime("2021-12-16", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+                "submittedAt": datetime.strptime("2021-12-16", "%Y-%m-%d")
+                .replace(tzinfo=pytz.utc)
+                .timestamp(),
             },
         ).datum
         == "2021-12-15"
@@ -708,7 +726,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": datetime.strptime("2021-12-16", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+                "submittedAt": datetime.strptime("2021-12-16", "%Y-%m-%d")
+                .replace(tzinfo=pytz.utc)
+                .timestamp(),
             },
         ).datum
         is None
@@ -720,7 +740,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": datetime.strptime("2021-12-16", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+                "submittedAt": datetime.strptime("2021-12-16", "%Y-%m-%d")
+                .replace(tzinfo=pytz.utc)
+                .timestamp(),
             },
         ).datum
         is None
@@ -732,7 +754,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeLower",
-                "submittedAt": datetime.strptime("2021-12-16", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+                "submittedAt": datetime.strptime("2021-12-16", "%Y-%m-%d")
+                .replace(tzinfo=pytz.utc)
+                .timestamp(),
             },
         ).datum
         is None

--- a/preprocessing/nextclade/tests/test_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_processing_functions.py
@@ -505,7 +505,9 @@ def test_preprocessing_without_consensus_sequences():
         accessionVersion=f"LOC_01.1",
         data=UnprocessedData(
             submitter="test_submitter",
-            submittedAt="2024-01-01T00:00:00Z",
+            submittedAt=str(datetime.strptime("2021-12-15", "%Y-%m-%d")
+                .replace(tzinfo=pytz.utc)
+                .timestamp()),
             metadata={
                 "ncbi_required_collection_date": "2024-01-01",
                 "name_required": sequence_name,

--- a/preprocessing/nextclade/tests/test_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_processing_functions.py
@@ -600,9 +600,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": datetime.strptime("2021-12-15", "%Y-%m-%d")
+                "submittedAt": str(datetime.strptime("2021-12-15", "%Y-%m-%d")
                 .replace(tzinfo=pytz.utc)
-                .timestamp(),
+                .timestamp()),
             },
         ).datum
         == "2021-12"
@@ -614,9 +614,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeLower",
-                "submittedAt": datetime.strptime("2021-12-15", "%Y-%m-%d")
+                "submittedAt": str(datetime.strptime("2021-12-15", "%Y-%m-%d")
                 .replace(tzinfo=pytz.utc)
-                .timestamp(),
+                .timestamp()),
             },
         ).datum
         == "2021-12-01"
@@ -628,9 +628,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": datetime.strptime("2022-12-15", "%Y-%m-%d")
+                "submittedAt": str(datetime.strptime("2022-12-15", "%Y-%m-%d")
                 .replace(tzinfo=pytz.utc)
-                .timestamp(),
+                .timestamp()),
             },
         ).datum
         == "2021-12-31"
@@ -642,9 +642,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": datetime.strptime("2021-12-15", "%Y-%m-%d")
+                "submittedAt": str(datetime.strptime("2021-12-15", "%Y-%m-%d")
                 .replace(tzinfo=pytz.utc)
-                .timestamp(),
+                .timestamp()),
             },
         ).datum
         == "2021-12-15"
@@ -656,9 +656,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": datetime.strptime("2021-03-15", "%Y-%m-%d")
+                "submittedAt": str(datetime.strptime("2021-03-15", "%Y-%m-%d")
                 .replace(tzinfo=pytz.utc)
-                .timestamp(),
+                .timestamp()),
             },
         ).datum
         == "2021-02-28"
@@ -670,9 +670,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": datetime.strptime("2021-12-15", "%Y-%m-%d")
+                "submittedAt": str(datetime.strptime("2021-12-15", "%Y-%m-%d")
                 .replace(tzinfo=pytz.utc)
-                .timestamp(),
+                .timestamp()),
             },
         ).datum
         == "2021-12-15"
@@ -684,9 +684,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": datetime.strptime("2022-01-15", "%Y-%m-%d")
+                "submittedAt": str(datetime.strptime("2022-01-15", "%Y-%m-%d")
                 .replace(tzinfo=pytz.utc)
-                .timestamp(),
+                .timestamp()),
             },
         ).datum
         == "2021-12-31"
@@ -698,9 +698,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": datetime.strptime("2021-12-16", "%Y-%m-%d")
+                "submittedAt": str(datetime.strptime("2021-12-16", "%Y-%m-%d")
                 .replace(tzinfo=pytz.utc)
-                .timestamp(),
+                .timestamp()),
             },
         ).datum
         == "2021-12-15"
@@ -712,9 +712,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": datetime.strptime("2021-12-16", "%Y-%m-%d")
+                "submittedAt": str(datetime.strptime("2021-12-16", "%Y-%m-%d")
                 .replace(tzinfo=pytz.utc)
-                .timestamp(),
+                .timestamp()),
             },
         ).datum
         == "2021-12-15"
@@ -726,9 +726,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": datetime.strptime("2021-12-16", "%Y-%m-%d")
+                "submittedAt": str(datetime.strptime("2021-12-16", "%Y-%m-%d")
                 .replace(tzinfo=pytz.utc)
-                .timestamp(),
+                .timestamp()),
             },
         ).datum
         is None
@@ -740,9 +740,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": datetime.strptime("2021-12-16", "%Y-%m-%d")
+                "submittedAt": str(datetime.strptime("2021-12-16", "%Y-%m-%d")
                 .replace(tzinfo=pytz.utc)
-                .timestamp(),
+                .timestamp()),
             },
         ).datum
         is None
@@ -754,9 +754,9 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeLower",
-                "submittedAt": datetime.strptime("2021-12-16", "%Y-%m-%d")
+                "submittedAt": str(datetime.strptime("2021-12-16", "%Y-%m-%d")
                 .replace(tzinfo=pytz.utc)
-                .timestamp(),
+                .timestamp()),
             },
         ).datum
         is None

--- a/preprocessing/nextclade/tests/test_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_processing_functions.py
@@ -503,6 +503,7 @@ def test_preprocessing_without_consensus_sequences():
         accessionVersion=f"LOC_01.1",
         data=UnprocessedData(
             submitter="test_submitter",
+            submittedAt="2024-01-01T00:00:00Z",
             metadata={
                 "ncbi_required_collection_date": "2024-01-01",
                 "name_required": sequence_name

--- a/preprocessing/nextclade/tests/test_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_processing_functions.py
@@ -1,7 +1,9 @@
 # ruff: noqa: S101
 from dataclasses import dataclass
+from datetime import datetime
 
 import pytest
+import pytz
 from factory_methods import (
     ProcessedEntryFactory,
     ProcessingAnnotationTestCase,
@@ -596,7 +598,10 @@ def test_parse_date_into_range() -> None:
             {"date": "2021-12"},
             "field_name",
             ["field_name"],
-            {"fieldType": "dateRangeString", "submittedAt": "2021-12-15"},
+            {
+                "fieldType": "dateRangeString",
+                "submittedAt": datetime.strptime("2021-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+            },
         ).datum
         == "2021-12"
     ), "dateRangeString: 2021-12 should be returned as is."
@@ -605,7 +610,10 @@ def test_parse_date_into_range() -> None:
             {"date": "2021-12"},
             "field_name",
             ["field_name"],
-            {"fieldType": "dateRangeLower", "submittedAt": "2021-12-15"},
+            {
+                "fieldType": "dateRangeLower",
+                "submittedAt": datetime.strptime("2021-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+            },
         ).datum
         == "2021-12-01"
     ), "dateRangeLower: 2021-12 should be returned as 2021-12-01."
@@ -614,7 +622,10 @@ def test_parse_date_into_range() -> None:
             {"date": "2021-12"},
             "field_name",
             ["field_name"],
-            {"fieldType": "dateRangeUpper", "submittedAt": "2022-12-15"},
+            {
+                "fieldType": "dateRangeUpper",
+                "submittedAt": datetime.strptime("2022-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+            },
         ).datum
         == "2021-12-31"
     ), "dateRangeUpper: 2021-12 should be returned as 2021-12-31."
@@ -623,7 +634,10 @@ def test_parse_date_into_range() -> None:
             {"date": "2021-12"},
             "field_name",
             ["field_name"],
-            {"fieldType": "dateRangeUpper", "submittedAt": "2021-12-15"},
+            {
+                "fieldType": "dateRangeUpper",
+                "submittedAt": datetime.strptime("2021-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+            },
         ).datum
         == "2021-12-15"
     ), "dateRangeUpper: 2021-12 should be returned as submittedAt time: 2021-12-15."
@@ -632,7 +646,10 @@ def test_parse_date_into_range() -> None:
             {"date": "2021-02"},
             "field_name",
             ["field_name"],
-            {"fieldType": "dateRangeUpper", "submittedAt": "2021-03-15"},
+            {
+                "fieldType": "dateRangeUpper",
+                "submittedAt": datetime.strptime("2021-03-15", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+            },
         ).datum
         == "2021-02-28"
     ), "dateRangeUpper: 2021-02 should be returned as 2021-02-28."
@@ -641,7 +658,10 @@ def test_parse_date_into_range() -> None:
             {"date": "2021"},
             "field_name",
             ["field_name"],
-            {"fieldType": "dateRangeUpper", "submittedAt": "2021-12-15"},
+            {
+                "fieldType": "dateRangeUpper",
+                "submittedAt": datetime.strptime("2021-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+            },
         ).datum
         == "2021-12-15"
     ), "dateRangeUpper: 2021 should be returned as 2021-12-15."
@@ -650,7 +670,10 @@ def test_parse_date_into_range() -> None:
             {"date": "2021"},
             "field_name",
             ["field_name"],
-            {"fieldType": "dateRangeUpper", "submittedAt": "2022-01-15"},
+            {
+                "fieldType": "dateRangeUpper",
+                "submittedAt": datetime.strptime("2022-01-15", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+            },
         ).datum
         == "2021-12-31"
     ), "dateRangeUpper: 2021 should be returned as 2021-12-31."
@@ -659,7 +682,10 @@ def test_parse_date_into_range() -> None:
             {"date": "2021-12", "releaseDate": "2021-12-15"},
             "field_name",
             ["field_name"],
-            {"fieldType": "dateRangeUpper", "submittedAt": "2021-12-16"},
+            {
+                "fieldType": "dateRangeUpper",
+                "submittedAt": datetime.strptime("2021-12-16", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+            },
         ).datum
         == "2021-12-15"
     ), "dateRangeUpper: 2021-12 with releaseDate 2021-12-15 should be returned as 2021-12-15."
@@ -668,7 +694,10 @@ def test_parse_date_into_range() -> None:
             {"date": "", "releaseDate": "2021-12-15"},
             "field_name",
             ["field_name"],
-            {"fieldType": "dateRangeUpper", "submittedAt": "2021-12-16"},
+            {
+                "fieldType": "dateRangeUpper",
+                "submittedAt": datetime.strptime("2021-12-16", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+            },
         ).datum
         == "2021-12-15"
     ), "dateRangeUpper: empty date with releaseDate 2021-12-15 should be returned as 2021-12-15."
@@ -677,7 +706,10 @@ def test_parse_date_into_range() -> None:
             {"date": ""},
             "field_name",
             ["field_name"],
-            {"fieldType": "dateRangeString", "submittedAt": "2021-12-16"},
+            {
+                "fieldType": "dateRangeString",
+                "submittedAt": datetime.strptime("2021-12-16", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+            },
         ).datum
         is None
     ), "dateRangeString: empty date should be returned as None."
@@ -686,7 +718,10 @@ def test_parse_date_into_range() -> None:
             {"date": "not.date"},
             "field_name",
             ["field_name"],
-            {"fieldType": "dateRangeString", "submittedAt": "2021-12-16"},
+            {
+                "fieldType": "dateRangeString",
+                "submittedAt": datetime.strptime("2021-12-16", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+            },
         ).datum
         is None
     ), "dateRangeString: invalid date should be returned as None."
@@ -695,7 +730,10 @@ def test_parse_date_into_range() -> None:
             {"date": "", "releaseDate": "2021-12-15"},
             "field_name",
             ["field_name"],
-            {"fieldType": "dateRangeLower", "submittedAt": "2021-12-16"},
+            {
+                "fieldType": "dateRangeLower",
+                "submittedAt": datetime.strptime("2021-12-16", "%Y-%m-%d").replace(tzinfo=pytz.utc),
+            },
         ).datum
         is None
     ), "dateRangeLower: empty date should be returned as None."


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/4613

### Screenshot
From looking at https://github.com/loculus-project/loculus/pull/2268 we pass the `submittedAt` timestamp to preprocessing - this should be used instead of `now` for the upper bound as `now` will change each time the sequence is reprocessed. 

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://fix-release-date-range.loculus.org