### PR TITLE
feat(prepro): change how `alignment_requirement` errors are determined and add tests

### DIFF
--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -478,7 +478,7 @@
                       "docsIncludePrefix": false,
                       "type": "string",
                       "enum": ["ALL", "ANY"],
-                      "description": "If multi-segmented viruses should require ALL segments align or ANY segment aligns"
+                      "description": "If multi-segmented viruses should require ALL segments (that the user provides) align or ANY segment aligns"
                     },
                     "nextclade_dataset_server": {
                       "groups": ["nextcladePipelineConfigFile"],

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -17,6 +17,9 @@ CLI_TYPES = [str, int, float, bool]
 
 
 class AlignmentRequirement(Enum):
+    # Determines whether ALL or ANY segments must align.
+    # ANY: warn if some segments fail and some segments align
+    # ALL: error if any segment fails even if some segments align
     ANY = "ANY"
     ALL = "ALL"
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -17,7 +17,7 @@ CLI_TYPES = [str, int, float, bool]
 
 
 class AlignmentRequirement(Enum):
-    # Determines whether ALL or ANY segments must align.
+    # Determines whether ALL or ANY segments that a user provides must align.
     # ANY: warn if some segments fail and some segments align
     # ALL: error if any segment fails even if some segments align
     ANY = "ANY"

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -4,6 +4,7 @@ import dataclasses
 import logging
 import os
 from dataclasses import dataclass
+from enum import Enum
 from types import UnionType
 from typing import Any, get_args
 
@@ -15,33 +16,41 @@ logger = logging.getLogger(__name__)
 CLI_TYPES = [str, int, float, bool]
 
 
+class AlignmentRequirement(Enum):
+    ANY = "ANY"
+    ALL = "ALL"
+
+
 @dataclass
 class Config:
-    organism: str = "mpox"
+    config_file: str | None = None
+    log_level: str = "DEBUG"
+    keep_tmp_dir: bool = False
+    batch_size: int = 5
+    pipeline_version: int = 1
+
     backend_host: str = ""  # populated in get_config if left empty, so we can use organism
     keycloak_host: str = "http://127.0.0.1:8083"
     keycloak_user: str = "preprocessing_pipeline"
     keycloak_password: str = "preprocessing_pipeline"  # noqa: S105
     keycloak_token_path: str = "realms/loculus/protocol/openid-connect/token"  # noqa: S105
+
+    organism: str = "mpox"
+    genes: list[str] = dataclasses.field(default_factory=list)
+    nucleotideSequences: list[str] = dataclasses.field(default_factory=lambda: ["main"])  # noqa: N815
+    processing_spec: dict[str, dict[str, Any]] = dataclasses.field(default_factory=dict)
+    multi_segment: bool = False
+
+    alignment_requirement: AlignmentRequirement = AlignmentRequirement.ALL
     nextclade_dataset_name: str | None = None
     nextclade_dataset_name_map: dict[str, str] | None = None
     nextclade_dataset_tag: str | None = None
     nextclade_dataset_server: str = "https://data.clades.nextstrain.org/v3"
     nextclade_dataset_server_map: dict[str, str] | None = None
+
     require_nextclade_sort_match: bool = False
     minimizer_url: str | None = None
     accepted_dataset_matches: list[str] = dataclasses.field(default_factory=list)
-    config_file: str | None = None
-    log_level: str = "DEBUG"
-    genes: list[str] = dataclasses.field(default_factory=list)
-    nucleotideSequences: list[str] = dataclasses.field(default_factory=lambda: ["main"])  # noqa: N815
-    keep_tmp_dir: bool = False
-    reference_length: int = 197209
-    batch_size: int = 5
-    processing_spec: dict[str, dict[str, Any]] = dataclasses.field(default_factory=dict)
-    pipeline_version: int = 1
-    multi_segment: bool = False
-    alignment_requirement: str = "ALL"
 
 
 def load_config_from_yaml(config_file: str, config: Config | None = None) -> Config:
@@ -81,9 +90,7 @@ def generate_argparse_from_dataclass(config_cls: type[Config]) -> argparse.Argum
     return parser
 
 
-def get_config(
-    config_file: str | None = None, ignore_args: bool = False
-) -> Config:
+def get_config(config_file: str | None = None, ignore_args: bool = False) -> Config:
     """
     Config precedence: Direct function args > CLI args > ENV variables > config file > default
 

--- a/preprocessing/nextclade/tests/factory_methods.py
+++ b/preprocessing/nextclade/tests/factory_methods.py
@@ -143,6 +143,45 @@ class ProcessedEntryFactory:
             ]
         )
 
+        warnings = [
+            ProcessingAnnotation(
+                unprocessedFields=[
+                    AnnotationSource(
+                        name=field,
+                        type=AnnotationSourceType.METADATA,
+                    )
+                    for field in warning.unprocessed_field_names
+                ],
+                processedFields=[
+                    AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
+                    for field in warning.processed_field_names
+                ],
+                message=warning.message,
+            )
+            for warning in metadata_warnings
+            if warning.type == AnnotationSourceType.METADATA
+        ]
+        warnings.extend(
+            [
+                ProcessingAnnotation(
+                    unprocessedFields=[
+                        AnnotationSource(
+                            name=field,
+                            type=AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
+                        )
+                        for field in warning.unprocessed_field_names
+                    ],
+                    processedFields=[
+                        AnnotationSource(name=field, type=AnnotationSourceType.NUCLEOTIDE_SEQUENCE)
+                        for field in warning.processed_field_names
+                    ],
+                    message=warning.message,
+                )
+                for warning in metadata_warnings
+                if warning.type == AnnotationSourceType.NUCLEOTIDE_SEQUENCE
+            ]
+        )
+
         return ProcessedEntry(
             accession=accession,
             version=1,
@@ -155,23 +194,7 @@ class ProcessedEntryFactory:
                 aminoAcidInsertions=processed_alignment.aminoAcidInsertions,
             ),
             errors=errors,
-            warnings=[
-                ProcessingAnnotation(
-                    unprocessedFields=[
-                        AnnotationSource(
-                            name=field,
-                            type=AnnotationSourceType.METADATA,
-                        )
-                        for field in warning.unprocessed_field_names
-                    ],
-                    processedFields=[
-                        AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                        for field in warning.processed_field_names
-                    ],
-                    message=warning.message,
-                )
-                for warning in metadata_warnings
-            ],
+            warnings=warnings,
         )
 
 

--- a/preprocessing/nextclade/tests/factory_methods.py
+++ b/preprocessing/nextclade/tests/factory_methods.py
@@ -77,24 +77,25 @@ class UnprocessedEntryFactory:
         )
 
 
-def build_processing_annotations(items: list[ProcessingAnnotationHelper]):
+def build_processing_annotations(
+    items: list[ProcessingAnnotationHelper],
+) -> list[ProcessingAnnotation]:
     annotations = []
     for item in items:
-        if item.type in {AnnotationSourceType.METADATA, AnnotationSourceType.NUCLEOTIDE_SEQUENCE}:
-            annotation_type = item.type
-            annotations.append(
-                ProcessingAnnotation(
-                    unprocessedFields=[
-                        AnnotationSource(name=field, type=annotation_type)
-                        for field in item.unprocessed_field_names
-                    ],
-                    processedFields=[
-                        AnnotationSource(name=field, type=annotation_type)
-                        for field in item.processed_field_names
-                    ],
-                    message=item.message,
-                )
+        annotation_type: AnnotationSourceType = item.type
+        annotations.append(
+            ProcessingAnnotation(
+                unprocessedFields=[
+                    AnnotationSource(name=field, type=annotation_type)
+                    for field in item.unprocessed_field_names
+                ],
+                processedFields=[
+                    AnnotationSource(name=field, type=annotation_type)
+                    for field in item.processed_field_names
+                ],
+                message=item.message,
             )
+        )
     return annotations
 
 

--- a/preprocessing/nextclade/tests/factory_methods.py
+++ b/preprocessing/nextclade/tests/factory_methods.py
@@ -77,7 +77,7 @@ class UnprocessedEntryFactory:
         )
 
 
-def build_processing_annotations(items):
+def build_processing_annotations(items: list[ProcessingAnnotationHelper]):
     annotations = []
     for item in items:
         if item.type in {AnnotationSourceType.METADATA, AnnotationSourceType.NUCLEOTIDE_SEQUENCE}:

--- a/preprocessing/nextclade/tests/multi_segment_config.yaml
+++ b/preprocessing/nextclade/tests/multi_segment_config.yaml
@@ -1,4 +1,5 @@
 batch_size: 100
+alignment_requirement: ALL
 genes:
 - NPEbolaSudan
 - VP35EbolaSudan

--- a/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
+++ b/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
@@ -633,12 +633,8 @@ def test_preprocessing_multi_segment_any_requirement(test_case_def: Case):
     verify_processed_entry(processed_entry, test_case.expected_output, test_case.name)
 
 
-@pytest.fixture(scope="module")
-def config():
-    return get_config(MULTI_SEGMENT_CONFIG, ignore_args=True)
-
-
-def test_preprocessing_without_metadata(config: Config) -> None:
+def test_preprocessing_without_metadata() -> None:
+    config = get_config(MULTI_SEGMENT_CONFIG, ignore_args=True)
     sequence_entry_data = UnprocessedEntry(
         accessionVersion="LOC_01.1",
         data=UnprocessedData(

--- a/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
+++ b/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
@@ -510,15 +510,14 @@ multi_segment_case_definitions_any_requirement = [
                 ["alignment"],
                 "No segment aligned.",
                 AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
-            ),
-            ProcessingAnnotationHelper(
+            )
+        ],
+        expected_warnings=[ProcessingAnnotationHelper(
                 ["ebola-sudan"],
                 ["ebola-sudan"],
                 "Nucleotide sequence for ebola-sudan failed to align",
                 AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
-            ),
-        ],
-        expected_warnings=[],
+            )],
         expected_processed_alignment=ProcessedAlignment(
             unalignedNucleotideSequences={
                 "ebola-sudan": invalid_sequence(),

--- a/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
+++ b/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
@@ -390,7 +390,10 @@ multi_segment_case_definitions = [
             },
             aminoAcidInsertions={},  # TODO: this is odd, should be the same as empty nuc insertions
         ),
-    ),
+    )
+]
+
+multi_segment_case_definitions_all_requirement = [
     Case(
         name="with one failed alignment, one not uploaded",
         input_metadata={},
@@ -437,9 +440,6 @@ multi_segment_case_definitions = [
             aminoAcidInsertions={},
         ),
     ),
-]
-
-multi_segment_case_definitions_all_requirement = [
     Case(
         name="with one failed alignment, one succeeded",
         input_metadata={},
@@ -489,6 +489,52 @@ multi_segment_case_definitions_all_requirement = [
 ]
 
 multi_segment_case_definitions_any_requirement = [
+    Case(
+        name="with one failed alignment, one not uploaded",
+        input_metadata={},
+        input_sequence={"ebola-sudan": invalid_sequence()},
+        accession_id="1",
+        expected_metadata={
+            "totalInsertedNucs_ebola-sudan": None,
+            "totalSnps_ebola-sudan": None,
+            "totalDeletedNucs_ebola-sudan": None,
+            "length_ebola-sudan": 53,
+            "totalInsertedNucs_ebola-zaire": None,
+            "totalSnps_ebola-zaire": None,
+            "totalDeletedNucs_ebola-zaire": None,
+            "length_ebola-zaire": 0,
+        },
+        expected_errors=[
+            ProcessingAnnotationHelper(
+                ["alignment"],
+                ["alignment"],
+                "No segment aligned.",
+                AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
+            ),
+            ProcessingAnnotationHelper(
+                ["ebola-sudan"],
+                ["ebola-sudan"],
+                "Nucleotide sequence for ebola-sudan failed to align",
+                AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
+            ),
+        ],
+        expected_warnings=[],
+        expected_processed_alignment=ProcessedAlignment(
+            unalignedNucleotideSequences={
+                "ebola-sudan": invalid_sequence(),
+                "ebola-zaire": None,
+            },
+            alignedNucleotideSequences={"ebola-sudan": None, "ebola-zaire": None},
+            nucleotideInsertions={"ebola-sudan": []},  # TODO: this is odd
+            alignedAminoAcidSequences={
+                "NPEbolaSudan": None,
+                "VP35EbolaSudan": None,
+                "VP24EbolaZaire": None,
+                "LEbolaZaire": None,
+            },
+            aminoAcidInsertions={},
+        ),
+    ),
     Case(
         name="with one failed alignment, one succeeded",
         input_metadata={},


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/4698, https://github.com/loculus-project/loculus/issues/4764

1. make `alignment_requirement` an enum, drop unused `reference_length`, reorder config options
2. determine if no segment aligned without using metadata (will now work correctly even when no nextclade metadata fields are used) -> add tests for case where there is no metadata to ensure this always works without errors
3. Add tests for alignment_requirement=ANY` config option

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable