### PR TITLE
fix(website): avoid storing default field visibilities

### DIFF
--- a/website/src/components/SearchPage/SearchFullUI.spec.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.spec.tsx
@@ -6,8 +6,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { type InnerSearchFullUIProps, SearchFullUI } from './SearchFullUI';
 import { testConfig, testOrganism } from '../../../vitest.setup.ts';
 import { lapisClientHooks } from '../../services/serviceHooks.ts';
-import type { MetadataFilter, Schema } from '../../types/config.ts';
+import type { FieldValues, MetadataFilter, Schema } from '../../types/config.ts';
 import type { ReferenceAccession, ReferenceGenomesSequenceNames } from '../../types/referencesGenomes.ts';
+import type { ClientConfig } from '../../types/runtimeConfig.ts';
 
 global.ResizeObserver = class FakeResizeObserver {
     observe() {}
@@ -78,6 +79,12 @@ function renderSearchFullUI({
     searchFormFilters = [...defaultSearchFormFilters],
     clientConfig = testConfig.public,
     referenceGenomesSequenceNames = defaultReferenceGenomesSequenceNames,
+    hiddenFieldValues = {},
+}: {
+    searchFormFilters?: MetadataFilter[];
+    clientConfig?: ClientConfig;
+    referenceGenomesSequenceNames?: ReferenceGenomesSequenceNames;
+    hiddenFieldValues?: FieldValues;
 } = {}) {
     const metadataSchema: MetadataFilter[] = searchFormFilters.map((filter) => ({
         ...filter,
@@ -101,6 +108,7 @@ function renderSearchFullUI({
         initialData: [],
         initialCount: 0,
         initialQueryDict: {},
+        hiddenFieldValues,
     } satisfies InnerSearchFullUIProps;
 
     render(
@@ -259,6 +267,42 @@ describe('SearchFullUI', () => {
         await waitFor(() => {
             expect(window.history.state.path).toContain('visibility_field1=false');
             expect(window.history.state.path).not.toContain('visibility_field2=false');
+        });
+    });
+
+    it('does not add hidden field values to the URL when selecting none', async () => {
+        renderSearchFullUI({
+            searchFormFilters: [
+                ...defaultSearchFormFilters,
+                {
+                    name: 'isRevocation',
+                    type: 'string',
+                    displayName: 'isRevocation',
+                    autocomplete: false,
+                    initiallyVisible: false,
+                },
+                {
+                    name: 'versionStatus',
+                    type: 'string',
+                    displayName: 'versionStatus',
+                    autocomplete: false,
+                    initiallyVisible: false,
+                },
+            ],
+            hiddenFieldValues: {
+                isRevocation: 'false',
+                versionStatus: 'LATEST_VERSION',
+            },
+        });
+        const customizeButton = await screen.findByRole('button', { name: 'Add search fields' });
+        await userEvent.click(customizeButton);
+        const selectNoneButton = await screen.findByRole('button', { name: 'Select none' });
+        await userEvent.click(selectNoneButton);
+        const closeButton = await screen.findByTestId('field-selector-close-button');
+        await userEvent.click(closeButton);
+        await waitFor(() => {
+            expect(window.history.state.path).not.toContain('isRevocation=');
+            expect(window.history.state.path).not.toContain('versionStatus=');
         });
     });
 

--- a/website/src/components/SearchPage/SearchFullUI.spec.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.spec.tsx
@@ -245,7 +245,7 @@ describe('SearchFullUI', () => {
         expect(screen.queryByLabelText('Field 1')).not.toBeInTheDocument();
     });
 
-    it('does not store default invisible search field visibilities', async () => {
+    it('does not store default invisible search field visibilities in URL when set to false as this is unneeded', async () => {
         renderSearchFullUI({
             searchFormFilters: [
                 ...defaultSearchFormFilters,

--- a/website/src/components/SearchPage/SearchFullUI.spec.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.spec.tsx
@@ -117,6 +117,7 @@ describe('SearchFullUI', () => {
                 href: '',
             },
         });
+        window.history.replaceState({ path: '' }, '', '');
 
         mockUseAggregated.mockReturnValue({
             data: {
@@ -236,6 +237,31 @@ describe('SearchFullUI', () => {
         expect(screen.queryByLabelText('Field 1')).not.toBeInTheDocument();
     });
 
+    it('does not store default invisible search field visibilities', async () => {
+        renderSearchFullUI({
+            searchFormFilters: [
+                ...defaultSearchFormFilters,
+                {
+                    name: 'field2',
+                    type: 'string',
+                    displayName: 'Field 2',
+                    autocomplete: false,
+                    initiallyVisible: false,
+                },
+            ],
+        });
+        const customizeButton = await screen.findByRole('button', { name: 'Add search fields' });
+        await userEvent.click(customizeButton);
+        const selectNoneButton = await screen.findByRole('button', { name: 'Select none' });
+        await userEvent.click(selectNoneButton);
+        const closeButton = await screen.findByTestId('field-selector-close-button');
+        await userEvent.click(closeButton);
+        await waitFor(() => {
+            expect(window.history.state.path).toContain('visibility_field1=false');
+            expect(window.history.state.path).not.toContain('visibility_field2=false');
+        });
+    });
+
     it('should update the URL with query parameters when a search is performed', async () => {
         renderSearchFullUI();
 
@@ -260,5 +286,19 @@ describe('SearchFullUI', () => {
         const closeButton = await screen.findByTestId('field-selector-close-button');
         await userEvent.click(closeButton);
         expect(screen.getByRole('columnheader', { name: 'Field 4' })).toBeVisible();
+    });
+
+    it('does not store default invisible column visibilities', async () => {
+        renderSearchFullUI({});
+        const customizeButton = await screen.findByRole('button', { name: 'Customize columns' });
+        await userEvent.click(customizeButton);
+        const selectNoneButton = await screen.findByRole('button', { name: 'Select none' });
+        await userEvent.click(selectNoneButton);
+        const closeButton = await screen.findByTestId('field-selector-close-button');
+        await userEvent.click(closeButton);
+        await waitFor(() => {
+            expect(window.history.state.path).toContain('column_field1=false');
+            expect(window.history.state.path).not.toContain('column_field4=false');
+        });
     });
 });

--- a/website/src/components/SearchPage/SearchFullUI.spec.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.spec.tsx
@@ -332,7 +332,7 @@ describe('SearchFullUI', () => {
         expect(screen.getByRole('columnheader', { name: 'Field 4' })).toBeVisible();
     });
 
-    it('does not store default invisible column visibilities', async () => {
+    it('does not store default invisible column visibilities when selecting none', async () => {
         renderSearchFullUI({});
         const customizeButton = await screen.findByRole('button', { name: 'Customize columns' });
         await userEvent.click(customizeButton);

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -222,10 +222,24 @@ export const InnerSearchFullUI = ({
     };
 
     const setASearchVisibility = (fieldName: string, visible: boolean) => {
-        setState((prev: any) => ({
-            ...prev,
-            [`${VISIBILITY_PREFIX}${fieldName}`]: visible ? 'true' : 'false',
-        }));
+        setState((prev: any) => {
+            const newState = { ...prev };
+            const key = `${VISIBILITY_PREFIX}${fieldName}`;
+            const metadataField = schema.metadata.find((field) => {
+                let name = field.name;
+                if (field.rangeOverlapSearch) {
+                    name = field.rangeOverlapSearch.rangeName;
+                }
+                return name === fieldName;
+            });
+            const defaultVisible = metadataField?.initiallyVisible === true;
+            if (visible === defaultVisible) {
+                delete newState[key];
+            } else {
+                newState[key] = visible ? 'true' : 'false';
+            }
+            return newState;
+        });
         // if visible is false, we should also remove the field from the fieldValues
         if (!visible) {
             setSomeFieldValues([fieldName, '']);

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -238,11 +238,13 @@ export const InnerSearchFullUI = ({
             } else {
                 newState[key] = visible ? 'true' : 'false';
             }
+            if (!visible) {
+                delete newState[fieldName];
+            }
             return newState;
         });
-        // if visible is false, we should also remove the field from the fieldValues
         if (!visible) {
-            setSomeFieldValues([fieldName, '']);
+            setPage(1);
         }
     };
 


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/4940 resolves https://github.com/loculus-project/loculus/issues/4935
- prevent search fields from storing default visibilities in URL
- verify default invisibilities for search fields and columns are not persisted
- fix issue where hiding hidden fields meant that the hidden fields were disapplied



------
https://chatgpt.com/codex/tasks/task_e_68b95c6c1f7083259a87f07766c896ea

🚀 Preview: https://codex-fix-url-storage-for.loculus.org