### PR TITLE
feat(deployment): allow optional dev database exposure

### DIFF
--- a/kubernetes/loculus/templates/ingressroute.yaml
+++ b/kubernetes/loculus/templates/ingressroute.yaml
@@ -49,6 +49,7 @@ spec:
 {{- $backendHost := printf "backend%s%s" .Values.subdomainSeparator .Values.host }}
 {{- $keycloakHost := (printf "authentication%s%s" $.Values.subdomainSeparator $.Values.host) }}
 {{- $minioHost := (printf "s3%s%s" $.Values.subdomainSeparator $.Values.host) }}
+{{- $databaseHost := (printf "database%s%s" $.Values.subdomainSeparator $.Values.host) }}
 {{- $middlewareList := list (printf "%s-compression-middleware@kubernetescrd" $.Release.Namespace) }}
 {{- if $.Values.enforceHTTPS }}
 {{- $middlewareList = append $middlewareList (printf "%s-redirect-middleware@kubernetescrd" $.Release.Namespace) }}
@@ -143,6 +144,23 @@ spec:
   tls:
   - hosts:
     - "{{ $keycloakHost }}"
+---
+{{- if and $.Values.dangerouslyExposeDevelopmentDatabase $.Values.runDevelopmentMainDatabase $.Values.host }}
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: loculus-database-ingress
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: HostSNI(`{{ $databaseHost }}`)
+      services:
+        - name: loculus-database-service
+          port: 5432
+  tls:
+    passthrough: true
+{{- end }}
 ---
 {{- if and .Values.s3.enabled .Values.runDevelopmentS3 }}
 apiVersion: networking.k8s.io/v1

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1114,6 +1114,12 @@
       "default": true,
       "description": "If true, runs a development database within the cluster."
     },
+    "dangerouslyExposeDevelopmentDatabase": {
+      "groups": ["db"],
+      "type": "boolean",
+      "default": false,
+      "description": "If true, exposes the in-cluster development database via a public subdomain."
+    },
     "runDevelopmentKeycloakDatabase": {
       "groups": ["db"],
       "type": "boolean",

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2064,6 +2064,7 @@ secrets:
       secretKey: "dummySecretKey"
 runDevelopmentKeycloakDatabase: true
 runDevelopmentMainDatabase: true
+dangerouslyExposeDevelopmentDatabase: false
 runDevelopmentS3: true
 developmentDatabasePersistence: false
 enforceHTTPS: true


### PR DESCRIPTION
## Summary
- add a `dangerouslyExposeDevelopmentDatabase` flag to the Helm values and schema so administrators can opt into routing the in-cluster development PostgreSQL instance through Traefik
- when the flag is enabled, create an `IngressRouteTCP` on the database subdomain that forwards traffic to the dev database service via TLS passthrough while continuing to gate creation on the database being deployed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd8a77d5608325aaee8f4b4d1ac2e8

🚀 Preview: Add `preview` label to enable