### PR TITLE
chore(ci): Unignore astro for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,8 +19,6 @@ updates:
     - dependency-name: "flowbite-react"
     - dependency-name: "@types/node"
       versions: [">=23"] # Increase when we update node version in .nvmrc
-    - dependency-name: "astro"
-    # see https://github.com/loculus-project/loculus/issues/4662
     groups:
       minor:
         update-types:


### PR DESCRIPTION
resolves: https://github.com/loculus-project/loculus/issues/4468

The issue in question should have been fixed upstream in Astro - https://github.com/withastro/astro/issues/13989

🚀 Preview: Add `preview` label to enable