### PR TITLE
fix(k8s): use absolute path to config for ena-deposition submission list cronjob

### DIFF
--- a/kubernetes/loculus/templates/ena-submission-deployment.yaml
+++ b/kubernetes/loculus/templates/ena-submission-deployment.yaml
@@ -102,10 +102,10 @@ spec:
                   key: password
           args:
             - ena_deposition 
-            - "--config-file=/package/config/config.yaml"
+            - "--config-file=/config/config.yaml"
           volumeMounts:
             - name: loculus-ena-submission-config-volume
-              mountPath: /package/config/config.yaml
+              mountPath: /config/config.yaml
               subPath: config.yaml
       volumes:
         - name: loculus-ena-submission-config-volume
@@ -177,10 +177,10 @@ spec:
               args:
                 - python
                 - "scripts/get_ena_submission_list.py"
-                - "--config-file=config/config.yaml"
+                - "--config-file=/config/config.yaml"
               volumeMounts:
                 - name: loculus-ena-submission-config-volume
-                  mountPath: /package/config/config.yaml
+                  mountPath: /config/config.yaml
                   subPath: config.yaml
           volumes:
             - name: loculus-ena-submission-config-volume


### PR DESCRIPTION
I changed the workdir of the image in https://github.com/loculus-project/loculus/pull/4577 and this breaks the relative path.

This should be rolled out to prod with priority to get submission list working again.

resolves #

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)
