### PR TITLE
fix(website): handle array values in substring search for multi-select fields

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -677,51 +677,6 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/@babel/plugin-proposal-export-namespace-from": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.18.9.tgz",
-            "integrity": "sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==",
-            "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-export-namespace-from instead.",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.18.9",
-                "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-export-namespace-from": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
-            "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.3"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
-            "integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-module-transforms": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
         "node_modules/@babel/plugin-transform-react-jsx-self": {
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",

--- a/website/src/components/SearchPage/DownloadDialog/SequenceFilters.spec.ts
+++ b/website/src/components/SearchPage/DownloadDialog/SequenceFilters.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'vitest';
+
+import { FieldFilterSet } from './SequenceFilters';
+import { SINGLE_REFERENCE } from '../../../types/referencesGenomes';
+import { MetadataFilterSchema } from '../../../utils/search';
+
+describe('FieldFilterSet', () => {
+    test('should handle array values with enableSubstringSearch correctly', () => {
+        // Create a metadata schema with a field that has enableSubstringSearch
+        const metadataSchema = [
+            {
+                name: 'authorAffiliations',
+                displayName: 'Author affiliations',
+                type: 'string' as const,
+                autocomplete: true,
+                substringSearch: true,
+                generateIndex: true,
+            },
+        ];
+
+        const filterSchema = new MetadataFilterSchema(metadataSchema);
+
+        // Create field values with an array value (multi-select scenario)
+        const fieldValues = {
+            authorAffiliations: ['University of Example', 'Research Institute'],
+        };
+
+        const hiddenFieldValues = {};
+        const referenceGenomeLightweightSchema = {
+            [SINGLE_REFERENCE]: {
+                nucleotideSegmentNames: [],
+                geneNames: [],
+                insdcAccessionFull: [],
+            },
+        };
+
+        const filterSet = new FieldFilterSet(
+            filterSchema,
+            fieldValues,
+            hiddenFieldValues,
+            referenceGenomeLightweightSchema,
+        );
+
+        // This should not throw an error
+        expect(() => filterSet.toApiParams()).not.toThrow();
+
+        // Verify the result contains the regex versions
+        const apiParams = filterSet.toApiParams();
+        expect(apiParams['authorAffiliations.regex']).toEqual(['(?i)University of Example', '(?i)Research Institute']);
+        expect(apiParams.authorAffiliations).toBeUndefined();
+    });
+
+    test('should handle string values with enableSubstringSearch correctly', () => {
+        const metadataSchema = [
+            {
+                name: 'country',
+                displayName: 'Country',
+                type: 'string' as const,
+                substringSearch: true,
+                generateIndex: true,
+            },
+        ];
+
+        const filterSchema = new MetadataFilterSchema(metadataSchema);
+
+        // Create field values with a string value
+        const fieldValues = {
+            country: 'United States',
+        };
+
+        const hiddenFieldValues = {};
+        const referenceGenomeLightweightSchema = {
+            [SINGLE_REFERENCE]: {
+                nucleotideSegmentNames: [],
+                geneNames: [],
+                insdcAccessionFull: [],
+            },
+        };
+
+        const filterSet = new FieldFilterSet(
+            filterSchema,
+            fieldValues,
+            hiddenFieldValues,
+            referenceGenomeLightweightSchema,
+        );
+
+        // This should not throw an error
+        expect(() => filterSet.toApiParams()).not.toThrow();
+
+        // Verify the result contains the regex version
+        const apiParams = filterSet.toApiParams();
+        expect(apiParams['country.regex']).toBe('(?i)United States');
+        expect(apiParams.country).toBeUndefined();
+    });
+});

--- a/website/src/components/SearchPage/DownloadDialog/SequenceFilters.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/SequenceFilters.tsx
@@ -95,9 +95,18 @@ export class FieldFilterSet implements SequenceFilter {
         );
         for (const filterName of Object.keys(sequenceFilters)) {
             if (this.filterSchema.isSubstringSearchEnabled(filterName) && sequenceFilters[filterName] !== undefined) {
-                sequenceFilters[filterName.concat('.regex')] = makeCaseInsensitiveLiteralSubstringRegex(
-                    sequenceFilters[filterName],
-                );
+                const filterValue = sequenceFilters[filterName];
+                if (Array.isArray(filterValue)) {
+                    // For array values (multi-select fields), apply regex to each element
+                    sequenceFilters[filterName.concat('.regex')] = filterValue.map((value: any) =>
+                        makeCaseInsensitiveLiteralSubstringRegex(String(value)),
+                    );
+                } else {
+                    // For string values, apply regex directly
+                    sequenceFilters[filterName.concat('.regex')] = makeCaseInsensitiveLiteralSubstringRegex(
+                        String(filterValue),
+                    );
+                }
                 delete sequenceFilters[filterName];
             }
         }


### PR DESCRIPTION
When enableSubstringSearch is true for a multi-select field (like authorAffiliations), the value can be an array rather than a string. This was causing a TypeError when the code attempted to call .replace() on an array value.

Fixed by checking if the filter value is an array and handling both cases:
- Arrays: apply regex transformation to each element
- Strings: apply regex transformation directly

Added comprehensive tests to verify the fix handles both scenarios correctly.

Fixes #5181

Generated with [Claude Code](https://claude.ai/code)

🚀 Preview: Add `preview` label to enable