### PR TITLE
fix(backend): fix typo in CleanUpAuxTableTask.kt

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/CleanUpAuxTableTask.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/CleanUpAuxTableTask.kt
@@ -34,7 +34,7 @@ class CleanUpAuxTableTask(
 
         if (deletedCount > 0) {
             log.info { "Deleted $deletedCount auxTable entries older than $hourCutoff" }
-            auditLogger.log("CLEANUP", "Deleted $deletedCount auxTable entries older than 24 hours.")
+            auditLogger.log("CLEANUP", "Deleted $deletedCount auxTable entries older than $hourCutoff hours.")
         }
     }
 }


### PR DESCRIPTION
resolves #

### Screenshot
Prior to merge I switched the clean up times from 2 to 24 hours but I didn't update the debug message - this does that https://github.com/loculus-project/loculus/pull/5189
### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable