### PR TITLE
feat(website): rewrite sequence preview url and navigation

### DIFF
--- a/website/tests/pages/search/preview.spec.ts
+++ b/website/tests/pages/search/preview.spec.ts
@@ -1,0 +1,28 @@
+import { routes } from '../../../src/routes/routes.ts';
+import { getAccessionVersionString } from '../../../src/utils/extractAccessionVersion.ts';
+import { baseUrl, dummyOrganism, expect, test } from '../../e2e.fixture';
+import { getTestSequences } from '../../util/testSequenceProvider.ts';
+
+ test.describe('sequence preview url handling', () => {
+     test('updates url and back returns to search', async ({ searchPage, page }) => {
+         const accessionVersion = getAccessionVersionString(getTestSequences().testSequenceEntry);
+
+         await searchPage.goto();
+         await searchPage.getAccessionField().click();
+         await searchPage.getAccessionField().fill(accessionVersion);
+         await searchPage.page.waitForURL(
+             `${baseUrl}${routes.searchPage(dummyOrganism.key)}?accession=${accessionVersion}`,
+         );
+
+         const row = searchPage.page.locator('tbody tr').first();
+         await row.locator('td').nth(2).click();
+
+         await expect(searchPage.page.getByTestId('sequence-preview-modal')).toBeVisible();
+         await expect(searchPage.page).toHaveURL(
+             `${baseUrl}${routes.sequenceEntryDetailsPage(accessionVersion)}`,
+         );
+
+         await page.goBack();
+         await expect(searchPage.page).toHaveURL(`${baseUrl}${routes.searchPage(dummyOrganism.key)}`);
+     });
+ });


### PR DESCRIPTION
## Summary
- rewrite URL to /seq/[accession] when sequence preview opens
- ensure browser back button closes preview and returns to search results
- cover URL rewrite and back navigation with Playwright test

## Testing
- `npm run test`
- `npm run check-types`
- `npm run format`
- `npx playwright test tests/pages/search/preview.spec.ts` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68c199a50e5c8325adebb3b42da7c83c

🚀 Preview: https://codex-rewrite-url-for-seq.loculus.org