### PR TITLE
fix(backend): allow original metadata retrieval when aux table is non-empty

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -406,10 +406,6 @@ open class SubmissionController(
             ),
         ],
     )
-    @ApiResponse(
-        responseCode = "423",
-        description = "Locked. New sequence entries are currently being uploaded.",
-    )
     @GetMapping("/get-original-metadata", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun getOriginalMetadata(
         @PathVariable @Valid organism: Organism,
@@ -425,11 +421,6 @@ open class SubmissionController(
         @HiddenParam authenticatedUser: AuthenticatedUser,
         @RequestParam compression: CompressionFormat?,
     ): ResponseEntity<StreamingResponseBody> {
-        val stillProcessing = submitModel.checkIfStillProcessingSubmittedData()
-        if (stillProcessing) {
-            return ResponseEntity.status(HttpStatus.LOCKED).build()
-        }
-
         val headers = HttpHeaders()
         headers.contentType = MediaType.parseMediaType(MediaType.APPLICATION_NDJSON_VALUE)
         if (compression != null) {

--- a/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
@@ -19,8 +19,6 @@ import org.loculus.backend.service.files.FilesDatabaseService
 import org.loculus.backend.service.files.S3Service
 import org.loculus.backend.service.groupmanagement.GroupManagementPreconditionValidator
 import org.loculus.backend.service.submission.CompressionAlgorithm
-import org.loculus.backend.service.submission.MetadataUploadAuxTable
-import org.loculus.backend.service.submission.SequenceUploadAuxTable
 import org.loculus.backend.service.submission.SubmissionIdFilesMappingPreconditionValidator
 import org.loculus.backend.service.submission.UploadDatabaseService
 import org.loculus.backend.utils.DateProvider
@@ -28,7 +26,6 @@ import org.loculus.backend.utils.FastaReader
 import org.loculus.backend.utils.metadataEntryStreamAsSequence
 import org.loculus.backend.utils.revisionEntryStreamAsSequence
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 import java.io.BufferedInputStream
 import java.io.File
@@ -422,15 +419,6 @@ class SubmitModel(
                 }
             }
         }
-    }
-
-    @Transactional(readOnly = true)
-    fun checkIfStillProcessingSubmittedData(): Boolean {
-        val metadataInAuxTable: Boolean =
-            MetadataUploadAuxTable.select(MetadataUploadAuxTable.submissionIdColumn).count() > 0
-        val sequencesInAuxTable: Boolean =
-            SequenceUploadAuxTable.select(SequenceUploadAuxTable.sequenceSubmissionIdColumn).count() > 0
-        return metadataInAuxTable || sequencesInAuxTable
     }
 
     private fun requiresConsensusSequenceFile(organism: Organism) = backendConfig.getInstanceConfig(organism)

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetOriginalMetadataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetOriginalMetadataEndpointTest.kt
@@ -166,7 +166,7 @@ class GetOriginalMetadataEndpointTest(
     }
 
     @Test
-    fun `GIVEN there are sequences currently being uploaded THEN returns locked`() {
+    fun `GIVEN there are sequences currently being uploaded THEN endpoint remains available`() {
         val uploadId = "upload id"
         val mockUser = mockk<AuthenticatedUser>()
         every { mockUser.username }.returns("username")
@@ -182,7 +182,7 @@ class GetOriginalMetadataEndpointTest(
         )
 
         submissionControllerClient.getOriginalMetadata()
-            .andExpect(status().isLocked)
+            .andExpect(status().isOk)
 
         uploadDatabaseService.deleteUploadData(uploadId)
 


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/5135

In the past we had a very confusing bug which led ingest to submit the same data multiple times. The true issue was that a kubernetes-reloader we were using triggered old remnant cron jobs to start immediately on roll-out of a new deployment and at the same time the ingest deployment also started. Then both would submit data and so we'd end up with two copies of the data. We battled this bug for a long time not understanding where the second data was coming from. I believe that as part of that we theorised that it might be coming from the time when data is in the aux tables before it moves to the main database table. So we merged https://github.com/loculus-project/loculus/pull/2846 which locks metadata retrieval when the aux table is non-empty. But now we have fixed the bug this should no longer required, and it would be good to remove this as it caused problems by blocking ingest when some stuff was left in the aux tables due to the backend restarting mid-submission.

- remove the HTTP 423 guard from `/get-original-metadata` so the endpoint continues to return data during uploads
- delete the auxiliary table polling helper that powered the lock check
- update the original metadata endpoint test to reflect the always-available behavior



------
https://chatgpt.com/codex/tasks/task_e_68dd274571248325969ba7b1d859c37a

🚀 Preview: Add `preview` label to enable