### PR TITLE
feat(website): add icons to organism submenu

### DIFF
--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -24,7 +24,7 @@ const extraItems = extraSequenceRelatedTopNavigationItems(currentOrganism);
                     {currentOrganismObject?.displayName || currentOrganism}
                 </span>
                 <span class='text-gray-300 mr-2'>|</span>
-                {sequenceRelatedItems.map(({ text, path }) => {
+                {sequenceRelatedItems.map(({ text, path, icon: iconComponent }) => {
                     // Use startsWith to match path prefixes (e.g., /organism/search matches /organism/search/details)
                     const isActive = currentPath.startsWith(path);
                     return (
@@ -34,11 +34,12 @@ const extraItems = extraSequenceRelatedTopNavigationItems(currentOrganism);
                                 isActive ? 'bg-primary-100 text-gray-900' : 'text-gray-700 hover:bg-gray-100'
                             }`}
                         >
+                            {iconComponent && <iconComponent class='inline-block w-4 h-4 mr-1 align-text-bottom' />}
                             {text}
                         </a>
                     );
                 })}
-                {extraItems.map(({ text, path }) => {
+                {extraItems.map(({ text, path, icon: iconComponent }) => {
                     const isActive = currentPath.startsWith(path);
                     return (
                         <a
@@ -47,6 +48,7 @@ const extraItems = extraSequenceRelatedTopNavigationItems(currentOrganism);
                                 isActive ? 'bg-primary-100 text-gray-900' : 'text-gray-700 hover:bg-gray-100'
                             }`}
                         >
+                            {iconComponent && <iconComponent class='inline-block w-4 h-4 mr-1 align-text-bottom' />}
                             {text}
                         </a>
                     );

--- a/website/src/routes/navigationItems.ts
+++ b/website/src/routes/navigationItems.ts
@@ -1,35 +1,46 @@
+import type { SVGProps, ForwardRefExoticComponent } from 'react';
+
 import { bottomNavigationItems } from './bottomNavigationItems.ts';
 import { extraStaticTopNavigationItems } from './extraTopNavigationItems.js';
 import { routes } from './routes.ts';
 import { getWebsiteConfig } from '../config.ts';
+import Upload from '~icons/icon-park-outline/upload';
+import ListSearch from '~icons/tabler/list-search';
 
 export const navigationItems = {
     top: topNavigationItems,
     bottom: bottomNavigationItems,
 };
 
-export type TopNavigationItems = {
+export type NavigationItemIcon = ForwardRefExoticComponent<SVGProps<SVGSVGElement>>;
+
+export type NavigationItem = {
     text: string;
     path: string;
-}[];
+    icon?: NavigationItemIcon;
+};
+
+export type TopNavigationItems = NavigationItem[];
 
 export function getSequenceRelatedItems(organism: string | undefined) {
     if (organism === undefined) {
         return [];
     }
 
-    const browseItem = {
+    const browseItem: NavigationItem = {
         text: 'Browse data',
         path: routes.searchPage(organism),
+        icon: ListSearch,
     };
 
     if (!getWebsiteConfig().enableSubmissionNavigationItem) {
         return [browseItem];
     }
 
-    const submitItem = {
+    const submitItem: NavigationItem = {
         text: 'Submit sequences',
         path: routes.submissionPageWithoutGroup(organism),
+        icon: Upload,
     };
     return [browseItem, submitItem];
 }


### PR DESCRIPTION
## Summary
- allow navigation items to include optional icons
- show list-search and upload icons in organism submenu for browse and submit links

## Testing
- `npm run format`
- `npm run check-types`
- `npm run test` *(fails: AggregateError ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68b04ea131688325b67d8d1990888527