### PR TITLE
Revert[breaking] "feat(deposition): send GCA accession as part of external metadata"

### DIFF
--- a/ena-submission/flyway/sql/V1.3__update_submission_status.sql
+++ b/ena-submission/flyway/sql/V1.3__update_submission_status.sql
@@ -1,3 +1,0 @@
-UPDATE submission_table
-SET status_all = 'SUBMITTED_ALL'
-WHERE status_all = 'SENT_TO_LOCULUS';

--- a/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
+++ b/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
@@ -61,9 +61,11 @@ def get_external_metadata(db_config: SimpleConnectionPool, entry: dict[str, Any]
         db_config, table_name=TableName.ASSEMBLY_TABLE, conditions=seq_key
     )
     if len(corresponding_assembly) == 1:
-        data["externalMetadata"]["gcaAccession"] = corresponding_assembly[0]["result"][
-            "gca_accession"
-        ]
+        # TODO(https://github.com/loculus-project/loculus/issues/2945):
+        # Add gcaAccession to values.yaml
+        # data["externalMetadata"]["gcaAccession"] = corresponding_assembly[0]["result"][
+        #     "gca_accession"
+        # ]
         insdc_accession_keys = [
             key
             for key in corresponding_assembly[0]["result"]


### PR DESCRIPTION
Reverts loculus-project/loculus#4677 due to https://github.com/loculus-project/loculus/issues/4686 (we need to update all project_id values in the submission table before this can be rolled out)

As PPX is the only user of the ena deposition pipeline and the change is not on prod I don't think we need to worry about rolling back the flyway migration

What's reverted here becomes part of #4688 so it's not lost at all.