### PR TITLE
fix(preprocessing): fix request id in log message

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/backend.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/backend.py
@@ -121,7 +121,7 @@ def fetch_unprocessed_sequences(
     response = requests.post(url, data=params, headers=headers, timeout=10)
     logger.info(
         f"Unprocessed data from backend: status code {response.status_code}, "
-        "request id: {response.headers.get('x-request-id')}"
+        f"request id: {response.headers.get('x-request-id')}"
     )
     match response.status_code:
         case HTTPStatus.NOT_MODIFIED:


### PR DESCRIPTION
It just showed:
`INFO:loculus_preprocessing.backend:Unprocessed data from backend: status code 200, request id: {response.headers.get('x-request-id')}`



### PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by appropriate, automated tests.~~
~~- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~~

🚀 Preview: Add `preview` label to enable