### PR TITLE
ci(integration-tests): use uv pip install for faster package installation

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -75,9 +75,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - name: Install CLI
-        run: cd cli && uv sync && uv build && uv pip install dist/*.whl
+        run: cd cli && uv sync && uv build && uv pip install --system dist/*.whl
       - name: Install keyring backend for CLI
-        run: uv pip install keyrings.alt
+        run: uv pip install --system keyrings.alt
       - name: Get Installed Playwright Version
         id: playwright-version
         run: cd integration-tests && echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV


### PR DESCRIPTION
- Replace `pip install` with `uv pip install` in integration tests workflow to leverage uv's 10-100x speedup for package operations

Probably doesn't matter as cluster start is rate limiting and anything we do between helm install and the installation being ready does not slow things down.