### PR TITLE
chore(backend): rename pipeline upgrade function to be explicit about caching and not overload

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -14,7 +14,6 @@ import org.jetbrains.exposed.sql.JoinType
 import org.jetbrains.exposed.sql.LongColumnType
 import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.SortOrder
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.less
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.plus
 import org.jetbrains.exposed.sql.Transaction
@@ -126,8 +125,6 @@ class SubmissionDatabaseService(
     init {
         Database.connect(pool)
     }
-
-    private var lastPreprocessedDataUpdate: String? = null
 
     fun streamUnprocessedSubmissions(
         numberOfSequenceEntries: Int,
@@ -1276,7 +1273,15 @@ class SubmissionDatabaseService(
         }
     }
 
-    fun useNewerProcessingPipelineIfPossible(): Map<String, Long?> {
+
+    private var lastPreprocessedDataUpdate: String? = null
+
+    /** Check if there have been newly preprocessed data since the last update check.
+     * Returns empty map if no changes to the prepro table since last check.
+     * If there are changes, runs useNewerProcessingPipelineIfPossible for each organism
+     * and returns a map of organism name to newly set pipeline version (or null if no new version was set).
+     */
+    fun runPipelineUpgradeIfPreproTableChanged(): Map<String, Long?> {
         val latestUpdate = transaction {
             UpdateTrackerTable
                 .select(UpdateTrackerTable.lastTimeUpdatedDbColumn)
@@ -1287,7 +1292,8 @@ class SubmissionDatabaseService(
 
         if (latestUpdate == null || latestUpdate == lastPreprocessedDataUpdate) {
             log.info {
-                "No updates in $SEQUENCE_ENTRIES_PREPROCESSED_DATA_TABLE_NAME; skipping pipeline version check"
+                "No changes in ${SEQUENCE_ENTRIES_PREPROCESSED_DATA_TABLE_NAME} table since " +
+                    "last check at $lastPreprocessedDataUpdate. Skipping pipeline upgrade check."
             }
             return emptyMap()
         }

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/UseNewerProcessingPipelineVersionTask.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/UseNewerProcessingPipelineVersionTask.kt
@@ -15,7 +15,7 @@ class UseNewerProcessingPipelineVersionTask(
 
     @Scheduled(fixedDelay = 10, timeUnit = TimeUnit.SECONDS)
     fun task() {
-        val newVersions = submissionDatabaseService.useNewerProcessingPipelineIfPossible()
+        val newVersions = submissionDatabaseService.runPipelineUpgradeIfPreproTableChanged()
 
         newVersions.forEach { (organism, latestVersion) ->
             if (latestVersion != null) {

--- a/backend/src/test/kotlin/org/loculus/backend/controller/debug/DeleteAllSequenceDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/debug/DeleteAllSequenceDataEndpointTest.kt
@@ -162,7 +162,7 @@ class DeleteAllSequenceDataEndpointTest(
             .map { PreparedProcessedData.successfullyProcessed(accession = it.accession, version = it.version) }
         submissionConvenienceClient.submitProcessedData(processedDataVersion2, pipelineVersion = 2)
 
-        val newVersions = submissionDatabaseService.useNewerProcessingPipelineIfPossible()
+        val newVersions = submissionDatabaseService.runPipelineUpgradeIfPreproTableChanged()
         assertThat("An update to v2 should be possible", newVersions["dummyOrganism"], `is`(2L))
     }
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
@@ -298,7 +298,7 @@ class GetReleasedDataEndpointTest(
         convenienceClient.approveProcessedSequenceEntries(accessionVersions)
         convenienceClient.extractUnprocessedData(pipelineVersion = 2)
         convenienceClient.submitProcessedData(processedData, pipelineVersion = 2)
-        submissionDatabaseService.useNewerProcessingPipelineIfPossible()
+        submissionDatabaseService.runPipelineUpgradeIfPreproTableChanged()
         val response = submissionControllerClient.getReleasedData()
         val responseBody = response.expectNdjsonAndGetContent<ReleasedData>()
         assertThat(responseBody.size, `is`(accessionVersions.size))

--- a/backend/src/test/kotlin/org/loculus/backend/service/submission/UseNewerProcessingPipelineVersionTaskTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/submission/UseNewerProcessingPipelineVersionTaskTest.kt
@@ -119,8 +119,8 @@ class UseNewerProcessingPipelineVersionTaskTest(
         convenienceClient.extractUnprocessedData(pipelineVersion = 1)
         convenienceClient.submitProcessedData(processedData, pipelineVersion = 1)
 
-        val firstCall = submissionDatabaseService.useNewerProcessingPipelineIfPossible()
-        val secondCall = submissionDatabaseService.useNewerProcessingPipelineIfPossible()
+        val firstCall = submissionDatabaseService.runPipelineUpgradeIfPreproTableChanged()
+        val secondCall = submissionDatabaseService.runPipelineUpgradeIfPreproTableChanged()
 
         assertThat(firstCall.keys, `is`(setOf(DEFAULT_ORGANISM)))
         assertThat(secondCall.isEmpty(), `is`(true))


### PR DESCRIPTION
Noticed when looking at https://github.com/loculus-project/loculus/pull/4862 that the function is overloaded which makes it harder to reason and doesn't make clear we cache so renamed the function and also added a doc string.

🚀 Preview: Add `preview` label to enable