### PR TITLE
fix(kubernetes): set lower materialization cutoff in SILO

### DIFF
--- a/kubernetes/loculus/templates/silo-deployment.yaml
+++ b/kubernetes/loculus/templates/silo-deployment.yaml
@@ -41,6 +41,8 @@ spec:
             - "16"
             - "--api-max-queued-http-connections"
             - "1000"
+            - "--query-materialization-cutoff"
+            - "3276"
           volumeMounts:
             - name: lapis-silo-shared-data
               mountPath: /data


### PR DESCRIPTION
to allow larger downloads of sequence files.
The default is 32767 (2^15 - 1), we'll try whether a tenth of that works.

due to https://github.com/pathoplexus/pathoplexus/issues/607

Also see https://loculus.slack.com/archives/C05G172HL6L/p1755500263174179

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://lowermaterializationcutof.loculus.org