### PR TITLE
feat(backend): omit nulls in insertions and sequences and do not require prepro to upload null sequences

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedDataPostprocessor.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedDataPostprocessor.kt
@@ -8,12 +8,15 @@ import org.springframework.stereotype.Service
 class ProcessedDataPostprocessor(
     private val compressionService: CompressionService,
     private val processedMetadataPostprocessor: ProcessedMetadataPostprocessor,
+    private val processedSequencesPostprocessor: ProcessedSequencesPostprocessor,
 ) {
     fun prepareForStorage(processedData: ProcessedData<String>, organism: Organism) = processedData
+        .let { processedSequencesPostprocessor.stripNullValuesFromSequences(it) }
         .let { compressionService.compressSequencesInProcessedData(it, organism) }
         .let { processedMetadataPostprocessor.stripNullValuesFromMetadata(it) }
 
     fun retrieveFromStoredValue(storedValue: ProcessedData<CompressedSequence>, organism: Organism) = storedValue
         .let { processedMetadataPostprocessor.filterOutExtraFieldsAndAddNulls(it, organism) }
         .let { compressionService.decompressSequencesInProcessedData(it, organism) }
+        .let { processedSequencesPostprocessor.filterOutExtraSequencesAndAddNulls(it, organism) }
 }

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequenceEntryValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequenceEntryValidator.kt
@@ -364,6 +364,7 @@ class ProcessedSequenceEntryValidator(private val schema: Schema, private val re
         validateNoUnknownAminoAcidSymbol(processedData.alignedAminoAcidSequences)
         validateNoUnknownAminoAcidSymbolInInsertion(processedData.aminoAcidInsertions)
     }
+
     // TODO: remove this method, add aligned amino acid sequences when streaming
     private fun validateNoMissingGene(gene: ReferenceSequence, processedData: ProcessedData<GeneticSequence>) {
         if (!processedData.alignedAminoAcidSequences.containsKey(gene.name)) {
@@ -407,7 +408,8 @@ class ProcessedSequenceEntryValidator(private val schema: Schema, private val re
             }
         }
     }
-    //TODO: remove this method, add insertions when streaming
+
+    // TODO: remove this method, add insertions when streaming
     private fun addMissingKeysForInsertions(
         processedData: ProcessedData<GeneticSequence>,
     ): ProcessedData<GeneticSequence> {

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequenceEntryValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequenceEntryValidator.kt
@@ -259,6 +259,7 @@ class ProcessedSequenceEntryValidator(private val schema: Schema, private val re
         )
     }
 
