### PR TITLE
feat(backend): indicate application/problem+json as content-type for errors

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/ExceptionHandler.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/ExceptionHandler.kt
@@ -119,7 +119,7 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
         detail: String?,
     ): ResponseEntity<ProblemDetail> = ResponseEntity
         .status(httpStatus)
-        .contentType(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .body(
             ProblemDetail.forStatus(httpStatus).also {
                 it.title = title

--- a/backend/src/test/kotlin/org/loculus/backend/controller/ExceptionHandlerTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/ExceptionHandlerTest.kt
@@ -70,7 +70,7 @@ class ExceptionHandlerTest(@Autowired val mockMvc: MockMvc) {
 
         mockMvc.perform(validRequest)
             .andExpect(status().isInternalServerError)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(jsonPath("$.title").value("Internal Server Error"))
             .andExpect(jsonPath("$.detail").value("SomeMessage"))
     }
@@ -81,7 +81,7 @@ class ExceptionHandlerTest(@Autowired val mockMvc: MockMvc) {
 
         mockMvc.perform(validRequest)
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(jsonPath("$.title").value("Unprocessable Entity"))
             .andExpect(jsonPath("$.detail").value("SomeMessage"))
     }
@@ -92,7 +92,7 @@ class ExceptionHandlerTest(@Autowired val mockMvc: MockMvc) {
 
         mockMvc.perform(validRequest)
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(jsonPath("$.title").value("Unprocessable Entity"))
             .andExpect(jsonPath("$.detail").value("SomeMessage"))
     }
@@ -132,7 +132,7 @@ class ExceptionHandlerWithMockedModelTest(@Autowired val mockMvc: MockMvc) {
                 .withAuth(),
         )
             .andExpect(status().isBadRequest)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(jsonPath("$.title").value("Bad Request"))
             .andExpect(jsonPath("$.detail", containsString("Invalid organism: unknownOrganism")))
     }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/datauseterms/DataUseTermsControllerTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/datauseterms/DataUseTermsControllerTest.kt
@@ -34,7 +34,7 @@ class DataUseTermsControllerTest(
 
         client.getDataUseTerms(nonExistingAccession)
             .andExpect(status().isNotFound)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail", containsString("Accession $nonExistingAccession not found")),
             )
@@ -95,7 +95,7 @@ class DataUseTermsControllerTest(
     fun `GIVEN non-existing accessions WHEN setting new data use terms THEN return unprocessable entity`() {
         client.changeDataUseTerms(DEFAULT_DATA_USE_CHANGE_REQUEST)
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail", containsString("Accessions 1, 2 do not exist")),
             )
@@ -139,7 +139,7 @@ class DataUseTermsControllerTest(
             jwt = generateJwtFor("user that is not a member of the group"),
         )
             .andExpect(status().isForbidden)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(jsonPath("\$.detail", containsString("not a member of group(s)")))
     }
 
@@ -200,7 +200,7 @@ class DataUseTermsControllerTest(
                 setupDataUseTerms = DataUseTerms.Open,
                 newDataUseTerms = DataUseTerms.Open,
                 expectedStatus = status().isUnprocessableEntity,
-                expectedContentType = MediaType.APPLICATION_JSON_VALUE,
+                expectedContentType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
                 expectedDetailContains = "The data use terms have already been set to 'Open'",
             ),
             DataUseTermsTestCase(
@@ -214,14 +214,14 @@ class DataUseTermsControllerTest(
                 setupDataUseTerms = DataUseTerms.Open,
                 newDataUseTerms = DataUseTerms.Restricted(dateMonthsFromNow(6)),
                 expectedStatus = status().isUnprocessableEntity,
-                expectedContentType = MediaType.APPLICATION_JSON_VALUE,
+                expectedContentType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
                 expectedDetailContains = "Cannot change data use terms from OPEN to RESTRICTED.",
             ),
             DataUseTermsTestCase(
                 setupDataUseTerms = DataUseTerms.Restricted(dateMonthsFromNow(6)),
                 newDataUseTerms = DataUseTerms.Restricted(dateMonthsFromNow(-1)),
                 expectedStatus = status().isBadRequest,
-                expectedContentType = MediaType.APPLICATION_JSON_VALUE,
+                expectedContentType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
                 expectedDetailContains = "The date 'restrictedUntil' must be in the future, " +
                     "up to a maximum of 1 year from now.",
             ),
@@ -229,7 +229,7 @@ class DataUseTermsControllerTest(
                 setupDataUseTerms = DataUseTerms.Restricted(dateMonthsFromNow(6)),
                 newDataUseTerms = DataUseTerms.Restricted(dateMonthsFromNow(7)),
                 expectedStatus = status().isUnprocessableEntity,
-                expectedContentType = MediaType.APPLICATION_JSON_VALUE,
+                expectedContentType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
                 expectedDetailContains = "Cannot extend restricted data use period. " +
                     "Please choose a date before ${dateMonthsFromNow(6)}.",
             ),

--- a/backend/src/test/kotlin/org/loculus/backend/controller/files/GetFilesEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/files/GetFilesEndpointTest.kt
@@ -11,7 +11,7 @@ import org.loculus.backend.controller.jwtForDefaultUser
 import org.loculus.backend.controller.submission.PreparedProcessedData
 import org.loculus.backend.controller.submission.SubmissionConvenienceClient
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -39,7 +39,7 @@ class GetFilesEndpointTest(
 
         filesClient.getFile(data.accession, data.version, "myFileCategory", "hello.txt")
             .andExpect(status().isForbidden())
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",

--- a/backend/src/test/kotlin/org/loculus/backend/controller/groupmanagement/GroupManagementControllerTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/groupmanagement/GroupManagementControllerTest.kt
@@ -198,7 +198,7 @@ class GroupManagementControllerTest(@Autowired private val client: GroupManageme
     fun `WHEN I query details of a non-existing group THEN expect error that group does not exist`() {
         client.getDetailsOfGroup(groupId = 123456789)
             .andExpect(status().isNotFound)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(jsonPath("\$.detail").value("Group 123456789 does not exist."))
     }
 
@@ -235,7 +235,7 @@ class GroupManagementControllerTest(@Autowired private val client: GroupManageme
 
         client.addUserToGroup(groupId = groupId, usernameToAdd = otherUser)
             .andExpect(status().isNotFound)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
                     "User $otherUser does not exist.",
@@ -274,7 +274,7 @@ class GroupManagementControllerTest(@Autowired private val client: GroupManageme
             jwt = jwtForDefaultUser,
         )
             .andExpect(status().isForbidden)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
                     "User $DEFAULT_USER_NAME is not a member of group(s) $groupId. Action not allowed.",
@@ -290,7 +290,7 @@ class GroupManagementControllerTest(@Autowired private val client: GroupManageme
 
         client.addUserToGroup(groupId = groupId, usernameToAdd = DEFAULT_USER_NAME, jwt = jwtForDefaultUser)
             .andExpect(status().isForbidden)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
                     "User $DEFAULT_USER_NAME is not a member of group(s) $groupId. Action not allowed.",
@@ -330,7 +330,7 @@ class GroupManagementControllerTest(@Autowired private val client: GroupManageme
 
         client.addUserToGroup(groupId = groupId, usernameToAdd = DEFAULT_USER_NAME)
             .andExpect(status().isNotFound)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
                     "Group(s) $groupId do not exist.",
@@ -346,7 +346,7 @@ class GroupManagementControllerTest(@Autowired private val client: GroupManageme
 
         client.addUserToGroup(groupId = groupId, usernameToAdd = DEFAULT_USER_NAME)
             .andExpect(status().isConflict)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
                     "User $DEFAULT_USER_NAME is already member of the group $groupId.",
@@ -380,7 +380,7 @@ class GroupManagementControllerTest(@Autowired private val client: GroupManageme
 
         client.removeUserFromGroup(groupId = groupId, userToRemove = DEFAULT_USER_NAME)
             .andExpect(status().isNotFound)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
                     "Group(s) $groupId do not exist.",
@@ -397,7 +397,7 @@ class GroupManagementControllerTest(@Autowired private val client: GroupManageme
 
         client.removeUserFromGroup(groupId = groupId, userToRemove = DEFAULT_USER_NAME)
             .andExpect(status().isForbidden)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
                     "User $DEFAULT_USER_NAME is not a member of group(s) " +

--- a/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/AuthorsEndpointsTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/AuthorsEndpointsTest.kt
@@ -23,7 +23,7 @@ class AuthorsEndpointsTest(@Autowired private val client: SeqSetCitationsControl
         every { keycloakAdapter.getUsersWithName(any()) } returns listOf()
         client.getAuthor(username = MOCK_USERNAME)
             .andExpect(status().isNotFound)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(jsonPath("\$.detail").value("Author profile $MOCK_USERNAME does not exist"))
     }
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/SeqSetEndpointsTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/SeqSetEndpointsTest.kt
@@ -45,7 +45,7 @@ class SeqSetEndpointsTest(@Autowired private val client: SeqSetCitationsControll
     fun `WHEN calling get seqSet of non-existing id and version THEN returns not found`() {
         client.getSeqSet(MOCK_SEQSET_ID, MOCK_SEQSET_VERSION)
             .andExpect(status().isNotFound)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -167,7 +167,7 @@ class SeqSetEndpointsTest(@Autowired private val client: SeqSetCitationsControll
 
         client.deleteSeqSet(seqSetId, 1)
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -192,7 +192,7 @@ class SeqSetEndpointsTest(@Autowired private val client: SeqSetCitationsControll
 
         client.getSeqSet(seqSetId, 1)
             .andExpect(status().isNotFound)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail", containsString("SeqSet $seqSetId, version 1 does not exist")),
             )

--- a/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/SeqSetValidationEndpointsTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/SeqSetValidationEndpointsTest.kt
@@ -36,7 +36,7 @@ class SeqSetValidationEndpointsTest(
         val accessionJson = """[{"accession": "ABCD", "type": "loculus"}]"""
         client.validateSeqSetRecords(seqSetRecords = accessionJson)
             .andExpect(status().isUnprocessableEntity())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -47,7 +47,7 @@ class SeqSetValidationEndpointsTest(
         val accessionVersionJson = """[{"accession": "ABCD.1", "type": "loculus"}]"""
         client.validateSeqSetRecords(seqSetRecords = accessionVersionJson)
             .andExpect(status().isUnprocessableEntity())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -61,7 +61,7 @@ class SeqSetValidationEndpointsTest(
         val accessionJson = """[{"accession": "ABCD.EF", "type": "loculus"}]"""
         client.validateSeqSetRecords(seqSetRecords = accessionJson)
             .andExpect(status().isUnprocessableEntity())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -80,7 +80,7 @@ class SeqSetValidationEndpointsTest(
 
         client.validateSeqSetRecords(seqSetRecords = accessionJson)
             .andExpect(status().isUnprocessableEntity())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -101,7 +101,7 @@ class SeqSetValidationEndpointsTest(
         ]"""
         client.validateSeqSetRecords(seqSetRecords = accessionJson)
             .andExpect(status().isUnprocessableEntity())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -123,7 +123,7 @@ class SeqSetValidationEndpointsTest(
     fun `WHEN writing seqSet with missing name THEN returns unprocessable entity`() {
         client.createSeqSet(seqSetName = "")
             .andExpect(status().isUnprocessableEntity())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -132,7 +132,7 @@ class SeqSetValidationEndpointsTest(
             )
         client.updateSeqSet(seqSetName = "")
             .andExpect(status().isUnprocessableEntity())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -153,7 +153,7 @@ class SeqSetValidationEndpointsTest(
 
         client.updateSeqSet(seqSetId = seqSetId, seqSetRecords = accessionJson)
             .andExpect(status().isUnprocessableEntity())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -166,7 +166,7 @@ class SeqSetValidationEndpointsTest(
     fun `WHEN writing seqSet with missing records THEN returns unprocessable entity`() {
         client.createSeqSet(seqSetRecords = "[]")
             .andExpect(status().isUnprocessableEntity())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -175,7 +175,7 @@ class SeqSetValidationEndpointsTest(
             )
         client.updateSeqSet(seqSetRecords = "[]")
             .andExpect(status().isUnprocessableEntity())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -203,7 +203,7 @@ class SeqSetValidationEndpointsTest(
         }
         createSeqSetWithDOI(accessionJson)
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ApproveProcessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ApproveProcessedDataEndpointTest.kt
@@ -110,7 +110,7 @@ class ApproveProcessedDataEndpointTest(
 
         client.approveProcessedSequenceEntries(scope = ALL, accessionVersions, jwt = generateJwtFor("other user"))
             .andExpect(status().isForbidden)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "$.detail",
@@ -139,7 +139,7 @@ class ApproveProcessedDataEndpointTest(
             ),
         )
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(jsonPath("$.detail", containsString("Accession versions $nonExistentAccession.1 do not exist")))
 
         convenienceClient.getSequenceEntry(processedAccessionVersion).assertStatusIs(PROCESSED)
@@ -159,7 +159,7 @@ class ApproveProcessedDataEndpointTest(
             ),
         )
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "$.detail",
@@ -189,7 +189,7 @@ class ApproveProcessedDataEndpointTest(
             accessionVersionsInCorrectState + accessionVersionNotInCorrectState,
         )
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "$.detail",
@@ -220,7 +220,7 @@ class ApproveProcessedDataEndpointTest(
             organism = OTHER_ORGANISM,
         )
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("$.detail")
                     .value(containsString("accession versions are not of organism otherOrganism")),

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/DeleteSequencesEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/DeleteSequencesEndpointTest.kt
@@ -112,7 +112,7 @@ class DeleteSequencesEndpointTest(
             }
         deletionResult.andExpect(status().isUnprocessableEntity)
             .andExpect(
-                content().contentType(MediaType.APPLICATION_JSON_VALUE),
+                content().contentType(MediaType.APPLICATION_PROBLEM_JSON),
             )
             .andExpect(
                 jsonPath("\$.detail", containsString(errorString)),
@@ -137,7 +137,7 @@ class DeleteSequencesEndpointTest(
             accessionVersionsFilter = listOf(nonExistingAccession, nonExistingVersion),
         )
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -258,7 +258,7 @@ class DeleteSequencesEndpointTest(
             organism = OTHER_ORGANISM,
         )
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail", containsString("accession versions are not of organism $OTHER_ORGANISM:")),
             )
@@ -275,7 +275,7 @@ class DeleteSequencesEndpointTest(
             jwt = generateJwtFor(notSubmitter),
         )
             .andExpect(status().isForbidden)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail", containsString("is not a member of group")),
             )

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetDataToEditEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetDataToEditEndpointTest.kt
@@ -63,7 +63,7 @@ class GetDataToEditEndpointTest(
 
         client.getSequenceEntryToEdit(nonExistentAccession, 1)
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
                     "Accession versions $nonExistentAccession.1 do not exist",
@@ -83,7 +83,7 @@ class GetDataToEditEndpointTest(
             .andExpect(status().isOk)
         client.getSequenceEntryToEdit(firstAccession, 1, organism = OTHER_ORGANISM)
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
                     containsString(
@@ -101,7 +101,7 @@ class GetDataToEditEndpointTest(
 
         client.getSequenceEntryToEdit("1", nonExistentAccessionVersion)
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
                     "Accession versions 1.$nonExistentAccessionVersion do not exist",
@@ -120,7 +120,7 @@ class GetDataToEditEndpointTest(
             jwt = generateJwtFor(userNameThatDoesNotHavePermissionToQuery),
         )
             .andExpect(status().isForbidden)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail", containsString("is not a member of group")),
             )

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ReviseEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ReviseEndpointTest.kt
@@ -37,7 +37,9 @@ import org.loculus.backend.controller.jwtForDefaultUser
 import org.loculus.backend.controller.jwtForSuperUser
 import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.web.servlet.ResultMatcher
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -141,7 +143,7 @@ class ReviseEndpointTest(
             ),
             SubmitFiles.sequenceFileWith(),
         ).andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
                     "Accessions 123 do not exist",
@@ -161,7 +163,7 @@ class ReviseEndpointTest(
             organism = OTHER_ORGANISM,
         )
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
                     containsString("accession versions are not of organism otherOrganism:"),
@@ -180,7 +182,7 @@ class ReviseEndpointTest(
             jwt = generateJwtFor(notSubmitter),
         )
             .andExpect(status().isForbidden)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -198,7 +200,7 @@ class ReviseEndpointTest(
             DefaultFiles.sequencesFile,
         )
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -219,7 +221,7 @@ class ReviseEndpointTest(
             sequencesFile = null,
         )
             .andExpect(status().isBadRequest)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value("Submissions for organism $DEFAULT_ORGANISM require a sequence file."),
             )
@@ -239,7 +241,7 @@ class ReviseEndpointTest(
             organism = ORGANISM_WITHOUT_CONSENSUS_SEQUENCES,
         )
             .andExpect(status().isBadRequest)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -319,7 +321,7 @@ class ReviseEndpointTest(
             ),
         )
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -348,7 +350,7 @@ class ReviseEndpointTest(
             ),
         )
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -384,7 +386,7 @@ class ReviseEndpointTest(
             ),
         )
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/RevokeEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/RevokeEndpointTest.kt
@@ -68,7 +68,7 @@ class RevokeEndpointTest(
         val nonExistingAccession = "123"
         client.revokeSequenceEntries(listOf(nonExistingAccession))
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
                     "Accessions $nonExistingAccession do not exist",
@@ -83,7 +83,7 @@ class RevokeEndpointTest(
 
         client.revokeSequenceEntries(listOf(accessions.first()), organism = OTHER_ORGANISM)
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
                     containsString("accession versions are not of organism $OTHER_ORGANISM:"),
@@ -98,7 +98,7 @@ class RevokeEndpointTest(
         val notSubmitter = "nonExistingUser"
         client.revokeSequenceEntries(accessions, jwt = generateJwtFor(notSubmitter))
             .andExpect(status().isForbidden)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail", containsString("is not a member of group")),
             )
@@ -133,7 +133,7 @@ class RevokeEndpointTest(
 
         client.revokeSequenceEntries(accessions)
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
@@ -18,6 +18,7 @@ import org.loculus.backend.controller.jwtForAlternativeUser
 import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles
 import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles.NUMBER_OF_SEQUENCES
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -83,7 +84,7 @@ class SubmitEndpointFileSharingTest(
             ),
         )
             .andExpect(status().isUnprocessableEntity())
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -112,7 +113,7 @@ class SubmitEndpointFileSharingTest(
             ),
         )
             .andExpect(status().isBadRequest())
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -140,7 +141,7 @@ class SubmitEndpointFileSharingTest(
             ),
         )
             .andExpect(status().isBadRequest())
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -166,7 +167,7 @@ class SubmitEndpointFileSharingTest(
             ),
         )
             .andExpect(status().isUnprocessableEntity())
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -192,7 +193,7 @@ class SubmitEndpointFileSharingTest(
             ),
         )
             .andExpect(status().isUnprocessableEntity())
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -222,7 +223,7 @@ class SubmitEndpointFileSharingTest(
             ),
         )
             .andExpect(status().isUnprocessableEntity())
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
@@ -31,7 +31,9 @@ import org.loculus.backend.model.SubmitModel.AcceptedFileTypes.sequenceFileTypes
 import org.loculus.backend.service.submission.CompressionAlgorithm
 import org.loculus.backend.utils.DateProvider
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.http.MediaType
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.web.servlet.ResultMatcher
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -75,7 +77,7 @@ class SubmitEndpointTest(
             groupId = groupId,
         )
             .andExpect(status().isNotFound)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(jsonPath("\$.detail", containsString("Group(s) $groupId do not exist")))
     }
 
@@ -90,7 +92,7 @@ class SubmitEndpointTest(
             jwt = generateJwtFor(otherUser),
         )
             .andExpect(status().isForbidden)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -111,7 +113,7 @@ class SubmitEndpointTest(
             groupId = groupId,
         )
             .andExpect(status().isOk)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(APPLICATION_JSON))
             .andExpect(jsonPath("\$.length()").value(NUMBER_OF_SEQUENCES))
     }
 
@@ -128,7 +130,7 @@ class SubmitEndpointTest(
             groupId = groupId,
         )
             .andExpect(status().isOk)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(APPLICATION_JSON))
             .andExpect(jsonPath("\$.length()").value(NUMBER_OF_SEQUENCES))
             .andExpect(jsonPath("\$[0].submissionId").value("custom0"))
             .andExpect(jsonPath("\$[0].accession", containsString(backendConfig.accessionPrefix)))
@@ -144,7 +146,7 @@ class SubmitEndpointTest(
             groupId = groupId,
         )
             .andExpect(status().isOk)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(APPLICATION_JSON))
             .andExpect(jsonPath("\$.length()").value(NUMBER_OF_SEQUENCES))
             .andExpect(jsonPath("\$[0].submissionId").value("custom0"))
             .andExpect(jsonPath("\$[0].accession", containsString(backendConfig.accessionPrefix)))
@@ -181,7 +183,7 @@ class SubmitEndpointTest(
             groupId = groupId,
         )
             .andExpect(status().isBadRequest)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -211,7 +213,7 @@ class SubmitEndpointTest(
             groupId = groupId,
         )
             .andExpect(status().isUnprocessableEntity())
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -242,7 +244,7 @@ class SubmitEndpointTest(
             groupId = groupId,
         )
             .andExpect(status().isUnprocessableEntity())
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -262,7 +264,7 @@ class SubmitEndpointTest(
             fileMapping = mapOf("foo" to mapOf("bar" to listOf(FileIdAndName(UUID.randomUUID(), "baz")))),
         )
             .andExpect(status().isBadRequest)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -305,7 +307,7 @@ class SubmitEndpointTest(
             groupId = groupId,
         )
             .andExpect(status().isBadRequest)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value("Submissions for organism $DEFAULT_ORGANISM require a sequence file."),
             )
@@ -320,7 +322,7 @@ class SubmitEndpointTest(
             groupId = groupId,
         )
             .andExpect(status().isBadRequest)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -337,7 +339,7 @@ class SubmitEndpointTest(
             groupId = groupId,
         )
             .andExpect(status().isOk)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(APPLICATION_JSON))
             .andExpect(jsonPath("\$.length()").value(NUMBER_OF_SEQUENCES))
             .andExpect(jsonPath("\$[0].submissionId").value("custom0"))
             .andExpect(jsonPath("\$[0].accession", containsString(backendConfig.accessionPrefix)))
@@ -633,7 +635,7 @@ class SubmitEndpointTest(
             groupId = groupId,
         )
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
                     "The metadata file contains both 'id' and 'submissionId'. Only one is allowed.",

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitExternalMetadataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitExternalMetadataEndpointTest.kt
@@ -105,7 +105,7 @@ class SubmitExternalMetadataEndpointTest(
                 externalMetadataUpdater = "other_db",
             )
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail")
                     .value(containsString("Unknown fields in metadata: insdcAccessionFull")),
@@ -125,7 +125,7 @@ class SubmitExternalMetadataEndpointTest(
                 PreparedExternalMetadata.successfullySubmitted(accession = accession),
             )
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail")
                     .value(
@@ -148,7 +148,7 @@ class SubmitExternalMetadataEndpointTest(
                 PreparedExternalMetadata.successfullySubmitted(accession = accession),
             )
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail")
                     .value(

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
@@ -323,7 +323,7 @@ class SubmitProcessedDataEndpointTest(
             invalidDataScenario.processedDataThatNeedsAValidAccession.copy(accession = accessions.first()),
         )
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(jsonPath("\$.detail").value(invalidDataScenario.expectedErrorMessage))
 
         val sequenceStatus = convenienceClient.getSequenceEntry(
@@ -344,7 +344,7 @@ class SubmitProcessedDataEndpointTest(
             PreparedProcessedData.successfullyProcessed(accession = nonExistentAccession),
         )
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail")
                     .value(
@@ -370,7 +370,7 @@ class SubmitProcessedDataEndpointTest(
                 .copy(version = nonExistentVersion),
         )
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
                     "Accession version ${accessions.first()}.$nonExistentVersion does not exist " +
@@ -395,7 +395,7 @@ class SubmitProcessedDataEndpointTest(
             PreparedProcessedData.successfullyProcessed(accession = accessionsNotInProcessing.first()),
         )
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
                     "Accession version ${accessionsNotInProcessing.first()}.1 " +
@@ -428,7 +428,7 @@ class SubmitProcessedDataEndpointTest(
             """.replace(Regex("\\s"), ""),
         )
             .andExpect(status().isBadRequest)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(jsonPath("\$.detail").value(containsString("Failed to deserialize NDJSON")))
             .andExpect(jsonPath("\$.detail").value(containsString("failed for JSON property metadata")))
     }
@@ -442,7 +442,7 @@ class SubmitProcessedDataEndpointTest(
             organism = DEFAULT_ORGANISM,
         )
             .andExpect(status().isUnprocessableEntity)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail")
                     .value(containsString("$accession.1 is for organism otherOrganism")),


### PR DESCRIPTION
We already follow RFC9457 for the content, just not for the content-type: https://datatracker.ietf.org/doc/html/rfc9457

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
