### PR TITLE
feat(integration): add integration tests that run the ena cronjob

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -108,6 +108,18 @@ jobs:
           sed -n '/Running [0-9]\+ tests/,$p' output.txt >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           exit $EXIT_CODE
+      - name: Run get-ena-submission-list cronjob
+        run: |
+          JOB_NAME=loculus-get-ena-submission-list-$(date +%s)
+          kubectl create job --from=cronjob/loculus-get-ena-submission-list-cronjob $JOB_NAME
+          echo "Waiting for job $JOB_NAME to complete..."
+          if kubectl wait --for=condition=complete job/$JOB_NAME --timeout=120s; then
+            echo "✅ Job completed successfully"
+          else
+            echo "⚠️ Job did not complete successfully. Checking logs..."
+            kubectl logs job/$JOB_NAME
+            exit 1
+          fi
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2049,7 +2049,7 @@ secrets:
   slack-notifications:
     type: raw
     data:
-      slack-hook: "dummy"
+      slack-hook: ""
       slack-token: "dummy"
       slack-channel-id: "dummy"
   ena-submission:

--- a/kubernetes/loculus/values_e2e_and_dev.yaml
+++ b/kubernetes/loculus/values_e2e_and_dev.yaml
@@ -9,7 +9,7 @@ secrets:
 createTestAccounts: true
 backendExtraArgs:
   - "--loculus.debug-mode=true"
-disableEnaSubmission: true
+disableEnaSubmission: false
 auth:
   verifyEmail: false
 host: localhost:3000


### PR DESCRIPTION
resolves #

### Screenshot
Ensure that changes that would break the ena cronjob (e.g. https://github.com/loculus-project/loculus/pull/4904) will be caught by integration tests

### PR Checklist
- [x] Tested in https://github.com/loculus-project/loculus/pull/5221 that this test fails when the ena tests are broken e.g. due to a backend endpoint change

🚀 Preview: Add `preview` label to enable