### PR TITLE
Feat use column order to order search UI

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -97,7 +97,7 @@ defaultOrganismConfig: &defaultOrganismConfig
     # preprocessing: Preprocessing function to run on the field (optional: defaults to identity function on input field with same name)
     metadata:
       - name: sampleCollectionDate
-        displayName: Collection date
+        displayName: Date
         header: Sample details
         ingest: ncbiCollectionDate
         order: 10
@@ -113,7 +113,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         notSearchable: true
         columnWidth: 100
       - name: sampleCollectionDateRangeLower
-        displayName: Collection date (lower bound)
+        displayName: Date (lower bound)
         type: date
         initiallyVisible: true
         hideInSearchResultsTable: true
@@ -131,7 +131,7 @@ defaultOrganismConfig: &defaultOrganismConfig
           bound: lower
         noInput: true
       - name: sampleCollectionDateRangeUpper
-        displayName: Collection date (upper bound)
+        displayName: Date (upper bound)
         type: date
         initiallyVisible: true
         hideInSearchResultsTable: true
@@ -145,7 +145,7 @@ defaultOrganismConfig: &defaultOrganismConfig
             fieldType: dateRangeUpper
         rangeOverlapSearch:
           rangeName: sampleCollectionDateRange
-          rangeDisplayName: Collection date
+          rangeDisplayName: Date
           bound: upper
         noInput: true
       - name: displayName
@@ -198,7 +198,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         type: float
         guidance: Geo-coordinate longitude in decimal degree (WGS84) format, i.e. values in range -180 to 180, where positive values are east of the Prime Meridian.
       - name: geoLocCountry
-        displayName: Collection country
+        displayName: Country
         generateIndex: true
         autocomplete: true
         initiallyVisible: true
@@ -1266,7 +1266,7 @@ defaultOrganisms:
       - <<: *preprocessing
         version: 1
         configFile:
-          <<: *preprocessingConfigFile      
+          <<: *preprocessingConfigFile
           genes: [NP, VP35, VP40, GP, sGP, ssGP, VP30, VP24, L]
           nextclade_dataset_name: nextstrain/ebola/sudan
           nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/ebola/data_output
@@ -1418,7 +1418,7 @@ defaultOrganisms:
           required: true
           type: string
           lineageSystem: pangoLineage
-          options: 
+          options:
             - name: A
             - name: A.1
             - name: A.1.1
@@ -1532,7 +1532,7 @@ defaultOrganisms:
           required: true
           type: string
           lineageSystem: alternativeLineage
-          options: 
+          options:
             - name: A
             - name: A.1
             - name: A.1.1
@@ -1978,7 +1978,7 @@ enforceHTTPS: true
 registrationTermsMessage: >
   You must agree to the <a href="http://main.loculus.org/terms">terms of use</a>.
 
-enaDeposition: 
+enaDeposition:
   submitToEnaProduction: false
   enaDbName: Loculus
   enaUniqueSuffix: Loculus

--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -123,7 +123,6 @@ export const SearchForm = ({
                                 setTextValue={(value) => setSomeFieldValues(['accession', value])}
                             />
                         </div>
-
                         {showMutationSearch && (
                             <MutationField
                                 referenceGenomesSequenceNames={referenceGenomesSequenceNames}
@@ -131,16 +130,25 @@ export const SearchForm = ({
                                 onChange={(value) => setSomeFieldValues(['mutation', value])}
                             />
                         )}
-                        {visibleFields.map((filter) => (
-                            <SearchField
-                                field={filter}
-                                lapisUrl={lapisUrl}
-                                fieldValues={fieldValues}
-                                setSomeFieldValues={setSomeFieldValues}
-                                key={filter.name}
-                                lapisSearchParameters={lapisSearchParameters}
-                            />
-                        ))}
+
+                        {visibleFields
+                            .slice()
+                            .sort((a, b) => {
+                                // some fields have specified an 'order', default to 100 if not present
+                                const orderA = 'order' in a && typeof a.order === 'number' ? a.order : 100;
+                                const orderB = 'order' in b && typeof b.order === 'number' ? b.order : 100;
+                                return orderA - orderB;
+                            })
+                            .map((filter) => (
+                                <SearchField
+                                    field={filter}
+                                    lapisUrl={lapisUrl}
+                                    fieldValues={fieldValues}
+                                    setSomeFieldValues={setSomeFieldValues}
+                                    key={filter.name}
+                                    lapisSearchParameters={lapisSearchParameters}
+                                />
+                            ))}
                     </div>{' '}
                 </div>
             </div>


### PR DESCRIPTION
We specify the order of table columns in the `values.yml`, but fields are alphabetical in other places. in particular in the search UI and in the sample details page, we often have a sub-optimal ordering. E.g. here where Country should come before division:

<img width="296" height="168" alt="image" src="https://github.com/user-attachments/assets/227530ee-eb91-4d0a-8786-e40f00fd2d8d" />

Here, we re-use the order from the columns to order the search UI

<img width="412" height="306" alt="image" src="https://github.com/user-attachments/assets/439916e2-420b-410c-815f-9d46f69ed00f" />

I have not managed to do the same for the sequence details page. 

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)
