### PR TITLE
feat(website):demo of More tools option in dropdown

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
@@ -144,6 +144,22 @@ export const LinkOutMenu: FC<LinkOutMenuProps> = ({
                             </MenuItem>
                         ))}
                     </div>
+                    <div className='border-t border-gray-100'>
+                        <MenuItem>
+                            {({ focus }) => (
+                                <a
+                                    href='/tools'
+                                    target='_blank'
+                                    rel='noopener noreferrer'
+                                    className={`${
+                                        focus ? 'bg-gray-100 text-gray-900' : 'text-gray-700'
+                                    } flex items-center justify-between px-4 py-2 text-sm w-full text-left`}
+                                >
+                                    More tools
+                                </a>
+                            )}
+                        </MenuItem>
+                    </div>
                 </MenuItems>
             </Menu>
 


### PR DESCRIPTION
## Summary
- tweak the Tools dropdown to include an item linking to additional tools

## Testing
- `npm run format`
- `npm run check-types`
- `npm run test` *(all tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_687fbe31463c8325893e4cf93db7f21b

🚀 Preview: Add `preview` label to enable