### PR TITLE
feat(backend): log SQL queries [not to merge]

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/config/BackendSpringConfig.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/BackendSpringConfig.kt
@@ -9,10 +9,10 @@ import io.swagger.v3.oas.models.parameters.HeaderParameter
 import org.flywaydb.core.Flyway
 import org.jetbrains.exposed.spring.autoconfigure.ExposedAutoConfiguration
 import org.jetbrains.exposed.sql.DatabaseConfig
-import org.jetbrains.exposed.sql.Slf4jSqlDebugLogger
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.loculus.backend.controller.LoculusCustomHeaders
 import org.loculus.backend.log.REQUEST_ID_HEADER_DESCRIPTION
+import org.loculus.backend.log.SqlQueryLogger
 import org.loculus.backend.service.submission.CurrentProcessingPipelineTable
 import org.loculus.backend.utils.DateProvider
 import org.springdoc.core.customizers.OperationCustomizer
@@ -73,7 +73,7 @@ class BackendSpringConfig {
     @Bean
     fun databaseConfig() = DatabaseConfig {
         useNestedTransactions = true
-        sqlLogger = Slf4jSqlDebugLogger
+        sqlLogger = SqlQueryLogger()
     }
 
     @Bean

--- a/backend/src/main/kotlin/org/loculus/backend/log/SqlQueryLogger.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/log/SqlQueryLogger.kt
@@ -1,0 +1,19 @@
+package org.loculus.backend.log
+
+import mu.KotlinLogging
+import org.jetbrains.exposed.sql.SqlLogger
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.statements.StatementContext
+import org.jetbrains.exposed.sql.statements.expandArgs
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Logs every SQL query executed by Exposed.
+ */
+class SqlQueryLogger : SqlLogger {
+    override fun log(context: StatementContext, transaction: Transaction) {
+        logger.info { context.expandArgs(transaction) }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated `SqlQueryLogger` to capture and log every SQL statement executed by Exposed
- wire the new logger into the backend's `DatabaseConfig` so all transactions emit query logs

## Testing
- `./gradlew ktlintFormat` *(fails: Could not resolve com.pinterest.ktlint:ktlint-cli:1.7.1)*
- `USE_NONDOCKER_INFRA=true ./gradlew test --console=plain` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-stdlib:2.2.0)*

------
https://chatgpt.com/codex/tasks/task_e_689ddcc0dcd483258e743cd06efa651d

🚀 Preview: Add `preview` label to enable