### PR TITLE
fix(backend): fix spring boot warning about missing leading slash

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/SecurityConfig.kt
@@ -77,7 +77,7 @@ class SecurityConfig {
         .authorizeHttpRequests { auth ->
             auth.requestMatchers(
                 "/",
-                "favicon.ico",
+                "/favicon.ico",
                 "/error/**",
                 "/actuator/**",
                 "/api-docs**",


### PR DESCRIPTION
At startup, we get a warning about one of the patterns in the security config missing a slash:

`
org.springframework.security.config.annotation.web.AbstractRequestMatcherRegistry: One of the patterns in [/, favicon.ico, /error/**, /actuator/**, /api-docs**, /api-docs/**, /swagger-ui/**] is missing a leading slash. This is discouraged; please include the leading slash in all your request matcher patterns. In future versions of Spring Security, leaving out the leading slash will result in an exception.
`

from the warning we can see that it is the `favicon.ico`. 

This PR adds the leading slash.

#### Testing

I can see in the preview that the favicon is still loading fine.

### Screenshot

n/a

### PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by appropriate, automated tests.~~
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://fix-warning.loculus.org