### PR TITLE
feat(k8s): allow disabling organism by setting "enabled: false"

### DIFF
--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -182,7 +182,7 @@ enableDataUseTerms: {{ $.Values.dataUseTerms.enabled }}
 accessionPrefix: {{ quote $.Values.accessionPrefix }}
 {{- $commonMetadata := (include "loculus.commonMetadata" . | fromYaml).fields }}
 organisms:
-  {{- range $key, $instance := (.Values.organisms | default .Values.defaultOrganisms) }}
+  {{- range $key, $instance := (include "loculus.enabledOrganisms" . | fromJson) }}
   {{ $key }}:
     schema:
       {{- with ($instance.schema | include "loculus.patchMetadataSchema" | fromYaml) }}
@@ -343,7 +343,7 @@ fileSharing:
 websiteUrl: {{ include "loculus.websiteUrl" . }}
 backendUrl: {{ include "loculus.backendUrl" . }}
 organisms:
-  {{- range $key, $instance := (.Values.organisms | default .Values.defaultOrganisms) }}
+  {{- range $key, $instance := (include "loculus.enabledOrganisms" . | fromJson) }}
   {{ $key }}:
     schema:
       {{- with $instance.schema }}
@@ -478,7 +478,7 @@ fields:
 {{/* Generate ENA submission config from passed config object */}}
 {{- define "loculus.generateENASubmissionConfig" }}
 organisms:
-  {{- range $key, $instance := (.Values.organisms | default .Values.defaultOrganisms) }}
+  {{- range $key, $instance := (include "loculus.enabledOrganisms" . | fromJson) }}
   {{- if $instance.ingest }}
   {{ $key }}:
     {{- with $instance.schema }}

--- a/kubernetes/loculus/templates/_enabledOrganisms.tpl
+++ b/kubernetes/loculus/templates/_enabledOrganisms.tpl
@@ -1,7 +1,7 @@
 {{- define "loculus.enabledOrganisms" -}}
 {{- $enabled := dict -}}
 {{- range $key, $organism := (.Values.organisms | default .Values.defaultOrganisms) -}}
-{{- if ne ($organism.enabled | default true) false -}}
+{{- if ne $organism.enabled false -}}
 {{- $_ := set $enabled $key $organism -}}
 {{- end -}}
 {{- end -}}

--- a/kubernetes/loculus/templates/_enabledOrganisms.tpl
+++ b/kubernetes/loculus/templates/_enabledOrganisms.tpl
@@ -1,0 +1,9 @@
+{{- define "loculus.enabledOrganisms" -}}
+{{- $enabled := dict -}}
+{{- range $key, $organism := (.Values.organisms | default .Values.defaultOrganisms) -}}
+{{- if ne ($organism.enabled | default true) false -}}
+{{- $_ := set $enabled $key $organism -}}
+{{- end -}}
+{{- end -}}
+{{- $enabled | toJson -}}
+{{- end -}}

--- a/kubernetes/loculus/templates/_urls.tpl
+++ b/kubernetes/loculus/templates/_urls.tpl
@@ -53,7 +53,7 @@
 
 {{/* generates internal LAPIS urls from given config object */}}
 {{ define "loculus.generateInternalLapisUrls" }}
-  {{ range $key, $_ := (.Values.organisms | default .Values.defaultOrganisms) }}
+  {{ range $key, $_ := (include "loculus.enabledOrganisms" . | fromJson) }}
     "{{ $key }}": "{{ if not $.Values.disableWebsite }}http://{{ template "loculus.lapisServiceName" $key }}:8080{{ else -}}http://{{ $.Values.localHost }}:8080/{{ $key }}{{ end }}"
   {{ end }}
 {{ end }}
@@ -61,8 +61,10 @@
 {{/* generates external LAPIS urls from { config, host } */}}
 {{ define "loculus.generateExternalLapisUrls"}}
 {{ $lapisUrlTemplate := .lapisUrlTemplate }}
-{{ range $key, $_ := (.config.organisms | default .config.defaultOrganisms) }}
+{{ range $key, $organism := (.config.organisms | default .config.defaultOrganisms) }}
+{{- if ne ($organism.enabled | default true) false }}
 "{{ $key -}}": "{{ $lapisUrlTemplate | replace "%organism%" $key }}"
+{{- end }}
 {{ end }}
 {{ end }}
 

