### PR TITLE
refactor(ingest): extract loculus_client

### DIFF
--- a/ingest/environment.yml
+++ b/ingest/environment.yml
@@ -10,7 +10,6 @@ dependencies:
   - biopython
   - click
   - curl
-  - defusedxml
   - ijson
   - jsonlines
   - ncbi-datasets-cli >=16.40.1


### PR DESCRIPTION
Move library-like functions out of call_loculus.py into loculus_client.py for better code structure.

Based on https://github.com/loculus-project/loculus/pull/4864

### Testing
- ingest tests are good!
- preview looks good to me

### PR Checklist
- ~~All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

preview: https://ingest-refactor-loculus-c.loculus.org/