### PR TITLE
fix(deployment): handle missing pipeline versions

### DIFF
--- a/kubernetes/loculus/silo_import_job.sh
+++ b/kubernetes/loculus/silo_import_job.sh
@@ -155,11 +155,15 @@ download_lineage_definitions() {
     return
   fi
 
-  pipelineVersion=$(zstd -d -c "$new_input_data_path" | jq -r '.metadata.pipelineVersion' | sort -u)
+  pipelineVersion=$(zstd -d -c "$new_input_data_path" \
+    | jq -r '.metadata.pipelineVersion // empty' \
+    | sed '/^$/d' \
+    | sed '/^null$/d' \
+    | sort -u)
 
   if [[ -z "$pipelineVersion" ]]; then
     echo "No pipeline version found. Writing empty lineage definition file."
-    echo "{}" > $lineage_definition_file
+    echo "{}" > "$lineage_definition_file"
   elif [[ $(echo "$pipelineVersion" | wc -l) -eq 1 ]]; then
     echo "Single pipeline version: $pipelineVersion"
 


### PR DESCRIPTION
## Summary
- ensure the silo import job ignores empty or null pipelineVersion metadata when determining which lineage definitions to download
- treat the absence of a usable pipeline version as "no version" by writing an empty lineage definition file rather than failing
- add quoting when writing the lineage file path to avoid issues with spaces or globbing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d54c5fde188325a061ef4691e22312