### PR TITLE
chore(deps): bump SILO to use backported bug-fix version 0.7.10.1, bump LAPIS from 0.5.11 to 0.5.14

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1985,12 +1985,12 @@ additionalHeadHTML: ""
 images:
   lapisSilo:
     repository: "ghcr.io/genspectrum/lapis-silo"
-    tag: "v0.7.10.1"
-    pullPolicy: IfNotPresent
+    tag: "v0.7.10.1@sha256:96e431192d6493ed71ac10bc273710df21e7c520a77bebaa7d94ff859264d36c"
+    pullPolicy: Always
   lapis:
     repository: "ghcr.io/genspectrum/lapis"
     tag: "0.5.14"
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   website:
     repository: "ghcr.io/loculus-project/website"
     pullPolicy: Always


### PR DESCRIPTION
This backports the bugfix https://github.com/GenSpectrum/LAPIS-SILO/issues/838, where internal exceptions during query execution were able to indefinitely hang the query execution, thus permanently blooking a worker thread from the thread pool. After all worker threads were blocked by this, SILO was able to become unresponsive

Manual testing consisted of downloading datasets and testing all search pages

### PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by appropriate, automated tests.~~
- [X] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://update-silo-0-7-10-1.loculus.org