### PR TITLE
fix(website): replace aligned with reference-aligned

### DIFF
--- a/website/src/components/ReviewPage/SequencesDialog.tsx
+++ b/website/src/components/ReviewPage/SequencesDialog.tsx
@@ -73,9 +73,10 @@ const extractProcessedSequences = (data: SequenceEntryToEdit): ProcessedSequence
             let label = sequenceName;
             if (type !== 'gene') {
                 if (label === 'main') {
-                    label = type === 'unaligned' ? 'Sequence' : 'Aligned';
+                    label = type === 'unaligned' ? 'Sequence' : 'Reference-aligned';
                 } else {
-                    label = type === 'unaligned' ? `${sequenceName} (unaligned)` : `${sequenceName} (aligned)`;
+                    label =
+                        type === 'unaligned' ? `${sequenceName} (unaligned)` : `${sequenceName} (reference-aligned)`;
                 }
             }
             return { label, sequence };

--- a/website/src/components/SearchPage/DownloadDialog/DownloadDataType.ts
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDataType.ts
@@ -19,9 +19,11 @@ export const dataTypeForFilename = (dataType: DownloadDataType): string => {
             // segment is undefined in case of single segmented (not e.g. main)
             return dataType.segment !== undefined ? `nuc-${dataType.segment}` : 'nuc';
         case 'alignedNucleotideSequences':
-            return dataType.segment !== undefined ? `aligned-nuc-${dataType.segment}` : 'aligned-nuc';
+            return dataType.segment !== undefined
+                ? `reference-aligned-nuc-${dataType.segment}`
+                : 'reference-aligned-nuc';
         case 'alignedAminoAcidSequences':
-            return `aligned-aa-${dataType.gene}`;
+            return `reference-aligned-aa-${dataType.gene}`;
     }
 };
 

--- a/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
@@ -157,7 +157,7 @@ export const DownloadForm: FC<DownloadFormProps> = ({
                   ),
               },
               {
-                  label: <>Aligned nucleotide sequences</>,
+                  label: <>Reference-aligned nucleotide sequences</>,
                   subOptions: isMultiSegmented ? (
                       <div className='px-8'>
                           <DropdownOptionBlock
@@ -173,7 +173,7 @@ export const DownloadForm: FC<DownloadFormProps> = ({
                   ) : undefined,
               },
               {
-                  label: <>Aligned amino acid sequences</>,
+                  label: <>Reference-aligned amino acid sequences</>,
                   subOptions: (
                       <div className='px-8'>
                           <DropdownOptionBlock

--- a/website/src/components/SequenceDetailsPage/SequenceContainer.spec.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceContainer.spec.tsx
@@ -63,7 +63,7 @@ describe('SequencesContainer', () => {
 
         click('Load sequences');
 
-        click('Aligned nucleotide sequence');
+        click('Reference-aligned nucleotide sequence');
         await waitFor(() => {
             expect(
                 screen.getByText(singleSegmentSequence, {
@@ -90,7 +90,7 @@ describe('SequencesContainer', () => {
 
         click('Load sequences');
 
-        click(`${multiSegmentName} (aligned)`);
+        click(`${multiSegmentName} (reference-aligned)`);
         await waitFor(() => {
             expect(
                 screen.getByText(multiSegmentSequence, {

--- a/website/src/components/SequenceDetailsPage/SequencesContainer.tsx
+++ b/website/src/components/SequenceDetailsPage/SequencesContainer.tsx
@@ -113,7 +113,7 @@ const SequenceTabs: FC<SequenceTabsProps> = ({
                 />
                 <BoxWithTabsTab
                     isActive={activeTab === 'gene'}
-                    label='Aligned amino acid sequences'
+                    label='Reference-aligned amino acid sequences'
                     onClick={() => setActiveTab('gene')}
                 />
             </BoxWithTabsTabBar>
@@ -199,7 +199,7 @@ const AlignmentSequenceTabs: FC<NucleotideSequenceTabsProps> = ({
                     setType(alignedSequenceSegment(onlySegment));
                     setActiveTab('aligned');
                 }}
-                label='Aligned nucleotide sequence'
+                label='Reference-aligned nucleotide sequence'
             />
         );
     }
@@ -214,7 +214,7 @@ const AlignmentSequenceTabs: FC<NucleotideSequenceTabsProps> = ({
                         setType(alignedSequenceSegment(segmentName));
                         setActiveTab('aligned');
                     }}
-                    label={`${segmentName} (aligned)`}
+                    label={`${segmentName} (reference-aligned)`}
                 />
             ))}
         </>

--- a/website/tests/pages/sequences/sequences.page.ts
+++ b/website/tests/pages/sequences/sequences.page.ts
@@ -18,7 +18,7 @@ export class SequencePage {
 
     constructor(public readonly page: Page) {
         this.loadButton = this.page.getByRole('button', { name: 'Load sequences' });
-        this.specificProteinTab = this.page.getByRole('button', { name: 'Aligned amino acid sequences' });
+        this.specificProteinTab = this.page.getByRole('button', { name: 'Reference-aligned amino acid sequences' });
         this.geneDropdown = this.page.locator('select');
         this.versionLink = this.page.getByText(/Version \d+/);
         this.allVersions = this.page.getByRole('link', {


### PR DESCRIPTION
## Summary
- replace "aligned" with "reference-aligned" in download options and sequence dialogs
- update sequence details tabs and file naming to use "reference-aligned"
- adjust tests for new "reference-aligned" terminology

## Testing
- `npm run format`
- `npm run check-types`
- `npm run test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a6260a38048325b3dd284fd1636627