### PR TITLE
feat!(deposition): simplify biosample mapping config, support optional extra metadata fields

### DIFF
--- a/ena-submission/config/defaults.yaml
+++ b/ena-submission/config/defaults.yaml
@@ -85,6 +85,7 @@ metadata_mapping:
   'geographic location (longitude)':
     loculus_fields: [geoLocLongitude]
     units: DD
+optional_metadata_mapping:
   'GISAID accession':
     loculus_fields: [gisaidIsolateId]
 metadata_mapping_mandatory_field_defaults:

--- a/ena-submission/config/defaults.yaml
+++ b/ena-submission/config/defaults.yaml
@@ -57,16 +57,10 @@ metadata_mapping:
     loculus_fields: [purposeOfSampling]
   'host disease outcome':
     loculus_fields: [hostHealthOutcome]
-  'host common name':
-    loculus_fields: [hostNameCommon]
-    default: "not provided"
   'host age':
     loculus_fields: [hostAge]
   'host health state':
     loculus_fields: [hostHealthState]
-    default: "not provided"
-  'host sex':
-    loculus_fields: [hostGender]
     default: "not provided"
   'host scientific name':
     loculus_fields: [hostNameScientific]
@@ -76,9 +70,6 @@ metadata_mapping:
   'collecting institution':
     loculus_fields: [sequencedByOrganization, authorAffiliations]
     default: "not provided"
-  'collector name':
-    loculus_fields: []
-    default: "not provided"
   'receipt date':
     loculus_fields: [sampleReceivedDate]
   'isolation source host-associated':
@@ -87,20 +78,26 @@ metadata_mapping:
     loculus_fields: [environmentalSite, environmentalMaterial]
   'authors':
     loculus_fields: [authors]
+  'collector name':
+    loculus_fields: []
+    default: "not provided"
   'geographic location (latitude)':
     loculus_fields: [geoLocLatitude]
     units: DD
   'geographic location (longitude)':
     loculus_fields: [geoLocLongitude]
     units: DD
+  'host sex':
+    loculus_fields: [hostGender]
+    default: "not provided"
   "host subject id":
     loculus_fields: []
     default: "not provided"
-optional_metadata_mapping:
+  'host common name':
+    loculus_fields: [hostNameCommon]
+    default: "not provided"
   'GISAID accession':
     loculus_fields: [gisaidIsolateId]
-metadata_mapping_mandatory_field_defaults:
-  "host common name": "not provided"
 db_username: postgres
 db_password: unsecure
 db_url: "jdbc:postgresql://127.0.0.1:5432/loculus"

--- a/ena-submission/config/defaults.yaml
+++ b/ena-submission/config/defaults.yaml
@@ -20,7 +20,7 @@ ena_http_post_retry_attempts: 1
 min_between_publicness_checks: 720
 log_level: DEBUG
 #ena_checklist: ERC000033 - do not use until all fields are mapped to ENA accepted options
-manifest_fields_mapping: 
+manifest_fields_mapping:
   authors:
     loculus_fields: [authors]
     function: reformat_authors
@@ -41,7 +41,7 @@ metadata_mapping:
     loculus_fields: [exposureEvent]
   'type exposure':
     loculus_fields: [exposureEvent]
-  hospitalisation:
+  'hospitalisation':
     loculus_fields: [hostHealthState]
     function: match
     args: [Hospital]
@@ -59,18 +59,26 @@ metadata_mapping:
     loculus_fields: [hostHealthOutcome]
   'host common name':
     loculus_fields: [hostNameCommon]
+    default: "not provided"
   'host age':
     loculus_fields: [hostAge]
   'host health state':
     loculus_fields: [hostHealthState]
+    default: "not provided"
   'host sex':
     loculus_fields: [hostGender]
+    default: "not provided"
   'host scientific name':
     loculus_fields: [hostNameScientific]
   'isolate':
     loculus_fields: [specimenCollectorSampleId]
+    default: "not provided"
   'collecting institution':
     loculus_fields: [sequencedByOrganization, authorAffiliations]
+    default: "not provided"
+  'collector name':
+    loculus_fields: []
+    default: "not provided"
   'receipt date':
     loculus_fields: [sampleReceivedDate]
   'isolation source host-associated':
@@ -85,17 +93,13 @@ metadata_mapping:
   'geographic location (longitude)':
     loculus_fields: [geoLocLongitude]
     units: DD