--- a/kubernetes/loculus/templates/_urls.tpl
+++ b/kubernetes/loculus/templates/_urls.tpl
@@ -62,7 +62,7 @@
 {{ define "loculus.generateExternalLapisUrls"}}
 {{ $lapisUrlTemplate := .lapisUrlTemplate }}
 {{ range $key, $organism := (.config.organisms | default .config.defaultOrganisms) }}
-{{- if ne ($organism.enabled | default true) false }}
+{{- if ne $organism.enabled false }}
 "{{ $key -}}": "{{ $lapisUrlTemplate | replace "%organism%" $key }}"
 {{- end }}
 {{ end }}

--- a/kubernetes/loculus/templates/ingest-config.yaml
+++ b/kubernetes/loculus/templates/ingest-config.yaml
@@ -3,7 +3,7 @@
 {{- $backendHost := .Values.environment | eq "server" | ternary (printf "https://backend%s%s" .Values.subdomainSeparator $.Values.host) ($testconfig | ternary (printf "http://%s:8079" $.Values.localHost) "http://loculus-backend-service:8079") }}
 {{- $enaDepositionHost := $testconfig | ternary (printf "http://%s:5000" $.Values.localHost) "http://loculus-ena-submission-service:5000" }}
 {{- $keycloakHost := $testconfig | ternary (printf "http://%s:8083" $.Values.localHost) "http://loculus-keycloak-service:8083" }}
-{{- range $key, $values := (.Values.organisms | default .Values.defaultOrganisms) }}
+{{- range $key, $values := (include "loculus.enabledOrganisms" . | fromJson) }}
 {{- if $values.ingest }}
 {{- $metadata := (include "loculus.patchMetadataSchema" $values.schema | fromYaml).metadata }}
 {{- $nucleotideSequencesList := (include "loculus.patchMetadataSchema" $values.schema | fromYaml).nucleotideSequences | default (list "main")}}

--- a/kubernetes/loculus/templates/ingest-deployment.yaml
+++ b/kubernetes/loculus/templates/ingest-deployment.yaml
@@ -1,6 +1,6 @@
 {{- $dockerTag := include "loculus.dockerTag" .Values }}
 {{- if not .Values.disableIngest }}
-{{- range $key, $value := (.Values.organisms | default .Values.defaultOrganisms) }}
+{{- range $key, $value := (include "loculus.enabledOrganisms" . | fromJson) }}
 {{- if $value.ingest }}
 ---
 apiVersion: apps/v1

--- a/kubernetes/loculus/templates/lapis-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-deployment.yaml
@@ -1,6 +1,6 @@
 {{- $dockerTag := include "loculus.dockerTag" .Values }}
 
