### PR TITLE
feat(ingest): fix `submissionId` misnaming in cronjob

### DIFF
--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -356,7 +356,7 @@ def regroup_and_revoke(metadata, sequences, map, config: Config, group_id):
     Submit segments in new sequence groups and revoke segments in old (incorrect) groups in Loculus.
     """
     response = submit_or_revise(metadata, sequences, config, group_id, mode="submit")
-    submission_id_to_new_accessions = {}  # Map from id to new loculus accession
+    submission_id_to_new_accessions = {}  # Map from submissionId to new loculus accession
     for item in response:
         submission_id_to_new_accessions[item["submissionId"]] = item["accession"]
 

--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -358,7 +358,7 @@ def regroup_and_revoke(metadata, sequences, map, config: Config, group_id):
     response = submit_or_revise(metadata, sequences, config, group_id, mode="submit")
     submission_id_to_new_accessions = {}  # Map from id to new loculus accession
     for item in response:
-        submission_id_to_new_accessions[item["id"]] = item["accession"]
+        submission_id_to_new_accessions[item["submissionId"]] = item["accession"]
 
     to_revoke = json.load(open(map, encoding="utf-8"))
 


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/4856#issuecomment-3187807064

I would like to have this on genspectrum before I do db surgery

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable