### PR TITLE
fix(deployment): allow substring search for INSDC accession

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -620,6 +620,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         header: "INSDC"
         orderOnDetailsPage: 1040
         ingest: genbankAccession
+        enableSubstringSearch: true
         noInput: true
         perSegment: true
         oneHeader: true


### PR DESCRIPTION
## Summary
- allow searching INSDC accessions without version numbers by enabling substring matching in the deployment config

## Testing
- `pre-commit run --files kubernetes/loculus/values.yaml` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c58f9f957c832583f453814a8c3b34