### PR TITLE
feat(preprocessing): add timestamps to logging output

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/__main__.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/__main__.py
@@ -1,13 +1,14 @@
 import logging
 
 from .config import get_config
+from .logging_config import configure_logging
 from .prepro import run
 
 logger = logging.getLogger(__name__)
 
 
 def cli_entry() -> None:
-    logging.basicConfig(level=logging.INFO)
+    configure_logging(level=logging.INFO)
 
     config = get_config()
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -11,6 +11,7 @@ from typing import Any, get_args
 import yaml
 
 from loculus_preprocessing.datatypes import MoleculeType, Topology
+from loculus_preprocessing.logging_config import configure_logging
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +140,7 @@ def get_config(config_file: str | None = None, ignore_args: bool = False) -> Con
     # Set just log level this early from env, so we can debug log during config loading
     env_log_level = os.environ.get("PREPROCESSING_LOG_LEVEL")
     if env_log_level:
-        logging.basicConfig(level=env_log_level)
+        configure_logging(level=env_log_level)
 
     if not ignore_args:
         parser = generate_argparse_from_dataclass(Config)

--- a/preprocessing/nextclade/src/loculus_preprocessing/logging_config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/logging_config.py
@@ -1,0 +1,12 @@
+"""Logging configuration for the preprocessing pipeline"""
+
+import logging
+
+
+def configure_logging(level: str | int = logging.INFO) -> None:
+    """Configure logging with timestamps and consistent format"""
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )


### PR DESCRIPTION
Add timestamps and structured formatting to all log messages in the preprocessing pipeline to improve debugging and operational visibility.

Changes:
- Created new `logging_config.py` module to centralize logging configuration
- Updated `__main__.py` to use centralized logging configuration
- Updated `config.py` to use centralized logging configuration
- Eliminated duplication of logging format configuration

Log format example:
2025-10-16 14:23:45 - loculus_preprocessing.backend - INFO - Fetching 5 unprocessed sequences from http://loculus-backend-service:8079/h1n1pdm/extract-unprocessed-data

This makes it easier to:
- Track when timeout errors occur
- Measure operation duration
- Debug issues in production environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by appropriate, automated tests.~~
- ~~Any manual testing that has been done is documented (i.e. what exactly was tested?)~~

🚀 Preview: Add `preview` label to enable