### PR TITLE
feat(backend): clean up auxTable entries that are older than 2 hours

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/CleanUpAuxTableTask.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/CleanUpAuxTableTask.kt
@@ -1,0 +1,30 @@
+package org.loculus.backend.service.maintenance
+
+import org.loculus.backend.log.AuditLogger
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+private val log = mu.KotlinLogging.logger {}
+
+@Component
+class CleanUpAuxTableTask(
+    private val auxTableService: MetadataUploadAuxTable,
+    private val auditLogger: AuditLogger,
+) {
+
+    /**
+     * Runs every hour and deletes auxTable entries older than 2 hours.
+     */
+    @Scheduled(fixedDelay = 1, timeUnit = java.util.concurrent.TimeUnit.HOURS)
+    fun task() {
+        val cutoff = Instant.now().minus(2, ChronoUnit.HOURS)
+        val deletedCount = auxTableService.deleteOlderThan(cutoff)
+
+        if (deletedCount > 0) {
+            log.info { "Deleted $deletedCount auxTable entries older than $cutoff" }
+            auditLogger.info("CLEANUP", "Deleted $deletedCount auxTable entries older than 2 hours.")
+        }
+    }
+}


### PR DESCRIPTION
resolves #

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)
