### PR TITLE
fix(tests): skip webkit test with false positive connection issues

### DIFF
--- a/website/tests/pages/review/index.spec.ts
+++ b/website/tests/pages/review/index.spec.ts
@@ -50,7 +50,8 @@ test.describe('The review page', () => {
         await reviewPage.waitForTotalSequenceCountCorrect(total, 'less');
     });
 
-    test('approve restricted sequences', async ({ reviewPage, loginAsTestUser }) => {
+    test('approve restricted sequences', async ({ reviewPage, loginAsTestUser, browserName }) => {
+        test.skip(browserName === 'webkit', 'Webkit has false positive connection issues');
         const { token, groupId } = await loginAsTestUser();
 
         await reviewPage.goto(groupId);


### PR DESCRIPTION
Skip 'approve restricted sequences' test on webkit browser due to
connection termination issues that appear to be browser-specific
false positives. This test has been failing in many runs, so it's
worth disabling to avoid this annoying false positive.

See failing run: https://github.com/loculus-project/loculus/actions/runs/17461610870/job/49587405743

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

🚀 Preview: Add `preview` label to enable