### PR TITLE
chore(config): Update LAPIS to v0.5.19

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1989,7 +1989,7 @@ images:
     pullPolicy: Always
   lapis:
     repository: "ghcr.io/genspectrum/lapis"
-    tag: "0.5.14"
+    tag: "v0.5.19"
     pullPolicy: Always
   website:
     repository: "ghcr.io/loculus-project/website"


### PR DESCRIPTION
This includes a cherry-picked fix for the memory issue we experienced in SILO. LAPIS was not closing connections it made to SILO on behalf of a client, even if the client had closed the connection.

This fix was cherry-picked onto v0.5.18 to create v0.5.19 which should be compatible with the current SILO version used by Loculus.

Uses: https://github.com/GenSpectrum/LAPIS/pull/1403

### Other changes

#### Bug Fixes
lapis: also don't log the stack trace when SILO says that it's not available yet (https://github.com/GenSpectrum/LAPIS/issues/1376) ([b4ee14d](https://github.com/GenSpectrum/LAPIS/commit/b4ee14d752c0d0342fd866ac402de585df51d9a4))
lapis: don't spam the log with stack traces when SILO can't be reached (https://github.com/GenSpectrum/LAPIS/issues/1373) ([0e35d0f](https://github.com/GenSpectrum/LAPIS/commit/0e35d0f2c0dd72058be71b050e97ec710536e9eb))
lapis: fix 500 server error in *mutationsOverTime endpoints (https://github.com/GenSpectrum/LAPIS/issues/1357) ([d056d6c](https://github.com/GenSpectrum/LAPIS/commit/d056d6cc075a15c72bd77b3d9991cefe6baf7139))
lapis: fix response schema of /phyloSubtree in OpenAPI spec (https://github.com/GenSpectrum/LAPIS/issues/1336) ([c3c3e75](https://github.com/GenSpectrum/LAPIS/commit/c3c3e75d73a8f3ddec153f62650d529f0ee82ca4))
lapis: increase maximum string length in JSON parser (https://github.com/GenSpectrum/LAPIS/issues/1332) ([1765428](https://github.com/GenSpectrum/LAPIS/commit/17654285b0b29347fcb89a7c43ebeb42f2b87c25))
lapis: truncate error details if they are too long (https://github.com/GenSpectrum/LAPIS/issues/1334) ([b51157d](https://github.com/GenSpectrum/LAPIS/commit/b51157d466eca6b9d1a57a8082763e91eb9e63c4))

#### Features
lapis: make thread count for SILO client configurable (https://github.com/GenSpectrum/LAPIS/issues/1352) ([d541fb8](https://github.com/GenSpectrum/LAPIS/commit/d541fb8a6018cbaf4d6d47b3fae7a45dfbe939bf))
lapis: mutationsOverTime endpoint: return total sequence count per dateRange (https://github.com/GenSpectrum/LAPIS/issues/1316) ([b29c921](https://github.com/GenSpectrum/LAPIS/commit/b29c9214cd247211e329fb32e82c0889d6fc4d81))
lapis: add example value to /phyloSubtree endpoints docs (https://github.com/GenSpectrum/LAPIS/issues/1337) ([21e659e](https://github.com/GenSpectrum/LAPIS/commit/21e659ecfd8ffe76cb4a415f04c74bb5357bbe14))

### PR Checklist
- [x] Tested if memory leak is still seen on preview: 
https://grafana.loculus.org/explore?schemaVersion=1&panes=%7B%22pyk%22:%7B%22datasource%22:%22decyzhq5ockqoe%22,%22queries%22:%5B%7B%22refId%22:%22B%22,%22expr%22:%22container_memory_rss%7Bcontainer%3D%5C%22silo%5C%22,%20namespace%3D%5C%22prev-anna-parker-patch-2%5C%22%7D%20%2F%2010%5E6%22,%22range%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22decyzhq5ockqoe%22%7D,%22editorMode%22:%22code%22%7D%5D,%22range%22:%7B%22from%22:%22now-30m%22,%22to%22:%22now%22%7D%7D%7D&orgId=1

Cancel requests with 
```
curl 'https://lapis-anna-parker-patch-2.loculus.org/west-nile/sample/alignedNucleotideSequences' --max-filesize 100
```
then upload sequences to trigger SILO preprocessing.

Do this once more to check the effects on memory load

<img width="2450" height="1120" alt="image" src="https://github.com/user-attachments/assets/e5923c25-25f8-4883-b73c-83ce78e4f914" />

Do the same on main:
<img width="2450" height="1120" alt="image" src="https://github.com/user-attachments/assets/d415541d-3cb1-4fd5-94c8-5940027d8ffa" />

🚀 Preview: https://anna-parker-patch-2.loculus.org