### PR TITLE
feat: display sizes of extra files on sequence details page

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/SecurityConfig.kt
@@ -61,6 +61,10 @@ class SecurityConfig {
         "/files/get/**",
     )
 
+    private val headEndpointsThatArePublic = arrayOf(
+        "/files/get/**",
+    )
+
     private val debugEndpoints = arrayOf(
         "/debug/*",
     )
@@ -85,6 +89,7 @@ class SecurityConfig {
                 "/swagger-ui/**",
             ).permitAll()
             auth.requestMatchers(HttpMethod.GET, *getEndpointsThatArePublic).permitAll()
+            auth.requestMatchers(HttpMethod.HEAD, *headEndpointsThatArePublic).permitAll()
             auth.requestMatchers(HttpMethod.OPTIONS).permitAll()
             auth.requestMatchers(*endpointsForPreprocessingPipeline).hasAuthority(PREPROCESSING_PIPELINE)
             auth.requestMatchers(

--- a/backend/src/main/kotlin/org/loculus/backend/config/WebConfig.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/WebConfig.kt
@@ -13,7 +13,7 @@ class WebConfig : WebMvcConfigurer {
     override fun addCorsMappings(registry: CorsRegistry) {
         registry.addMapping("/**")
             .allowedOrigins("*") // Allow requests from any origin
-            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD")
             .allowedHeaders("*")
             .maxAge(3600) // Max age of pre-flight requests
     }

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/S3Service.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/S3Service.kt
@@ -24,6 +24,7 @@ import software.amazon.awssdk.services.s3.model.Tagging
 import software.amazon.awssdk.services.s3.model.UploadPartRequest
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest
+import software.amazon.awssdk.services.s3.presigner.model.HeadObjectPresignRequest
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest
 import software.amazon.awssdk.services.s3.presigner.model.UploadPartPresignRequest
 import java.net.URI
@@ -124,6 +125,21 @@ class S3Service(private val s3Config: S3Config) {
             .signatureDuration(Duration.ofSeconds(PRESIGNED_URL_EXPIRY_SECONDS.toLong()))
             .build()
         presigner.presignGetObject(presignRequest).url().toString()
+    }
+
+    fun createUrlToHeadPrivateFile(fileId: FileId): String = s3ErrorMapping {
+        val config = getS3BucketConfig()
+        val headRequest = HeadObjectRequest.builder()
+            .bucket(config.bucket)
+            .key(getFileIdPath(fileId))
+            .build()
+
+        val presignRequest = HeadObjectPresignRequest.builder()
+            .headObjectRequest(headRequest)
+            .signatureDuration(Duration.ofSeconds(PRESIGNED_URL_EXPIRY_SECONDS.toLong()))
+            .build()
+
+        presigner.presignHeadObject(presignRequest).url().toString()
     }
 
     /**

--- a/website/src/components/SequenceDetailsPage/DataTableEntryValue.tsx
+++ b/website/src/components/SequenceDetailsPage/DataTableEntryValue.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import sanitizeHtml from 'sanitize-html';
 
 import { DataUseTermsHistoryModal } from './DataUseTermsHistoryModal';
@@ -37,13 +37,40 @@ const FileListComponent: React.FC<{ jsonString: string }> = ({ jsonString }) => 
         <ul>
             {fileEntries.map((fileEntry) => (
                 <li key={fileEntry.fileId}>
-                    <a href={fileEntry.url} className='underline'>
+                    <a href={fileEntry.url} className='underline mr-2'>
                         {fileEntry.name}
                     </a>
+                    <FileSizeComponent url={fileEntry.url} />
                 </li>
             ))}
         </ul>
     );
+};
+
+const FileSizeComponent: React.FC<{ url: string }> = ({ url }) => {
+    const [fileSize, setFileSize] = useState<number | null>(null);
+
+    useEffect(() => {
+        void fetch(url, { method: 'HEAD', redirect: 'follow' }).then((response) => {
+            const contentLength = response.headers.get('Content-Length');
+            setFileSize(Number.parseInt(contentLength!));
+        });
+    }, [url]);
+
+    if (fileSize === null) {
+        return <></>;
+    }
+
+    return <span className='text-gray-400'>({prettyFormatBytes(fileSize)})</span>;
+};
+
+const prettyFormatBytes = (bytes: number): string => {
+    if (bytes === 0) {
+        return '0 bytes';
+    }
+    const sizes = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(1000));
+    return (bytes / 1000 ** i).toFixed() + ' ' + sizes[i];
 };
 
 const CustomDisplayComponent: React.FC<Props> = ({ data, dataUseTermsHistory }) => {


### PR DESCRIPTION
resolves #4110

This implements the display of file sizes of extra files on the sequence details page by sending HEAD requests from the frontend to retrieve the content size (following @theosanderson's suggestion in the issue to not include the information in the JSON object that SILO receives but query lazily).

Remaining:
- [ ] This does not work if `fileSharing.outputFileUrlType` is set to `website`.

### Screenshot

<img width="485" height="150" alt="Screenshot 2025-09-22 at 21 41 01" src="https://github.com/user-attachments/assets/73590917-cd04-4821-a502-a75d79991bf9" />

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

