### PR TITLE
test(website): ignore incomplete chunk console error

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -12,7 +12,7 @@
                 "@astrojs/starlight": "^0.35.2",
                 "@astrojs/starlight-tailwind": "^3.0.1",
                 "@astrojs/tailwind": "^6.0.2",
-                "astro": "^5.12.7",
+                "astro": "^5.12.8",
                 "prettier": "^3.6.2",
                 "prettier-plugin-astro": "^0.14.1",
                 "prettier-plugin-tailwindcss": "^0.6.14",
@@ -2268,13 +2268,13 @@
             }
         },
         "node_modules/astro": {
-            "version": "5.12.7",
-            "resolved": "https://registry.npmjs.org/astro/-/astro-5.12.7.tgz",
-            "integrity": "sha512-PGXbxql0SekhP46Ci4P3OFRdBp0+5HRKj6bcjZ/Upq5gyF0T2KzCJgj5JRxot+8qpSu8Jz9wksWzQnV2cfvi3A==",
+            "version": "5.12.8",
+            "resolved": "https://registry.npmjs.org/astro/-/astro-5.12.8.tgz",
+            "integrity": "sha512-KkJ7FR+c2SyZYlpakm48XBiuQcRsrVtdjG5LN5an0givI/tLik+ePJ4/g3qrAVhYMjJOxBA2YgFQxANPiWB+Mw==",
             "dependencies": {
                 "@astrojs/compiler": "^2.12.2",
-                "@astrojs/internal-helpers": "0.7.0",
-                "@astrojs/markdown-remark": "6.3.4",
+                "@astrojs/internal-helpers": "0.7.1",
+                "@astrojs/markdown-remark": "6.3.5",
                 "@astrojs/telemetry": "3.3.0",
                 "@capsizecss/unpack": "^2.4.0",
                 "@oslojs/encoding": "^1.1.0",
@@ -2364,16 +2364,16 @@
             }
         },
         "node_modules/astro/node_modules/@astrojs/internal-helpers": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.0.tgz",
