### PR TITLE
fix(website): align group icon on review page

### DIFF
--- a/website/src/components/Submission/SubmissionGroupSelector.tsx
+++ b/website/src/components/Submission/SubmissionGroupSelector.tsx
@@ -27,11 +27,11 @@ export const SubmissionGroupSelector: FC<GroupSelectorProps> = ({ groups, select
     );
 
     if (groups.length === 1) {
-        return <div className='mb-2 ml-4'>{groupNameElement}</div>;
+        return <div className='mb-2'>{groupNameElement}</div>;
     }
 
     return (
-        <div className='mb-2 ml-4'>
+        <div className='mb-2'>
             <div className='dropdown'>
                 <div tabIndex={0} role='button' className=''>
                     {groupNameElement} <IwwaArrowDown className='inline-block -mt-1 h-5 w-5' />


### PR DESCRIPTION
- remove extra left margin from group selector so the group icon aligns with the review page title

<img width="501" height="221" alt="image" src="https://github.com/user-attachments/assets/cadb80fa-0476-4087-a7d5-01e9847bfbfa" />

********

<img width="559" height="302" alt="image" src="https://github.com/user-attachments/assets/d582bbdb-bc61-45ab-86c5-af97416ecaeb" />

🚀 Preview: Add `preview` label to enable