### PR TITLE
fix(deployment): Change startup probe path from '/actuator/health' to '/sample/info' for LAPIS deployment

### DIFF
--- a/kubernetes/loculus/templates/lapis-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-deployment.yaml
@@ -45,7 +45,7 @@ spec:
               subPath: reference_genomes.json
           startupProbe:
             httpGet:
-              path: /actuator/health
+              path: /sample/info
               port: 8080
             periodSeconds: 5
             failureThreshold: 36 # 3 minutes to start


### PR DESCRIPTION
We should wait until LAPIS is actually ready to serve data - this was a misconfiguration and led to problems when new LAPIS came up before new SILO was ready

🚀 Preview: https://startup-probe.loculus.org