### PR TITLE
fix(docs): fix missing proxy header in k3d/nginx tutorial

### DIFF
--- a/docs/src/content/docs/for-administrators/setup-with-k3d-and-nginx.mdx
+++ b/docs/src/content/docs/for-administrators/setup-with-k3d-and-nginx.mdx
@@ -251,6 +251,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Prefix /backend/;
     }
 
     location / {


### PR DESCRIPTION
This fixes a missing line in the "Setup with k3d and nginx" tutorial. It is needed so that the Backend Swagger knows where it is and loads the config from the right location.

🚀 Preview: Add `preview` label to enable