### PR TITLE
feat(website): multi pathogen support: show correct segments in download modal

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx
@@ -170,8 +170,8 @@ describe('DownloadDialog', () => {
         });
         await checkAgreement();
 
-        let [path, query] = getDownloadHref()?.split('?') ?? [];
-        expect(path).toBe(`${defaultLapisUrl}/sample/details`);
+        let { path, query } = parseDownloadHref();
+        expectRouteInPathMatches(path, `/sample/details`);
         expect(query).toMatch(
             /downloadAsFile=true&downloadFileBasename=ebola_metadata_\d{4}-\d{2}-\d{2}T\d{4}&dataUseTerms=OPEN&dataFormat=tsv&fields=accessionVersion%2Cfield1%2Cfield2&accession=accession1&accession=accession2&versionStatus=LATEST_VERSION&isRevocation=false&field1=value1/,
         );
@@ -179,8 +179,8 @@ describe('DownloadDialog', () => {
         await userEvent.click(screen.getByLabelText(rawNucleotideSequencesLabel));
         await userEvent.click(screen.getByLabelText(gzipCompressionLabel));
 
-        [path, query] = getDownloadHref()?.split('?') ?? [];
-        expect(path).toBe(`${defaultLapisUrl}/sample/unalignedNucleotideSequences`);
+        ({ path, query } = parseDownloadHref());
+        expectRouteInPathMatches(path, `/sample/unalignedNucleotideSequences`);
         expect(query).toMatch(
             /downloadAsFile=true&downloadFileBasename=ebola_nuc_\d{4}-\d{2}-\d{2}T\d{4}&dataUseTerms=OPEN&dataFormat=fasta&compression=gzip&accession=accession1&accession=accession2&versionStatus=LATEST_VERSION&isRevocation=false&field1=value1/,
         );
@@ -188,8 +188,8 @@ describe('DownloadDialog', () => {
         await userEvent.click(screen.getByLabelText(/include restricted data/));
         await userEvent.click(screen.getByLabelText(/Zstandard/));
 
-        [path, query] = getDownloadHref()?.split('?') ?? [];
-        expect(path).toBe(`${defaultLapisUrl}/sample/unalignedNucleotideSequences`);
+        ({ path, query } = parseDownloadHref());
+        expectRouteInPathMatches(path, `/sample/unalignedNucleotideSequences`);
         expect(query).toMatch(
             /downloadAsFile=true&downloadFileBasename=ebola_nuc_\d{4}-\d{2}-\d{2}T\d{4}&dataFormat=fasta&compression=zstd&accession=accession1&accession=accession2&versionStatus=LATEST_VERSION&isRevocation=false&field1=value1/,
         );
@@ -199,8 +199,8 @@ describe('DownloadDialog', () => {
         await renderDialog({ downloadParams: new SequenceEntrySelection(new Set(['SEQID1', 'SEQID2'])) });
         await checkAgreement();
 
-        let [path, query] = getDownloadHref()?.split('?') ?? [];
-        expect(path).toBe(`${defaultLapisUrl}/sample/details`);
+        let { path, query } = parseDownloadHref();
+        expectRouteInPathMatches(path, `/sample/details`);
         expect(query).toMatch(
             /downloadAsFile=true&downloadFileBasename=ebola_metadata_\d{4}-\d{2}-\d{2}T\d{4}&dataUseTerms=OPEN&dataFormat=tsv&fields=accessionVersion%2Cfield1%2Cfield2&accessionVersion=SEQID1&accessionVersion=SEQID2/,
         );
@@ -208,8 +208,8 @@ describe('DownloadDialog', () => {
         await userEvent.click(screen.getByLabelText(rawNucleotideSequencesLabel));
         await userEvent.click(screen.getByLabelText(gzipCompressionLabel));
 
-        [path, query] = getDownloadHref()?.split('?') ?? [];
-        expect(path).toBe(`${defaultLapisUrl}/sample/unalignedNucleotideSequences`);
+        ({ path, query } = parseDownloadHref());
+        expectRouteInPathMatches(path, `/sample/unalignedNucleotideSequences`);
         expect(query).toMatch(
             /downloadAsFile=true&downloadFileBasename=ebola_nuc_\d{4}-\d{2}-\d{2}T\d{4}&dataUseTerms=OPEN&dataFormat=fasta&compression=gzip&accessionVersion=SEQID1&accessionVersion=SEQID2/,
         );
@@ -217,8 +217,8 @@ describe('DownloadDialog', () => {
         await userEvent.click(screen.getByLabelText(/include restricted data/));
         await userEvent.click(screen.getByLabelText(/Zstandard/));
 
-        [path, query] = getDownloadHref()?.split('?') ?? [];
-        expect(path).toBe(`${defaultLapisUrl}/sample/unalignedNucleotideSequences`);
+        ({ path, query } = parseDownloadHref());
+        expectRouteInPathMatches(path, `/sample/unalignedNucleotideSequences`);
         expect(query).toMatch(
             /downloadAsFile=true&downloadFileBasename=ebola_nuc_\d{4}-\d{2}-\d{2}T\d{4}&dataFormat=fasta&compression=zstd&accessionVersion=SEQID1&accessionVersion=SEQID2/,
         );
@@ -240,7 +240,7 @@ describe('DownloadDialog', () => {
         await renderDialog({ metadata: orderedMetadata });
         await checkAgreement();
 
-        const [, query] = getDownloadHref()?.split('?') ?? [];
+        const { query } = parseDownloadHref();
         expect(query).toMatch(/fields=accessionVersion%2Cfield2%2Cfield1/);
     });
 
@@ -248,8 +248,8 @@ describe('DownloadDialog', () => {
         await renderDialog({ allowSubmissionOfConsensusSequences: false });
         await checkAgreement();
 
-        const [path] = getDownloadHref()?.split('?') ?? [];
-        expect(path).toBe(`${defaultLapisUrl}/sample/details`);
+        const { path } = parseDownloadHref();
+        expectRouteInPathMatches(path, `/sample/details`);
 
         expect(screen.queryByLabelText(rawNucleotideSequencesLabel)).not.toBeInTheDocument();
         expect(screen.getByLabelText(gzipCompressionLabel)).toBeInTheDocument();
@@ -308,8 +308,8 @@ describe('DownloadDialog', () => {
         });
         await checkAgreement();
 
-        const [path, query] = getDownloadHref()?.split('?') ?? [];
-        expect(path).toBe(`${defaultLapisUrl}/sample/details`);
+        const { path, query } = parseDownloadHref();
+        expectRouteInPathMatches(path, `/sample/details`);
         expect(query).toMatch(/field2=/);
         expect(query).not.toMatch(/field1=/);
     });
@@ -361,7 +361,7 @@ describe('DownloadDialog', () => {
             await userEvent.click(screen.getByLabelText(displayNameFastaHeaderStyleLabel));
 
             const [path, query] = getDownloadHref()?.split('?') ?? [];
-            expect(path).toBe('https://lapis/sample/unalignedNucleotideSequences');
+            expectRouteInPathMatches(path, `/sample/unalignedNucleotideSequences`);
             expect(query).toMatch(
                 /^downloadAsFile=true&downloadFileBasename=ebola_nuc_\d{4}-\d{2}-\d{2}T\d{4}&dataUseTerms=OPEN&fastaHeaderTemplate=%7Bfield1%7D%7C%7Bfield2%7D&accession=accession1&accession=accession2&field1=value1/,
             );
@@ -379,6 +379,20 @@ describe('DownloadDialog', () => {
             expect(screen.getByText('select a genotype', { exact: false })).toBeVisible();
         });
 
+        test('should download all raw segments when no suborganism is selected', async () => {
+            await renderDialog({
+                referenceGenomesSequenceNames: multiPathogenReferenceGenome,
+                selectedSuborganism: null,
+                suborganismIdentifierField: 'genotype',
+            });
+
+            await checkAgreement();
+            await userEvent.click(screen.getByLabelText(rawNucleotideSequencesLabel));
+
+            const { path } = parseDownloadHref();
+            expectRouteInPathMatches(path, `/sample/unalignedNucleotideSequences`);
+        });
+
         test('should enable the aligned sequence downloads when suborganism is selected', async () => {
             await renderDialog({
                 referenceGenomesSequenceNames: multiPathogenReferenceGenome,
@@ -388,6 +402,49 @@ describe('DownloadDialog', () => {
 
             expect(screen.getByLabelText(alignedNucleotideSequencesLabel)).toBeEnabled();
             expect(screen.getByLabelText(alignedAminoAcidSequencesLabel)).toBeEnabled();
+        });
+
+        test('should download only the selected raw suborganism sequences when suborganism is selected', async () => {
+            await renderDialog({
+                referenceGenomesSequenceNames: multiPathogenReferenceGenome,
+                selectedSuborganism: 'suborganism1',
+                suborganismIdentifierField: 'genotype',
+            });
+
+            await checkAgreement();
+            await userEvent.click(screen.getByLabelText(rawNucleotideSequencesLabel));
+
+            const { path } = parseDownloadHref();
+            expectRouteInPathMatches(path, `/sample/unalignedNucleotideSequences/suborganism1`);
+        });
+
+        test('should download only the selected aligned suborganism sequences when suborganism is selected', async () => {
+            await renderDialog({
+                referenceGenomesSequenceNames: multiPathogenReferenceGenome,
+                selectedSuborganism: 'suborganism1',
+                suborganismIdentifierField: 'genotype',
+            });
+
+            await checkAgreement();
+            await userEvent.click(screen.getByLabelText(alignedNucleotideSequencesLabel));
+
+            const { path } = parseDownloadHref();
+            expectRouteInPathMatches(path, `/sample/alignedNucleotideSequences/suborganism1`);
+        });
+
+        test('should download only the selected aligned suborganism amino acid sequences when suborganism is selected', async () => {
+            await renderDialog({
+                referenceGenomesSequenceNames: multiPathogenReferenceGenome,
+                selectedSuborganism: 'suborganism1',
+                suborganismIdentifierField: 'genotype',
+            });
+
+            await checkAgreement();
+            await userEvent.click(screen.getByLabelText(alignedAminoAcidSequencesLabel));
+            await userEvent.selectOptions(screen.getByRole('combobox', { name: 'alignedAminoAcidSequences' }), 'gene2');
+
+            const { path } = parseDownloadHref();
+            expectRouteInPathMatches(path, `/sample/alignedAminoAcidSequences/suborganism1-gene2`);
         });
     });
 });
@@ -400,4 +457,13 @@ async function checkAgreement() {
 function getDownloadHref() {
     const downloadButton = screen.getByRole('link', { name: 'Download' });
     return downloadButton.getAttribute('href');
+}
+
+function parseDownloadHref() {
+    const [path, query] = getDownloadHref()?.split('?') ?? [undefined, undefined];
+    return { path, query };
+}
+
+function expectRouteInPathMatches(path: string | undefined, route: string) {
+    expect(path).toBe(`${defaultLapisUrl}${route}`);
 }

--- a/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
@@ -298,7 +298,7 @@ function getSequenceNames(
         return {
             nucleotideSequences: [],
             genes: [],
-            useMultiSegmentEndpoint: false, // LAPIS is multisegmented, since we're in multi pathogen case here. Use the "download all segments" endpoint which we get by pretending we're single segmented.
+            useMultiSegmentEndpoint: false, // When no suborganism is selected, use the "all segments" endpoint to download all available segments, even though LAPIS is multisegmented. That endpoint is available at the same route as the single segmented endpoint.
         };
     }
 

--- a/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
@@ -9,13 +9,13 @@ import { routes } from '../../../routes/routes.ts';
 import { ACCESSION_VERSION_FIELD } from '../../../settings.ts';
 import type { Metadata, Schema } from '../../../types/config.ts';
 import { type ReferenceGenomesSequenceNames, SINGLE_REFERENCE } from '../../../types/referencesGenomes.ts';
-import type { SequenceName } from '../../../utils/sequenceTypeHelpers.ts';
 import {
     getMultiPathogenNucleotideSequenceNames,
     getMultiPathogenSequenceName,
     getSinglePathogenSequenceName,
     isMultiSegmented,
-} from '../../SequenceDetailsPage/SequencesDisplay/getSequenceNames.tsx';
+    type SequenceName,
+} from '../../../utils/sequenceTypeHelpers.ts';
 import { formatLabel } from '../SuborganismSelector.tsx';
 import { stillRequiresSuborganismSelection } from '../stillRequiresSuborganismSelection.tsx';
 

--- a/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useState } from 'react';
+import { type FC, useEffect, useMemo, useState } from 'react';
 
 import type { DownloadDataType } from './DownloadDataType.ts';
 import type { DownloadOption } from './DownloadUrlGenerator.ts';
@@ -9,6 +9,13 @@ import { routes } from '../../../routes/routes.ts';
 import { ACCESSION_VERSION_FIELD } from '../../../settings.ts';
 import type { Metadata, Schema } from '../../../types/config.ts';
 import { type ReferenceGenomesSequenceNames, SINGLE_REFERENCE } from '../../../types/referencesGenomes.ts';
+import type { SequenceName } from '../../../utils/sequenceTypeHelpers.ts';
+import {
+    getMultiPathogenNucleotideSequenceNames,
+    getMultiPathogenSequenceName,
+    getSinglePathogenSequenceName,
+    isMultiSegmented,
+} from '../../SequenceDetailsPage/SequencesDisplay/getSequenceNames.tsx';
 import { formatLabel } from '../SuborganismSelector.tsx';
 import { stillRequiresSuborganismSelection } from '../stillRequiresSuborganismSelection.tsx';
 
@@ -59,9 +66,9 @@ export const DownloadForm: FC<DownloadFormProps> = ({
     const [includeRichFastaHeaders, setIncludeRichFastaHeaders] = useState(0);
 
     const [isFieldSelectorOpen, setIsFieldSelectorOpen] = useState(false);
-    const { nucleotideSequences, genes, useMultiSegmentEndpoint } = getSequenceNames(
-        referenceGenomesSequenceNames,
-        selectedSuborganism,
+    const { nucleotideSequences, genes, useMultiSegmentEndpoint } = useMemo(
+        () => getSequenceNames(referenceGenomesSequenceNames, selectedSuborganism),
+        [referenceGenomesSequenceNames, selectedSuborganism],
     );
 
     useEffect(() => {
@@ -73,20 +80,24 @@ export const DownloadForm: FC<DownloadFormProps> = ({
             case 1:
                 downloadDataType = {
                     type: 'unalignedNucleotideSequences',
-                    segment: useMultiSegmentEndpoint ? nucleotideSequences[unalignedNucleotideSequence] : undefined,
+                    segment: useMultiSegmentEndpoint
+                        ? nucleotideSequences[unalignedNucleotideSequence].lapisName
+                        : undefined,
                     includeRichFastaHeaders: includeRichFastaHeaders === 1,
                 };
                 break;
             case 2:
                 downloadDataType = {
                     type: 'alignedNucleotideSequences',
-                    segment: useMultiSegmentEndpoint ? nucleotideSequences[alignedNucleotideSequence] : undefined,
+                    segment: useMultiSegmentEndpoint
+                        ? nucleotideSequences[alignedNucleotideSequence].lapisName
+                        : undefined,
                 };
                 break;
             case 3:
                 downloadDataType = {
                     type: 'alignedAminoAcidSequences',
-                    gene: genes[alignedAminoAcidSequence],
+                    gene: genes[alignedAminoAcidSequence].lapisName,
                 };
                 break;
             default:
@@ -138,11 +149,11 @@ export const DownloadForm: FC<DownloadFormProps> = ({
             label: <>Raw nucleotide sequences</>,
             subOptions: (
                 <div className='px-8'>
-                    {useMultiSegmentEndpoint ? (
+                    {isMultiSegmented(nucleotideSequences) ? (
                         <DropdownOptionBlock
                             name='unalignedNucleotideSequences'
                             options={nucleotideSequences.map((segment) => ({
-                                label: <>{segment}</>,
+                                label: <>{segment.label}</>,
                             }))}
                             selected={unalignedNucleotideSequence}
                             onSelect={setUnalignedNucleotideSequence}
@@ -177,12 +188,12 @@ export const DownloadForm: FC<DownloadFormProps> = ({
             rawNucleotideSequencesOption,
             {
                 label: <>Aligned nucleotide sequences</>,
-                subOptions: useMultiSegmentEndpoint ? (
+                subOptions: isMultiSegmented(nucleotideSequences) ? (
                     <div className='px-8'>
                         <DropdownOptionBlock
                             name='alignedNucleotideSequences'
-                            options={nucleotideSequences.map((gene) => ({
-                                label: <>{gene}</>,
+                            options={nucleotideSequences.map((segment) => ({
+                                label: <>{segment.label}</>,
                             }))}
                             selected={alignedNucleotideSequence}
                             onSelect={setAlignedNucleotideSequence}
@@ -198,7 +209,7 @@ export const DownloadForm: FC<DownloadFormProps> = ({
                         <DropdownOptionBlock
                             name='alignedAminoAcidSequences'
                             options={genes.map((gene) => ({
-                                label: <>{gene}</>,
+                                label: <>{gene.label}</>,
                             }))}
                             selected={alignedAminoAcidSequence}
                             onSelect={setAlignedAminoAcidSequence}
@@ -273,20 +284,28 @@ export const DownloadForm: FC<DownloadFormProps> = ({
 function getSequenceNames(
     referenceGenomesSequenceNames: ReferenceGenomesSequenceNames,
     selectedSuborganism: string | null,
-) {
+): { nucleotideSequences: SequenceName[]; genes: SequenceName[]; useMultiSegmentEndpoint: boolean } {
     if (SINGLE_REFERENCE in referenceGenomesSequenceNames) {
         const { nucleotideSequences, genes } = referenceGenomesSequenceNames[SINGLE_REFERENCE];
-        return { nucleotideSequences, genes, useMultiSegmentEndpoint: nucleotideSequences.length > 1 };
+        return {
+            nucleotideSequences: nucleotideSequences.map(getSinglePathogenSequenceName),
+            genes: genes.map(getSinglePathogenSequenceName),
+            useMultiSegmentEndpoint: isMultiSegmented(nucleotideSequences),
+        };
     }
 
     if (selectedSuborganism === null) {
         return {
             nucleotideSequences: [],
             genes: [],
-            useMultiSegmentEndpoint: false, // LAPIS is multisegmented, since we're in multi pathogen case here. Use the endpoint that returns all segments.
+            useMultiSegmentEndpoint: false, // LAPIS is multisegmented, since we're in multi pathogen case here. Use the "download all segments" endpoint which we get by pretending we're single segmented.
         };
     }
 
     const { nucleotideSequences, genes } = referenceGenomesSequenceNames[selectedSuborganism];
-    return { nucleotideSequences, genes, useMultiSegmentEndpoint: true }; // TODO segment names...
+    return {
+        nucleotideSequences: getMultiPathogenNucleotideSequenceNames(nucleotideSequences, selectedSuborganism),
+        genes: genes.map((name) => getMultiPathogenSequenceName(name, selectedSuborganism)),
+        useMultiSegmentEndpoint: true,
+    };
 }

--- a/website/src/components/SearchPage/DownloadDialog/OptionBlock.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/OptionBlock.tsx
@@ -67,7 +67,7 @@ export const DropdownOptionBlock: FC<OptionBlockProps> = ({
         <div className='max-w-80'>
             <select
                 name={name}
-                title={name}
+                title={title ?? name}
                 className='select select-bordered w-full max-w-xs min-h-0 h-auto py-0'
                 disabled={disabled}
                 value={selected}

--- a/website/src/components/SearchPage/DownloadDialog/OptionBlock.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/OptionBlock.tsx
@@ -67,6 +67,7 @@ export const DropdownOptionBlock: FC<OptionBlockProps> = ({
         <div className='max-w-80'>
             <select
                 name={name}
+                title={name}
                 className='select select-bordered w-full max-w-xs min-h-0 h-auto py-0'
                 disabled={disabled}
                 value={selected}

--- a/website/src/components/SequenceDetailsPage/SequencesDisplay/SequencesContainer.tsx
+++ b/website/src/components/SequenceDetailsPage/SequencesDisplay/SequencesContainer.tsx
@@ -1,7 +1,7 @@
 import { type Dispatch, type FC, type SetStateAction, useEffect, useState } from 'react';
 
 import { SequencesViewer } from './SequenceViewer.tsx';
-import { getSequenceNames, isMultiSegmented } from './getSequenceNames.tsx';
+import { getSequenceNames } from './getSequenceNames.tsx';
 import { type ReferenceGenomesSequenceNames, type Suborganism } from '../../../types/referencesGenomes.ts';
 import type { ClientConfig } from '../../../types/runtimeConfig.ts';
 import {
@@ -9,6 +9,7 @@ import {
     geneSequence,
     isAlignedSequence,
     isGeneSequence,
+    isMultiSegmented,
     isUnalignedSequence,
     type SequenceName,
     type SequenceType,

--- a/website/src/components/SequenceDetailsPage/SequencesDisplay/getSequenceNames.tsx
+++ b/website/src/components/SequenceDetailsPage/SequencesDisplay/getSequenceNames.tsx
@@ -13,27 +13,37 @@ export function getSequenceNames(
 
     if (suborganism === SINGLE_REFERENCE) {
         return {
-            nucleotideSegmentNames: nucleotideSequences.map((name) => ({ lapisName: name, label: name })),
-            genes: genes.map((name) => ({ lapisName: name, label: name })),
+            nucleotideSegmentNames: nucleotideSequences.map(getSinglePathogenSequenceName),
+            genes: genes.map(getSinglePathogenSequenceName),
             isMultiSegmented: isMultiSegmented(nucleotideSequences),
         };
     }
 
-    const nucleotideSegmentNames =
-        nucleotideSequences.length === 1
-            ? [{ lapisName: suborganism, label: 'main' }]
-            : nucleotideSequences.map((name) => ({
-                  lapisName: `${suborganism}-${name}`,
-                  label: name,
-              }));
-
+    const nucleotideSegmentNames = getMultiPathogenNucleotideSequenceNames(nucleotideSequences, suborganism);
     return {
         nucleotideSegmentNames,
-        genes: genes.map((name) => ({
-            lapisName: `${suborganism}-${name}`,
-            label: name,
-        })),
+        genes: genes.map((name) => getMultiPathogenSequenceName(name, suborganism)),
         isMultiSegmented: true, // LAPIS treats the suborganisms as multiple nucleotide segments -> always true
+    };
+}
+
+export function getMultiPathogenNucleotideSequenceNames(nucleotideSequences: string[], suborganism: string) {
+    return nucleotideSequences.length === 1
+        ? [{ lapisName: suborganism, label: 'main' }]
+        : nucleotideSequences.map((name) => getMultiPathogenSequenceName(name, suborganism));
+}
+
+export function getSinglePathogenSequenceName(name: string): SequenceName {
+    return {
+        lapisName: name,
+        label: name,
+    };
+}
+
+export function getMultiPathogenSequenceName(name: string, suborganism: string): SequenceName {
+    return {
+        lapisName: `${suborganism}-${name}`,
+        label: name,
     };
 }
 

--- a/website/src/components/SequenceDetailsPage/SequencesDisplay/getSequenceNames.tsx
+++ b/website/src/components/SequenceDetailsPage/SequencesDisplay/getSequenceNames.tsx
@@ -1,5 +1,11 @@
 import { type ReferenceGenomesSequenceNames, SINGLE_REFERENCE } from '../../../types/referencesGenomes.ts';
-import type { SequenceName } from '../../../utils/sequenceTypeHelpers.ts';
+import {
+    getMultiPathogenNucleotideSequenceNames,
+    getMultiPathogenSequenceName,
+    getSinglePathogenSequenceName,
+    isMultiSegmented,
+    type SequenceName,
+} from '../../../utils/sequenceTypeHelpers.ts';
 
 export function getSequenceNames(
     referenceGenomeSequenceNames: ReferenceGenomesSequenceNames,
@@ -25,28 +31,4 @@ export function getSequenceNames(
         genes: genes.map((name) => getMultiPathogenSequenceName(name, suborganism)),
         isMultiSegmented: true, // LAPIS treats the suborganisms as multiple nucleotide segments -> always true
     };
-}
-
-export function getMultiPathogenNucleotideSequenceNames(nucleotideSequences: string[], suborganism: string) {
-    return nucleotideSequences.length === 1
-        ? [{ lapisName: suborganism, label: 'main' }]
-        : nucleotideSequences.map((name) => getMultiPathogenSequenceName(name, suborganism));
-}
-
-export function getSinglePathogenSequenceName(name: string): SequenceName {
-    return {
-        lapisName: name,
-        label: name,
-    };
-}
-
-export function getMultiPathogenSequenceName(name: string, suborganism: string): SequenceName {
-    return {
-        lapisName: `${suborganism}-${name}`,
-        label: name,
-    };
-}
-
-export function isMultiSegmented(nucleotideSegmentNames: unknown[]) {
-    return nucleotideSegmentNames.length > 1;
 }

--- a/website/src/utils/sequenceTypeHelpers.ts
+++ b/website/src/utils/sequenceTypeHelpers.ts
@@ -8,6 +8,30 @@ export type SequenceName = {
     label: string;
 };
 
+export function getMultiPathogenNucleotideSequenceNames(nucleotideSequences: string[], suborganism: string) {
+    return nucleotideSequences.length === 1
+        ? [{ lapisName: suborganism, label: 'main' }]
+        : nucleotideSequences.map((name) => getMultiPathogenSequenceName(name, suborganism));
+}
+
+export function getSinglePathogenSequenceName(name: string): SequenceName {
+    return {
+        lapisName: name,
+        label: name,
+    };
+}
+
+export function getMultiPathogenSequenceName(name: string, suborganism: string): SequenceName {
+    return {
+        lapisName: `${suborganism}-${name}`,
+        label: name,
+    };
+}
+
+export function isMultiSegmented(nucleotideSegmentNames: unknown[]) {
+    return nucleotideSegmentNames.length > 1;
+}
+
 export const unalignedSequenceSegment = (segmentName: SequenceName): SequenceType => ({
     type: 'nucleotide',
     aligned: false,


### PR DESCRIPTION
resolves #4997

Make sure that the correct segments and genes are displayed and downloaded. All downloads should now work in the multi pathogen case.

* When downloading raw sequences when no suborganism is selected yet, it will download all segments that are not null (#5092 is still open here).
* When downloading raw sequences when a suborganism is selected, it will download the corresponding segment only.

### Screenshot

<img width="885" height="704" alt="image" src="https://github.com/user-attachments/assets/58c82616-7196-45df-844c-61e47c87f09d" />

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
  - sequence download works
    - for EV as expected
    - for west nile as before

🚀 Preview: Add `preview` label to enable