### PR TITLE
feat(ingest): move defaults to config

### DIFF
--- a/ingest/config/defaults.yaml
+++ b/ingest/config/defaults.yaml
@@ -73,3 +73,5 @@ db_password: unsecure
 db_url: "jdbc:postgresql://127.0.0.1:5432/loculus"
 batch_chunk_size: 10000  # Batch size for submitting sequences to Loculus backend
 nextclade_dataset_server: https://data.clades.nextstrain.org/v3
+time_between_approve_requests_seconds: 60
+backend_request_timeout_seconds: 600


### PR DESCRIPTION
resolves Missing sequences on main

### Screenshot
Ingest sets default config values from the default.yaml config - these values override any defaults set inside a Config object used in a script. If a default value is not set in the default config it becomes a default empty string and will not be parsed correctly. 

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://fix-ingest-timeout.loculus.org