### PR TITLE
fix(website): don't allow `\` in mutations in mutation search

### DIFF
--- a/website/src/utils/mutation.spec.ts
+++ b/website/src/utils/mutation.spec.ts
@@ -28,13 +28,29 @@ describe('mutation', () => {
             });
         });
 
-        it.each(['INVALID:MUTATION', 'AA-10T', 'INS_', 'GENE:', ':::', 'ins_A:23:T', 'ins_23:A:T', 'INS_4:G:T'])(
-            'returns undefined for invalid mutation string %s',
-            (input) => {
-                const result = parseMutationString(input, mockLightweightSchema);
-                expect(result).toBeUndefined();
-            },
-        );
+        it('parses a valid mutation string with "."', () => {
+            const result = parseMutationString('A23.', mockLightweightSchema);
+            expect(result).toEqual({
+                baseType: 'nucleotide',
+                mutationType: 'substitutionOrDeletion',
+                text: 'A23.',
+            });
+        });
+
+        it.each([
+            'INVALID:MUTATION',
+            'AA-10T',
+            '123\\',
+            'INS_',
+            'GENE:',
+            ':::',
+            'ins_A:23:T',
+            'ins_23:A:T',
+            'INS_4:G:T',
+        ])('returns undefined for invalid mutation string %s', (input) => {
+            const result = parseMutationString(input, mockLightweightSchema);
+            expect(result).toBeUndefined();
+        });
     });
 
     describe('multi-segment', () => {
@@ -58,6 +74,7 @@ describe('mutation', () => {
         it.each([
             'INVALID:MUTATION',
             '12345',
+            '12345\\',
             'AA-10T',
             'INS_',
             'GENE:',

--- a/website/src/utils/mutation.ts
+++ b/website/src/utils/mutation.ts
@@ -123,7 +123,7 @@ const isValidAminoAcidMutationQuery = (
         if (!existingGenes.has(gene)) {
             return false;
         }
-        return /^[A-Z*]?[0-9]+[A-Z-*\\.]?$/.test(mutation);
+        return /^[A-Z*]?[0-9]+[A-Z-*.]?$/.test(mutation);
     } catch (_) {
         return false;
     }
@@ -186,7 +186,7 @@ const isValidNucleotideMutationQuery = (
             }
             mutation = _mutation;
         }
-        return /^[A-Z]?[0-9]+[A-Z-\\.]?$/.test(mutation);
+        return /^[A-Z]?[0-9]+[A-Z-.]?$/.test(mutation);
     } catch (_) {
         return false;
     }


### PR DESCRIPTION
This looks like broken escaping to me, but `.` doesn't need to be escaped here?

### Screenshot

On current main without the fix:
<img width="632" height="253" alt="image" src="https://github.com/user-attachments/assets/07b6beaf-d01f-41b5-a759-45b9effd57ce" />


### PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by appropriate, automated tests.
~~- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~~

🚀 Preview: Add `preview` label to enable