### PR TITLE
feat!(kubernetes): [CFG] add support for multiple reference genomes

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
@@ -43,6 +43,8 @@ enum class FileUrlType {
     override fun toString(): String = lowerCase(name)
 }
 
+const val SINGLE_REFERENCE_GENOME_KEY = "singleReference"
+
 typealias Suborganism = String
 
 data class InstanceConfig(val schema: Schema, val referenceGenomes: Map<Suborganism, ReferenceGenome>)

--- a/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
@@ -43,7 +43,9 @@ enum class FileUrlType {
     override fun toString(): String = lowerCase(name)
 }
 
-data class InstanceConfig(val schema: Schema, val referenceGenomes: ReferenceGenome)
+typealias Suborganism = String
+
+data class InstanceConfig(val schema: Schema, val referenceGenomes: Map<Suborganism, ReferenceGenome>)
 
 data class Schema(
     val organismName: String,

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/CompressionService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/CompressionService.kt
@@ -181,6 +181,7 @@ class CompressionService(private val backendConfig: BackendConfig) {
         backendConfig
             .getInstanceConfig(organism)
             .referenceGenomes
+            .values.first()
             .getNucleotideSegmentReference(
                 segmentName,
             )
@@ -189,6 +190,7 @@ class CompressionService(private val backendConfig: BackendConfig) {
     private fun getDictionaryForAminoAcidSequence(geneName: String, organism: Organism): ByteArray? = backendConfig
         .getInstanceConfig(organism)
         .referenceGenomes
+        .values.first()
         .getAminoAcidGeneReference(
             geneName,
         )

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/EmptyProcessedDataProvider.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/EmptyProcessedDataProvider.kt
@@ -11,15 +11,16 @@ import org.springframework.stereotype.Component
 class EmptyProcessedDataProvider(private val backendConfig: BackendConfig) {
     fun provide(organism: Organism): ProcessedData<GeneticSequence> {
         val (schema, referenceGenomes) = backendConfig.getInstanceConfig(organism)
+        val referenceGenome = referenceGenomes.values.first()
 
-        val nucleotideSequences = referenceGenomes.nucleotideSequences.map { it.name }.associateWith { null }
+        val nucleotideSequences = referenceGenome.nucleotideSequences.map { it.name }.associateWith { null }
         return ProcessedData(
             metadata = schema.metadata.map { it.name }.associateWith { NullNode.instance },
             unalignedNucleotideSequences = nucleotideSequences,
             alignedNucleotideSequences = nucleotideSequences,
-            alignedAminoAcidSequences = referenceGenomes.genes.map { it.name }.associateWith { null },
-            nucleotideInsertions = referenceGenomes.nucleotideSequences.map { it.name }.associateWith { emptyList() },
-            aminoAcidInsertions = referenceGenomes.genes.map { it.name }.associateWith { emptyList() },
+            alignedAminoAcidSequences = referenceGenome.genes.map { it.name }.associateWith { null },
+            nucleotideInsertions = referenceGenome.nucleotideSequences.map { it.name }.associateWith { emptyList() },
+            aminoAcidInsertions = referenceGenome.genes.map { it.name }.associateWith { emptyList() },
             files = null,
         )
     }

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequenceEntryValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequenceEntryValidator.kt
@@ -191,7 +191,10 @@ class ExternalMetadataValidator(private val schema: Schema) {
 class ProcessedSequenceEntryValidatorFactory(private val backendConfig: BackendConfig) {
     fun create(organism: Organism): ProcessedSequenceEntryValidator {
         val instanceConfig = backendConfig.organisms[organism.name]!!
-        return ProcessedSequenceEntryValidator(instanceConfig.schema, instanceConfig.referenceGenomes)
+        return ProcessedSequenceEntryValidator(
+            schema = instanceConfig.schema,
+            referenceGenome = instanceConfig.referenceGenomes.values.first(),
+        )
     }
 }
 

--- a/backend/src/main/kotlin/org/loculus/backend/utils/ParseFastaHeader.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/ParseFastaHeader.kt
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service
 @Service
 class ParseFastaHeader(private val backendConfig: BackendConfig) {
     fun parse(submissionId: String, organism: Organism): Pair<SubmissionId, SegmentName> {
-        val referenceGenome = backendConfig.getInstanceConfig(organism).referenceGenomes
+        val referenceGenome = backendConfig.getInstanceConfig(organism).referenceGenomes.values.first()
 
         if (referenceGenome.nucleotideSequences.size == 1) {
             return Pair(submissionId, "main")

--- a/backend/src/test/kotlin/org/loculus/backend/config/BackendSpringConfigTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/config/BackendSpringConfigTest.kt
@@ -65,8 +65,8 @@ class BackendSpringConfigTest {
 fun backendConfig(metadataList: List<Metadata>, earliestReleaseDate: EarliestReleaseDate) = BackendConfig(
     organisms = mapOf(
         DEFAULT_ORGANISM to InstanceConfig(
-            Schema(DEFAULT_ORGANISM, metadataList, earliestReleaseDate = earliestReleaseDate),
-            ReferenceGenome(emptyList(), emptyList()),
+            schema = Schema(DEFAULT_ORGANISM, metadataList, earliestReleaseDate = earliestReleaseDate),
+            referenceGenomes = mapOf(DEFAULT_ORGANISM to ReferenceGenome(emptyList(), emptyList())),
         ),
     ),
     accessionPrefix = "FOO_",

--- a/backend/src/test/kotlin/org/loculus/backend/config/BackendSpringConfigTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/config/BackendSpringConfigTest.kt
@@ -66,7 +66,7 @@ fun backendConfig(metadataList: List<Metadata>, earliestReleaseDate: EarliestRel
     organisms = mapOf(
         DEFAULT_ORGANISM to InstanceConfig(
             schema = Schema(DEFAULT_ORGANISM, metadataList, earliestReleaseDate = earliestReleaseDate),
-            referenceGenomes = mapOf(DEFAULT_ORGANISM to ReferenceGenome(emptyList(), emptyList())),
+            referenceGenomes = mapOf(SINGLE_REFERENCE_GENOME_KEY to ReferenceGenome(emptyList(), emptyList())),
         ),
     ),
     accessionPrefix = "FOO_",

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
@@ -77,6 +77,8 @@ class SubmissionConvenienceClient(
 
         val isMultiSegmented = instanceConfig
             .referenceGenomes
+            .values
+            .first()
             .nucleotideSequences.size > 1
 
         val doesNotAllowConsensusSequenceFile = !instanceConfig.schema

--- a/backend/src/test/kotlin/org/loculus/backend/service/submission/EmptyProcessedDataProviderTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/submission/EmptyProcessedDataProviderTest.kt
@@ -12,6 +12,7 @@ import org.loculus.backend.config.Metadata
 import org.loculus.backend.config.MetadataType
 import org.loculus.backend.config.ReferenceGenome
 import org.loculus.backend.config.ReferenceSequence
+import org.loculus.backend.config.SINGLE_REFERENCE_GENOME_KEY
 import org.loculus.backend.config.Schema
 import org.loculus.backend.controller.DEFAULT_ORGANISM
 
@@ -36,7 +37,7 @@ class EmptyProcessedDataProviderTest {
                         ),
                     ),
                     referenceGenomes = mapOf(
-                        DEFAULT_ORGANISM to ReferenceGenome(
+                        SINGLE_REFERENCE_GENOME_KEY to ReferenceGenome(
                             listOf(
                                 ReferenceSequence(FIRST_NUCLEOTIDE_SEQUENCE, "the sequence"),
                                 ReferenceSequence(SECOND_NUCLEOTIDE_SEQUENCE, "the sequence"),

--- a/backend/src/test/kotlin/org/loculus/backend/service/submission/EmptyProcessedDataProviderTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/submission/EmptyProcessedDataProviderTest.kt
@@ -35,14 +35,16 @@ class EmptyProcessedDataProviderTest {
                             Metadata(name = SECOND_METADATA_FIELD, type = MetadataType.DATE, required = false),
                         ),
                     ),
-                    referenceGenomes = ReferenceGenome(
-                        listOf(
-                            ReferenceSequence(FIRST_NUCLEOTIDE_SEQUENCE, "the sequence"),
-                            ReferenceSequence(SECOND_NUCLEOTIDE_SEQUENCE, "the sequence"),
-                        ),
-                        listOf(
-                            ReferenceSequence(FIRST_AMINO_ACID_SEQUENCE, "the sequence"),
-                            ReferenceSequence(SECOND_AMINO_ACID_SEQUENCE, "the sequence"),
+                    referenceGenomes = mapOf(
+                        DEFAULT_ORGANISM to ReferenceGenome(
+                            listOf(
+                                ReferenceSequence(FIRST_NUCLEOTIDE_SEQUENCE, "the sequence"),
+                                ReferenceSequence(SECOND_NUCLEOTIDE_SEQUENCE, "the sequence"),
+                            ),
+                            listOf(
+                                ReferenceSequence(FIRST_AMINO_ACID_SEQUENCE, "the sequence"),
+                                ReferenceSequence(SECOND_AMINO_ACID_SEQUENCE, "the sequence"),
+                            ),
                         ),
                     ),
                 ),

--- a/backend/src/test/resources/backend_config.json
+++ b/backend/src/test/resources/backend_config.json
@@ -5,22 +5,24 @@
     "organisms": {
         "dummyOrganism": {
             "referenceGenomes": {
-                "nucleotideSequences": [
-                    {
-                        "name": "main",
-                        "sequence": "ATTAAAGGTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCT"
-                    }
-                ],
-                "genes": [
-                    {
-                        "name": "someLongGene",
-                        "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
-                    },
-                    {
-                        "name": "someShortGene",
-                        "sequence": "MADS"
-                    }
-                ]
+                "dummyOrganism": {
+                    "nucleotideSequences": [
+                        {
+                            "name": "main",
+                            "sequence": "ATTAAAGGTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCT"
+                        }
+                    ],
+                    "genes": [
+                        {
+                            "name": "someLongGene",
+                            "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
+                        },
+                        {
+                            "name": "someShortGene",
+                            "sequence": "MADS"
+                        }
+                    ]
+                }
             },
             "schema": {
                 "organismName": "Test",
@@ -104,26 +106,28 @@
         },
         "otherOrganism": {
             "referenceGenomes": {
-                "nucleotideSequences": [
-                    {
-                        "name": "notOnlySegment",
-                        "sequence": "ATCG"
-                    },
-                    {
-                        "name": "secondSegment",
-                        "sequence": "AAAAAAAAAAAAAAAA"
-                    }
-                ],
-                "genes": [
-                    {
-                        "name": "someLongGene",
-                        "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
-                    },
-                    {
-                        "name": "someShortGene",
-                        "sequence": "MADS"
-                    }
-                ]
+                "otherOrganism": {
+                    "nucleotideSequences": [
+                        {
+                            "name": "notOnlySegment",
+                            "sequence": "ATCG"
+                        },
+                        {
+                            "name": "secondSegment",
+                            "sequence": "AAAAAAAAAAAAAAAA"
+                        }
+                    ],
+                    "genes": [
+                        {
+                            "name": "someLongGene",
+                            "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
+                        },
+                        {
+                            "name": "someShortGene",
+                            "sequence": "MADS"
+                        }
+                    ]
+                }
             },
             "schema": {
                 "organismName": "Test",
@@ -188,8 +192,10 @@
         },
         "dummyOrganismWithoutConsensusSequences": {
             "referenceGenomes": {
-                "nucleotideSequences": [],
-                "genes": []
+                "dummyOrganismWithoutConsensusSequences": {
+                    "nucleotideSequences": [],
+                    "genes": []
+                }
             },
             "schema": {
                 "organismName": "Test without consensus sequences",

--- a/backend/src/test/resources/backend_config.json
+++ b/backend/src/test/resources/backend_config.json
@@ -5,7 +5,7 @@
     "organisms": {
         "dummyOrganism": {
             "referenceGenomes": {
-                "dummyOrganism": {
+                "singleReference": {
                     "nucleotideSequences": [
                         {
                             "name": "main",
@@ -106,7 +106,7 @@
         },
         "otherOrganism": {
             "referenceGenomes": {
-                "otherOrganism": {
+                "singleReference": {
                     "nucleotideSequences": [
                         {
                             "name": "notOnlySegment",
@@ -192,7 +192,7 @@
         },
         "dummyOrganismWithoutConsensusSequences": {
             "referenceGenomes": {
-                "dummyOrganismWithoutConsensusSequences": {
+                "singleReference": {
                     "nucleotideSequences": [],
                     "genes": []
                 }

--- a/backend/src/test/resources/backend_config_data_use_terms_disabled.json
+++ b/backend/src/test/resources/backend_config_data_use_terms_disabled.json
@@ -5,22 +5,24 @@
   "organisms": {
     "dummyOrganism": {
       "referenceGenomes": {
-        "nucleotideSequences": [
-          {
-            "name": "main",
-            "sequence": "ATTAAAGGTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCT"
-          }
-        ],
-        "genes": [
-          {
-            "name": "someLongGene",
-            "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
-          },
-          {
-            "name": "someShortGene",
-            "sequence": "MADS"
-          }
-        ]
+        "dummyOrganism": {
+          "nucleotideSequences": [
+            {
+              "name": "main",
+              "sequence": "ATTAAAGGTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCT"
+            }
+          ],
+          "genes": [
+            {
+              "name": "someLongGene",
+              "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
+            },
+            {
+              "name": "someShortGene",
+              "sequence": "MADS"
+            }
+          ]
+        }
       },
       "schema": {
         "organismName": "Test",

--- a/backend/src/test/resources/backend_config_data_use_terms_disabled.json
+++ b/backend/src/test/resources/backend_config_data_use_terms_disabled.json
@@ -5,7 +5,7 @@
   "organisms": {
     "dummyOrganism": {
       "referenceGenomes": {
-        "dummyOrganism": {
+        "singleReference": {
           "nucleotideSequences": [
             {
               "name": "main",

--- a/backend/src/test/resources/backend_config_s3.json
+++ b/backend/src/test/resources/backend_config_s3.json
@@ -5,22 +5,24 @@
     "organisms": {
         "dummyOrganism": {
             "referenceGenomes": {
-                "nucleotideSequences": [
-                    {
-                        "name": "main",
-                        "sequence": "ATTAAAGGTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCT"
-                    }
-                ],
-                "genes": [
-                    {
-                        "name": "someLongGene",
-                        "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
-                    },
-                    {
-                        "name": "someShortGene",
-                        "sequence": "MADS"
-                    }
-                ]
+                "dummyOrganism": {
+                    "nucleotideSequences": [
+                        {
+                            "name": "main",
+                            "sequence": "ATTAAAGGTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCT"
+                        }
+                    ],
+                    "genes": [
+                        {
+                            "name": "someLongGene",
+                            "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
+                        },
+                        {
+                            "name": "someShortGene",
+                            "sequence": "MADS"
+                        }
+                    ]
+                }
             },
             "schema": {
                 "organismName": "Test",
@@ -119,26 +121,28 @@
         },
         "otherOrganism": {
             "referenceGenomes": {
-                "nucleotideSequences": [
-                    {
-                        "name": "notOnlySegment",
-                        "sequence": "ATCG"
-                    },
-                    {
-                        "name": "secondSegment",
-                        "sequence": "AAAAAAAAAAAAAAAA"
-                    }
-                ],
-                "genes": [
-                    {
-                        "name": "someLongGene",
-                        "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
-                    },
-                    {
-                        "name": "someShortGene",
-                        "sequence": "MADS"
-                    }
-                ]
+                "otherOrganism": {
+                    "nucleotideSequences": [
+                        {
+                            "name": "notOnlySegment",
+                            "sequence": "ATCG"
+                        },
+                        {
+                            "name": "secondSegment",
+                            "sequence": "AAAAAAAAAAAAAAAA"
+                        }
+                    ],
+                    "genes": [
+                        {
+                            "name": "someLongGene",
+                            "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
+                        },
+                        {
+                            "name": "someShortGene",
+                            "sequence": "MADS"
+                        }
+                    ]
+                }
             },
             "schema": {
                 "organismName": "Test",
@@ -203,8 +207,10 @@
         },
         "dummyOrganismWithoutConsensusSequences": {
             "referenceGenomes": {
-                "nucleotideSequences": [],
-                "genes": []
+                "dummyOrganismWithoutConsensusSequences": {
+                    "nucleotideSequences": [],
+                    "genes": []
+                }
             },
             "schema": {
                 "organismName": "Test without consensus sequences",

--- a/backend/src/test/resources/backend_config_s3.json
+++ b/backend/src/test/resources/backend_config_s3.json
@@ -5,7 +5,7 @@
     "organisms": {
         "dummyOrganism": {
             "referenceGenomes": {
-                "dummyOrganism": {
+                "singleReference": {
                     "nucleotideSequences": [
                         {
                             "name": "main",
@@ -121,7 +121,7 @@
         },
         "otherOrganism": {
             "referenceGenomes": {
-                "otherOrganism": {
+                "singleReference": {
                     "nucleotideSequences": [
                         {
                             "name": "notOnlySegment",
@@ -207,7 +207,7 @@
         },
         "dummyOrganismWithoutConsensusSequences": {
             "referenceGenomes": {
-                "dummyOrganismWithoutConsensusSequences": {
+                "singleReference": {
                     "nucleotideSequences": [],
                     "genes": []
                 }

--- a/backend/src/test/resources/backend_config_single_segment.json
+++ b/backend/src/test/resources/backend_config_single_segment.json
@@ -8,7 +8,7 @@
     "organisms": {
         "dummyOrganism": {
             "referenceGenomes": {
-                "dummyOrganism": {
+                "singleReference": {
                     "nucleotideSequences": [
                         {
                             "name": "main",

--- a/backend/src/test/resources/backend_config_single_segment.json
+++ b/backend/src/test/resources/backend_config_single_segment.json
@@ -8,22 +8,24 @@
     "organisms": {
         "dummyOrganism": {
             "referenceGenomes": {
-                "nucleotideSequences": [
-                    {
-                        "name": "main",
-                        "sequence": "ACGT"
-                    }
-                ],
-                "genes": [
-                    {
-                        "name": "someLongGene",
-                        "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
-                    },
-                    {
-                        "name": "someShortGene",
-                        "sequence": "MADS"
-                    }
-                ]
+                "dummyOrganism": {
+                    "nucleotideSequences": [
+                        {
+                            "name": "main",
+                            "sequence": "ACGT"
+                        }
+                    ],
+                    "genes": [
+                        {
+                            "name": "someLongGene",
+                            "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
+                        },
+                        {
+                            "name": "someShortGene",
+                            "sequence": "MADS"
+                        }
+                    ]
+              }
             },
             "schema": {
                 "organismName": "Test",

--- a/docs/src/content/docs/for-administrators/my-first-loculus.md
+++ b/docs/src/content/docs/for-administrators/my-first-loculus.md
@@ -155,7 +155,7 @@ organisms:
           genes: []
           batch_size: 100
     referenceGenomes:
-      angelovirus:
+      singleReference:
         nucleotideSequences:
           - name: 'main'
             sequence: 'NNN' # We are not performing alignment here, so this sequence doesn't matter

--- a/docs/src/content/docs/for-administrators/my-first-loculus.md
+++ b/docs/src/content/docs/for-administrators/my-first-loculus.md
@@ -155,10 +155,11 @@ organisms:
           genes: []
           batch_size: 100
     referenceGenomes:
-      nucleotideSequences:
-        - name: 'main'
-          sequence: 'NNN' # We are not performing alignment here, so this sequence doesn't matter
-      genes: []
+      angelovirus:
+        nucleotideSequences:
+          - name: 'main'
+            sequence: 'NNN' # We are not performing alignment here, so this sequence doesn't matter
+        genes: []
 createTestAccounts: true
 ```
 <!-- prettier-ignore-end -->

--- a/docs/src/content/docs/for-administrators/setup-with-k3d-and-nginx.mdx
+++ b/docs/src/content/docs/for-administrators/setup-with-k3d-and-nginx.mdx
@@ -146,10 +146,11 @@ organisms:
           genes: []
           batch_size: 100
     referenceGenomes:
-      nucleotideSequences:
-        - name: 'main'
-          sequence: 'NNN' # We are not performing alignment here, so this sequence doesn't matter
-      genes: []
+      angelovirus:
+        nucleotideSequences:
+          - name: 'main'
+            sequence: 'NNN' # We are not performing alignment here, so this sequence doesn't matter
+        genes: []
 ```
 
 ## Step 4: Install and deploy

--- a/docs/src/content/docs/for-administrators/setup-with-k3d-and-nginx.mdx
+++ b/docs/src/content/docs/for-administrators/setup-with-k3d-and-nginx.mdx
@@ -146,7 +146,7 @@ organisms:
           genes: []
           batch_size: 100
     referenceGenomes:
-      angelovirus:
+      singleReference:
         nucleotideSequences:
           - name: 'main'
             sequence: 'NNN' # We are not performing alignment here, so this sequence doesn't matter

--- a/docs/src/content/docs/for-administrators/setup-with-kubernetes.md
+++ b/docs/src/content/docs/for-administrators/setup-with-kubernetes.md
@@ -123,10 +123,11 @@ organisms:
       errors: true
       randomWarnError: true
     referenceGenomes:
-      nucleotideSequences:
-        - name: 'main'
-          sequence: '[[URL:https://cov2tree.nyc3.cdn.digitaloceanspaces.com/reference.txt]]'
-      genes: []
+      ebolavirus-sudan:
+        nucleotideSequences:
+          - name: 'main'
+            sequence: '[[URL:https://cov2tree.nyc3.cdn.digitaloceanspaces.com/reference.txt]]'
+        genes: []
 ```
 
 In this example, the configuration for the "ebolavirus-sudan" organism is defined. It includes schema settings, website display options, silo configuration, preprocessing details, and reference genome information.

--- a/docs/src/content/docs/for-administrators/setup-with-kubernetes.md
+++ b/docs/src/content/docs/for-administrators/setup-with-kubernetes.md
@@ -123,7 +123,7 @@ organisms:
       errors: true
       randomWarnError: true
     referenceGenomes:
-      ebolavirus-sudan:
+      singleReference:
         nucleotideSequences:
           - name: 'main'
             sequence: '[[URL:https://cov2tree.nyc3.cdn.digitaloceanspaces.com/reference.txt]]'

--- a/docs/src/content/docs/reference/helm-chart-config.mdx
+++ b/docs/src/content/docs/reference/helm-chart-config.mdx
@@ -122,6 +122,10 @@ For [our ingest pipeline](https://github.com/loculus-project/loculus/tree/main/i
 
 <SchemaDocs group='ingestPipelineConfigFile' fieldColumnClass='w-28' />
 
+### Reference Genome (type)
+
+<SchemaDocs group='reference-genome' fieldColumnClass='w-48' />
+
 ### NucleotideSequence (type)
 
 <SchemaDocs group='nucleotide-sequence' fieldColumnClass='w-48' />

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -371,8 +371,8 @@ organisms:
       {{- end }}
       {{- end }}
     referenceGenomes:
-      {{- range $subOrganismName, $referenceGenome := $instance.referenceGenomes }}
-      {{ $subOrganismName }}:
+      {{- range $suborganismName, $referenceGenome := $instance.referenceGenomes }}
+      {{ $suborganismName }}:
         {{ $referenceGenomes := include "loculus.generateReferenceGenome" $referenceGenome | fromYaml }}
         {{ $referenceGenomes | toYaml | nindent 10 }}
       {{- end }}

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -371,8 +371,11 @@ organisms:
       {{- end }}
       {{- end }}
     referenceGenomes:
-      {{ $referenceGenomes:= include "loculus.generateReferenceGenome" $instance.referenceGenomes | fromYaml }}
-      {{ $referenceGenomes | toYaml |nindent 8}}
+      {{- range $subOrganismName, $referenceGenome := $instance.referenceGenomes }}
+      {{ $subOrganismName }}:
+        {{ $referenceGenomes := include "loculus.generateReferenceGenome" $referenceGenome | fromYaml }}
+        {{ $referenceGenomes | toYaml | nindent 10 }}
+      {{- end }}
   {{- end }}
 {{- end }}
 

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -371,12 +371,17 @@ organisms:
       {{- end }}
       {{- end }}
     referenceGenomes:
-      {{- range $subOrganismName, $referenceGenome := $instance.referenceGenomes }}
-      {{ $subOrganismName }}:
-        {{ $referenceGenomes := include "loculus.generateReferenceGenome" $referenceGenome | fromYaml }}
-        {{ $referenceGenomes | toYaml | nindent 10 }}
-      {{- end }}
+      {{ $referenceGenomes:= include "loculus.generateReferenceGenomes" $instance.referenceGenomes | fromYaml }}
+      {{ $referenceGenomes | toYaml | nindent 8}}
   {{- end }}
+{{- end }}
+
+{{- define "loculus.generateReferenceGenomes" }}
+{{- range $subOrganismName, $referenceGenome := . }}
+{{ $subOrganismName }}:
+  {{ $referenceGenomes := include "loculus.generateReferenceGenome" $referenceGenome | fromYaml }}
+  {{ $referenceGenomes | toYaml | nindent 2 }}
+{{- end }}
 {{- end }}
 
 {{- define "loculus.generateReferenceGenome" }}

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -371,17 +371,12 @@ organisms:
       {{- end }}
       {{- end }}
     referenceGenomes:
-      {{ $referenceGenomes:= include "loculus.generateReferenceGenomes" $instance.referenceGenomes | fromYaml }}
-      {{ $referenceGenomes | toYaml | nindent 8}}
+      {{- range $subOrganismName, $referenceGenome := $instance.referenceGenomes }}
+      {{ $subOrganismName }}:
+        {{ $referenceGenomes := include "loculus.generateReferenceGenome" $referenceGenome | fromYaml }}
+        {{ $referenceGenomes | toYaml | nindent 10 }}
+      {{- end }}
   {{- end }}
-{{- end }}
-
-{{- define "loculus.generateReferenceGenomes" }}
-{{- range $subOrganismName, $referenceGenome := . }}
-{{ $subOrganismName }}:
-  {{ $referenceGenomes := include "loculus.generateReferenceGenome" $referenceGenome | fromYaml }}
-  {{ $referenceGenomes | toYaml | nindent 2 }}
-{{- end }}
 {{- end }}
 
 {{- define "loculus.generateReferenceGenome" }}

--- a/kubernetes/loculus/templates/lapis-silo-database-config.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-database-config.yaml
@@ -4,7 +4,8 @@
 
 {{- range $key, $instance := (include "loculus.enabledOrganisms" . | fromJson) }}
 
-{{- $referenceGenomes:= include "loculus.generateReferenceGenomes" $instance.referenceGenomes | fromYaml }}
+{{- $firstReferenceGenome := first (values $instance.referenceGenomes) }}
+{{- $referenceGenomes:= include "loculus.generateReferenceGenome" $firstReferenceGenome | fromYaml }}
 {{- $lineageSystem := $instance | include "loculus.lineageSystemForOrganism" }}
 ---
 apiVersion: v1

--- a/kubernetes/loculus/templates/lapis-silo-database-config.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-database-config.yaml
@@ -4,7 +4,7 @@
 
 {{- range $key, $instance := (include "loculus.enabledOrganisms" . | fromJson) }}
 
-{{- $referenceGenomes:= include "loculus.generateReferenceGenome" $instance.referenceGenomes | fromYaml }}
+{{- $referenceGenomes:= include "loculus.generateReferenceGenomes" $instance.referenceGenomes | fromYaml }}
 {{- $lineageSystem := $instance | include "loculus.lineageSystemForOrganism" }}
 ---
 apiVersion: v1

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -602,16 +602,18 @@
           "description": "TODO"
         },
         "referenceGenomes": {
+          "groups": ["organism"],
           "docsIncludePrefix": false,
           "type": "object",
-          "description": "The reference genome by the suborganism name (or the organism name if there are no suborganisms)",
+          "description": "An object where the keys are the suborganism names (or the organism name if there are no suborganisms) and the values are a [Reference Genome (type)](#reference-genome)",
           "patternProperties": {
             "^[a-zA-Z0-9_-]+$": {
               "type": "object",
               "additionalProperties": false,
               "properties": {
                 "nucleotideSequences": {
-                  "groups": ["organism"],
+                  "groups": ["reference-genome"],
+                  "docsIncludePrefix": false,
                   "type": "array",
                   "description": "Array of [Nucleotide sequence (type)](#nucleotidesequence-type)",
                   "items": {
@@ -640,7 +642,8 @@
                   }
                 },
                 "genes": {
-                  "groups": ["organism"],
+                  "groups": ["reference-genome"],
+                  "docsIncludePrefix": false,
                   "type": "array",
                   "description": "Array of [Gene (type)](#gene-type)",
                   "items": {

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -605,7 +605,7 @@
           "groups": ["organism"],
           "docsIncludePrefix": false,
           "type": "object",
-          "description": "An object where the keys are the suborganism names (or the organism name if there are no suborganisms) and the values are a [Reference Genome (type)](#reference-genome)",
+          "description": "An object where the keys are the suborganism names (or the organism name if there are no suborganisms) and the values are a [Reference Genome](#reference-genome-type). If there is only one suborganism, then the key must be \"singleReference\".",
           "patternProperties": {
             "^[a-zA-Z0-9_-]+$": {
               "type": "object",

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -604,61 +604,68 @@
         "referenceGenomes": {
           "docsIncludePrefix": false,
           "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "nucleotideSequences": {
-              "groups": ["organism"],
-              "type": "array",
-              "description": "Array of [Nucleotide sequence (type)](#nucleotidesequence-type)",
-              "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "name": {
-                    "groups": ["nucleotide-sequence"],
-                    "docsIncludePrefix": false,
-                    "type": "string",
-                    "description": "Name of the sequence"
-                  },
-                  "sequence": {
-                    "groups": ["nucleotide-sequence"],
-                    "docsIncludePrefix": false,
-                    "type": "string"
-                  },
-                  "insdcAccessionFull": {
-                    "groups": ["nucleotide-sequence"],
-                    "docsIncludePrefix": false,
-                    "type": "string",
-                    "description": "INSDC accession of the sequence"
+          "description": "The reference genome by the suborganism name (or the organism name if there are no suborganisms)",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "nucleotideSequences": {
+                  "groups": ["organism"],
+                  "type": "array",
+                  "description": "Array of [Nucleotide sequence (type)](#nucleotidesequence-type)",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "groups": ["nucleotide-sequence"],
+                        "docsIncludePrefix": false,
+                        "type": "string",
+                        "description": "Name of the sequence"
+                      },
+                      "sequence": {
+                        "groups": ["nucleotide-sequence"],
+                        "docsIncludePrefix": false,
+                        "type": "string"
+                      },
+                      "insdcAccessionFull": {
+                        "groups": ["nucleotide-sequence"],
+                        "docsIncludePrefix": false,
+                        "type": "string",
+                        "description": "INSDC accession of the sequence"
+                      }
+                    },
+                    "required": ["name", "sequence"]
                   }
                 },
-                "required": ["name", "sequence"]
-              }
-            },
-            "genes": {
-              "groups": ["organism"],
-              "type": "array",
-              "description": "Array of [Gene (type)](#gene-type)",
-              "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "name": {
-                    "groups": ["gene"],
-                    "docsIncludePrefix": false,
-                    "type": "string",
-                    "description": "Name of the sequence."
-                  },
-                  "sequence": {
-                    "groups": ["gene"],
-                    "docsIncludePrefix": false,
-                    "type": "string"
+                "genes": {
+                  "groups": ["organism"],
+                  "type": "array",
+                  "description": "Array of [Gene (type)](#gene-type)",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "groups": ["gene"],
+                        "docsIncludePrefix": false,
+                        "type": "string",
+                        "description": "Name of the sequence."
+                      },
+                      "sequence": {
+                        "groups": ["gene"],
+                        "docsIncludePrefix": false,
+                        "type": "string"
+                      }
+                    },
+                    "required": ["name", "sequence"]
                   }
-                },
-                "required": ["name", "sequence"]
+                }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": ["schema"]

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -605,7 +605,7 @@
           "groups": ["organism"],
           "docsIncludePrefix": false,
           "type": "object",
-          "description": "An object where the keys are the suborganism names (or the organism name if there are no suborganisms) and the values are a [Reference Genome](#reference-genome-type). If there is only one suborganism, then the key must be \"singleReference\".",
+          "description": "An object where the keys are the suborganism names and the values are a [Reference Genome](#reference-genome-type). If there is only one suborganism, then the key must be \"singleReference\".",
           "patternProperties": {
             "^[a-zA-Z0-9_-]+$": {
               "type": "object",

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1214,7 +1214,7 @@ defaultOrganismConfig: &defaultOrganismConfig
       scientific_name: "Sudan ebolavirus"
       molecule_type: "genomic RNA"
   referenceGenomes:
-    ebola-sudan:
+    singleReference:
       nucleotideSequences:
         - name: "main"
           sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/reference.fasta]]"
@@ -1319,7 +1319,7 @@ defaultOrganisms:
         scientific_name: "West Nile virus"
         molecule_type: "genomic RNA"
     referenceGenomes:
-      west-nile:
+      singleReference:
         nucleotideSequences:
           - name: main
             sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/reference.fasta]]"
@@ -1416,7 +1416,7 @@ defaultOrganisms:
           - "--withErrors"
           - "--randomWarnError"
     referenceGenomes:
-      dummy-organism:
+      singleReference:
         nucleotideSequences:
           - name: "main"
             sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/reference.fasta]]"
@@ -1505,7 +1505,7 @@ defaultOrganisms:
           - "--watch"
           - "--disableConsensusSequences"
     referenceGenomes:
-      dummy-organism-with-files:
+      singleReference:
         nucleotideSequences: []
         genes: []
   not-aligned-organism:
@@ -1570,7 +1570,7 @@ defaultOrganisms:
           genes: []
           batch_size: 100
     referenceGenomes:
-      not-aligned-organism:
+      singleReference:
         nucleotideSequences:
           - name: "main"
             sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/reference.fasta]]"
@@ -1645,7 +1645,7 @@ defaultOrganisms:
         scientific_name: "Orthonairovirus haemorrhagiae"
         molecule_type: "genomic RNA"
     referenceGenomes:
-      cchf:
+      singleReference:
         nucleotideSequences:
           - name: L
             sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/cchf/reference_L.fasta]]"

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1214,29 +1214,30 @@ defaultOrganismConfig: &defaultOrganismConfig
       scientific_name: "Sudan ebolavirus"
       molecule_type: "genomic RNA"
   referenceGenomes:
-    nucleotideSequences:
-      - name: "main"
-        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/reference.fasta]]"
-        insdcAccessionFull: NC_002549.1
-    genes:
-      - name: NP
-        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/NP.fasta]]"
-      - name: VP35
-        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/VP35.fasta]]"
-      - name: VP40
-        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/VP40.fasta]]"
-      - name: GP
-        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/GP.fasta]]"
-      - name: ssGP
-        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/ssGP.fasta]]"
-      - name: sGP
-        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/sGP.fasta]]"
-      - name: VP30
-        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/VP30.fasta]]"
-      - name: VP24
-        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/VP24.fasta]]"
-      - name: L
-        sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/L.fasta]]"
+    ebola-sudan:
+      nucleotideSequences:
+        - name: "main"
+          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/reference.fasta]]"
+          insdcAccessionFull: NC_002549.1
+      genes:
+        - name: NP
+          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/NP.fasta]]"
+        - name: VP35
+          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/VP35.fasta]]"
+        - name: VP40
+          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/VP40.fasta]]"
+        - name: GP
+          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/GP.fasta]]"
+        - name: ssGP
+          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/ssGP.fasta]]"
+        - name: sGP
+          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/sGP.fasta]]"
+        - name: VP30
+          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/VP30.fasta]]"
+        - name: VP24
+          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/VP24.fasta]]"
+        - name: L
+          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/L.fasta]]"
 defaultOrganisms:
   ebola-sudan:
     <<: *defaultOrganismConfig
@@ -1318,33 +1319,34 @@ defaultOrganisms:
         scientific_name: "West Nile virus"
         molecule_type: "genomic RNA"
     referenceGenomes:
-      nucleotideSequences:
-        - name: main
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/reference.fasta]]"
-          insdcAccessionFull: NC_009942.1
-      genes:
-        - name: 2K
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/2K.fasta]]"
-        - name: NS1
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/NS1.fasta]]"
-        - name: NS2A
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/NS2A.fasta]]"
-        - name: NS2B
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/NS2B.fasta]]"
-        - name: NS3
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/NS3.fasta]]"
-        - name: NS4A
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/NS4A.fasta]]"
-        - name: NS4B
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/NS4B.fasta]]"
-        - name: NS5
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/NS5.fasta]]"
-        - name: capsid
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/capsid.fasta]]"
-        - name: env
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/env.fasta]]"
-        - name: prM
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/prM.fasta]]"
+      west-nile:
+        nucleotideSequences:
+          - name: main
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/reference.fasta]]"
+            insdcAccessionFull: NC_009942.1
+        genes:
+          - name: 2K
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/2K.fasta]]"
+          - name: NS1
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/NS1.fasta]]"
+          - name: NS2A
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/NS2A.fasta]]"
+          - name: NS2B
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/NS2B.fasta]]"
+          - name: NS3
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/NS3.fasta]]"
+          - name: NS4A
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/NS4A.fasta]]"
+          - name: NS4B
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/NS4B.fasta]]"
+          - name: NS5
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/NS5.fasta]]"
+          - name: capsid
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/capsid.fasta]]"
+          - name: env
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/env.fasta]]"
+          - name: prM
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/prM.fasta]]"
   dummy-organism:
     schema:
       image: "https://www.un.org/sites/un2.un.org/files/field/image/1583952355.1997.jpg"
@@ -1414,34 +1416,35 @@ defaultOrganisms:
           - "--withErrors"
           - "--randomWarnError"
     referenceGenomes:
-      nucleotideSequences:
-        - name: "main"
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/reference.fasta]]"
-      genes:
-        - name: "E"
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/E.fasta]]"
-        - name: "M"
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/M.fasta]]"
-        - name: "N"
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/N.fasta]]"
-        - name: "ORF1a"
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF1a.fasta]]"
-        - name: "ORF1b"
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF1b.fasta]]"
-        - name: "ORF3a"
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF3a.fasta]]"
-        - name: "ORF6"
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF6.fasta]]"
-        - name: "ORF7a"
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF7a.fasta]]"
-        - name: "ORF7b"
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF7b.fasta]]"
-        - name: "ORF8"
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF8.fasta]]"
-        - name: "ORF9b"
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF9b.fasta]]"
-        - name: "S"
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/S.fasta]]"
+      dummy-organism:
+        nucleotideSequences:
+          - name: "main"
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/reference.fasta]]"
+        genes:
+          - name: "E"
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/E.fasta]]"
+          - name: "M"
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/M.fasta]]"
+          - name: "N"
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/N.fasta]]"
+          - name: "ORF1a"
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF1a.fasta]]"
+          - name: "ORF1b"
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF1b.fasta]]"
+          - name: "ORF3a"
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF3a.fasta]]"
+          - name: "ORF6"
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF6.fasta]]"
+          - name: "ORF7a"
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF7a.fasta]]"
+          - name: "ORF7b"
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF7b.fasta]]"
+          - name: "ORF8"
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF8.fasta]]"
+          - name: "ORF9b"
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF9b.fasta]]"
+          - name: "S"
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/S.fasta]]"
   dummy-organism-with-files:
     schema:
       image: "https://cdn.who.int/media/images/default-source/mca/mca-covid-19/coronavirus-2.tmb-1920v.jpg?sfvrsn=4dba955c_19"
@@ -1502,8 +1505,9 @@ defaultOrganisms:
           - "--watch"
           - "--disableConsensusSequences"
     referenceGenomes:
-      nucleotideSequences: []
-      genes: []
+      dummy-organism-with-files:
+        nucleotideSequences: []
+        genes: []
   not-aligned-organism:
     enabled: true
     schema:
@@ -1566,10 +1570,11 @@ defaultOrganisms:
           genes: []
           batch_size: 100
     referenceGenomes:
-      nucleotideSequences:
-        - name: "main"
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/reference.fasta]]"
-      genes: []
+      not-aligned-organism:
+        nucleotideSequences:
+          - name: "main"
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/reference.fasta]]"
+        genes: []
   cchf:
     <<: *defaultOrganismConfig
     schema:
@@ -1640,23 +1645,24 @@ defaultOrganisms:
         scientific_name: "Orthonairovirus haemorrhagiae"
         molecule_type: "genomic RNA"
     referenceGenomes:
-      nucleotideSequences:
-        - name: L
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/cchf/reference_L.fasta]]"
-          insdcAccessionFull: NC_005301.3
-        - name: M
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/cchf/reference_M.fasta]]"
-          insdcAccessionFull: NC_005300.2
-        - name: S
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/cchf/reference_S.fasta]]"
-          insdcAccessionFull: NC_005302.1
-      genes:
-        - name: RdRp
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/cchf/RdRp.fasta]]"
-        - name: GPC
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/cchf/GPC.fasta]]"
-        - name: NP
-          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/cchf/NP.fasta]]"
+      cchf:
+        nucleotideSequences:
+          - name: L
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/cchf/reference_L.fasta]]"
+            insdcAccessionFull: NC_005301.3
+          - name: M
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/cchf/reference_M.fasta]]"
+            insdcAccessionFull: NC_005300.2
+          - name: S
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/cchf/reference_S.fasta]]"
+            insdcAccessionFull: NC_005302.1
+        genes:
+          - name: RdRp
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/cchf/RdRp.fasta]]"
+          - name: GPC
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/cchf/GPC.fasta]]"
+          - name: NP
+            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/cchf/NP.fasta]]"
 auth:
   verifyEmail: false
   resetPasswordAllowed: true

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -226,7 +226,7 @@ export function getLapisUrl(serviceConfig: ServiceUrls, organism: string): strin
     return serviceConfig.lapisUrls[organism];
 }
 
-export function getReferenceGenomes(organism: string): ReferenceGenome {
+export function getReferenceGenome(organism: string): ReferenceGenome {
     return Object.values(getConfig(organism).referenceGenomes)[0];
 }
 
@@ -238,7 +238,7 @@ const getAccession = (n: NamedSequence): ReferenceAccession => {
 };
 
 export const getReferenceGenomesSequenceNames = (organism: string): ReferenceGenomesSequenceNames => {
-    const referenceGenomes = getReferenceGenomes(organism);
+    const referenceGenomes = getReferenceGenome(organism);
     return {
         nucleotideSequences: referenceGenomes.nucleotideSequences.map((n) => n.name),
         genes: referenceGenomes.genes.map((n) => n.name),

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -5,17 +5,17 @@ import type { z, ZodError } from 'zod';
 
 import { ACCESSION_FIELD, SUBMISSION_ID_INPUT_FIELD } from './settings.ts';
 import {
+    type InputField,
     type InstanceConfig,
     type Schema,
+    type SequenceFlaggingConfig,
     type WebsiteConfig,
     websiteConfig,
-    type InputField,
-    type SequenceFlaggingConfig,
 } from './types/config.ts';
 import {
     type NamedSequence,
     type ReferenceAccession,
-    type ReferenceGenomes,
+    type ReferenceGenome,
     type ReferenceGenomesSequenceNames,
 } from './types/referencesGenomes.ts';
 import { runtimeConfig, type RuntimeConfig, type ServiceUrls } from './types/runtimeConfig.ts';
@@ -226,8 +226,8 @@ export function getLapisUrl(serviceConfig: ServiceUrls, organism: string): strin
     return serviceConfig.lapisUrls[organism];
 }
 
-export function getReferenceGenomes(organism: string): ReferenceGenomes {
-    return getConfig(organism).referenceGenomes;
+export function getReferenceGenomes(organism: string): ReferenceGenome {
+    return Object.values(getConfig(organism).referenceGenomes)[0];
 }
 
 const getAccession = (n: NamedSequence): ReferenceAccession => {

--- a/website/src/pages/[organism]/api/_sequences.spec.ts
+++ b/website/src/pages/[organism]/api/_sequences.spec.ts
@@ -7,7 +7,7 @@ import { getConfiguredOrganisms, getLapisUrl, getReferenceGenome, getRuntimeConf
 
 vi.mock('../../../config.ts', () => ({
     getConfiguredOrganisms: vi.fn(),
-    getReferenceGenomes: vi.fn(),
+    getReferenceGenome: vi.fn(),
     getLapisUrl: vi.fn(),
     getSchema: vi.fn(),
     getRuntimeConfig: vi.fn(),

--- a/website/src/pages/[organism]/api/_sequences.spec.ts
+++ b/website/src/pages/[organism]/api/_sequences.spec.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, type Mock, test, vi } from 'vi
 
 import { GET } from './sequences.ts';
 import { mockRequest, testConfig } from '../../../../vitest.setup.ts';
-import { getConfiguredOrganisms, getLapisUrl, getReferenceGenomes, getRuntimeConfig } from '../../../config.ts';
+import { getConfiguredOrganisms, getLapisUrl, getReferenceGenome, getRuntimeConfig } from '../../../config.ts';
 
 vi.mock('../../../config.ts', () => ({
     getConfiguredOrganisms: vi.fn(),
@@ -16,19 +16,19 @@ vi.mock('../../../config.ts', () => ({
 const organism = 'testOrganism';
 
 const getConfiguredOrganismsMock = getConfiguredOrganisms as Mock<typeof getConfiguredOrganisms>;
-const getReferenceGenomesMock = getReferenceGenomes as Mock<typeof getReferenceGenomes>;
+const getReferenceGenomeMock = getReferenceGenome as Mock<typeof getReferenceGenome>;
 const getLapisUrlMock = getLapisUrl as Mock<typeof getLapisUrl>;
 const getRuntimeConfigMock = getRuntimeConfig as Mock<typeof getRuntimeConfig>;
 
 function mockSingleSegmented() {
-    getReferenceGenomesMock.mockImplementation(() => ({
+    getReferenceGenomeMock.mockImplementation(() => ({
         nucleotideSequences: [{ name: 'main', sequence: 'ACGT' }],
         genes: [],
     }));
 }
 
 function mockMultiSegmented() {
-    getReferenceGenomesMock.mockImplementation(() => ({
+    getReferenceGenomeMock.mockImplementation(() => ({
         nucleotideSequences: [
             { name: 'segment1', sequence: 'ACGT' },
             { name: 'segment2', sequence: 'ACGT' },
@@ -71,7 +71,7 @@ describe('The sequences endpoint', () => {
         });
 
         test('should reject request when segment is set', async () => {
-            getReferenceGenomesMock.mockImplementation(() => ({
+            getReferenceGenomeMock.mockImplementation(() => ({
                 nucleotideSequences: [{ name: 'main', sequence: 'ACGT' }],
                 genes: [],
             }));

--- a/website/src/pages/[organism]/api/sequences.ts
+++ b/website/src/pages/[organism]/api/sequences.ts
@@ -6,7 +6,7 @@ import { err, ok } from 'neverthrow';
 import { z } from 'zod';
 
 import { cleanOrganism } from '../../../components/Navigation/cleanOrganism.ts';
-import { getReferenceGenomes } from '../../../config.ts';
+import { getReferenceGenome } from '../../../config.ts';
 import { LapisClient } from '../../../services/lapisClient.ts';
 import { ACCESSION_VERSION_FIELD } from '../../../settings.ts';
 import type { ProblemDetail } from '../../../types/backend.ts';
@@ -85,7 +85,7 @@ function getSearchParams(url: URL, organism: string) {
     searchParams.delete('headerFields');
     searchParams.delete('downloadFileBasename');
 
-    const nucleotideSequences = getReferenceGenomes(organism).nucleotideSequences;
+    const nucleotideSequences = getReferenceGenome(organism).nucleotideSequences;
     const isMultiSegmented = nucleotideSequences.length > 1;
     if (isMultiSegmented) {
         if (segment === undefined) {

--- a/website/src/pages/seq/[accessionVersion].fa/index.ts
+++ b/website/src/pages/seq/[accessionVersion].fa/index.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 
-import { getReferenceGenomes } from '../../../config.ts';
+import { getReferenceGenome } from '../../../config.ts';
 import { routes } from '../../../routes/routes.ts';
 import { LapisClient } from '../../../services/lapisClient.ts';
 import { createDownloadAPIRoute } from '../../../utils/createDownloadAPIRoute.ts';
@@ -11,7 +11,7 @@ export const GET: APIRoute = createDownloadAPIRoute(
     routes.sequenceEntryFastaPage,
     async (accessionVersion: string, organism: string) => {
         const lapisClient = LapisClient.createForOrganism(organism);
-        const referenceGenomes = getReferenceGenomes(organism);
+        const referenceGenomes = getReferenceGenome(organism);
         const segmentNames = referenceGenomes.nucleotideSequences.map((s) => s.name);
         const isMultiSegmented = segmentNames.length > 1;
 

--- a/website/src/types/referencesGenomes.ts
+++ b/website/src/types/referencesGenomes.ts
@@ -12,10 +12,16 @@ const namedSequence = z.object({
 });
 export type NamedSequence = z.infer<typeof namedSequence>;
 
-export const referenceGenomes = z.object({
+export const referenceGenome = z.object({
     nucleotideSequences: z.array(namedSequence),
     genes: z.array(namedSequence),
 });
+export type ReferenceGenome = z.infer<typeof referenceGenome>;
+
+export const suborganism = z.string();
+export const referenceGenomes = z
+    .record(suborganism, referenceGenome)
+    .refine((value) => Object.entries(value).length > 0, 'The reference genomes must not be empty.');
 export type ReferenceGenomes = z.infer<typeof referenceGenomes>;
 
 export type NucleotideSegmentNames = string[];


### PR DESCRIPTION
resolves #4691 

Breaking change in the config:

The reference genomes became a dictionary `[suborganismName, referenceGenome]`. Before:
```yaml
    referenceGenomes:
        nucleotideSequences:
          - name: 'main'
            sequence: 'NNN'
        genes: []
```

After:
```yaml
    referenceGenomes:
      singleReference:
        nucleotideSequences:
          - name: 'main'
            sequence: 'NNN'
        genes: []
```

The key must be `singleReference` if there only one suborganism. (Maybe we'll bind logic to that specific name and it's easier to drop that requirement later compared to adding it)


This is supposed to be minimally invasive and change as few place in the code as possible. For now this simply assumes that each organism has exactly one reference genome configured (handling multiple ones in the code will be the next step).

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://4691-multi-pathogen-suppo.loculus.org