-{{- range $key, $organism := (.Values.organisms | default .Values.defaultOrganisms) }}
+{{- range $key, $organism := (include "loculus.enabledOrganisms" . | fromJson) }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/kubernetes/loculus/templates/lapis-ingress.yaml
+++ b/kubernetes/loculus/templates/lapis-ingress.yaml
@@ -1,5 +1,5 @@
 {{- $lapisHost := printf "lapis%s%s" .Values.subdomainSeparator .Values.host }}
-{{- $organismKeys := keys ( .Values.organisms | default .Values.defaultOrganisms ) }}
+{{- $organismKeys := keys (include "loculus.enabledOrganisms" . | fromJson) }}
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:

--- a/kubernetes/loculus/templates/lapis-service.yaml
+++ b/kubernetes/loculus/templates/lapis-service.yaml
@@ -1,4 +1,4 @@
-{{- range $key, $_ := (.Values.organisms | default .Values.defaultOrganisms) }}
+{{- range $key, $_ := (include "loculus.enabledOrganisms" . | fromJson) }}
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/loculus/templates/lapis-silo-database-config.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-database-config.yaml
@@ -2,7 +2,7 @@
 {{- $importScriptLines := .Files.Lines "silo_import_job.sh" }}
 {{- $importScriptWrapperLines := .Files.Lines "silo_import_wrapper.sh" }}
 
-{{- range $key, $instance := (.Values.organisms | default .Values.defaultOrganisms) }}
+{{- range $key, $instance := (include "loculus.enabledOrganisms" . | fromJson) }}
 
 {{- $referenceGenomes:= include "loculus.generateReferenceGenome" $instance.referenceGenomes | fromYaml }}
 {{- $lineageSystem := $instance | include "loculus.lineageSystemForOrganism" }}

--- a/kubernetes/loculus/templates/loculus-preprocessing-config.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-config.yaml
@@ -1,4 +1,4 @@
-{{- range $organism, $organismConfig := (.Values.organisms | default .Values.defaultOrganisms) }}
+{{- range $organism, $organismConfig := (include "loculus.enabledOrganisms" . | fromJson) }}
 {{- $metadata := ($organismConfig.schema | include "loculus.patchMetadataSchema" | fromYaml).metadata }}
 {{- $rawNucleotideSequences := (($organismConfig.schema | include "loculus.patchMetadataSchema" | fromYaml).nucleotideSequences) }}
 {{- $nucleotideSequences := ($rawNucleotideSequences | default "" ) }}

--- a/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-deployment.yaml
@@ -6,7 +6,7 @@
 {{- $testconfig := .Values.testconfig | default false }}
 {{- $keycloakHost := $testconfig | ternary (printf "http://%s:8083" $.Values.localHost) "http://loculus-keycloak-service:8083" }}
 {{- if not .Values.disablePreprocessing }}
-{{- range $organism, $organismConfig := (.Values.organisms | default .Values.defaultOrganisms) }}
+{{- range $organism, $organismConfig := (include "loculus.enabledOrganisms" . | fromJson) }}
 {{- range $processingIndex, $processingConfig := $organismConfig.preprocessing }}
 {{- $thisDockerTag := $processingConfig.dockerTag | default $dockerTag }}
 {{- $replicas := $processingConfig.replicas | default 1 }}

--- a/kubernetes/loculus/templates/silo-deployment.yaml
+++ b/kubernetes/loculus/templates/silo-deployment.yaml
@@ -1,7 +1,7 @@
 {{- $dockerTag := include "loculus.dockerTag" .Values }}
 {{- $keycloakTokenUrl := "http://loculus-keycloak-service:8083/realms/loculus/protocol/openid-connect/token" }}
 
-{{- range $key, $organism := (.Values.organisms | default .Values.defaultOrganisms) }}
+{{- range $key, $organism := (include "loculus.enabledOrganisms" . | fromJson) }}
 {{- $lineageSystem := $organism | include "loculus.lineageSystemForOrganism" }}
 ---
 apiVersion: apps/v1

--- a/kubernetes/loculus/templates/silo-service.yaml
+++ b/kubernetes/loculus/templates/silo-service.yaml
@@ -1,4 +1,4 @@
-{{- range $key, $_ := (.Values.organisms | default .Values.defaultOrganisms) }}
+{{- range $key, $_ := (include "loculus.enabledOrganisms" . | fromJson) }}
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -205,6 +205,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "enabled": {
+          "groups": ["organism"],
+          "type": "boolean",
+          "default": true,
+          "description": "Whether this organism is enabled."
+        },
         "schema": {
           "groups": ["organism"],
           "docsIncludePrefix": false,

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1266,7 +1266,6 @@ defaultOrganisms:
           url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences+rich|fasta]}}&dataset-name=nextstrain/wnv/all-lineages&dataset-server=https://raw.githubusercontent.com/nextstrain/nextclade_data/wnv/data_output"
         - name: "Country map"
           url: "https://mapoplexus.genomium.org/?url={{[metadata+accessionVersion,accession,version,geoLocAdmin1,geoLocAdmin2,geoLocCity,geoLocCountry,geoLocSite,hostNameCommon,hostNameScientific,authors,sampleCollectionDate]}}"
-
       metadataAdd:
         - name: lineage
           header: "Lineage"
@@ -1506,6 +1505,7 @@ defaultOrganisms:
       nucleotideSequences: []
       genes: []
   not-aligned-organism:
+    enabled: false
     schema:
       image: "https://cdn.who.int/media/images/default-source/mca/mca-covid-19/coronavirus-2.tmb-1920v.jpg?sfvrsn=4dba955c_19"
       organismName: "Test organism (without alignment)"

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1505,7 +1505,7 @@ defaultOrganisms:
       nucleotideSequences: []
       genes: []
   not-aligned-organism:
-    enabled: false
+    enabled: true
     schema:
       image: "https://cdn.who.int/media/images/default-source/mca/mca-covid-19/coronavirus-2.tmb-1920v.jpg?sfvrsn=4dba955c_19"
       organismName: "Test organism (without alignment)"


### PR DESCRIPTION
- I've updated the schema
- Tested that `not-aligned-organism` doesn't appear in produced config files anymore

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://enable-false.loculus.org