-            "integrity": "sha512-+yrFHlYnknIFxi3QfbVgyHQigkfgsU9SKMjYqijq1Q6xzPco+SmaYXgcw0W7+KnWCifni4o61cgwzMkld7jkXg=="
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.1.tgz",
+            "integrity": "sha512-7dwEVigz9vUWDw3nRwLQ/yH/xYovlUA0ZD86xoeKEBmkz9O6iELG1yri67PgAPW6VLL/xInA4t7H0CK6VmtkKQ=="
         },
         "node_modules/astro/node_modules/@astrojs/markdown-remark": {
-            "version": "6.3.4",
-            "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.4.tgz",
-            "integrity": "sha512-ARu+6J3006U3NylQk2OmV0tVsXGbkz+ofgxE3S0/KuCxyk3HvZ5FQ5jQDTYCDOAdFY1376tRn0S/sUjT3KZxfw==",
+            "version": "6.3.5",
+            "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.5.tgz",
+            "integrity": "sha512-MiR92CkE2BcyWf3b86cBBw/1dKiOH0qhLgXH2OXA6cScrrmmks1Rr4Tl0p/lFpvmgQQrP54Pd1uidJfmxGrpWQ==",
             "dependencies": {
-                "@astrojs/internal-helpers": "0.7.0",
+                "@astrojs/internal-helpers": "0.7.1",
                 "@astrojs/prism": "3.3.0",
                 "github-slugger": "^2.0.0",
                 "hast-util-from-html": "^2.0.3",
@@ -10231,13 +10231,13 @@
             "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="
         },
         "astro": {
-            "version": "5.12.7",
-            "resolved": "https://registry.npmjs.org/astro/-/astro-5.12.7.tgz",
-            "integrity": "sha512-PGXbxql0SekhP46Ci4P3OFRdBp0+5HRKj6bcjZ/Upq5gyF0T2KzCJgj5JRxot+8qpSu8Jz9wksWzQnV2cfvi3A==",
+            "version": "5.12.8",
+            "resolved": "https://registry.npmjs.org/astro/-/astro-5.12.8.tgz",
+            "integrity": "sha512-KkJ7FR+c2SyZYlpakm48XBiuQcRsrVtdjG5LN5an0givI/tLik+ePJ4/g3qrAVhYMjJOxBA2YgFQxANPiWB+Mw==",
             "requires": {
                 "@astrojs/compiler": "^2.12.2",
-                "@astrojs/internal-helpers": "0.7.0",
-                "@astrojs/markdown-remark": "6.3.4",
+                "@astrojs/internal-helpers": "0.7.1",
+                "@astrojs/markdown-remark": "6.3.5",
                 "@astrojs/telemetry": "3.3.0",
                 "@capsizecss/unpack": "^2.4.0",
                 "@oslojs/encoding": "^1.1.0",
@@ -10301,16 +10301,16 @@
             },
             "dependencies": {
                 "@astrojs/internal-helpers": {
-                    "version": "0.7.0",
-                    "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.0.tgz",
-                    "integrity": "sha512-+yrFHlYnknIFxi3QfbVgyHQigkfgsU9SKMjYqijq1Q6xzPco+SmaYXgcw0W7+KnWCifni4o61cgwzMkld7jkXg=="
+                    "version": "0.7.1",
+                    "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.1.tgz",
+                    "integrity": "sha512-7dwEVigz9vUWDw3nRwLQ/yH/xYovlUA0ZD86xoeKEBmkz9O6iELG1yri67PgAPW6VLL/xInA4t7H0CK6VmtkKQ=="
                 },
                 "@astrojs/markdown-remark": {
-                    "version": "6.3.4",
-                    "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.4.tgz",
-                    "integrity": "sha512-ARu+6J3006U3NylQk2OmV0tVsXGbkz+ofgxE3S0/KuCxyk3HvZ5FQ5jQDTYCDOAdFY1376tRn0S/sUjT3KZxfw==",
+                    "version": "6.3.5",
+                    "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.5.tgz",
+                    "integrity": "sha512-MiR92CkE2BcyWf3b86cBBw/1dKiOH0qhLgXH2OXA6cScrrmmks1Rr4Tl0p/lFpvmgQQrP54Pd1uidJfmxGrpWQ==",
                     "requires": {
-                        "@astrojs/internal-helpers": "0.7.0",
+                        "@astrojs/internal-helpers": "0.7.1",
                         "@astrojs/prism": "3.3.0",
                         "github-slugger": "^2.0.0",
                         "hast-util-from-html": "^2.0.3",

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,7 +17,7 @@
         "@astrojs/starlight": "^0.35.2",
         "@astrojs/starlight-tailwind": "^3.0.1",
         "@astrojs/tailwind": "^6.0.2",
-        "astro": "^5.12.7",
+        "astro": "^5.12.8",
         "prettier": "^3.6.2",
         "prettier-plugin-astro": "^0.14.1",
         "prettier-plugin-tailwindcss": "^0.6.14",

--- a/docs/src/content/docs/reference/helm-chart-config.mdx
+++ b/docs/src/content/docs/reference/helm-chart-config.mdx
@@ -79,11 +79,15 @@ Definition of metadata fields for sequence entries of an organism, for example t
 
 Use the optional `customDisplay` object on a metadata field to change how the
 value appears on the sequence details page. The object can contain
-`type`, `url`, `html`, `value` and `displayGroup` properties. The `type`
+`type`, `url`, `html`, `value`, `linkMenuItems` and `displayGroup` properties. The `type`
 property controls the behaviour:
 
 - `link` – open the value as a hyperlink using the `url` where `__value__` is
   replaced by the actual value.
+- `linkWithMenu` – display the value as a hyperlink with a dropdown menu for
+  multiple link options. Requires `linkMenuItems` array with objects containing
+  `name` and `url` properties. The first item is used as the default/primary link
+  that opens when clicking the value directly.
 - `badge` – show mutation lists as coloured badges (requires `value`).
 - `htmlTemplate` – replace `__value__` in the provided `html` string and render
   the resulting HTML snippet.
@@ -96,6 +100,23 @@ property controls the behaviour:
 
 When `displayGroup` is provided, all entries with the same group are collapsed
 into a single row.
+
+##### Example: linkWithMenu for INSDC accessions
+
+```yaml
+- name: insdcAccessionFull
+  displayName: INSDC accession
+  customDisplay:
+    type: linkWithMenu
+    linkMenuItems:
+      - name: View in NCBI
+        url: 'https://www.ncbi.nlm.nih.gov/nuccore/__value__'
+      - name: View in ENA
+        url: 'https://www.ebi.ac.uk/ena/browser/view/__value__'
+      - name: View in DDBJ
+        url: 'https://www.ddbj.nig.ac.jp/entry/__value__'
+  header: 'INSDC'
+```
 
 ### Preprocessing (type)
 

--- a/integration-tests/AGENTS.md
+++ b/integration-tests/AGENTS.md
@@ -1,0 +1,4 @@
+ 
+ Here is a good example of how to run tests against main:
+
+  PLAYWRIGHT_TEST_BASE_URL=https://main.loculus.org npx playwright test  --reporter=list    

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -285,7 +285,16 @@ organisms:
   {{- if .customDisplay }}
   customDisplay:
     type: {{ quote .customDisplay.type }}
+    {{- if .customDisplay.url }}
     url: {{ .customDisplay.url }}
+    {{- end }}
+    {{- if .customDisplay.linkMenuItems }}
+    linkMenuItems:
+      {{- range .customDisplay.linkMenuItems }}
+      - name: {{ quote .name }}
+        url: {{ quote .url }}
+      {{- end }}
+    {{- end }}
     {{- if .customDisplay.displayGroup }}
     displayGroup: {{ quote .customDisplay.displayGroup }}
     {{- end }}

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -593,8 +593,14 @@ defaultOrganismConfig: &defaultOrganismConfig
       - name: insdcAccessionFull
         displayName: INSDC accession
         customDisplay:
-          type: link
-          url: "https://www.ncbi.nlm.nih.gov/nuccore/__value__"
+          type: linkWithMenu
+          linkMenuItems:
+            - name: View in NCBI
+              url: "https://www.ncbi.nlm.nih.gov/nuccore/__value__"
+            - name: View in ENA
+              url: "https://www.ebi.ac.uk/ena/browser/view/__value__"
+            - name: View in DDBJ
+              url: "https://getentry.ddbj.nig.ac.jp/getentry/na/__value__"
         header: "INSDC"
         ingest: genbankAccession
         noInput: true
@@ -602,8 +608,14 @@ defaultOrganismConfig: &defaultOrganismConfig
         oneHeader: true
       - name: bioprojectAccession
         customDisplay:
-          type: link
-          url: "https://www.ncbi.nlm.nih.gov/bioproject/__value__"
+          type: linkWithMenu
+          linkMenuItems:
+            - name: View in NCBI
+              url: "https://www.ncbi.nlm.nih.gov/bioproject/__value__"
+            - name: View in ENA
+              url: "https://www.ebi.ac.uk/ena/browser/view/__value__"
+            - name: View in DDBJ
+              url: "https://ddbj.nig.ac.jp/search/entry/bioproject/__value__"
         header: "INSDC"
         ingest: bioprojects
         guidance: "Only add this field if you want your sequences to be linked to an existing public bioproject in the INSDC. If you do not have a bioproject, leave this field blank - we will create a bioproject for you on submission of your consensus sequence."
@@ -613,14 +625,20 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: GCA accession
         customDisplay:
           type: link
-          url: "https://www.ncbi.nlm.nih.gov/datasets/genome/__value__"
+          url: "https://www.ebi.ac.uk/ena/browser/view/__value__"
         header: "INSDC"
         noInput: true
         oneHeader: true
       - name: biosampleAccession
         customDisplay:
-          type: link
-          url: "https://www.ncbi.nlm.nih.gov/biosample/__value__"
+          type: linkWithMenu
+          linkMenuItems:
+            - name: View in NCBI
+              url: "https://www.ncbi.nlm.nih.gov/biosample/__value__"
+            - name: View in ENA
+              url: "https://www.ebi.ac.uk/ena/browser/view/__value__"
+            - name: View in DDBJ
+              url: "https://ddbj.nig.ac.jp/search/entry/biosample/__value__"
         header: "INSDC"
         guidance: "Only add this field if you have already submitted the raw reads to the INSDC, read more at https://pathoplexus.org/docs/how-to/upload-sequences. If you add this field we will not create a new biosample for you and assume you have submitted all required metadata in the linked biosample."
         definition: "Accession of corresponding public biosample of the raw reads in the INSDC"

--- a/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from enum import Enum, StrEnum, unique
+from enum import StrEnum, unique
 from typing import Any
 
 AccessionVersion = str
@@ -47,6 +47,18 @@ class ProcessingAnnotation:
 
     def __hash__(self):
         return hash((self.unprocessedFields, self.processedFields, self.message))
+
+    @classmethod
+    def from_fields(cls, input_fields, output_fields, type, message):
+        return cls(
+            unprocessedFields=[AnnotationSource(name=f, type=type) for f in input_fields],
+            processedFields=[AnnotationSource(name=f, type=type) for f in output_fields],
+            message=message,
+        )
+
+    @classmethod
+    def from_single(cls, name: str, type, message: str):
+        return cls.from_fields([name], [name], type, message)
 
 
 @dataclass

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -159,14 +159,10 @@ class ProcessingFunctions:
                 datum=None,
                 warnings=[],
                 errors=[
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=(
                             f"Internal Error: Function {function_name} did not return "
                             f"ProcessingResult with input {input_data} and args {args}, "
@@ -204,14 +200,10 @@ class ProcessingFunctions:
             parsed_date = datetime.strptime(date, "%Y-%m-%d").astimezone(pytz.utc)
             if parsed_date > datetime.now(tz=pytz.utc):
                 warnings.append(
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message="Date is in the future.",
                     )
                 )
@@ -224,14 +216,10 @@ class ProcessingFunctions:
                 datum=None,
                 warnings=warnings,
                 errors=[
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=error_message,
                     )
                 ],
@@ -270,14 +258,10 @@ class ProcessingFunctions:
                 datum=None,
                 warnings=[],
                 errors=[
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=(
                             f"Internal Error: Function parse_into_ranges did not receive valid "
                             f"submittedAt date, with input {input_data} and args {args}, "
@@ -354,14 +338,10 @@ class ProcessingFunctions:
 
             if message:
                 warnings.append(
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=f"Metadata field {output_field}:'{input_date_str}' - " + message,
                     )
                 )
@@ -371,30 +351,23 @@ class ProcessingFunctions:
                     f"Lower range of date: {datum.date_range_lower} > {datetime.now(tz=pytz.utc)}"
                 )
                 errors.append(
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
-                        message=f"Metadata field {output_field}:"
-                        f"'{input_date_str}' is in the future.",
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
+                        message=(
+                            f"Metadata field {output_field}:'{input_date_str}' is in the future."
+                        ),
                     )
                 )
 
             if release_date and datum.date_range_lower and (datum.date_range_lower > release_date):
                 logger.debug(f"Lower range of date: {parsed_date} > release_date: {release_date}")
                 errors.append(
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=(
                             f"Metadata field {output_field}:'{input_date_str}'"
                             "is after release date."
@@ -425,14 +398,10 @@ class ProcessingFunctions:
             datum=None,
             warnings=[],
             errors=[
-                ProcessingAnnotation(
-                    processedFields=[
-                        AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                    ],
-                    unprocessedFields=[
-                        AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                        for field in input_fields
-                    ],
+                ProcessingAnnotation.from_fields(
+                    input_fields,
+                    [output_field],
+                    AnnotationSourceType.METADATA,
                     message=f"Metadata field {output_field}: "
                     f"Date {input_date_str} could not be parsed.",
                 )
@@ -492,16 +461,10 @@ class ProcessingFunctions:
 
                 if message:
                     warnings.append(
-                        ProcessingAnnotation(
-                            processedFields=[
-                                AnnotationSource(
-                                    name=output_field, type=AnnotationSourceType.METADATA
-                                )
-                            ],
-                            unprocessedFields=[
-                                AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                                for field in input_fields
-                            ],
+                        ProcessingAnnotation.from_fields(
+                            input_fields,
+                            [output_field],
+                            AnnotationSourceType.METADATA,
                             message=f"Metadata field {output_field}:'{date_str}' - " + message,
                         )
                     )
@@ -509,16 +472,10 @@ class ProcessingFunctions:
                 if parsed_date > datetime.now(tz=pytz.utc):
                     logger.debug(f"parsed_date: {parsed_date} > {datetime.now(tz=pytz.utc)}")
                     errors.append(
-                        ProcessingAnnotation(
-                            processedFields=[
-                                AnnotationSource(
-                                    name=output_field, type=AnnotationSourceType.METADATA
-                                )
-                            ],
-                            unprocessedFields=[
-                                AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                                for field in input_fields
-                            ],
+                        ProcessingAnnotation.from_fields(
+                            input_fields,
+                            [output_field],
+                            AnnotationSourceType.METADATA,
                             message=f"Metadata field {output_field}:'{date_str}' is in the future.",
                         )
                     )
@@ -526,16 +483,10 @@ class ProcessingFunctions:
                 if release_date and parsed_date > release_date:
                     logger.debug(f"parsed_date: {parsed_date} > release_date: {release_date}")
                     errors.append(
-                        ProcessingAnnotation(
-                            processedFields=[
-                                AnnotationSource(
-                                    name=output_field, type=AnnotationSourceType.METADATA
-                                )
-                            ],
-                            unprocessedFields=[
-                                AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                                for field in input_fields
-                            ],
+                        ProcessingAnnotation.from_fields(
+                            input_fields,
+                            [output_field],
+                            AnnotationSourceType.METADATA,
                             message=(
                                 f"Metadata field {output_field}:'{date_str}'is after release date."
                             ),
@@ -551,14 +502,10 @@ class ProcessingFunctions:
             datum=None,
             warnings=[],
             errors=[
-                ProcessingAnnotation(
-                    processedFields=[
-                        AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                    ],
-                    unprocessedFields=[
-                        AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                        for field in input_fields
-                    ],
+                ProcessingAnnotation.from_fields(
+                    input_fields,
+                    [output_field],
+                    AnnotationSourceType.METADATA,
                     message=f"Metadata field {output_field}: Date format is not recognized.",
                 )
             ],
@@ -598,14 +545,10 @@ class ProcessingFunctions:
             return ProcessingResult(
                 datum=None,
                 errors=[
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=error_message,
                     )
                 ],
@@ -632,14 +575,10 @@ class ProcessingFunctions:
                 datum=None,
                 warnings=[],
                 errors=[
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=(
                             f"Internal Error: Function concatenate did not receive accession_version "
                             f"ProcessingResult with input {input_data} and args {args}, "
@@ -655,14 +594,10 @@ class ProcessingFunctions:
 
         def add_errors():
             errors.append(
-                ProcessingAnnotation(
-                    processedFields=[
-                        AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                    ],
-                    unprocessedFields=[
-                        AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                        for field in input_fields
-                    ],
+                ProcessingAnnotation.from_fields(
+                    input_fields,
+                    [output_field],
+                    AnnotationSourceType.METADATA,
                     message="Concatenation failed."
                     "This may be a configuration error, please contact the administrator.",
                 )
@@ -736,14 +671,10 @@ class ProcessingFunctions:
         except ValueError as e:
             logger.error(f"Concatenate failed with {e} (accession_version: {accession_version})")
             errors.append(
-                ProcessingAnnotation(
-                    processedFields=[
-                        AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                    ],
-                    unprocessedFields=[
-                        AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                        for field in input_fields
-                    ],
+                ProcessingAnnotation.from_fields(
+                    input_fields,
+                    [output_field],
+                    AnnotationSourceType.METADATA,
                     message=(
                         f"Concatenation failed for {output_field}. This is a technical error, "
                         "please contact the administrator."
@@ -792,14 +723,10 @@ class ProcessingFunctions:
             return ProcessingResult(
                 datum=None,
                 errors=[
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=error_message,
                     )
                 ],
@@ -813,14 +740,10 @@ class ProcessingFunctions:
                     + author_format_description
                 )
                 warnings.append(
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=warning_message,
                     )
                 )
@@ -831,14 +754,10 @@ class ProcessingFunctions:
                     "`Smith, Anna; Perez, Tom J.; Xu, X.L.`."
                 )
                 warnings.append(
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=warning_message,
                     )
                 )
@@ -854,14 +773,10 @@ class ProcessingFunctions:
         return ProcessingResult(
             datum=None,
             errors=[
-                ProcessingAnnotation(
-                    processedFields=[
-                        AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                    ],
-                    unprocessedFields=[
-                        AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                        for field in input_fields
-                    ],
+                ProcessingAnnotation.from_fields(
+                    input_fields,
+                    [output_field],
+                    AnnotationSourceType.METADATA,
                     message=error_message,
                 )
             ],
@@ -890,14 +805,10 @@ class ProcessingFunctions:
             return ProcessingResult(datum=None, warnings=warnings, errors=errors)
         if not isinstance(pattern, str):
             errors.append(
-                ProcessingAnnotation(
-                    processedFields=[
-                        AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                    ],
-                    unprocessedFields=[
-                        AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                        for field in input_fields
-                    ],
+                ProcessingAnnotation.from_fields(
+                    input_fields,
+                    [output_field],
+                    AnnotationSourceType.METADATA,
                     message=(
                         f"Internal Error: Function check_regex did not receive valid "
                         f"regex pattern, with input {input_data} and args {args}, "
@@ -910,14 +821,10 @@ class ProcessingFunctions:
         if re.match(pattern, regex_field):
             return ProcessingResult(datum=regex_field, warnings=warnings, errors=errors)
         errors.append(
-            ProcessingAnnotation(
-                processedFields=[
-                    AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                ],
-                unprocessedFields=[
-                    AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                    for field in input_fields
-                ],
+            ProcessingAnnotation.from_fields(
+                input_fields,
+                [output_field],
+                AnnotationSourceType.METADATA,
                 message=f"The value '{regex_field}' does not match the expected regex pattern: '{pattern}'.",
             )
         )
@@ -933,14 +840,10 @@ class ProcessingFunctions:
                 datum=None,
                 warnings=[],
                 errors=[
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=f"No data found for output field: {output_field}",
                     )
                 ],
@@ -1006,14 +909,10 @@ class ProcessingFunctions:
                 datum=None,
                 warnings=[],
                 errors=[
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=(
                             "Website configuration error: no options list specified for field "
                             f"{output_field}, please contact an administrator."
@@ -1041,14 +940,10 @@ class ProcessingFunctions:
             return ProcessingResult(
                 datum=input_datum,
                 warnings=[
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=error_msg,
                     )
                 ],
@@ -1059,19 +954,16 @@ class ProcessingFunctions:
                 datum=None,
                 warnings=[],
                 errors=[
-                    ProcessingAnnotation(
-                        processedFields=[
-                            AnnotationSource(name=output_field, type=AnnotationSourceType.METADATA)
-                        ],
-                        unprocessedFields=[
-                            AnnotationSource(name=field, type=AnnotationSourceType.METADATA)
-                            for field in input_fields
-                        ],
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
                         message=error_msg,
                     )
                 ],
             )
         return ProcessingResult(datum=output_datum, warnings=[], errors=[])
+
 
 def format_frameshift(input: str | None) -> str | None:
     """

--- a/preprocessing/nextclade/src/loculus_preprocessing/sequence_checks.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/sequence_checks.py
@@ -1,5 +1,4 @@
 from .datatypes import (
-    AnnotationSource,
     AnnotationSourceType,
     NucleotideSequence,
     ProcessingAnnotation,
@@ -34,21 +33,17 @@ def errors_if_non_iupac(
             non_iupac_symbols = set(sequence.upper()) - UNALIGNED_NUCLEOTIDE_SYMBOLS
             if non_iupac_symbols:
                 errors.append(
-                    ProcessingAnnotation(
-                        unprocessedFields=[
-                            AnnotationSource(
-                                name=segment, type=AnnotationSourceType.NUCLEOTIDE_SEQUENCE
-                            )
-                        ],
-                        processedFields=[
-                            AnnotationSource(
-                                name=segment, type=AnnotationSourceType.NUCLEOTIDE_SEQUENCE
-                            )
-                        ],
+                    ProcessingAnnotation.from_single(
+                        segment,
+                        AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
                         message=(
                             f"Found non-IUPAC symbols in the {segment} sequence: "
-                            + ", ".join(non_iupac_symbols) + (". Gap characters (-) are not "
-                            "allowed in raw sequences." if "-" in non_iupac_symbols else "")
+                            + ", ".join(non_iupac_symbols)
+                            + (
+                                ". Gap characters (-) are not allowed in raw sequences."
+                                if "-" in non_iupac_symbols
+                                else ""
+                            )
                         ),
                     )
                 )

--- a/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
+++ b/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
@@ -25,7 +25,7 @@ from loculus_preprocessing.datatypes import (
     UnprocessedEntry,
 )
 from loculus_preprocessing.embl import create_flatfile, reformat_authors_from_loculus_to_embl_style
-from loculus_preprocessing.prepro import process_all
+from loculus_preprocessing.prepro import ProcessingAnnotationAlignment, process_all
 from loculus_preprocessing.processing_functions import (
     format_frameshift,
     format_stop_codon,
@@ -403,8 +403,8 @@ multi_segment_case_definitions_all_requirement = [
         },
         expected_errors=[
             ProcessingAnnotationHelper(
-                ["alignment"],
-                ["alignment"],
+                [ProcessingAnnotationAlignment],
+                [ProcessingAnnotationAlignment],
                 "No segment aligned.",
                 AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
             ),
@@ -490,8 +490,8 @@ multi_segment_case_definitions_any_requirement = [
         },
         expected_errors=[
             ProcessingAnnotationHelper(
-                ["alignment"],
-                ["alignment"],
+                [ProcessingAnnotationAlignment],
+                [ProcessingAnnotationAlignment],
                 "No segment aligned.",
                 AnnotationSourceType.NUCLEOTIDE_SEQUENCE,
             )
@@ -709,10 +709,7 @@ def test_create_flatfile():
 
     result = process_all([sequence_entry_data], EBOLA_SUDAN_DATASET, config)
 
-    embl_str = create_flatfile(
-        config,
-        result[0]
-    )
+    embl_str = create_flatfile(config, result[0])
     expected_embl = Path(SINGLE_SEGMENT_EMBL).read_text(encoding="utf-8")
     assert embl_str == expected_embl
 

--- a/website/src/components/SequenceDetailsPage/DataTableEntryValue.tsx
+++ b/website/src/components/SequenceDetailsPage/DataTableEntryValue.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import sanitizeHtml from 'sanitize-html';
 
 import { DataUseTermsHistoryModal } from './DataUseTermsHistoryModal';
+import { LinkWithMenuComponent } from './LinkWithMenuComponent';
 import { SubstitutionsContainers } from './MutationBadge';
 import { type TableDataEntry } from './types.ts';
 import { type DataUseTermsHistoryEntry } from '../../types/backend.ts';
@@ -67,6 +68,10 @@ const CustomDisplayComponent: React.FC<Props> = ({ data, dataUseTermsHistory }) 
                     >
                         {value}
                     </a>
+                )}
+
+                {customDisplay?.type === 'linkWithMenu' && customDisplay.linkMenuItems !== undefined && (
+                    <LinkWithMenuComponent value={value} linkMenuItems={customDisplay.linkMenuItems} />
                 )}
                 {customDisplay?.type === 'htmlTemplate' && customDisplay.html !== undefined && (
                     /* eslint-disable @typescript-eslint/naming-convention */

--- a/website/src/components/SequenceDetailsPage/LinkWithMenuComponent.tsx
+++ b/website/src/components/SequenceDetailsPage/LinkWithMenuComponent.tsx
@@ -1,0 +1,65 @@
+import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
+import React from 'react';
+
+import type { LinkMenuItem } from '../../types/config';
+import IwwaArrowDown from '~icons/iwwa/arrow-down';
+
+interface LinkWithMenuComponentProps {
+    value: string | number | boolean;
+    linkMenuItems: LinkMenuItem[];
+}
+
+export const LinkWithMenuComponent: React.FC<LinkWithMenuComponentProps> = ({ value, linkMenuItems }) => {
+    if (linkMenuItems.length === 0) {
+        return <span>{value}</span>;
+    }
+
+    const primaryLink = linkMenuItems[0];
+    const hasMultipleLinks = linkMenuItems.length > 1;
+
+    const generateUrl = (urlTemplate: string) => {
+        return urlTemplate.replace('__value__', value.toString());
+    };
+
+    if (!hasMultipleLinks) {
+        return (
+            <a href={generateUrl(primaryLink.url)} target='_blank' rel='noopener noreferrer' className='underline'>
+                {value}
+            </a>
+        );
+    }
+
+    return (
+        <div className='inline-flex items-center'>
+            <a href={generateUrl(primaryLink.url)} target='_blank' rel='noopener noreferrer' className='underline'>
+                {value}
+            </a>
+            <Menu as='div' className='relative inline-block text-left ml-1'>
+                <MenuButton className='inline-flex items-center p-1 text-gray-600 hover:text-gray-900'>
+                    <IwwaArrowDown className='h-3 w-3' aria-hidden='true' />
+                </MenuButton>
+                <MenuItems className='absolute left-0 mt-2 w-48 origin-top-left rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none z-10'>
+                    <div className='py-1'>
+                        {linkMenuItems.map((linkItem) => (
+                            <MenuItem key={linkItem.name}>
+                                {({ focus }) => (
+                                    <a
+                                        href={generateUrl(linkItem.url)}
+                                        target='_blank'
+                                        rel='noopener noreferrer'
+                                        className={`
+                                            ${focus ? 'bg-gray-100 text-gray-900' : 'text-gray-700'}
+                                            block px-4 py-2 text-sm
+                                        `}
+                                    >
+                                        {linkItem.name}
+                                    </a>
+                                )}
+                            </MenuItem>
+                        ))}
+                    </div>
+                </MenuItems>
+            </Menu>
+        </div>
+    );
+};

--- a/website/src/components/Submission/SubmissionGroupSelector.tsx
+++ b/website/src/components/Submission/SubmissionGroupSelector.tsx
@@ -27,11 +27,11 @@ export const SubmissionGroupSelector: FC<GroupSelectorProps> = ({ groups, select
     );
 
     if (groups.length === 1) {
-        return <div className='mb-2 ml-4'>{groupNameElement}</div>;
+        return <div className='mb-2'>{groupNameElement}</div>;
     }
 
     return (
-        <div className='mb-2 ml-4'>
+        <div className='mb-2'>
             <div className='dropdown'>
                 <div tabIndex={0} role='button' className=''>
                     {groupNameElement} <IwwaArrowDown className='inline-block -mt-1 h-5 w-5' />

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -19,12 +19,18 @@ export const segmentedMutations = z.object({
     mutations: z.array(mutationProportionCount),
 });
 
+export const linkMenuItem = z.object({
+    name: z.string(),
+    url: z.string(),
+});
+
 export const customDisplay = z.object({
     type: z.string(),
     url: z.string().optional(),
     html: z.string().optional(),
     value: z.array(segmentedMutations).optional(),
     displayGroup: z.string().optional(),
+    linkMenuItems: z.array(linkMenuItem).optional(),
 });
 
 /**
@@ -78,6 +84,7 @@ export const inputField = z.object({
 
 export type InputFieldOption = z.infer<typeof inputFieldOption>;
 export type InputField = z.infer<typeof inputField>;
+export type LinkMenuItem = z.infer<typeof linkMenuItem>;
 export type CustomDisplay = z.infer<typeof customDisplay>;
 export type Metadata = z.infer<typeof metadata>;
 export type MetadataType = z.infer<typeof metadataPossibleTypes>;

--- a/website/tests/util/throwOnConsole.ts
+++ b/website/tests/util/throwOnConsole.ts
@@ -11,6 +11,7 @@ const messagesToIgnore = [
     /downloadable font: kern: Too large subtable/, // firefox only, keycloak only, https://github.com/keycloak/keycloak/issues/29486
     /downloadable font: Table discarded/, // firefox only, keycloak only
     /Target page, context or browser has been closed/, // Playwright specific warning after browser is closed
+    /Failed to load resource: net::ERR_INCOMPLETE_CHUNKED_ENCODING/, // network request aborted during tests
 ];
 
 export function throwOnConsole(page: Page) {

--- a/website/tests/util/throwOnConsole.ts
+++ b/website/tests/util/throwOnConsole.ts
@@ -11,7 +11,7 @@ const messagesToIgnore = [
     /downloadable font: kern: Too large subtable/, // firefox only, keycloak only, https://github.com/keycloak/keycloak/issues/29486
     /downloadable font: Table discarded/, // firefox only, keycloak only
     /Target page, context or browser has been closed/, // Playwright specific warning after browser is closed
-    /Failed to load resource: net::ERR_INCOMPLETE_CHUNKED_ENCODING/, // network request aborted during tests
+    /ERR_INCOMPLETE_CHUNKED_ENCODING/, // network request aborted during tests
 ];
 
 export function throwOnConsole(page: Page) {


### PR DESCRIPTION
## Summary
- prevent console checks from failing on incomplete chunked network errors by ignoring `ERR_INCOMPLETE_CHUNKED_ENCODING`

## Testing
- `npm run format`
- `npm run test` *(fails: connect ECONNREFUSED ::1:3000)*
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_6899fd9712048325872d62c56b968367

🚀 Preview: Add `preview` label to enable