### PR TITLE
feat(k8s): add 6 more metadata schema constraints to values.schema.json

### DIFF
--- a/.github/workflows/helm-schema-lint.yaml
+++ b/.github/workflows/helm-schema-lint.yaml
@@ -25,5 +25,5 @@ jobs:
       - name: Run Helm lint on values files
         run: |
           helm lint kubernetes/loculus -f kubernetes/loculus/values.yaml
-          helm lint kubernetes/loculus -f kubernetes/loculus/values_e2e_and_dev.yaml
-          helm lint kubernetes/loculus -f kubernetes/loculus/values_preview_server.yaml
+          helm lint kubernetes/loculus -f kubernetes/loculus/values.yaml -f kubernetes/loculus/values_e2e_and_dev.yaml
+          helm lint kubernetes/loculus -f kubernetes/loculus/values.yaml -f kubernetes/loculus/values_preview_server.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,10 @@ repos:
     # Run the formatter.
     - id: ruff-format
       files: ^ena-submission/
+- repo: local
+  hooks:
+    - id: prettier-values-schema
+      name: prettier (values.schema.json)
+      entry: npx prettier@3.6.2 --write
+      language: system
+      files: ^kubernetes/loculus/values\.schema\.json$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,16 @@ repos:
       entry: npx prettier@3.6.2 --write
       language: system
       files: ^kubernetes/loculus/values\.schema\.json$
+    - id: helm-lint
+      name: helm lint
+      entry: bash
+      args:
+        - -c
+        - |
+          set -euo pipefail
+          helm lint kubernetes/loculus -f kubernetes/loculus/values.yaml
+          helm lint kubernetes/loculus -f kubernetes/loculus/values.yaml -f kubernetes/loculus/values_e2e_and_dev.yaml
+          helm lint kubernetes/loculus -f kubernetes/loculus/values.yaml -f kubernetes/loculus/values_preview_server.yaml
+      language: system
+      pass_filenames: false
+      files: ^kubernetes/loculus/

--- a/kubernetes/AGENTS.md
+++ b/kubernetes/AGENTS.md
@@ -7,3 +7,11 @@ After editing `kubernetes/loculus/values.schema.json`, run prettier to format it
 ```bash
 npx prettier@3.6.2 --write kubernetes/loculus/values.schema.json
 ```
+
+## Testing schema and values changes
+
+After changing values.schema.json or values.yaml, run helm lint to validate:
+
+```bash
+helm lint kubernetes/loculus -f kubernetes/loculus/values.yaml
+```

--- a/kubernetes/AGENTS.md
+++ b/kubernetes/AGENTS.md
@@ -1,0 +1,9 @@
+# Kubernetes Directory
+
+## Formatting values.schema.json
+
+After editing `kubernetes/loculus/values.schema.json`, run prettier to format it:
+
+```bash
+npx prettier@3.6.2 --write kubernetes/loculus/values.schema.json
+```

