### PR TITLE
feat(config): prevent autocomplete and enableSubstringSearch from being set together in json schema

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -578,7 +578,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Author affiliations
         desired: true
         enableSubstringSearch: true
-        autocomplete: true
         header: Authors
         ingest: ncbiSubmitterAffiliation
         includeInDownloadsByDefault: true


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/5181

Add a check to the json.schema to prevent autocomplete being used with enableSubString search

### Screenshot

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?) -> test by adding both and ensuring that helm linter fails: https://github.com/loculus-project/loculus/actions/runs/18280002544/job/52040666765?pr=5184

🚀 Preview: Add `preview` label to enable