### PR TITLE
fix(backend): handle duplicate selects in extract-unprocessed gracefully, no longer stream results

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -124,20 +124,6 @@ class SubmissionDatabaseService(
         Database.connect(pool)
     }
 
-    fun streamUnprocessedSubmissions(
-        numberOfSequenceEntries: Int,
-        organism: Organism,
-        pipelineVersion: Long,
-    ): Sequence<UnprocessedData> {
-        log.info { "Request received to stream up to $numberOfSequenceEntries unprocessed submissions for $organism." }
-
-        return fetchUnprocessedEntriesAndUpdateToInProcessing(
-            organism,
-            numberOfSequenceEntries,
-            pipelineVersion,
-        )
-    }
-
     fun getCurrentProcessingPipelineVersion(organism: Organism): Long {
         val table = CurrentProcessingPipelineTable
         return table
@@ -149,15 +135,21 @@ class SubmissionDatabaseService(
             .first()
     }
 
-    private fun fetchUnprocessedEntriesAndUpdateToInProcessing(
-        organism: Organism,
+    data class FetchUnprocessedResult(val data: List<UnprocessedData>, val hadConflict: Boolean = false)
+
+    fun fetchUnprocessedSubmissions(
         numberOfSequenceEntries: Int,
+        organism: Organism,
         pipelineVersion: Long,
-    ): Sequence<UnprocessedData> {
+    ): FetchUnprocessedResult {
+        log.info {
+            "Request received to fetch up to $numberOfSequenceEntries unprocessed submissions for $organism."
+        }
         val table = SequenceEntriesTable
         val preprocessing = SequenceEntriesPreprocessedDataTable
 
-        return table
+        // Select and lock the rows
+        val selectedRows = table
             .select(
                 table.accessionColumn,
                 table.versionColumn,
@@ -181,52 +173,57 @@ class SubmissionDatabaseService(
             .orderBy(table.accessionColumn)
             .limit(numberOfSequenceEntries)
             .forUpdate(ForUpdate(mode = MODE.SKIP_LOCKED))
-            .fetchSize(streamBatchSize)
-            .asSequence()
-            .chunked(streamBatchSize)
-            .map { chunk ->
-                val chunkOfUnprocessedData = chunk.map {
-                    val originalData = compressionService.decompressSequencesInOriginalData(
-                        it[table.originalDataColumn]!!,
-                        organism,
-                    )
-                    val originalDataWithFileUrls = OriginalDataWithFileUrls(
-                        originalData.metadata,
-                        originalData.unalignedNucleotideSequences,
-                        originalData.files?.let {
-                            it.mapValues {
-                                it.value.map { f ->
-                                    val presignedUrl = s3Service.createUrlToReadPrivateFile(f.fileId)
-                                    FileIdAndNameAndReadUrl(f.fileId, f.name, presignedUrl)
-                                }
-                            }
-                        },
-                    )
-                    UnprocessedData(
-                        accession = it[table.accessionColumn],
-                        version = it[table.versionColumn],
-                        data = originalDataWithFileUrls,
-                        submissionId = it[table.submissionIdColumn],
-                        submitter = it[table.submitterColumn],
-                        groupId = it[table.groupIdColumn],
-                        submittedAt = it[table.submittedAtTimestampColumn].toTimestamp(),
-                    )
+            .toList()
+
+        try {
+            if (selectedRows.isNotEmpty()) {
+                preprocessing.batchInsert(selectedRows) { it ->
+                    this[preprocessing.accessionColumn] = it[table.accessionColumn]
+                    this[preprocessing.versionColumn] = it[table.versionColumn]
+                    this[preprocessing.pipelineVersionColumn] = pipelineVersion
+                    this[preprocessing.processingStatusColumn] = IN_PROCESSING.name
+                    this[preprocessing.startedProcessingAtColumn] = dateProvider.getCurrentDateTime()
                 }
-                updateStatusToProcessing(chunkOfUnprocessedData, pipelineVersion)
-                chunkOfUnprocessedData
             }
-            .flatten()
-    }
 
-    private fun updateStatusToProcessing(sequenceEntries: List<UnprocessedData>, pipelineVersion: Long) {
-        log.info { "updating status to processing. Number of sequence entries: ${sequenceEntries.size}" }
+            val data = selectedRows.map { it ->
+                val originalData = compressionService.decompressSequencesInOriginalData(
+                    it[table.originalDataColumn]!!,
+                    organism,
+                )
+                val originalDataWithFileUrls = OriginalDataWithFileUrls(
+                    originalData.metadata,
+                    originalData.unalignedNucleotideSequences,
+                    originalData.files?.let {
+                        it.mapValues {
+                            it.value.map { f ->
+                                val presignedUrl = s3Service.createUrlToReadPrivateFile(f.fileId)
+                                FileIdAndNameAndReadUrl(f.fileId, f.name, presignedUrl)
+                            }
+                        }
+                    },
+                )
+                UnprocessedData(
+                    accession = it[table.accessionColumn],
+                    version = it[table.versionColumn],
+                    data = originalDataWithFileUrls,
+                    submissionId = it[table.submissionIdColumn],
+                    submitter = it[table.submitterColumn],
+                    groupId = it[table.groupIdColumn],
+                    submittedAt = it[table.submittedAtTimestampColumn].toTimestamp(),
+                )
+            }
 
-        SequenceEntriesPreprocessedDataTable.batchInsert(sequenceEntries) {
-            this[SequenceEntriesPreprocessedDataTable.accessionColumn] = it.accession
-            this[SequenceEntriesPreprocessedDataTable.versionColumn] = it.version
-            this[SequenceEntriesPreprocessedDataTable.pipelineVersionColumn] = pipelineVersion
-            this[SequenceEntriesPreprocessedDataTable.processingStatusColumn] = IN_PROCESSING.name
-            this[SequenceEntriesPreprocessedDataTable.startedProcessingAtColumn] = dateProvider.getCurrentDateTime()
+            return FetchUnprocessedResult(data, hadConflict = false)
+        } catch (e: Exception) {
+            if (e.message?.contains("duplicate key") == true) {
+                // Another client got some of these entries
+                // Return empty list with conflict flag
+                log.info { "Duplicate key conflict - returning empty result without ETag" }
+                return FetchUnprocessedResult(emptyList(), hadConflict = true)
+            } else {
+                throw e
+            }
         }
     }
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ExtractUnprocessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ExtractUnprocessedDataEndpointTest.kt
@@ -83,7 +83,7 @@ class ExtractUnprocessedDataEndpointTest(
                 startLatch.await() // Wait for signal to start
                 val response = client.extractUnprocessedData(
                     numberOfSequenceEntries = DefaultFiles.NUMBER_OF_SEQUENCES,
-                    organism = DEFAULT_ORGANISM
+                    organism = DEFAULT_ORGANISM,
                 )
                 val responseBody = response.expectNdjsonAndGetContent<UnprocessedData>()
                 client1Results.addAll(responseBody)
@@ -99,7 +99,7 @@ class ExtractUnprocessedDataEndpointTest(
                 startLatch.await() // Wait for signal to start
                 val response = client.extractUnprocessedData(
                     numberOfSequenceEntries = DefaultFiles.NUMBER_OF_SEQUENCES,
-                    organism = DEFAULT_ORGANISM
+                    organism = DEFAULT_ORGANISM,
                 )
                 val responseBody = response.expectNdjsonAndGetContent<UnprocessedData>()
                 client2Results.addAll(responseBody)
@@ -133,7 +133,7 @@ class ExtractUnprocessedDataEndpointTest(
         assertThat(
             "No accession should be returned to both clients, but found duplicates: $duplicateAccessions",
             duplicateAccessions,
-            `is`(empty())
+            `is`(empty()),
         )
 
         // Check that all submitted entries were extracted exactly once
@@ -143,14 +143,14 @@ class ExtractUnprocessedDataEndpointTest(
         assertThat(
             "All submitted entries should be extracted exactly once",
             allExtractedAccessions,
-            `is`(expectedAccessions)
+            `is`(expectedAccessions),
         )
 
         // Verify total count
         assertThat(
             "Total extracted entries should equal submitted entries",
             client1Results.size + client2Results.size,
-            `is`(DefaultFiles.NUMBER_OF_SEQUENCES)
+            `is`(DefaultFiles.NUMBER_OF_SEQUENCES),
         )
     }
 


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/1882
resolves https://github.com/loculus-project/loculus/issues/3394

In extract-unprocessed, when multiple clients call at the same time, it can happen that they both select the same rows which then causes an insertion error due to duplicate primary keys.

The more parallel prepros we add the more often the errors happen. So this blocks scalability of preprocessing: we're stuck with slow preprocessing: right now mpox takes ~3hr. For SC2 it'd be unacceptably slow.

This PR:
1. Adds a failing test, provoking the error
1. Switches the endpoint to non-streaming to handle such errors gracefully by returning nothing instead of garbled ndjson.

### Screenshot

These errors should no longer happen with these changes:
<img width="1653" height="752" alt="image" src="https://github.com/user-attachments/assets/617fbd62-803f-49d9-bc15-a548043351dd" />

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable