### PR TITLE
feat(website): add aligned sequence fasta endpoint

### DIFF
--- a/website/src/pages/seq/[accessionVersion].aligned.fa/index.ts
+++ b/website/src/pages/seq/[accessionVersion].aligned.fa/index.ts
@@ -1,0 +1,22 @@
+import type { APIRoute } from 'astro';
+
+import { getReferenceGenome } from '../../../config.ts';
+import { routes } from '../../../routes/routes.ts';
+import { LapisClient } from '../../../services/lapisClient.ts';
+import { createDownloadAPIRoute } from '../../../utils/createDownloadAPIRoute.ts';
+
+export const GET: APIRoute = createDownloadAPIRoute(
+    'text/x-fasta',
+    'fa',
+    routes.sequenceEntryAlignedFastaPage,
+    async (accessionVersion: string, organism: string) => {
+        const lapisClient = LapisClient.createForOrganism(organism);
+        const referenceGenomes = getReferenceGenome(organism);
+        const segmentNames = referenceGenomes.nucleotideSequences.map((s) => s.name);
+        const isMultiSegmented = segmentNames.length > 1;
+
+        return !isMultiSegmented
+            ? lapisClient.getAlignedSequenceFasta(accessionVersion)
+            : lapisClient.getAlignedMultiSegmentSequenceFasta(accessionVersion, segmentNames);
+    },
+);

--- a/website/src/routes/routes.ts
+++ b/website/src/routes/routes.ts
@@ -31,6 +31,13 @@ export const routes = {
         `/seq/${getAccessionVersionString(accessionVersion)}/versions`,
     sequenceEntryFastaPage: (accessionVersion: AccessionVersion | string, download = false) =>
         sequenceEntryDownloadUrl(accessionVersion, FileType.FASTA, download),
+    sequenceEntryAlignedFastaPage: (accessionVersion: AccessionVersion | string, download = false) => {
+        let url = `${routes.sequenceEntryDetailsPage(accessionVersion)}.aligned.${FileType.FASTA}`;
+        if (download) {
+            url += '?download';
+        }
+        return url;
+    },
     sequenceEntryTsvPage: (accessionVersion: AccessionVersion | string, download = false) =>
         sequenceEntryDownloadUrl(accessionVersion, FileType.TSV, download),
     createGroup: () => '/user/createGroup',

--- a/website/tests/pages/sequences/accession.aligned.fa.spec.ts
+++ b/website/tests/pages/sequences/accession.aligned.fa.spec.ts
@@ -1,0 +1,33 @@
+import { routes } from '../../../src/routes/routes.ts';
+import { getAccessionVersionString } from '../../../src/utils/extractAccessionVersion.ts';
+import { baseUrl, expect, test } from '../../e2e.fixture';
+import { getTestSequences } from '../../util/testSequenceProvider.ts';
+
+const alignedSequence = 'N' + 'A'.repeat(29902);
+
+test.describe('The sequence.aligned.fa page', () => {
+    test('can load and show aligned fasta file', async () => {
+        const testSequences = getTestSequences();
+
+        const url = `${baseUrl}${routes.sequenceEntryAlignedFastaPage(testSequences.testSequenceEntry)}`;
+        const response = await fetch(url);
+        const corsHeader = response.headers.get('Access-Control-Allow-Origin');
+        expect(corsHeader).toBe('*');
+        const content = await response.text();
+        expect(content).toBe(`>${getAccessionVersionString(testSequences.testSequenceEntry)}\n${alignedSequence}\n`);
+    });
+
+    test('can download aligned fasta file', async () => {
+        const testSequences = getTestSequences();
+
+        const downloadUrl = `${baseUrl}${routes.sequenceEntryAlignedFastaPage(testSequences.testSequenceEntry, true)}`;
+        const response = await fetch(downloadUrl);
+        const corsHeader = response.headers.get('Access-Control-Allow-Origin');
+        expect(corsHeader).toBe('*');
+        const contentDisposition = response.headers.get('Content-Disposition');
+
+        expect(contentDisposition).not.toBeNull();
+        expect(contentDisposition).toContain('attachment');
+        expect(contentDisposition).toContain(getAccessionVersionString(testSequences.testSequenceEntry));
+    });
+});


### PR DESCRIPTION
## Summary
- add API route for `.aligned.fa` to serve aligned nucleotide sequences
- extend Lapis client with aligned sequence helpers
- test aligned FASTA download and access

## Testing
- `npm run format`
- `npm run check-types`
- `npm run test -- --run` *(fails: ECONNREFUSED connect localhost:3000)*

------
https://chatgpt.com/codex/tasks/task_e_68b7323bfaf88325b49bc438c7c07b0e