### PR TITLE
revision options

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionControllerDescriptions.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionControllerDescriptions.kt
@@ -114,9 +114,9 @@ The version will increase by one in respect to the original accession version.
 
 const val REVISED_METADATA_FILE_DESCRIPTION = """
 A TSV (tab separated values) file containing the metadata of the revised data.
-The first row must contain the column names. The column '$HEADER_TO_CONNECT_METADATA_AND_SEQUENCES' is required and must be unique within the 
+The first row must contain the column names. The column '$HEADER_TO_CONNECT_METADATA_AND_SEQUENCES' is required and must be unique within the
 provided dataset. It is used to associate metadata to the sequences in the sequences fasta file.
-Additionally, the column 'accession' is required and must match the accession of the original sequence entry.
+Additionally, the column 'accession' is required and must match the accession of the original sequence entry. Only the metadata columns present in this file will be updated; omitted columns keep their previous values.
 """
 
 const val SUBMIT_DESCRIPTION = """
@@ -129,11 +129,12 @@ may cause data duplication.
 
 const val REVISE_DESCRIPTION = """
 Submit revised data for new accession versions as multipart/form-data. The following rules apply:
- - Given sequence entries must exist (identified by the column 'accession' in the metadata file) 
+ - Given sequence entries must exist (identified by the column 'accession' in the metadata file)
  - The submitting user is member of the group that a sequence entry was initially submitted for.
  - The last accession version is in status  'APPROVED_FOR_RELEASE', i.e. revisable
  - The provided files contain only specified content
