### PR TITLE
doc(deployment): add missing ingest/prepro config options to values schema

### DIFF
--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -610,6 +610,12 @@
                     "docsIncludePrefix": false,
                     "type": "array",
                     "description": "Array of strings. The dataset names that are accepted as matches when using nextclade sort, if not specified use nextclade_dataset_name."
+                  },
+                  "backend_request_timeout_seconds": {
+                    "groups": ["nextcladePipelineConfigFile"],
+                    "docsIncludePrefix": false,
+                    "type": "integer",
+                    "description": "Timeout in seconds for requests to the backend server for data to process"
                   }
                 }
               }
@@ -684,6 +690,12 @@
                       "docsIncludePrefix": false,
                       "type": "integer",
                       "description": "Timeout in seconds for requests to the backend server for data to process"
+                    },
+                    "time_between_approve_requests_seconds": {
+                      "groups": ["ingestPipelineConfigFile"],
+                      "docsIncludePrefix": false,
+                      "type": "integer",
+                      "description": "Time in seconds to wait between approve requests"
                     }
                   },
                   "required": ["method"]


### PR DESCRIPTION
PR #5249 added three new configurable options to ingest and preprocessing:

1. `backend_request_timeout_seconds` for **ingest** ✓ (was added to schema)
2. `backend_request_timeout_seconds` for **preprocessing** ✗ (missing from schema)
3. `time_between_approve_requests_seconds` for **ingest** ✗ (missing from schema)

This PR adds the two missing config options to `values.schema.json`:

- Added `backend_request_timeout_seconds` to the preprocessing (Nextclade) pipeline configFile schema
- Added `time_between_approve_requests_seconds` to the ingest pipeline configFile schema

Both fields are now properly documented in the values schema, allowing users to configure these timeouts in their deployment values files.

## Test plan

- [x] Schema validated with `helm lint kubernetes/loculus -f kubernetes/loculus/values.yaml`
- [x] Schema formatted with `npx prettier@3.6.2 --write kubernetes/loculus/values.schema.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable