### PR TITLE
Fix dummy-organism `lineage` field not found error

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1375,7 +1375,7 @@ defaultOrganisms:
       metadataTemplate:
         - country
         - date
-      metadata:
+      metadata: &DummyMetadata
         - name: date
           type: date
           initiallyVisible: true
@@ -1492,38 +1492,7 @@ defaultOrganisms:
       files:
         - name: raw_reads
       metadata:
-        - name: date
-          type: date
-          initiallyVisible: true
-          header: "Collection Details"
-          required: true
-          preprocessing:
-            function: parse_and_assert_past_date
-            inputs:
-              date: date
-        - name: region
-          type: string
-          initiallyVisible: true
-          generateIndex: true
-          autocomplete: true
-          header: "Collection Details"
-        - name: country
-          initiallyVisible: true
-          type: string
-          generateIndex: true
-          autocomplete: true
-          header: "Collection Details"
-        - name: division
-          initiallyVisible: true
-          type: string
-          generateIndex: true
-          autocomplete: true
-          header: "Collection Details"
-        - name: host
-          initiallyVisible: true
-          type: string
-          autocomplete: true
-          header: "Collection Details"
+        <<: *DummyMetadata
       website:
         tableColumns:
           - country

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1375,7 +1375,7 @@ defaultOrganisms:
       metadataTemplate:
         - country
         - date
-      metadata: &DummyMetadata
+      metadata: &dummyMetadata
         - name: date
           type: date
           initiallyVisible: true
@@ -1491,8 +1491,7 @@ defaultOrganisms:
             - name: raw_reads
       files:
         - name: raw_reads
-      metadata:
-        <<: *DummyMetadata
+      metadata: *dummyMetadata
       website:
         tableColumns:
           - country

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1408,6 +1408,8 @@ defaultOrganisms:
           type: string
           autocomplete: true
           header: "Collection Details"
+        - name: lineage
+          initiallyVisible: false
         - name: pangoLineage
           initiallyVisible: true
           displayName: "Pango lineage"

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1410,6 +1410,7 @@ defaultOrganisms:
           header: "Collection Details"
         - name: lineage
           initiallyVisible: false
+          notSearchable: true
         - name: pangoLineage
           initiallyVisible: true
           displayName: "Pango lineage"


### PR DESCRIPTION
Somehow I didn't test https://github.com/loculus-project/loculus/pull/4848 well enough - the dummy-organism needs `PangoLineage` not `lineage` and is rejecting the `lineage field.

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented - I now tested submission works on the preview

🚀 Preview: https://dummy-fix.loculus.org