### PR TITLE
feat(prepro): do not show "No segment aligned" error for single segmented organisms

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -819,7 +819,7 @@ def process_single(  # noqa: C901
         if unprocessed.alignedNucleotideSequences.get(segment, None):
             aligned_segments.add(segment)
 
-    if not aligned_segments:
+    if not aligned_segments and config.multi_segment:
         errors.append(
             ProcessingAnnotation(
                 unprocessedFields=[

--- a/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
+++ b/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
@@ -203,14 +203,6 @@ single_segment_case_definitions = [
             "length": len(invalid_sequence()),
         },
         expected_errors=[
-            # TODO: This error shouldn't show for single segmented organism
-            # Only the bottom one should
-            ProcessingAnnotationHelper(
-                ["alignment"],
-                ["alignment"],
-                "No segment aligned.",
-                AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
-            ),
             ProcessingAnnotationHelper(
                 ["main"],
                 ["main"],


### PR DESCRIPTION
resolves #https://github.com/loculus-project/loculus/issues/4765

### Screenshot

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable