### PR TITLE
refactor(backend): use constant to refer to submission id for better reference

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionControllerDescriptions.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionControllerDescriptions.kt
@@ -1,8 +1,10 @@
 package org.loculus.backend.controller
 
+import org.loculus.backend.model.HEADER_TO_CONNECT_METADATA_AND_SEQUENCES_ALTERNATE_FOR_BACKCOMPAT
+
 const val SUBMIT_RESPONSE_DESCRIPTION = """
 Returns a list of accession, version and submissionId of the submitted sequence entries. 
-The submissionId is the (locally unique) id provided by the submitter as 'submissionId' in the metadata file. 
+The submissionId is the (locally unique) id provided by the submitter as '$HEADER_TO_CONNECT_METADATA_AND_SEQUENCES_ALTERNATE_FOR_BACKCOMPAT' in the metadata file. 
 The version will be 1 for every sequence. 
 The accession is the (globally unique) id that the system assigned to the sequence entry. 
 You can use this response to associate the user provided submissionId with the system assigned accession.
@@ -16,16 +18,16 @@ const val METADATA_FILE_DESCRIPTION = """
 A TSV (tab separated values) file containing the metadata of the submitted sequence entries. 
 The file may be compressed with zstd, xz, zip, gzip, lzma, bzip2 (with common extensions).
 It must contain the column names.
-The field 'submissionId' is required and must be unique within the provided dataset.
+The field '$HEADER_TO_CONNECT_METADATA_AND_SEQUENCES_ALTERNATE_FOR_BACKCOMPAT' is required and must be unique within the provided dataset.
 It is used to associate metadata to the sequences in the sequences fasta file.
 """
 const val SEQUENCE_FILE_DESCRIPTION = """
 A fasta file containing the unaligned nucleotide sequences of the submitted sequences.
 The file may be compressed with zstd, xz, zip, gzip, lzma, bzip2 (with common extensions).
 If the underlying organism has a single segment,
-the headers of the fasta file must match the 'submissionId' field in the metadata file.
+the headers of the fasta file must match the '$HEADER_TO_CONNECT_METADATA_AND_SEQUENCES_ALTERNATE_FOR_BACKCOMPAT' field in the metadata file.
 If the underlying organism has multiple segments,
-the headers of the fasta file must be of the form '>[submissionId]_[segmentName]'.
+the headers of the fasta file must be of the form '>[$HEADER_TO_CONNECT_METADATA_AND_SEQUENCES_ALTERNATE_FOR_BACKCOMPAT]_[segmentName]'.
 """
 
 const val GROUP_ID_DESCRIPTION = """

--- a/backend/src/main/kotlin/org/loculus/backend/utils/ParseFastaHeader.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/ParseFastaHeader.kt
@@ -3,6 +3,7 @@ package org.loculus.backend.utils
 import org.loculus.backend.api.Organism
 import org.loculus.backend.config.BackendConfig
 import org.loculus.backend.controller.BadRequestException
+import org.loculus.backend.model.HEADER_TO_CONNECT_METADATA_AND_SEQUENCES_ALTERNATE_FOR_BACKCOMPAT
 import org.loculus.backend.model.SegmentName
 import org.loculus.backend.model.SubmissionId
 import org.springframework.stereotype.Service
@@ -22,7 +23,7 @@ class ParseFastaHeader(private val backendConfig: BackendConfig) {
         if (lastDelimiter == -1) {
             throw BadRequestException(
                 "The FASTA header $submissionId does not contain the segment name. Please provide the" +
-                    " segment name in the format <submissionId>_<segment name>",
+                    " segment name in the format <$HEADER_TO_CONNECT_METADATA_AND_SEQUENCES_ALTERNATE_FOR_BACKCOMPAT>_<segment name>",
             )
         }
         val isolateId = submissionId.substring(0, lastDelimiter)


### PR DESCRIPTION
Apparently some controller descriptions were forgotten to be adapted in #3711. This doesn't intend to change anything, but help with preparations for #4296.

resolves #

### Screenshot

### PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by appropriate, automated tests.~~
~~- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~~

🚀 Preview: Add `preview` label to enable