### PR TITLE
fix(preprocessing): increase timeout for extract-unprocessed-data to prevent stuck sequences

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/backend.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/backend.py
@@ -121,7 +121,7 @@ def fetch_unprocessed_sequences(
         **({"If-None-Match": etag} if etag else {}),
     }
     logger.debug(f"Requesting data with ETag: {etag}")
-    response = requests.post(url, data=params, headers=headers, timeout=10)
+    response = requests.post(url, data=params, headers=headers, timeout=30)
     logger.info(
         f"Unprocessed data from backend: status code {response.status_code}, "
         f"request id: {response.headers.get('x-request-id')}"


### PR DESCRIPTION
Increase the timeout for the `/extract-unprocessed-data` API call from 10 to 30 seconds.

The backend marks sequences as 'in-processing' when this endpoint is called. If the request times out before completion, sequences remain stuck in the 'in-processing' state and become unavailable for processing until they time out on the backend side.

The 10-second timeout was causing premature timeouts in production, leading to sequences being incorrectly marked as in-processing. A 30-second timeout provides more headroom while we investigate the root cause of slow backend response times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable