### PR TITLE
feat(website): don't show suborganism name in gene/segment names on review page sequence dialog

### DIFF
--- a/website/src/components/ReviewPage/ReviewCard.tsx
+++ b/website/src/components/ReviewPage/ReviewCard.tsx
@@ -43,6 +43,7 @@ type ReviewCardProps = {
     organism: string;
     accessToken: string;
     filesEnabled: boolean;
+    segmentAndGeneDisplayNameMap: Map<string, string | null>;
 };
 
 export const ReviewCard: FC<ReviewCardProps> = ({
@@ -55,6 +56,7 @@ export const ReviewCard: FC<ReviewCardProps> = ({
     organism,
     accessToken,
     filesEnabled,
+    segmentAndGeneDisplayNameMap,
 }) => {
     const [isSequencesDialogOpen, setSequencesDialogOpen] = useState(false);
     const [isFilesDialogOpen, setFilesDialogOpen] = useState(false);
@@ -119,6 +121,7 @@ export const ReviewCard: FC<ReviewCardProps> = ({
                 isOpen={isSequencesDialogOpen}
                 onClose={() => setSequencesDialogOpen(false)}
                 dataToView={data}
+                segmentAndGeneDisplayNameMap={segmentAndGeneDisplayNameMap}
             />
             <FilesDialog isOpen={isFilesDialogOpen} onClose={() => setFilesDialogOpen(false)} dataToView={data} />
         </div>

--- a/website/src/components/ReviewPage/ReviewPage.spec.tsx
+++ b/website/src/components/ReviewPage/ReviewPage.spec.tsx
@@ -16,6 +16,7 @@ import {
     warningsProcessingResult,
     errorsProcessingResult,
 } from '../../types/backend.ts';
+import { SINGLE_REFERENCE } from '../../types/referencesGenomes.ts';
 
 const unreleasedSequencesRegex = /You do not currently have any unreleased sequences awaiting review.*/;
 
@@ -30,6 +31,9 @@ function renderReviewPage() {
             accessToken={testAccessToken}
             clientConfig={testConfig.public}
             filesEnabled={false}
+            referenceGenomeLightweightSchema={{
+                [SINGLE_REFERENCE]: { nucleotideSegmentNames: [], geneNames: [], insdcAccessionFull: [] },
+            }}
         />,
     );
 }

--- a/website/src/components/ReviewPage/ReviewPage.tsx
+++ b/website/src/components/ReviewPage/ReviewPage.tsx
@@ -1,6 +1,6 @@
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
 import Pagination from '@mui/material/Pagination';
-import { type ChangeEvent, type FC, useState } from 'react';
+import { type ChangeEvent, type FC, useMemo, useState } from 'react';
 import { toast } from 'react-toastify';
 
 import { ReviewCard } from './ReviewCard.tsx';
@@ -10,20 +10,22 @@ import {
     approveAllDataScope,
     deleteAllDataScope,
     deleteProcessedDataWithErrorsScope,
+    errorsProcessingResult,
     type GetSequencesResponse,
     type Group,
-    processedStatus,
     inProcessingStatus,
+    noIssuesProcessingResult,
     type PageQuery,
+    processedStatus,
     receivedStatus,
     type SequenceEntryStatus,
-    errorsProcessingResult,
     warningsProcessingResult,
-    noIssuesProcessingResult,
 } from '../../types/backend.ts';
+import { type ReferenceGenomesLightweightSchema } from '../../types/referencesGenomes.ts';
 import { type ClientConfig } from '../../types/runtimeConfig.ts';
 import { getAccessionVersionString } from '../../utils/extractAccessionVersion.ts';
 import { displayConfirmationDialog } from '../ConfirmationDialog.tsx';
+import { getSegmentAndGeneDisplayNameMap } from './getSegmentAndGeneDisplayNameMap.tsx';
 import { getLastApprovalTimeKey } from '../SearchPage/RecentSequencesBanner.tsx';
 import { withQueryProvider } from '../common/withQueryProvider.tsx';
 import BiTrash from '~icons/bi/trash';
@@ -43,6 +45,7 @@ type ReviewPageProps = {
     accessToken: string;
     metadataDisplayNames: Map<string, string>;
     filesEnabled: boolean;
+    referenceGenomeLightweightSchema: ReferenceGenomesLightweightSchema;
 };
 
 const pageSizeOptions = [10, 20, 50, 100] as const;
@@ -81,6 +84,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({
     accessToken,
     metadataDisplayNames,
     filesEnabled,
+    referenceGenomeLightweightSchema,
 }) => {
     const [pageQuery, setPageQuery] = useState<PageQuery>({ pageOneIndexed: 1, size: pageSizeOptions[2] });
 
@@ -122,6 +126,11 @@ const InnerReviewPage: FC<ReviewPageProps> = ({
         const newSize = parseInt(event.target.value, 10);
         setPageQuery({ pageOneIndexed: 1, size: newSize });
     };
+
+    const segmentAndGeneDisplayNameMap = useMemo(
+        () => getSegmentAndGeneDisplayNameMap(referenceGenomeLightweightSchema),
+        [referenceGenomeLightweightSchema],
+    );
 
     let sequencesData = hooks.getSequences.data;
 
@@ -381,6 +390,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({
                             organism={organism}
                             accessToken={accessToken}
                             filesEnabled={filesEnabled}
+                            segmentAndGeneDisplayNameMap={segmentAndGeneDisplayNameMap}
                         />
                     </div>
                 );

--- a/website/src/components/ReviewPage/SequencesDialog.spec.tsx
+++ b/website/src/components/ReviewPage/SequencesDialog.spec.tsx
@@ -8,7 +8,12 @@ import { processedStatus, type SequenceEntryToEdit } from '../../types/backend.t
 describe('SequencesDialog', () => {
     test('should only show existing sequences', async () => {
         const { getByText, queryByText, getByRole } = render(
-            <SequencesDialog isOpen={true} onClose={() => undefined} dataToView={dataToView} />,
+            <SequencesDialog
+                isOpen={true}
+                onClose={() => undefined}
+                dataToView={dataToView}
+                segmentAndGeneDisplayNameMap={new Map()}
+            />,
         );
 
         await waitFor(() => {
@@ -32,6 +37,28 @@ describe('SequencesDialog', () => {
 
         expect(queryByText(new RegExp(sequence2))).not.toBeInTheDocument();
         expect(queryByText(new RegExp(gene2))).not.toBeInTheDocument();
+    });
+
+    test('should show mapped segment names', async () => {
+        const { getByRole } = render(
+            <SequencesDialog
+                isOpen={true}
+                onClose={() => undefined}
+                dataToView={dataToView}
+                segmentAndGeneDisplayNameMap={
+                    new Map([
+                        [sequence1, 'mappedName1'],
+                        [gene1, 'mappedGeneName1'],
+                    ])
+                }
+            />,
+        );
+
+        await waitFor(() => {
+            expect(getByRole('button', { name: `mappedName1 (aligned)` })).toBeVisible();
+            expect(getByRole('button', { name: `mappedName1 (unaligned)` })).toBeVisible();
+            expect(getByRole('button', { name: 'mappedGeneName1' })).toBeVisible();
+        });
     });
 });
 

--- a/website/src/components/ReviewPage/SequencesDialog.tsx
+++ b/website/src/components/ReviewPage/SequencesDialog.tsx
@@ -8,6 +8,7 @@ type SequencesDialogProps = {
     isOpen: boolean;
     onClose: () => void;
     dataToView: SequenceEntryToEdit | undefined;
+    segmentAndGeneDisplayNameMap: Map<string, string | null>;
 };
 
 type ProcessedSequence = {
@@ -15,12 +16,17 @@ type ProcessedSequence = {
     sequence: string;
 };
 
-export const SequencesDialog: FC<SequencesDialogProps> = ({ isOpen, onClose, dataToView }) => {
+export const SequencesDialog: FC<SequencesDialogProps> = ({
+    isOpen,
+    onClose,
+    dataToView,
+    segmentAndGeneDisplayNameMap,
+}) => {
     const [activeTab, setActiveTab] = useState(0);
 
     if (!isOpen || !dataToView) return null;
 
-    const processedSequences = extractProcessedSequences(dataToView);
+    const processedSequences = extractProcessedSequences(dataToView, segmentAndGeneDisplayNameMap);
 
     if (processedSequences.length === 0) {
         return null;
@@ -58,7 +64,10 @@ export const SequencesDialog: FC<SequencesDialogProps> = ({ isOpen, onClose, dat
     );
 };
 
-const extractProcessedSequences = (data: SequenceEntryToEdit): ProcessedSequence[] => {
+const extractProcessedSequences = (
+    data: SequenceEntryToEdit,
+    segmentAndGeneDisplayNameMap: Map<string, string | null>,
+): ProcessedSequence[] => {
     return [
         { type: 'unaligned', sequences: data.processedData.unalignedNucleotideSequences },
         { type: 'aligned', sequences: data.processedData.alignedNucleotideSequences },
@@ -67,12 +76,12 @@ const extractProcessedSequences = (data: SequenceEntryToEdit): ProcessedSequence
         Object.entries(sequences)
             .filter((tuple): tuple is [string, string] => tuple[1] !== null)
             .map(([sequenceName, sequence]) => {
-                let label = sequenceName;
+                let label = segmentAndGeneDisplayNameMap.get(sequenceName) ?? sequenceName;
                 if (type !== 'gene') {
                     if (label === 'main') {
                         label = type === 'unaligned' ? 'Sequence' : 'Aligned';
                     } else {
-                        label = type === 'unaligned' ? `${sequenceName} (unaligned)` : `${sequenceName} (aligned)`;
+                        label = type === 'unaligned' ? `${label} (unaligned)` : `${label} (aligned)`;
                     }
                 }
                 return { label, sequence };

--- a/website/src/components/ReviewPage/getSegmentAndGeneDisplayNameMap.spec.tsx
+++ b/website/src/components/ReviewPage/getSegmentAndGeneDisplayNameMap.spec.tsx
@@ -1,0 +1,51 @@
+import { describe, test, expect } from 'vitest';
+
+import { getSegmentAndGeneDisplayNameMap } from './getSegmentAndGeneDisplayNameMap.tsx';
+import { SINGLE_REFERENCE } from '../../types/referencesGenomes.ts';
+
+describe('getSegmentAndGeneDisplayNameMap', () => {
+    test('should map nothing if there is only a single reference', () => {
+        const map = getSegmentAndGeneDisplayNameMap({
+            [SINGLE_REFERENCE]: { nucleotideSegmentNames: [], geneNames: [], insdcAccessionFull: [] },
+        });
+
+        expect(map.size).equals(0);
+    });
+
+    test('should map segments and genes for multiple references', () => {
+        const map = getSegmentAndGeneDisplayNameMap({
+            suborganism1: {
+                nucleotideSegmentNames: ['segment1', 'segment2'],
+                geneNames: ['gene1', 'gene2'],
+                insdcAccessionFull: [],
+            },
+            suborganism2: {
+                nucleotideSegmentNames: ['segment1', 'segment2'],
+                geneNames: ['gene1', 'gene3'],
+                insdcAccessionFull: [],
+            },
+        });
+
+        expect(map.get('suborganism1-segment1')).equals('segment1');
+        expect(map.get('suborganism2-segment1')).equals('segment1');
+        expect(map.get('suborganism2-gene3')).equals('gene3');
+    });
+
+    test('should map segment names to "main" when suborganism only has one segment', () => {
+        const map = getSegmentAndGeneDisplayNameMap({
+            suborganism1: {
+                nucleotideSegmentNames: ['main'],
+                geneNames: ['gene1', 'gene2'],
+                insdcAccessionFull: [],
+            },
+            suborganism2: {
+                nucleotideSegmentNames: ['main'],
+                geneNames: ['gene1', 'gene3'],
+                insdcAccessionFull: [],
+            },
+        });
+
+        expect(map.get('suborganism1')).equals('main');
+        expect(map.get('suborganism2')).equals('main');
+    });
+});

--- a/website/src/components/ReviewPage/getSegmentAndGeneDisplayNameMap.tsx
+++ b/website/src/components/ReviewPage/getSegmentAndGeneDisplayNameMap.tsx
@@ -1,0 +1,29 @@
+import { type ReferenceGenomesLightweightSchema, SINGLE_REFERENCE } from '../../types/referencesGenomes.ts';
+import {
+    getMultiPathogenNucleotideSequenceNames,
+    getMultiPathogenSequenceName,
+} from '../../utils/sequenceTypeHelpers.ts';
+
+export function getSegmentAndGeneDisplayNameMap(
+    referenceGenomeLightweightSchema: ReferenceGenomesLightweightSchema,
+): Map<string, string | null> {
+    if (SINGLE_REFERENCE in referenceGenomeLightweightSchema) {
+        return new Map();
+    }
+
+    const segmentMappingEntries = Object.entries(referenceGenomeLightweightSchema).flatMap(
+        ([suborganism, suborganismSchema]) =>
+            getMultiPathogenNucleotideSequenceNames(suborganismSchema.nucleotideSegmentNames, suborganism).map(
+                ({ lapisName, label }) => [lapisName, label] as const,
+            ),
+    );
+
+    const geneMappingEntries = Object.entries(referenceGenomeLightweightSchema).flatMap(
+        ([suborganism, suborganismSchema]) =>
+            suborganismSchema.geneNames
+                .map((geneName) => getMultiPathogenSequenceName(geneName, suborganism))
+                .map(({ lapisName, label }) => [lapisName, label] as const),
+    );
+
+    return new Map([...segmentMappingEntries, ...geneMappingEntries]);
+}

--- a/website/src/pages/[organism]/submission/[groupId]/review.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/review.astro
@@ -1,7 +1,12 @@
 ---
 import { ReviewPage } from '../../../../components/ReviewPage/ReviewPage';
 import SubmissionPageWrapper from '../../../../components/Submission/SubmissionPageWrapper.astro';
-import { getMetadataDisplayNames, getRuntimeConfig, outputFilesEnabled } from '../../../../config';
+import {
+    getMetadataDisplayNames,
+    getReferenceGenomeLightweightSchema,
+    getRuntimeConfig,
+    outputFilesEnabled,
+} from '../../../../config';
 import { type ClientConfig } from '../../../../types/runtimeConfig';
 import { getAccessToken } from '../../../../utils/getAccessToken';
 import { getGroupsAndCurrentGroup } from '../../../../utils/submissionPages';
@@ -12,6 +17,7 @@ const groupsResult = await getGroupsAndCurrentGroup(Astro.params, Astro.locals.s
 const clientConfig: ClientConfig = getRuntimeConfig().public;
 const filesEnabled = outputFilesEnabled(organism);
 const metadataDisplayNames: Map<string, string> = getMetadataDisplayNames(organism);
+const referenceGenomeLightweightSchema = getReferenceGenomeLightweightSchema(organism);
 ---
 
 <SubmissionPageWrapper title='Review current submissions' groupsResult={groupsResult}>
@@ -25,6 +31,7 @@ const metadataDisplayNames: Map<string, string> = getMetadataDisplayNames(organi
                     accessToken={getAccessToken(Astro.locals.session)!}
                     metadataDisplayNames={metadataDisplayNames}
                     filesEnabled={filesEnabled}
+                    referenceGenomeLightweightSchema={referenceGenomeLightweightSchema}
                     client:load
                 />
             ),


### PR DESCRIPTION
resolves #5180

### Screenshot
Before:
<img width="755" height="568" alt="image" src="https://github.com/user-attachments/assets/40cd496c-8d75-4176-9401-426f968502ae" />


After:
<img width="755" height="568" alt="image" src="https://github.com/user-attachments/assets/11bc5757-0b9c-4627-8a94-e455b2a59dd6" />

### PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
  - works for EV, CCHF, dummy organism

🚀 Preview: https://5180-multi-pathogen-suppo.loculus.org