### PR TITLE
fix(deployment): Make the backend use the user given S3-endpoint for the file-sharing feature

### DIFF
--- a/kubernetes/loculus/templates/_urls.tpl
+++ b/kubernetes/loculus/templates/_urls.tpl
@@ -28,7 +28,7 @@
         {{- printf "http://%s:8084" $.Values.localHost -}}
     {{- end -}}
   {{- else -}}
-    {{- printf "http://%s:8084" $.Values.localHost -}}
+    {{- $.Values.s3.bucket.endpoint }}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
I'm working on a prod deployment of Loculus, and I disabled the development S3 and configured my own bucket, and I found this setting still in my backend Pod:

```yaml
    - name: S3_BUCKET_ENDPOINT
      value: http://localhost:8084
```

The backend also generates pre-signed URLs with the `localhost:8084`, instead of the proper endpoint.

I changed it so that the backend uses the user-given endpoint.

I've tested this in our setup, with a Hetzner bucket, and it's working.

### Screenshot
n/A

### PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by appropriate, automated tests.~~
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable