### PR TITLE
feat!(website): add details page ordering

### DIFF
--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -25,6 +25,7 @@ fields:
     displayName: Submission ID
     type: string
     header: Submission details
+    orderOnDetailsPage: 5000
     enableSubstringSearch: true
     includeInDownloadsByDefault: true
   - name: isRevocation
@@ -38,6 +39,7 @@ fields:
     autocomplete: true
     hideOnSequenceDetailsPage: true
     header: Submission details
+    orderOnDetailsPage: 5010
   - name: groupName
     type: string
     generateIndex: true
@@ -45,6 +47,7 @@ fields:
     header: Submission details
     displayName: Submitting group
     includeInDownloadsByDefault: true
+    orderOnDetailsPage: 5020
     customDisplay:
       type: submittingGroup
       displayGroup: group
@@ -54,6 +57,7 @@ fields:
     autocomplete: true
     header: Submission details
     displayName: Submitting group (numeric ID)
+    orderOnDetailsPage: 5030
     customDisplay:
       type: submittingGroup
       displayGroup: group
@@ -61,17 +65,20 @@ fields:
     type: timestamp
     displayName: Date submitted
     header: Submission details
+    orderOnDetailsPage: 5040
   - name: submittedDate
     type: string
     hideOnSequenceDetailsPage: true
     generateIndex: true
     autocomplete: true
     displayName: Date submitted (exact)
+    orderOnDetailsPage: 5050
   - name: releasedAtTimestamp
     type: timestamp
     displayName: Date released
     header: Submission details
     columnWidth: 100
+    orderOnDetailsPage: 5060
   - name: releasedDate
     type: string
     hideOnSequenceDetailsPage: true
@@ -79,6 +86,7 @@ fields:
     autocomplete: true
     displayName: Date released (exact)
     columnWidth: 100
+    orderOnDetailsPage: 5070
   {{- if $.Values.dataUseTerms.enabled }}
   - name: dataUseTerms
     type: string
@@ -119,6 +127,7 @@ fields:
     type: string
     displayName: Version comment
     header: Submission details
+    orderOnDetailsPage: 5000
   - name: pipelineVersion
     type: int
     notSearchable: true

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -90,11 +90,13 @@ fields:
     customDisplay:
       type: dataUseTerms
     header: Data use terms
+    orderOnDetailsPage: 610
   - name: dataUseTermsRestrictedUntil
     type: date
     displayName: Data use terms restricted until
     hideOnSequenceDetailsPage: true
     header: Data use terms
+    orderOnDetailsPage: 620
   {{- if $.Values.dataUseTerms.urls }}
   - name: dataUseTermsUrl
     displayName: Data use terms URL
@@ -105,6 +107,7 @@ fields:
     customDisplay:
       type: link
       url: "__value__"
+    orderOnDetailsPage: 630
   {{- end}}
   {{- end}}
   - name: versionStatus

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -279,6 +279,9 @@ organisms:
   {{- if .order }}
   order: {{ .order }}
   {{- end }}
+  {{- if .orderOnDetailsPage }}
+  orderOnDetailsPage: {{ .orderOnDetailsPage }}
+  {{- end }}
   {{- if .includeInDownloadsByDefault }}
   includeInDownloadsByDefault: {{ .includeInDownloadsByDefault }}
   {{- end }}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -139,6 +139,11 @@
           "type": "boolean",
           "description": "If true, hides the field on the sequence details page."
         },
+        "orderOnDetailsPage": {
+          "groups": ["metadata"],
+          "type": "number",
+          "description": "Determines the order on the sequence details page."
+        },
         "hideInSearchResultsTable": {
           "groups": ["metadata"],
           "type": "boolean",

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -101,6 +101,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         header: Sample details
         ingest: ncbiCollectionDate
         order: 10
+        orderOnDetailsPage: 200
         includeInDownloadsByDefault: true
         preprocessing:
           function: parse_date_into_range
@@ -118,6 +119,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         initiallyVisible: true
         hideInSearchResultsTable: true
         header: Sample details
+        orderOnDetailsPage: 220
         preprocessing:
           function: parse_date_into_range
           inputs:
@@ -136,6 +138,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         initiallyVisible: true
         hideInSearchResultsTable: true
         header: Sample details
+        orderOnDetailsPage: 240
         preprocessing:
           function: parse_date_into_range
           inputs:
@@ -162,6 +165,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: NCBI release date
         type: date
         header: "INSDC"
+        orderOnDetailsPage: 1000
         preprocessing:
           function: parse_timestamp
           inputs:
@@ -175,10 +179,12 @@ defaultOrganismConfig: &defaultOrganismConfig
         rangeSearch: true
         noInput: true
         includeInDownloadsByDefault: true
+        orderOnDetailsPage: 300
       - name: ncbiUpdateDate
         type: date
         displayName: NCBI update date
         header: "INSDC"
+        orderOnDetailsPage: 1020
         preprocessing:
           function: parse_timestamp
           inputs:
@@ -191,11 +197,13 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Latitude
         header: Sample details
         type: float
+        orderOnDetailsPage: 420
         guidance: Geo-coordinate latitude in decimal degree (WGS84) format, i.e. values in range -90 to 90, where positive values are north of the Equator.
       - name: geoLocLongitude
         displayName: Longitude
         header: Sample details
         type: float
+        orderOnDetailsPage: 440
         guidance: Geo-coordinate longitude in decimal degree (WGS84) format, i.e. values in range -180 to 180, where positive values are east of the Prime Meridian.
       - name: geoLocCountry
         displayName: Collection country
@@ -205,6 +213,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         includeInDownloadsByDefault: true
         header: Sample details
         order: 20
+        orderOnDetailsPage: 400
         ingest: country
         required: true
         options:
@@ -523,6 +532,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         initiallyVisible: true
         header: Sample details
         order: 30
+        orderOnDetailsPage: 460
         ingest: division
       - name: geoLocAdmin2
         displayName: Collection subdivision level 2
@@ -530,12 +540,14 @@ defaultOrganismConfig: &defaultOrganismConfig
         generateIndex: true
         autocomplete: true
         header: Sample details
+        orderOnDetailsPage: 480
       - name: geoLocCity
         displayName: Collection city
         desired: true
         generateIndex: true
         autocomplete: true
         header: Sample details
+        orderOnDetailsPage: 500
       - name: geoLocSite
         ontology_id: GENEPIO:0100436
         definition: The name of a specific geographical location e.g. Credit River (rather than river).
@@ -543,12 +555,14 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Credit River
         displayName: Collection site
         header: Sample details
+        orderOnDetailsPage: 520
       - name: specimenCollectorSampleId
         displayName: Isolate name
         desired: true
         header: Sample details
         ingest: ncbiIsolateName
         enableSubstringSearch: true
+        orderOnDetailsPage: 600
       - name: authors
         displayName: Authors
         type: authors
@@ -556,6 +570,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         desired: true
         enableSubstringSearch: true
         order: 40
+        orderOnDetailsPage: 800
         includeInDownloadsByDefault: true
         ingest: ncbiSubmitterNames
         preprocessing:
@@ -570,6 +585,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         header: Authors
         ingest: ncbiSubmitterAffiliation
         includeInDownloadsByDefault: true
+        orderOnDetailsPage: 820
       - name: ncbiSubmitterCountry
         displayName: NCBI submitter country
         generateIndex: true
@@ -602,6 +618,7 @@ defaultOrganismConfig: &defaultOrganismConfig
             - name: View in DDBJ
               url: "https://getentry.ddbj.nig.ac.jp/getentry/na/__value__"
         header: "INSDC"
+        orderOnDetailsPage: 1040
         ingest: genbankAccession
         noInput: true
         perSegment: true
@@ -617,6 +634,7 @@ defaultOrganismConfig: &defaultOrganismConfig
             - name: View in DDBJ
               url: "https://ddbj.nig.ac.jp/search/entry/bioproject/__value__"
         header: "INSDC"
+        orderOnDetailsPage: 1060
         ingest: bioprojects
         guidance: "Only add this field if you want your sequences to be linked to an existing public bioproject in the INSDC. If you do not have a bioproject, leave this field blank - we will create a bioproject for you on submission of your consensus sequence."
         definition: "Accession of public bioproject in the INSDC your consensus sequences should be uploaded tp"
@@ -627,6 +645,7 @@ defaultOrganismConfig: &defaultOrganismConfig
           type: link
           url: "https://www.ebi.ac.uk/ena/browser/view/__value__"
         header: "INSDC"
+        orderOnDetailsPage: 1100
         noInput: true
         oneHeader: true
       - name: biosampleAccession
@@ -640,6 +659,7 @@ defaultOrganismConfig: &defaultOrganismConfig
             - name: View in DDBJ
               url: "https://ddbj.nig.ac.jp/search/entry/biosample/__value__"
         header: "INSDC"
+        orderOnDetailsPage: 1080
         guidance: "Only add this field if you have already submitted the raw reads to the INSDC, read more at https://pathoplexus.org/docs/how-to/upload-sequences. If you add this field we will not create a new biosample for you and assume you have submitted all required metadata in the linked biosample."
         definition: "Accession of corresponding public biosample of the raw reads in the INSDC"
         example: "SAMN12345678"
@@ -648,6 +668,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Culture ID
         desired: true
         header: Sample details
+        orderOnDetailsPage: 620
       - name: sampleReceivedDate
         ontology_id: GENEPIO:0001177
         definition: The date on which the sample was received by the laboratory.
@@ -656,6 +677,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Sample received date
         desired: true
         type: date
+        orderOnDetailsPage: 260
         preprocessing:
           function: parse_and_assert_past_date
           inputs:
@@ -664,12 +686,14 @@ defaultOrganismConfig: &defaultOrganismConfig
       - name: sampleType
         displayName: Sample type
         header: Sampling
+        orderOnDetailsPage: 1200
       - name: purposeOfSampling
         ontology_id: GENEPIO:0001198
         definition: The reason that the sample was collected.
         guidance: Select a value from the pick list in the template
         example: Diagnostic testing
         header: Sampling
+        orderOnDetailsPage: 1220
         ingest: ncbiPurposeOfSampling
       - name: presamplingActivity
         ontology_id: GENEPIO:0100433
@@ -678,6 +702,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Antimicrobial pre-treatment [GENEPIO:0100537]
         displayName: Presampling activity
         header: Sampling
+        orderOnDetailsPage: 1240
       - name: anatomicalMaterial
         ontology_id: GENEPIO:0001211
         definition: A substance obtained from an anatomical part of an organism e.g. tissue, blood.
@@ -685,6 +710,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Blood [UBERON:0000178]
         displayName: Anatomical material
         header: Sampling
+        orderOnDetailsPage: 1260
       - name: anatomicalPart
         ontology_id: GENEPIO:0001214
         definition: An anatomical part of an organism e.g. oropharynx.
@@ -692,6 +718,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Nasopharynx (NP) [UBERON:0001728]
         displayName: Anatomical part
         header: Sampling
+        orderOnDetailsPage: 1280
       - name: bodyProduct
         ontology_id: GENEPIO:0001216
         definition: A substance excreted/secreted from an organism e.g. feces, urine, sweat.
@@ -699,6 +726,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Feces [UBERON:0001988]
         displayName: Body product
         header: Sampling
+        orderOnDetailsPage: 1300
       - name: environmentalMaterial
         ontology_id: GENEPIO:0001223
         definition: A substance obtained from the natural or man-made environment e.g. soil, water, sewage, door handle, bed handrail, face mask.
@@ -706,6 +734,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Face mask [OBI:0002787]
         displayName: Environmental material
         header: Sampling
+        orderOnDetailsPage: 1320
       - name: environmentalSite
         ontology_id: GENEPIO:0001232
         definition: An environmental location may describe a site in the natural or built environment e.g. hospital, wet market, bat cave.
@@ -713,6 +742,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Hospital [ENVO:00002173]
         displayName: Environmental site
         header: Sampling
+        orderOnDetailsPage: 1340
       - name: collectionDevice
         ontology_id: GENEPIO:0001234
         definition: The instrument or container used to collect the sample e.g. swab.
@@ -721,6 +751,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Collection device
         header: Sampling
         desired: true
+        orderOnDetailsPage: 1360
       - name: collectionMethod
         ontology_id: GENEPIO:0001241
         definition: The process used to collect the sample e.g. phlebotomy, necropsy.
@@ -729,6 +760,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Collection method
         header: Sampling
         desired: true
+        orderOnDetailsPage: 1380
       - name: foodProduct
         ontology_id: GENEPIO:0100444
         definition: A material consumed and digested for nutritional value or enjoyment.
@@ -736,6 +768,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Feather meal [FOODON:00003927]; Bone meal [ENVO:02000054]; Chicken breast [FOODON:00002703]
         displayName: Food product
         header: Sampling
+        orderOnDetailsPage: 1400
       - name: foodProductProperties
         ontology_id: GENEPIO:0100445
         definition: Any characteristic of the food product pertaining to its state, processing, a label claim, or implications for consumers.
@@ -743,6 +776,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Food (chopped) [FOODON:00002777]; Ready-to-eat (RTE) [FOODON:03316636]
         displayName: Food product properties
         header: Sampling
+        orderOnDetailsPage: 1420
       - name: specimenProcessing
         ontology_id: GENEPIO:0100435
         definition: The processing applied to samples post-collection, prior to further testing, characterization, or isolation procedures.
@@ -750,6 +784,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Samples pooled [OBI:0600016]
         displayName: Specimen processing
         header: Specimen processing
+        orderOnDetailsPage: 1500
       - name: specimenProcessingDetails
         ontology_id: GENEPIO:0100311
         definition: Detailed information regarding the processing applied to a sample during or after receiving the sample.
@@ -757,6 +792,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: 25 swabs were pooled and further prepared as a single sample during library prep.
         displayName: Specimen processing details
         header: Specimen processing
+        orderOnDetailsPage: 1520
       - name: experimentalSpecimenRoleType
         ontology_id: GENEPIO:0100921
         definition: The type of role that the sample represents in the experiment.
@@ -788,6 +824,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Host gender
         header: Host
         ingest: ncbiHostSex
+        orderOnDetailsPage: 1640
       - name: hostOriginCountry
         ontology_id: GENEPIO:0100438
         definition: The country of origin of the host.
@@ -823,6 +860,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Recovered [NCIT:C49498]
         displayName: Host health outcome
         header: Host
+        orderOnDetailsPage: 1740
       - name: travelHistory
         ontology_id: GENEPIO:0001416
         definition: Travel history in last six months.
@@ -830,6 +868,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Canada, Vancouver; USA, Seattle; Italy, Milan
         displayName: Travel history
         header: Host
+        orderOnDetailsPage: 1760
       - name: exposureEvent
         ontology_id: GENEPIO:0001417
         definition: Event leading to exposure.
@@ -837,6 +876,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Mass Gathering [GENEPIO:0100237]
         displayName: Exposure event
         header: Host
+        orderOnDetailsPage: 1780
       - name: hostRole
         ontology_id: GENEPIO:0001419
         definition: The role of the host in relation to the exposure setting.
@@ -844,6 +884,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Patient [OMRSE:00000030]
         displayName: Host role
         header: Host
+        orderOnDetailsPage: 1800
       - name: exposureSetting
         ontology_id: GENEPIO:0001428
         definition: The setting leading to exposure.
@@ -851,6 +892,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Healthcare Setting [GENEPIO:0100201]
         displayName: Exposure setting
         header: Host
+        orderOnDetailsPage: 1820
       - name: exposureDetails
         ontology_id: GENEPIO:0001431
         definition: Additional host exposure information.
@@ -858,18 +900,21 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: "Host role - Other: Bus Driver"
         displayName: Exposure details
         header: Host
+        orderOnDetailsPage: 1840
       - name: previousInfectionDisease
         definition: The name of the disease previously experienced by the host.
         guidance: Provide the name(s) of the previous of ongoing disease(s). Multiple diseases can be separated by a semi-colon.
         example: COVID-19
         displayName: Previous infection (disease)
         header: Host
+        orderOnDetailsPage: 1860
       - name: previousInfectionOrganism
         definition: The name of the pathogen causing the disease previously experienced by the host.
         guidance: Provide the name(s) of the pathogen(s) causing the previous or ongoing infections. Multiple pathogen names can be separated using a semi-colon.
         example: Sudden Acute Respiratory Syndrome Coronavirus 2 (SARS-CoV-2)
         displayName: Previous infection (organism)
         header: Host
+        orderOnDetailsPage: 1880
       - name: hostVaccinationStatus
         ontology_id: GENEPIO:0001404
         definition: The vaccination status of the host (fully vaccinated, partially vaccinated, or not vaccinated).
@@ -877,6 +922,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Fully Vaccinated [GENEPIO:0100100]
         displayName: Host vaccination status
         header: Host
+        orderOnDetailsPage: 1900
       - name: purposeOfSequencing
         ontology_id: GENEPIO:0001445
         definition: The reason that the sample was sequenced.
@@ -884,6 +930,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Baseline surveillance (random sampling) [GENEPIO:0100005]
         displayName: Purpose of sequencing
         header: Sequencing
+        orderOnDetailsPage: 2000
       - name: sequencingDate
         ontology_id: GENEPIO:0001447
         definition: The date the sample was sequenced.
@@ -891,6 +938,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: "2021-04-26"
         displayName: Sequencing date
         type: date
+        orderOnDetailsPage: 2020
         preprocessing:
           function: parse_and_assert_past_date
           inputs:
@@ -904,6 +952,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: https://github.com/joshquick/artic-ncov2019/blob/master/primer_schemes/nCoV-2019/V3/nCoV-2019.tsv
         displayName: Amplicon PCR primer scheme
         header: Sequencing
+        orderOnDetailsPage: 2040
       - name: ampliconSize
         ontology_id: GENEPIO:0001449
         definition: The length of the amplicon generated by PCR amplification.
@@ -911,6 +960,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: 300bp
         displayName: Amplicon size
         header: Sequencing
+        orderOnDetailsPage: 2060
       - name: sequencingInstrument
         ontology_id: GENEPIO:0001452
         definition: The model of the sequencing instrument used.
@@ -919,6 +969,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Sequencing instrument
         header: Sequencing
         desired: true
+        orderOnDetailsPage: 2080
       - name: sequencingProtocol
         ontology_id: GENEPIO:0001454
         definition: The protocol used to generate the sequence.
@@ -927,6 +978,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Sequencing protocol
         header: Sequencing
         desired: true
+        orderOnDetailsPage: 2100
       - name: sequencingAssayType
         ontology_id: GENEPIO:0100997
         definition: The overarching sequencing methodology that was used to determine the sequence of a biomaterial.
@@ -934,6 +986,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: whole genome sequencing assay [OBI:0002117]
         displayName: Sequencing assay type
         header: Sequencing
+        orderOnDetailsPage: 2120
       - name: sequencedByOrganization
         ontology_id: GENEPIO:0100416
         definition: The name of the agency, organization or institution responsible for sequencing the isolate's genome.
@@ -941,6 +994,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Public Health Agency of Canada (PHAC) [GENEPIO:0100551]
         displayName: Sequenced by
         header: Sequencing
+        orderOnDetailsPage: 2140
       - name: sequencedByContactName
         ontology_id: GENEPIO:0100471
         definition: The name or title of the contact responsible for follow-up regarding the sequence.
@@ -948,6 +1002,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Enterics Lab Manager
         displayName: Sequenced by - contact name
         header: Sequencing
+        orderOnDetailsPage: 2160
       - name: sequencedByContactEmail
         ontology_id: GENEPIO:0100422
         definition: The email address of the contact responsible for follow-up regarding the sequence.
@@ -955,6 +1010,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: enterics@lab.ca
         displayName: Sequenced by - contact email
         header: Sequencing
+        orderOnDetailsPage: 2180
       - name: rawSequenceDataProcessingMethod
         ontology_id: GENEPIO:0001458
         definition: The method used for raw data processing such as removing barcodes, adapter trimming, filtering etc.
@@ -962,6 +1018,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Porechop 0.2.3
         displayName: Raw sequence data processing method
         header: Sequencing
+        orderOnDetailsPage: 2200
       - name: dehostingMethod
         ontology_id: GENEPIO:0001459
         definition: The method used to remove host reads from the pathogen sequence.
@@ -969,6 +1026,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Nanostripper 1.2.3
         displayName: Dehosting method
         header: Sequencing
+        orderOnDetailsPage: 2220
       - name: referenceGenomeAccession
         ontology_id: GENEPIO:0001485
         definition: A persistent, unique identifier of a genome database entry.
@@ -976,6 +1034,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: NC_045512.2
         displayName: Reference genome accession
         header: Sequencing
+        orderOnDetailsPage: 2240
       - name: consensusSequenceSoftwareName
         ontology_id: GENEPIO:0001463
         definition: The name of software used to generate the consensus sequence.
@@ -983,6 +1042,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Ivar
         displayName: Consensus sequence software name
         header: Sequencing
+        orderOnDetailsPage: 2260
       - name: consensusSequenceSoftwareVersion
         ontology_id: GENEPIO:0001469
         definition: The version of the software used to generate the consensus sequence.
@@ -990,6 +1050,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: "1.3"
         displayName: Consensus sequence software version
         header: Sequencing
+        orderOnDetailsPage: 2280
       - name: depthOfCoverage
         ontology_id: GENEPIO:0001474
         definition: The average number of reads representing a given nucleotide in the reconstructed sequence.
@@ -999,6 +1060,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         type: int
         header: Sequencing
         desired: true
+        orderOnDetailsPage: 2300
       - name: breadthOfCoverage
         ontology_id: GENEPIO:0001475
         definition: The threshold used as a cut-off for the depth of coverage.
@@ -1007,6 +1069,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Breadth of coverage
         type: int
         header: Sequencing
+        orderOnDetailsPage: 2320
       - name: qualityControlMethodName
         ontology_id: GENEPIO:0100557
         definition: The name of the method used to assess whether a sequence passed a predetermined quality control threshold.
@@ -1014,6 +1077,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: ncov-tools
         displayName: Quality control method name
         header: Sequencing
+        orderOnDetailsPage: 2340
       - name: qualityControlMethodVersion
         ontology_id: GENEPIO:0100558
         definition: The version number of the method used to assess whether a sequence passed a predetermined quality control threshold.
@@ -1021,6 +1085,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: "1.2.3"
         displayName: Quality control method version
         header: Sequencing
+        orderOnDetailsPage: 2360
       - name: qualityControlDetermination
         ontology_id: GENEPIO:0100559
         definition: The determination of a quality control assessment.
@@ -1028,6 +1093,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: sequence failed quality control
         displayName: Quality control determination
         header: Sequencing
+        orderOnDetailsPage: 2380
       - name: qualityControlIssues
         ontology_id: GENEPIO:0100560
         definition: The reason contributing to, or causing, a low quality determination in a quality control assessment.
@@ -1035,6 +1101,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: low average genome coverage
         displayName: Quality control issues
         header: Sequencing
+        orderOnDetailsPage: 2400
       - name: qualityControlDetails
         ontology_id: GENEPIO:0100561
         definition: The details surrounding a low quality determination in a quality control assessment.
@@ -1042,20 +1109,26 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: CT value of 39. Low viral load. Low DNA concentration after amplification.
         displayName: Quality control details
         header: Diagnostics
+        orderOnDetailsPage: 2500
       - name: diagnosticMeasurementMethod
         displayName: Diagnostic measurement method
         header: Diagnostics
+        orderOnDetailsPage: 2520
       - name: diagnosticTargetPresence
         displayName: Diagnostic target presence
         header: Diagnostics
+        orderOnDetailsPage: 2540
       - name: diagnosticTargetGeneName
         displayName: Gene name
         header: Diagnostics
+        orderOnDetailsPage: 2560
       - name: diagnosticMeasurementValue
         displayName: Diagnostic measurement value
         header: Diagnostics
+        orderOnDetailsPage: 2580
       - name: diagnosticMeasurementUnit
         displayName: Diagnostic measurement unit
+        orderOnDetailsPage: 2600
         header: Diagnostics
       - name: length
         type: int
@@ -1065,17 +1138,20 @@ defaultOrganismConfig: &defaultOrganismConfig
         initiallyVisible: true
         perSegment: true
         displayName: Length
+        orderOnDetailsPage: 2700
       - name: hostNameScientific
         generateIndex: true
         autocomplete: true
         header: "Host"
         ingest: ncbiHostName
         desired: true
+        orderOnDetailsPage: 1560
       - name: hostNameCommon
         generateIndex: true
         autocomplete: true
         header: "Host"
         ingest: ncbiHostCommonName
+        orderOnDetailsPage: 1580
       - name: hostTaxonId
         type: int
         autocomplete: true
@@ -1085,22 +1161,27 @@ defaultOrganismConfig: &defaultOrganismConfig
         header: "Host"
         ingest: ncbiHostTaxId
         desired: true
+        orderOnDetailsPage: 1540
       - name: isLabHost
         type: boolean
         autocomplete: true
         header: "Host"
         ingest: ncbiIsLabHost
+        orderOnDetailsPage: 1920
       - name: cellLine
         generateIndex: true
+        orderOnDetailsPage: 1940
         autocomplete: true
         header: "Host"
       - name: passageNumber
         type: int
         header: "Host"
+        orderOnDetailsPage: 1960
       - name: passageMethod
         generateIndex: true
         autocomplete: true
         header: "Host"
+        orderOnDetailsPage: 1980
       - name: ncbiSourceDb
         generateIndex: true
         autocomplete: true
@@ -1128,6 +1209,7 @@ defaultOrganismConfig: &defaultOrganismConfig
           type: link
           url: "https://www.ncbi.nlm.nih.gov/sra/?term=__value__"
         header: "INSDC"
+        orderOnDetailsPage: 1120
         ingest: ncbiSraAccessions
       - name: totalSnps
         type: int
@@ -1136,6 +1218,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         rangeSearch: true
         perSegment: true
         displayName: Total SNPs
+        orderOnDetailsPage: 2720
         preprocessing:
           inputs: {input: nextclade.totalSubstitutions}
       - name: totalInsertedNucs
@@ -1145,6 +1228,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         rangeSearch: true
         perSegment: true
         displayName: Total inserted nucs
+        orderOnDetailsPage: 2740
         preprocessing:
           inputs: {input: nextclade.totalInsertions}
       - name: totalDeletedNucs
@@ -1153,6 +1237,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         noInput: true
         rangeSearch: true
         perSegment: true
+        orderOnDetailsPage: 2760
         preprocessing:
           inputs: {input: nextclade.totalDeletions}
         displayName: Total deleted nucs
@@ -1163,9 +1248,11 @@ defaultOrganismConfig: &defaultOrganismConfig
         rangeSearch: true
         perSegment: true
         displayName: Total ambiguous nucs
+        orderOnDetailsPage: 2780
         preprocessing:
           inputs: {input: "nextclade.totalNonACGTNs"}
       - name: totalUnknownNucs
+        orderOnDetailsPage: 2800
         type: int
         header: "Alignment and QC metrics"
         noInput: true
@@ -1181,6 +1268,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         noInput: true
         perSegment: true
         displayName: Total frame shifts
+        orderOnDetailsPage: 2820
         preprocessing:
           inputs: {input: nextclade.totalFrameShifts}
       - name: frameShifts
@@ -1188,6 +1276,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         noInput: true
         perSegment: true
         displayName: Frame shifts
+        orderOnDetailsPage: 2840
         preprocessing:
           inputs: {input: nextclade.frameShifts}
       - name: completeness
@@ -1197,6 +1286,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         perSegment: true
         displayName: Completeness
         rangeSearch: true
+        orderOnDetailsPage: 2860
         customDisplay:
           type: percentage
         preprocessing:

--- a/website/src/components/SequenceDetailsPage/getDataTableData.spec.ts
+++ b/website/src/components/SequenceDetailsPage/getDataTableData.spec.ts
@@ -22,6 +22,40 @@ describe('getDataTableData', () => {
                 .find((x) => x.type.kind === 'metadata' && x.type.metadataType === 'authors'),
         ).toBeUndefined();
     });
