### PR TITLE
feat(deployment): Add liveness probe to silo-deployment.yaml

### DIFF
--- a/kubernetes/loculus/templates/silo-deployment.yaml
+++ b/kubernetes/loculus/templates/silo-deployment.yaml
@@ -54,6 +54,14 @@ spec:
             periodSeconds: 10
             failureThreshold: 3
             timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 5
         - name: silo-preprocessing
           image: "{{ $.Values.images.lapisSilo.repository }}:{{ $.Values.images.lapisSilo.tag }}"
           imagePullPolicy: "{{ $.Values.images.lapisSilo.pullPolicy }}"


### PR DESCRIPTION
Uses https://github.com/GenSpectrum/LAPIS-SILO/pull/979 to ensure we restart SILO if it gets unhealthy (sorry for the delay I didn't notice this get added at the time)

🚀 Preview: https://silo-liveness.loculus.org