+  "host subject id":
+    loculus_fields: []
+    default: "not provided"
 optional_metadata_mapping:
   'GISAID accession':
     loculus_fields: [gisaidIsolateId]
 metadata_mapping_mandatory_field_defaults:
-  isolate: "not provided"
-  "collecting institution": "not provided"
-  "collector name": "not provided"
-  "host scientific name": "not provided"
-  "host sex": "not provided"
-  "host health state": "not provided"
-  "host subject id": "not provided"
   "host common name": "not provided"
 db_username: postgres
 db_password: unsecure

--- a/ena-submission/config/defaults.yaml
+++ b/ena-submission/config/defaults.yaml
@@ -85,6 +85,8 @@ metadata_mapping:
   'geographic location (longitude)':
     loculus_fields: [geoLocLongitude]
     units: DD
+  'GISAID accession':
+    loculus_fields: [gisaidIsolateId]
 metadata_mapping_mandatory_field_defaults:
   isolate: "not provided"
   "collecting institution": "not provided"

--- a/ena-submission/scripts/deposition_dry_run.py
+++ b/ena-submission/scripts/deposition_dry_run.py
@@ -126,7 +126,7 @@ def local_ena_submission_generator(
             "curl -X POST $ena_submission_url "
             "-u '$ena_submission_username:$ena_submission_password' "
             "-F 'SUBMISSION=@project/submission.xml' -F 'PROJECT=@project/project.xml'"
-            " --max-time 10 > {output}"
+            " --max-time 50 > {output}"
             "\n Remember to submit to wwwdev. if you do not want to submit to production"
         )
 
@@ -150,7 +150,7 @@ def local_ena_submission_generator(
             "curl -X POST $ena_submission_url "
             "-u '$ena_submission_username:$ena_submission_password' "
             "-F 'SUBMISSION=@sample/submission.xml' -F 'SAMPLE=@sample/sample.xml'"
-            " --max-time 10 > {output}"
+            " --max-time 50 > {output}"
             "\n Remember to submit to wwwdev. if you do not want to submit to production"
         )
 

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -6,7 +6,7 @@ import json
 import logging
 import unittest
 from pathlib import Path
-from typing import Final
+from typing import Any, Final
 from unittest import mock
 
 import xmltodict
@@ -81,6 +81,9 @@ test_project_xml_failure_response = (
 )
 
 test_sample_xml_request = Path("test/test_sample_request.xml").read_text(encoding="utf-8")