+
+    test('should order headers and rows by orderOnDetailsPage', () => {
+        const entries: TableDataEntry[] = [
+            {
+                label: 'A1',
+                name: 'a1',
+                value: 'v1',
+                header: 'Header A',
+                type: { kind: 'metadata', metadataType: 'string' },
+                orderOnDetailsPage: 20,
+            },
+            {
+                label: 'B1',
+                name: 'b1',
+                value: 'v2',
+                header: 'Header B',
+                type: { kind: 'metadata', metadataType: 'string' },
+                orderOnDetailsPage: 5,
+            },
+            {
+                label: 'A2',
+                name: 'a2',
+                value: 'v3',
+                header: 'Header A',
+                type: { kind: 'metadata', metadataType: 'string' },
+                orderOnDetailsPage: 10,
+            },
+        ];
+
+        const data = getDataTableData(entries);
+
+        expect(data.table.map((t) => t.header)).toStrictEqual(['Header B', 'Header A']);
+        expect(data.table[1].rows.map((r) => r.name)).toStrictEqual(['a2', 'a1']);
+    });
 });
 
 const testTableDataEntries: TableDataEntry[] = [
@@ -31,6 +65,7 @@ const testTableDataEntries: TableDataEntry[] = [
         value: 'value1',
         header: 'Header 1',
         type: { kind: 'metadata', metadataType: 'string' },
+        orderOnDetailsPage: 1,
     },
     {
         label: 'Metadata Field 2',
@@ -38,6 +73,7 @@ const testTableDataEntries: TableDataEntry[] = [
         value: 'value2',
         header: 'Header 1',
         type: { kind: 'metadata', metadataType: 'timestamp' },
+        orderOnDetailsPage: 3,
     },
     {
         label: 'Metadata Field 3',
@@ -45,6 +81,7 @@ const testTableDataEntries: TableDataEntry[] = [
         value: 'value3',
         header: 'Header 2',
         type: { kind: 'metadata', metadataType: 'int' },
+        orderOnDetailsPage: 2,
     },
     {
         label: 'Authors',
@@ -52,5 +89,6 @@ const testTableDataEntries: TableDataEntry[] = [
         value: 'Last1, First1; Last2, First2; Last3, First3',
         header: 'Header 2',
         type: { kind: 'metadata', metadataType: 'authors' },
+        orderOnDetailsPage: 4,
     },
 ];

--- a/website/src/components/SequenceDetailsPage/getDataTableData.spec.ts
+++ b/website/src/components/SequenceDetailsPage/getDataTableData.spec.ts
@@ -56,6 +56,47 @@ describe('getDataTableData', () => {
         expect(data.table.map((t) => t.header)).toStrictEqual(['Header B', 'Header A']);
         expect(data.table[1].rows.map((r) => r.name)).toStrictEqual(['a2', 'a1']);
     });
+
+    test('should ignore rows without orderOnDetailsPage when computing header order', () => {
+        const entries: TableDataEntry[] = [
+            {
+                label: 'A1',
+                name: 'a1',
+                value: 'v1',
+                header: 'Header A',
+                type: { kind: 'metadata', metadataType: 'string' },
+                orderOnDetailsPage: 20,
+            },
+            {
+                label: 'A2',
+                name: 'a2',
+                value: 'v2',
+                header: 'Header A',
+                type: { kind: 'metadata', metadataType: 'string' },
+            },
+            {
+                label: 'B1',
+                name: 'b1',
+                value: 'v3',
+                header: 'Header B',
+                type: { kind: 'metadata', metadataType: 'string' },
+                orderOnDetailsPage: 10,
+            },
+            {
+                label: 'B2',
+                name: 'b2',
+                value: 'v4',
+                header: 'Header B',
+                type: { kind: 'metadata', metadataType: 'string' },
+            },
+        ];
+
+        const data = getDataTableData(entries);
+
+        expect(data.table.map((t) => t.header)).toStrictEqual(['Header B', 'Header A']);
+        expect(data.table[0].rows.map((r) => r.name)).toStrictEqual(['b1', 'b2']);
+        expect(data.table[1].rows.map((r) => r.name)).toStrictEqual(['a1', 'a2']);
+    });
 });
 
 const testTableDataEntries: TableDataEntry[] = [

--- a/website/src/components/SequenceDetailsPage/getDataTableData.ts
+++ b/website/src/components/SequenceDetailsPage/getDataTableData.ts
@@ -37,6 +37,7 @@ function grouping(listTableDataEntries: TableDataEntry[]): TableDataEntry[] {
                     header: entry.header,
                     customDisplay: entry.customDisplay,
                     label: entry.label,
+                    orderOnDetailsPage: entry.orderOnDetailsPage,
                 });
             }
             groupedEntries.get(entry.customDisplay.displayGroup)!.push(entry);
@@ -102,9 +103,20 @@ export function getDataTableData(listTableDataEntries: TableDataEntry[]): DataTa
         }
         tableHeaderMap.get(entry.header)!.push(entry);
     }
+
+    const headerGroups: { header: string; rows: TableDataEntry[]; meanOrder: number }[] = [];
     for (const [header, rows] of tableHeaderMap.entries()) {
-        result.table.push({ header, rows });
+        rows.sort(
+            (a, b) =>
+                (a.orderOnDetailsPage ?? Number.MAX_SAFE_INTEGER) - (b.orderOnDetailsPage ?? Number.MAX_SAFE_INTEGER),
+        );
+        const meanOrder =
+            rows.reduce((sum, r) => sum + (r.orderOnDetailsPage ?? Number.MAX_SAFE_INTEGER), 0) / rows.length;
+        headerGroups.push({ header, rows, meanOrder });
     }
+
+    headerGroups.sort((a, b) => a.meanOrder - b.meanOrder);
+    result.table = headerGroups.map(({ header, rows }) => ({ header, rows }));
 
     return result;
 }

--- a/website/src/components/SequenceDetailsPage/getDataTableData.ts
+++ b/website/src/components/SequenceDetailsPage/getDataTableData.ts
@@ -108,10 +108,13 @@ export function getDataTableData(listTableDataEntries: TableDataEntry[]): DataTa
     for (const [header, rows] of tableHeaderMap.entries()) {
         rows.sort(
             (a, b) =>
-                (a.orderOnDetailsPage ?? Number.MAX_SAFE_INTEGER) - (b.orderOnDetailsPage ?? Number.MAX_SAFE_INTEGER),
+                (a.orderOnDetailsPage ?? Number.POSITIVE_INFINITY) - (b.orderOnDetailsPage ?? Number.POSITIVE_INFINITY),
         );
+        const definedOrders = rows.map((r) => r.orderOnDetailsPage).filter((o): o is number => o !== undefined);
         const meanOrder =
-            rows.reduce((sum, r) => sum + (r.orderOnDetailsPage ?? Number.MAX_SAFE_INTEGER), 0) / rows.length;
+            definedOrders.length > 0
+                ? definedOrders.reduce((sum, o) => sum + o, 0) / definedOrders.length
+                : Number.POSITIVE_INFINITY;
         headerGroups.push({ header, rows, meanOrder });
     }
 

--- a/website/src/components/SequenceDetailsPage/getTableData.ts
+++ b/website/src/components/SequenceDetailsPage/getTableData.ts
@@ -157,9 +157,7 @@ function toTableData(config: Schema) {
                 value: mapValueToDisplayedValue(details[metadata.name], metadata),
                 header: metadata.header ?? '',
                 type: { kind: 'metadata', metadataType: metadata.type },
-                ...(metadata.orderOnDetailsPage !== undefined
-                    ? { orderOnDetailsPage: metadata.orderOnDetailsPage }
-                    : {}),
+                orderOnDetailsPage: metadata.orderOnDetailsPage,
             }));
 
         if (config.submissionDataTypes.consensusSequences) {

--- a/website/src/components/SequenceDetailsPage/getTableData.ts
+++ b/website/src/components/SequenceDetailsPage/getTableData.ts
@@ -157,6 +157,9 @@ function toTableData(config: Schema) {
                 value: mapValueToDisplayedValue(details[metadata.name], metadata),
                 header: metadata.header ?? '',
                 type: { kind: 'metadata', metadataType: metadata.type },
+                ...(metadata.orderOnDetailsPage !== undefined
+                    ? { orderOnDetailsPage: metadata.orderOnDetailsPage }
+                    : {}),
             }));
 
         if (config.submissionDataTypes.consensusSequences) {

--- a/website/src/components/SequenceDetailsPage/types.ts
+++ b/website/src/components/SequenceDetailsPage/types.ts
@@ -15,5 +15,6 @@ export const tableDataEntrySchema = z.object({
     header: z.string(),
     customDisplay: customDisplay.optional(),
     type: tableDataEntryTypeSchema,
+    orderOnDetailsPage: z.number().optional(),
 });
 export type TableDataEntry = z.infer<typeof tableDataEntrySchema>;

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -63,6 +63,7 @@ export const metadata = z.object({
     lineageSearch: z.boolean().optional(),
     columnWidth: z.number().optional(),
     order: z.number().optional(),
+    orderOnDetailsPage: z.number().optional(),
     includeInDownloadsByDefault: z.boolean().optional(),
 });
 


### PR DESCRIPTION
This PR introduces a new `orderOnDetailsPage` property for metadata fields that allows explicit control over the display order of fields on the sequence details page. Previously, fields were displayed in a relatively unspecified order, making it difficult to create a logical and user-friendly layout. Headed groups are sorted by the mean of their members' orders.

## Changes

### Core Implementation
- **Added `orderOnDetailsPage` property to metadata schema** (`values.schema.json`)
  - Type: number
  - Description: "Determines the order on the sequence details page"
  - Optional property that can be added to any metadata field

- **Updated template processing** (`_common-metadata.tpl`)
  - Template now includes `orderOnDetailsPage` values when defined
  - Properly propagates the property through the configuration pipeline

- **Frontend implementation** (`website/src/components/SequenceDetailsPage/`)
  - Modified `getDataTableData.ts` to sort fields by `orderOnDetailsPage` value
  - Fields with `orderOnDetailsPage` are displayed first, in ascending order
  - Fields without `orderOnDetailsPage` maintain their original order after ordered fields
  - Added comprehensive test coverage in `getDataTableData.spec.ts`

### Field Ordering Applied
Added sensible `orderOnDetailsPage` values to all metadata fields in `values.yaml`

## Testing

- ✅ Added unit tests for the sorting logic
- ✅ Tests cover fields with and without `orderOnDetailsPage`
- ✅ Tests verify proper header ordering based on field ordering

## Breaking changes

This will reorder your sequence details page as it sets a default order of 5000 for the `Submission details`. You can configure other field orders around this to decide how to order the page.

🚀 Preview: https://codex-add-orderondetailsp.loculus.org