### PR TITLE
feat(website): support multi-entry search fields

### DIFF
--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -17,6 +17,7 @@ fields:
     type: string
     notSearchable: true
     hideOnSequenceDetailsPage: true
+    multiEntry: true
   - name: version
     type: int
     notSearchable: true

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -154,6 +154,11 @@
           "type": "boolean",
           "description": "Whether this field should be included in metadata downloads by default."
         },
+        "multiEntry": {
+          "groups": ["metadata"],
+          "type": "boolean",
+          "description": "If true, the search UI treats the field as a multi-entry text area where multiple values can be provided separated by whitespace or punctuation."
+        },
         "perSegment": {
           "groups": ["metadata"],
           "type": "boolean",

--- a/website/src/components/SearchPage/DownloadDialog/SequenceFilters.spec.ts
+++ b/website/src/components/SearchPage/DownloadDialog/SequenceFilters.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { FieldFilterSet } from './SequenceFilters';
+import { MetadataFilterSchema } from '../../../utils/search';
+
+describe('FieldFilterSet', () => {
+    const emptyHiddenValues = {};
+    const referenceGenomes = { nucleotideSequences: [], genes: [], insdcAccessionFull: [] };
+
+    it('converts multi-entry accession strings into accession arrays without versions', () => {
+        const schema = new MetadataFilterSchema([{ name: 'accession', type: 'string', multiEntry: true }]);
+        const filterSet = new FieldFilterSet(
+            schema,
+            { accession: 'LOC_1 LOC_2.3' },
+            emptyHiddenValues,
+            referenceGenomes,
+        );
+
+        const params = filterSet.toApiParams();
+
+        expect(params.accession).toEqual(['LOC_1', 'LOC_2']);
+    });
+
+    it('converts generic multi-entry fields into arrays', () => {
+        const schema = new MetadataFilterSchema([{ name: 'sampleId', type: 'string', multiEntry: true }]);
+        const filterSet = new FieldFilterSet(schema, { sampleId: 'a,b; c' }, emptyHiddenValues, referenceGenomes);
+
+        const params = filterSet.toApiParams();
+
+        expect(params.sampleId).toEqual(['a', 'b', 'c']);
+    });
+});

--- a/website/src/components/SearchPage/SearchForm.spec.tsx
+++ b/website/src/components/SearchPage/SearchForm.spec.tsx
@@ -19,6 +19,14 @@ const queryClient = new QueryClient();
 
 const defaultSearchFormFilters: MetadataFilter[] = [
     {
+        name: 'accession',
+        type: 'string',
+        displayName: 'Accession',
+        autocomplete: false,
+        initiallyVisible: true,
+        multiEntry: true,
+    },
+    {
         name: 'field1',
         type: 'string',
         autocomplete: false,
@@ -86,6 +94,13 @@ describe('SearchForm', () => {
         expect(screen.getByText('Field 1')).toBeInTheDocument();
         // For multi-select autocomplete fields, the label is in aria-label
         expect(screen.getByLabelText('Field 3')).toBeInTheDocument();
+    });
+
+    it('renders accession as multiline when configured', () => {
+        renderSearchForm();
+
+        const accessionInput = screen.getByLabelText('Accession');
+        expect(accessionInput.tagName).toBe('TEXTAREA');
     });
 
     it('handles field value changes', async () => {

--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -57,6 +57,14 @@ export const SearchForm = ({
     const { isOpen: isMobileOpen, close: closeOnMobile, toggle: toggleMobileOpen } = useOffCanvas();
     const toggleFieldSelector = () => setIsFieldSelectorOpen(!isFieldSelectorOpen);
 
+    const accessionFilter: MetadataFilter = filterSchema.getFilter('accession') ?? {
+        name: 'accession',
+        type: 'string',
+        displayName: 'Accession',
+        autocomplete: false,
+        multiEntry: true,
+    };
+
     const fieldItems: FieldItem[] = filterSchema.filters
         .filter((filter) => filter.name !== 'accession') // Exclude accession field
         .map((filter) => ({
@@ -120,6 +128,7 @@ export const SearchForm = ({
                     <div className='flex flex-col'>
                         <div className='mb-1'>
                             <AccessionField
+                                field={accessionFilter}
                                 textValue={'accession' in fieldValues ? fieldValues.accession! : ''}
                                 setTextValue={(value) => setSomeFieldValues(['accession', value])}
                             />
@@ -233,6 +242,7 @@ const SearchField = ({ field, lapisUrl, fieldValues, setSomeFieldValues, lapisSe
                     field={field}
                     fieldValue={validateSingleValue(fieldValues[field.name], field.name)}
                     setSomeFieldValues={setSomeFieldValues}
+                    multiline={field.multiEntry === true}
                 />
             );
     }

--- a/website/src/components/SearchPage/fields/AccessionField.tsx
+++ b/website/src/components/SearchPage/fields/AccessionField.tsx
@@ -1,27 +1,23 @@
 import { type FC } from 'react';
 
 import { NormalTextField } from './NormalTextField.tsx';
+import type { MetadataFilter } from '../../../types/config.ts';
 
 type AccessionFieldProps = {
+    field: MetadataFilter;
     textValue: string;
     setTextValue: (value: string) => void;
 };
 
-export const AccessionField: FC<AccessionFieldProps> = ({ textValue, setTextValue }) => {
+export const AccessionField: FC<AccessionFieldProps> = ({ field, textValue, setTextValue }) => {
     return (
         <NormalTextField
-            field={{
-                type: 'string',
-                displayName: 'Accession',
-                autocomplete: false,
-                name: 'accession',
-                notSearchable: false,
-            }}
+            field={field}
             setSomeFieldValues={([, filter]) => {
                 setTextValue(filter as string);
             }}
             fieldValue={textValue}
-            multiline
+            multiline={field.multiEntry === true}
         />
     );
 };

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -65,6 +65,7 @@ export const metadata = z.object({
     order: z.number().optional(),
     orderOnDetailsPage: z.number().optional(),
     includeInDownloadsByDefault: z.boolean().optional(),
+    multiEntry: z.boolean().optional(),
 });
 
 export const inputFieldOption = z.object({

--- a/website/src/utils/search.spec.ts
+++ b/website/src/utils/search.spec.ts
@@ -26,4 +26,19 @@ describe('MetadataFilterSchema', () => {
         const result = schema.getFieldValuesFromQuery({ field1: [NULL_QUERY_VALUE, NULL_QUERY_VALUE] }, {});
         expect(result.field1).toEqual([null, null]);
     });
+
+    it('keeps multi-entry fields as strings when parsing query state', () => {
+        const schema = new MetadataFilterSchema([{ name: 'accession', type: 'string', multiEntry: true }]);
+        const result = schema.getFieldValuesFromQuery({ accession: 'LOC_1 LOC_2' }, {});
+        expect(result.accession).toBe('LOC_1 LOC_2');
+    });
+
+    it('identifies multi-entry fields', () => {
+        const schema = new MetadataFilterSchema([
+            { name: 'accession', type: 'string', multiEntry: true },
+            { name: 'field1', type: 'string' },
+        ]);
+        expect(schema.isMultiEntry('accession')).toBe(true);
+        expect(schema.isMultiEntry('field1')).toBe(false);
+    });
 });


### PR DESCRIPTION
## Summary
- allow metadata definitions to mark fields as multi-entry and surface that metadata through the search schema
- update the search form, field rendering, and API parameter building to respect multi-entry fields and cover the behavior with new unit tests
- document the capability in the Helm schema and mark the accession metadata as multi-entry by default

## Testing
- npm run test -- --run *(fails: backend requests return ECONNREFUSED in the test environment)*
- npm run check-types
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68cebc8ccffc8325b0329a42413e4c8c

🚀 Preview: https://codex-make-fields-support.loculus.org