+test_sample_xml_request_gisaid = Path("test/test_sample_request_gisaid.xml").read_text(
+    encoding="utf-8"
+)
 test_sample_xml_response = Path("test/test_sample_response.xml").read_text(encoding="utf-8")
 revision_submission_xml_request = Path("test/test_revision_submission_request.xml").read_text(
     encoding="utf-8"
@@ -93,19 +96,25 @@ process_response_text = Path("test/get_ena_analysis_process_response.json").read
 # Test sample
 with open("test/approved_ena_submission_list_test.json", encoding="utf-8") as f:
     loculus_sample: dict = json.load(f)
-sample_data_in_submission_table = {
-    "accession": "LOC_0001TLY",
-    "version": "1",
-    "group_id": 2,
-    "organism": "Test organism",
-    "metadata": loculus_sample["LOC_0001TLY.1"]["metadata"],
-    "unaligned_nucleotide_sequences": {
-        "seg1": None,
-        "seg2": "GCGGCACGTCAGTACGTAAGTGTATCTCAAAGAAATACTTAACTTTGAGAGAGTGAATT",
-        "seg3": "CTTAACTTTGAGAGAGTGAATT",
-    },
-    "center_name": "Fake center name",
-}
+
+
+def sample_data_in_submission_table() -> dict[str, Any]:
+    """Returns a sample data structure that mimics the one used in the submission table."""
+    return {
+        "accession": "LOC_0001TLY",
+        "version": "1",
+        "group_id": 2,
+        "organism": "Test organism",
+        "metadata": loculus_sample["LOC_0001TLY.1"]["metadata"],
+        "unaligned_nucleotide_sequences": {
+            "seg1": None,
+            "seg2": "GCGGCACGTCAGTACGTAAGTGTATCTCAAAGAAATACTTAACTTTGAGAGAGTGAATT",
+            "seg3": "CTTAACTTTGAGAGAGTGAATT",
+        },
+        "center_name": "Fake center name",
+    }
+
+
 project_table_entry = {"group_id": "2", "organism": "Test organism"}
 sample_table_entry = {
     "accession": "LOC_0001TLY",
@@ -185,18 +194,34 @@ class TestCreateSample:
         config = mock_config()
         sample_set = construct_sample_set_object(
             config,
-            sample_data_in_submission_table,
+            sample_data_in_submission_table(),
             sample_table_entry,
         )
         assert xmltodict.parse(
             dataclass_to_xml(sample_set, root_name="SAMPLE_SET")
         ) == xmltodict.parse(test_sample_xml_request)
 
+    def test_sample_set_with_gisaid(self):
+        config = mock_config()
+        sample_data = (
+            sample_data_in_submission_table.deepcopy()
+        )  # Avoid modifying the original data
+        sample_data = sample_data_in_submission_table()
+        sample_data["metadata"]["gisaidIsolateId"] = "EPI_ISL_12345"
+        sample_set = construct_sample_set_object(
+            config,
+            sample_data_in_submission_table(),
+            sample_table_entry,
+        )
+        files = get_sample_xml(sample_set, revision=False)
+        submission = files["SUBMISSION"]
+        assert xmltodict.parse(submission) == xmltodict.parse(test_sample_xml_request)
+
     def test_sample_revision(self):
         config = mock_config()
         sample_set = construct_sample_set_object(
             config,
-            sample_data_in_submission_table,
+            sample_data_in_submission_table(),
             sample_table_entry,
         )
         files = get_sample_xml(sample_set, revision=True)
@@ -206,7 +231,7 @@ class TestCreateSample:
 
 class AssemblyCreationTests(unittest.TestCase):
     def setUp(self):
-        self.unaligned_sequences_multi = sample_data_in_submission_table[
+        self.unaligned_sequences_multi = sample_data_in_submission_table()[
             "unaligned_nucleotide_sequences"
         ]
         self.unaligned_sequences = {
@@ -280,7 +305,7 @@ class AssemblyCreationTests(unittest.TestCase):
             config,
             sample_accession,
             study_accession,
-            sample_data_in_submission_table,
+            sample_data_in_submission_table(),
         )
         manifest_file_name = create_manifest(manifest, is_broker=True)
         data = {}

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -203,19 +203,16 @@ class TestCreateSample:
 
     def test_sample_set_with_gisaid(self):
         config = mock_config()
-        sample_data = (
-            sample_data_in_submission_table.deepcopy()
-        )  # Avoid modifying the original data
         sample_data = sample_data_in_submission_table()
         sample_data["metadata"]["gisaidIsolateId"] = "EPI_ISL_12345"
         sample_set = construct_sample_set_object(
             config,
-            sample_data_in_submission_table(),
+            sample_data,
             sample_table_entry,
         )
-        files = get_sample_xml(sample_set, revision=False)
-        submission = files["SUBMISSION"]
-        assert xmltodict.parse(submission) == xmltodict.parse(test_sample_xml_request)
+        assert xmltodict.parse(
+            dataclass_to_xml(sample_set, root_name="SAMPLE_SET")
+        ) == xmltodict.parse(test_sample_xml_request_gisaid)
 
     def test_sample_revision(self):
         config = mock_config()

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -56,11 +56,7 @@ def mock_config():
     }
     config.organisms = {"Test organism": {"enaDeposition": metadata_dict}}
     config.metadata_mapping = defaults["metadata_mapping"]
-    config.optional_metadata_mapping = defaults["optional_metadata_mapping"]
     config.manifest_fields_mapping = defaults["manifest_fields_mapping"]
-    config.metadata_mapping_mandatory_field_defaults = defaults[
-        "metadata_mapping_mandatory_field_defaults"
-    ]
     config.ena_checklist = "ERC000033"
     config.set_alias_suffix = None
     config.is_broker = True
@@ -172,7 +168,7 @@ class ProjectCreationTests(unittest.TestCase):
         ) == xmltodict.parse(text_project_xml_request)
 
 
-class SampleCreationTests(unittest.TestCase):
+class TestCreateSample:
     @mock.patch("requests.post")
     def test_create_sample_success(self, mock_post):
         mock_post.return_value = mock_requests_post(200, test_sample_xml_response)
@@ -183,7 +179,7 @@ class SampleCreationTests(unittest.TestCase):
             "biosample_accession": "SAMEA104174130",
             "ena_submission_accession": "ERA979927",
         }
-        self.assertEqual(response.result, desired_response)
+        assert response.result == desired_response
 
     def test_sample_set_construction(self):
         config = mock_config()
