### PR TITLE
[cli-branch] feat(website): add loculus info endpoint

### DIFF
--- a/website/src/pages/loculus-info/index.ts
+++ b/website/src/pages/loculus-info/index.ts
@@ -14,10 +14,8 @@ export const GET: APIRoute = async ({ request }) => {
             keycloak: keycloakUrl,
             website: new URL(request.url).origin,
         },
-        version: process.env.LOCULUS_VERSION ?? '',
         minCliVersion: '0.0.0',
         title: website.name,
-        description: website.welcomeMessageHTML ?? null,
         organisms: website.organisms,
     };
     return new Response(JSON.stringify(response), {

--- a/website/src/pages/loculus-info/index.ts
+++ b/website/src/pages/loculus-info/index.ts
@@ -1,0 +1,28 @@
+import type { APIRoute } from 'astro';
+
+import { getRuntimeConfig, getWebsiteConfig } from '../../config';
+import { getAuthBaseUrl } from '../../utils/getAuthUrl';
+
+export const GET: APIRoute = async ({ request }) => {
+    const runtime = getRuntimeConfig();
+    const website = getWebsiteConfig();
+    const keycloakUrl = await getAuthBaseUrl();
+    const response = {
+        hosts: {
+            backend: runtime.public.backendUrl,
+            lapis: runtime.public.lapisUrls,
+            keycloak: keycloakUrl ?? runtime.serverSide.keycloakUrl,
+            website: new URL(request.url).origin,
+        },
+        version: process.env.LOCULUS_VERSION ?? '',
+        minCliVersion: '0.0.0',
+        title: website.name,
+        description: website.welcomeMessageHTML ?? null,
+        organisms: website.organisms,
+    };
+    return new Response(JSON.stringify(response), {
+        headers: {
+            'Content-Type': 'application/json', // eslint-disable-line @typescript-eslint/naming-convention
+        },
+    });
+};

--- a/website/src/pages/loculus-info/index.ts
+++ b/website/src/pages/loculus-info/index.ts
@@ -11,7 +11,7 @@ export const GET: APIRoute = async ({ request }) => {
         hosts: {
             backend: runtime.public.backendUrl,
             lapis: runtime.public.lapisUrls,
-            keycloak: keycloakUrl ?? runtime.serverSide.keycloakUrl,
+            keycloak: keycloakUrl,
             website: new URL(request.url).origin,
         },
         version: process.env.LOCULUS_VERSION ?? '',


### PR DESCRIPTION
relates to #4643

Adds a `GET /loculus-info` endpoint on the website that returns various information in JSON about the Loculus instance. Most importantly, this allows discovery of the publicly accessible hostnames for all the different components. It also includes the organism schema.

------
https://chatgpt.com/codex/tasks/task_e_686fb7d820d88325a70b9bdfa87b951b

https://codex-add-loculus-info-en.loculus.org/loculus-info

🚀 Preview: https://codex-add-loculus-info-en.loculus.org