--- a/kubernetes/CLAUDE.md
+++ b/kubernetes/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -207,15 +207,9 @@
       "required": ["name"],
       "allOf": [
         {
-          "if": {
-            "properties": { "autocomplete": { "const": true } },
-            "required": ["autocomplete"]
-          },
-          "then": {
-            "anyOf": [
-              { "not": { "required": ["enableSubstringSearch"] } },
-              { "properties": { "enableSubstringSearch": { "const": false } } }
-            ]
+          "not": {
+            "description": "autocomplete and enableSubstringSearch cannot both be set",
+            "required": ["autocomplete", "enableSubstringSearch"]
           }
         },
         {
@@ -237,9 +231,9 @@
           },
           "then": {
             "properties": {
-              "type": { "enum": ["string", "int", "float", "number", "boolean"] }
+              "type": { "enum": ["string", "authors", "int", "float", "number", "boolean"] }
             },
-            "errorMessage": "When autocomplete is true, type must be 'string', 'int', 'float', 'number', or 'boolean'"
+            "errorMessage": "When autocomplete is true, type must be 'string', 'authors', 'int', 'float', 'number', or 'boolean'"
           }
         },
         {

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -207,43 +207,82 @@
       "required": ["name"],
       "allOf": [
         {
-          "description": "autocomplete and enableSubstringSearch cannot both be set",
           "not": {
+            "description": "autocomplete and enableSubstringSearch cannot both be set",
             "required": ["autocomplete", "enableSubstringSearch"]
           }
         },
         {
-          "description": "generateIndex requires type string",
-          "anyOf": [{ "not": { "required": ["generateIndex"] } }, { "properties": { "type": { "const": "string" } } }]
+          "if": {
+            "properties": { "generateIndex": { "const": true } },
+            "required": ["generateIndex"]
+          },
+          "then": {
+            "properties": {
+              "type": { "enum": ["string", "authors"] }
+            },
+            "errorMessage": "When generateIndex is true, type must be 'string' or 'authors'"
+          }
         },
         {
-          "description": "autocomplete requires type string",
-          "anyOf": [{ "not": { "required": ["autocomplete"] } }, { "properties": { "type": { "const": "string" } } }]
+          "if": {
+            "properties": { "autocomplete": { "const": true } },
+            "required": ["autocomplete"]
+          },
+          "then": {
+            "properties": {
+              "type": { "enum": ["string", "int", "float", "number", "boolean"] }
+            },
+            "errorMessage": "When autocomplete is true, type must be 'string', 'int', 'float', 'number', or 'boolean'"
+          }
         },
         {
-          "description": "enableSubstringSearch requires type string",
-          "anyOf": [
-            { "not": { "required": ["enableSubstringSearch"] } },
-            { "properties": { "type": { "const": "string" } } }
-          ]
+          "if": {
+            "properties": { "enableSubstringSearch": { "const": true } },
+            "required": ["enableSubstringSearch"]
+          },
+          "then": {
+            "properties": {
+              "type": { "enum": ["string", "authors"] }
+            },
+            "errorMessage": "When enableSubstringSearch is true, type must be 'string' or 'authors'"
+          }
         },
         {
-          "description": "lineageSystem requires type string",
-          "anyOf": [{ "not": { "required": ["lineageSystem"] } }, { "properties": { "type": { "const": "string" } } }]
+          "if": {
+            "properties": { "lineageSystem": { "type": "string" } },
+            "required": ["lineageSystem"]
+          },
+          "then": {
+            "properties": {
+              "type": { "enum": ["string", "authors"] }
+            },
+            "errorMessage": "When lineageSystem is set, type must be 'string' or 'authors'"
+          }
         },
         {
-          "description": "rangeSearch requires numeric or date type",
-          "anyOf": [
-            { "not": { "required": ["rangeSearch"] } },
-            { "properties": { "type": { "enum": ["int", "float", "number", "date"] } } }
-          ]
+          "if": {
+            "properties": { "rangeSearch": { "const": true } },
+            "required": ["rangeSearch"]
+          },
+          "then": {
+            "properties": {
+              "type": { "enum": ["int", "float", "number", "date"] }
+            },
+            "errorMessage": "When rangeSearch is true, type must be numeric or date ('int', 'float', 'number', or 'date')"
+          }
         },
         {
-          "description": "rangeOverlapSearch requires numeric or date type",
-          "anyOf": [
-            { "not": { "required": ["rangeOverlapSearch"] } },
-            { "properties": { "type": { "enum": ["int", "float", "number", "date"] } } }
-          ]
+          "if": {
+            "properties": { "rangeOverlapSearch": { "type": "object" } },
+            "required": ["rangeOverlapSearch"]
+          },
+          "then": {
+            "properties": {
+              "type": { "enum": ["int", "float", "number", "date"] }
+            },
+            "errorMessage": "When rangeOverlapSearch is set, type must be numeric or date ('int', 'float', 'number', or 'date')"
+          }
         }
       ]
     },

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -207,9 +207,15 @@
       "required": ["name"],
       "allOf": [
         {
-          "not": {
-            "description": "autocomplete and enableSubstringSearch cannot both be set",
-            "required": ["autocomplete", "enableSubstringSearch"]
+          "if": {
+            "properties": { "autocomplete": { "const": true } },
+            "required": ["autocomplete"]
+          },
+          "then": {
+            "anyOf": [
+              { "not": { "required": ["enableSubstringSearch"] } },
+              { "properties": { "enableSubstringSearch": { "const": false } } }
+            ]
           }
         },
         {

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -207,10 +207,43 @@
       "required": ["name"],
       "allOf": [
         {
+          "description": "autocomplete and enableSubstringSearch cannot both be set",
           "not": {
-            "description": "autocomplete and enableSubstringSearch cannot both be set",
             "required": ["autocomplete", "enableSubstringSearch"]
           }
+        },
+        {
+          "description": "generateIndex requires type string",
+          "anyOf": [{ "not": { "required": ["generateIndex"] } }, { "properties": { "type": { "const": "string" } } }]
+        },
+        {
+          "description": "autocomplete requires type string",
+          "anyOf": [{ "not": { "required": ["autocomplete"] } }, { "properties": { "type": { "const": "string" } } }]
+        },
+        {
+          "description": "enableSubstringSearch requires type string",
+          "anyOf": [
+            { "not": { "required": ["enableSubstringSearch"] } },
+            { "properties": { "type": { "const": "string" } } }
+          ]
+        },
+        {
+          "description": "lineageSystem requires type string",
+          "anyOf": [{ "not": { "required": ["lineageSystem"] } }, { "properties": { "type": { "const": "string" } } }]
+        },
+        {
+          "description": "rangeSearch requires numeric or date type",
+          "anyOf": [
+            { "not": { "required": ["rangeSearch"] } },
+            { "properties": { "type": { "enum": ["int", "float", "number", "date"] } } }
+          ]
+        },
+        {
+          "description": "rangeOverlapSearch requires numeric or date type",
+          "anyOf": [
+            { "not": { "required": ["rangeOverlapSearch"] } },
+            { "properties": { "type": { "enum": ["int", "float", "number", "date"] } } }
+          ]
         }
       ]
     },


### PR DESCRIPTION
Extend the JSON Schema validation to enforce type requirements for metadata configuration options (building on #5184):

- generateIndex requires type: string
- autocomplete requires type: string, int, float, number, or boolean
- enableSubstringSearch requires type: string
- lineageSystem requires type: string
- rangeSearch requires numeric or date types (int, float, number, or date)
- rangeOverlapSearch requires numeric or date types (int, float, number, or date)

I also add AGENTS.md (and CLAUDE.md symlink) to kubernetes dir to instruct to run prettier.

I also added a pre-commit hook to prettier-format the schema automatically and validate it with helm lint. The helm lint action now gets the values.yamls applied over each other the way we do it in practice (preview on top of basic values).

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable