### PR TITLE
docs: improve image schema documentation

### DIFF
--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -715,7 +715,7 @@
           "groups": ["image"],
           "type": "string",
           "enum": ["Always", "IfNotPresent", "Never"],
-          "description": "The pull policy to use. Always: always pull the image. IfNotPresent: pull if not present locally. Never: never pull, use local image only. If not specified, defaults to Always if tag is 'latest' or empty, otherwise IfNotPresent."
+          "description": "The pull policy to use. Always: always pull the image. IfNotPresent: pull if not present locally. Never: never pull, use local image only."
         }
       },
       "required": ["repository", "pullPolicy"],

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -709,12 +709,13 @@
         "tag": {
           "groups": ["image"],
           "type": "string",
-          "description": "The tag to pull. Examples: latest, 0.5.7"
+          "description": "The tag to pull. Examples: latest, 0.5.7. Can include a digest to absolutely pin the image (tags can move): v0.7.10.1@sha256:96e431192d6493ed71ac10bc273710df21e7c520a77bebaa7d94ff859264d36c"
         },
         "pullPolicy": {
           "groups": ["image"],
           "type": "string",
-          "description": "The pull policy to use. Examples: IfNotPresent, Always."
+          "enum": ["Always", "IfNotPresent", "Never"],
+          "description": "The pull policy to use. Always: always pull the image. IfNotPresent: pull if not present locally. Never: never pull, use local image only. If not specified, defaults to Always if tag is 'latest' or empty, otherwise IfNotPresent."
         }
       },
       "required": ["repository", "pullPolicy"],


### PR DESCRIPTION
## Summary
- Clarify that the `tag` field in imageSpec can include a digest to absolutely pin the image (e.g., `v0.7.10.1@sha256:...`)
- Add proper enum constraints to `pullPolicy` field (Always, IfNotPresent, Never)
- Document default pullPolicy behavior based on tag value

🤖 Generated with [Claude Code](https://claude.ai/code)

🚀 Preview: Add `preview` label to enable