### PR TITLE
fix(website): wrap review card tooltips

### DIFF
--- a/website/src/utils/CustomTooltip.tsx
+++ b/website/src/utils/CustomTooltip.tsx
@@ -1,6 +1,12 @@
+import type { ComponentProps, FC } from 'react';
 import { Tooltip } from 'react-tooltip';
 
-export const CustomTooltip: React.FC<React.ComponentProps<typeof Tooltip>> = ({ ...props }) => (
+export const CustomTooltip: FC<ComponentProps<typeof Tooltip>> = ({ className, ...props }) => (
     // Set positionStrategy and z-index to make the Tooltip float above the ReviewPage toolbar
-    <Tooltip positionStrategy='fixed' className='z-20' place='right' {...props} />
+    <Tooltip
+        positionStrategy='fixed'
+        place='right'
+        className={`z-20 max-w-xs whitespace-pre-wrap break-words ${className ?? ''}`}
+        {...props}
+    />
 );


### PR DESCRIPTION
## Summary
- allow tooltips to wrap and limit width on review cards

## Testing
- `npm run format`
- `npm run test` *(fails: CANCELLED Test run cancelled due to connection errors)*
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_68b56520bbf88325988cedbb9dbd12f8