### PR TITLE
refactor(prepro): add a creation classmethod to the ProcessingAnnotation and use

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from enum import Enum, StrEnum, unique
+from enum import StrEnum, unique
 from typing import Any
 
 AccessionVersion = str

--- a/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
@@ -48,6 +48,18 @@ class ProcessingAnnotation:
     def __hash__(self):
         return hash((self.unprocessedFields, self.processedFields, self.message))
 
+    @classmethod
+    def from_fields(cls, input_fields, output_fields, type, message):
+        return cls(
+            unprocessedFields=[AnnotationSource(name=f, type=type) for f in input_fields],
+            processedFields=[AnnotationSource(name=f, type=type) for f in output_fields],
+            message=message,
+        )
+
+    @classmethod
+    def from_single(cls, name: str, type, message: str):
+        return cls.from_fields([name], [name], type, message)
+
 
 @dataclass
 class UnprocessedData:

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -204,8 +204,10 @@ def run_sort(
             ProcessingAnnotation.from_single(
                 ProcessingAnnotationAlignment,
                 AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
-                message="Sequence does not appear to match reference, per `nextclade sort`. "
-                "Double check you are submitting to the correct organism.",
+                message=(
+                    "Sequence does not appear to match reference, per `nextclade sort`. "
+                    "Double check you are submitting to the correct organism."
+                ),
             ),
         )
 
@@ -299,8 +301,10 @@ def enrich_with_nextclade(  # noqa: C901, PLR0912, PLR0914, PLR0915
                 ProcessingAnnotation.from_single(
                     ProcessingAnnotationAlignment,
                     AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
-                    message="Found unknown segments in the input data - "
-                    "check your segments are annotated correctly.",
+                    message=(
+                        "Found unknown segments in the input data - "
+                        "check your segments are annotated correctly."
+                    ),
                 ),
             )
 
@@ -778,8 +782,10 @@ def processed_entry_with_errors(id) -> SubmissionData:
                 ProcessingAnnotation.from_single(
                     "unknown",
                     AnnotationSourceType.METADATA,
-                    message=f"Failed to process submission with id: {id} - please review your "
-                    "submission or reach out to an administrator if this error persists.",
+                    message=(
+                        f"Failed to process submission with id: {id} - please review your "
+                        "submission or reach out to an administrator if this error persists."
+                    ),
                 ),
             ],
             warnings=[],

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -355,8 +355,9 @@ class ProcessingFunctions:
                         input_fields,
                         [output_field],
                         AnnotationSourceType.METADATA,
-                        message=f"Metadata field {output_field}:"
-                        f"'{input_date_str}' is in the future.",
+                        message=(
+                            f"Metadata field {output_field}:'{input_date_str}' is in the future."
+                        ),
                     )
                 )
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -159,14 +159,10 @@ class ProcessingFunctions:
                 datum=None,
                 warnings=[],
                 errors=[
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=(
                             f"Internal Error: Function {function_name} did not return "
                             f"ProcessingResult with input {input_data} and args {args}, "
@@ -204,14 +200,10 @@ class ProcessingFunctions:
             parsed_date = datetime.strptime(date, "%Y-%m-%d").astimezone(pytz.utc)
             if parsed_date > datetime.now(tz=pytz.utc):
                 warnings.append(
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message="Date is in the future.",
                     )
                 )
@@ -224,14 +216,10 @@ class ProcessingFunctions:
                 datum=None,
                 warnings=warnings,
                 errors=[
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=error_message,
                     )
                 ],
@@ -270,14 +258,10 @@ class ProcessingFunctions:
                 datum=None,
                 warnings=[],
                 errors=[
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=(
                             f"Internal Error: Function parse_into_ranges did not receive valid "
                             f"submittedAt date, with input {input_data} and args {args}, "
@@ -354,14 +338,10 @@ class ProcessingFunctions:
 
             if message:
                 warnings.append(
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=f"Metadata field {output_field}:'{input_date_str}' - " + message,
                     )
                 )
@@ -371,14 +351,10 @@ class ProcessingFunctions:
                     f"Lower range of date: {datum.date_range_lower} > {datetime.now(tz=pytz.utc)}"
                 )
                 errors.append(
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=f"Metadata field {output_field}:"
                         f"'{input_date_str}' is in the future.",
                     )
