### PR TITLE
fix(website): prevent blank search when clearing autocomplete

### DIFF
--- a/website/src/components/SearchPage/fields/AutoCompleteField.spec.tsx
+++ b/website/src/components/SearchPage/fields/AutoCompleteField.spec.tsx
@@ -230,6 +230,37 @@ describe('AutoCompleteField', () => {
         expect(setSomeFieldValues).toHaveBeenCalledWith(['testField', '']);
     });
 
+    it('clears selection when text is deleted with the keyboard', async () => {
+        mockUseAggregated.mockReturnValue({
+            data: {
+                data: [{ testField: 'Option 1', count: 10 }],
+            },
+            isLoading: false,
+            error: null,
+            mutate: vi.fn(),
+        });
+        render(
+            <AutoCompleteField
+                field={field}
+                optionsProvider={{
+                    type: 'generic',
+                    lapisUrl,
+                    lapisSearchParameters,
+                    fieldName: field.name,
+                }}
+                setSomeFieldValues={setSomeFieldValues}
+                fieldValue='Option 1'
+            />,
+        );
+
+        const input = screen.getByLabelText('Test Field');
+        await userEvent.click(input);
+        await userEvent.clear(input);
+        await userEvent.type(input, '{backspace}');
+
+        expect(setSomeFieldValues).toHaveBeenCalledWith(['testField', '']);
+    });
+
     it('allows selecting blank option', async () => {
         mockUseAggregated.mockReturnValue({
             data: {

--- a/website/src/components/SearchPage/fields/AutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/AutoCompleteField.tsx
@@ -59,16 +59,20 @@ export const AutoCompleteField = ({
         return allMatchedOptions.slice(0, maxDisplayedOptions);
     }, [options, query, maxDisplayedOptions]);
 
+    const comboboxValue = fieldValue === null ? NULL_QUERY_VALUE : fieldValue;
+
     return (
         <DisabledUntilHydrated>
             <Combobox
                 immediate
-                value={fieldValue}
-                onChange={(value) => setSomeFieldValues([field.name, value ?? NULL_QUERY_VALUE])}
+                value={comboboxValue}
+                onChange={(value) => setSomeFieldValues([field.name, value ?? ''])}
             >
                 <div className='relative'>
                     <ComboboxInput
-                        displayValue={(value: string | number | null) => (value === null ? '(blank)' : String(value))}
+                        displayValue={(value: string | number | null) =>
+                            value === NULL_QUERY_VALUE ? '(blank)' : value === null ? '' : String(value)
+                        }
                         onChange={(event) => setQuery(event.target.value)}
                         onFocus={load}
                         placeholder={field.displayName ?? field.name}

--- a/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
+++ b/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 
 import { lapisClientHooks } from '../../../services/serviceHooks.ts';
 import type { LineageDefinition } from '../../../types/lapis.ts';
+import { NULL_QUERY_VALUE } from '../../../utils/search.ts';
 import type { LapisSearchParameters } from '../DownloadDialog/SequenceFilters.tsx';
 
 export type Option = {
@@ -66,7 +67,7 @@ const createGenericOptionsHook = (
             )
             .map((it) => ({
                 option: it[fieldName] === null ? '(blank)' : it[fieldName].toString(),
-                value: it[fieldName] === null ? null : it[fieldName].toString(),
+                value: it[fieldName] === null ? NULL_QUERY_VALUE : it[fieldName].toString(),
                 count: it.count,
             }))
             .sort((a, b) => (a.option.toLowerCase() < b.option.toLowerCase() ? -1 : 1));


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/4959 - this is a stopgap until the new AutoComplete code


- avoid sending `_null_` when keyboard-clearing autocomplete values
- encode blank option values explicitly and update combobox display logic
- cover keyboard clearing with a regression test



------
https://chatgpt.com/codex/tasks/task_e_68bb30eb2da083258c99e060458a6ec5

🚀 Preview: Add `preview` label to enable