### PR TITLE
fix(deposition): Pin webin cli to less-broken build 9.0.1_hdfd78af_0  (using old slightly buggy wrapper)

### DIFF
--- a/ena-submission/environment.yml
+++ b/ena-submission/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   # Extra dependencies
   - beautifulsoup4
   - click
-  - ena-webin-cli =9.0.1
+  - ena-webin-cli =9.0.1=hdfd78af_0
   - fastapi
   - pydantic
   - jsonlines


### PR DESCRIPTION
Turns out I made things worse (at least for us) trying to fix the bioconda ena-webin-cli wrapper. Pinning to old only slightly broken is better than totally broken.