### PR TITLE
test: Extend timeout to get options from LAPIS in search pages

### DIFF
--- a/integration-tests/tests/pages/search.page.ts
+++ b/integration-tests/tests/pages/search.page.ts
@@ -31,7 +31,7 @@ export class SearchPage {
 
         await this.page.waitForTimeout(500);
 
-        await this.page.getByRole('option').first().click({ timeout: 3000 });
+        await this.page.getByRole('option').first().click({ timeout: 15000 });
 
         await this.page.keyboard.press('Escape');
         await this.page.waitForTimeout(200);


### PR DESCRIPTION
This _could_ be the cause of https://github.com/loculus-project/loculus/issues/5096 (i.e. maybe LAPIS is slow in some circumstances). It might well not be - but in any case it makes sense to allow more than 3 seconds in case.