### PR TITLE
fix(e2e): make search test more specific to avoid flakiness due to duplicate dates

### DIFF
--- a/website/tests/pages/search/index.spec.ts
+++ b/website/tests/pages/search/index.spec.ts
@@ -34,9 +34,9 @@ test.describe('The search page', () => {
         searchPage.page.getByText('Search returned 1 sequence');
         await expect(accessionLink).toBeVisible();
 
-        const rowLocator = searchPage.page.locator('tr');
-        await expect(rowLocator.getByText('2002-12-15')).toBeVisible();
-        await expect(rowLocator.getByText('A.1.1')).toBeVisible();
+        const specificRowLocator = searchPage.page.locator('tr').filter({ hasText: testAccessionVersion });
+        await expect(specificRowLocator.getByText('2002-12-15')).toBeVisible();
+        await expect(specificRowLocator.getByText('A.1.1')).toBeVisible();
 
         await accessionLink.click();
         await expect(searchPage.page.getByText('Amino acid mutations')).toBeVisible({ timeout: 30000 });


### PR DESCRIPTION
It's weird that this test failed - it's explicitly for searching a single accession, yet the results appear to have multiple rows. Rerunning fixed it. Anyways, this strict check here may or may not help - it probably doesn't harm.

```
test('should search one existing sequence entry by accession, then click it', async ({ searchPage }) => {
```

## Summary
- Fixes flaky E2E test that was failing with strict mode violations due to multiple elements matching the same date: https://github.com/loculus-project/loculus/actions/runs/17587884419/job/49960726931?pr=4992#step:21:35
- All test sequences use hardcoded date '2002-12-15' in test data generation, causing the test to find 40+ matching elements
- Made the test more specific by filtering to only look within the row containing the searched accession

🤖 Generated with [Claude Code](https://claude.ai/code)

🚀 Preview: Add `preview` label to enable