### PR TITLE
refactor(website): don't duplicate the state in useUrlParamState

### DIFF
--- a/website/src/hooks/useUrlParamState.ts
+++ b/website/src/hooks/useUrlParamState.ts
@@ -1,4 +1,4 @@
-import { type Dispatch, type SetStateAction, useCallback, useEffect, useState } from 'react';
+import { type Dispatch, type SetStateAction, useCallback, useMemo } from 'react';
 
 import type { QueryState } from '../components/SearchPage/useQueryAsState.ts';
 
@@ -23,8 +23,9 @@ function useUrlParamState<T>(
     paramType: ParamType = 'string',
     shouldRemove: (value: T) => boolean,
 ): [T, (newValue: T) => void] {
-    const [valueState, setValueState] = useState<T>(
-        paramName in queryState ? parseUrlValue(queryState[paramName], paramType) : defaultValue,
+    const valueState = useMemo(
+        () => (paramName in queryState ? parseUrlValue(queryState[paramName], paramType) : defaultValue),
+        [paramName, queryState, paramType, defaultValue],
     );
 
     function parseUrlValue(urlValue: string | string[] | undefined, type: ParamType): T {
@@ -59,23 +60,7 @@ function useUrlParamState<T>(
         [paramName, setState, shouldRemove],
     );
 
-    const setValue = useCallback(
-        (newValue: T) => {
-            setValueState(newValue);
-            updateUrlParam(newValue);
-        },
-        [updateUrlParam],
-    );
-
-    useEffect(() => {
-        const urlValue = paramName in queryState ? parseUrlValue(queryState[paramName], paramType) : defaultValue;
-
-        if (JSON.stringify(urlValue) !== JSON.stringify(valueState)) {
-            setValueState(urlValue);
-        }
-    }, [queryState, paramName, paramType, defaultValue, valueState]);
-
-    return [valueState, setValue];
+    return [valueState, updateUrlParam];
 }
 
 export default useUrlParamState;


### PR DESCRIPTION
It's a derived state, let's make it a proper derived state. We don't need a separate, intermediate state that we need to be careful about syncing correctly.

### Screenshot

### PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by appropriate, automated tests.~~
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
  - `halfScreen` and `selectedSeq` still seem to work as before

🚀 Preview: https://useurlparamstate.loculus.org