### PR TITLE
feat(backend): only add the merged reference genomes to the backend config

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
@@ -43,11 +43,7 @@ enum class FileUrlType {
     override fun toString(): String = lowerCase(name)
 }
 
-const val SINGLE_REFERENCE_GENOME_KEY = "singleReference"
-
-typealias Suborganism = String
-
-data class InstanceConfig(val schema: Schema, val referenceGenomes: Map<Suborganism, ReferenceGenome>)
+data class InstanceConfig(val schema: Schema, val referenceGenome: ReferenceGenome)
 
 data class Schema(
     val organismName: String,

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/CompressionService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/CompressionService.kt
@@ -180,8 +180,7 @@ class CompressionService(private val backendConfig: BackendConfig) {
     private fun getDictionaryForNucleotideSequenceSegment(segmentName: String, organism: Organism): ByteArray? =
         backendConfig
             .getInstanceConfig(organism)
-            .referenceGenomes
-            .values.first()
+            .referenceGenome
             .getNucleotideSegmentReference(
                 segmentName,
             )
@@ -189,8 +188,7 @@ class CompressionService(private val backendConfig: BackendConfig) {
 
     private fun getDictionaryForAminoAcidSequence(geneName: String, organism: Organism): ByteArray? = backendConfig
         .getInstanceConfig(organism)
-        .referenceGenomes
-        .values.first()
+        .referenceGenome
         .getAminoAcidGeneReference(
             geneName,
         )

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/EmptyProcessedDataProvider.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/EmptyProcessedDataProvider.kt
@@ -10,8 +10,7 @@ import org.springframework.stereotype.Component
 @Component
 class EmptyProcessedDataProvider(private val backendConfig: BackendConfig) {
     fun provide(organism: Organism): ProcessedData<GeneticSequence> {
-        val (schema, referenceGenomes) = backendConfig.getInstanceConfig(organism)
-        val referenceGenome = referenceGenomes.values.first()
+        val (schema, referenceGenome) = backendConfig.getInstanceConfig(organism)
 
         val nucleotideSequences = referenceGenome.nucleotideSequences.map { it.name }.associateWith { null }
         return ProcessedData(

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequenceEntryValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequenceEntryValidator.kt
@@ -193,7 +193,7 @@ class ProcessedSequenceEntryValidatorFactory(private val backendConfig: BackendC
         val instanceConfig = backendConfig.organisms[organism.name]!!
         return ProcessedSequenceEntryValidator(
             schema = instanceConfig.schema,
-            referenceGenome = instanceConfig.referenceGenomes.values.first(),
+            referenceGenome = instanceConfig.referenceGenome,
         )
     }
 }

--- a/backend/src/main/kotlin/org/loculus/backend/utils/ParseFastaHeader.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/ParseFastaHeader.kt
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service
 @Service
 class ParseFastaHeader(private val backendConfig: BackendConfig) {
     fun parse(submissionId: String, organism: Organism): Pair<SubmissionId, SegmentName> {
-        val referenceGenome = backendConfig.getInstanceConfig(organism).referenceGenomes.values.first()
+        val referenceGenome = backendConfig.getInstanceConfig(organism).referenceGenome
 
         if (referenceGenome.nucleotideSequences.size == 1) {
             return Pair(submissionId, "main")

--- a/backend/src/test/kotlin/org/loculus/backend/config/BackendSpringConfigTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/config/BackendSpringConfigTest.kt
@@ -66,7 +66,7 @@ fun backendConfig(metadataList: List<Metadata>, earliestReleaseDate: EarliestRel
     organisms = mapOf(
         DEFAULT_ORGANISM to InstanceConfig(
             schema = Schema(DEFAULT_ORGANISM, metadataList, earliestReleaseDate = earliestReleaseDate),
-            referenceGenomes = mapOf(SINGLE_REFERENCE_GENOME_KEY to ReferenceGenome(emptyList(), emptyList())),
+            referenceGenome = ReferenceGenome(emptyList(), emptyList()),
         ),
     ),
     accessionPrefix = "FOO_",

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
@@ -77,9 +77,7 @@ class SubmissionConvenienceClient(
         val instanceConfig = backendConfig.getInstanceConfig(Organism(organism))
 
         val isMultiSegmented = instanceConfig
-            .referenceGenomes
-            .values
-            .first()
+            .referenceGenome
             .nucleotideSequences.size > 1
 
         val doesNotAllowConsensusSequenceFile = !instanceConfig.schema

--- a/backend/src/test/kotlin/org/loculus/backend/service/submission/EmptyProcessedDataProviderTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/submission/EmptyProcessedDataProviderTest.kt
@@ -12,7 +12,6 @@ import org.loculus.backend.config.Metadata
 import org.loculus.backend.config.MetadataType
 import org.loculus.backend.config.ReferenceGenome
 import org.loculus.backend.config.ReferenceSequence
-import org.loculus.backend.config.SINGLE_REFERENCE_GENOME_KEY
 import org.loculus.backend.config.Schema
 import org.loculus.backend.controller.DEFAULT_ORGANISM
 
@@ -36,16 +35,14 @@ class EmptyProcessedDataProviderTest {
                             Metadata(name = SECOND_METADATA_FIELD, type = MetadataType.DATE, required = false),
                         ),
                     ),
-                    referenceGenomes = mapOf(
-                        SINGLE_REFERENCE_GENOME_KEY to ReferenceGenome(
-                            listOf(
-                                ReferenceSequence(FIRST_NUCLEOTIDE_SEQUENCE, "the sequence"),
-                                ReferenceSequence(SECOND_NUCLEOTIDE_SEQUENCE, "the sequence"),
-                            ),
-                            listOf(
-                                ReferenceSequence(FIRST_AMINO_ACID_SEQUENCE, "the sequence"),
-                                ReferenceSequence(SECOND_AMINO_ACID_SEQUENCE, "the sequence"),
-                            ),
+                    referenceGenome = ReferenceGenome(
+                        listOf(
+                            ReferenceSequence(FIRST_NUCLEOTIDE_SEQUENCE, "the sequence"),
+                            ReferenceSequence(SECOND_NUCLEOTIDE_SEQUENCE, "the sequence"),
+                        ),
+                        listOf(
+                            ReferenceSequence(FIRST_AMINO_ACID_SEQUENCE, "the sequence"),
+                            ReferenceSequence(SECOND_AMINO_ACID_SEQUENCE, "the sequence"),
                         ),
                     ),
                 ),

--- a/backend/src/test/resources/backend_config.json
+++ b/backend/src/test/resources/backend_config.json
@@ -4,25 +4,23 @@
     "backendUrl": "http://dummy-backend.com",
     "organisms": {
         "dummyOrganism": {
-            "referenceGenomes": {
-                "singleReference": {
-                    "nucleotideSequences": [
-                        {
-                            "name": "main",
-                            "sequence": "ATTAAAGGTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCT"
-                        }
-                    ],
-                    "genes": [
-                        {
-                            "name": "someLongGene",
-                            "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
-                        },
-                        {
-                            "name": "someShortGene",
-                            "sequence": "MADS"
-                        }
-                    ]
-                }
+            "referenceGenome": {
+                "nucleotideSequences": [
+                    {
+                        "name": "main",
+                        "sequence": "ATTAAAGGTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCT"
+                    }
+                ],
+                "genes": [
+                    {
+                        "name": "someLongGene",
+                        "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
+                    },
+                    {
+                        "name": "someShortGene",
+                        "sequence": "MADS"
+                    }
+                ]
             },
             "schema": {
                 "organismName": "Test",
@@ -105,29 +103,27 @@
             }
         },
         "otherOrganism": {
-            "referenceGenomes": {
-                "singleReference": {
-                    "nucleotideSequences": [
-                        {
-                            "name": "notOnlySegment",
-                            "sequence": "ATCG"
-                        },
-                        {
-                            "name": "secondSegment",
-                            "sequence": "AAAAAAAAAAAAAAAA"
-                        }
-                    ],
-                    "genes": [
-                        {
-                            "name": "someLongGene",
-                            "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
-                        },
-                        {
-                            "name": "someShortGene",
-                            "sequence": "MADS"
-                        }
-                    ]
-                }
+            "referenceGenome": {
+                "nucleotideSequences": [
+                    {
+                        "name": "notOnlySegment",
+                        "sequence": "ATCG"
+                    },
+                    {
+                        "name": "secondSegment",
+                        "sequence": "AAAAAAAAAAAAAAAA"
+                    }
+                ],
+                "genes": [
+                    {
+                        "name": "someLongGene",
+                        "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
+                    },
+                    {
+                        "name": "someShortGene",
+                        "sequence": "MADS"
+                    }
+                ]
             },
             "schema": {
                 "organismName": "Test",
@@ -191,11 +187,9 @@
             }
         },
         "dummyOrganismWithoutConsensusSequences": {
-            "referenceGenomes": {
-                "singleReference": {
-                    "nucleotideSequences": [],
-                    "genes": []
-                }
+            "referenceGenome": {
+                "nucleotideSequences": [],
+                "genes": []
             },
             "schema": {
                 "organismName": "Test without consensus sequences",

--- a/backend/src/test/resources/backend_config_data_use_terms_disabled.json
+++ b/backend/src/test/resources/backend_config_data_use_terms_disabled.json
@@ -1,114 +1,112 @@
 {
-  "accessionPrefix": "LOC_",
-  "websiteUrl": "https://example.com",
-  "backendUrl": "http://dummy-backend.com",
-  "organisms": {
-    "dummyOrganism": {
-      "referenceGenomes": {
-        "singleReference": {
-          "nucleotideSequences": [
-            {
-              "name": "main",
-              "sequence": "ATTAAAGGTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCT"
-            }
-          ],
-          "genes": [
-            {
-              "name": "someLongGene",
-              "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
+    "accessionPrefix": "LOC_",
+    "websiteUrl": "https://example.com",
+    "backendUrl": "http://dummy-backend.com",
+    "organisms": {
+        "dummyOrganism": {
+            "referenceGenome": {
+                "nucleotideSequences": [
+                    {
+                        "name": "main",
+                        "sequence": "ATTAAAGGTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCT"
+                    }
+                ],
+                "genes": [
+                    {
+                        "name": "someLongGene",
+                        "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
+                    },
+                    {
+                        "name": "someShortGene",
+                        "sequence": "MADS"
+                    }
+                ]
             },
-            {
-              "name": "someShortGene",
-              "sequence": "MADS"
+            "schema": {
+                "organismName": "Test",
+                "allowSubmissionOfConsensusSequences": true,
+                "metadata": [
+                    {
+                        "name": "date",
+                        "type": "date",
+                        "required": true
+                    },
+                    {
+                        "name": "dateSubmitted",
+                        "type": "date"
+                    },
+                    {
+                        "name": "region",
+                        "type": "string",
+                        "autocomplete": true,
+                        "required": true
+                    },
+                    {
+                        "name": "country",
+                        "type": "string",
+                        "autocomplete": true,
+                        "required": true
+                    },
+                    {
+                        "name": "division",
+                        "type": "string",
+                        "autocomplete": true
+                    },
+                    {
+                        "name": "host",
+                        "type": "string",
+                        "autocomplete": true
+                    },
+                    {
+                        "name": "age",
+                        "type": "int"
+                    },
+                    {
+                        "name": "sex",
+                        "type": "string",
+                        "autocomplete": true
+                    },
+                    {
+                        "name": "pangoLineage",
+                        "type": "string",
+                        "autocomplete": true
+                    },
+                    {
+                        "name": "qc",
+                        "type": "float"
+                    },
+                    {
+                        "name": "booleanColumn",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "insdcAccessionFull",
+                        "type": "string"
+                    },
+                    {
+                        "name": "other_db_accession",
+                        "type": "string"
+                    }
+                ],
+                "externalMetadata": [
+                    {
+                        "name": "insdcAccessionFull",
+                        "type": "string",
+                        "externalMetadataUpdater": "ena"
+                    },
+                    {
+                        "name": "other_db_accession",
+                        "type": "string",
+                        "externalMetadataUpdater": "other_db"
+                    }
+                ]
             }
-          ]
         }
-      },
-      "schema": {
-        "organismName": "Test",
-        "allowSubmissionOfConsensusSequences": true,
-        "metadata": [
-          {
-            "name": "date",
-            "type": "date",
-            "required": true
-          },
-          {
-            "name": "dateSubmitted",
-            "type": "date"
-          },
-          {
-            "name": "region",
-            "type": "string",
-            "autocomplete": true,
-            "required": true
-          },
-          {
-            "name": "country",
-            "type": "string",
-            "autocomplete": true,
-            "required": true
-          },
-          {
-            "name": "division",
-            "type": "string",
-            "autocomplete": true
-          },
-          {
-            "name": "host",
-            "type": "string",
-            "autocomplete": true
-          },
-          {
-            "name": "age",
-            "type": "int"
-          },
-          {
-            "name": "sex",
-            "type": "string",
-            "autocomplete": true
-          },
-          {
-            "name": "pangoLineage",
-            "type": "string",
-            "autocomplete": true
-          },
-          {
-            "name": "qc",
-            "type": "float"
-          },
-          {
-            "name": "booleanColumn",
-            "type": "boolean"
-          },
-          {
-            "name": "insdcAccessionFull",
-            "type": "string"
-          },
-          {
-            "name": "other_db_accession",
-            "type": "string"
-          }
-        ],
-        "externalMetadata": [
-          {
-            "name": "insdcAccessionFull",
-            "type": "string",
-            "externalMetadataUpdater": "ena"
-          },
-          {
-            "name": "other_db_accession",
-            "type": "string",
-            "externalMetadataUpdater": "other_db"
-          }
-        ]
-      }
+    },
+    "dataUseTerms": {
+        "enabled": false
+    },
+    "s3": {
+        "enabled": false
     }
-  },
-  "dataUseTerms": {
-    "enabled": false
-  },
-  "s3": {
-    "enabled": false
-  }
 }

--- a/backend/src/test/resources/backend_config_s3.json
+++ b/backend/src/test/resources/backend_config_s3.json
@@ -4,25 +4,23 @@
     "backendUrl": "http://dummy-backend.com",
     "organisms": {
         "dummyOrganism": {
-            "referenceGenomes": {
-                "singleReference": {
-                    "nucleotideSequences": [
-                        {
-                            "name": "main",
-                            "sequence": "ATTAAAGGTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCT"
-                        }
-                    ],
-                    "genes": [
-                        {
-                            "name": "someLongGene",
-                            "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
-                        },
-                        {
-                            "name": "someShortGene",
-                            "sequence": "MADS"
-                        }
-                    ]
-                }
+            "referenceGenome": {
+                "nucleotideSequences": [
+                    {
+                        "name": "main",
+                        "sequence": "ATTAAAGGTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCT"
+                    }
+                ],
+                "genes": [
+                    {
+                        "name": "someLongGene",
+                        "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
+                    },
+                    {
+                        "name": "someShortGene",
+                        "sequence": "MADS"
+                    }
+                ]
             },
             "schema": {
                 "organismName": "Test",
@@ -32,15 +30,25 @@
                     "files": {
                         "enabled": true,
                         "categories": [
-                            {"name": "myFileCategory"},
-                            {"name": "myOtherFileCategory"}
+                            {
+                                "name": "myFileCategory"
+                            },
+                            {
+                                "name": "myOtherFileCategory"
+                            }
                         ]
                     }
                 },
                 "files": [
-                    {"name": "myFileCategory"},
-                    {"name": "myOtherFileCategory"},
-                    {"name": "myProcessedOnlyFileCategory"}
+                    {
+                        "name": "myFileCategory"
+                    },
+                    {
+                        "name": "myOtherFileCategory"
+                    },
+                    {
+                        "name": "myProcessedOnlyFileCategory"
+                    }
                 ],
                 "metadata": [
                     {
@@ -120,29 +128,27 @@
             }
         },
         "otherOrganism": {
-            "referenceGenomes": {
-                "singleReference": {
-                    "nucleotideSequences": [
-                        {
-                            "name": "notOnlySegment",
-                            "sequence": "ATCG"
-                        },
-                        {
-                            "name": "secondSegment",
-                            "sequence": "AAAAAAAAAAAAAAAA"
-                        }
-                    ],
-                    "genes": [
-                        {
-                            "name": "someLongGene",
-                            "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
-                        },
-                        {
-                            "name": "someShortGene",
-                            "sequence": "MADS"
-                        }
-                    ]
-                }
+            "referenceGenome": {
+                "nucleotideSequences": [
+                    {
+                        "name": "notOnlySegment",
+                        "sequence": "ATCG"
+                    },
+                    {
+                        "name": "secondSegment",
+                        "sequence": "AAAAAAAAAAAAAAAA"
+                    }
+                ],
+                "genes": [
+                    {
+                        "name": "someLongGene",
+                        "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
+                    },
+                    {
+                        "name": "someShortGene",
+                        "sequence": "MADS"
+                    }
+                ]
             },
             "schema": {
                 "organismName": "Test",
@@ -206,11 +212,9 @@
             }
         },
         "dummyOrganismWithoutConsensusSequences": {
-            "referenceGenomes": {
-                "singleReference": {
-                    "nucleotideSequences": [],
-                    "genes": []
-                }
+            "referenceGenome": {
+                "nucleotideSequences": [],
+                "genes": []
             },
             "schema": {
                 "organismName": "Test without consensus sequences",

--- a/backend/src/test/resources/backend_config_single_segment.json
+++ b/backend/src/test/resources/backend_config_single_segment.json
@@ -7,25 +7,23 @@
     },
     "organisms": {
         "dummyOrganism": {
-            "referenceGenomes": {
-                "singleReference": {
-                    "nucleotideSequences": [
-                        {
-                            "name": "main",
-                            "sequence": "ACGT"
-                        }
-                    ],
-                    "genes": [
-                        {
-                            "name": "someLongGene",
-                            "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
-                        },
-                        {
-                            "name": "someShortGene",
-                            "sequence": "MADS"
-                        }
-                    ]
-              }
+            "referenceGenome": {
+                "nucleotideSequences": [
+                    {
+                        "name": "main",
+                        "sequence": "ACGT"
+                    }
+                ],
+                "genes": [
+                    {
+                        "name": "someLongGene",
+                        "sequence": "AAAAAAAAAAAAAAAAAAAAAAAAA"
+                    },
+                    {
+                        "name": "someShortGene",
+                        "sequence": "MADS"
+                    }
+                ]
             },
             "schema": {
                 "organismName": "Test",

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -370,12 +370,9 @@ organisms:
         externalFields: []
       {{- end }}
       {{- end }}
-    referenceGenomes:
-      {{- range $suborganismName, $referenceGenome := $instance.referenceGenomes }}
-      {{ $suborganismName }}:
-        {{ $referenceGenomes := include "loculus.generateReferenceGenome" $referenceGenome | fromYaml }}
-        {{ $referenceGenomes | toYaml | nindent 10 }}
-      {{- end }}
+    referenceGenome:
+      {{- $referenceGenome := include "loculus.mergeReferenceGenomes" $instance.referenceGenomes | fromYaml }}
+      {{ $referenceGenome | toYaml | nindent 10 }}
   {{- end }}
 {{- end }}
 

--- a/kubernetes/loculus/templates/lapis-silo-database-config.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-database-config.yaml
@@ -25,7 +25,7 @@ data:
     {{- end }}
 
   reference_genomes.json: |
-    {{ include "loculus.mergeReferenceGenomes" $instance.referenceGenomes | fromYaml | toJson}}
+    {{ include "loculus.mergeReferenceGenomes" $instance.referenceGenomes | fromYaml | toJson }}
 
   silo_import_job.sh: |
     {{ range $importScriptLines }}


### PR DESCRIPTION
Instead of the full non-merged reference genomes, only supply the merged one to the backend. That should give as a working preview with entero-viruses fastest.
The validation of the preprocessing results will simply work with that.
The initial submission will still be in the multi segmented style, but we can tackle that later.

Apparently requires https://github.com/loculus-project/loculus/pull/4767 to have working ingest for the EVs.

This is a partial revert of #4692:
- The values.yaml config changes stay (extra level of hierarchy for each suborganism)
- The rename in backend of `referenceGenomes` -> `referenceGenome` stays but the backend config goes back to what it was before, flat.
- Website changes stay

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
  - the organisms on the preview still seem to work as before.

🚀 Preview: https://onlymergedrefgenomeforbac.loculus.org