### PR TITLE
chore(deps): add sha256 digest to lapis image

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1989,7 +1989,7 @@ images:
     pullPolicy: Always
   lapis:
     repository: "ghcr.io/genspectrum/lapis"
-    tag: "v0.5.19"
+    tag: "v0.5.19@sha256:6a6e434e8670541dc8478a5e6bd9e7c70ecd5cf3232b81834253398b0e260ece"
     pullPolicy: Always
   website:
     repository: "ghcr.io/loculus-project/website"


### PR DESCRIPTION
Digest is from: https://github.com/genspectrum/LAPIS/pkgs/container/lapis/544882049?tag=v0.5.19