### PR TITLE
feat(ingest): enable nextclade sort to be used for non-segmented viruses

### DIFF
--- a/ingest/scripts/parse_nextclade_sort_output.py
+++ b/ingest/scripts/parse_nextclade_sort_output.py
@@ -62,9 +62,9 @@ def parse_file(
 
     header = list(config.minimizer_parser)
     header.append("seqName")
-    # Filter out rows where 'segment' is NOT in nucleotide_sequences
-    # these cases are not explicitly supported by loculus
     if "segment" in config.minimizer_parser:
+        # Filter out rows where 'segment' is NOT in nucleotide_sequences
+        # these cases are not explicitly supported by loculus
         filtered_df = df_highest_per_group[df_highest_per_group["segment"].isin(allowed_segments)]
         filtered_df.to_csv(output_file, columns=header, sep="\t", index=False)
     else:


### PR DESCRIPTION
resolves https://github.com/pathoplexus/pathoplexus/issues/630

In https://github.com/loculus-project/loculus/pull/4767 we fixed an error but introduced a new one as we now assume that the `minimizer_parser` always contains the `segment` field. This is true for segmented viruses - however, we can also use the minimizer to filter non-segmented viruses by subtype (as we do for RSV). Thus, the ingest script was no longer working for RSV as the `minimizer_parser` did not contain the `segment` field.

### PR Checklist
- [x] I will now put this on a PPX preview to test: https://github.com/pathoplexus/pathoplexus/pull/631

🚀 Preview: Add `preview` label to enable