### PR TITLE
fix(website): change to not show `-1` when sequence counts are not available

### DIFF
--- a/website/src/components/IndexPage/OrganismCard.astro
+++ b/website/src/components/IndexPage/OrganismCard.astro
@@ -32,7 +32,7 @@ const isTotalSequenceUnavailable = organismStatistics.totalSequences === -1;
             <span class='font-bold'>
                 {
                     isTotalSequenceUnavailable ? (
-                        <span class='inline-flex h-5 w-16 items-center rounded bg-slate-200 align-middle animate-pulse'>
+                        <span class='inline-flex h-5 w-5 items-center rounded bg-slate-200 align-middle animate-pulse'>
                             <span class='sr-only'>Sequence count unavailable</span>
                         </span>
                     ) : (


### PR DESCRIPTION
When sequence counts are not available which can happen for example due to roll-outs or resource limitations (though should be very rare) we show `-1` sequences on the organism cards. This looks like a bug rather than intended behaviour so isn't ideal. Here we display a pulsing playholder instead which hopefully to some extent implies a temporary but anticipated situation.

This looks like this, but with pulsing:

<img width="1188" height="749" alt="image" src="https://github.com/user-attachments/assets/61851184-51ba-4507-8562-79794d3e982f" />


We could also just show a message

------
https://chatgpt.com/codex/tasks/task_e_68daab2cbd948325ac62d66cee535885

🚀 Preview: Add `preview` label to enable