### PR TITLE
chore(integration-tests): silence CLI test logging

### DIFF
--- a/integration-tests/tests/pages/CliPage.ts
+++ b/integration-tests/tests/pages/CliPage.ts
@@ -362,29 +362,6 @@ export class CliPage {
     }
 
     /**
-     * Log CLI result for debugging (always includes stderr if present)
-     */
-    logCliResult(operation: string, result: CliResult, logStdout: boolean = false): void {
-        const parts = [`${operation}:`];
-
-        if (result.exitCode !== 0) {
-            parts.push(`❌ Exit code: ${result.exitCode}`);
-        } else {
-            parts.push(`✅ Success`);
-        }
-
-        if (logStdout && result.stdout) {
-            parts.push(`STDOUT: ${result.stdout}`);
-        }
-
-        if (result.stderr) {
-            parts.push(`STDERR: ${result.stderr}`);
-        }
-
-        console.log(parts.join('\n'));
-    }
-
-    /**
      * Get status of sequences
      */
     async getStatus(options: {

--- a/integration-tests/tests/specs/cli/auth.spec.ts
+++ b/integration-tests/tests/specs/cli/auth.spec.ts
@@ -27,9 +27,6 @@ cliTest.describe('CLI Authentication', () => {
         expect(invalidLoginResult.exitCode).not.toBe(0);
         expect(invalidLoginResult.stderr).toContain('Invalid username or password');
 
-        // Log the failed login attempt for debugging
-        cliPage.logCliResult('Failed login attempt (expected)', invalidLoginResult);
-
         // Step 4: Login with valid credentials
         const validLoginResult = await cliPage.login('testuser', 'testuser');
         cliPage.assertSuccess(validLoginResult, 'Valid login');

--- a/integration-tests/tests/specs/cli/get.spec.ts
+++ b/integration-tests/tests/specs/cli/get.spec.ts
@@ -64,6 +64,5 @@ cliTest.describe('CLI Get/Search', () => {
         });
         expect(invalidOrganismResult.exitCode).not.toBe(0);
         expect(invalidOrganismResult.stderr).toMatch(/LAPIS not available|failed|not found/);
-        cliPage.logCliResult('Invalid organism (expected failure)', invalidOrganismResult);
     });
 });

--- a/integration-tests/tests/specs/cli/release.spec.ts
+++ b/integration-tests/tests/specs/cli/release.spec.ts
@@ -39,7 +39,6 @@ cliTest.describe('CLI Release Command', () => {
                         break;
                     }
                 } else {
-                    cliPage.logCliResult(`Error checking status (attempt ${i + 1})`, statusResult);
                     cliPage.assertSuccess(statusResult, 'Status check for processed sequences');
                 }
 

--- a/integration-tests/tests/specs/cli/status.spec.ts
+++ b/integration-tests/tests/specs/cli/status.spec.ts
@@ -113,7 +113,6 @@ cliTest.describe('CLI Status Command', () => {
         });
         expect(invalidOrganismResult.exitCode).not.toBe(0);
         expect(invalidOrganismResult.stderr).toMatch(/Error|error|fail|Abort/);
-        cliPage.logCliResult('Invalid organism (expected failure)', invalidOrganismResult);
 
         // Test invalid status filter
         const invalidStatusResult = await cliPage.execute([
@@ -124,7 +123,6 @@ cliTest.describe('CLI Status Command', () => {
         ]);
         expect(invalidStatusResult.exitCode).not.toBe(0);
         expect(invalidStatusResult.stderr).toMatch(/Invalid value|Error/);
-        cliPage.logCliResult('Invalid status filter (expected failure)', invalidStatusResult);
 
         // Test invalid result filter
         const invalidResultResult = await cliPage.execute([

--- a/integration-tests/tests/specs/cli/submit.spec.ts
+++ b/integration-tests/tests/specs/cli/submit.spec.ts
@@ -32,7 +32,6 @@ ATCGATCGATCGATCGATCGATCG`;
             group: groupId,
         });
 
-        cliPage.logCliResult('Submit sequences', submitResult, true);
         cliPage.assertSuccess(submitResult, 'Submit sequences');
         expect(submitResult.stdout).toContain('Submission successful');
     });


### PR DESCRIPTION
## Summary
- remove logCliResult helper and stop logging CLI results on success
- strip debug logging from CLI integration tests to reduce console noise

## Testing
- `npm run format:check`
- `PLAYWRIGHT_TEST_BASE_URL=https://main.loculus.org npx playwright test tests/specs/cli/auth.spec.ts --project=cli-tests` *(fails: navigate to register)*

------
https://chatgpt.com/codex/tasks/task_e_6899d5cfc934832580048a4888f13ee9

🚀 Preview: Add `preview` label to enable