### PR TITLE
doc(backend): Add description to `/revise`'s fileMapping param

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -104,13 +104,7 @@ open class SubmissionController(
                 " It is the date when the sequence entries will become 'OPEN'." +
                 " Format: YYYY-MM-DD",
         ) @RequestParam restrictedUntil: String?,
-        @Parameter(
-            description =
-            "A JSON object. `{submissionID: {<fileCategory>: [{fileId: <fileId>, name: <fileName>}]}}`. " +
-                "Files first need to be uploaded. Request pre-signed URLs to upload files using the " +
-                "/files/request-upload endpoint.",
-        )
-        @RequestPart fileMapping: String?,
+        @Parameter(description = FILE_MAPPING_DESCRIPTION) @RequestPart fileMapping: String?,
     ): List<SubmissionIdMapping> {
         var innerDataUseTermsType = DataUseTermsType.OPEN
         if (backendConfig.dataUseTerms.enabled) {
@@ -140,13 +134,9 @@ open class SubmissionController(
     fun revise(
         @PathVariable @Valid organism: Organism,
         @HiddenParam authenticatedUser: AuthenticatedUser,
-        @Parameter(
-            description = REVISED_METADATA_FILE_DESCRIPTION,
-        ) @RequestParam metadataFile: MultipartFile,
-        @Parameter(
-            description = SEQUENCE_FILE_DESCRIPTION,
-        ) @RequestParam sequenceFile: MultipartFile?,
-        @RequestPart fileMapping: String?,
+        @Parameter(description = REVISED_METADATA_FILE_DESCRIPTION) @RequestParam metadataFile: MultipartFile,
+        @Parameter(description = SEQUENCE_FILE_DESCRIPTION) @RequestParam sequenceFile: MultipartFile?,
+        @Parameter(description = FILE_MAPPING_DESCRIPTION) @RequestPart fileMapping: String?,
     ): List<SubmissionIdMapping> {
         val fileMappingParsed = parseFileMapping(fileMapping, organism)
         val params = SubmissionParams.RevisionSubmissionParams(

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionControllerDescriptions.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionControllerDescriptions.kt
@@ -30,6 +30,12 @@ If the underlying organism has multiple segments,
 the headers of the fasta file must be of the form '>[$HEADER_TO_CONNECT_METADATA_AND_SEQUENCES]_[segmentName]'.
 """
 
+const val FILE_MAPPING_DESCRIPTION = """
+"A JSON object. `{submissionID: {<fileCategory>: [{fileId: <fileId>, name: <fileName>}]}}`. " +
+        "Files first need to be uploaded. Request pre-signed URLs to upload files using the " +
+        "/files/request-upload endpoint.",
+"""
+
 const val GROUP_ID_DESCRIPTION = """
 The group id of the submitting group which the user is a member of.
 A submitting group is a set of users that share access to the same sequence entries.


### PR DESCRIPTION
Resolves #4801

resolves #

### Screenshot
<img width="2846" height="704" alt="image" src="https://github.com/user-attachments/assets/62159a57-b385-46b0-8213-e6306b9d93be" />


### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://swagger-fix.loculus.org