### PR TITLE
feat!(config): use new cchf dataset

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -60,7 +60,12 @@ if SEGMENTED:
         for segment in config["nucleotide_sequences"]:
             dataset_server_map[segment] = segment_identification.get(
                 "nextclade_dataset_server_map", {}
-            ).get(segment, segment_identification.get("nextclade_dataset_server", "https://data.clades.nextstrain.org/v3"))
+            ).get(
+                segment,
+                segment_identification.get(
+                    "nextclade_dataset_server", "https://data.clades.nextstrain.org/v3"
+                ),
+            )
             dataset_name_map[segment] = segment_identification.get(
                 "nextclade_dataset_name_map", {}
             ).get(

--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -62,7 +62,9 @@ if SEGMENTED:
                 "nextclade_dataset_server_map", {}
             ).get(
                 segment,
-                segment_identification.get("nextclade_dataset_server"),
+                segment_identification.get(
+                    "nextclade_dataset_server", config.get("nextclade_dataset_server")
+                ),
             )
             dataset_name_map[segment] = segment_identification.get(
                 "nextclade_dataset_name_map", {}

--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -60,7 +60,7 @@ if SEGMENTED:
         for segment in config["nucleotide_sequences"]:
             dataset_server_map[segment] = segment_identification.get(
                 "nextclade_dataset_server_map", {}
-            ).get(segment, segment_identification.get("nextclade_dataset_server"))
+            ).get(segment, segment_identification.get("nextclade_dataset_server", "https://data.clades.nextstrain.org/v3"))
             dataset_name_map[segment] = segment_identification.get(
                 "nextclade_dataset_name_map", {}
             ).get(

--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -62,9 +62,7 @@ if SEGMENTED:
                 "nextclade_dataset_server_map", {}
             ).get(
                 segment,
-                segment_identification.get(
-                    "nextclade_dataset_server", "https://data.clades.nextstrain.org/v3"
-                ),
+                segment_identification.get("nextclade_dataset_server"),
             )
             dataset_name_map[segment] = segment_identification.get(
                 "nextclade_dataset_name_map", {}

--- a/ingest/config/defaults.yaml
+++ b/ingest/config/defaults.yaml
@@ -71,5 +71,5 @@ approve_timeout_min: "25" # Cronjobs run every 30min, make approve stop before i
 db_username: postgres
 db_password: unsecure
 db_url: "jdbc:postgresql://127.0.0.1:5432/loculus"
-batch_chunk_size: 10000
+batch_chunk_size: 10000  # Batch size for submitting sequences to Loculus backend
 nextclade_dataset_server: https://data.clades.nextstrain.org/v3

--- a/ingest/config/defaults.yaml
+++ b/ingest/config/defaults.yaml
@@ -72,3 +72,4 @@ db_username: postgres
 db_password: unsecure
 db_url: "jdbc:postgresql://127.0.0.1:5432/loculus"
 batch_chunk_size: 10000
+nextclade_dataset_server: https://data.clades.nextstrain.org/v3

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1691,11 +1691,11 @@ defaultOrganisms:
       image: "/images/organisms/cchf_small.jpg"
       linkOuts:
         - name: "Nextclade (L)"
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:L+rich|fasta]}}&dataset-name=nextstrain/cchfv/linked/L&dataset-server=https://raw.githubusercontent.com/nextstrain/nextclade_data/cornelius-cchfv/data_output"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:L+rich|fasta]}}&dataset-name=community/pathoplexus/cchfv/L&dataset-server=https://raw.githubusercontent.com/nextstrain/nextclade_data/anya-copy/data_output"
         - name: "Nextclade (M)"
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:M+rich|fasta]}}&dataset-name=nextstrain/cchfv/linked/M&dataset-server=https://raw.githubusercontent.com/nextstrain/nextclade_data/cornelius-cchfv/data_output"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:M+rich|fasta]}}&dataset-name=community/pathoplexus/cchfv/M&dataset-server=https://raw.githubusercontent.com/nextstrain/nextclade_data/anya-copy/data_output"
         - name: "Nextclade (S)"
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:S+rich|fasta]}}&dataset-name=nextstrain/cchfv/linked/S&dataset-server=https://raw.githubusercontent.com/nextstrain/nextclade_data/cornelius-cchfv/data_output"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:S+rich|fasta]}}&dataset-name=community/pathoplexus/cchfv/S&dataset-server=https://raw.githubusercontent.com/nextstrain/nextclade_data/anya-copy/data_output"
       metadataAdd:
         - name: hostNameScientific
           generateIndex: true
