### PR TITLE
feat(kubernetes): update SILO to 0.7.4 and LAPIS to 0.5.8

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1668,11 +1668,11 @@ additionalHeadHTML: ""
 images:
   lapisSilo:
     repository: "ghcr.io/genspectrum/lapis-silo"
-    tag: "0.6.0"
+    tag: "0.7.4"
     pullPolicy: IfNotPresent
   lapis:
     repository: "ghcr.io/genspectrum/lapis"
-    tag: "0.5.3"
+    tag: "0.5.8"
     pullPolicy: IfNotPresent
   website:
     repository: "ghcr.io/loculus-project/website"

--- a/website/tests/api/sequences.spec.ts
+++ b/website/tests/api/sequences.spec.ts
@@ -5,7 +5,7 @@ import { getTestSequences } from '../util/testSequenceProvider.ts';
 test.describe('The sequences endpoint', () => {
     const testSequenceEntry = getTestSequences().testSequenceEntry;
 
-    test('should have usable logout button', async ({ request }) => {
+    test('should return pipe-separated header fields', async ({ request }) => {
         const query = new URLSearchParams([
             ['headerFields', 'accessionVersion'],
             ['headerFields', 'country'],


### PR DESCRIPTION
# SILO Change Log

## [0.7.4](https://github.com/GenSpectrum/LAPIS-SILO/compare/v0.7.3...v0.7.4) (2025-07-21)


### Bug Fixes

* **silo:** accept more characters in newick string and improve error messages ([#891](https://github.com/GenSpectrum/LAPIS-SILO/issues/891)) ([5f8bc9e](https://github.com/GenSpectrum/LAPIS-SILO/commit/5f8bc9e5c2672089f16ea545766fae48fc31d391))
* **silo:** correctly deduplicate requested fields ([78f4146](https://github.com/GenSpectrum/LAPIS-SILO/commit/78f41460cfff10a182c1ec8712ea6c69c2f7eb1e))

## [0.7.3](https://github.com/GenSpectrum/LAPIS-SILO/compare/v0.7.2...v0.7.3) (2025-07-17)


### Features

* enable filtering for recombinant lineages with specifiable mode for including all recombinant sublineages or only the ones that are fully contained in the clade of the filtered node ([6e335dd](https://github.com/GenSpectrum/LAPIS-SILO/commit/6e335dda520c2e9c12d34165f2188a0daa5aa74f))


### Bug Fixes

* **benchmarking:** only depend on WisePulse for the tool to run, not for the data ([#875](https://github.com/GenSpectrum/LAPIS-SILO/issues/875)) ([1aa4dc9](https://github.com/GenSpectrum/LAPIS-SILO/commit/1aa4dc9661b7840a9ad35f35474886b752f7df5d))
* **silo:** handle newick files with new line at end ([#889](https://github.com/GenSpectrum/LAPIS-SILO/issues/889)) ([7f31fa7](https://github.com/GenSpectrum/LAPIS-SILO/commit/7f31fa75b8a3bb1501b1e30c65dd525b178bfc3c))

## [0.7.2](https://github.com/GenSpectrum/LAPIS-SILO/compare/v0.7.1...v0.7.2) (2025-07-08)


### Features

* add the field `additionalFields` to Fasta action ([#861](https://github.com/GenSpectrum/LAPIS-SILO/issues/861)) ([80777f1](https://github.com/GenSpectrum/LAPIS-SILO/commit/80777f188d58137d067a908a2f37420f497c466a))
* **benchmarking:** add benchmarking/ directory with benchmark runner code ([be93833](https://github.com/GenSpectrum/LAPIS-SILO/commit/be938338e30d2fc0547e6c15244dd6efef28f080))
* **benchmarking:** add copy of the evobench-probes library ([b73e414](https://github.com/GenSpectrum/LAPIS-SILO/commit/b73e4144876c3b3a91cf642208c4dfb375993568))
* **benchmarking:** add probe on query plan execution ([f2d96df](https://github.com/GenSpectrum/LAPIS-SILO/commit/f2d96df44244b7e6a69649166fec825a9b0868e1))
* **benchmarking:** add probes on all operator evaluate methods ([96b14c6](https://github.com/GenSpectrum/LAPIS-SILO/commit/96b14c6ae87ef57ca74ef97d1cec527173bdd85c))
* **benchmarking:** add probes on Date sort optimization ([44b61de](https://github.com/GenSpectrum/LAPIS-SILO/commit/44b61de097a6a5fd30ae3fb911fd17ef2315af55))
* **benchmarking:** re-use the TCP address/port immediately ([8d8940f](https://github.com/GenSpectrum/LAPIS-SILO/commit/8d8940f3077a606e447d938e7c211df73ae4a5b8))
* enable Backpressure when streaming batches ([3af7d04](https://github.com/GenSpectrum/LAPIS-SILO/commit/3af7d04d46b7febfd1534177122c3d75fc6d9d7d))
* show the error message when failing with a Poco::Net::NetException ([07c42b2](https://github.com/GenSpectrum/LAPIS-SILO/commit/07c42b24be8995585a8ec0a4c830937aa384dc26))
* **silo:** add MostRecentCommonAncestor action ([#834](https://github.com/GenSpectrum/LAPIS-SILO/issues/834)) ([157f186](https://github.com/GenSpectrum/LAPIS-SILO/commit/157f1868e608560009fd2c1f0f3f015333e4a081))


### Bug Fixes

* **benchmarking:** update location of sorted_input_file.* ([02daf40](https://github.com/GenSpectrum/LAPIS-SILO/commit/02daf405593f6da0fb715441bb8f94e4779b6adb))
* better error message if the DateBetween column is not of type date ([9b7fa99](https://github.com/GenSpectrum/LAPIS-SILO/commit/9b7fa9961e07cce58694bf5aba4441e405cdb67c))
* change default streaming batch size from 50000 to 32767 to avoid reslicing batches ([718fd22](https://github.com/GenSpectrum/LAPIS-SILO/commit/718fd22f9ea8abe01c2f29182718b37c121e0e43))
* improve error messages when ndjson file is invalid ([#850](https://github.com/GenSpectrum/LAPIS-SILO/issues/850)) ([dcff2e9](https://github.com/GenSpectrum/LAPIS-SILO/commit/dcff2e9278c1a12854680a8434e13665b82ff8b6))
* stop streaming response when network stream is interrupted ([d58d668](https://github.com/GenSpectrum/LAPIS-SILO/commit/d58d668e09e6d08ea6cb8eb4e01713a1053cc7fa))
* use arrow::acero::SourceNode when constructing a TableScan ([7035f1f](https://github.com/GenSpectrum/LAPIS-SILO/commit/7035f1f60258749e1568b2659d83aadf45d4e08e))

## [0.7.1](https://github.com/GenSpectrum/LAPIS-SILO/compare/v0.7.0...v0.7.1) (2025-07-02)


### Bug Fixes

* add proper error messages for invalid groupByFields ([2c8babb](https://github.com/GenSpectrum/LAPIS-SILO/commit/2c8babb68e7f628228581d4c30bdad83cff53b06))
* evaluate the bitmaps in the preparation of the QueryPlan to not send wrong http headers ([9c831c9](https://github.com/GenSpectrum/LAPIS-SILO/commit/9c831c95f45bb45ed013186db18db6051f2c7d38))
* make TableScan react to StopProducing calls ([#855](https://github.com/GenSpectrum/LAPIS-SILO/issues/855)) ([ea3ee7d](https://github.com/GenSpectrum/LAPIS-SILO/commit/ea3ee7df8438564ca559b12d0569b19741b86222))
* throw an error when silo tries to start on a port that is already in use ([e0ee23b](https://github.com/GenSpectrum/LAPIS-SILO/commit/e0ee23b9d1467a9e7f586ca183b5697ad60a9e92))

## [0.7.0](https://github.com/GenSpectrum/LAPIS-SILO/compare/v0.6.0...v0.7.0) (2025-06-30)


### ⚠ BREAKING CHANGES

* the field sequenceName in the Fasta and FastaAligned is now named sequenceNames and required to be an array ([#804](https://github.com/GenSpectrum/LAPIS-SILO/issues/804))
* change field sequenceName to sequenceNames in Insertions action ([#821](https://github.com/GenSpectrum/LAPIS-SILO/issues/821))
* change field sequenceName to sequenceNames in Mutations action ([#819](https://github.com/GenSpectrum/LAPIS-SILO/issues/819))
* rename DatabaseInfo field `totalSize` to `verticalBitmapsSize` and `nBitmapsSize` to `horizontalBitmapsSize` ([#805](https://github.com/GenSpectrum/LAPIS-SILO/issues/805))
* Null values are no longer ordered as the smallest element, but at the start or end instead. This is decided based on the sort-order of the first orderByField to mimic old behavior. This leads to a breaking change when ordering by multiple fields with mismatching order direction ([#799](https://github.com/GenSpectrum/LAPIS-SILO/issues/799)) 
* all unaligned nucleotide sequences are prefixed with `unaligned_` in the api requests and response ([#795](https://github.com/GenSpectrum/LAPIS-SILO/issues/795))

### Features

* streaming implementation of the SILO query engine based on the arrow framework ([#765](https://github.com/GenSpectrum/LAPIS-SILO/issues/765), [#775](https://github.com/GenSpectrum/LAPIS-SILO/issues/775), [#792](https://github.com/GenSpectrum/LAPIS-SILO/issues/792), [#795](https://github.com/GenSpectrum/LAPIS-SILO/issues/795), [#799](https://github.com/GenSpectrum/LAPIS-SILO/issues/799), [#809](https://github.com/GenSpectrum/LAPIS-SILO/issues/809), [#821](https://github.com/GenSpectrum/LAPIS-SILO/issues/821), [#829](https://github.com/GenSpectrum/LAPIS-SILO/issues/829), [#837](https://github.com/GenSpectrum/LAPIS-SILO/issues/837))
* cache DatabaseInfo, add amino acid sequence columns to size info ([bc0d0a2](https://github.com/GenSpectrum/LAPIS-SILO/commit/bc0d0a2210922bf712bf744d9f1d4bf889054541))
* **silo:** add function to get all clades that are descendants of an internal node ([#815](https://github.com/GenSpectrum/LAPIS-SILO/issues/815)) ([d1f9989](https://github.com/GenSpectrum/LAPIS-SILO/commit/d1f99894b603d4dd398fd890d48276b698c83661))
* **silo:** add recommended vscode extensions to .vscode folder for developers using vscode ([d2c74db](https://github.com/GenSpectrum/LAPIS-SILO/commit/d2c74db6e2fb00d98f687a0dbf958d378127718b))
* **silo:** improve the docs and update build_with_conan.py ([#779](https://github.com/GenSpectrum/LAPIS-SILO/issues/779)) ([f176fd6](https://github.com/GenSpectrum/LAPIS-SILO/commit/f176fd6c4e0a26e638a63f577bb90db49c89d9f4))
* **silo:** read in phylogenetic tree files and create tree structure ([#806](https://github.com/GenSpectrum/LAPIS-SILO/issues/806)) ([f3d3f36](https://github.com/GenSpectrum/LAPIS-SILO/commit/f3d3f36fea44f0d6b8727fdc66a8fed6501110e3))
* **silo:** refactor phylotree to use nodeId for children and parent and serialize ([#822](https://github.com/GenSpectrum/LAPIS-SILO/issues/822)) ([29e8361](https://github.com/GenSpectrum/LAPIS-SILO/commit/29e83611fa191e439894407222917d660f1aefb6))


### Bug Fixes

* avoid dropping the input bitmap of Selections in a nested And query ([e87093c](https://github.com/GenSpectrum/LAPIS-SILO/commit/e87093c4f0b254d526663bfe1658c1be3209a1ee))
* correctly error when the input data contains illegal insertion characters ([4867c32](https://github.com/GenSpectrum/LAPIS-SILO/commit/4867c320c495226add39a981c25287866bc49302))
* remove erroneous warning printed on every preprocessing run ([82b65c8](https://github.com/GenSpectrum/LAPIS-SILO/commit/82b65c8a91aebe80bc15453a2196be98501e672a))

# LAPIS Change Log

## [0.5.8](https://github.com/GenSpectrum/LAPIS/compare/v0.5.7...v0.5.8) (2025-07-21)


### Features

* **lapis:** add aminoAcidMutationsOverTime ([#1270](https://github.com/GenSpectrum/LAPIS/issues/1270)) ([c9adf26](https://github.com/GenSpectrum/LAPIS/commit/c9adf264268cbbdf291ff4b84649e3a114012868)), closes [#1214](https://github.com/GenSpectrum/LAPIS/issues/1214)


## [0.5.7](https://github.com/GenSpectrum/LAPIS/compare/v0.5.6...v0.5.7) (2025-07-18)


### Features

* **lapis:** add parameter `fastaHeaderTemplate` to customize the fasta header in sequences endpoints ([#1258](https://github.com/GenSpectrum/LAPIS/issues/1258)) ([ac7fc29](https://github.com/GenSpectrum/LAPIS/commit/ac7fc29bb3d7eb8f76a2b12f6661cf89cf7fad37)), closes [#857](https://github.com/GenSpectrum/LAPIS/issues/857)
* **lapis:** drop sorting by segment/gene from docs of sequence endpoints ([#1268](https://github.com/GenSpectrum/LAPIS/issues/1268)) ([bc67a7c](https://github.com/GenSpectrum/LAPIS/commit/bc67a7c109e129744f1da932375fd6671fab9cdf)), closes [#1248](https://github.com/GenSpectrum/LAPIS/issues/1248)

## [0.5.6](https://github.com/GenSpectrum/LAPIS/compare/v0.5.5...v0.5.6) (2025-07-15)


### Features

* **lapis:** add nucleotideMutationsOverTime endpoint ([#1229](https://github.com/GenSpectrum/LAPIS/issues/1229)) ([cade8d9](https://github.com/GenSpectrum/LAPIS/commit/cade8d9a1ec217c3d449c882b77a1ac07574a7bb)), closes [#1205](https://github.com/GenSpectrum/LAPIS/issues/1205)

## [0.5.5](https://github.com/GenSpectrum/LAPIS/compare/v0.5.4...v0.5.5) (2025-07-01)


### Bug Fixes

* **lapis:** also return sequences that are null when requesting JSON or NDJSON ([#1256](https://github.com/GenSpectrum/LAPIS/issues/1256)) ([a888965](https://github.com/GenSpectrum/LAPIS/commit/a888965c000abafd80cebeb5a88861ab2a93dd8e)), closes [#1255](https://github.com/GenSpectrum/LAPIS/issues/1255)

## [0.5.4](https://github.com/GenSpectrum/LAPIS/compare/v0.5.3...v0.5.4) (2025-07-01)


### Features

* **lapis:** adapt to SILO changes that renamed the unaligned sequences to have the "unaligned_" prefix ([#1225](https://github.com/GenSpectrum/LAPIS/issues/1225)) ([d669335](https://github.com/GenSpectrum/LAPIS/commit/d6693359a987708e932b1aefb8e4e5ca82e1cce9))
* **lapis:** add endpoint `/sample/alignedAminoAcidSequences` to download all genes at once ([#1242](https://github.com/GenSpectrum/LAPIS/issues/1242)) ([36dfd5f](https://github.com/GenSpectrum/LAPIS/commit/36dfd5fe16998721b681859ed8c990d49cb788ed))
* **lapis:** add endpoint `/sample/unalignedNucleotideSequences` for multi-segmented organism to download several sequences at once ([#1246](https://github.com/GenSpectrum/LAPIS/issues/1246)) ([f9275c2](https://github.com/GenSpectrum/LAPIS/commit/f9275c2875b19b74f654a0018cbef1faa66e2182))
* **lapis:** add endpoint to download all aligned segments (or a subset) at once (for multi segmented organisms) ([#1235](https://github.com/GenSpectrum/LAPIS/issues/1235)) ([6207d32](https://github.com/GenSpectrum/LAPIS/commit/6207d32bf736eb4b4689916b7eb2c661327363b5))

🚀 Preview: https://update-silo-lapis.loculus.org