### PR TITLE
feat(deployment): allow multiple values files and allow values for `deploy.py config`

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -379,6 +379,7 @@ def generate_configs(from_live, live_host, enable_ena, values_files=None):
             live_host,
             ena_submission_configout_path,
             values_files=values_files,
+            enableEnaSubmission=True,
         )
 
     ingest_configmap_path = temp_dir_path / "config.yaml"
@@ -429,6 +430,7 @@ def generate_config(
     live_host=None,
     output_path=None,
     values_files=None,
+    enableEnaSubmission=False,
 ):
     if from_live and live_host:
         number_of_dots = live_host.count(".")
@@ -465,6 +467,8 @@ def generate_config(
     else:
         helm_template_cmd.extend(["--set", "environment=local"])
         helm_template_cmd.extend(["--set", "testconfig=true"])
+    if enableEnaSubmission:
+        helm_template_cmd.extend(["--set", "disableEnaSubmission=false"])
     helm_output = run_command(helm_template_cmd, capture_output=True, text=True).stdout
     if args.dry_run:
         return


### PR DESCRIPTION
In deploy.py:

- allow repeated `--values` flags
- allow `--values` for `config`
- allow ENA submission to be enabled properly (by @anna-parker )


------
https://chatgpt.com/codex/tasks/task_e_6877a2a48dc48325a77302e171e6b1fc

🚀 Preview: Add `preview` label to enable