### PR TITLE
feat(ingest): never remove segment field from metadata and filter out nextclade sort matches that are not supported

### DIFF
--- a/ingest/scripts/heuristic_group_segments.py
+++ b/ingest/scripts/heuristic_group_segments.py
@@ -211,11 +211,6 @@ def main(
                 if segment in group
             ]
         )
-        if not joint_key:
-            logger.warning(
-                f"Group {group} has no known segments, skipping."
-            )
-            continue
         for segment, accession in group.items():
             fasta_id_map[accession] = f"{joint_key}_{segment}"
 

--- a/ingest/scripts/heuristic_group_segments.py
+++ b/ingest/scripts/heuristic_group_segments.py
@@ -211,6 +211,11 @@ def main(
                 if segment in group
             ]
         )
+        if not joint_key:
+            logger.warning(
+                f"Group {group} has no known segments, skipping."
+            )
+            continue
         for segment, accession in group.items():
             fasta_id_map[accession] = f"{joint_key}_{segment}"
 

--- a/ingest/scripts/parse_nextclade_sort_output.py
+++ b/ingest/scripts/parse_nextclade_sort_output.py
@@ -65,6 +65,7 @@ def parse_file(
     header = list(config.minimizer_parser)
     header.append("seqName")
     # Filter out rows where 'segment' is NOT in nucleotide_sequences
+    # these cases are not explicitly supported by loculus
     filtered_df = df_highest_per_group[df_highest_per_group["segment"].isin(allowed_segments)]
     filtered_df.to_csv(output_file, columns=header, sep="\t", index=False)
 

--- a/ingest/scripts/parse_nextclade_sort_output.py
+++ b/ingest/scripts/parse_nextclade_sort_output.py
@@ -41,7 +41,9 @@ def parse(field: str, index: int) -> str:
     return field.split("_")[index] if len(field.split("_")) > index else ""
 
 
-def parse_file(config: NextcladeSortParams, sort_results: str, output_file: str):
+def parse_file(
+    config: NextcladeSortParams, sort_results: str, output_file: str, allowed_segments: list[str]
+) -> None:
     df = pd.read_csv(sort_results, sep="\t", dtype={"index": "Int64"})
 
     no_rows = df.shape[0]
@@ -62,7 +64,9 @@ def parse_file(config: NextcladeSortParams, sort_results: str, output_file: str)
         )
     header = list(config.minimizer_parser)
     header.append("seqName")
-    df_highest_per_group.to_csv(output_file, columns=header, sep="\t", index=False)
+    # Filter out rows where 'segment' is NOT in nucleotide_sequences
+    filtered_df = df_highest_per_group[df_highest_per_group["segment"].isin(allowed_segments)]
+    filtered_df.to_csv(output_file, columns=header, sep="\t", index=False)
 
 
 @click.command()
@@ -94,7 +98,12 @@ def main(config_file: str, sort_results: str, output: str, log_level: str) -> No
     if "segment" not in config.segment_identification.minimizer_parser and config.segmented:
         error_msg = "minimizer_parser must include 'segment'"
         raise ValueError(error_msg)
-    parse_file(config.segment_identification, sort_results, output)
+    parse_file(
+        config.segment_identification,
+        sort_results,
+        output,
+        allowed_segments=config.nucleotide_sequences,
+    )
 
 
 if __name__ == "__main__":

