### PR TITLE
fix(website): restore URL storage when query shortens

### DIFF
--- a/website/src/components/SearchPage/useQueryAsState.js
+++ b/website/src/components/SearchPage/useQueryAsState.js
@@ -20,24 +20,37 @@ export default function useQueryAsState(defaultDict) {
     }, []);
 
     useEffect(() => {
-        if (useUrlStorage) {
-            const urlParams = new URLSearchParams();
-            for (const [key, value] of Object.entries(valueDict)) {
-                urlParams.set(key, value);
-            }
-            let newUrl = window.location.protocol + "//" + window.location.host + window.location.pathname + "?" + urlParams.toString();
+        const urlParams = new URLSearchParams();
+        for (const [key, value] of Object.entries(valueDict)) {
+            urlParams.set(key, value);
+        }
+        let newUrl =
+            window.location.protocol +
+            '//' +
+            window.location.host +
+            window.location.pathname +
+            '?' +
+            urlParams.toString();
 
-            // Avoid '*' at the end because some systems do not recognize it as part of the link
-            if (newUrl.endsWith("*")) {
-                newUrl = newUrl.concat("&");
-            }
-            
-            if (newUrl.length > MAX_URL_LENGTH) {
+        // Avoid '*' at the end because some systems do not recognize it as part of the link
+        if (newUrl.endsWith('*')) {
+            newUrl = newUrl.concat('&');
+        }
+
+        if (newUrl.length > MAX_URL_LENGTH) {
+            if (useUrlStorage) {
                 setUseUrlStorage(false);
-                window.history.replaceState({ path: window.location.pathname }, '', window.location.pathname);
-            } else {
-                window.history.replaceState({ path: newUrl }, '', newUrl);
+                window.history.replaceState(
+                    { path: window.location.pathname },
+                    '',
+                    window.location.pathname,
+                );
             }
+        } else {
+            if (!useUrlStorage) {
+                setUseUrlStorage(true);
+            }
+            window.history.replaceState({ path: newUrl }, '', newUrl);
         }
     }, [valueDict, useUrlStorage]);
 

--- a/website/src/components/SearchPage/useQueryAsState.spec.ts
+++ b/website/src/components/SearchPage/useQueryAsState.spec.ts
@@ -71,4 +71,23 @@ describe('useQueryAsState', () => {
 
         expect(replaceStateMock).toHaveBeenCalledWith({ path: '/test' }, '', '/test');
     });
+
+    test('re-enables URL storage when length drops below max', () => {
+        const longValue = 'a'.repeat(2000);
+        const { result } = renderHook(() => useQueryAsState({}));
+
+        act(() => {
+            result.current[1]({ longKey: longValue });
+        });
+
+        act(() => {
+            result.current[1]({ shortKey: 'b' });
+        });
+
+        expect(replaceStateMock).toHaveBeenLastCalledWith(
+            { path: 'http://localhost:3000/test?shortKey=b' },
+            '',
+            'http://localhost:3000/test?shortKey=b',
+        );
+    });
 });


### PR DESCRIPTION

- allow search state to return to URL when its encoded length falls below the max
- test that URL storage resumes after length shrinks

Prior to this if you hit "Select all" then "Select none" stuff would no longer be stored in the URL. Now that will only be the case while there is so much that the URL can't fit the info.


------
https://chatgpt.com/codex/tasks/task_e_68b997541e088325b80b74d2d010a880

🚀 Preview: https://codex-add-dynamic-url-sta.loculus.org