### PR TITLE
docs(prepro): Remove reference to nextclade pipeline being a work in progress

### DIFF
--- a/preprocessing/nextclade/README.md
+++ b/preprocessing/nextclade/README.md
@@ -1,6 +1,6 @@
-# Preprocessing Pipeline
+# Preprocessing pipeline
 
-This preprocessing pipeline is still a work in progress. It requests unaligned nucleotide sequences from `/extract-unprocessed-data` and submits the results of a Nextclade run to `/submit-processed-data`. If no nextclade dataset is given only perform metadata checks.
+This preprocessing pipeline has been developed by the Loculus team. It requests unaligned nucleotide sequences from `/extract-unprocessed-data` and submits the results of performing some metadata checks, and often a Nextclade run, to `/submit-processed-data`. If no nextclade dataset is given only perform metadata checks.
 
 ## Overview
 


### PR DESCRIPTION
While all our code is still in progress, the nextclade pipeline is no more so

resolves #

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable