### PR TITLE
feat(website): multi pathogen support: sequence details page: only show relevant mutation references

### DIFF
--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -422,6 +422,11 @@
                   "type": "string",
                   "enum": ["ascending", "descending"],
                   "description": "Default order direction."
+                },
+                "suborganismIdentifierField": {
+                  "groups": ["schema"],
+                  "type": "string",
+                  "description": "Must be set in the multi pathogen case. This metadata field is used to determine which suborganism a sequence entry belongs to."
                 }
               }
             }

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1843,6 +1843,7 @@ defaultOrganisms:
           - segment
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
+        suborganismIdentifierField: genotype
     preprocessing:
       - <<: *preprocessing
         configFile:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1772,7 +1772,7 @@ defaultOrganisms:
             sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/cchf/NP.fasta]]"
   enteroviruses:
     <<: *defaultOrganismConfig
-    enabled: false
+    enabled: true
     schema:
       <<: *schema
       organismName: "Enterovirus"

--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx
@@ -9,7 +9,11 @@ import { approxMaxAcceptableUrlLength } from '../../../routes/routes.ts';
 import { IS_REVOCATION_FIELD, VERSION_STATUS_FIELD } from '../../../settings.ts';
 import type { Metadata } from '../../../types/config.ts';
 import { versionStatuses } from '../../../types/lapis';
-import type { ReferenceGenomesSequenceNames, ReferenceAccession } from '../../../types/referencesGenomes.ts';
+import {
+    type ReferenceGenomesSequenceNames,
+    type ReferenceAccession,
+    SINGLE_REFERENCE,
+} from '../../../types/referencesGenomes.ts';
 import { MetadataFilterSchema } from '../../../utils/search.ts';
 
 vi.mock('./FieldSelector/FieldSelectorModal.tsx', () => ({
@@ -24,9 +28,11 @@ const defaultAccession: ReferenceAccession = {
 };
 
 const defaultReferenceGenome: ReferenceGenomesSequenceNames = {
-    nucleotideSequences: ['main'],
-    genes: ['gene1', 'gene2'],
-    insdcAccessionFull: [defaultAccession],
+    [SINGLE_REFERENCE]: {
+        nucleotideSequences: ['main'],
+        genes: ['gene1', 'gene2'],
+        insdcAccessionFull: [defaultAccession],
+    },
 };
 
 const defaultLapisUrl = 'https://lapis';
@@ -136,7 +142,7 @@ describe('DownloadDialog', () => {
                     field1: 'value1',
                 },
                 {},
-                { nucleotideSequences: [], genes: [], insdcAccessionFull: [] },
+                { [SINGLE_REFERENCE]: { nucleotideSequences: [], genes: [], insdcAccessionFull: [] } },
             ),
         });
         await checkAgreement();
@@ -274,7 +280,7 @@ describe('DownloadDialog', () => {
                     field2: 'value2',
                 },
                 {},
-                { nucleotideSequences: [], genes: [], insdcAccessionFull: [] },
+                { [SINGLE_REFERENCE]: { nucleotideSequences: [], genes: [], insdcAccessionFull: [] } },
             ),
         });
         await checkAgreement();
@@ -323,7 +329,7 @@ describe('DownloadDialog', () => {
                         field1: 'value1',
                     },
                     {},
-                    { nucleotideSequences: [], genes: [], insdcAccessionFull: [] },
+                    { [SINGLE_REFERENCE]: { nucleotideSequences: [], genes: [], insdcAccessionFull: [] } },
                 ),
             });
 

--- a/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
@@ -55,7 +55,7 @@ export const DownloadForm: FC<DownloadFormProps> = ({
 
     const [isFieldSelectorOpen, setIsFieldSelectorOpen] = useState(false);
 
-    const {nucleotideSequences,genes  } = getFirstSequenceNames(referenceGenomesSequenceNames);
+    const { nucleotideSequences, genes } = getFirstSequenceNames(referenceGenomesSequenceNames);
 
     const isMultiSegmented = nucleotideSequences.length > 1;
 
@@ -68,18 +68,14 @@ export const DownloadForm: FC<DownloadFormProps> = ({
             case 1:
                 downloadDataType = {
                     type: 'unalignedNucleotideSequences',
-                    segment: isMultiSegmented
-                        ? nucleotideSequences[unalignedNucleotideSequence]
-                        : undefined,
+                    segment: isMultiSegmented ? nucleotideSequences[unalignedNucleotideSequence] : undefined,
                     includeRichFastaHeaders: includeRichFastaHeaders === 1,
                 };
                 break;
             case 2:
                 downloadDataType = {
                     type: 'alignedNucleotideSequences',
-                    segment: isMultiSegmented
-                        ? nucleotideSequences[alignedNucleotideSequence]
-                        : undefined,
+                    segment: isMultiSegmented ? nucleotideSequences[alignedNucleotideSequence] : undefined,
                 };
                 break;
             case 3:

--- a/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
@@ -9,7 +9,7 @@ import { routes } from '../../../routes/routes.ts';
 import { ACCESSION_VERSION_FIELD } from '../../../settings.ts';
 import type { Metadata } from '../../../types/config.ts';
 import type { Schema } from '../../../types/config.ts';
-import type { ReferenceGenomesSequenceNames } from '../../../types/referencesGenomes.ts';
+import { getFirstSequenceNames, type ReferenceGenomesSequenceNames } from '../../../types/referencesGenomes.ts';
 
 type DownloadFormProps = {
     referenceGenomesSequenceNames: ReferenceGenomesSequenceNames;
@@ -55,7 +55,9 @@ export const DownloadForm: FC<DownloadFormProps> = ({
 
     const [isFieldSelectorOpen, setIsFieldSelectorOpen] = useState(false);
 
-    const isMultiSegmented = referenceGenomesSequenceNames.nucleotideSequences.length > 1;
+    const {nucleotideSequences,genes  } = getFirstSequenceNames(referenceGenomesSequenceNames);
+
+    const isMultiSegmented = nucleotideSequences.length > 1;
 
     useEffect(() => {
         let downloadDataType: DownloadDataType;
@@ -67,7 +69,7 @@ export const DownloadForm: FC<DownloadFormProps> = ({
                 downloadDataType = {
                     type: 'unalignedNucleotideSequences',
                     segment: isMultiSegmented
-                        ? referenceGenomesSequenceNames.nucleotideSequences[unalignedNucleotideSequence]
+                        ? nucleotideSequences[unalignedNucleotideSequence]
                         : undefined,
                     includeRichFastaHeaders: includeRichFastaHeaders === 1,
                 };
@@ -76,14 +78,14 @@ export const DownloadForm: FC<DownloadFormProps> = ({
                 downloadDataType = {
                     type: 'alignedNucleotideSequences',
                     segment: isMultiSegmented
-                        ? referenceGenomesSequenceNames.nucleotideSequences[alignedNucleotideSequence]
+                        ? nucleotideSequences[alignedNucleotideSequence]
                         : undefined,
                 };
                 break;
             case 3:
                 downloadDataType = {
                     type: 'alignedAminoAcidSequences',
-                    gene: referenceGenomesSequenceNames.genes[alignedAminoAcidSequence],
+                    gene: genes[alignedAminoAcidSequence],
                 };
                 break;
             default:
@@ -106,8 +108,8 @@ export const DownloadForm: FC<DownloadFormProps> = ({
         alignedAminoAcidSequence,
         includeRichFastaHeaders,
         isMultiSegmented,
-        referenceGenomesSequenceNames.nucleotideSequences,
-        referenceGenomesSequenceNames.genes,
+        nucleotideSequences,
+        genes,
         onChange,
         selectedFields,
     ]);
@@ -134,7 +136,7 @@ export const DownloadForm: FC<DownloadFormProps> = ({
                           {isMultiSegmented ? (
                               <DropdownOptionBlock
                                   name='unalignedNucleotideSequences'
-                                  options={referenceGenomesSequenceNames.nucleotideSequences.map((segment) => ({
+                                  options={nucleotideSequences.map((segment) => ({
                                       label: <>{segment}</>,
                                   }))}
                                   selected={unalignedNucleotideSequence}
@@ -162,7 +164,7 @@ export const DownloadForm: FC<DownloadFormProps> = ({
                       <div className='px-8'>
                           <DropdownOptionBlock
                               name='alignedNucleotideSequences'
-                              options={referenceGenomesSequenceNames.nucleotideSequences.map((gene) => ({
+                              options={nucleotideSequences.map((gene) => ({
                                   label: <>{gene}</>,
                               }))}
                               selected={alignedNucleotideSequence}
@@ -178,7 +180,7 @@ export const DownloadForm: FC<DownloadFormProps> = ({
                       <div className='px-8'>
                           <DropdownOptionBlock
                               name='alignedAminoAcidSequences'
-                              options={referenceGenomesSequenceNames.genes.map((gene) => ({
+                              options={genes.map((gene) => ({
                                   label: <>{gene}</>,
                               }))}
                               selected={alignedAminoAcidSequence}

--- a/website/src/components/SearchPage/DownloadDialog/SequenceFilters.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/SequenceFilters.tsx
@@ -1,5 +1,5 @@
 import { type FieldValues } from '../../../types/config.ts';
-import type { ReferenceGenomesSequenceNames } from '../../../types/referencesGenomes.ts';
+import { type ReferenceGenomesSequenceNames, SINGLE_REFERENCE } from '../../../types/referencesGenomes.ts';
 import { intoMutationSearchParams } from '../../../utils/mutation.ts';
 import { MetadataFilterSchema } from '../../../utils/search.ts';
 
@@ -7,6 +7,7 @@ import { MetadataFilterSchema } from '../../../utils/search.ts';
  TODO(#3451) we should use `unknown` or proper types instead of `any` */
 
 export type LapisSearchParameters = Record<string, any>;
+
 export interface SequenceFilter {
     /**
      * Whether this filter is actually filtering anything or not.
@@ -74,7 +75,7 @@ export class FieldFilterSet implements SequenceFilter {
             new MetadataFilterSchema([]),
             {},
             {},
-            { nucleotideSequences: [], genes: [], insdcAccessionFull: [] },
+            { [SINGLE_REFERENCE]: { nucleotideSequences: [], genes: [], insdcAccessionFull: [] } },
         );
     }
 

--- a/website/src/components/SearchPage/SearchForm.spec.tsx
+++ b/website/src/components/SearchPage/SearchForm.spec.tsx
@@ -6,7 +6,11 @@ import { describe, expect, it, vi } from 'vitest';
 import { SearchForm } from './SearchForm';
 import { testConfig, testOrganism } from '../../../vitest.setup.ts';
 import type { MetadataFilter } from '../../types/config.ts';
-import type { ReferenceGenomesSequenceNames, ReferenceAccession } from '../../types/referencesGenomes.ts';
+import {
+    type ReferenceGenomesSequenceNames,
+    type ReferenceAccession,
+    SINGLE_REFERENCE,
+} from '../../types/referencesGenomes.ts';
 import { MetadataFilterSchema } from '../../utils/search.ts';
 
 global.ResizeObserver = class FakeResizeObserver {
@@ -40,9 +44,11 @@ const defaultAccession: ReferenceAccession = {
 };
 
 const defaultReferenceGenomesSequenceNames: ReferenceGenomesSequenceNames = {
-    nucleotideSequences: ['main'],
-    genes: ['gene1', 'gene2'],
-    insdcAccessionFull: [defaultAccession],
+    [SINGLE_REFERENCE]: {
+        nucleotideSequences: ['main'],
+        genes: ['gene1', 'gene2'],
+        insdcAccessionFull: [defaultAccession],
+    },
 };
 
 const searchVisibilities = new Map<string, boolean>([

--- a/website/src/components/SearchPage/SearchFullUI.spec.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.spec.tsx
@@ -7,7 +7,11 @@ import { type InnerSearchFullUIProps, SearchFullUI } from './SearchFullUI';
 import { testConfig, testOrganism } from '../../../vitest.setup.ts';
 import { lapisClientHooks } from '../../services/serviceHooks.ts';
 import type { FieldValues, MetadataFilter, Schema } from '../../types/config.ts';
-import type { ReferenceAccession, ReferenceGenomesSequenceNames } from '../../types/referencesGenomes.ts';
+import type {
+    ReferenceAccession,
+    ReferenceGenomesSequenceNames,
+    SINGLE_REFERENCE,
+} from '../../types/referencesGenomes.ts';
 import type { ClientConfig } from '../../types/runtimeConfig.ts';
 
 global.ResizeObserver = class FakeResizeObserver {
@@ -70,9 +74,11 @@ const defaultAccession: ReferenceAccession = {
 };
 
 const defaultReferenceGenomesSequenceNames: ReferenceGenomesSequenceNames = {
-    nucleotideSequences: ['main'],
-    genes: ['gene1', 'gene2'],
-    insdcAccessionFull: [defaultAccession],
+    [SINGLE_REFERENCE]: {
+        nucleotideSequences: ['main'],
+        genes: ['gene1', 'gene2'],
+        insdcAccessionFull: [defaultAccession],
+    },
 };
 
 function renderSearchFullUI({

--- a/website/src/components/SearchPage/SearchFullUI.spec.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.spec.tsx
@@ -7,9 +7,9 @@ import { type InnerSearchFullUIProps, SearchFullUI } from './SearchFullUI';
 import { testConfig, testOrganism } from '../../../vitest.setup.ts';
 import { lapisClientHooks } from '../../services/serviceHooks.ts';
 import type { FieldValues, MetadataFilter, Schema } from '../../types/config.ts';
-import type {
-    ReferenceAccession,
-    ReferenceGenomesSequenceNames,
+import {
+    type ReferenceAccession,
+    type ReferenceGenomesSequenceNames,
     SINGLE_REFERENCE,
 } from '../../types/referencesGenomes.ts';
 import type { ClientConfig } from '../../types/runtimeConfig.ts';

--- a/website/src/components/SearchPage/fields/MutationField.spec.tsx
+++ b/website/src/components/SearchPage/fields/MutationField.spec.tsx
@@ -3,7 +3,11 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
 
 import { MutationField } from './MutationField.tsx';
-import type { ReferenceGenomesSequenceNames, ReferenceAccession } from '../../../types/referencesGenomes.ts';
+import {
+    type ReferenceGenomesSequenceNames,
+    type ReferenceAccession,
+    SINGLE_REFERENCE,
+} from '../../../types/referencesGenomes.ts';
 
 const singleAccession: ReferenceAccession = {
     name: 'main',
@@ -11,9 +15,11 @@ const singleAccession: ReferenceAccession = {
 };
 
 const singleSegmentedReferenceGenome: ReferenceGenomesSequenceNames = {
-    nucleotideSequences: ['main'],
-    genes: ['gene1', 'gene2'],
-    insdcAccessionFull: [singleAccession],
+    [SINGLE_REFERENCE]: {
+        nucleotideSequences: ['main'],
+        genes: ['gene1', 'gene2'],
+        insdcAccessionFull: [singleAccession],
+    },
 };
 
 const multiAccession1: ReferenceAccession = {
@@ -27,9 +33,11 @@ const multiAccession2: ReferenceAccession = {
 };
 
 const multiSegmentedReferenceGenome: ReferenceGenomesSequenceNames = {
-    nucleotideSequences: ['seg1', 'seg2'],
-    genes: ['gene1', 'gene2'],
-    insdcAccessionFull: [multiAccession1, multiAccession2],
+    [SINGLE_REFERENCE]: {
+        nucleotideSequences: ['seg1', 'seg2'],
+        genes: ['gene1', 'gene2'],
+        insdcAccessionFull: [multiAccession1, multiAccession2],
+    },
 };
 
 function renderField(

--- a/website/src/components/SequenceDetailsPage/DataTable.tsx
+++ b/website/src/components/SequenceDetailsPage/DataTable.tsx
@@ -6,13 +6,17 @@ import ReferenceSequenceLinkButton from './ReferenceSequenceLinkButton';
 import { type DataTableData } from './getDataTableData';
 import { type TableDataEntry } from './types';
 import { type DataUseTermsHistoryEntry } from '../../types/backend';
-import { type ReferenceAccession } from '../../types/referencesGenomes';
+import {
+    getFirstSequenceNames,
+    type ReferenceAccession,
+    type ReferenceGenomesSequenceNames,
+} from '../../types/referencesGenomes';
 import AkarInfo from '~icons/ri/information-line';
 
 interface Props {
     dataTableData: DataTableData;
     dataUseTermsHistory: DataUseTermsHistoryEntry[];
-    reference: ReferenceAccession[];
+    referenceGenomeSequenceNames: ReferenceGenomesSequenceNames;
 }
 
 const ReferenceDisplay = ({ reference }: { reference: ReferenceAccession[] }) => {
@@ -31,8 +35,8 @@ const ReferenceDisplay = ({ reference }: { reference: ReferenceAccession[] }) =>
     ));
 };
 
-const DataTableComponent: React.FC<Props> = ({ dataTableData, dataUseTermsHistory, reference }) => {
-    const hasReferenceAccession = reference.filter((item) => item.insdcAccessionFull !== undefined).length > 0;
+const DataTableComponent: React.FC<Props> = ({ dataTableData, dataUseTermsHistory, referenceGenomeSequenceNames }) => {
+    const hasReferenceAccession = getFirstSequenceNames(referenceGenomeSequenceNames).insdcAccessionFull.filter((item) => item.insdcAccessionFull !== undefined).length > 0;
 
     return (
         <div>

--- a/website/src/components/SequenceDetailsPage/DataTable.tsx
+++ b/website/src/components/SequenceDetailsPage/DataTable.tsx
@@ -7,9 +7,9 @@ import { type DataTableData } from './getDataTableData';
 import { type TableDataEntry } from './types';
 import { type DataUseTermsHistoryEntry } from '../../types/backend';
 import {
-    getFirstSequenceNames,
     type ReferenceAccession,
     type ReferenceGenomesSequenceNames,
+    type Suborganism,
 } from '../../types/referencesGenomes';
 import AkarInfo from '~icons/ri/information-line';
 
@@ -17,6 +17,7 @@ interface Props {
     dataTableData: DataTableData;
     dataUseTermsHistory: DataUseTermsHistoryEntry[];
     referenceGenomeSequenceNames: ReferenceGenomesSequenceNames;
+    suborganism: Suborganism;
 }
 
 const ReferenceDisplay = ({ reference }: { reference: ReferenceAccession[] }) => {
@@ -35,8 +36,14 @@ const ReferenceDisplay = ({ reference }: { reference: ReferenceAccession[] }) =>
     ));
 };
 
-const DataTableComponent: React.FC<Props> = ({ dataTableData, dataUseTermsHistory, referenceGenomeSequenceNames }) => {
-    const hasReferenceAccession = getFirstSequenceNames(referenceGenomeSequenceNames).insdcAccessionFull.filter((item) => item.insdcAccessionFull !== undefined).length > 0;
+const DataTableComponent: React.FC<Props> = ({
+    dataTableData,
+    dataUseTermsHistory,
+    referenceGenomeSequenceNames,
+    suborganism,
+}) => {
+    const reference = referenceGenomeSequenceNames[suborganism].insdcAccessionFull;
+    const hasReferenceAccession = reference.filter((item) => item.insdcAccessionFull !== undefined).length > 0;
 
     return (
         <div>

--- a/website/src/components/SequenceDetailsPage/RevocationEntryDataTable.astro
+++ b/website/src/components/SequenceDetailsPage/RevocationEntryDataTable.astro
@@ -44,8 +44,10 @@ const relevantFieldsForRevocationVersions = [
 
 const relevantData = tableData.filter((entry) => relevantFieldsForRevocationVersions.includes(entry.name));
 const dataTableData = getDataTableData(relevantData);
-
-const reference = referenceGenomeSequenceNames.insdcAccessionFull;
 ---
 
-<DataTable dataTableData={dataTableData} dataUseTermsHistory={dataUseTermsHistory} reference={reference} />
+<DataTable
+    dataTableData={dataTableData}
+    dataUseTermsHistory={dataUseTermsHistory}
+    referenceGenomeSequenceNames={referenceGenomeSequenceNames}
+/>

--- a/website/src/components/SequenceDetailsPage/RevocationEntryDataTable.astro
+++ b/website/src/components/SequenceDetailsPage/RevocationEntryDataTable.astro
@@ -17,15 +17,16 @@ import {
     DATA_USE_TERMS_FIELD,
 } from '../../settings';
 import { type DataUseTermsHistoryEntry } from '../../types/backend';
-import type { ReferenceGenomesSequenceNames } from '../../types/referencesGenomes';
+import type { ReferenceGenomesSequenceNames, Suborganism } from '../../types/referencesGenomes';
 
 interface Props {
     tableData: TableDataEntry[];
     dataUseTermsHistory: DataUseTermsHistoryEntry[];
     referenceGenomeSequenceNames: ReferenceGenomesSequenceNames;
+    suborganism: Suborganism;
 }
 
-const { tableData, dataUseTermsHistory, referenceGenomeSequenceNames } = Astro.props;
+const { tableData, dataUseTermsHistory, referenceGenomeSequenceNames, suborganism } = Astro.props;
 
 const relevantFieldsForRevocationVersions = [
     ACCESSION_VERSION_FIELD,
@@ -49,5 +50,6 @@ const dataTableData = getDataTableData(relevantData);
 <DataTable
     dataTableData={dataTableData}
     dataUseTermsHistory={dataUseTermsHistory}
+    suborganism={suborganism}
     referenceGenomeSequenceNames={referenceGenomeSequenceNames}
 />

--- a/website/src/components/SequenceDetailsPage/SequenceContainer.spec.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceContainer.spec.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
-import React, { act } from 'react';
+import { act } from 'react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { SequencesContainer } from './SequencesContainer.tsx';

--- a/website/src/components/SequenceDetailsPage/SequenceContainer.spec.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceContainer.spec.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { SequencesContainer } from './SequencesContainer.tsx';
 import { mockRequest, testConfig, testOrganism } from '../../../vitest.setup.ts';
+import { type NucleotideSegmentNames, SINGLE_REFERENCE } from '../../types/referencesGenomes.ts';
 
 vi.mock('../../config', () => ({
     getLapisUrl: vi.fn().mockReturnValue('http://lapis.dummy'),
@@ -16,15 +17,23 @@ const accessionVersion = 'accession';
 function renderSequenceViewer({
     nucleotideSegmentNames,
     genes,
-}: Pick<React.ComponentProps<typeof SequencesContainer>, 'nucleotideSegmentNames' | 'genes'>) {
+}: {
+    nucleotideSegmentNames: NucleotideSegmentNames;
+    genes: string[];
+}) {
     render(
         <QueryClientProvider client={queryClient}>
             <SequencesContainer
                 organism={testOrganism}
                 accessionVersion={accessionVersion}
                 clientConfig={testConfig.public}
-                genes={genes}
-                nucleotideSegmentNames={nucleotideSegmentNames}
+                referenceGenomeSequenceNames={{
+                    [SINGLE_REFERENCE]: {
+                        genes,
+                        nucleotideSequences: nucleotideSegmentNames,
+                        insdcAccessionFull: [],
+                    },
+                }}
                 loadSequencesAutomatically={false}
             />
         </QueryClientProvider>,

--- a/website/src/components/SequenceDetailsPage/SequenceDataUI.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceDataUI.tsx
@@ -10,7 +10,7 @@ import { routes } from '../../routes/routes';
 import { DATA_USE_TERMS_FIELD } from '../../settings.ts';
 import { type DataUseTermsHistoryEntry, type Group, type RestrictedDataUseTerms } from '../../types/backend';
 import { type Schema, type SequenceFlaggingConfig } from '../../types/config';
-import { type ReferenceGenomesSequenceNames } from '../../types/referencesGenomes';
+import { type ReferenceGenomesSequenceNames, type Suborganism } from '../../types/referencesGenomes';
 import { type ClientConfig } from '../../types/runtimeConfig';
 import { EditDataUseTermsButton } from '../DataUseTerms/EditDataUseTermsButton';
 import RestrictedUseWarning from '../common/RestrictedUseWarning';
@@ -19,6 +19,7 @@ import MdiEye from '~icons/mdi/eye';
 interface Props {
     tableData: TableDataEntry[];
     organism: string;
+    suborganism: Suborganism;
     accessionVersion: string;
     dataUseTermsHistory: DataUseTermsHistoryEntry[];
     schema: Schema;
@@ -32,6 +33,7 @@ interface Props {
 export const SequenceDataUI: FC<Props> = ({
     tableData,
     organism,
+    suborganism,
     accessionVersion,
     dataUseTermsHistory,
     schema,
@@ -62,6 +64,7 @@ export const SequenceDataUI: FC<Props> = ({
             {isRestricted && <RestrictedUseWarning />}
             <DataTable
                 dataTableData={dataTableData}
+                suborganism={suborganism}
                 dataUseTermsHistory={dataUseTermsHistory}
                 referenceGenomeSequenceNames={referenceGenomeSequenceNames}
             />

--- a/website/src/components/SequenceDetailsPage/SequenceDataUI.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceDataUI.tsx
@@ -51,10 +51,6 @@ export const SequenceDataUI: FC<Props> = ({
     const dataUseTerms = tableData.find((entry) => entry.name === DATA_USE_TERMS_FIELD);
     const isRestricted = dataUseTerms?.value.toString().toUpperCase() === 'RESTRICTED';
 
-    const genes = referenceGenomeSequenceNames.genes;
-    const nucleotideSegmentNames = referenceGenomeSequenceNames.nucleotideSequences;
-    const reference = referenceGenomeSequenceNames.insdcAccessionFull;
-
     const loadSequencesAutomatically = schema.loadSequencesAutomatically === true;
 
     const dataTableData = getDataTableData(tableData);
@@ -64,15 +60,18 @@ export const SequenceDataUI: FC<Props> = ({
     return (
         <>
             {isRestricted && <RestrictedUseWarning />}
-            <DataTable dataTableData={dataTableData} dataUseTermsHistory={dataUseTermsHistory} reference={reference} />
+            <DataTable
+                dataTableData={dataTableData}
+                dataUseTermsHistory={dataUseTermsHistory}
+                referenceGenomeSequenceNames={referenceGenomeSequenceNames}
+            />
             {schema.submissionDataTypes.consensusSequences && (
                 <div className='mt-10'>
                     <SequencesContainer
                         organism={organism}
                         accessionVersion={accessionVersion}
                         clientConfig={clientConfig}
-                        genes={genes}
-                        nucleotideSegmentNames={nucleotideSegmentNames}
+                        referenceGenomeSequenceNames={referenceGenomeSequenceNames}
                         loadSequencesAutomatically={loadSequencesAutomatically}
                     />
                 </div>

--- a/website/src/components/SequenceDetailsPage/SequencesContainer.tsx
+++ b/website/src/components/SequenceDetailsPage/SequencesContainer.tsx
@@ -1,7 +1,11 @@
 import { type Dispatch, type FC, type SetStateAction, useState, useEffect } from 'react';
 
 import { SequencesViewer } from './SequenceViewer';
-import type { NucleotideSegmentNames, ReferenceGenomesSequenceNames } from '../../types/referencesGenomes.ts';
+import {
+    getFirstSequenceNames,
+    type NucleotideSegmentNames,
+    type ReferenceGenomesSequenceNames,
+} from '../../types/referencesGenomes.ts';
 import type { ClientConfig } from '../../types/runtimeConfig';
 import {
     alignedSequenceSegment,
@@ -30,6 +34,8 @@ export const InnerSequencesContainer: FC<SequenceContainerProps> = ({
     referenceGenomeSequenceNames,
     loadSequencesAutomatically,
 }) => {
+    const { nucleotideSequences: nucleotideSegmentNames, genes } = getFirstSequenceNames(referenceGenomeSequenceNames);
+
     const [loadSequences, setLoadSequences] = useState(false);
     useEffect(() => {
         if (loadSequencesAutomatically) {

--- a/website/src/components/SequenceDetailsPage/SequencesContainer.tsx
+++ b/website/src/components/SequenceDetailsPage/SequencesContainer.tsx
@@ -1,7 +1,7 @@
 import { type Dispatch, type FC, type SetStateAction, useState, useEffect } from 'react';
 
 import { SequencesViewer } from './SequenceViewer';
-import type { NucleotideSegmentNames } from '../../types/referencesGenomes.ts';
+import type { NucleotideSegmentNames, ReferenceGenomesSequenceNames } from '../../types/referencesGenomes.ts';
 import type { ClientConfig } from '../../types/runtimeConfig';
 import {
     alignedSequenceSegment,
@@ -19,8 +19,7 @@ type SequenceContainerProps = {
     organism: string;
     accessionVersion: string;
     clientConfig: ClientConfig;
-    genes: string[];
-    nucleotideSegmentNames: NucleotideSegmentNames;
+    referenceGenomeSequenceNames: ReferenceGenomesSequenceNames;
     loadSequencesAutomatically: boolean;
 };
 
@@ -28,8 +27,7 @@ export const InnerSequencesContainer: FC<SequenceContainerProps> = ({
     organism,
     accessionVersion,
     clientConfig,
-    genes,
-    nucleotideSegmentNames,
+    referenceGenomeSequenceNames,
     loadSequencesAutomatically,
 }) => {
     const [loadSequences, setLoadSequences] = useState(false);

--- a/website/src/components/SequenceDetailsPage/getTableData.spec.ts
+++ b/website/src/components/SequenceDetailsPage/getTableData.spec.ts
@@ -24,6 +24,7 @@ const schema: Schema = {
     submissionDataTypes: {
         consensusSequences: true,
     },
+    suborganismIdentifierField: 'genotype',
 };
 
 const singleReferenceGenomes: ReferenceGenomes = {

--- a/website/src/components/SequenceDetailsPage/getTableData.ts
+++ b/website/src/components/SequenceDetailsPage/getTableData.ts
@@ -70,14 +70,23 @@ export async function getTableData(
 
 function getSuborganism(
     details: Details,
-    _schema: Schema,
+    schema: Schema,
     referenceGenomes: ReferenceGenomes,
     accessionVersion: string,
 ): Result<Suborganism, ProblemDetail> {
     if (SINGLE_REFERENCE in referenceGenomes) {
         return ok(SINGLE_REFERENCE);
     }
-    const suborganismField = 'genotype'; // TODO read from schema
+    const suborganismField = schema.suborganismIdentifierField;
+    if (suborganismField === undefined) {
+        return err({
+            type: 'about:blank',
+            title: 'Invalid configuration',
+            status: 0,
+            detail: `No 'suborganismIdentifierField' has been configured in the schema for organism ${schema.organismName}`,
+            instance: '/seq/' + accessionVersion,
+        });
+    }
     const value = details[suborganismField];
     const suborganismResult = z.string().safeParse(value);
     if (!suborganismResult.success) {

--- a/website/src/components/Submission/FileUpload/SequenceEntryUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/SequenceEntryUploadComponent.tsx
@@ -7,7 +7,7 @@ import { ColumnMappingModal } from './ColumnMappingModal';
 import { FileUploadComponent } from './FileUploadComponent';
 import { FASTA_FILE_KIND, METADATA_FILE_KIND, RawFile, type ProcessedFile } from './fileProcessing';
 import type { InputField } from '../../../types/config';
-import type { ReferenceGenomesSequenceNames } from '../../../types/referencesGenomes';
+import { getFirstSequenceNames, type ReferenceGenomesSequenceNames } from '../../../types/referencesGenomes';
 import { dataUploadDocsUrl } from '../dataUploadDocsUrl';
 import type { ColumnMapping } from './ColumnMapping';
 
@@ -100,10 +100,13 @@ export const SequenceEntryUpload: FC<SequenceEntryUploadProps> = ({
                         unique <i>submissionId</i> for the full multi-segmented sample, e.g. <b>sample1</b>. Sequence
                         data should be a FASTA file with each header indicating the <i>submissionId</i> and the segment,
                         i.e.{' '}
-                        {referenceGenomeSequenceNames.nucleotideSequences.map((name, index) => (
+                        {getFirstSequenceNames(referenceGenomeSequenceNames).nucleotideSequences.map((name, index) => (
                             <span key={index} className='font-bold'>
                                 sample1_{name}
-                                {index !== referenceGenomeSequenceNames.nucleotideSequences.length - 1 ? ', ' : ''}
+                                {index !==
+                                getFirstSequenceNames(referenceGenomeSequenceNames).nucleotideSequences.length - 1
+                                    ? ', '
+                                    : ''}
                             </span>
                         ))}
                         .

--- a/website/src/components/Submission/FormOrUploadWrapper.spec.tsx
+++ b/website/src/components/Submission/FormOrUploadWrapper.spec.tsx
@@ -6,6 +6,7 @@ import { describe, expect, test, vi } from 'vitest';
 import { FormOrUploadWrapper, type FileFactory, type InputError, type SequenceData } from './FormOrUploadWrapper';
 import { SUBMISSION_ID_INPUT_FIELD } from '../../settings';
 import type { InputField } from '../../types/config';
+import { SINGLE_REFERENCE } from '../../types/referencesGenomes.ts';
 
 const DUMMY_METADATA_TEMPLATE_FIELDS = new Map<string, InputField[]>([
     [
@@ -60,9 +61,11 @@ const MockSaveWrapper = ({
                 organism='foo'
                 setFileFactory={setFileFactory}
                 referenceGenomeSequenceNames={{
-                    nucleotideSequences: ['foo', 'bar'],
-                    genes: [],
-                    insdcAccessionFull: [],
+                    [SINGLE_REFERENCE]: {
+                        nucleotideSequences: ['foo', 'bar'],
+                        genes: [],
+                        insdcAccessionFull: [],
+                    },
                 }}
                 metadataTemplateFields={DUMMY_METADATA_TEMPLATE_FIELDS}
                 submissionDataTypes={{

--- a/website/src/components/Submission/FormOrUploadWrapper.tsx
+++ b/website/src/components/Submission/FormOrUploadWrapper.tsx
@@ -5,7 +5,7 @@ import type { ColumnMapping } from './FileUpload/ColumnMapping';
 import { SequenceEntryUpload } from './FileUpload/SequenceEntryUploadComponent';
 import type { ProcessedFile } from './FileUpload/fileProcessing';
 import type { InputField, SubmissionDataTypes } from '../../types/config';
-import type { ReferenceGenomesSequenceNames } from '../../types/referencesGenomes';
+import { getFirstSequenceNames, type ReferenceGenomesSequenceNames } from '../../types/referencesGenomes';
 import { EditableMetadata, MetadataForm } from '../Edit/MetadataForm';
 import { EditableSequences, SequencesForm } from '../Edit/SequencesForm';
 
@@ -63,10 +63,10 @@ export const FormOrUploadWrapper: FC<FormOrUploadWrapperProps> = ({
     submissionDataTypes,
 }) => {
     const enableConsensusSequences = submissionDataTypes.consensusSequences;
-    const isMultiSegmented = referenceGenomeSequenceNames.nucleotideSequences.length > 1;
+    const isMultiSegmented = getFirstSequenceNames(referenceGenomeSequenceNames).nucleotideSequences.length > 1;
     const [editableMetadata, setEditableMetadata] = useState(EditableMetadata.empty());
     const [editableSequences, setEditableSequences] = useState(
-        EditableSequences.fromSequenceNames(referenceGenomeSequenceNames.nucleotideSequences),
+        EditableSequences.fromSequenceNames(getFirstSequenceNames(referenceGenomeSequenceNames).nucleotideSequences),
     );
 
     const [metadataFile, setMetadataFile] = useState<ProcessedFile | undefined>(undefined);

--- a/website/src/components/Submission/SubmissionForm.spec.tsx
+++ b/website/src/components/Submission/SubmissionForm.spec.tsx
@@ -8,7 +8,11 @@ import { SubmissionForm } from './SubmissionForm';
 import { mockRequest, testAccessToken, testConfig, testGroups, testOrganism } from '../../../vitest.setup.ts';
 import { SUBMISSION_ID_INPUT_FIELD } from '../../settings.ts';
 import type { Group, ProblemDetail, SubmissionIdMapping } from '../../types/backend.ts';
-import type { ReferenceAccession, ReferenceGenomesSequenceNames } from '../../types/referencesGenomes.ts';
+import {
+    type ReferenceAccession,
+    type ReferenceGenomesSequenceNames,
+    SINGLE_REFERENCE,
+} from '../../types/referencesGenomes.ts';
 
 vi.mock('../../api', () => ({
     getClientLogger: () => ({
@@ -45,9 +49,11 @@ const defaultAccession: ReferenceAccession = {
 };
 
 const defaultReferenceGenomesSequenceNames: ReferenceGenomesSequenceNames = {
-    nucleotideSequences: ['main'],
-    genes: ['gene1', 'gene2'],
-    insdcAccessionFull: [defaultAccession],
+    [SINGLE_REFERENCE]: {
+        nucleotideSequences: ['main'],
+        genes: ['gene1', 'gene2'],
+        insdcAccessionFull: [defaultAccession],
+    },
 };
 
 function renderSubmissionForm({

--- a/website/src/components/common/ActiveFilters.spec.tsx
+++ b/website/src/components/common/ActiveFilters.spec.tsx
@@ -21,7 +21,13 @@ describe('ActiveFilters', () => {
                             new MetadataFilterSchema([]),
                             { field1: 'value1', mutations: 'A123T,G234C' },
                             {},
-                            { nucleotideSequences: ['main'], genes: [], insdcAccessionFull: [] },
+                            {
+                                [SINGLE_REFERENCE]: {
+                                    nucleotideSequences: ['main'],
+                                    genes: [],
+                                    insdcAccessionFull: [],
+                                },
+                            },
                         )
                     }
                 />,
@@ -62,7 +68,7 @@ describe('ActiveFilters', () => {
                             new MetadataFilterSchema([]),
                             { field1: 'value1' },
                             {},
-                            { nucleotideSequences: [], genes: [], insdcAccessionFull: [] },
+                            { [SINGLE_REFERENCE]: { nucleotideSequences: [], genes: [], insdcAccessionFull: [] } },
                         )
                     }
                     removeFilter={mockRemoveFilter}

--- a/website/src/components/common/ActiveFilters.spec.tsx
+++ b/website/src/components/common/ActiveFilters.spec.tsx
@@ -2,9 +2,9 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ActiveFilters } from './ActiveFilters';
+import { SINGLE_REFERENCE } from '../../types/referencesGenomes.ts';
 import { MetadataFilterSchema } from '../../utils/search';
 import { FieldFilterSet, SequenceEntrySelection } from '../SearchPage/DownloadDialog/SequenceFilters';
-import { SINGLE_REFERENCE } from '../../types/referencesGenomes.ts';
 
 describe('ActiveFilters', () => {
     describe('with LAPIS filters', () => {

--- a/website/src/components/common/ActiveFilters.spec.tsx
+++ b/website/src/components/common/ActiveFilters.spec.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ActiveFilters } from './ActiveFilters';
 import { MetadataFilterSchema } from '../../utils/search';
 import { FieldFilterSet, SequenceEntrySelection } from '../SearchPage/DownloadDialog/SequenceFilters';
+import { SINGLE_REFERENCE } from '../../types/referencesGenomes.ts';
 
 describe('ActiveFilters', () => {
     describe('with LAPIS filters', () => {
@@ -84,7 +85,7 @@ describe('ActiveFilters', () => {
                             new MetadataFilterSchema([{ name: 'releaseTimestamp', type: 'timestamp' }]),
                             { releaseTimestamp: '1742288104' },
                             {},
-                            { nucleotideSequences: [], genes: [], insdcAccessionFull: [] },
+                            { [SINGLE_REFERENCE]: { nucleotideSequences: [], genes: [], insdcAccessionFull: [] } },
                         )
                     }
                 />,
@@ -104,7 +105,7 @@ describe('ActiveFilters', () => {
                             ]),
                             { authorAffiliations: 'foo' },
                             {},
-                            { nucleotideSequences: [], genes: [], insdcAccessionFull: [] },
+                            { [SINGLE_REFERENCE]: { nucleotideSequences: [], genes: [], insdcAccessionFull: [] } },
                         )
                     }
                 />,

--- a/website/src/components/common/ActiveFilters.spec.tsx
+++ b/website/src/components/common/ActiveFilters.spec.tsx
@@ -45,7 +45,7 @@ describe('ActiveFilters', () => {
                             new MetadataFilterSchema([]),
                             { field1: null },
                             {},
-                            { nucleotideSequences: [], genes: [], insdcAccessionFull: [] },
+                            { [SINGLE_REFERENCE]: { nucleotideSequences: [], genes: [], insdcAccessionFull: [] } },
                         )
                     }
                 />,

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -16,6 +16,7 @@ import {
     type NamedSequence,
     type ReferenceAccession,
     type ReferenceGenome,
+    type ReferenceGenomes,
     type ReferenceGenomesSequenceNames,
 } from './types/referencesGenomes.ts';
 import { runtimeConfig, type RuntimeConfig, type ServiceUrls } from './types/runtimeConfig.ts';
@@ -226,8 +227,15 @@ export function getLapisUrl(serviceConfig: ServiceUrls, organism: string): strin
     return serviceConfig.lapisUrls[organism];
 }
 
+/**
+ * TODO(#3984) this should be removed. Use `getReferenceGenomes` instead.
+ */
 export function getReferenceGenome(organism: string): ReferenceGenome {
     return Object.values(getConfig(organism).referenceGenomes)[0];
+}
+
+export function getReferenceGenomes(organism: string): ReferenceGenomes {
+    return getConfig(organism).referenceGenomes;
 }
 
 const getAccession = (n: NamedSequence): ReferenceAccession => {
@@ -238,12 +246,17 @@ const getAccession = (n: NamedSequence): ReferenceAccession => {
 };
 
 export const getReferenceGenomesSequenceNames = (organism: string): ReferenceGenomesSequenceNames => {
-    const referenceGenomes = getReferenceGenome(organism);
-    return {
-        nucleotideSequences: referenceGenomes.nucleotideSequences.map((n) => n.name),
-        genes: referenceGenomes.genes.map((n) => n.name),
-        insdcAccessionFull: referenceGenomes.nucleotideSequences.map((n) => getAccession(n)),
-    };
+    const referenceGenomes = getReferenceGenomes(organism);
+    return Object.fromEntries(
+        Object.entries(referenceGenomes).map(([suborganism, referenceGenome]) => [
+            suborganism,
+            {
+                nucleotideSequences: referenceGenome.nucleotideSequences.map((n) => n.name),
+                genes: referenceGenome.genes.map((n) => n.name),
+                insdcAccessionFull: referenceGenome.nucleotideSequences.map((n) => getAccession(n)),
+            },
+        ]),
+    );
 };
 
 export function seqSetsAreEnabled() {

--- a/website/src/pages/[organism]/submission/edit/[accession]/[version].astro
+++ b/website/src/pages/[organism]/submission/edit/[accession]/[version].astro
@@ -9,8 +9,8 @@ import {
 } from '../../../../../config';
 import BaseLayout from '../../../../../layouts/BaseLayout.astro';
 import { createBackendClient } from '../../../../../services/backendClientFactory';
-import { getAccessToken } from '../../../../../utils/getAccessToken';
 import { getFirstSequenceNames } from '../../../../../types/referencesGenomes';
+import { getAccessToken } from '../../../../../utils/getAccessToken';
 
 const version = Astro.params.version!;
 const accession = Astro.params.accession!;

--- a/website/src/pages/[organism]/submission/edit/[accession]/[version].astro
+++ b/website/src/pages/[organism]/submission/edit/[accession]/[version].astro
@@ -10,6 +10,7 @@ import {
 import BaseLayout from '../../../../../layouts/BaseLayout.astro';
 import { createBackendClient } from '../../../../../services/backendClientFactory';
 import { getAccessToken } from '../../../../../utils/getAccessToken';
+import { getFirstSequenceNames } from '../../../../../types/referencesGenomes';
 
 const version = Astro.params.version!;
 const accession = Astro.params.accession!;
@@ -29,7 +30,7 @@ const accessToken = getAccessToken(Astro.locals.session)!;
 
 const clientConfig = getRuntimeConfig().public;
 const schema = getSchema(organism);
-const segmentNames = getReferenceGenomesSequenceNames(organism).nucleotideSequences;
+const segmentNames = getFirstSequenceNames(getReferenceGenomesSequenceNames(organism)).nucleotideSequences;
 
 const dataToEdit = await createBackendClient().getDataToEdit(organism, accessToken, accession, version);
 ---

--- a/website/src/pages/seq/[accessionVersion]/details.json.ts
+++ b/website/src/pages/seq/[accessionVersion]/details.json.ts
@@ -35,6 +35,7 @@ export const GET: APIRoute = async (req) => {
         dataUseTermsHistory: result.dataUseTermsHistory,
         schema,
         clientConfig,
+        suborganism: result.suborganism,
         isRevocation: result.isRevocation,
         sequenceEntryHistory: result.sequenceEntryHistory,
     };

--- a/website/src/pages/seq/[accessionVersion]/getSequenceDetailsTableData.ts
+++ b/website/src/pages/seq/[accessionVersion]/getSequenceDetailsTableData.ts
@@ -2,12 +2,13 @@ import { Result } from 'neverthrow';
 
 import { getTableData } from '../../../components/SequenceDetailsPage/getTableData';
 import { type TableDataEntry } from '../../../components/SequenceDetailsPage/types.ts';
-import { getSchema } from '../../../config.ts';
+import { getReferenceGenomes, getSchema } from '../../../config.ts';
 import { routes } from '../../../routes/routes.ts';
 import { createBackendClient } from '../../../services/backendClientFactory.ts';
 import { LapisClient } from '../../../services/lapisClient.ts';
 import type { DataUseTermsHistoryEntry, ProblemDetail } from '../../../types/backend.ts';
 import type { SequenceEntryHistory } from '../../../types/lapis.ts';
+import type { Suborganism } from '../../../types/referencesGenomes.ts';
 import { parseAccessionVersionFromString } from '../../../utils/extractAccessionVersion.ts';
 
 export enum SequenceDetailsTableResultType {
@@ -21,6 +22,7 @@ export type TableData = {
     tableData: TableDataEntry[];
     sequenceEntryHistory: SequenceEntryHistory;
     dataUseTermsHistory: DataUseTermsHistoryEntry[];
+    suborganism: Suborganism;
     isRevocation: boolean;
 };
 
@@ -49,9 +51,10 @@ export const getSequenceDetailsTableData = async (
     }
 
     const schema = getSchema(organism);
+    const referenceGenomes = getReferenceGenomes(organism);
 
     const [tableDataResult, sequenceEntryHistoryResult, dataUseHistoryResult] = await Promise.all([
-        getTableData(accessionVersion, schema, lapisClient),
+        getTableData(accessionVersion, schema, referenceGenomes, lapisClient),
         lapisClient.getAllSequenceEntryHistoryForAccession(accession),
         backendClient.getDataUseTermsHistory(accession),
     ]);
@@ -62,6 +65,7 @@ export const getSequenceDetailsTableData = async (
             tableData: tableData.data,
             sequenceEntryHistory,
             dataUseTermsHistory,
+            suborganism: tableData.suborganism,
             isRevocation: tableData.isRevocation,
         }),
     );

--- a/website/src/pages/seq/[accessionVersion]/index.astro
+++ b/website/src/pages/seq/[accessionVersion]/index.astro
@@ -74,6 +74,7 @@ const sequenceFlaggingConfig = getWebsiteConfig().sequenceFlagging;
                                     tableData={result.tableData}
                                     dataUseTermsHistory={result.dataUseTermsHistory}
                                     referenceGenomeSequenceNames={getReferenceGenomesSequenceNames(organism)}
+                                    suborganism={result.suborganism}
                                 />
                             ) : (
                                 <SequenceDataUI

--- a/website/src/pages/seq/[accessionVersion]/index.astro
+++ b/website/src/pages/seq/[accessionVersion]/index.astro
@@ -79,6 +79,7 @@ const sequenceFlaggingConfig = getWebsiteConfig().sequenceFlagging;
                                 <SequenceDataUI
                                     tableData={result.tableData}
                                     organism={organism}
+                                    suborganism={result.suborganism}
                                     referenceGenomeSequenceNames={getReferenceGenomesSequenceNames(organism)}
                                     accessionVersion={accessionVersion}
                                     dataUseTermsHistory={result.dataUseTermsHistory}

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -151,6 +151,7 @@ export const schema = z.object({
     loadSequencesAutomatically: z.boolean().optional(),
     richFastaHeaderFields: z.array(z.string()).optional(),
     linkOuts: z.array(linkOut).optional(),
+    suborganismIdentifierField: z.string().optional(),
 });
 export type Schema = z.infer<typeof schema>;
 

--- a/website/src/types/detailsJson.ts
+++ b/website/src/types/detailsJson.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { dataUseTermsHistoryEntry } from './backend.ts';
 import { schema } from './config.ts';
 import { parsedSequenceEntryHistoryEntrySchema } from './lapis.ts';
+import { suborganism } from './referencesGenomes.ts';
 import { serviceUrls } from './runtimeConfig.ts';
 import { tableDataEntrySchema } from '../components/SequenceDetailsPage/types.ts';
 
@@ -13,6 +14,7 @@ export const detailsJsonSchema = z.object({
     dataUseTermsHistory: z.array(dataUseTermsHistoryEntry),
     schema: schema,
     clientConfig: serviceUrls,
+    suborganism: suborganism,
     isRevocation: z.boolean(),
     sequenceEntryHistory: z.array(parsedSequenceEntryHistoryEntrySchema),
 });

--- a/website/src/types/referencesGenomes.ts
+++ b/website/src/types/referencesGenomes.ts
@@ -37,4 +37,9 @@ export type ReferenceGenomesSequenceNames = Record<
     }
 >;
 
+// TODO(#3984) this should probably be removed when we're done with the feature
+export function getFirstSequenceNames(referenceGenomesSequenceNames: ReferenceGenomesSequenceNames) {
+    return Object.values(referenceGenomesSequenceNames)[0];
+}
+
 export const SINGLE_REFERENCE = 'singleReference';

--- a/website/src/types/referencesGenomes.ts
+++ b/website/src/types/referencesGenomes.ts
@@ -19,6 +19,8 @@ export const referenceGenome = z.object({
 export type ReferenceGenome = z.infer<typeof referenceGenome>;
 
 export const suborganism = z.string();
+export type Suborganism = z.infer<typeof suborganism>;
+
 export const referenceGenomes = z
     .record(suborganism, referenceGenome)
     .refine((value) => Object.entries(value).length > 0, 'The reference genomes must not be empty.');
@@ -26,8 +28,13 @@ export type ReferenceGenomes = z.infer<typeof referenceGenomes>;
 
 export type NucleotideSegmentNames = string[];
 
-export type ReferenceGenomesSequenceNames = {
-    nucleotideSequences: NucleotideSegmentNames;
-    genes: string[];
-    insdcAccessionFull: ReferenceAccession[];
-};
+export type ReferenceGenomesSequenceNames = Record<
+    Suborganism,
+    {
+        nucleotideSequences: NucleotideSegmentNames;
+        genes: string[];
+        insdcAccessionFull: ReferenceAccession[];
+    }
+>;
+
+export const SINGLE_REFERENCE = 'singleReference';

--- a/website/src/utils/mutation.spec.ts
+++ b/website/src/utils/mutation.spec.ts
@@ -7,14 +7,16 @@ import {
     removeMutationQueries,
     intoMutationSearchParams,
 } from './mutation';
-import type { ReferenceGenomesSequenceNames } from '../types/referencesGenomes';
+import { type ReferenceGenomesSequenceNames, SINGLE_REFERENCE } from '../types/referencesGenomes';
 
 describe('mutation', () => {
     describe('single segment', () => {
         const mockReferenceGenomes: ReferenceGenomesSequenceNames = {
-            nucleotideSequences: ['main'],
-            genes: ['GENE1', 'GENE2'],
-            insdcAccessionFull: [],
+            [SINGLE_REFERENCE]: {
+                nucleotideSequences: ['main'],
+                genes: ['GENE1', 'GENE2'],
+                insdcAccessionFull: [],
+            },
         };
 
         it('parses a valid mutation string', () => {
@@ -37,9 +39,11 @@ describe('mutation', () => {
 
     describe('multi-segment', () => {
         const mockReferenceGenomes: ReferenceGenomesSequenceNames = {
-            nucleotideSequences: ['SEQ1', 'SEQ2'],
-            genes: ['GENE1', 'GENE2'],
-            insdcAccessionFull: [],
+            [SINGLE_REFERENCE]: {
+                nucleotideSequences: ['SEQ1', 'SEQ2'],
+                genes: ['GENE1', 'GENE2'],
+                insdcAccessionFull: [],
+            },
         };
 
         it('parses a valid mutation string', () => {

--- a/website/src/utils/mutation.ts
+++ b/website/src/utils/mutation.ts
@@ -1,5 +1,5 @@
 import type { BaseType } from './sequenceTypeHelpers';
-import type { ReferenceGenomesSequenceNames } from '../types/referencesGenomes';
+import { getFirstSequenceNames, type ReferenceGenomesSequenceNames } from '../types/referencesGenomes';
 
 export type MutationType = 'substitutionOrDeletion' | 'insertion';
 
@@ -93,7 +93,7 @@ const isValidAminoAcidInsertionQuery = (
 ): boolean => {
     try {
         // TODO(#3984) make it multi pathogen aware
-        const referenceGenomesSequenceNames = Object.values(referenceGenomesSequenceNames_)[0];
+        const referenceGenomesSequenceNames = getFirstSequenceNames(referenceGenomesSequenceNames_);
         const textUpper = text.toUpperCase();
         if (!textUpper.startsWith('INS_')) {
             return false;
@@ -116,7 +116,7 @@ const isValidAminoAcidMutationQuery = (
 ): boolean => {
     try {
         // TODO(#3984) make it multi pathogen aware
-        const referenceGenomesSequenceNames = Object.values(referenceGenomesSequenceNames_)[0];
+        const referenceGenomesSequenceNames = getFirstSequenceNames(referenceGenomesSequenceNames_);
         const textUpper = text.toUpperCase();
         const [gene, mutation] = textUpper.split(':');
         const existingGenes = new Set(referenceGenomesSequenceNames.genes.map((g) => g.toUpperCase()));
@@ -135,7 +135,7 @@ const isValidNucleotideInsertionQuery = (
 ): boolean => {
     try {
         // TODO(#3984) make it multi pathogen aware
-        const referenceGenomesSequenceNames = Object.values(referenceGenomesSequenceNames_)[0];
+        const referenceGenomesSequenceNames = getFirstSequenceNames(referenceGenomesSequenceNames_);
         const isMultiSegmented = referenceGenomesSequenceNames.nucleotideSequences.length > 1;
         const textUpper = text.toUpperCase();
         if (!textUpper.startsWith('INS_')) {
@@ -172,7 +172,7 @@ const isValidNucleotideMutationQuery = (
 ): boolean => {
     try {
         // TODO(#3984) make it multi pathogen aware
-        const referenceGenomesSequenceNames = Object.values(referenceGenomesSequenceNames_)[0];
+        const referenceGenomesSequenceNames = getFirstSequenceNames(referenceGenomesSequenceNames_);
         const isMultiSegmented = referenceGenomesSequenceNames.nucleotideSequences.length > 1;
         const textUpper = text.toUpperCase();
         let mutation = textUpper;

--- a/website/src/utils/mutation.ts
+++ b/website/src/utils/mutation.ts
@@ -89,9 +89,11 @@ export const intoMutationSearchParams = (
 
 const isValidAminoAcidInsertionQuery = (
     text: string,
-    referenceGenomesSequenceNames: ReferenceGenomesSequenceNames,
+    referenceGenomesSequenceNames_: ReferenceGenomesSequenceNames,
 ): boolean => {
     try {
+        // TODO(#3984) make it multi pathogen aware
+        const referenceGenomesSequenceNames = Object.values(referenceGenomesSequenceNames_)[0];
         const textUpper = text.toUpperCase();
         if (!textUpper.startsWith('INS_')) {
             return false;
@@ -110,9 +112,11 @@ const isValidAminoAcidInsertionQuery = (
 
 const isValidAminoAcidMutationQuery = (
     text: string,
-    referenceGenomesSequenceNames: ReferenceGenomesSequenceNames,
+    referenceGenomesSequenceNames_: ReferenceGenomesSequenceNames,
 ): boolean => {
     try {
+        // TODO(#3984) make it multi pathogen aware
+        const referenceGenomesSequenceNames = Object.values(referenceGenomesSequenceNames_)[0];
         const textUpper = text.toUpperCase();
         const [gene, mutation] = textUpper.split(':');
         const existingGenes = new Set(referenceGenomesSequenceNames.genes.map((g) => g.toUpperCase()));
@@ -127,9 +131,11 @@ const isValidAminoAcidMutationQuery = (
 
 const isValidNucleotideInsertionQuery = (
     text: string,
-    referenceGenomesSequenceNames: ReferenceGenomesSequenceNames,
+    referenceGenomesSequenceNames_: ReferenceGenomesSequenceNames,
 ): boolean => {
     try {
+        // TODO(#3984) make it multi pathogen aware
+        const referenceGenomesSequenceNames = Object.values(referenceGenomesSequenceNames_)[0];
         const isMultiSegmented = referenceGenomesSequenceNames.nucleotideSequences.length > 1;
         const textUpper = text.toUpperCase();
         if (!textUpper.startsWith('INS_')) {
@@ -162,9 +168,11 @@ const isValidNucleotideInsertionQuery = (
 
 const isValidNucleotideMutationQuery = (
     text: string,
-    referenceGenomesSequenceNames: ReferenceGenomesSequenceNames,
+    referenceGenomesSequenceNames_: ReferenceGenomesSequenceNames,
 ): boolean => {
     try {
+        // TODO(#3984) make it multi pathogen aware
+        const referenceGenomesSequenceNames = Object.values(referenceGenomesSequenceNames_)[0];
         const isMultiSegmented = referenceGenomesSequenceNames.nucleotideSequences.length > 1;
         const textUpper = text.toUpperCase();
         let mutation = textUpper;


### PR DESCRIPTION
resolves #4784

This PR contains:
* squashed versions of #4767 and #4770 because they are required to get a working preview (they should be dropped before merging)
* compute the suborganism from the respective LAPIS field
  * Still to do: How do we configure which field that should be? Add a field to `defaultOrganisms.[organism].schema.website`?
* making the `ReferenceGenomesSequenceNames` a dictionary `{ [suborganism]: <the object with the names> } and propagate this through the website (a lot of noise...)
* read the first value of that dictionary almost everywhere
  * This is to keep the website in a working state until it's properly implemented everywhere. The single pathogen case will stay untouched. In the multi pathogen case, some things that are shown on the website might be wrong until follow up PR "fix" it by properly implementing it.
* in the mutations section of the details page, only show the references of the respective sequence entry:
  * `Mutations called relative to the -->this here<-- reference`


### Screenshot
<img width="949" height="413" alt="image" src="https://github.com/user-attachments/assets/3ee3be36-1451-49e9-9acd-68250f169c32" />

### PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [ ] The implemented feature is covered by appropriate, automated tests.
  - I did not find any unit test for the part where the data table is shown to check that it shows the correct references there.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)
  - For enterovirus entries with different genotypes, it only shows the reference of the suborganism (the one that is in the reference genome)
  - For other organisms, it still shows the correct references, too.

🚀 Preview: https://4772-multi-pathogen-suppo.loculus.org