### PR TITLE
fix(website): rename organism submenu labels

### DIFF
--- a/integration-tests/tests/pages/navigation.page.ts
+++ b/integration-tests/tests/pages/navigation.page.ts
@@ -47,7 +47,7 @@ export class NavigationPage {
         await this.page.getByRole('link', { name: linkText, exact: true }).first().click();
     }
 
-    async clickSubmitSequences() {
-        await this.clickOrganismNavigationLink('Submit sequences');
+    async clickSequenceSubmission() {
+        await this.clickOrganismNavigationLink('Sequence submission');
     }
 }

--- a/integration-tests/tests/pages/review.page.ts
+++ b/integration-tests/tests/pages/review.page.ts
@@ -33,7 +33,7 @@ export class ReviewPage {
         await this.page.goto('/');
         await this.navigation.openOrganismNavigation();
         await this.navigation.selectOrganism('Ebola Sudan');
-        await this.navigation.clickSubmitSequences();
+        await this.navigation.clickSequenceSubmission();
         await this.page.getByRole('link', { name: "Review Review your group's" }).click();
     }
 

--- a/integration-tests/tests/pages/submission.page.ts
+++ b/integration-tests/tests/pages/submission.page.ts
@@ -19,12 +19,12 @@ class SubmissionPage {
         await this.page.goto('/');
         await this.navigation.openOrganismNavigation();
         await this.navigation.selectOrganism(organism);
-        await this.navigation.waitForOrganismNavigationLink('Submit sequences');
+        await this.navigation.waitForOrganismNavigationLink('Sequence submission');
     }
 
     async navigateToSubmissionPage(organism: string = 'Ebola Sudan') {
         await this.navigateToOrganism(organism);
-        await this.navigation.clickSubmitSequences();
+        await this.navigation.clickSequenceSubmission();
 
         // Click on the submit upload link
         await this.page.getByRole('link', { name: 'Submit Upload new sequences.' }).click();

--- a/integration-tests/tests/specs/features/navigation.spec.ts
+++ b/integration-tests/tests/specs/features/navigation.spec.ts
@@ -9,8 +9,8 @@ const organismIndependentNavigationItems = [
 ];
 
 const organismNavigationItems = [
-    { link: 'Browse data', title: '[Organism] - Browse' },
-    { link: 'Submit sequences', title: 'Submission portal' },
+    { link: 'Data explorer', title: '[Organism] - Browse' },
+    { link: 'Sequence submission', title: 'Submission portal' },
     { link: 'My account', title: 'My account' },
 ];
 

--- a/integration-tests/tests/specs/features/revise-sequence.spec.ts
+++ b/integration-tests/tests/specs/features/revise-sequence.spec.ts
@@ -13,7 +13,7 @@ test('revising sequence data works: segment can be deleted; segment can be edite
     await searchPage.cchf();
 
     const navigation = new NavigationPage(page);
-    await navigation.clickSubmitSequences();
+    await navigation.clickSequenceSubmission();
     await page.getByRole('link', { name: "View View your group's" }).click();
 
     const loculusId = await searchPage.waitForLoculusId();

--- a/integration-tests/tests/specs/features/submission-flow.spec.ts
+++ b/integration-tests/tests/specs/features/submission-flow.spec.ts
@@ -12,7 +12,7 @@ test.describe('Submission flow', () => {
         const submissionPage = new SingleSequenceSubmissionPage(pageWithACreatedUser);
         await submissionPage.navigateToOrganism('Ebola Sudan');
         const navigation = new NavigationPage(pageWithACreatedUser);
-        await navigation.clickSubmitSequences();
+        await navigation.clickSequenceSubmission();
         await pageWithACreatedUser.getByRole('link', { name: 'create a submitting group' }).click();
     });
 

--- a/website/src/routes/navigationItems.ts
+++ b/website/src/routes/navigationItems.ts
@@ -29,7 +29,7 @@ export function getSequenceRelatedItems(organism: string | undefined) {
     }
 
     const browseItem = {
-        text: 'Browse data',
+        text: 'Data explorer',
         path: routes.searchPage(organism),
         icon: SearchIcon,
     };
@@ -39,7 +39,7 @@ export function getSequenceRelatedItems(organism: string | undefined) {
     }
 
     const submitItem = {
-        text: 'Submit sequences',
+        text: 'Sequence submission',
         path: routes.submissionPageWithoutGroup(organism),
         icon: UploadIcon,
     };


### PR DESCRIPTION
## Summary
- rename the organism submenu entry that points to the search experience from "Browse data" to "Data explorer" in the website navigation configuration
- update the submission submenu entry label to "Sequence submission" and propagate the new wording through all Playwright helpers and feature specs that exercise the navigation menu
- adjust the navigation page object to expose a `clickSequenceSubmission` helper so downstream tests clearly reflect the new menu wording

## Testing
- npm run test (pass)
- npm run check-types (pass)
- npm run format (pass)
- npm run format (integration-tests) *(fails: eslint configuration depends on @eslint/js which is not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f0ed5b71bc8325a25d87e06e9b32ad

🚀 Preview: Add `preview` label to enable