### PR TITLE
fix(website): recognize `ins_gene:123:TTT:whatever` as an invalid insertion

### DIFF
--- a/website/src/utils/mutation.spec.ts
+++ b/website/src/utils/mutation.spec.ts
@@ -65,6 +65,8 @@ describe('mutation', () => {
             'ins_A:23:T',
             'ins_23:A:T',
             'INS_4:G:T',
+            'INS_label-GENE1:23:TTT:',
+            'INS_label-GENE1:23:TTT:INVALID',
         ])('returns undefined for invalid mutation string %s', (input) => {
             const result = parseMutationString(input, mockSuborganismSegmentAndGeneInfo);
             expect(result).toBeUndefined();

--- a/website/src/utils/mutation.ts
+++ b/website/src/utils/mutation.ts
@@ -106,17 +106,21 @@ const isValidAminoAcidInsertionQuery = (
 ): MutationTestResult => {
     try {
         const textUpper = text.toUpperCase();
-        if (!textUpper.startsWith('INS_')) {
+
+        const regex = /^INS_(?<gene>[A-Z0-9_-]+):(?<position>\d+):(?<insertion>[A-Z*?]+)$/;
+        const match = regex.exec(textUpper);
+
+        if (match === null) {
             return INVALID;
         }
-        const query = textUpper.slice(4);
-        const [gene, position, insertion] = query.split(':');
+
+        const { gene, position, insertion } = match.groups as { gene: string; position: string; insertion: string };
 
         const geneInfo = suborganismSegmentAndGeneInfo.geneInfos.find(
             (geneInfo) => geneInfo.label.toUpperCase() === gene,
         );
 
-        if (geneInfo === undefined || !Number.isInteger(Number(position)) || !/^[A-Z*?]+$/.test(insertion)) {
+        if (geneInfo === undefined) {
             return INVALID;
         }
 


### PR DESCRIPTION
related to #5222

### Screenshot

### PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by appropriate, automated tests.
~~- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~~

🚀 Preview: Add `preview` label to enable