### PR TITLE
fix(deps): Revert 'chore(deps): update silo to 0.7.10.3 (#5109)'

### DIFF
--- a/kubernetes/loculus/templates/silo-deployment.yaml
+++ b/kubernetes/loculus/templates/silo-deployment.yaml
@@ -33,9 +33,6 @@ spec:
           image: "{{ $.Values.images.lapisSilo.repository }}:{{ $.Values.images.lapisSilo.tag }}"
           imagePullPolicy: "{{ $.Values.images.lapisSilo.pullPolicy }}"
           {{- include "loculus.resources" (list "silo" $.Values $key) | nindent 10 }}
-          env:
-            - name: SPDLOG_LEVEL
-              value: "debug"
           ports:
             - containerPort: 8081
           args:

--- a/kubernetes/loculus/templates/silo-deployment.yaml
+++ b/kubernetes/loculus/templates/silo-deployment.yaml
@@ -33,6 +33,9 @@ spec:
           image: "{{ $.Values.images.lapisSilo.repository }}:{{ $.Values.images.lapisSilo.tag }}"
           imagePullPolicy: "{{ $.Values.images.lapisSilo.pullPolicy }}"
           {{- include "loculus.resources" (list "silo" $.Values $key) | nindent 10 }}
+          env:
+            - name: SPDLOG_LEVEL
+              value: "debug"
           ports:
             - containerPort: 8081
           args:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1985,7 +1985,7 @@ additionalHeadHTML: ""
 images:
   lapisSilo:
     repository: "ghcr.io/genspectrum/lapis-silo"
-    tag: "v0.7.10.3@sha256:fe21e12b09ad178b2b7cc7208c9af348ad9d780b8d4d2a054f13fa58d7ba79da"
+    tag: "v0.7.10.2@sha256:18b03238e879c1cb990fed71679afa0d6335bec7e20c15e2bd1b53787df32321"
     pullPolicy: Always
   lapis:
     repository: "ghcr.io/genspectrum/lapis"


### PR DESCRIPTION
This reverts commit bf2e75a906fc64d67a028e75f655449d0e03027e from #5109

SILO 0.7.10.3 seems to make the memory leak worse rather than better.

I downloaded unaligned nucleotide sequences a couple hundred times using curl and compared memory increases of 0.7.10.3 vs 0.7.10.2 (using pyimport preview as it uses the 0.7.10.2).

In both cases, SILO memory usage increase a lot, up from ~120MB prior - but 0.7.10.3 is a lot worse than 0.7.10.2 and definitely not better - as one would expect based on PR description (it's not quite clear which issue it should have fixed but it sounds like memory usage was supposed to improve).

With a few hundred downloads, current main (with 0.7.10.3) saw a 9-fold increase in SILO RAM usage for west nile, from 124MB to 1080MB while previous version 0.7.10.2 increased to 540MB and stayed stable there - while 0.7.10.3's growth continued in a seemingly unbounded manner. Note, the full sequence download is just 58MB.

To reproduce, simply run:

```
while true; 
do curl -m -s "https://lapis-main.loculus.org/west-nile/sample/unalignedNucleotideSequences?downloadAsFile=true&downloadFileBasename=ebola-sudan_nuc_2025-10-01T1531&fastaHeaderTemplate=%7BdisplayName%7D&versionStatus=LATEST_VERSION&isRevocation=false" >/dev/null;
done
```

for a while and observe results on Grafana.

<img width="1632" height="542" alt="iTerm2 2025-10-01 18 01 34" src="https://github.com/user-attachments/assets/6927d70e-d764-442c-b818-593be8923c38" />

See on [Grafana](https://grafana.loculus.org/explore?schemaVersion=1&panes=%7B%22o9y%22:%7B%22datasource%22:%22decyzhq5ockqoe%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22container_memory_rss%7Bcontainer%3D%5C%22silo%5C%22,namespace%3D%5C%22prev-main%5C%22,pod%3D~%5C%22.%2Awest-nile.%2A%5C%22%7D%20%2F%201000000%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22decyzhq5ockqoe%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22%7B%7Bpod%7D%7D%22,%22exemplar%22:false%7D,%7B%22refId%22:%22B%22,%22expr%22:%22container_memory_rss%7Bcontainer%3D%5C%22silo%5C%22,namespace%3D%5C%22prev-pyimport%5C%22,pod%3D~%5C%22.%2Awest-nile.%2A%5C%22%7D%20%2F%201000000%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22decyzhq5ockqoe%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22%7B%7Bnamespace%7D%7D-%7B%7Bpod%7D%7D%22%7D%5D,%22range%22:%7B%22from%22:%22now-30m%22,%22to%22:%22now%22%7D%7D%7D&orgId=1)

Update: I managed to also make 0.7.10.2 go up a lot in memory. The "trick" seems to be to abort requests from client side - just hitting ctrl+c on a running curl a few times makes memory go up. Maybe this can help fix the issue.

🚀 Preview: Add `preview` label to enable