### PR TITLE
refactor!(website): enable extra sequence-related nav items in Pathoplexus

### DIFF
--- a/website/src/routes/extraTopNavigationItems.ts
+++ b/website/src/routes/extraTopNavigationItems.ts
@@ -1,1 +1,8 @@
-export const extraTopNavigationItems = [];
+// The following code is in a separate file so that it can be overwritten by Pathoplexus.
+import type { TopNavigationItems } from './navigationItems.ts';
+
+export const extraStaticTopNavigationItems = [];
+
+export const extraSequenceRelatedTopNavigationItems = (_: string | undefined): TopNavigationItems => {
+    return [];
+};

--- a/website/src/routes/navigationItems.ts
+++ b/website/src/routes/navigationItems.ts
@@ -1,5 +1,5 @@
 import { bottomNavigationItems } from './bottomNavigationItems.ts';
-import { extraTopNavigationItems } from './extraTopNavigationItems.js';
+import { extraSequenceRelatedTopNavigationItems, extraStaticTopNavigationItems } from './extraTopNavigationItems.js';
 import { routes } from './routes.ts';
 import { getWebsiteConfig } from '../config.ts';
 
@@ -8,7 +8,10 @@ export const navigationItems = {
     bottom: bottomNavigationItems,
 };
 
-export type TopNavigationItems = ReturnType<(typeof navigationItems)['top']>;
+export type TopNavigationItems = {
+    text: string;
+    path: string;
+}[];
 
 function getSequenceRelatedItems(organism: string | undefined) {
     const browseItem = {
@@ -65,5 +68,11 @@ function topNavigationItems(organism: string | undefined, isLoggedIn: boolean, l
     const seqSetsItems = getSeqSetsItems();
     const accountItems = getAccountItems(isLoggedIn, loginUrl, organism);
 
-    return [...sequenceRelatedItems, ...seqSetsItems, ...extraTopNavigationItems, ...accountItems];
+    return [
+        ...sequenceRelatedItems,
+        ...extraSequenceRelatedTopNavigationItems(organism),
+        ...seqSetsItems,
+        ...extraStaticTopNavigationItems,
+        ...accountItems,
+    ];
 }


### PR DESCRIPTION
This refactoring is needed for https://github.com/pathoplexus/pathoplexus/pull/590 so that the top navigation for tools can be organism-specific.

### PR Checklist
- ~[ ] All necessary documentation has been adapted.~
- ~[ ] The implemented feature is covered by appropriate, automated tests.~
- ~[ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~

🚀 Preview: https://extra-sequence-related-na.loculus.org