### PR TITLE
fix(backend): validate group exists for multipart upload

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
@@ -120,10 +120,7 @@ class FilesController(
         @RequestParam
         numberFiles: Int = 1,
     ): List<FileIdAndWriteUrl> {
-        filesPreconditionValidator.apply {
-            validateGroupExists(groupId)
-            validateUserIsAllowedToUploadFileForGroup(groupId, authenticatedUser)
-        }
+        filesPreconditionValidator.validateUserIsAllowedToUploadFileForGroup(groupId, authenticatedUser)
         val response = mutableListOf<FileIdAndWriteUrl>()
         if (numberFiles < 1) {
             throw BadRequestException("Number of files must be at least 1")
@@ -161,10 +158,7 @@ class FilesController(
         @RequestParam
         numberParts: Int = 1,
     ): List<FileIdAndMultipartWriteUrl> {
-        filesPreconditionValidator.apply {
-            validateGroupExists(groupId)
-            validateUserIsAllowedToUploadFileForGroup(groupId, authenticatedUser)
-        }
+        filesPreconditionValidator.validateUserIsAllowedToUploadFileForGroup(groupId, authenticatedUser)
         val response = mutableListOf<FileIdAndMultipartWriteUrl>()
         repeat(numberFiles) {
             val fileId = generateFileId()

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/FilesPreconditionValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/FilesPreconditionValidator.kt
@@ -15,14 +15,10 @@ class FilesPreconditionValidator(
      */
     @Transactional(readOnly = true)
     fun validateUserIsAllowedToUploadFileForGroup(groupId: Int, authenticatedUser: AuthenticatedUser) {
+        groupManagementPreconditionValidator.validateGroupExists(groupId)
         if (authenticatedUser.isPreprocessingPipeline) {
             return
         }
         groupManagementPreconditionValidator.validateUserIsAllowedToModifyGroup(groupId, authenticatedUser)
-    }
-
-    @Transactional(readOnly = true)
-    fun validateGroupExists(groupId: Int) {
-        groupManagementPreconditionValidator.validateGroupExists(groupId)
     }
 }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/files/RequestMultipartUploadEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/files/RequestMultipartUploadEndpointTest.kt
@@ -112,6 +112,8 @@ class RequestMultipartUploadEndpointTest(
         val groupId = groupManagementClient.createNewGroup().andGetGroupId() + 100
         client.requestMultipartUploads(groupId = groupId, 1, 1)
             .andExpect(status().isNotFound)
+        client.requestMultipartUploads(groupId = groupId, 1, 1, jwt = jwtForProcessingPipeline)
+            .andExpect(status().isNotFound)
     }
 
     @Test

--- a/backend/src/test/kotlin/org/loculus/backend/controller/files/RequestUploadEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/files/RequestUploadEndpointTest.kt
@@ -98,6 +98,8 @@ class RequestUploadEndpointTest(
         val nonExistentGroupId = -1
         client.requestUploads(groupId = nonExistentGroupId, numberFiles = 1)
             .andExpect(status().isNotFound)
+        client.requestUploads(groupId = nonExistentGroupId, numberFiles = 1, jwt = jwtForProcessingPipeline)
+            .andExpect(status().isNotFound)
     }
 
     @Test


### PR DESCRIPTION
- ensure the multipart upload endpoint reuses the same group validation as the single-upload endpoint so that nonexistent groups are rejected before issuing S3 URLs
- otherwise the preprocessing pipeline service account would bypass the group-existence check when initiating multipart uploads which isn't a huge problem but seems worth avoiding

_PR came from asking Codex to find and fix a bug but seems legitimately worth fixing - I haven't done anything except see tests still pass_


------
https://chatgpt.com/codex/tasks/task_e_68d2ef1060188325824e2ef59cf2bad4

🚀 Preview: Add `preview` label to enable