### PR TITLE
fix(deposition): separate and increase timeouts for public visibility checks

### DIFF
--- a/ena-submission/config/defaults.yaml
+++ b/ena-submission/config/defaults.yaml
@@ -13,6 +13,8 @@ time_between_iterations: 10
 min_between_github_requests: 2
 min_between_ena_checks: 5
 ena_http_timeout_seconds: 60
+ena_public_search_timeout_seconds: 120
+ncbi_public_search_timeout_seconds: 120
 ena_http_get_retry_attempts: 3
 # Don't retry posts by default as they might not be idempotent
 ena_http_post_retry_attempts: 1

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -69,7 +69,7 @@ class ENAVisibilityChecker(VisibilityChecker):
         response = requests.get(
             f"https://www.ebi.ac.uk/ena/browser/api/{file_type}/{accession}",
             allow_redirects=False,
-            timeout=config.ena_http_timeout_seconds,
+            timeout=config.ena_public_search_timeout_seconds,
         )
         if response.status_code == HTTPStatus.OK:
             return datetime.now(pytz.UTC)
@@ -95,7 +95,7 @@ def _check_and_cache_ncbi_gca(config: Config, path_segments: GcaCacheKey) -> boo
     response = requests.get(
         f"https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/{url_path}/",
         allow_redirects=False,
-        timeout=config.ena_http_timeout_seconds,
+        timeout=config.ncbi_public_search_timeout_seconds,
     )
 
     if response.status_code == HTTPStatus.OK:
@@ -143,7 +143,7 @@ class NCBIVisibilityChecker(VisibilityChecker):
         response = requests.get(
             f"https://www.ncbi.nlm.nih.gov/{path}/{accession}/",
             allow_redirects=False,
-            timeout=getattr(config, "ncbi_http_timeout_seconds", 30),
+            timeout=config.ncbi_public_search_timeout_seconds,
         )
         if response.status_code == HTTPStatus.OK:
             return datetime.now(pytz.UTC)

--- a/ena-submission/src/ena_deposition/config.py
+++ b/ena-submission/src/ena_deposition/config.py
@@ -47,6 +47,8 @@ class Config:
     ena_deposition_host: str
     ena_deposition_port: int
     ena_http_timeout_seconds: int = 60
+    ena_public_search_timeout_seconds: int = 120
+    ncbi_public_search_timeout_seconds: int = 120
     ena_http_get_retry_attempts: int = 3
     # By default, don't retry HTTP post requests to ENA
     ena_http_post_retry_attempts: int = 1


### PR DESCRIPTION
There were potential test failures due to timeouts being potentially too short. Looking into it I noticed that we were using timeout configs inconsistently. This is low risk, low impact stuff.

---

Separate public API visibility check timeouts from submission API timeouts:
- Add `ena_public_search_timeout_seconds` (120s) for ENA browser API checks
- Add `ncbi_public_search_timeout_seconds` (120s) for NCBI visibility checks
- Previously used `ena_http_timeout_seconds` (60s) for both submission and public checks
- NCBI non-GCA checks were hardcoded to 30s

This fixes timeout issues with NCBI visibility checks by increasing from 30s to 120s.