### PR TITLE
fix(kubernetes): don't generate ENA deposition config if there is no config for it

### DIFF
--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -503,7 +503,7 @@ fields:
 {{- define "loculus.generateENASubmissionConfig" }}
 organisms:
   {{- range $key, $instance := (include "loculus.enabledOrganisms" . | fromJson) }}
-  {{- if $instance.ingest }}
+  {{- if $instance.enaDeposition }}
   {{ $key }}:
     {{- with $instance.schema }}
     {{- $nucleotideSequences := .nucleotideSequences | default (list "main")}}


### PR DESCRIPTION
https://github.com/loculus-project/loculus/pull/5028 currently has failing CI since the helm lint fails. I think it's due to this change: 
https://github.com/loculus-project/loculus/commit/ef6db73e8b65d1045523b7808f03ea6df10de583

I believe that this PR is the fix. Please check.

### Screenshot

### PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by appropriate, automated tests.~~
~~- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~~

🚀 Preview: Add `preview` label to enable