@@ -1734,8 +1734,8 @@ defaultOrganisms:
         configFile:
           <<: *preprocessingConfigFile
           log_level: DEBUG
-          nextclade_dataset_name: nextstrain/cchfv/linked
-          nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/cornelius-cchfv/data_output
+          nextclade_dataset_name: community/pathoplexus/cchfv
+          nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/anya-copy/data_output
           genes: [RdRp, GPC, NP]
     ingest:
       <<: *ingest
@@ -1744,8 +1744,8 @@ defaultOrganisms:
         taxon_id: 3052518
         segment_identification:
           method: "align"
-          nextclade_dataset_name: nextstrain/cchfv/linked
-          nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/cornelius-cchfv/data_output
+          nextclade_dataset_name: community/pathoplexus/cchfv
+          nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/anya-copy/data_output
     enaDeposition:
       configFile:
         taxon_id: 3052518

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -51,6 +51,8 @@ lineageSystemDefinitions:
     2: https://raw.githubusercontent.com/loculus-project/loculus/c400348ea0ba0b8178aa43475d5c7539fc097997/preprocessing/dummy/lineage.yaml
   alternativeLineage:
     4: https://raw.githubusercontent.com/loculus-project/loculus/fe3b2974071acc9a25856d650350f8a952040a7c/preprocessing/dummy/lineage-alternative.yaml
+  cchfS:
+    1: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/cchf/S/2025-09-12/lineages.yaml
 defaultOrganismConfig: &defaultOrganismConfig
   schema: &schema
     loadSequencesAutomatically: true
@@ -1691,11 +1693,11 @@ defaultOrganisms:
       image: "/images/organisms/cchf_small.jpg"
       linkOuts:
         - name: "Nextclade (L)"
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:L+rich|fasta]}}&dataset-name=community/pathoplexus/cchfv/L&dataset-server=https://raw.githubusercontent.com/nextstrain/nextclade_data/anya-copy/data_output"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:L+rich|fasta]}}&dataset-name=community/pathoplexus/cchfv/L"
         - name: "Nextclade (M)"
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:M+rich|fasta]}}&dataset-name=community/pathoplexus/cchfv/M&dataset-server=https://raw.githubusercontent.com/nextstrain/nextclade_data/anya-copy/data_output"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:M+rich|fasta]}}&dataset-name=community/pathoplexus/cchfv/M"
         - name: "Nextclade (S)"
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:S+rich|fasta]}}&dataset-name=community/pathoplexus/cchfv/S&dataset-server=https://raw.githubusercontent.com/nextstrain/nextclade_data/anya-copy/data_output"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:S+rich|fasta]}}&dataset-name=community/pathoplexus/cchfv/S"
       metadataAdd:
         - name: hostNameScientific
           generateIndex: true
@@ -1711,6 +1713,7 @@ defaultOrganisms:
           autocomplete: true
           initiallyVisible: true
           includeInDownloadsByDefault: true
+          lineageSystem: cchfS
           preprocessing:
             args: 
               segment: S
@@ -1736,7 +1739,6 @@ defaultOrganisms:
           <<: *preprocessingConfigFile
           log_level: DEBUG
           nextclade_dataset_name: community/pathoplexus/cchfv
-          nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/anya-copy/data_output
           genes: [RdRp, GPC, NP]
     ingest:
       <<: *ingest
@@ -1746,7 +1748,6 @@ defaultOrganisms:
         segment_identification:
           method: "align"
           nextclade_dataset_name: community/pathoplexus/cchfv
-          nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/anya-copy/data_output
     enaDeposition:
       configFile:
         taxon_id: 3052518

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1328,6 +1328,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         genes: []
         batch_size: 100
         create_embl_file: true
+        nextclade_dataset_server: https://data.clades.nextstrain.org/v3
   ingest: &ingest
     image: ghcr.io/loculus-project/ingest
     configFile: &ingestConfigFile
