### PR TITLE
feat(backend): scope released data etags to pipeline runs

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -41,7 +41,6 @@ import org.loculus.backend.controller.LoculusCustomHeaders.X_TOTAL_RECORDS
 import org.loculus.backend.log.ORGANISM_MDC_KEY
 import org.loculus.backend.log.REQUEST_ID_MDC_KEY
 import org.loculus.backend.log.RequestIdContext
-import org.loculus.backend.model.RELEASED_DATA_RELATED_TABLES
 import org.loculus.backend.model.ReleasedDataModel
 import org.loculus.backend.model.SubmissionParams
 import org.loculus.backend.model.SubmitModel
@@ -313,9 +312,7 @@ open class SubmissionController(
             description = "(Optional) Only retrieve all released data if Etag has changed.",
         ) @RequestHeader(value = HttpHeaders.IF_NONE_MATCH, required = false) ifNoneMatch: String?,
     ): ResponseEntity<StreamingResponseBody> {
-        val lastDatabaseWriteETag = releasedDataModel.getLastDatabaseWriteETag(
-            RELEASED_DATA_RELATED_TABLES,
-        )
+        val lastDatabaseWriteETag = releasedDataModel.getReleasedDataETag(organism)
         if (ifNoneMatch == lastDatabaseWriteETag) {
             return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build()
         }

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -312,7 +312,9 @@ open class SubmissionController(
             description = "(Optional) Only retrieve all released data if Etag has changed.",
         ) @RequestHeader(value = HttpHeaders.IF_NONE_MATCH, required = false) ifNoneMatch: String?,
     ): ResponseEntity<StreamingResponseBody> {
-        val lastDatabaseWriteETag = releasedDataModel.getReleasedDataETag(organism)
+        val lastDatabaseWriteETag = releasedDataModel.getLatestFinishedProcessingAtForReleasedDataOfOrganismCurrentPipeline(
+            organism,
+        )
         if (ifNoneMatch == lastDatabaseWriteETag) {
             return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build()
         }

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -312,9 +312,7 @@ open class SubmissionController(
             description = "(Optional) Only retrieve all released data if Etag has changed.",
         ) @RequestHeader(value = HttpHeaders.IF_NONE_MATCH, required = false) ifNoneMatch: String?,
     ): ResponseEntity<StreamingResponseBody> {
-        val lastDatabaseWriteETag = releasedDataModel.getLatestFinishedProcessingAtForReleasedDataOfOrganismCurrentPipeline(
-            organism,
-        )
+        val lastDatabaseWriteETag = releasedDataModel.getOrganismReleasedLastProcessedTime(organism)
         if (ifNoneMatch == lastDatabaseWriteETag) {
             return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build()
         }

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -18,14 +18,10 @@ import org.loculus.backend.api.ReleasedData
 import org.loculus.backend.api.VersionStatus
 import org.loculus.backend.config.BackendConfig
 import org.loculus.backend.config.FileUrlType
-import org.loculus.backend.service.datauseterms.DATA_USE_TERMS_TABLE_NAME
 import org.loculus.backend.service.files.S3Service
 import org.loculus.backend.service.groupmanagement.GROUPS_TABLE_NAME
 import org.loculus.backend.service.submission.METADATA_UPLOAD_AUX_TABLE_NAME
 import org.loculus.backend.service.submission.RawProcessedData
-import org.loculus.backend.service.submission.SEQUENCE_ENTRIES_PREPROCESSED_DATA_TABLE_NAME
-import org.loculus.backend.service.submission.SEQUENCE_ENTRIES_TABLE_NAME
-import org.loculus.backend.service.submission.SEQUENCE_UPLOAD_AUX_TABLE_NAME
 import org.loculus.backend.service.submission.SubmissionDatabaseService
 import org.loculus.backend.service.submission.UpdateTrackerTable
 import org.loculus.backend.service.submission.dbtables.CURRENT_PROCESSING_PIPELINE_TABLE_NAME
@@ -42,18 +38,6 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 private val log = KotlinLogging.logger { }
-
-val RELEASED_DATA_RELATED_TABLES: List<String> =
-    listOf(
-        CURRENT_PROCESSING_PIPELINE_TABLE_NAME,
-        EXTERNAL_METADATA_TABLE_NAME,
-        GROUPS_TABLE_NAME,
-        METADATA_UPLOAD_AUX_TABLE_NAME,
-        SEQUENCE_ENTRIES_TABLE_NAME,
-        SEQUENCE_ENTRIES_PREPROCESSED_DATA_TABLE_NAME,
-        SEQUENCE_UPLOAD_AUX_TABLE_NAME,
-        DATA_USE_TERMS_TABLE_NAME,
-    )
 
 @Service
 open class ReleasedDataModel(
@@ -88,6 +72,16 @@ open class ReleasedDataModel(
                     organism,
                 )
             }
+    }
+
+    @Transactional(readOnly = true)
+    open fun getReleasedDataETag(organism: Organism): String {
+        val pipelineVersion = submissionDatabaseService.getCurrentProcessingPipelineVersion(organism)
+        val lastFinishedProcessingAt =
+            submissionDatabaseService.getLatestFinishedProcessingAt(organism, pipelineVersion)
+        val lastFinishedProcessingAtFormatted = lastFinishedProcessingAt ?: ""
+        val etagValue = "$pipelineVersion:$lastFinishedProcessingAtFormatted"
+        return "\"$etagValue\""
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -75,7 +75,7 @@ open class ReleasedDataModel(
     }
 
     @Transactional(readOnly = true)
-    open fun getLatestFinishedProcessingAtForReleasedDataOfOrganismCurrentPipeline(organism: Organism): String {
+    open fun getOrganismReleasedLastProcessedTime(organism: Organism): String {
         val pipelineVersion = submissionDatabaseService.getCurrentProcessingPipelineVersion(organism)
         val lastFinishedProcessingAt =
             submissionDatabaseService.getLatestFinishedProcessingAtForReleasedData(organism, pipelineVersion)

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -75,10 +75,10 @@ open class ReleasedDataModel(
     }
 
     @Transactional(readOnly = true)
-    open fun getReleasedDataETag(organism: Organism): String {
+    open fun getLatestFinishedProcessingAtForReleasedDataOfOrganismCurrentPipeline(organism: Organism): String {
         val pipelineVersion = submissionDatabaseService.getCurrentProcessingPipelineVersion(organism)
         val lastFinishedProcessingAt =
-            submissionDatabaseService.getLatestFinishedProcessingAt(organism, pipelineVersion)
+            submissionDatabaseService.getLatestFinishedProcessingAtForReleasedData(organism, pipelineVersion)
         val lastFinishedProcessingAtFormatted = lastFinishedProcessingAt ?: ""
         val etagValue = "$pipelineVersion:$lastFinishedProcessingAtFormatted"
         return "\"$etagValue\""

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -81,9 +81,13 @@ open class ReleasedDataModel(
             submissionDatabaseService.getLatestFinishedProcessingAtForReleasedData(organism, pipelineVersion)
         val lastExternalMetadataUpdatedAt =
             submissionDatabaseService.getLatestExternalMetadataUpdatedAtForReleasedData(organism)
+        val lastDataUseTermsUpdatedAt =
+            submissionDatabaseService.getLatestDataUseTermsUpdatedAtForReleasedData(organism)
         val lastFinishedProcessingAtFormatted = lastFinishedProcessingAt ?: ""
         val lastExternalMetadataUpdatedAtFormatted = lastExternalMetadataUpdatedAt ?: ""
-        val etagValue = "$pipelineVersion:$lastFinishedProcessingAtFormatted:$lastExternalMetadataUpdatedAtFormatted"
+        val lastDataUseTermsUpdatedAtFormatted = lastDataUseTermsUpdatedAt ?: ""
+        val etagValue =
+            "$pipelineVersion:$lastFinishedProcessingAtFormatted:$lastExternalMetadataUpdatedAtFormatted:$lastDataUseTermsUpdatedAtFormatted"
         return "\"$etagValue\""
     }
 

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -79,8 +79,11 @@ open class ReleasedDataModel(
         val pipelineVersion = submissionDatabaseService.getCurrentProcessingPipelineVersion(organism)
         val lastFinishedProcessingAt =
             submissionDatabaseService.getLatestFinishedProcessingAtForReleasedData(organism, pipelineVersion)
+        val lastExternalMetadataUpdatedAt =
+            submissionDatabaseService.getLatestExternalMetadataUpdatedAtForReleasedData(organism)
         val lastFinishedProcessingAtFormatted = lastFinishedProcessingAt ?: ""
-        val etagValue = "$pipelineVersion:$lastFinishedProcessingAtFormatted"
+        val lastExternalMetadataUpdatedAtFormatted = lastExternalMetadataUpdatedAt ?: ""
+        val etagValue = "$pipelineVersion:$lastFinishedProcessingAtFormatted:$lastExternalMetadataUpdatedAtFormatted"
         return "\"$etagValue\""
     }
 

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -216,6 +216,36 @@ class SubmissionDatabaseService(
         }
     }
 
+    fun getLatestDataUseTermsUpdatedAtForReleasedData(organism: Organism): String? {
+        val sql =
+            """
+            select
+                max(dut.change_date) as last_data_use_terms_updated_at
+            from data_use_terms_table dut
+            inner join sequence_entries se
+                on se.accession = dut.accession
+            where se.organism = ?
+                and se.released_at is not null
+            """
+                .trimIndent()
+
+        return transaction {
+            exec(
+                sql,
+                listOf(
+                    Pair(VarCharColumnType(), organism.name),
+                ),
+                explicitStatementType = StatementType.SELECT,
+            ) { resultSet ->
+                if (!resultSet.next()) {
+                    null
+                } else {
+                    resultSet.getTimestamp("last_data_use_terms_updated_at")?.toInstant()?.toString()
+                }
+            }
+        }
+    }
+
     private fun fetchUnprocessedEntriesAndUpdateToInProcessing(
         organism: Organism,
         numberOfSequenceEntries: Int,

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -156,7 +156,7 @@ class SubmissionDatabaseService(
             select
                 max(sep.finished_processing_at) as last_finished_processing_at
             from sequence_entries_preprocessed_data sep
-            inner join sequence_entries se
+                join sequence_entries se
                 on se.accession = sep.accession
                 and se.version = sep.version
             where se.organism = ?

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -150,6 +150,13 @@ class SubmissionDatabaseService(
             .first()
     }
 
+    fun getAllCurrentProcessingPipelineVersions(): Map<String, Long> {
+        val table = CurrentProcessingPipelineTable
+        return table
+            .selectAll()
+            .associate { it[table.organismColumn] to it[table.versionColumn] }
+    }
+
     fun getLatestFinishedProcessingAtForReleasedData(organism: Organism, pipelineVersion: Long): String? {
         val sql =
             """

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -185,6 +185,37 @@ class SubmissionDatabaseService(
         }
     }
 
+    fun getLatestExternalMetadataUpdatedAtForReleasedData(organism: Organism): String? {
+        val sql =
+            """
+            select
+                max(em.updated_metadata_at) as last_updated_metadata_at
+            from external_metadata em
+            inner join sequence_entries se
+                on se.accession = em.accession
+                and se.version = em.version
+            where se.organism = ?
+                and se.released_at is not null
+            """
+                .trimIndent()
+
+        return transaction {
+            exec(
+                sql,
+                listOf(
+                    Pair(VarCharColumnType(), organism.name),
+                ),
+                explicitStatementType = StatementType.SELECT,
+            ) { resultSet ->
+                if (!resultSet.next()) {
+                    null
+                } else {
+                    resultSet.getTimestamp("last_updated_metadata_at")?.toInstant()?.toString()
+                }
+            }
+        }
+    }
+
     private fun fetchUnprocessedEntriesAndUpdateToInProcessing(
         organism: Organism,
         numberOfSequenceEntries: Int,

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -150,11 +150,39 @@ class SubmissionDatabaseService(
             .first()
     }
 
-    fun getAllCurrentProcessingPipelineVersions(): Map<String, Long> {
-        val table = CurrentProcessingPipelineTable
-        return table
-            .selectAll()
-            .associate { it[table.organismColumn] to it[table.versionColumn] }
+    fun getLatestFinishedProcessingAtForReleasedData(organism: Organism, pipelineVersion: Long): String? {
+        val sql =
+            """
+            select
+                max(sep.finished_processing_at) as last_finished_processing_at
+            from sequence_entries_preprocessed_data sep
+            inner join sequence_entries se
+                on se.accession = sep.accession
+                and se.version = sep.version
+            where se.organism = ?
+                and sep.pipeline_version = ?
+                and sep.processing_status = ?
+                and se.released_at is not null
+            """
+                .trimIndent()
+
+        return transaction {
+            exec(
+                sql,
+                listOf(
+                    Pair(VarCharColumnType(), organism.name),
+                    Pair(LongColumnType(), pipelineVersion),
+                    Pair(VarCharColumnType(), PROCESSED.name),
+                ),
+                explicitStatementType = StatementType.SELECT,
+            ) { resultSet ->
+                if (!resultSet.next()) {
+                    null
+                } else {
+                    resultSet.getTimestamp("last_finished_processing_at")?.toInstant()?.toString()
+                }
+            }
+        }
     }
 
     private fun fetchUnprocessedEntriesAndUpdateToInProcessing(

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
@@ -54,6 +54,7 @@ import org.loculus.backend.controller.DEFAULT_ORGANISM
 import org.loculus.backend.controller.DEFAULT_PIPELINE_VERSION
 import org.loculus.backend.controller.DEFAULT_USER_NAME
 import org.loculus.backend.controller.EndpointTest
+import org.loculus.backend.controller.OTHER_ORGANISM
 import org.loculus.backend.controller.datauseterms.DataUseTermsControllerClient
 import org.loculus.backend.controller.dateMonthsFromNow
 import org.loculus.backend.controller.expectNdjsonAndGetContent
@@ -227,6 +228,19 @@ class GetReleasedDataEndpointTest(
         val responseBodyMoreData = responseAfterMoreDataAdded
             .expectNdjsonAndGetContent<ReleasedData>()
         assertThat(responseBodyMoreData.size, greaterThan(NUMBER_OF_SEQUENCES))
+    }
+
+    @Test
+    fun `GIVEN other organism data is processed THEN etag for default organism does not change`() {
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease()
+
+        val firstResponse = submissionControllerClient.getReleasedData()
+        val initialEtag = firstResponse.andReturn().response.getHeader(ETAG)
+
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(organism = OTHER_ORGANISM)
+
+        submissionControllerClient.getReleasedData(ifNoneMatch = initialEtag)
+            .andExpect(status().isNotModified)
     }
 
     @Test


### PR DESCRIPTION
resolves #5110 


- compute released data etags from the latest finished preprocessing timestamp within the organism's current pipeline version
- expose a database helper to look up the max `finished_processing_at` and wire the controller to the new model method
- add a regression test to ensure processing a different organism does not invalidate another organism's cache entry


------
https://chatgpt.com/codex/tasks/task_e_68d6bd56ee5083258a4248b46c4345c2

🚀 Preview: Add `preview` label to enable