@@ -387,14 +363,10 @@ class ProcessingFunctions:
             if release_date and datum.date_range_lower and (datum.date_range_lower > release_date):
                 logger.debug(f"Lower range of date: {parsed_date} > release_date: {release_date}")
                 errors.append(
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=(
                             f"Metadata field {output_field}:'{input_date_str}'"
                             "is after release date."
@@ -425,14 +397,10 @@ class ProcessingFunctions:
             datum=None,
             warnings=[],
             errors=[
-                ProcessingAnnotation(
-                    processedFields=[
-                        AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                    ],
-                    unprocessedFields=[
-                        AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                        for field in input_fields
-                    ],
+                ProcessingAnnotation.from_fields(
+                    input_fields,
+                    [output_field],
+                    AnnotationSourceType.METADATA,
                     message=f"Metadata field {output_field}: "
                     f"Date {input_date_str} could not be parsed.",
                 )
@@ -492,16 +460,10 @@ class ProcessingFunctions:
 
                 if message:
                     warnings.append(
-                        ProcessingAnnotation(
-                            processedFields=[
-                                AnnotationSource(
-                                    name=output_field, type=AnnotationSourceType.METADATA
-                                )
-                            ],
-                            unprocessedFields=[
-                                AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                                for field in input_fields
-                            ],
+                        ProcessingAnnotation.from_fields(
+                            input_fields,
+                            [output_field],
+                            AnnotationSourceType.METADATA,
                             message=f"Metadata field {output_field}:'{date_str}' - " + message,
                         )
                     )
@@ -509,16 +471,10 @@ class ProcessingFunctions:
                 if parsed_date > datetime.now(tz=pytz.utc):
                     logger.debug(f"parsed_date: {parsed_date} > {datetime.now(tz=pytz.utc)}")
                     errors.append(
-                        ProcessingAnnotation(
-                            processedFields=[
-                                AnnotationSource(
-                                    name=output_field, type=AnnotationSourceType.METADATA
-                                )
-                            ],
-                            unprocessedFields=[
-                                AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                                for field in input_fields
-                            ],
+                        ProcessingAnnotation.from_fields(
+                            input_fields,
+                            [output_field],
+                            AnnotationSourceType.METADATA,
                             message=f"Metadata field {output_field}:'{date_str}' is in the future.",
                         )
                     )
@@ -526,16 +482,10 @@ class ProcessingFunctions:
                 if release_date and parsed_date > release_date:
                     logger.debug(f"parsed_date: {parsed_date} > release_date: {release_date}")
                     errors.append(
-                        ProcessingAnnotation(
-                            processedFields=[
-                                AnnotationSource(
-                                    name=output_field, type=AnnotationSourceType.METADATA
-                                )
-                            ],
-                            unprocessedFields=[
-                                AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                                for field in input_fields
-                            ],
+                        ProcessingAnnotation.from_fields(
+                            input_fields,
+                            [output_field],
+                            AnnotationSourceType.METADATA,
                             message=(
                                 f"Metadata field {output_field}:'{date_str}'is after release date."
                             ),
@@ -551,14 +501,10 @@ class ProcessingFunctions:
             datum=None,
             warnings=[],
             errors=[
-                ProcessingAnnotation(
-                    processedFields=[
-                        AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                    ],
-                    unprocessedFields=[
-                        AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                        for field in input_fields
-                    ],
+                ProcessingAnnotation.from_fields(
+                    input_fields,
+                    [output_field],
+                    AnnotationSourceType.METADATA,
                     message=f"Metadata field {output_field}: Date format is not recognized.",
                 )
             ],
@@ -598,14 +544,10 @@ class ProcessingFunctions:
             return ProcessingResult(
                 datum=None,
                 errors=[
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=error_message,
                     )
                 ],
@@ -632,14 +574,10 @@ class ProcessingFunctions:
                 datum=None,
                 warnings=[],
                 errors=[
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=(
                             f"Internal Error: Function concatenate did not receive accession_version "
                             f"ProcessingResult with input {input_data} and args {args}, "
@@ -655,14 +593,10 @@ class ProcessingFunctions:
 
         def add_errors():
             errors.append(
-                ProcessingAnnotation(
-                    processedFields=[
-                        AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                    ],
-                    unprocessedFields=[
-                        AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                        for field in input_fields
-                    ],
+                ProcessingAnnotation.from_fields(
+                    input_fields,
+                    [output_field],
+                    AnnotationSourceType.METADATA,
                     message="Concatenation failed."
                     "This may be a configuration error, please contact the administrator.",
                 )
@@ -736,14 +670,10 @@ class ProcessingFunctions:
         except ValueError as e:
             logger.error(f"Concatenate failed with {e} (accession_version: {accession_version})")
             errors.append(
-                ProcessingAnnotation(
-                    processedFields=[
-                        AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                    ],
-                    unprocessedFields=[
-                        AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                        for field in input_fields
-                    ],
+                ProcessingAnnotation.from_fields(
+                    input_fields,
+                    [output_field],
+                    AnnotationSourceType.METADATA,
                     message=(
                         f"Concatenation failed for {output_field}. This is a technical error, "
                         "please contact the administrator."
@@ -792,14 +722,10 @@ class ProcessingFunctions:
             return ProcessingResult(
                 datum=None,
                 errors=[
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=error_message,
                     )
                 ],
@@ -813,14 +739,10 @@ class ProcessingFunctions:
                     + author_format_description
                 )
                 warnings.append(
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=warning_message,
                     )
                 )
@@ -831,14 +753,10 @@ class ProcessingFunctions:
                     "`Smith, Anna; Perez, Tom J.; Xu, X.L.`."
                 )
                 warnings.append(
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=warning_message,
                     )
                 )
@@ -854,14 +772,10 @@ class ProcessingFunctions:
         return ProcessingResult(
             datum=None,
             errors=[
-                ProcessingAnnotation(
-                    processedFields=[
-                        AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                    ],
-                    unprocessedFields=[
-                        AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                        for field in input_fields
-                    ],
+                ProcessingAnnotation.from_fields(
+                    input_fields,
+                    [output_field],
+                    AnnotationSourceType.METADATA,
                     message=error_message,
                 )
             ],
@@ -890,14 +804,10 @@ class ProcessingFunctions:
             return ProcessingResult(datum=None, warnings=warnings, errors=errors)
         if not isinstance(pattern, str):
             errors.append(
-                ProcessingAnnotation(
-                    processedFields=[
-                        AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                    ],
-                    unprocessedFields=[
-                        AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                        for field in input_fields
-                    ],
+                ProcessingAnnotation.from_fields(
+                    input_fields,
+                    [output_field],
+                    AnnotationSourceType.METADATA,
                     message=(
                         f"Internal Error: Function check_regex did not receive valid "
                         f"regex pattern, with input {input_data} and args {args}, "
@@ -910,14 +820,10 @@ class ProcessingFunctions:
         if re.match(pattern, regex_field):
             return ProcessingResult(datum=regex_field, warnings=warnings, errors=errors)
         errors.append(
-            ProcessingAnnotation(
-                processedFields=[
-                    AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                ],
-                unprocessedFields=[
-                    AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                    for field in input_fields
-                ],
+            ProcessingAnnotation.from_fields(
+                input_fields,
+                [output_field],
+                AnnotationSourceType.METADATA,
                 message=f"The value '{regex_field}' does not match the expected regex pattern: '{pattern}'.",
             )
         )
@@ -933,14 +839,10 @@ class ProcessingFunctions:
                 datum=None,
                 warnings=[],
                 errors=[
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=f"No data found for output field: {output_field}",
                     )
                 ],
@@ -1006,14 +908,10 @@ class ProcessingFunctions:
                 datum=None,
                 warnings=[],
                 errors=[
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=(
                             "Website configuration error: no options list specified for field "
                             f"{output_field}, please contact an administrator."
@@ -1041,14 +939,10 @@ class ProcessingFunctions:
             return ProcessingResult(
                 datum=input_datum,
                 warnings=[
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=error_msg,
                     )
                 ],
@@ -1059,19 +953,16 @@ class ProcessingFunctions:
                 datum=None,
                 warnings=[],
                 errors=[
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=error_msg,
                     )
                 ],
             )
         return ProcessingResult(datum=output_datum, warnings=[], errors=[])
+
 
 def format_frameshift(input: str | None) -> str | None:
     """

--- a/preprocessing/nextclade/src/loculus_preprocessing/sequence_checks.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/sequence_checks.py
@@ -1,5 +1,4 @@
 from .datatypes import (
-    AnnotationSource,
     AnnotationSourceType,
     NucleotideSequence,
     ProcessingAnnotation,
@@ -34,21 +33,17 @@ def errors_if_non_iupac(
             non_iupac_symbols = set(sequence.upper()) - UNALIGNED_NUCLEOTIDE_SYMBOLS
             if non_iupac_symbols:
                 errors.append(
-                    ProcessingAnnotation(
-                        unprocessedFields=[
-                            AnnotationSource(
-                                name=segment, type=AnnotationSourceType.NUCLEOTIDE_SEQUENCE
-                            )
-                        ],
-                        processedFields=[
-                            AnnotationSource(
-                                name=segment, type=AnnotationSourceType.NUCLEOTIDE_SEQUENCE
-                            )
-                        ],
+                    ProcessingAnnotation.from_single(
+                        segment,
+                        AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
                         message=(
                             f"Found non-IUPAC symbols in the {segment} sequence: "
-                            + ", ".join(non_iupac_symbols) + (". Gap characters (-) are not "
-                            "allowed in raw sequences." if "-" in non_iupac_symbols else "")
+                            + ", ".join(non_iupac_symbols)
+                            + (
+                                ". Gap characters (-) are not allowed in raw sequences."
+                                if "-" in non_iupac_symbols
+                                else ""
+                            )
                         ),
                     )
                 )

--- a/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
+++ b/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
@@ -25,7 +25,7 @@ from loculus_preprocessing.datatypes import (
     UnprocessedEntry,
 )
 from loculus_preprocessing.embl import create_flatfile, reformat_authors_from_loculus_to_embl_style
-from loculus_preprocessing.prepro import process_all
+from loculus_preprocessing.prepro import ProcessingAnnotationAlignment, process_all
 from loculus_preprocessing.processing_functions import (
     format_frameshift,
     format_stop_codon,
@@ -403,8 +403,8 @@ multi_segment_case_definitions_all_requirement = [
         },
         expected_errors=[
             ProcessingAnnotationHelper(
-                ["alignment"],
-                ["alignment"],
+                [ProcessingAnnotationAlignment],
+                [ProcessingAnnotationAlignment],
                 "No segment aligned.",
                 AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
             ),
@@ -490,8 +490,8 @@ multi_segment_case_definitions_any_requirement = [
         },
         expected_errors=[
             ProcessingAnnotationHelper(
-                ["alignment"],
-                ["alignment"],
+                [ProcessingAnnotationAlignment],
+                [ProcessingAnnotationAlignment],
                 "No segment aligned.",
                 AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
             )
@@ -709,10 +709,7 @@ def test_create_flatfile():
 
     result = process_all([sequence_entry_data], EBOLA_SUDAN_DATASET, config)
 
-    embl_str = create_flatfile(
-        config,
-        result[0]
-    )
+    embl_str = create_flatfile(config, result[0])
     expected_embl = Path(SINGLE_SEGMENT_EMBL).read_text(encoding="utf-8")
     assert embl_str == expected_embl
 


### PR DESCRIPTION
resolves #

Always writing out the full annotation type annoyed me so I created some constructors and did a refactor - this significantly decreases the lines of code and is IMO much easier to read

### Screenshot

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable