### PR TITLE
fix(ena-submission): use random suffix in aliases for testing to avoid CI failures due to duplicate aliases

### DIFF
--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -1,6 +1,6 @@
 import json
 import logging
-import secrets
+import random
 import string
 import threading
 import time
@@ -165,7 +165,7 @@ def make_assembly_name(accession: str, version: str, test: bool = False) -> str:
     Unlike biosample revisions, assembly revisions require a new assemblyName.
     """
     if test:
-        entropy = "".join(secrets.choice(string.ascii_letters + string.digits) for _ in range(4))
+        entropy = "".join(random.choices(string.ascii_letters + string.digits, k=4))  # noqa: S311
         timestamp = datetime.now(tz=pytz.utc).strftime("%Y%m%d_%H%M%S")
         return f"{accession}.{version}_{timestamp}_{entropy}"
     return f"{accession}.{version}"

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -4,8 +4,8 @@ import gzip
 import json
 import logging
 import os
+import random
 import re
-import secrets
 import string
 import subprocess  # noqa: S404
 import tempfile
@@ -158,7 +158,7 @@ def get_alias(prefix: str, test=False, set_alias_suffix: str | None = None) -> X
     if set_alias_suffix:
         return XmlAttribute(f"{prefix}:{set_alias_suffix}")
     if test:
-        entropy = "".join(secrets.choice(string.ascii_letters + string.digits) for _ in range(4))
+        entropy = "".join(random.choices(string.ascii_letters + string.digits, k=4))  # noqa: S311
         timestamp = datetime.datetime.now(tz=pytz.utc).strftime("%Y%m%d_%H%M%S")
         return XmlAttribute(f"{prefix}:{timestamp}_{entropy}")
 


### PR DESCRIPTION
resolves #4985

### PR Checklist
- [x] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable