### PR TITLE
feat(website): enable CORS for sequence details and FASTA

### DIFF
--- a/website/src/pages/seq/[accessionVersion]/details.json.ts
+++ b/website/src/pages/seq/[accessionVersion]/details.json.ts
@@ -42,6 +42,7 @@ export const GET: APIRoute = async (req) => {
     return new Response(JSON.stringify(detailsDataUIProps), {
         headers: {
             'Content-Type': 'application/json', // eslint-disable-line @typescript-eslint/naming-convention
+            'Access-Control-Allow-Origin': '*', // eslint-disable-line @typescript-eslint/naming-convention
         },
     });
 };

--- a/website/src/utils/createDownloadAPIRoute.ts
+++ b/website/src/utils/createDownloadAPIRoute.ts
@@ -56,6 +56,7 @@ export function createDownloadAPIRoute(
 
         const headers: Record<string, string> = {
             'Content-Type': contentType, // eslint-disable-line @typescript-eslint/naming-convention
+            'Access-Control-Allow-Origin': '*', // eslint-disable-line @typescript-eslint/naming-convention
         };
         if (isDownload) {
             const filename = `${accessionVersion}.${fileSuffix}`;

--- a/website/tests/pages/sequences/accession.fa.spec.ts
+++ b/website/tests/pages/sequences/accession.fa.spec.ts
@@ -9,6 +9,8 @@ test.describe('The sequence.fa page', () => {
 
         const url = `${baseUrl}${routes.sequenceEntryFastaPage(testSequences.testSequenceEntry)}`;
         const response = await fetch(url);
+        const corsHeader = response.headers.get('Access-Control-Allow-Origin');
+        expect(corsHeader).toBe('*');
         const content = await response.text();
         expect(content).toBe(
             `>${getAccessionVersionString(testSequences.testSequenceEntry)}\n${testSequenceEntryData.unaligned}\n`,
@@ -20,6 +22,8 @@ test.describe('The sequence.fa page', () => {
 
         const downloadUrl = `${baseUrl}${routes.sequenceEntryFastaPage(testSequences.testSequenceEntry, true)}`;
         const response = await fetch(downloadUrl);
+        const corsHeader = response.headers.get('Access-Control-Allow-Origin');
+        expect(corsHeader).toBe('*');
         const contentDisposition = response.headers.get('Content-Disposition');
 
         expect(contentDisposition).not.toBeNull();


### PR DESCRIPTION
## Summary
- allow cross-origin requests for sequence details JSON
- set CORS headers on sequence download endpoints
- verify fasta endpoint exposes CORS headers

## Testing
- `npm run test`
- `npm run check-types`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68b6e378c7a48325967cc50b81ae4588

🚀 Preview: https://codex-enable-cors-for-det.loculus.org