### PR TITLE
chore(ci): use consistent ruff version to format/check ena-submission

### DIFF
--- a/.github/workflows/ena-submission-unit-tests.yaml
+++ b/.github/workflows/ena-submission-unit-tests.yaml
@@ -19,19 +19,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: astral-sh/ruff-action@v3
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v2
         with:
-          args: "format --check --diff"
-          src: "ena-submission"
+          environment-file: "ena-submission/environment.yml"
+          micromamba-version: "latest"
+          cache-environment: true
+      - name: Run ruff format check
+        run: ruff check . --fix --diff
+        shell: micromamba-shell {0}
+        working-directory: ena-submission
   lint:
     name: Lint code
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: astral-sh/ruff-action@v3
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v2
         with:
-          args: "check"
-          src: "ena-submission"
+          environment-file: "ena-submission/environment.yml"
+          micromamba-version: "latest"
+          cache-environment: true
+      - name: Run ruff check
+        run: ruff check .
+        shell: micromamba-shell {0}
+        working-directory: ena-submission
   unitTests:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/format-ena-deposition-on-dispatch.yml
+++ b/.github/workflows/format-ena-deposition-on-dispatch.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "ena-submission/**"
       - ".github/workflows/format-ena-deposition-on-dispatch.yml"
+      - "ruff.toml"
 jobs:
   format:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'format_me'))
@@ -18,16 +19,20 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-file: "ena-submission/environment.yml"
+          micromamba-version: "latest"
+          cache-environment: true
       - name: Run ruff format
-        uses: astral-sh/ruff-action@v3
-        with:
-          args: "format"
-          src: "ena-submission"
-      - name: Run ruff check --fix
-        uses: astral-sh/ruff-action@v3
-        with:
-          args: "check --fix"
-          src: "ena-submission"
+        run: ruff format .
+        shell: micromamba-shell {0}
+        working-directory: ena-submission
+      - name: Run ruff format
+        run: ruff check . --fix
+        shell: micromamba-shell {0}
+        working-directory: ena-submission
       - name: Commit and Push Changes
         run: |
           git config --global user.name 'Loculus bot'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.12.1
+  rev: v0.13.1
   hooks:
     # Run the linter and fix issues.
     - id: ruff-check

--- a/ena-submission/environment.yml
+++ b/ena-submission/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - xmltodict
   - biopython
   - pytz
-  - ruff =0.13.1
+  - ruff =0.13.1. # if changing update .pre-commit-config.yaml as well
   - tenacity
   - types-pytz
   - types-psycopg2

--- a/ena-submission/environment.yml
+++ b/ena-submission/environment.yml
@@ -22,6 +22,7 @@ dependencies:
   - xmltodict
   - biopython
   - pytz
+  - ruff =0.13.1
   - tenacity
   - types-pytz
   - types-psycopg2


### PR DESCRIPTION
Prevents breakage of CI on main due to new rules when new ruff version is released (it just happened).

This uses a consistent ruff version defined in environment.yml.

🚀 Preview: Add `preview` label to enable