### PR TITLE
feat(website): show long display name overlay on organism card

### DIFF
--- a/website/src/components/IndexPage/OrganismCard.astro
+++ b/website/src/components/IndexPage/OrganismCard.astro
@@ -33,7 +33,7 @@ const { key, image, displayName, longDisplayName, organismStatistics, numberDays
                     alt={displayName}
                 />
                 {longDisplayName && (
-                    <div class='absolute inset-0 flex rounded-t-[8px] bg-black/20 text-white text-center px-2 opacity-0 group-hover:opacity-90 transition-opacity duration-200'>
+                    <div class='absolute inset-0 flex rounded-t-[8px] align-center items-center bg-white/20 text-black px-2 opacity-0 group-hover:opacity-90 transition-opacity duration-200'>
                         {longDisplayName}
                     </div>
                 )}

--- a/website/src/components/IndexPage/OrganismCard.astro
+++ b/website/src/components/IndexPage/OrganismCard.astro
@@ -33,7 +33,7 @@ const { key, image, displayName, longDisplayName, organismStatistics, numberDays
                     alt={displayName}
                 />
                 {longDisplayName && (
-                    <div class='absolute inset-0 flex rounded-t-[8px] align-center items-center bg-white/40 text-black px-2 opacity-0 group-hover:opacity-90 transition-opacity duration-200'>
+                    <div class='absolute inset-0 flex rounded-t-[8px] align-center items-center bg-white/40 text-black px-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200'>
                         {longDisplayName}
                     </div>
                 )}

--- a/website/src/components/IndexPage/OrganismCard.astro
+++ b/website/src/components/IndexPage/OrganismCard.astro
@@ -33,7 +33,7 @@ const { key, image, displayName, longDisplayName, organismStatistics, numberDays
                     alt={displayName}
                 />
                 {longDisplayName && (
-                    <div class='absolute inset-0 flex items-center justify-center rounded-t-[8px] bg-black/40 text-white text-center px-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200'>
+                    <div class='absolute inset-0 flex rounded-t-[8px] bg-black/20 text-white text-center px-2 opacity-0 group-hover:opacity-90 transition-opacity duration-200'>
                         {longDisplayName}
                     </div>
                 )}

--- a/website/src/components/IndexPage/OrganismCard.astro
+++ b/website/src/components/IndexPage/OrganismCard.astro
@@ -33,7 +33,7 @@ const { key, image, displayName, longDisplayName, organismStatistics, numberDays
                     alt={displayName}
                 />
                 {longDisplayName && (
-                    <div class='absolute inset-0 flex rounded-t-[8px] align-center items-center bg-white/20 text-black px-2 opacity-0 group-hover:opacity-90 transition-opacity duration-200'>
+                    <div class='absolute inset-0 flex rounded-t-[8px] align-center items-center bg-white/40 text-black px-2 opacity-0 group-hover:opacity-90 transition-opacity duration-200'>
                         {longDisplayName}
                     </div>
                 )}

--- a/website/src/components/IndexPage/OrganismCard.astro
+++ b/website/src/components/IndexPage/OrganismCard.astro
@@ -17,16 +17,29 @@ const { key, image, displayName, longDisplayName, organismStatistics, numberDays
 
 <a
     href={routes.organismStartPage(key)}
-    class='shadow-[0_3px_10px_rgb(0,0,0,0.1)]
+    class='group shadow-[0_3px_10px_rgb(0,0,0,0.1)]
     block rounded-lg m-2 w-60
-    hover:brightness-115
     hover:shadow-[0_3px_10px_rgb(0,0,0,0.2)]
     hover:no-underline
     transition-all duration-200 ease-in-out
     mx-auto sm:mx-0'
-    title={longDisplayName}
 >
-    {image !== undefined && <img src={image} class='h-40 w-full object-cover rounded-t-[8px]' alt={displayName} />}
+    {
+        image !== undefined && (
+            <div class='relative'>
+                <img
+                    src={image}
+                    class='h-40 w-full object-cover rounded-t-[8px] transition-colors duration-200 group-hover:brightness-75'
+                    alt={displayName}
+                />
+                {longDisplayName && (
+                    <div class='absolute inset-0 flex items-center justify-center rounded-t-[8px] bg-black/40 text-white text-center px-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200'>
+                        {longDisplayName}
+                    </div>
+                )}
+            </div>
+        )
+    }
     <div class='my-4 mx-4 h-28 flex flex-col justify-between text-slate-900'>
         <h3 class='font-semibold mb-2'>{displayName}</h3>
         <p class='text-sm leading-7'>

--- a/website/src/components/IndexPage/OrganismCard.astro
+++ b/website/src/components/IndexPage/OrganismCard.astro
@@ -29,7 +29,7 @@ const { key, image, displayName, longDisplayName, organismStatistics, numberDays
             <div class='relative'>
                 <img
                     src={image}
-                    class='h-40 w-full object-cover rounded-t-[8px] transition-colors duration-200 group-hover:brightness-75'
+                    class='h-40 w-full object-cover rounded-t-[8px] transition-colors duration-200 group-hover:brightness-115'
                     alt={displayName}
                 />
                 {longDisplayName && (


### PR DESCRIPTION
## Summary
- display an overlay with `longDisplayName` on hover for organism cards
- darken the image while hovered

## Testing
- `npm run format`
- `npm run check-types`
- `npm run test -- --run` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_686d7f2ab61c8325b2a5491708102641

🚀 Preview: https://codex-update-organism-car.loculus.org