- 
+ - If no sequence file is provided, existing sequence and file data are reused
+
 If any of above is not fulfilled, this will return an error and roll back the whole transaction.
 """
 

--- a/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
@@ -288,7 +288,8 @@ class SubmitModel(
                 }
 
                 is SubmissionParams.RevisionSubmissionParams -> {
-                    revisionEntryStreamAsSequence(metadataStream)
+                    val requireSubmissionId = submissionParams.sequenceFile != null
+                    revisionEntryStreamAsSequence(metadataStream, requireSubmissionId)
                         .chunked(batchSize)
                         .forEach { batch ->
                             uploadDatabaseService.batchInsertRevisedMetadataInAuxTable(

--- a/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
@@ -129,7 +129,10 @@ class SubmitModel(
         )
 
         val metadataSubmissionIds = uploadDatabaseService.getMetadataUploadSubmissionIds(uploadId).toSet()
-        if (requiresConsensusSequenceFile(submissionParams.organism)) {
+        if (
+            requiresConsensusSequenceFile(submissionParams.organism) &&
+            submissionParams.sequenceFile != null
+        ) {
             log.debug { "Validating submission with uploadId $uploadId" }
             val sequenceSubmissionIds = uploadDatabaseService.getSequenceUploadSubmissionIds(uploadId).toSet()
             validateSubmissionIdSetsForConsensusSequences(metadataSubmissionIds, sequenceSubmissionIds)
@@ -188,7 +191,10 @@ class SubmitModel(
 
         val sequenceFile = submissionParams.sequenceFile
         if (sequenceFile == null) {
-            if (requiresConsensusSequenceFile(submissionParams.organism)) {
+            if (
+                submissionParams.uploadType == UploadType.ORIGINAL &&
+                requiresConsensusSequenceFile(submissionParams.organism)
+            ) {
                 throw BadRequestException(
                     "Submissions for organism ${submissionParams.organism.name} require a sequence file.",
                 )

--- a/backend/src/main/kotlin/org/loculus/backend/utils/MetadataEntry.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/MetadataEntry.kt
@@ -77,7 +77,10 @@ fun metadataEntryStreamAsSequence(metadataInputStream: InputStream): Sequence<Me
 
 data class RevisionEntry(val submissionId: SubmissionId?, val accession: Accession, val metadata: Map<String, String>)
 
-fun revisionEntryStreamAsSequence(metadataInputStream: InputStream, requireSubmissionId: Boolean = true): Sequence<RevisionEntry> {
+fun revisionEntryStreamAsSequence(
+    metadataInputStream: InputStream,
+    requireSubmissionId: Boolean = true,
+): Sequence<RevisionEntry> {
     val csvParser = CSVFormat.TDF.builder().setHeader().setSkipHeaderRecord(true).get()
         .parse(InputStreamReader(metadataInputStream))
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
@@ -424,7 +424,7 @@ class SubmissionConvenienceClient(
     ): List<SubmissionIdMapping> {
         val result = client.reviseSequenceEntries(
             DefaultFiles.getRevisedMetadataFile(accessions),
-            DefaultFiles.sequencesFile,
+            sequencesFile = null,
             organism = organism,
         ).andExpect(status().isOk)
 

--- a/docs/src/content/docs/for-users/revise-sequences.md
+++ b/docs/src/content/docs/for-users/revise-sequences.md
@@ -8,15 +8,26 @@ The process of submitting revisions is very similar to original submission. The 
 
 ## Preparing the metadata file
 
-The metadata file should include all the metadata fields that were originally included, **both** those that you wish to update and that should remain the same. (Not including a metadata column will set its value to 'empty'.)
+The metadata file needs to include an `accession` column, which contains the Loculus accessions assigned at initial submission. 
 
-The metadata file should only have rows of data for the sequences in the FASTA file. It needs to include an `accession` column, which includes the Loculus accessions assigned at initial submission. You should also include the `id` column, which will match the sequence ids in your FASTA file. (In the case of segmented organisms, the FASTA ids will additionally contain segment suffix, e.g. `_L` for segment L)
+For **metadata-only revisions** (no sequence changes):
+- Include only the metadata fields you wish to update
+- Fields not included in your file will retain their previous values
+- To clear a field's value, include the column and leave the value empty
+- The `id` column is optional when not providing sequences
 
-## Preparing the FASTA file
+For **revisions with sequence changes**:
+- Include the `id` column to match sequence ids in your FASTA file
+- In the case of segmented organisms, the FASTA ids will additionally contain segment suffix, e.g. `_L` for segment L
 
-Create a FASTA file that contains only the sequences you'd like to revise, with whatever changes you'd like to make. There is no reason to edit the sequence names in the FASTA file, as long as they still match those in your metadata file.
+## Preparing the FASTA file (optional)
 
-Even if you are not revising the sequence, you must provide a FASTA file that matches the metadata file you are uploading. It should only contain the sequences that are in the metadata file (if this is fewer than your original submission), and does not otherwise need to be edited.
+A FASTA file is **only required if you are updating sequences**. For metadata-only revisions, you can skip this step entirely.
+
+If you are revising sequences:
+- Create a FASTA file that contains only the sequences you'd like to revise
+- Include whatever sequence changes you'd like to make
+- Ensure sequence names match the `id` values in your metadata file
 
 ## Submitting the revision
 

--- a/website/src/components/Submission/FileUpload/SequenceEntryUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/SequenceEntryUploadComponent.tsx
@@ -75,7 +75,14 @@ export const SequenceEntryUpload: FC<SequenceEntryUploadProps> = ({
                         <span>
                             <strong>
                                 For revisions, your metadata file must contain an "accession" column, containing for
-                                each row the accession already in the database. <br />
+                                each row the accession already in the database.{' '}
+                                {enableConsensusSequences && (
+                                    <>
+                                        Sequence files are optional - if not provided, existing sequences will be
+                                        retained.
+                                    </>
+                                )}
+                                <br />
                             </strong>
                         </span>
                     )}
@@ -133,7 +140,9 @@ export const SequenceEntryUpload: FC<SequenceEntryUploadProps> = ({
                 <div className='flex flex-col lg:flex-row gap-6'>
                     {enableConsensusSequences && (
                         <div className='w-60 space-y-2'>
-                            <label className='text-gray-900 font-medium text-sm block'>Sequence file</label>
+                            <label className='text-gray-900 font-medium text-sm block'>
+                                Sequence file{action === 'revise' && ' (optional)'}
+                            </label>
                             <FileUploadComponent
                                 setFile={setSequenceFile}
                                 name='sequence_file'

--- a/website/src/components/Submission/FormOrUploadWrapper.tsx
+++ b/website/src/components/Submission/FormOrUploadWrapper.tsx
@@ -110,7 +110,7 @@ export const FormOrUploadWrapper: FC<FormOrUploadWrapperProps> = ({
                         }
 
                         const sFile = sequenceFile?.inner();
-                        if (enableConsensusSequences && sFile === undefined) {
+                        if (enableConsensusSequences && sFile === undefined && action === 'submit') {
                             return { type: 'error', errorMessage: 'Please specify a sequences file.' };
                         }
 


### PR DESCRIPTION
# WIP: Metadata-Only Revision Enhancement

## Summary
Enhanced the revision functionality to support metadata-only updates, allowing users to revise metadata without providing sequence files.

## Key Changes

### Backend
- Made `submissionId` optional in revision metadata when no sequence file is provided
- Enabled inheritance of `submissionId` from previous versions when not specified
- Updated SQL queries to properly merge metadata fields from previous versions
- Added support for partial metadata updates (only specified fields are updated)
- Empty string values now properly override existing values

### Frontend
- Sequence files are now optional for revisions
- Added "(optional)" label to sequence file field in revision form
- Added explanatory text about metadata-only revisions
- Updated validation to only require sequence files for initial submissions

### Documentation
- Updated user documentation to explain metadata-only revisions
- Clarified that only specified metadata fields are updated
- Documented how to clear field values (include column with empty value)
- Made it clear that sequence files are optional for revisions

## Testing
Added comprehensive test coverage including:
- Verification that `submissionId` is taken from submitted file when provided
- Verification that `submissionId` is inherited from previous version when not provided  
- Verification that empty string values properly override existing values
- All existing revision tests continue to pass

## Usage Examples

### Metadata-only revision (minimal TSV):
```
accession	host
LOC_000001Y	new host value
```

### Clear a field value:
```
accession	submissionId	region
LOC_000001Y	sample1	
```
(This would clear the region field while keeping other fields unchanged)

### Update multiple fields:
```
accession	host	region	collectionDate
LOC_000001Y	Homo sapiens	Europe	2024-01-15
```
(Only these three fields would be updated; all other fields remain unchanged)

## Benefits
- Simplified workflow for metadata corrections
- Reduced data transfer for metadata-only updates
- More flexible revision process
- Maintains backward compatibility with existing revision workflows

🚀 Preview: Add `preview` label to enable