### PR TITLE
fix(website): Fix aberrant semicolon in author list

### DIFF
--- a/website/src/components/SequenceDetailsPage/AuthorList.tsx
+++ b/website/src/components/SequenceDetailsPage/AuthorList.tsx
@@ -39,7 +39,7 @@ export const AuthorList: FC<AuthorsListProps> = ({ authors }) => {
                         {', '}
                     </span>
                 ))}
-                <span>...; </span>
+                <span>..., </span>
                 {data.afterEllipsis.map((author, index) => (
                     <span key={index}>
                         {author}


### PR DESCRIPTION
Just spotted this (see just before last author):

<img width="1363" height="165" alt="image" src="https://github.com/user-attachments/assets/8ab75736-72f1-41a1-ac8b-11c098ce1b6b" />

🚀 Preview: Add `preview` label to enable