+    // TODO: remove this method
     private fun addMissingNucleotideSequences(
         processedData: ProcessedData<GeneticSequence>,
     ): ProcessedData<GeneticSequence> {
@@ -363,7 +364,7 @@ class ProcessedSequenceEntryValidator(private val schema: Schema, private val re
         validateNoUnknownAminoAcidSymbol(processedData.alignedAminoAcidSequences)
         validateNoUnknownAminoAcidSymbolInInsertion(processedData.aminoAcidInsertions)
     }
-
+    // TODO: remove this method, add aligned amino acid sequences when streaming
     private fun validateNoMissingGene(gene: ReferenceSequence, processedData: ProcessedData<GeneticSequence>) {
         if (!processedData.alignedAminoAcidSequences.containsKey(gene.name)) {
             throw ProcessingValidationException("Missing the required gene '${gene.name}'.")
@@ -406,7 +407,7 @@ class ProcessedSequenceEntryValidator(private val schema: Schema, private val re
             }
         }
     }
-
+    //TODO: remove this method, add insertions when streaming
     private fun addMissingKeysForInsertions(
         processedData: ProcessedData<GeneticSequence>,
     ): ProcessedData<GeneticSequence> {

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequencesPostprocessor.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequencesPostprocessor.kt
@@ -13,6 +13,12 @@ class ProcessedSequencesPostprocessor(private val backendConfig: BackendConfig) 
             .filterValues { it != null },
         alignedNucleotideSequences = processedData.alignedNucleotideSequences
             .filterValues { it != null },
+        alignedAminoAcidSequences = processedData.alignedAminoAcidSequences
+            .filterValues { it != null },
+        aminoAcidInsertions = processedData.aminoAcidInsertions
+            .filterValues { !it.isNullOrEmpty() },
+        nucleotideInsertions = processedData.nucleotideInsertions
+            .filterValues { !it.isNullOrEmpty() },
     )
 
     /** Filter out any extra sequences that are not in the current schema and add nulls for any missing sequences. */
@@ -35,6 +41,30 @@ class ProcessedSequencesPostprocessor(private val backendConfig: BackendConfig) 
             .map { it.name }
             .associateWith { seqName ->
                 processedData.alignedNucleotideSequences[seqName]
+            },
+        alignedAminoAcidSequences = backendConfig
+            .getInstanceConfig(organism)
+            .referenceGenome
+            .genes
+            .map { it.name }
+            .associateWith { geneName ->
+                processedData.alignedAminoAcidSequences[geneName]
+            },
+        aminoAcidInsertions = backendConfig
+            .getInstanceConfig(organism)
+            .referenceGenome
+            .genes
+            .map { it.name }
+            .associateWith { geneName ->
+                processedData.aminoAcidInsertions[geneName] ?: emptyList()
+            },
+        nucleotideInsertions = backendConfig
+            .getInstanceConfig(organism)
+            .referenceGenome
+            .nucleotideSequences
+            .map { it.name }
+            .associateWith { seqName ->
+                processedData.nucleotideInsertions[seqName] ?: emptyList()
             },
     )
 }

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequencesPostprocessor.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequencesPostprocessor.kt
@@ -1,0 +1,38 @@
+package org.loculus.backend.service.submission
+
+import com.fasterxml.jackson.databind.node.NullNode
+import org.loculus.backend.api.Organism
+import org.loculus.backend.api.ProcessedData
+import org.loculus.backend.config.BackendConfig
+import org.springframework.stereotype.Service
+
+@Service
+class ProcessedSequencesPostprocessor(private val backendConfig: BackendConfig) {
+    fun <SequenceType> stripNullValuesFromSequences(processedData: ProcessedData<SequenceType>) = processedData.copy(
+        unalignedNucleotideSequences = processedData.unalignedNucleotideSequences
+            .filterValues { it!=null },
+        alignedNucleotideSequences = processedData.alignedNucleotideSequences
+            .filterValues { it!=null },
+    )
+
+    /** Filter out any extra sequences that are not in the current schema and add nulls for any missing sequences. */
+    fun <SequenceType> filterOutExtraSequencesAndAddNulls(processedData: ProcessedData<SequenceType>, organism: Organism) =
+        processedData.copy(
+            unalignedNucleotideSequences = backendConfig
+                .getInstanceConfig(organism)
+                .referenceGenome
+                .nucleotideSequences
+                .map { it.name }
+                .associateWith { seqName ->
+                    processedData.unalignedNucleotideSequences[seqName]
+                },
+            alignedNucleotideSequences = backendConfig
+                .getInstanceConfig(organism)
+                .referenceGenome
+                .nucleotideSequences
+                .map { it.name }
+                .associateWith { seqName ->
+                    processedData.alignedNucleotideSequences[seqName]
+                },
+        )
+}

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequencesPostprocessor.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/ProcessedSequencesPostprocessor.kt
@@ -10,29 +10,31 @@ import org.springframework.stereotype.Service
 class ProcessedSequencesPostprocessor(private val backendConfig: BackendConfig) {
     fun <SequenceType> stripNullValuesFromSequences(processedData: ProcessedData<SequenceType>) = processedData.copy(
         unalignedNucleotideSequences = processedData.unalignedNucleotideSequences
-            .filterValues { it!=null },
+            .filterValues { it != null },
         alignedNucleotideSequences = processedData.alignedNucleotideSequences
-            .filterValues { it!=null },
+            .filterValues { it != null },
     )
 
     /** Filter out any extra sequences that are not in the current schema and add nulls for any missing sequences. */
-    fun <SequenceType> filterOutExtraSequencesAndAddNulls(processedData: ProcessedData<SequenceType>, organism: Organism) =
-        processedData.copy(
-            unalignedNucleotideSequences = backendConfig
-                .getInstanceConfig(organism)
-                .referenceGenome
-                .nucleotideSequences
-                .map { it.name }
-                .associateWith { seqName ->
-                    processedData.unalignedNucleotideSequences[seqName]
-                },
-            alignedNucleotideSequences = backendConfig
-                .getInstanceConfig(organism)
-                .referenceGenome
-                .nucleotideSequences
-                .map { it.name }
-                .associateWith { seqName ->
-                    processedData.alignedNucleotideSequences[seqName]
-                },
-        )
+    fun <SequenceType> filterOutExtraSequencesAndAddNulls(
+        processedData: ProcessedData<SequenceType>,
+        organism: Organism,
+    ) = processedData.copy(
+        unalignedNucleotideSequences = backendConfig
+            .getInstanceConfig(organism)
+            .referenceGenome
+            .nucleotideSequences
+            .map { it.name }
+            .associateWith { seqName ->
+                processedData.unalignedNucleotideSequences[seqName]
+            },
+        alignedNucleotideSequences = backendConfig
+            .getInstanceConfig(organism)
+            .referenceGenome
+            .nucleotideSequences
+            .map { it.name }
+            .associateWith { seqName ->
+                processedData.alignedNucleotideSequences[seqName]
+            },
+    )
 }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
