### PR TITLE
feat(kubernetes): update SILO to backported bug-fix version 0.7.10.1

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1989,7 +1989,7 @@ images:
     pullPolicy: IfNotPresent
   lapis:
     repository: "ghcr.io/genspectrum/lapis"
-    tag: "0.5.11"
+    tag: "0.5.14"
     pullPolicy: IfNotPresent
   website:
     repository: "ghcr.io/loculus-project/website"

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1985,7 +1985,7 @@ additionalHeadHTML: ""
 images:
   lapisSilo:
     repository: "ghcr.io/genspectrum/lapis-silo"
-    tag: "0.7.10"
+    tag: "v0.7.10.1"
     pullPolicy: IfNotPresent
   lapis:
     repository: "ghcr.io/genspectrum/lapis"


### PR DESCRIPTION
This backports the bugfix https://github.com/GenSpectrum/LAPIS-SILO/issues/838, where internal exceptions during query execution were able to indefinitely hang the query execution, thus permanently blooking a worker thread from the thread pool. After all worker threads were blocked by this, SILO was able to become unresponsive

🚀 Preview: https://update-silo-0-7-10-1.loculus.org