### PR TITLE
feat(website): display configurable group creation guidelines

### DIFF
--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -179,6 +179,9 @@ gitHubEditLink: {{ quote $.Values.gitHubEditLink }}
 {{ if $.Values.welcomeMessageHTML }}
 welcomeMessageHTML: {{ quote $.Values.welcomeMessageHTML }}
 {{end}}
+{{ if $.Values.groupCreationGuidelines }}
+groupCreationGuidelines: {{ $.Values.groupCreationGuidelines | toJson }}
+{{end}}
 {{ if $.Values.additionalHeadHTML }}
 additionalHeadHTML: {{ quote $.Values.additionalHeadHTML }}
 {{end}}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -798,6 +798,14 @@
       "type": ["string", "null"],
       "description": "A custom welcome message to be shown on the landing page"
     },
+    "groupCreationGuidelines": {
+      "groups": ["general"],
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Guidelines displayed on the group creation page"
+    },
     "additionalHeadHTML": {
       "groups": ["general"],
       "type": "string",

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2166,3 +2166,6 @@ defaultResources:
 ingest:
   ncbiGatewayUrl: null
   mirrorBucket: null
+groupCreationGuidelines:
+  - Use a name that will uniquely identify your group
+  - You may want to include a geographic location rather than just a generic name like "Pathogen Research Group"

--- a/website/src/components/Group/GroupForm.spec.tsx
+++ b/website/src/components/Group/GroupForm.spec.tsx
@@ -55,4 +55,15 @@ describe('GroupForm', () => {
         expect(screen.getByLabelText(/postal/i)).toHaveValue(postalCode);
         expect(screen.getByLabelText(/country/i)).toHaveValue(country);
     });
+
+    test('renders guidelines when provided', () => {
+        const guidelines = ['Follow the terms of use.', 'Ensure contact information is accurate.'];
+
+        render(<GroupForm title='' buttonText='' onSubmit={noOpSubmit} guidelines={guidelines} />);
+
+        expect(screen.getByRole('heading', { name: /group creation guidelines/i })).toBeVisible();
+        guidelines.forEach((guideline) => {
+            expect(screen.getByText(guideline)).toBeVisible();
+        });
+    });
 });

--- a/website/src/components/Group/GroupForm.tsx
+++ b/website/src/components/Group/GroupForm.tsx
@@ -36,6 +36,10 @@ interface GroupFormProps {
      * @returns A submit success or error.
      */
     onSubmit: (group: NewGroup) => Promise<GroupSubmitResult>;
+    /**
+     * Optional list of guidelines to display above the form.
+     */
+    guidelines?: string[];
 }
 
 export type GroupSubmitSuccess = {
@@ -48,7 +52,7 @@ export type GroupSubmitError = {
 };
 export type GroupSubmitResult = GroupSubmitSuccess | GroupSubmitError;
 
-export const GroupForm: FC<GroupFormProps> = ({ title, buttonText, defaultGroupData, onSubmit }) => {
+export const GroupForm: FC<GroupFormProps> = ({ title, buttonText, defaultGroupData, onSubmit, guidelines }) => {
     const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);
 
     const internalOnSubmit = async (e: FormEvent<HTMLFormElement>) => {
@@ -75,6 +79,17 @@ export const GroupForm: FC<GroupFormProps> = ({ title, buttonText, defaultGroupD
     return (
         <div className='p-4 max-w-6xl mx-auto'>
             <h2 className='title'>{title}</h2>
+
+            {guidelines !== undefined && guidelines.length > 0 && (
+                <div className='mt-4 rounded-md border border-blue-200 bg-blue-50 p-4 text-sm text-gray-700'>
+                    <h3 className='text-base font-semibold leading-6 text-gray-900'>Group creation guidelines</h3>
+                    <ul className='mt-2 list-disc space-y-2 pl-5'>
+                        {guidelines.map((guideline, index) => (
+                            <li key={index}>{guideline}</li>
+                        ))}
+                    </ul>
+                </div>
+            )}
 
             {errorMessage !== undefined && (
                 <ErrorFeedback message={errorMessage} onClose={() => setErrorMessage(undefined)} />

--- a/website/src/components/User/GroupCreationForm.tsx
+++ b/website/src/components/User/GroupCreationForm.tsx
@@ -10,9 +10,10 @@ import { withQueryProvider } from '../common/withQueryProvider.tsx';
 interface GroupManagerProps {
     clientConfig: ClientConfig;
     accessToken: string;
+    groupCreationGuidelines?: string[];
 }
 
-const InnerGroupCreationForm: FC<GroupManagerProps> = ({ clientConfig, accessToken }) => {
+const InnerGroupCreationForm: FC<GroupManagerProps> = ({ clientConfig, accessToken, groupCreationGuidelines }) => {
     const { createGroup } = useGroupCreation({
         clientConfig,
         accessToken,
@@ -34,7 +35,14 @@ const InnerGroupCreationForm: FC<GroupManagerProps> = ({ clientConfig, accessTok
         }
     };
 
-    return <GroupForm title='Create a new submitting group' buttonText='Create group' onSubmit={handleCreateGroup} />;
+    return (
+        <GroupForm
+            title='Create a new submitting group'
+            buttonText='Create group'
+            onSubmit={handleCreateGroup}
+            guidelines={groupCreationGuidelines}
+        />
+    );
 };
 
 export const GroupCreationForm = withQueryProvider(InnerGroupCreationForm);

--- a/website/src/pages/user/createGroup.astro
+++ b/website/src/pages/user/createGroup.astro
@@ -1,14 +1,21 @@
 ---
 import { GroupCreationForm } from '../../components/User/GroupCreationForm.tsx';
-import { getRuntimeConfig } from '../../config';
+import { getRuntimeConfig, getWebsiteConfig } from '../../config';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getAccessToken } from '../../utils/getAccessToken';
 
 const accessToken = getAccessToken(Astro.locals.session)!;
 
-const clientConfig = getRuntimeConfig().public;
+const runtimeConfig = getRuntimeConfig();
+const clientConfig = runtimeConfig.public;
+const { groupCreationGuidelines } = getWebsiteConfig();
 ---
 
 <BaseLayout title='Create group'>
-    <GroupCreationForm clientConfig={clientConfig} accessToken={accessToken} client:load />
+    <GroupCreationForm
+        clientConfig={clientConfig}
+        accessToken={accessToken}
+        groupCreationGuidelines={groupCreationGuidelines}
+        client:load
+    />
 </BaseLayout>

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -190,6 +190,7 @@ export const websiteConfig = z.object({
     bannerMessage: z.string().optional(),
     bannerMessageURL: z.string().optional(),
     welcomeMessageHTML: z.string().optional().nullable(),
+    groupCreationGuidelines: z.array(z.string()).optional(),
     additionalHeadHTML: z.string().optional(),
     gitHubEditLink: z.string().optional(),
     gitHubMainUrl: z.string().optional(),


### PR DESCRIPTION
## Summary
- add a `groupCreationGuidelines` option to the website configuration, including Helm template rendering and values schema validation
- pass the configured guidelines into the group creation flow and surface them above the form in the shared `GroupForm`
- cover the new display path with a unit test to ensure guidelines render when provided

## Testing
- npm run format
- npm run test
- npm run check-types

------
https://chatgpt.com/codex/tasks/task_e_68cad9b9fb188325a355fba467c43487

🚀 Preview: Add `preview` label to enable