### PR TITLE
fix(deployment): Add LOCULUS_VERSION to keycloak to restart it on deployment

### DIFF
--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -99,7 +99,7 @@ spec:
             # see https://github.com/keycloak/keycloak/blob/77b58275ca06d1cbe430c51db74479a7e1b409b5/quarkus/dist/src/main/content/bin/kc.sh#L95-L150
             - name: KC_RUN_IN_CONTAINER
               value: "true"
-            {{- if .Values.runDevelopmentMainDatabase  }}
+            {{- if .Values.runDevelopmentKeycloakDatabase  }}
             - name: LOCULUS_VERSION
               value: {{ $dockerTag }}
             {{- end }}


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/4607
Adds something that will restart keycloak when loculus is bumped in the case that we are running development databases, for Loculus preview deployments.

🚀 Preview: https://restart-kc.loculus.org