--- a/ingest/scripts/prepare_metadata.py
+++ b/ingest/scripts/prepare_metadata.py
@@ -114,6 +114,10 @@ def main(
             val = record.pop(from_key)
             record[to_key] = val
 
+        # Keep segment field if segmented and it is in rename
+        if config.segmented and "segment" in config.rename:
+            record["segment"] = record[config.rename["segment"]]
+
     keys_to_keep = set(config.rename.values()) | set(config.keep)
     if config.segmented:
         keys_to_keep.add("segment")
@@ -138,9 +142,8 @@ def main(
         filtered_record = {k: str(v) for k, v in record.items() if v is not None and str(v)}
 
         # rename "id" to "submissionId" for back-compatibility with old hashes
-        
         filtered_record["submissionId"] = filtered_record.pop("id")
-        
+        filtered_record["segment"] = record.get("segment", "")
 
         metadata_dump = json.dumps(filtered_record, sort_keys=True)
         prehash = metadata_dump + sequence_hash

--- a/ingest/scripts/prepare_metadata.py
+++ b/ingest/scripts/prepare_metadata.py
@@ -111,13 +111,14 @@ def main(
 
     for record in metadata:
         for from_key, to_key in config.rename.items():
-            val = record.pop(from_key)
+            # segment is a required field for the ingest grouping scripts
+            # Keep segment field if config.segmented even if it is specified to be renamed
+            val = (
+                record.get(from_key)
+                if (from_key == "segment" and config.segmented)
+                else record.pop(from_key)
+            )
             record[to_key] = val
-
-        # segment is a required field for the ingest grouping scripts
-        # Keep segment field if config.segmented even if it is specified to be renamed
-        if config.segmented and "segment" in config.rename:
-            record["segment"] = record[config.rename["segment"]]
 
     keys_to_keep = set(config.rename.values()) | set(config.keep)
     if config.segmented:

--- a/ingest/scripts/prepare_metadata.py
+++ b/ingest/scripts/prepare_metadata.py
@@ -143,7 +143,6 @@ def main(
 
         # rename "id" to "submissionId" for back-compatibility with old hashes
         filtered_record["submissionId"] = filtered_record.pop("id")
-        filtered_record["segment"] = record.get("segment", "")
 
         metadata_dump = json.dumps(filtered_record, sort_keys=True)
         prehash = metadata_dump + sequence_hash

--- a/ingest/scripts/prepare_metadata.py
+++ b/ingest/scripts/prepare_metadata.py
@@ -114,7 +114,8 @@ def main(
             val = record.pop(from_key)
             record[to_key] = val
 
-        # Keep segment field if segmented and it is in rename
+        # segment is a required field for the ingest grouping scripts
+        # Keep segment field if config.segmented and it is in rename
         if config.segmented and "segment" in config.rename:
             record["segment"] = record[config.rename["segment"]]
 

--- a/ingest/scripts/prepare_metadata.py
+++ b/ingest/scripts/prepare_metadata.py
@@ -115,7 +115,7 @@ def main(
             record[to_key] = val
 
         # segment is a required field for the ingest grouping scripts
-        # Keep segment field if config.segmented and it is in rename
+        # Keep segment field if config.segmented even if it is specified to be renamed
         if config.segmented and "segment" in config.rename:
             record["segment"] = record[config.rename["segment"]]
 

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1665,7 +1665,7 @@ defaultOrganisms:
             sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/cchf/NP.fasta]]"
   enteroviruses:
     <<: *defaultOrganismConfig
-    enabled: false
+    enabled: true
     schema:
       <<: *schema
       organismName: "Enterovirus"
@@ -1748,7 +1748,7 @@ defaultOrganisms:
       <<: *ingest
       configFile:
         <<: *ingestConfigFile
-        taxon_id: 12059 # Enterovirus (all EVs)
+        taxon_id: 138948 # Enterovirus A (once we include non-A, broaden to 12059)
         segment_identification:
           method: "minimizer"
           minimizer_index: "https://raw.githubusercontent.com/alejandra-gonzalezsanchez/loculus-evs/master/evs_minimizer-index.json"

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1665,7 +1665,7 @@ defaultOrganisms:
             sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/cchf/NP.fasta]]"
   enteroviruses:
     <<: *defaultOrganismConfig
-    enabled: true
+    enabled: false
     schema:
       <<: *schema
       organismName: "Enterovirus"


### PR DESCRIPTION
resolves #

Main is failing with the error 
```
 File "/package/scripts/heuristic_group_segments.py", line 145, in main
    segment = values["segment"]
              ~~~~~~^^^^^^^^^^^
KeyError: 'segment'
```
`segment` is a keyword in the heuristic grouping script. However, in the enteroviruses config we renamed `segment` to genotype. This rename meant that `segment` was nolonger a field in the metadata - leading the heuristic grouping script to break. This PR should ensure that even if we rename `segment` the `segment` field should stay in the metadata as it is a required field for grouping.

This PR also covers the case where nextclade sort assigns a segment to a sequence which is not a valid segment - in this case we also drop these matches. This is important as the backend (for now) does not allow submission of unknown segments and will error - also ingest has been written with this state in mind and assumes we only assign known segments. 

This was fixed in @alejandra-gonzalezsanchez's PR: https://github.com/loculus-project/loculus/pull/4570

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://small-ingest-fixes.loculus.org