@@ -57,7 +57,7 @@ import java.net.http.HttpResponse
 import java.util.UUID
 
 @EndpointTest(
-    properties = ["${BackendSpringProperty.BACKEND_CONFIG_PATH}=$S3_CONFIG" ],
+    properties = ["${BackendSpringProperty.BACKEND_CONFIG_PATH}=$S3_CONFIG"],
 )
 class SubmitProcessedDataEndpointTest(
     @Autowired val submissionControllerClient: SubmissionControllerClient,
@@ -867,24 +867,6 @@ class SubmitProcessedDataEndpointTest(
 
         @JvmStatic
         fun provideInvalidNucleotideSequenceDataScenarios() = listOf(
-            InvalidDataScenario(
-                name = "data with missing segment in unaligned nucleotide sequences",
-                processedDataThatNeedsAValidAccession = PreparedProcessedData
-                    .withMissingSegmentInUnalignedNucleotideSequences(
-                        accession = "DoesNotMatter",
-                        segment = "main",
-                    ),
-                expectedErrorMessage = "Missing the required segment 'main' in 'unalignedNucleotideSequences'.",
-            ),
-            InvalidDataScenario(
-                name = "data with missing segment in aligned nucleotide sequences",
-                processedDataThatNeedsAValidAccession = PreparedProcessedData
-                    .withMissingSegmentInAlignedNucleotideSequences(
-                        accession = "DoesNotMatter",
-                        segment = "main",
-                    ),
-                expectedErrorMessage = "Missing the required segment 'main' in 'alignedNucleotideSequences'.",
-            ),
             InvalidDataScenario(
                 name = "data with unknown segment in alignedNucleotideSequences",
                 processedDataThatNeedsAValidAccession = PreparedProcessedData

--- a/backend/src/test/kotlin/org/loculus/backend/service/ProcessedSequencesPostprocessorTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/ProcessedSequencesPostprocessorTest.kt
@@ -1,0 +1,104 @@
+package org.loculus.backend.service
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasKey
+import org.hamcrest.Matchers.not
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.loculus.backend.SpringBootTestWithoutDatabase
+import org.loculus.backend.api.Organism
+import org.loculus.backend.api.ProcessedData
+import org.loculus.backend.config.BackendConfig
+import org.loculus.backend.config.DataUseTerms
+import org.loculus.backend.config.InstanceConfig
+import org.loculus.backend.config.ReferenceGenome
+import org.loculus.backend.config.ReferenceSequence
+import org.loculus.backend.config.Schema
+import org.loculus.backend.controller.DEFAULT_ORGANISM
+import org.loculus.backend.service.submission.ProcessedSequencesPostprocessor
+import org.springframework.beans.factory.annotation.Autowired
+
+private const val FIRST_NUCLEOTIDE_SEQUENCE = "firstNucleotideSequence"
+private const val SECOND_NUCLEOTIDE_SEQUENCE = "secondNucleotideSequence"
+private const val FIRST_AMINO_ACID_SEQUENCE = "firstAminoAcidSequence"
+private const val SECOND_AMINO_ACID_SEQUENCE = "secondAminoAcidSequence"
+
+@SpringBootTestWithoutDatabase
+class ProcessedSequencesPostprocessorTest(
+    @Autowired private val processedSequencesPostprocessor: ProcessedSequencesPostprocessor,
+) {
+
+    @Test
+    fun `Processed Sequences Postprocessor correctly round trips sequences`() {
+        val backendConfig = BackendConfig(
+            accessionPrefix = "LOC_",
+            organisms = mapOf(
+                DEFAULT_ORGANISM to InstanceConfig(
+                    schema = Schema(
+                        FIRST_NUCLEOTIDE_SEQUENCE,
+                        listOf(),
+                    ),
+                    referenceGenome = ReferenceGenome(
+                        listOf(
+                            ReferenceSequence(FIRST_NUCLEOTIDE_SEQUENCE, "the sequence"),
+                            ReferenceSequence(SECOND_NUCLEOTIDE_SEQUENCE, "the sequence"),
+                        ),
+                        listOf(
+                            ReferenceSequence(FIRST_AMINO_ACID_SEQUENCE, "the sequence"),
+                            ReferenceSequence(SECOND_AMINO_ACID_SEQUENCE, "the sequence"),
+                        ),
+                    ),
+                ),
+            ),
+            dataUseTerms = DataUseTerms(true, null),
+            websiteUrl = "example.com",
+            backendUrl = "http://dummy-backend.com",
+        )
+        val organism = Organism(backendConfig.organisms.keys.first())
+        val configuredSequences = backendConfig.getInstanceConfig(organism).referenceGenome.nucleotideSequences
+            .map { it.name }
+            .sorted()
+        require(configuredSequences.size >= 2) { "Test requires at least 2 configured sequences" }
+
+        val configuredPresent = configuredSequences[0]
+        val configuredNull = configuredSequences[1]
+        val unconfiguredPresent = "unconfigured_present"
+        val unconfiguredNull = "unconfigured_null"
+
+        val testData = ProcessedData<String>(
+            metadata = emptyMap(),
+            unalignedNucleotideSequences = mapOf(
+                configuredPresent to "ATCGTACGATCG",
+                configuredNull to null,
+                unconfiguredPresent to "NNGATCGTACGATC",
+                unconfiguredNull to null,
+            ),
+            alignedNucleotideSequences = mapOf(
+                configuredPresent to "ATCGTACGATCG",
+                configuredNull to null,
+                unconfiguredPresent to "GATCGTACGATC",
+                unconfiguredNull to null,
+            ),
+            nucleotideInsertions = emptyMap(),
+            alignedAminoAcidSequences = emptyMap(),
+            aminoAcidInsertions = emptyMap(),
+            files = null,
+        )
+
+        val condensed = processedSequencesPostprocessor.stripNullValuesFromSequences(testData)
+        val expanded = processedSequencesPostprocessor.filterOutExtraSequencesAndAddNulls(condensed, organism)
+
+        // Check storage
+        assertThat(condensed.unalignedNucleotideSequences, not(hasKey(configuredNull)))
+        assertThat(condensed.unalignedNucleotideSequences, not(hasKey(unconfiguredNull)))
+        assertThat(condensed.unalignedNucleotideSequences, hasKey(configuredPresent))
+        assertThat(condensed.unalignedNucleotideSequences, hasKey(unconfiguredPresent))
+        assertEquals(condensed.unalignedNucleotideSequences[configuredPresent], testData.unalignedNucleotideSequences[configuredPresent])
+
+        // Check storage retrieval
+        assertEquals(expanded.unalignedNucleotideSequences[configuredPresent], testData.unalignedNucleotideSequences[configuredPresent])
+        assertEquals(expanded.unalignedNucleotideSequences[configuredNull], testData.unalignedNucleotideSequences[configuredNull])
+        assertThat(expanded.unalignedNucleotideSequences, not(hasKey(unconfiguredPresent)))
+        assertThat(expanded.unalignedNucleotideSequences, not(hasKey(unconfiguredNull)))
+    }
+}

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -681,10 +681,6 @@ def processed_entry_no_alignment(  # noqa: PLR0913, PLR0917
     nucleotide_insertions: dict[SegmentName, list[NucleotideInsertion]] = {}
     amino_acid_insertions: dict[GeneName, list[AminoAcidInsertion]] = {}
 
-    for segment in config.nucleotideSequences:
-        aligned_nucleotide_sequences[segment] = None
-        nucleotide_insertions[segment] = []
-
     for gene in config.genes:
         amino_acid_insertions[gene] = []
         aligned_aminoacid_sequences[gene] = None

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -83,10 +83,8 @@ def parse_nextclade_tsv(
         for row in reader:
             id = row["seqName"]
 
-            nuc_ins_str: list[NucleotideInsertion] = (
-                list(row["insertions"].split(",")) if row["insertions"] else []
-            )
-            nucleotide_insertions[id][segment] = nuc_ins_str
+            if row["insertions"]:
+                nucleotide_insertions[id][segment] = list(row["insertions"].split(","))
 
             aa_ins_split = row["aaInsertions"].split(",")
             for ins in aa_ins_split:
@@ -285,8 +283,6 @@ def enrich_with_nextclade(  # noqa: C901, PLR0912, PLR0914, PLR0915
         aligned_nucleotide_sequences[id] = {}
         alerts.warnings[id] = []
         alerts.errors[id] = []
-        for gene in config.genes:
-            aligned_aminoacid_sequences[id][gene] = None
         num_valid_segments = 0
         num_duplicate_segments = 0
         for segment in config.nucleotideSequences:
@@ -680,10 +676,6 @@ def processed_entry_no_alignment(  # noqa: PLR0913, PLR0917
     aligned_aminoacid_sequences: dict[GeneName, AminoAcidSequence | None] = {}
     nucleotide_insertions: dict[SegmentName, list[NucleotideInsertion]] = {}
     amino_acid_insertions: dict[GeneName, list[AminoAcidInsertion]] = {}
-
-    for gene in config.genes:
-        amino_acid_insertions[gene] = []
-        aligned_aminoacid_sequences[gene] = None
 
     return SubmissionData(
         processed_entry=ProcessedEntry(

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -754,8 +754,6 @@ def process_single(  # noqa: C901
 
     for segment in config.nucleotideSequences:
         sequence = unaligned_nucleotide_sequences.get(segment, None)
-        if not sequence:
-            unprocessed.unalignedNucleotideSequences[segment] = None
         key = "length" if segment == "main" else "length_" + segment
         if key in config.processing_spec:
             output_metadata[key] = len(sequence) if sequence else 0

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -290,7 +290,6 @@ def enrich_with_nextclade(  # noqa: C901, PLR0912, PLR0914, PLR0915
         num_valid_segments = 0
         num_duplicate_segments = 0
         for segment in config.nucleotideSequences:
-            aligned_nucleotide_sequences[id][segment] = None
             unaligned_segment = [
                 data
                 for data in entry.data.unalignedNucleotideSequences
@@ -320,8 +319,7 @@ def enrich_with_nextclade(  # noqa: C901, PLR0912, PLR0914, PLR0915
                 unaligned_nucleotide_sequences[id][segment] = (
                     entry.data.unalignedNucleotideSequences[unaligned_segment[0]]
                 )
-            else:
-                unaligned_nucleotide_sequences[id][segment] = None
+                aligned_nucleotide_sequences[id][segment] = None
         if (
             len(entry.data.unalignedNucleotideSequences)
             - num_valid_segments

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -662,10 +662,9 @@ def get_metadata(  # noqa: PLR0913, PLR0917
     return processing_result
 
 
-def processed_entry_no_alignment(  # noqa: PLR0913, PLR0917
+def processed_entry_no_alignment(
     id: AccessionVersion,
     unprocessed: UnprocessedData,
-    config: Config,
     output_metadata: ProcessedMetadata,
     errors: list[ProcessingAnnotation],
     warnings: list[ProcessingAnnotation],
@@ -795,7 +794,7 @@ def process_single(  # noqa: C901
 
     if isinstance(unprocessed, UnprocessedData):
         return processed_entry_no_alignment(
-            id, unprocessed, config, output_metadata, errors, warnings
+            id, unprocessed, output_metadata, errors, warnings
         )
 
     aligned_segments = set()

--- a/preprocessing/nextclade/tests/factory_methods.py
+++ b/preprocessing/nextclade/tests/factory_methods.py
@@ -49,9 +49,9 @@ class ProcessedAlignment:
         default_factory=lambda: {"main": None}
     )
     alignedNucleotideSequences: dict[str, str | None] = field(  # noqa: N815
-        default_factory=lambda: {"main": None}
+        default_factory=dict
     )
-    nucleotideInsertions: dict[str, list[str]] = field(default_factory=lambda: {"main": []})  # noqa: N815
+    nucleotideInsertions: dict[str, list[str]] = field(default_factory=dict)  # noqa: N815
     alignedAminoAcidSequences: dict[str, str | None] = field(default_factory=dict)  # noqa: N815
     aminoAcidInsertions: dict[str, list[str]] = field(default_factory=dict)  # noqa: N815
 
@@ -150,7 +150,7 @@ class ProcessedEntryFactory:
 class Case:
     name: str
     input_metadata: dict[str, str | None] = field(default_factory=dict)
-    input_sequence: dict[str, str | None] = field(default_factory=lambda: {"main": ""})
+    input_sequence: dict[str, str | None] = field(default_factory=lambda: {"main": None})
     accession_id: str = "000999"
     expected_metadata: dict[str, ProcessedMetadataValue] = field(default_factory=dict)
     expected_errors: list[ProcessingAnnotationHelper] | None = None

--- a/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
+++ b/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
@@ -128,7 +128,7 @@ single_segment_case_definitions = [
         expected_processed_alignment=ProcessedAlignment(
             unalignedNucleotideSequences={"main": sequence_with_mutation("single")},
             alignedNucleotideSequences={"main": sequence_with_mutation("single")},
-            nucleotideInsertions={"main": []},
+            nucleotideInsertions={},
             alignedAminoAcidSequences={
                 "NPEbolaSudan": ebola_sudan_aa(sequence_with_mutation("single"), "NP"),
                 "VP35EbolaSudan": ebola_sudan_aa(sequence_with_mutation("single"), "VP35"),
@@ -178,7 +178,7 @@ single_segment_case_definitions = [
         expected_processed_alignment=ProcessedAlignment(
             unalignedNucleotideSequences={"main": sequence_with_deletion("single")},
             alignedNucleotideSequences={"main": sequence_with_deletion("single", aligned=True)},
-            nucleotideInsertions={"main": []},
+            nucleotideInsertions={},
             alignedAminoAcidSequences={
                 "NPEbolaSudan": ebola_sudan_aa(
                     sequence_with_deletion("single", aligned=True), "NP"
@@ -259,7 +259,7 @@ multi_segment_case_definitions = [
                 "ebola-sudan": sequence_with_mutation("ebola-sudan"),
                 "ebola-zaire": sequence_with_mutation("ebola-zaire"),
             },
-            nucleotideInsertions={"ebola-sudan": [], "ebola-zaire": []},
+            nucleotideInsertions={},
             alignedAminoAcidSequences={
                 "NPEbolaSudan": ebola_sudan_aa(sequence_with_mutation("single"), "NP"),
                 "VP35EbolaSudan": ebola_sudan_aa(sequence_with_mutation("single"), "VP35"),

--- a/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
+++ b/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
@@ -222,11 +222,8 @@ single_segment_case_definitions = [
         expected_processed_alignment=ProcessedAlignment(
             unalignedNucleotideSequences={"main": invalid_sequence()},
             alignedNucleotideSequences={"main": None},
-            nucleotideInsertions={"main": []},
-            alignedAminoAcidSequences={
-                "NPEbolaSudan": None,
-                "VP35EbolaSudan": None,
-            },
+            nucleotideInsertions={},
+            alignedAminoAcidSequences={},
             aminoAcidInsertions={},
         ),
     ),
@@ -340,7 +337,7 @@ multi_segment_case_definitions = [
                 "ebola-sudan": sequence_with_deletion("ebola-sudan", aligned=True),
                 "ebola-zaire": sequence_with_deletion("ebola-zaire", aligned=True),
             },
-            nucleotideInsertions={"ebola-sudan": [], "ebola-zaire": []},
+            nucleotideInsertions={},
             alignedAminoAcidSequences={
                 "NPEbolaSudan": ebola_sudan_aa(
                     sequence_with_deletion("ebola-sudan", aligned=True),
@@ -386,14 +383,12 @@ multi_segment_case_definitions = [
             alignedNucleotideSequences={
                 "ebola-zaire": sequence_with_mutation("ebola-zaire"),
             },
-            nucleotideInsertions={"ebola-zaire": []},
+            nucleotideInsertions={},
             alignedAminoAcidSequences={
-                "NPEbolaSudan": None,
-                "VP35EbolaSudan": None,
                 "VP24EbolaZaire": ebola_zaire_aa(sequence_with_mutation("ebola-zaire"), "VP24"),
                 "LEbolaZaire": ebola_zaire_aa(sequence_with_mutation("ebola-zaire"), "L"),
             },
-            aminoAcidInsertions={},  # TODO: this is odd, should be the same as empty nuc insertions
+            aminoAcidInsertions={},
         ),
     ),
 ]
@@ -434,13 +429,8 @@ multi_segment_case_definitions_all_requirement = [
                 "ebola-sudan": invalid_sequence(),
             },
             alignedNucleotideSequences={"ebola-sudan": None},
-            nucleotideInsertions={"ebola-sudan": []},  # TODO: this is odd
-            alignedAminoAcidSequences={
-                "NPEbolaSudan": None,
-                "VP35EbolaSudan": None,
-                "VP24EbolaZaire": None,
-                "LEbolaZaire": None,
-            },
+            nucleotideInsertions={},
+            alignedAminoAcidSequences={},
             aminoAcidInsertions={},
         ),
     ),
@@ -480,10 +470,8 @@ multi_segment_case_definitions_all_requirement = [
                 "ebola-sudan": None,
                 "ebola-zaire": sequence_with_mutation("ebola-zaire"),
             },
-            nucleotideInsertions={"ebola-sudan": [], "ebola-zaire": []},
+            nucleotideInsertions={},
             alignedAminoAcidSequences={
-                "NPEbolaSudan": None,
-                "VP35EbolaSudan": None,
                 "VP24EbolaZaire": ebola_zaire_aa(sequence_with_mutation("ebola-zaire"), "VP24"),
                 "LEbolaZaire": ebola_zaire_aa(sequence_with_mutation("ebola-zaire"), "L"),
             },
@@ -527,16 +515,10 @@ multi_segment_case_definitions_any_requirement = [
         expected_processed_alignment=ProcessedAlignment(
             unalignedNucleotideSequences={
                 "ebola-sudan": invalid_sequence(),
-                "ebola-zaire": None,
             },
-            alignedNucleotideSequences={"ebola-sudan": None, "ebola-zaire": None},
-            nucleotideInsertions={"ebola-sudan": []},  # TODO: this is odd
-            alignedAminoAcidSequences={
-                "NPEbolaSudan": None,
-                "VP35EbolaSudan": None,
-                "VP24EbolaZaire": None,
-                "LEbolaZaire": None,
-            },
+            alignedNucleotideSequences={"ebola-sudan": None},
+            nucleotideInsertions={},
+            alignedAminoAcidSequences={},
             aminoAcidInsertions={},
         ),
     ),
@@ -576,10 +558,8 @@ multi_segment_case_definitions_any_requirement = [
                 "ebola-sudan": None,
                 "ebola-zaire": sequence_with_mutation("ebola-zaire"),
             },
-            nucleotideInsertions={"ebola-sudan": [], "ebola-zaire": []},
+            nucleotideInsertions={},
             alignedAminoAcidSequences={
-                "NPEbolaSudan": None,
-                "VP35EbolaSudan": None,
                 "VP24EbolaZaire": ebola_zaire_aa(sequence_with_mutation("ebola-zaire"), "VP24"),
                 "LEbolaZaire": ebola_zaire_aa(sequence_with_mutation("ebola-zaire"), "L"),
             },

--- a/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
+++ b/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
@@ -364,7 +364,6 @@ multi_segment_case_definitions = [
         name="with one succeeded and one not uploaded",
         input_metadata={},
         input_sequence={
-            "ebola-sudan": None,
             "ebola-zaire": sequence_with_mutation("ebola-zaire"),
         },
         accession_id="1",
@@ -382,11 +381,9 @@ multi_segment_case_definitions = [
         expected_warnings=[],
         expected_processed_alignment=ProcessedAlignment(
             unalignedNucleotideSequences={
-                "ebola-sudan": None,
                 "ebola-zaire": sequence_with_mutation("ebola-zaire"),
             },
             alignedNucleotideSequences={
-                "ebola-sudan": None,
                 "ebola-zaire": sequence_with_mutation("ebola-zaire"),
             },
             nucleotideInsertions={"ebola-zaire": []},
@@ -435,9 +432,8 @@ multi_segment_case_definitions_all_requirement = [
         expected_processed_alignment=ProcessedAlignment(
             unalignedNucleotideSequences={
                 "ebola-sudan": invalid_sequence(),
-                "ebola-zaire": None,
             },
-            alignedNucleotideSequences={"ebola-sudan": None, "ebola-zaire": None},
+            alignedNucleotideSequences={"ebola-sudan": None},
             nucleotideInsertions={"ebola-sudan": []},  # TODO: this is odd
             alignedAminoAcidSequences={
                 "NPEbolaSudan": None,

--- a/preprocessing/specification.md
+++ b/preprocessing/specification.md
@@ -138,7 +138,7 @@ The `metadata` field should contain a flat object consisting of the fields speci
 The `unalignedNucleotideSequences`, `alignedNucleotideSequences`, and `alignedAminoAcidSequences` fields contain objects with the segment/gene name as key and the sequence as value.
 If there is only a single segment (e.g., as in SARS-CoV-2), the segment name of the nucleotide sequence should be `main`.
 
-If a segment or a gene is not present in the sequence, the value should be `null`.
+If a segment or a gene is not present in the sequence, the segment or gene is not required in the map. Alternatively, the value can be set to `null`.
 
 Examples:
 
@@ -162,7 +162,7 @@ SARS-CoV-2 amino acid sequences:
 
 #### Insertions
 
-The `nucleotideInsertions` and `aminoAcidInsertions` fields contain dictionaries from the segment name or gene name to a list of `NucleotideInsertion`s or `AminoAcidInsertion`s. If there are no insertions the list should be empty.
+The `nucleotideInsertions` and `aminoAcidInsertions` fields contain dictionaries from the segment name or gene name to a list of `NucleotideInsertion`s or `AminoAcidInsertion`s. If there are no insertions the segment name or gene name can be omitted from the list or an empty list may be returned.
 
 Examples:
 


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/4814, resolves https://github.com/loculus-project/loculus/issues/4763

### Screenshot

Similar to in https://github.com/loculus-project/loculus/pull/3232 now that we have multi-pathogens we also want to facilitate the easy addition of new "segments" (i.e. suborganisms) and their genes. 

We can do this again in an efficient way where we do not store nulls in the backend but impute the `null` entries while streaming - this also means that we can drop the requirement on prepro to add nulls for all "missing" segments and genes - decreasing the amount of data we have to stream.

This PR omits `null` entries and empty lists for nucleotide and amino acid sequences as well as insertions.

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented: confirmed that CCHF preview is same state as main as prepro no longer returns `null` when a segment is missing this is a way to confirm that LAPIS is still receiving the correct values.

🚀 Preview: https://sequence-hydration.loculus.org