### PR TITLE
feat(website): use lg breakpoint for nav bar

### DIFF
--- a/website/src/components/Navigation/Navigation.astro
+++ b/website/src/components/Navigation/Navigation.astro
@@ -25,13 +25,13 @@ const topNavigationItems = navigationItems.top(selectedOrganism?.key, isLoggedIn
 ---
 
 <div class='flex justify-end relative'>
-    <div class='subtitle hidden md:flex md:z-6 gap-4 items-center'>
+    <div class='subtitle hidden lg:flex lg:z-6 gap-4 items-center'>
         <AccessionSearchBox className='' client:load />
         {topNavigationItems.map(({ text, path }) => <a href={path}>{text}</a>)}
     </div>
 
     <div
-        class='md:hidden z-0'
+        class='lg:hidden z-0'
         style={{
             position: 'absolute',
             right: '1.5rem',


### PR DESCRIPTION
We have more nav bar links on Pathoplexus and now the layout can now get messed up.

<img width="771" height="786" alt="image" src="https://github.com/user-attachments/assets/99e3ad8b-6e9f-40df-97ec-8010e4c86c4d" />


This is a simple way to fix it - using the sandwich menu on slightly wider screens - in the future we could make this configurable or based on the number of nav bar items


- switch navigation bar breakpoints from `md` to `lg` so desktop links display on larger screens only


------
https://chatgpt.com/codex/tasks/task_e_68a6376ddff483258d010a1c976a78d6

🚀 Preview: Add `preview` label to enable