### PR TITLE
chore(deps): bump SILO to use backported health-check in version 0.7.10.2

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1989,7 +1989,7 @@ additionalHeadHTML: ""
 images:
   lapisSilo:
     repository: "ghcr.io/genspectrum/lapis-silo"
-    tag: "v0.7.10.1@sha256:96e431192d6493ed71ac10bc273710df21e7c520a77bebaa7d94ff859264d36c"
+    tag: "v0.7.10.2@sha256:ec1da285d79eda3f910ca00520572170f9d4794a6bc7e8df727368130698e9d3"
     pullPolicy: Always
   lapis:
     repository: "ghcr.io/genspectrum/lapis"

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1989,7 +1989,7 @@ additionalHeadHTML: ""
 images:
   lapisSilo:
     repository: "ghcr.io/genspectrum/lapis-silo"
-    tag: "v0.7.10.2@sha256:ec1da285d79eda3f910ca00520572170f9d4794a6bc7e8df727368130698e9d3"
+    tag: "v0.7.10.2@sha256:18b03238e879c1cb990fed71679afa0d6335bec7e20c15e2bd1b53787df32321"
     pullPolicy: Always
   lapis:
     repository: "ghcr.io/genspectrum/lapis"


### PR DESCRIPTION
This is required for #4983.

This changes the SILO image to include the cherry picked commit:

[feat(silo): add a health endpoint that checks whether the api is able to answer requests](https://github.com/GenSpectrum/LAPIS-SILO/pull/978/commits/789ddf5b68872940b330c9b271631b6097009cc9)

See:
https://github.com/GenSpectrum/LAPIS-SILO/pull/978/commits

🚀 Preview: https://update-silo-0-7-10-2.loculus.org