### PR TITLE
make db persistent using old cchf dataset

### DIFF
--- a/kubernetes/loculus/templates/loculus-database-standin.yaml
+++ b/kubernetes/loculus/templates/loculus-database-standin.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: loculus-database
   annotations:
-    argocd.argoproj.io/sync-options: Replace=true
+    argocd.argoproj.io/sync-options: Replace=false
 spec:
   replicas: 1
   selector:
@@ -42,6 +42,6 @@ spec:
           value: "trust"
         {{ if not .Values.developmentDatabasePersistence }}
         - name: LOCULUS_VERSION
-          value: {{ $dockerTag }}
+          value: "commit-eeb5989"
         {{- end }}
 {{- end }}

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1691,11 +1691,11 @@ defaultOrganisms:
       image: "/images/organisms/cchf_small.jpg"
       linkOuts:
         - name: "Nextclade (L)"
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:L+rich|fasta]}}&dataset-name=nextstrain/cchfv/linked/L&dataset-server=https://raw.githubusercontent.com/nextstrain/nextclade_data/cornelius-cchfv/data_output"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:L+rich|fasta]}}&dataset-name=community/pathoplexus/cchfv/L&dataset-server=https://raw.githubusercontent.com/nextstrain/nextclade_data/anya-copy/data_output"
         - name: "Nextclade (M)"
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:M+rich|fasta]}}&dataset-name=nextstrain/cchfv/linked/M&dataset-server=https://raw.githubusercontent.com/nextstrain/nextclade_data/cornelius-cchfv/data_output"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:M+rich|fasta]}}&dataset-name=community/pathoplexus/cchfv/M&dataset-server=https://raw.githubusercontent.com/nextstrain/nextclade_data/anya-copy/data_output"
         - name: "Nextclade (S)"
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:S+rich|fasta]}}&dataset-name=nextstrain/cchfv/linked/S&dataset-server=https://raw.githubusercontent.com/nextstrain/nextclade_data/cornelius-cchfv/data_output"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:S+rich|fasta]}}&dataset-name=community/pathoplexus/cchfv/S&dataset-server=https://raw.githubusercontent.com/nextstrain/nextclade_data/anya-copy/data_output"
       metadataAdd:
         - name: hostNameScientific
           generateIndex: true
@@ -1737,6 +1737,14 @@ defaultOrganisms:
           nextclade_dataset_name: nextstrain/cchfv/linked
           nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/cornelius-cchfv/data_output
           genes: [RdRp, GPC, NP]
+      - <<: *preprocessing
+        version: 2
+        configFile:
+          <<: *preprocessingConfigFile
+          log_level: DEBUG
+          nextclade_dataset_name: community/pathoplexus/cchfv
+          nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/anya-copy/data_output
+          genes: [RdRp, GPC, NP]
     ingest:
       <<: *ingest
       configFile:
@@ -1744,8 +1752,8 @@ defaultOrganisms:
         taxon_id: 3052518
         segment_identification:
           method: "align"
-          nextclade_dataset_name: nextstrain/cchfv/linked
-          nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/cornelius-cchfv/data_output
+          nextclade_dataset_name: community/pathoplexus/cchfv
+          nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/anya-copy/data_output
     enaDeposition:
       configFile:
         taxon_id: 3052518


### PR DESCRIPTION
resolves #

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

Exactly 1 sequence must be revoked as it can no longer be grouped : https://loculus.slack.com/archives/C07FP0BGHDZ/p1757518656855529

This makes sense as now there are 3 segments from the same institute submitted on the same day without further identifiers - making grouping infeasible: 
<img width="2108" height="374" alt="image" src="https://github.com/user-attachments/assets/20d4e5f4-f738-470a-8a17-52510baed429" />


🚀 Preview: https://persistency-check-cchf.loculus.org