@@ -1724,6 +1725,7 @@ defaultOrganisms:
           - sampleCollectionDate
           - geoLocCountry
           - geoLocAdmin1
+          - lineage
           - authors
           - authorAffiliations
           - ncbiReleaseDate

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1704,6 +1704,7 @@ defaultOrganisms:
           ingest: ncbiHostName
           initiallyVisible: true
         - name: lineage
+          displayName: "Segment S Lineage"
           header: "Lineage"
           noInput: true
           generateIndex: true
@@ -1711,6 +1712,8 @@ defaultOrganisms:
           initiallyVisible: true
           includeInDownloadsByDefault: true
           preprocessing:
+            args: 
+              segment: S
             inputs: {input: nextclade.clade}
       website:
         <<: *website

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1279,6 +1279,17 @@ defaultOrganismConfig: &defaultOrganismConfig
         orderOnDetailsPage: 2840
         preprocessing:
           inputs: {input: nextclade.frameShifts}
+      - name: totalStopCodons
+        type: int
+        header: "Alignment and QC metrics"
+        noInput: true
+        preprocessing:
+          inputs: {input: nextclade.qc.stopCodons.totalStopCodons}
+      - name: stopCodons
+        header: "Alignment and QC metrics"
+        noInput: true
+        preprocessing:
+          inputs: {input: nextclade.qc.stopCodons.stopCodons}
       - name: completeness
         type: float
         header: "Alignment and QC metrics"
@@ -1388,17 +1399,6 @@ defaultOrganisms:
           includeInDownloadsByDefault: true
           preprocessing:
             inputs: {input: nextclade.clade}
-        - name: totalStopCodons
-          type: int
-          header: "Alignment and QC metrics"
-          noInput: true
-          preprocessing:
-            inputs: {input: nextclade.qc.stopCodons.totalStopCodons}
-        - name: stopCodons
-          header: "Alignment and QC metrics"
-          noInput: true
-          preprocessing:
-            inputs: {input: nextclade.qc.stopCodons.stopCodons}
       website:
         <<: *website
         tableColumns:
@@ -1703,17 +1703,15 @@ defaultOrganisms:
           header: "Host"
           ingest: ncbiHostName
           initiallyVisible: true
-        - name: totalStopCodons
-          type: int
-          header: "Alignment and QC metrics"
+        - name: lineage
+          header: "Lineage"
           noInput: true
+          generateIndex: true
+          autocomplete: true
+          initiallyVisible: true
+          includeInDownloadsByDefault: true
           preprocessing:
-            inputs: {input: nextclade.qc.stopCodons.totalStopCodons}
-        - name: stopCodons
-          header: "Alignment and QC metrics"
-          noInput: true
-          preprocessing:
-            inputs: {input: nextclade.qc.stopCodons.stopCodons}
+            inputs: {input: nextclade.clade}
       website:
         <<: *website
         tableColumns:


### PR DESCRIPTION
resolves #

### Screenshot

This uses the newly merged CCHF dataset that now does QC and lineages! See details here: https://github.com/nextstrain/nextclade_data/pull/265

It also vastly improves alignment, especially of the M segment which has high variability at the start and end of the sequences - leading to many alignments previously failing the QC scores. 

Uses new lineage file: https://github.com/pathoplexus/silo-lineage-hierarchy-definitions/blob/main/definitions/cchf/S/2025-09-12/lineages.yaml

To release on PPX this requires a pipeline version update: https://github.com/pathoplexus/pathoplexus/pull/658 and the regroup-revoke cronjob will have to be run once.

### PR Checklist
- [ ] ~All necessary documentation has been adapted.~
- [ ] ~The implemented feature is covered by appropriate, automated tests.~
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?) -> tested the results on a persistent DB instance on loculus: https://github.com/loculus-project/loculus/pull/5003
Results: Exactly 1 sequence must be revoked as it can no longer be grouped : https://loculus.slack.com/archives/C07FP0BGHDZ/p1757518656855529

This makes sense as now there are 3 segments from the same institute submitted on the same day without further identifiers - making grouping infeasible: 
<img width="2108" height="374" alt="image" src="https://github.com/user-attachments/assets/20d4e5f4-f738-470a-8a17-52510baed429" />

🚀 Preview: https://test-new-cchf.loculus.org