### PR TITLE
chore(deployment): Remove "dummy organism without consensus sequences" from `defaultOrganism`

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1505,65 +1505,6 @@ defaultOrganisms:
     referenceGenomes:
       nucleotideSequences: []
       genes: []
-  dummy-organism-without-seqs:
-    schema:
-      image: "https://cdn.who.int/media/images/default-source/mca/mca-covid-19/coronavirus-2.tmb-1920v.jpg?sfvrsn=4dba955c_19"
-      organismName: "Test organism (without consensus sequences)"
-      nucleotideSequences: []
-      submissionDataTypes:
-        consensusSequences: false
-      metadata:
-        - name: date
-          type: date
-          initiallyVisible: true
-          header: "Collection Details"
-          required: true
-          preprocessing:
-            function: parse_and_assert_past_date
-            inputs:
-              date: date
-        - name: region
-          type: string
-          initiallyVisible: true
-          generateIndex: true
-          autocomplete: true
-          header: "Collection Details"
-        - name: country
-          initiallyVisible: true
-          type: string
-          generateIndex: true
-          autocomplete: true
-          header: "Collection Details"
-        - name: division
-          initiallyVisible: true
-          type: string
-          generateIndex: true
-          autocomplete: true
-          header: "Collection Details"
-        - name: host
-          initiallyVisible: true
-          type: string
-          autocomplete: true
-          header: "Collection Details"
-      website:
-        tableColumns:
-          - country
-          - division
-          - date
-        defaultOrder: descending
-        defaultOrderBy: date
-    preprocessing:
-      - version: 3
-        image: ghcr.io/loculus-project/preprocessing-nextclade
-        args:
-          - "prepro"
-        configFile:
-          log_level: DEBUG
-          genes: []
-          batch_size: 100
-    referenceGenomes:
-      nucleotideSequences: []
-      genes: []
   not-aligned-organism:
     schema:
       image: "https://cdn.who.int/media/images/default-source/mca/mca-covid-19/coronavirus-2.tmb-1920v.jpg?sfvrsn=4dba955c_19"


### PR DESCRIPTION
Remove "dummy organism without consensus sequences" from defaultOrganism

🚀 Preview: https://consensus.loculus.org