@@ -192,10 +188,9 @@ class SampleCreationTests(unittest.TestCase):
             sample_data_in_submission_table,
             sample_table_entry,
         )
-        self.assertEqual(
-            xmltodict.parse(dataclass_to_xml(sample_set, root_name="SAMPLE_SET")),
-            xmltodict.parse(test_sample_xml_request),
-        )
+        assert xmltodict.parse(
+            dataclass_to_xml(sample_set, root_name="SAMPLE_SET")
+        ) == xmltodict.parse(test_sample_xml_request)
 
     def test_sample_revision(self):
         config = mock_config()
@@ -206,10 +201,7 @@ class SampleCreationTests(unittest.TestCase):
         )
         files = get_sample_xml(sample_set, revision=True)
         revision = files["SUBMISSION"]
-        self.assertEqual(
-            xmltodict.parse(revision),
-            xmltodict.parse(revision_submission_xml_request),
-        )
+        assert xmltodict.parse(revision) == xmltodict.parse(revision_submission_xml_request)
 
 
 class AssemblyCreationTests(unittest.TestCase):

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -56,6 +56,7 @@ def mock_config():
     }
     config.organisms = {"Test organism": {"enaDeposition": metadata_dict}}
     config.metadata_mapping = defaults["metadata_mapping"]
