### PR TITLE
refactor(backend): use Spring Boot to parse SubmissionIdFilesMap

### DIFF
--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
@@ -269,7 +269,7 @@ class SubmitEndpointTest(
                 jsonPath(
                     "\$.detail",
                 ).value(
-                    "the otherOrganism organism does not support file submission.",
+                    "Organism 'otherOrganism' does not support file submission.",
                 ),
             )
     }


### PR DESCRIPTION
That's what the framework is for, no need to hand parse.

resolves #

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)
