### PR TITLE
Experimental tooltips on organism cards with longer names

### DIFF
--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -187,6 +187,9 @@ organisms:
     schema:
       {{- with ($instance.schema | include "loculus.patchMetadataSchema" | fromYaml) }}
       organismName: {{ quote .organismName }}
+      {{- if .longDisplayName }}
+      longDisplayName: {{ quote .longDisplayName }}
+      {{- end }}
       {{ if .linkOuts }}
       linkOuts:
         {{- range $linkOut := .linkOuts }}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -224,6 +224,12 @@
               "type": "string",
               "description": "Display name for the organism"
             },
+            "longDisplayName": {
+              "groups": ["schema"],
+              "docsIncludePrefix": false,
+              "type": "string",
+              "description": "Longer display name for the organism"
+            },
             "image": {
               "groups": ["schema"],
               "docsIncludePrefix": false,

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -55,6 +55,7 @@ defaultOrganismConfig: &defaultOrganismConfig
   schema: &schema
     loadSequencesAutomatically: true
     organismName: "Ebola Sudan"
+    longDisplayName: "Ebola virus (Sudan ebolavirus)"
     image: "/images/organisms/ebolasudan_small.jpg"
     linkOuts:
       - name: "Nextclade"
@@ -1260,6 +1261,7 @@ defaultOrganisms:
     schema:
       <<: *schema
       organismName: "West Nile Virus"
+      longDisplayName: "West Nile Virus (Flavivirus)"
       image: "/images/organisms/wnv_small.jpg"
       linkOuts:
         - name: "Nextclade"
@@ -1349,6 +1351,7 @@ defaultOrganisms:
     schema:
       image: "https://www.un.org/sites/un2.un.org/files/field/image/1583952355.1997.jpg"
       organismName: "Test Dummy Organism"
+      longDisplayName: "Test Dummy Organism for development"
       metadataTemplate:
         - country
         - date
@@ -1446,6 +1449,7 @@ defaultOrganisms:
     schema:
       image: "https://cdn.who.int/media/images/default-source/mca/mca-covid-19/coronavirus-2.tmb-1920v.jpg?sfvrsn=4dba955c_19"
       organismName: "Test organism (with files)"
+      longDisplayName: "Test organism including file submissions"
       nucleotideSequences: []
       submissionDataTypes:
         consensusSequences: false
@@ -1509,6 +1513,7 @@ defaultOrganisms:
     schema:
       image: "https://cdn.who.int/media/images/default-source/mca/mca-covid-19/coronavirus-2.tmb-1920v.jpg?sfvrsn=4dba955c_19"
       organismName: "Test organism (without alignment)"
+      longDisplayName: "Test organism without sequence alignment"
       metadata:
         - name: date
           type: date
@@ -1575,6 +1580,7 @@ defaultOrganisms:
     schema:
       <<: *schema
       organismName: "Crimean-Congo Hemorrhagic Fever Virus"
+      longDisplayName: "Crimean-Congo Hemorrhagic Fever Virus (Nairovirus)"
       nucleotideSequences: [L, M, S]
       image: "/images/organisms/cchf_small.jpg"
       linkOuts:

--- a/website/src/components/IndexPage/OrganismCard.astro
+++ b/website/src/components/IndexPage/OrganismCard.astro
@@ -7,11 +7,12 @@ interface Props {
     key: string;
     image: string | undefined;
     displayName: string;
+    longDisplayName: string | undefined;
     organismStatistics: OrganismStatistics;
     numberDaysAgoStatistics: number;
 }
 
-const { key, image, displayName, organismStatistics, numberDaysAgoStatistics } = Astro.props;
+const { key, image, displayName, longDisplayName, organismStatistics, numberDaysAgoStatistics } = Astro.props;
 ---
 
 <a
@@ -23,6 +24,7 @@ const { key, image, displayName, organismStatistics, numberDaysAgoStatistics } =
     hover:no-underline
     transition-all duration-200 ease-in-out
     mx-auto sm:mx-0'
+    title={longDisplayName ?? displayName}
 >
     {image !== undefined && <img src={image} class='h-40 w-full object-cover rounded-t-[8px]' alt={displayName} />}
     <div class='my-4 mx-4 h-28 flex flex-col justify-between text-slate-900'>

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -103,12 +103,14 @@ export function getMetadataDisplayNames(organism: string): Map<string, string> {
 export type Organism = {
     key: string;
     displayName: string;
+    longDisplayName?: string;
 };
 
 export function getConfiguredOrganisms() {
     return Object.entries(getWebsiteConfig().organisms).map(([key, instance]) => ({
         key,
         displayName: instance.schema.organismName,
+        longDisplayName: instance.schema.longDisplayName,
         image: instance.schema.image,
     }));
 }

--- a/website/src/pages/[organism]/api/_sequences.spec.ts
+++ b/website/src/pages/[organism]/api/_sequences.spec.ts
@@ -45,6 +45,7 @@ describe('The sequences endpoint', () => {
                 displayName: organism,
                 image: undefined,
                 description: undefined,
+                longDisplayName: undefined,
             },
         ]);
         getRuntimeConfigMock.mockImplementation(() => testConfig);

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -25,11 +25,12 @@ const organismStatisticsMap = await getOrganismStatisticsMap(
                 class=`flex flex-wrap justify-center gap-x-5  gap-y-4 ${getConfiguredOrganisms().length ===5 ? "max-w-4xl" : ""}`
             >
                 {
-                    getConfiguredOrganisms().map(({ key, displayName, image }) => (
+                    getConfiguredOrganisms().map(({ key, displayName, longDisplayName, image }) => (
                         <OrganismCard
                             key={key}
                             image={image}
                             displayName={displayName}
+                            longDisplayName={longDisplayName}
                             organismStatistics={organismStatisticsMap.get(key)!}
                             numberDaysAgoStatistics={numberDaysAgoStatistics}
                         />

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -130,6 +130,7 @@ export type SubmissionDataTypes = z.infer<typeof submissionDataTypesSchema>;
 
 export const schema = z.object({
     organismName: z.string(),
+    longDisplayName: z.string().optional(),
     image: z.string().optional(),
     files: z.array(fileCategory).optional(),
     metadata: z.array(metadata),


### PR DESCRIPTION
## Summary
- extend schema with `longDisplayName`
- expose the field from config
- show it as a tooltip on organism cards
- pass `longDisplayName` in the index page
- add Helm support for `longDisplayName`
- update example values

## Testing
- `npm run format`
- `npm run check-types`
- `npm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_686c4c29955c832596c2e5f10f95d922

🚀 Preview: https://codex-add-long-display-na.loculus.org