+    config.optional_metadata_mapping = defaults["optional_metadata_mapping"]
     config.manifest_fields_mapping = defaults["manifest_fields_mapping"]
     config.metadata_mapping_mandatory_field_defaults = defaults[
         "metadata_mapping_mandatory_field_defaults"

--- a/ena-submission/src/ena_deposition/config.py
+++ b/ena-submission/src/ena_deposition/config.py
@@ -11,6 +11,9 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class Config:
+    """Configuration for the ENA submission process.
+    See config/defaults.yaml for default values."""
+
     test: bool
     organisms: dict[str, dict[str, Any]]
     backend_url: str
@@ -32,9 +35,12 @@ class Config:
     slack_hook: str
     slack_token: str
     slack_channel_id: str
+    # Map from Biosample key to dict that defines:
+    # - which Loculus field(s) to use as input
+    # - (optional) how to transform the input into output
     metadata_mapping: dict[str, dict[str, str | list[str]]]
+    # Like metadata_mapping, but for fields that are only on some organisms
     optional_metadata_mapping: dict[str, dict[str, str | list[str]]]
-    metadata_mapping_mandatory_field_defaults: dict[str, str]
     manifest_fields_mapping: dict[str, dict[str, str | list[str]]]
     ingest_pipeline_submission_group: str
     ena_deposition_host: str

--- a/ena-submission/src/ena_deposition/config.py
+++ b/ena-submission/src/ena_deposition/config.py
@@ -33,6 +33,7 @@ class Config:
     slack_token: str
     slack_channel_id: str
     metadata_mapping: dict[str, dict[str, str | list[str]]]
+    optional_metadata_mapping: dict[str, dict[str, str | list[str]]]
     metadata_mapping_mandatory_field_defaults: dict[str, str]
     manifest_fields_mapping: dict[str, dict[str, str | list[str]]]
     ingest_pipeline_submission_group: str

--- a/ena-submission/src/ena_deposition/config.py
+++ b/ena-submission/src/ena_deposition/config.py
@@ -37,10 +37,11 @@ class Config:
     slack_channel_id: str
     # Map from Biosample key to dict that defines:
     # - which Loculus field(s) to use as input
-    # - (optional) how to transform the input into output
+    # - (optional) function: currently only "match" supported
+    # - (optional) args: list of regexes that match against values
+    # - (optional) units: units added to sample attribute
+    # - (optional) default: default value if field not in input data
     metadata_mapping: dict[str, dict[str, str | list[str]]]
-    # Like metadata_mapping, but for fields that are only on some organisms
-    optional_metadata_mapping: dict[str, dict[str, str | list[str]]]
     manifest_fields_mapping: dict[str, dict[str, str | list[str]]]
     ingest_pipeline_submission_group: str
     ena_deposition_host: str

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -57,8 +57,7 @@ class MetadataMapping:
 def get_sample_attributes(
     config: Config, sample_metadata: dict[str, str], row: dict[str, str]
 ) -> list[SampleAttribute]:
-    list_sample_attributes = []
-    mapped_fields = []
+    result: list[SampleAttribute] = []
     for field_name, field_config in config.metadata_mapping.items():
         mapping = MetadataMapping(
             loculus_fields=field_config["loculus_fields"],  # type: ignore[arg-type]
@@ -102,31 +101,14 @@ def get_sample_attributes(
             value = "; ".join(value for value in loculus_metadata_field_values if value is not None)
         value_or_default = value or mapping.default
         if value_or_default:
-            list_sample_attributes.append(
+            result.append(
                 SampleAttribute(
                     tag=field_name,
                     value=value_or_default,
                     units=mapping.units,
                 )
             )
-            mapped_fields.append(field_name)
-    for field_name, loculus in config.optional_metadata_mapping.items():
-        if field_name not in mapped_fields:
-            loculus_metadata_field_names = loculus["loculus_fields"]
-            loculus_metadata_field_values = [
-                sample_metadata.get(metadata) for metadata in loculus_metadata_field_names
-            ]
-            value = "; ".join(
-                [str(metadata) for metadata in loculus_metadata_field_values if metadata]
-            )
-            if value:
-                list_sample_attributes.append(
-                    SampleAttribute(
-                        tag=field_name,
-                        value=value,
-                    )
-                )
-    return list_sample_attributes
+    return result
 
 
 def construct_sample_set_object(

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -97,6 +97,22 @@ def get_sample_attributes(config: Config, sample_metadata: dict[str, str], row: 
                     value=default,
                 )
             )
+    for field, loculus in config.optional_metadata_mapping.items():
+        if field not in mapped_fields:
+            loculus_metadata_field_names = loculus["loculus_fields"]
+            loculus_metadata_field_values = [
+                sample_metadata.get(metadata) for metadata in loculus_metadata_field_names
+            ]
+            value = "; ".join(
+                [str(metadata) for metadata in loculus_metadata_field_values if metadata]
+            )
+            if value:
+                list_sample_attributes.append(
+                    SampleAttribute(
+                        tag=field,
+                        value=value,
+                    )
+                )
     return list_sample_attributes
 
 

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -44,7 +44,7 @@ from .submission_db_helper import (
 logger = logging.getLogger(__name__)
 
 
-def get_sample_attributes(config: Config, sample_metadata: dict[str, str], row: dict[str, str]):
+def get_sample_attributes(config: Config, sample_metadata: dict[str, str], row: dict[str, str]):  # noqa: PLR0912
     list_sample_attributes = []
     mapped_fields = []
     for field in config.metadata_mapping:

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -754,8 +754,7 @@ def get_ena_analysis_process(
 
 
 # TODO: Also pass the full segment list from config so we can handle someone submitting
-# a multi-segmented virus that has a main segment. This will require having one pipeline
-# per organism, not one pipeline for all. Wider changes, thus.
+# a multi-segmented virus that has a main segment.
 def get_chromsome_accessions(
     insdc_accession_range: str, segment_order: list[str]
 ) -> dict[str, str]:

--- a/ena-submission/test/test_sample_request_gisaid.xml
+++ b/ena-submission/test/test_sample_request_gisaid.xml
@@ -1,0 +1,80 @@
+<SAMPLE_SET>
+        <SAMPLE center_name="Fake center name" alias="LOC_0001TLY:Test organism:Test suffix">
+                <TITLE>Test scientific name: Genome sequencing</TITLE>
+                <SAMPLE_NAME>
+                        <TAXON_ID>Test taxon</TAXON_ID>
+                        <SCIENTIFIC_NAME>Test scientific name</SCIENTIFIC_NAME>
+                </SAMPLE_NAME>
+                <DESCRIPTION>Automated upload of Test scientific name sequences submitted by Fake center name from Loculus</DESCRIPTION>
+                <SAMPLE_LINKS>
+                        <SAMPLE_LINK>
+                                <XREF_LINK>
+                                        <DB>Loculus</DB>
+                                        <ID>LOC_0001TLY</ID>
+                                </XREF_LINK>
+                        </SAMPLE_LINK>
+                </SAMPLE_LINKS>
+                <SAMPLE_ATTRIBUTES>
+                        <SAMPLE_ATTRIBUTE>
+                                <TAG>hospitalisation</TAG>
+                                <VALUE>true</VALUE>
+                        </SAMPLE_ATTRIBUTE>
+                        <SAMPLE_ATTRIBUTE>
+                                <TAG>collection date</TAG>
+                                <VALUE>2023-08-26</VALUE>
+                        </SAMPLE_ATTRIBUTE>
+                        <SAMPLE_ATTRIBUTE>
+                                <TAG>geographic location (country and/or sea)</TAG>
+                                <VALUE>Pakistan</VALUE>
+                        </SAMPLE_ATTRIBUTE>
+                        <SAMPLE_ATTRIBUTE>
+                                <TAG>geographic location (region and locality)</TAG>
+                                <VALUE>Punjab; Rawalpindi; Rawalpindi</VALUE>
+                        </SAMPLE_ATTRIBUTE>
+                        <SAMPLE_ATTRIBUTE>
+                                <TAG>host health state</TAG>
+                                <VALUE>Hospital care required</VALUE>
+                        </SAMPLE_ATTRIBUTE>
+                        <SAMPLE_ATTRIBUTE>
+                                <TAG>host scientific name</TAG>
+                                <VALUE>Homo sapiens</VALUE>
+                        </SAMPLE_ATTRIBUTE>
+                        <SAMPLE_ATTRIBUTE>
+                                <TAG>isolate</TAG>
+                                <VALUE>CCHF/NIHPAK-19/2023</VALUE>
+                        </SAMPLE_ATTRIBUTE>
+                        <SAMPLE_ATTRIBUTE>
+                                <TAG>collecting institution</TAG>
+                                <VALUE>National Institute of Health, Department of Virology</VALUE>
+                        </SAMPLE_ATTRIBUTE>
+                        <SAMPLE_ATTRIBUTE>
+                                <TAG>authors</TAG>
+                                <VALUE>M. Ammar, M. Salman, M. Umair, Q. Ali, R. Hakim, S.A. Haider, Z. Jamal</VALUE>
+                        </SAMPLE_ATTRIBUTE>
+                        <SAMPLE_ATTRIBUTE>
+                                <TAG>collector name</TAG>
+                                <VALUE>not provided</VALUE>
+                        </SAMPLE_ATTRIBUTE>
+                        <SAMPLE_ATTRIBUTE>
+                                <TAG>host sex</TAG>
+                                <VALUE>not provided</VALUE>
+                        </SAMPLE_ATTRIBUTE>
+                        <SAMPLE_ATTRIBUTE>
+                                <TAG>host subject id</TAG>
+                                <VALUE>not provided</VALUE>
+                        </SAMPLE_ATTRIBUTE>
+                        <SAMPLE_ATTRIBUTE>
+                                <TAG>host common name</TAG>
+                                <VALUE>not provided</VALUE>
+                        </SAMPLE_ATTRIBUTE>
+                        <SAMPLE_ATTRIBUTE>
+                                <TAG>GISAID accession</TAG>
+                                <VALUE>EPI_ISL_12345</VALUE>
+                        </SAMPLE_ATTRIBUTE>
+                        <SAMPLE_ATTRIBUTE>
+                                <TAG>ENA-CHECKLIST</TAG>
+                                <VALUE>ERC000033</VALUE>
+                        </SAMPLE_ATTRIBUTE>
+                </SAMPLE_ATTRIBUTES>
+        </SAMPLE>
+</SAMPLE_SET>

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1756,7 +1756,6 @@ enaDeposition:
   enaDbName: Loculus
   enaUniqueSuffix: Loculus
   enaIsBroker: False
-  enaGithubTestUrl: "https://raw.githubusercontent.com/pathoplexus/ena-submission/test_branch/test/approved_ena_submission_list.json"
 subdomainSeparator: "-"
 replicas:
   website: 1

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1756,6 +1756,7 @@ enaDeposition:
   enaDbName: Loculus
   enaUniqueSuffix: Loculus
   enaIsBroker: False
+  enaGithubTestUrl: "https://raw.githubusercontent.com/pathoplexus/ena-submission/test_branch/test/approved_ena_submission_list.json"
 subdomainSeparator: "-"
 replicas:
   website: 1


### PR DESCRIPTION
Based on #4713 by @anna-parker

Refactor of the biosample mapping function `get_sample_attributes` that simplifies the config and adds support for optional extra fields.

This is so we can add GISAID accession as a Biosample attribute.

Adds a test that this actually works.

Breaking config changes:
- removes `metadata_mapping_mandatory_field_defaults`
- these are added through `default: "..."` entries in the `metadata_mapping` dict

Example:

```yaml
metadata_mapping:
  'host age':
    loculus_fields: [hostAge]
metadata_mapping_mandatory_field_defaults:
  'host age': 'not provided'
```

becomes

```yaml
metadata_mapping:
  'host age':
    loculus_fields: [hostAge]
  default: 'not provided'
```


resolves https://github.com/pathoplexus/ena-submission/issues/91

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable