### PR TITLE
feat(prepro): trim leading/trailing whitespace in string/regex metadata fields 

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -176,32 +176,6 @@ class ProcessingFunctions:
                 ],
             )
         return result
-    
-    @staticmethod
-    def strip_whitespace_from_metadata(
-        input_data: InputMetadata,
-        output_field: str,
-        input_fields: list[str],
-        args: FunctionArgs, 
-    ) -> ProcessingResult:
-        """
-        Removes leading and trailing whitespace from all metadata fields in input_fields.
-        """
-        warnings: list[ProcessingAnnotation] = []
-        errors: list[ProcessingAnnotation] = []
-
-        output_field = {}
-
-        for field in input_fields:
-            value = input_data.get(field)
-            if value is None:
-                continue
-            if not isinstance(value, str):
-                continue
-            output_field[field] = value.strip()
-
-        # Optional: store results under a single dictionary in the output field
-        return ProcessingResult(datum=output_field, warnings=warnings, errors=errors)
 
     @staticmethod
     def check_date(
@@ -932,7 +906,7 @@ class ProcessingFunctions:
                 )
             )
             return ProcessingResult(datum=None, warnings=warnings, errors=errors)
-
+        regex_field = regex_field.strip()
         if re.match(pattern, regex_field):
             return ProcessingResult(datum=regex_field, warnings=warnings, errors=errors)
         errors.append(
@@ -977,6 +951,8 @@ class ProcessingFunctions:
 
         errors: list[ProcessingAnnotation] = []
         output_datum: ProcessedMetadataValue
+        if isinstance(input_datum, str):
+            input_datum = input_datum.strip()
         if args and "type" in args:
             match args["type"]:
                 case "int":
@@ -1014,7 +990,10 @@ class ProcessingFunctions:
                             )
                         )
                 case _:
-                    output_datum = input_datum
+                    if isinstance(input_datum, str):
+                        output_datum = input_datum.strip()
+                    else:
+                        output_datum = input_datum
         else:
             output_datum = input_datum
         return ProcessingResult(datum=output_datum, warnings=[], errors=errors)

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -176,6 +176,32 @@ class ProcessingFunctions:
                 ],
             )
         return result
+    
+    @staticmethod
+    def strip_whitespace_from_metadata(
+        input_data: InputMetadata,
+        output_field: str,
+        input_fields: list[str],
+        args: FunctionArgs, 
+    ) -> ProcessingResult:
+        """
+        Removes leading and trailing whitespace from all metadata fields in input_fields.
+        """
+        warnings: list[ProcessingAnnotation] = []
+        errors: list[ProcessingAnnotation] = []
+
+        output_field = {}
+
+        for field in input_fields:
+            value = input_data.get(field)
+            if value is None:
+                continue
+            if not isinstance(value, str):
+                continue
+            output_field[field] = value.strip()
+
+        # Optional: store results under a single dictionary in the output field
+        return ProcessingResult(datum=output_field, warnings=warnings, errors=errors)
 
     @staticmethod
     def check_date(
@@ -1069,7 +1095,6 @@ class ProcessingFunctions:
                 ],
             )
         return ProcessingResult(datum=output_datum, warnings=[], errors=[])
-
 
 def format_frameshift(input: str | None) -> str | None:
     """

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -951,8 +951,6 @@ class ProcessingFunctions:
 
         errors: list[ProcessingAnnotation] = []
         output_datum: ProcessedMetadataValue
-        if isinstance(input_datum, str):
-            input_datum = input_datum.strip()
         if args and "type" in args:
             match args["type"]:
                 case "int":

--- a/preprocessing/nextclade/tests/test_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_processing_functions.py
@@ -498,6 +498,26 @@ test_case_definitions = [
         expected_errors=[],
         expected_warnings=[],
     ),
+    Case(
+        name="strip_spaces_in_metadata",
+        input_metadata={
+            "submissionId": "strip_spaces_in_metadata",
+            "name_required": "name",
+            "ncbi_required_collection_date": "2022-11-01",
+            "authors": " Smith, John II; Doe, A.B.C. ",
+            "regex_field": " EPI_ISL_123456 ",
+        },
+        accession_id="16",
+        expected_metadata={
+            "name_required": "name",
+            "required_collection_date": "2022-11-01",
+            "concatenated_string": "LOC_16.1/2022-11-01",
+            "authors": "Smith, John II; Doe, A. B. C.",
+            "regex_field": "EPI_ISL_123456",
+        },
+        expected_errors=[],
+        expected_warnings=[],
+    ),
 ]
 
 accepted_authors = {


### PR DESCRIPTION
resolves #4704 

Changes in `def identity(...)` in script `preprocessing_functions.py`:
- Metadata fields with types `int`, `float`, or `boolean` are not affected. For example, if `input_datum = " 3"` and the field is expected to be an `int`, the function converts it with `output_datum = int(input_datum)`, resulting in `input_datum = 3`. In this case, stripping whitespace is unnecessary.
- Metadata fields that are `strings` are now cleaned using `.strip() `to remove leading/trailing spaces and newlines.

Changes in `def check_regex(...)` in script `preprocessing_functions.py`:
- The `regex_field` is handled separately in this function (discovered during testing). To avoid mismatches due to whitespace, `regex_field = regex_field.strip()` has been added.

> **⚠️ Note:** Consider adding more fields to testing, to revise all possible options. Currently added `authors` and `regex_field` in Case `strip_spaces_in_metadata`
