### PR TITLE
feat(website): allow cors on /loculus-info endpoint, add options route

### DIFF
--- a/website/src/pages/loculus-info/index.ts
+++ b/website/src/pages/loculus-info/index.ts
@@ -3,6 +3,15 @@ import type { APIRoute } from 'astro';
 import { getRuntimeConfig, getWebsiteConfig } from '../../config';
 import { getAuthBaseUrl } from '../../utils/getAuthUrl';
 
+const corsHeaders = {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    'Access-Control-Allow-Origin': '*',
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    'Access-Control-Allow-Headers': 'Content-Type',
+} as const;
+
 export const GET: APIRoute = async ({ request }) => {
     const runtime = getRuntimeConfig();
     const website = getWebsiteConfig();
@@ -20,7 +29,14 @@ export const GET: APIRoute = async ({ request }) => {
     };
     return new Response(JSON.stringify(response), {
         headers: {
+            ...corsHeaders,
             'Content-Type': 'application/json', // eslint-disable-line @typescript-eslint/naming-convention
         },
     });
 };
+
+export const OPTIONS: APIRoute = () =>
+    new Response(null, {
+        status: 204,
+        headers: corsHeaders,
+    });


### PR DESCRIPTION
- add a reusable set of CORS headers for the `/loculus-info` API response, allowing access from any origin and explicitly listing supported request headers and methods
- attach the CORS headers to the JSON payload returned by the GET handler and implement an OPTIONS handler so that preflight requests receive the same permissive policy


------
https://chatgpt.com/codex/tasks/task_e_68dd73aa37fc8325b52713e1a1de0f7b

🚀 Preview: https://codex-add-cors-for-all-or.loculus.org