### PR TITLE
feat(website): review page, sequences dialog: only show sequences that exist for that entry

### DIFF
--- a/integration-tests/tests/specs/features/revise-sequence.spec.ts
+++ b/integration-tests/tests/specs/features/revise-sequence.spec.ts
@@ -38,11 +38,13 @@ test('revising sequence data works: segment can be deleted; segment can be edite
     await reviewPage.waitForZeroProcessing();
 
     await reviewPage.viewSequences();
-    await expect(reviewPage.sequenceViewerContent()).toBeHidden(); // L was deleted
 
     const tabs = await reviewPage.getAvailableSequenceTabs();
-    await reviewPage.switchSequenceTab(tabs[2]); // S tab
+    expect(tabs).not.toContain('L (aligned)');
+    expect(tabs).not.toContain('L (unaligned)');
 
+    expect(tabs).toContain('S (unaligned)');
+    await reviewPage.switchSequenceTab('S (unaligned)');
     expect(await reviewPage.getSequenceContent()).toBe('AAAAA');
 
     await reviewPage.closeSequencesDialog();

--- a/website/src/components/ReviewPage/SequencesDialog.spec.tsx
+++ b/website/src/components/ReviewPage/SequencesDialog.spec.tsx
@@ -12,22 +12,22 @@ describe('SequencesDialog', () => {
         );
 
         await waitFor(() => {
-            expect(getByText('unalignedSequence1Genome')).toBeVisible();
+            expect(getByText('ATTTGCC')).toBeVisible();
         });
 
         await userEvent.click(getByRole('button', { name: `${sequence1} (aligned)` }));
         await waitFor(() => {
-            expect(getByText('alignedSequence1Genome')).toBeVisible();
+            expect(getByText('A-T-T-T-G-C-C')).toBeVisible();
         });
 
         await userEvent.click(getByRole('button', { name: `${sequence1} (unaligned)` }));
         await waitFor(() => {
-            expect(getByText('unalignedSequence1Genome')).toBeVisible();
+            expect(getByText('ATTTGCC')).toBeVisible();
         });
 
         await userEvent.click(getByRole('button', { name: `gene1` }));
         await waitFor(() => {
-            expect(getByText('alignedGene1Protein')).toBeVisible();
+            expect(getByText('MADS*')).toBeVisible();
         });
 
         expect(queryByText(new RegExp(sequence2))).not.toBeInTheDocument();
@@ -53,15 +53,15 @@ const dataToView: SequenceEntryToEdit = {
     processedData: {
         metadata: {},
         unalignedNucleotideSequences: {
-            [sequence1]: 'unalignedSequence1Genome',
+            [sequence1]: 'ATTTGCC',
             [sequence2]: null,
         },
         alignedNucleotideSequences: {
-            [sequence1]: 'alignedSequence1Genome',
+            [sequence1]: 'A-T-T-T-G-C-C',
             [sequence2]: null,
         },
         alignedAminoAcidSequences: {
-            [gene1]: 'alignedGene1Protein',
+            [gene1]: 'MADS*',
             [gene2]: null,
         },
         nucleotideInsertions: {},

--- a/website/src/components/ReviewPage/SequencesDialog.spec.tsx
+++ b/website/src/components/ReviewPage/SequencesDialog.spec.tsx
@@ -1,0 +1,74 @@
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test } from 'vitest';
+
+import { SequencesDialog } from './SequencesDialog.tsx';
+import { processedStatus, type SequenceEntryToEdit } from '../../types/backend.ts';
+
+describe('SequencesDialog', () => {
+    test('should only show existing sequences', async () => {
+        const { getByText, queryByText, getByRole } = render(
+            <SequencesDialog isOpen={true} onClose={() => undefined} dataToView={dataToView} />,
+        );
+
+        await waitFor(() => {
+            expect(getByText('unalignedSequence1Genome')).toBeVisible();
+        });
+
+        await userEvent.click(getByRole('button', { name: `${sequence1} (aligned)` }));
+        await waitFor(() => {
+            expect(getByText('alignedSequence1Genome')).toBeVisible();
+        });
+
+        await userEvent.click(getByRole('button', { name: `${sequence1} (unaligned)` }));
+        await waitFor(() => {
+            expect(getByText('unalignedSequence1Genome')).toBeVisible();
+        });
+
+        await userEvent.click(getByRole('button', { name: `gene1` }));
+        await waitFor(() => {
+            expect(getByText('alignedGene1Protein')).toBeVisible();
+        });
+
+        expect(queryByText(new RegExp(sequence2))).not.toBeInTheDocument();
+        expect(queryByText(new RegExp(gene2))).not.toBeInTheDocument();
+    });
+});
+
+const sequence1 = 'sequence1';
+const sequence2 = 'sequence2';
+const gene1 = 'gene1';
+const gene2 = 'gene2';
+
+const dataToView: SequenceEntryToEdit = {
+    submissionId: 'test',
+    accession: 'test',
+    version: 0,
+    groupId: 0,
+    originalData: {
+        metadata: {},
+        unalignedNucleotideSequences: {},
+        files: null,
+    },
+    processedData: {
+        metadata: {},
+        unalignedNucleotideSequences: {
+            [sequence1]: 'unalignedSequence1Genome',
+            [sequence2]: null,
+        },
+        alignedNucleotideSequences: {
+            [sequence1]: 'alignedSequence1Genome',
+            [sequence2]: null,
+        },
+        alignedAminoAcidSequences: {
+            [gene1]: 'alignedGene1Protein',
+            [gene2]: null,
+        },
+        nucleotideInsertions: {},
+        aminoAcidInsertions: {},
+        files: null,
+    },
+    status: processedStatus,
+    errors: null,
+    warnings: null,
+};

--- a/website/src/components/ReviewPage/SequencesDialog.tsx
+++ b/website/src/components/ReviewPage/SequencesDialog.tsx
@@ -12,7 +12,7 @@ type SequencesDialogProps = {
 
 type ProcessedSequence = {
     label: string;
-    sequence: string | null;
+    sequence: string;
 };
 
 export const SequencesDialog: FC<SequencesDialogProps> = ({ isOpen, onClose, dataToView }) => {
@@ -48,14 +48,9 @@ export const SequencesDialog: FC<SequencesDialogProps> = ({ isOpen, onClose, dat
                         ))}
                     </BoxWithTabsTabBar>
                     <BoxWithTabsBox>
-                        {processedSequences[activeTab].sequence !== null && (
-                            <div className='overflow-auto' style={{ maxHeight: 'calc(80vh - 10rem)' }}>
-                                <FixedLengthTextViewer
-                                    text={processedSequences[activeTab].sequence}
-                                    maxLineLength={100}
-                                />
-                            </div>
-                        )}
+                        <div className='overflow-auto' style={{ maxHeight: 'calc(80vh - 10rem)' }}>
+                            <FixedLengthTextViewer text={processedSequences[activeTab].sequence} maxLineLength={100} />
+                        </div>
                     </BoxWithTabsBox>
                 </div>
             </div>
@@ -69,16 +64,18 @@ const extractProcessedSequences = (data: SequenceEntryToEdit): ProcessedSequence
         { type: 'aligned', sequences: data.processedData.alignedNucleotideSequences },
         { type: 'gene', sequences: data.processedData.alignedAminoAcidSequences },
     ].flatMap(({ type, sequences }) =>
-        Object.entries(sequences).map(([sequenceName, sequence]) => {
-            let label = sequenceName;
-            if (type !== 'gene') {
-                if (label === 'main') {
-                    label = type === 'unaligned' ? 'Sequence' : 'Aligned';
-                } else {
-                    label = type === 'unaligned' ? `${sequenceName} (unaligned)` : `${sequenceName} (aligned)`;
+        Object.entries(sequences)
+            .filter((tuple): tuple is [string, string] => tuple[1] !== null)
+            .map(([sequenceName, sequence]) => {
+                let label = sequenceName;
+                if (type !== 'gene') {
+                    if (label === 'main') {
+                        label = type === 'unaligned' ? 'Sequence' : 'Aligned';
+                    } else {
+                        label = type === 'unaligned' ? `${sequenceName} (unaligned)` : `${sequenceName} (aligned)`;
+                    }
                 }
-            }
-            return { label, sequence };
-        }),
+                return { label, sequence };
+            }),
     );
 };


### PR DESCRIPTION
resolves #4998


### Screenshot

Before:
<img width="1177" height="392" alt="image" src="https://github.com/user-attachments/assets/d0520bc9-6fb0-4a46-a877-1809f6fc45dd" />

After:
<img width="1177" height="392" alt="image" src="https://github.com/user-attachments/assets/fb5f1506-2950-4536-8f81-56d10e3796c2" />


### PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
  - see screenshots

🚀 Preview: Add `preview` label to enable