### PR TITLE
chore: update browserslist database to latest version

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -3063,9 +3063,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001707",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
-            "integrity": "sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==",
+            "version": "1.0.30001741",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
+            "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -10622,9 +10622,9 @@
             "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
         },
         "caniuse-lite": {
-            "version": "1.0.30001707",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
-            "integrity": "sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw=="
+            "version": "1.0.30001741",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
+            "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw=="
         },
         "ccount": {
             "version": "2.0.1",

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -774,9 +774,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001727",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-            "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+            "version": "1.0.30001741",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
+            "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
             "dev": true,
             "funding": [
                 {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -6415,9 +6415,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001707",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
-            "integrity": "sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==",
+            "version": "1.0.30001741",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
+            "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
             "funding": [
                 {
                     "type": "opencollective",


### PR DESCRIPTION
## Summary
- Updated caniuse-lite database across all frontend projects to version 1.0.30001741
- Ensures compatibility with the latest browser support data for CSS and JavaScript features

Commands run from root:

```
⏺ Bash(cd /Users/cr/code/loculus/website && npx update-browserslist-db@latest)
  ⎿  Latest version:     1.0.30001741
     Installed version:  1.0.30001707
     Removing old caniuse-lite from lock file
     … +7 lines (ctrl+r to expand)

⏺ Bash(cd /Users/cr/code/loculus/integration-tests && npx update-browserslist-db@latest)
  ⎿  Latest version:     1.0.30001741
     Installed version:  1.0.30001727
     Removing old caniuse-lite from lock file
     … +7 lines (ctrl+r to expand)

⏺ Bash(cd /Users/cr/code/loculus/docs && npx update-browserslist-db@latest)
  ⎿  Latest version:     1.0.30001741
     Installed version:  1.0.30001707
     Removing old caniuse-lite from lock file
     … +10 lines (ctrl+r to expand)
```

🤖 Generated with [Claude Code](https://claude.ai/code)

🚀 Preview: Add `preview` label to enable