### PR TITLE
fix(deposition): make submission list upload to Slack work again

### DIFF
--- a/ena-submission/src/ena_deposition/notifications.py
+++ b/ena-submission/src/ena_deposition/notifications.py
@@ -41,11 +41,13 @@ def upload_file_with_comment(
 ) -> web.SlackResponse:
     """Upload file with comment to slack channel"""
     client = WebClient(token=config.slack_token)
-    with zipfile.ZipFile(file_path, "w", zipfile.ZIP_DEFLATED) as zipf:
-        zipf.write(file_path, arcname=os.path.basename(file_path))
+    output_file_zip = os.path.basename(file_path) + ".zip"
+    zip = zipfile.ZipFile(output_file_zip, "w", zipfile.ZIP_DEFLATED)
+    zip.write(file_path)
+    zip.close()
     return client.files_upload_v2(
-        file=file_path,
-        title=file_path,
+        file=output_file_zip,
+        title=output_file_zip,
         channel=config.slack_channel_id,
         initial_comment=comment,
     )


### PR DESCRIPTION
resolves #

Since the refactor in https://github.com/loculus-project/loculus/pull/4577 the file is now being uploaded in bytes - this reverts the changes in the refactor that affected this function

### Screenshot

### PR Checklist
- ~[ ] All necessary documentation has been adapted.~
- [ ] The implemented feature is covered by appropriate, automated tests
-> Im not sure how best to test these slack notifications but would be good to in future think of a way to test them as they often break 
- [X] Any manual testing that has been done is documented (i.e. what exactly was tested?)
tested on preview, submitted sequences and then ran cronjob, was successful:

<img width="2034" height="296" alt="image" src="https://github.com/user-attachments/assets/ead6f9a9-a675-4616-b7d9-19c1f5210ca1" />


🚀 Preview: https://fix-notifications.loculus.org