### PR TITLE
fix(website): Standardize towards sentence case 

### DIFF
--- a/integration-tests/tests/pages/review.page.ts
+++ b/integration-tests/tests/pages/review.page.ts
@@ -9,7 +9,7 @@ export class ReviewPage {
 
     private viewSequencesButton = () => this.page.getByTestId(/view-sequences-/).first();
     private sequencesDialog = () =>
-        this.page.locator('div:has(> div > h2:text("Processed Sequences"))').first();
+        this.page.locator('div:has(> div > h2:text("Processed sequences"))').first();
     private sequencesDialogCloseButton = () =>
         this.sequencesDialog().getByRole('button', { name: '✕' });
     public sequenceViewerContent = () => this.page.getByTestId('fixed-length-text-viewer');

--- a/integration-tests/tests/specs/features/sequence-view.dependent.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-view.dependent.spec.ts
@@ -35,7 +35,7 @@ test.describe('Sequence view in review card', () => {
         await reviewPage.waitForZeroProcessing();
         await reviewPage.viewSequences();
 
-        const dialogTitle = page.getByText('Processed Sequences', { exact: true });
+        const dialogTitle = page.getByText('Processed sequences', { exact: true });
         await expect(dialogTitle).toBeVisible();
 
         const sequenceContent = await reviewPage.getSequenceContent();

--- a/website/src/components/DataUseTerms/EditDataUseTermsButton.tsx
+++ b/website/src/components/DataUseTerms/EditDataUseTermsButton.tsx
@@ -47,7 +47,7 @@ const InnerEditDataUseTermsButton: FC<EditDataUseTermsButtonProps> = ({
     return (
         <>
             <button className='btn btn-sm' onClick={openDialog}>
-                Edit Data Use Terms
+                Edit data use terms
             </button>
             <dialog ref={dialogRef} className='modal-box'>
                 <button
@@ -56,7 +56,7 @@ const InnerEditDataUseTermsButton: FC<EditDataUseTermsButtonProps> = ({
                 >
                     ✕
                 </button>
-                <label className='block text-sm font-medium leading-6 text-gray-900'>Edit Data Use Terms</label>
+                <label className='block text-sm font-medium leading-6 text-gray-900'>Edit data use terms</label>
                 <p className='text-sm text-gray-900 mb-4 py-2'>
                     Currently restricted until <b>{restrictedUntil.toFormat('yyyy-MM-dd')}</b>
                 </p>

--- a/website/src/components/DataUseTerms/EditDataUseTermsModal.tsx
+++ b/website/src/components/DataUseTerms/EditDataUseTermsModal.tsx
@@ -200,7 +200,7 @@ const EditControl: FC<EditControlProps> = ({ clientConfig, accessToken, state, c
                     <p>
                         You can release all the {state.restrictedCount} restricted sequences, moving them to the{' '}
                         <a href={routes.datauseTermsPage()} className='text-primary-600'>
-                            Open Data Use Terms
+                            Open data use terms
                         </a>
                         . If you want to pick a date for the restricted sequences, please narrow your selection down to
                         just restricted sequences. You can use the filters to do so.

--- a/website/src/components/Edit/EditPage.spec.tsx
+++ b/website/src/components/Edit/EditPage.spec.tsx
@@ -72,14 +72,14 @@ describe('EditPage', () => {
     test('should render without allowed submission of consensus sequences', () => {
         renderEditPage({ allowSubmissionOfConsensusSequences: false });
 
-        expect(screen.getByText(/Original Data/i)).toBeInTheDocument();
+        expect(screen.getByText(/Original data/i)).toBeInTheDocument();
         expectTextInSequenceData.originalMetadata(defaultReviewData.originalData.metadata);
     });
 
     test('should show original data', () => {
         renderEditPage();
 
-        expect(screen.getByText(/Original Data/i)).toBeInTheDocument();
+        expect(screen.getByText(/Original data/i)).toBeInTheDocument();
         expectTextInSequenceData.originalMetadata(defaultReviewData.originalData.metadata);
     });
 

--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -96,7 +96,7 @@ const InnerEditPage: FC<EditPageProps> = ({
             </div>
             <table className='customTable'>
                 <tbody className='w-full'>
-                    <Subtitle title='Original Data' bold />
+                    <Subtitle title='Original data' bold />
                     <SubmissionIdRow submissionId={dataToEdit.submissionId} />
                     <MetadataForm
                         editableMetadata={editableMetadata}

--- a/website/src/components/ReviewPage/ReviewPage.tsx
+++ b/website/src/components/ReviewPage/ReviewPage.tsx
@@ -173,7 +173,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({
                 You do not currently have any unreleased sequences awaiting review. You can view your released sequences
                 on the{' '}
                 <a href={routes.mySequencesPage(organism, group.groupId)} className='text-primary-600 hover:underline'>
-                    Released Sequences
+                    Released sequences
                 </a>{' '}
                 page.
             </div>
@@ -243,7 +243,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({
                 shape='rounded'
             />
             <div>
-                <label htmlFor='pageSize'>Page Size: </label>
+                <label htmlFor='pageSize'>Page size: </label>
                 <select id='pageSize' value={pageQuery.size} onChange={handleSizeChange}>
                     {pageSizeOptions.map((size) => (
                         <option key={size} value={size}>

--- a/website/src/components/ReviewPage/SequencesDialog.tsx
+++ b/website/src/components/ReviewPage/SequencesDialog.tsx
@@ -30,7 +30,7 @@ export const SequencesDialog: FC<SequencesDialogProps> = ({ isOpen, onClose, dat
         <div className='fixed inset-0 flex items-center justify-center z-50 overflow-auto bg-black bg-opacity-30'>
             <div className='bg-white rounded-lg p-6 max-w-6xl mx-3 w-full max-h-[90vh] flex flex-col'>
                 <div className='flex justify-between items-center mb-4'>
-                    <h2 className='text-xl font-semibold'>Processed Sequences</h2>
+                    <h2 className='text-xl font-semibold'>Processed sequences</h2>
                     <button className='text-gray-500 hover:text-gray-700' onClick={onClose}>
                         ✕
                     </button>

--- a/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
@@ -218,7 +218,7 @@ export const DownloadForm: FC<DownloadFormProps> = ({
             )}
             <RadioOptionBlock
                 name='dataType'
-                title='Data Type'
+                title='Data type'
                 options={dataTypeOptions}
                 selected={dataType}
                 onSelect={setDataType}

--- a/website/src/components/SearchPage/DownloadDialog/FieldSelector/FieldSelectorModal.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/FieldSelector/FieldSelectorModal.tsx
@@ -52,7 +52,7 @@ export const FieldSelectorModal: FC<FieldSelectorProps> = ({
 
     return (
         <CommonFieldSelectorModal
-            title='Select Fields to Download'
+            title='Select fields to download'
             isOpen={isOpen}
             onClose={onClose}
             fields={fieldItems}

--- a/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.spec.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.spec.tsx
@@ -104,7 +104,7 @@ describe('LinkOutMenu with enabled data use terms', () => {
 
         fireEvent.click(screen.getByRole('button', { name: /Tools/ }));
         fireEvent.click(screen.getByText('Basic'));
-        fireEvent.click(screen.getByText('Include Restricted-Use'));
+        fireEvent.click(screen.getByText('Include restricted-use'));
 
         expect(window.open).toHaveBeenCalled();
         expect(generateDownloadUrlSpy).toHaveBeenCalledWith(
@@ -130,7 +130,7 @@ describe('LinkOutMenu with enabled data use terms', () => {
 
         fireEvent.click(screen.getByRole('button', { name: /Tools/ }));
         fireEvent.click(screen.getByText('Basic'));
-        fireEvent.click(screen.getByText('Include Restricted-Use'));
+        fireEvent.click(screen.getByText('Include restricted-use'));
 
         expect(window.open).toHaveBeenCalled();
         expect(vi.mocked(window.open).mock.calls[0][0]).not.toBeUndefined();
@@ -152,7 +152,7 @@ describe('LinkOutMenu with enabled data use terms', () => {
 
         fireEvent.click(screen.getByRole('button', { name: /Tools/ }));
         fireEvent.click(screen.getByText('MetadataFields'));
-        fireEvent.click(screen.getByText('Include Restricted-Use'));
+        fireEvent.click(screen.getByText('Include restricted-use'));
 
         expect(generateDownloadUrlSpy).toHaveBeenCalledWith(
             mockSequenceFilter,
@@ -176,7 +176,7 @@ describe('LinkOutMenu with enabled data use terms', () => {
 
         fireEvent.click(screen.getByRole('button', { name: /Tools/ }));
         fireEvent.click(screen.getByText('MetadataSingle'));
-        fireEvent.click(screen.getByText('Include Restricted-Use'));
+        fireEvent.click(screen.getByText('Include restricted-use'));
 
         expect(generateDownloadUrlSpy).toHaveBeenCalledWith(
             mockSequenceFilter,

--- a/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
@@ -189,7 +189,7 @@ function LinkOutMenuDataUseTermModal(props: {
                         className='px-4 py-2 bg-primary-600 text-white rounded-md font-medium hover:bg-primary-700 transition-colors'
                         onClick={props.onClick1}
                     >
-                        Include Restricted-Use
+                        Include restricted-use
                     </button>
                 </div>
             </div>

--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -85,7 +85,7 @@ export const SearchForm = ({
                             <div className='flex items-center justify-between w-full mb-1 text-primary-700 text-sm'>
                                 <DisabledUntilHydrated>
                                     <button className='hover:underline' onClick={toggleFieldSelector}>
-                                        <StreamlineWrench className='inline-block' /> Add Search Fields
+                                        <StreamlineWrench className='inline-block' /> Add search fields
                                     </button>
                                 </DisabledUntilHydrated>
                                 <button
@@ -103,7 +103,7 @@ export const SearchForm = ({
                         </div>{' '}
                     </div>
                     <FieldSelectorModal
-                        title='Add Search Fields'
+                        title='Add search fields'
                         isOpen={isFieldSelectorOpen}
                         onClose={toggleFieldSelector}
                         fields={fieldItems}

--- a/website/src/components/SearchPage/SearchFullUI.spec.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.spec.tsx
@@ -225,7 +225,7 @@ describe('SearchFullUI', () => {
     it('toggle field visibility', async () => {
         renderSearchFullUI({});
         expect(await screen.findByLabelText('Field 1')).toBeVisible();
-        const customizeButton = await screen.findByRole('button', { name: 'Add Search Fields' });
+        const customizeButton = await screen.findByRole('button', { name: 'Add search fields' });
         await userEvent.click(customizeButton);
         const field1Checkbox = await screen.findByRole('checkbox', { name: 'Field 1' });
         expect(field1Checkbox).toBeChecked();

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -327,7 +327,7 @@ export const InnerSearchFullUI = ({
     return (
         <div className='flex flex-col md:flex-row gap-8 md:gap-4'>
             <FieldSelectorModal
-                title='Customize Columns'
+                title='Customize columns'
                 isOpen={isColumnModalOpen}
                 onClose={() => setIsColumnModalOpen(!isColumnModalOpen)}
                 fields={columnFieldItems}

--- a/website/src/components/SeqSetCitations/SeqSetItem.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItem.tsx
@@ -125,14 +125,14 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
                 <div className='flex flex-row py-1.5'>
                     <p className='mr-8 w-[120px] text-gray-500 text-right'>Total citations</p>
                     {seqSet.seqSetDOI === undefined || seqSet.seqSetDOI === null ? (
-                        <p className='text'>Cited By 0</p>
+                        <p className='text'>Cited by 0</p>
                     ) : (
                         <a
                             className='mr-4 cursor-pointer font-medium text-blue-600 hover:text-blue-800'
                             href={getCrossRefUrl()}
                             target='_blank'
                         >
-                            Cited By 0
+                            Cited by 0
                         </a>
                     )}
                 </div>

--- a/website/src/components/SequenceDetailsPage/DataUseTermsHistoryModal.tsx
+++ b/website/src/components/SequenceDetailsPage/DataUseTermsHistoryModal.tsx
@@ -45,14 +45,14 @@ const DataUseTermsHistoryDialog: FC<DataUseTermsHistoryContainerProps> = ({ data
                 <button className='btn btn-sm btn-circle btn-ghost absolute right-2 top-2'>✕</button>
             </form>
 
-            <h3 className='font-bold text-lg'>Data Use Terms History</h3>
+            <h3 className='font-bold text-lg'>Data use terms history</h3>
 
             <table className='table'>
                 <thead>
                     <tr>
                         <th>Changed</th>
                         <th>User</th>
-                        <th>Data Use Terms</th>
+                        <th>Data use terms</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/website/src/components/SequenceDetailsPage/ReferenceSequenceLinkButton.tsx
+++ b/website/src/components/SequenceDetailsPage/ReferenceSequenceLinkButton.tsx
@@ -61,7 +61,7 @@ const ReferenceSequenceLinkButton: React.FC<Props> = ({ reference }) => {
                             >
                                 <DialogPanel className='w-full max-w-2xl transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all'>
                                     <DialogTitle as='h3' className='font-bold text-2xl mb-4 text-primary-700'>
-                                        Reference Sequence
+                                        Reference sequence
                                     </DialogTitle>
                                     <button className='absolute right-2 top-2 p-1' onClick={closeDialog}>
                                         <X className='h-6 w-6' />

--- a/website/src/components/SequenceDetailsPage/SequenceDataUI.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceDataUI.tsx
@@ -89,7 +89,7 @@ export const SequenceDataUI: FC<Props> = ({
                 <>
                     <hr className='my-4' />
                     <div className='my-8'>
-                        <h2 className='text-xl font-bold mb-3'>Sequence Management</h2>
+                        <h2 className='text-xl font-bold mb-3'>Sequence management</h2>
                         <div className='text-sm text-gray-400 mb-4 block'>
                             <MdiEye className='w-6 h-6 inline-block mr-2' />
                             Only visible to group members

--- a/website/src/components/Submission/FileUpload/ColumnMappingModal.spec.tsx
+++ b/website/src/components/Submission/FileUpload/ColumnMappingModal.spec.tsx
@@ -40,7 +40,7 @@ describe('ColumnMappingModal', () => {
         const openButton = screen.getByText(/Add column mapping/i);
         await userEvent.click(openButton);
 
-        expect(await screen.findByText(/Remap Columns/i)).toBeInTheDocument();
+        expect(await screen.findByText(/Remap columns/i)).toBeInTheDocument();
     });
 
     it('loads and displays columns from the input file', async () => {

--- a/website/src/components/Submission/FileUpload/ColumnMappingModal.tsx
+++ b/website/src/components/Submission/FileUpload/ColumnMappingModal.tsx
@@ -105,7 +105,7 @@ export const ColumnMappingModal: FC<ColumnMappingModalProps> = ({
                 <br />
                 to map columns in your file to the fields expected by the database.
             </Tooltip>
-            <BaseDialog title='Remap Columns' isOpen={isOpen} onClose={closeDialog} fullWidth={false}>
+            <BaseDialog title='Remap columns' isOpen={isOpen} onClose={closeDialog} fullWidth={false}>
                 {currentMapping === null || inputColumns === null ? (
                     'Loading ...'
                 ) : (

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title='Not Found'>
+<BaseLayout title='Not found'>
     <div class='bc'>
         <h1 class='title'>Page not found</h1>
         <p>The page you are looking for does not exist.</p>

--- a/website/src/pages/500.astro
+++ b/website/src/pages/500.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title='Internal Server Error'>
+<BaseLayout title='Internal server error'>
     <div class='bc'>
         <h1 class='title'>An error occurred</h1>
     </div>

--- a/website/src/pages/503.astro
+++ b/website/src/pages/503.astro
@@ -15,9 +15,9 @@ if (serviceParam !== null && serviceParam !== '' && allowedServiceNames.includes
 }
 ---
 
-<BaseLayout title={`${service} Service Unavailable`}>
+<BaseLayout title={`${service} service unavailable`}>
     <div class='bc'>
-        <h1 class='title'>{`${service} Service Unavailable`}</h1>
+        <h1 class='title'>{`${service} service unavailable`}</h1>
         <p>
             The {bodyService} is currently unavailable. Please check back later.
         </p>

--- a/website/src/pages/[organism]/my_sequences.astro
+++ b/website/src/pages/[organism]/my_sequences.astro
@@ -21,7 +21,7 @@ if (groupsResult.isOk()) {
 }
 ---
 
-<BaseLayout title='My Sequences'>
+<BaseLayout title='My sequences'>
     <div>
         <p>
             {

--- a/website/src/pages/admin/dashboard.astro
+++ b/website/src/pages/admin/dashboard.astro
@@ -11,8 +11,8 @@ if (accessToken !== undefined) {
 }
 ---
 
-<BaseLayout title='Admin Dashboard'>
-    <h1 class='title mb-4'>Admin Dashboard</h1>
+<BaseLayout title='Admin dashboard'>
+    <h1 class='title mb-4'>Admin dashboard</h1>
     {
         accessToken === undefined ? (
             <p>You must be logged in.</p>

--- a/website/src/pages/api-documentation/index.astro
+++ b/website/src/pages/api-documentation/index.astro
@@ -22,9 +22,9 @@ const BUTTON_CLASS =
     'inline-block px-6 py-3 bg-primary-400 text-white font-semibold rounded-lg shadow-md hover:bg-primary-500  mr-2 hover:no-underline';
 ---
 
-<BaseLayout title='API Documentation'>
+<BaseLayout title='API documentation'>
     <div class='container mx-auto p-8'>
-        <h1 class='title'>API Documentation</h1>
+        <h1 class='title'>API documentation</h1>
 
         <div class='mb-10'>
             <p class='mt-4 mb-4'>
@@ -56,7 +56,7 @@ const BUTTON_CLASS =
                             href={routes.datauseTermsPage()}
                             class='underline text-primary-900 hover:text-primary-800 hover:no-underline'
                         >
-                            Data Use Terms
+                            Data use terms
                         </a>
                         .
                     </p>
@@ -65,32 +65,32 @@ const BUTTON_CLASS =
         </div>
 
         <div class='mb-10'>
-            <h2 class='text-xl font-semibold text-primary-400 mb-4'>Backend Server</h2>
+            <h2 class='text-xl font-semibold text-primary-400 mb-4'>Backend server</h2>
             <div class='mb-4'>
                 Please note that Loculus is under continuous development and the endpoints are subject to change.
             </div>
             <a class={BUTTON_CLASS} href={clientConfig.backendUrl + '/swagger-ui/index.html'}>
-                View Backend API Documentation
+                View backend API documentation
             </a>
             <div class='mt-8'>
-                <span class='font-medium'>URL of Backend Server:</span>
+                <span class='font-medium'>URL of backend server:</span>
                 <code>{clientConfig.backendUrl}</code>
             </div>
         </div>
 
         <div class='mb-10'>
-            <h2 class='text-xl font-semibold text-primary-400 mb-4'>LAPIS Query Engines</h2>
+            <h2 class='text-xl font-semibold text-primary-400 mb-4'>LAPIS query engines</h2>
             <div class='space-y-4'>
                 {
                     Object.entries(clientConfig.lapisUrls).map(([organism, url]) => (
                         <a class={BUTTON_CLASS} href={url + '/swagger-ui/index.html'}>
-                            {organismToDisplayName[organism]} LAPIS API Documentation
+                            {organismToDisplayName[organism]} LAPIS API documentation
                         </a>
                     ))
                 }
             </div>
             <div class='mt-8'>
-                <span class='font-medium'>URLs of LAPIS Query Engines:</span>
+                <span class='font-medium'>URLs of LAPIS query engines:</span>
                 <ul class='list-disc ml-6'>
                     {
                         Object.entries(clientConfig.lapisUrls).map(([organism, url]) => (
@@ -104,12 +104,12 @@ const BUTTON_CLASS =
         </div>
 
         <div>
-            <h2 class='text-xl font-semibold text-primary-400 mb-4'>Keycloak Server</h2>
+            <h2 class='text-xl font-semibold text-primary-400 mb-4'>Keycloak server</h2>
             <div>
                 We use the open source software <a href='https://www.keycloak.org/'>Keycloak</a> for authentication.
             </div>
             <div class='mt-2'>
-                <span class='font-medium'>URL of Keycloak Server:</span>
+                <span class='font-medium'>URL of Keycloak server:</span>
                 <code>{keycloakUrl}</code>
             </div>
         </div>

--- a/website/src/pages/seqsets/index.astro
+++ b/website/src/pages/seqsets/index.astro
@@ -96,7 +96,7 @@ const editAccountUrl = urlForKeycloakAccountPage(keycloakClient!) + '/#/personal
                         </div>
                     </div>
                     <div class='w-1/4 flex flex-col justify-start items-start pl-4'>
-                        <span class='text-xl'>Cited By</span>
+                        <span class='text-xl'>Cited by</span>
                         {/* We show an empty plot for now until we get real data. */}
                         <div>
                             <CitationPlot

--- a/website/src/pages/user/createGroup.astro
+++ b/website/src/pages/user/createGroup.astro
@@ -9,6 +9,6 @@ const accessToken = getAccessToken(Astro.locals.session)!;
 const clientConfig = getRuntimeConfig().public;
 ---
 
-<BaseLayout title='Create Group'>
+<BaseLayout title='Create group'>
     <GroupCreationForm clientConfig={clientConfig} accessToken={accessToken} client:load />
 </BaseLayout>

--- a/website/tests/pages/navigation.spec.ts
+++ b/website/tests/pages/navigation.spec.ts
@@ -2,7 +2,7 @@ import { baseUrl, dummyOrganism, test } from '../e2e.fixture';
 
 const organismIndependentNavigationItems = [
     { link: 'My account', title: 'My account' },
-    { link: 'API docs', title: 'API Documentation' },
+    { link: 'API docs', title: 'API documentation' },
 ];
 
 const organismNavigationItems = [


### PR DESCRIPTION
copy of https://github.com/loculus-project/loculus/pull/4746 with a branch name that can be previewed

Moves closer to consistency on sentence case re: https://github.com/loculus-project/loculus/issues/4745

- convert button texts and page titles to sentence case
- update UI headings in docs and dialogs
- adjust tests to match new sentence case labels


------
https://chatgpt.com/codex/tasks/task_e_687fabd313f883259f2aecd52dcc4c5c

🚀 Preview: https://codex-standardize-buttons.loculus.org