### PR TITLE
test(backend): make large batch submission test optional

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -20,6 +20,7 @@ jobs:
       CROSSREF_PASSWORD: ${{ secrets.CROSSREF_PASSWORD }}
       CROSSREF_ENDPOINT: ${{ secrets.CROSSREF_ENDPOINT }}
       CROSSREF_DOI_PREFIX: ${{ secrets.CROSSREF_DOI_PREFIX }}
+      RUN_EXTRA_TESTS: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'true' || 'false' }}
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitLargeBatchTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitLargeBatchTest.kt
@@ -1,17 +1,17 @@
 package org.loculus.backend.controller.submission
 
-import org.hamcrest.Matchers.containsString
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 import org.loculus.backend.controller.EndpointTest
 import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
 import org.loculus.backend.controller.groupmanagement.andGetGroupId
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.mock.web.MockMultipartFile
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @EndpointTest
+@EnabledIfEnvironmentVariable(named = "RUN_EXTRA_TESTS", matches = "true")
 class SubmitLargeBatchTest(
     @Autowired val submissionControllerClient: SubmissionControllerClient,
     @Autowired val groupManagementClient: GroupManagementControllerClient,


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/4829

## Summary
- guard the large batch submission test behind `RUN_EXTRA_TESTS`
- run the large batch test only on pushes to `main`

## Testing
Runs tests in 3 mins vs 7 mins without this


------
https://chatgpt.com/codex/tasks/task_e_6894a74aaf888325bbac36b00f1e28cc

🚀 Preview: Add `preview` label to enable