### PR TITLE
feat(deposition): only block revision if formatted authors field changes rather than unformatted

### DIFF
--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -394,8 +394,16 @@ def can_be_revised(config: Config, db_config: SimpleConnectionPool, entry: dict[
             last_entry = last_version_data[0]["metadata"].get(field)
             new_entry = entry["metadata"].get(field)
             if field == "authors":
-                last_entry = get_authors(last_entry) if last_entry else last_entry
-                new_entry = get_authors(new_entry) if new_entry else new_entry
+                try:
+                    last_entry = get_authors(last_entry) if last_entry else last_entry
+                    new_entry = get_authors(new_entry) if new_entry else new_entry
+                except Exception as e:
+                    logger.error(
+                        f"Error formatting authors field for comparison: {e}. "
+                        f"Traceback: {traceback.format_exc()}"
+                    )
+                    differing_fields.append(field)
+                    continue
             if last_entry != new_entry:
                 differing_fields.append(field)
     if differing_fields:


### PR DESCRIPTION
The ENA deposition pipeline blocks revisions if a metadata field changes that is in the manifest. This is because we cannot revise manifest fields through the API and need to notify ENA manually through email. 

This PR updates the code to check if the formatted authors' list changes (what we actually send to ENA) as opposed to the unformatted authors' list. 

See https://loculus.slack.com/archives/C05G172HL6L/p1761121808948159

Linked to https://github.com/loculus-project/loculus/issues/5296

🚀 Preview: Add `preview` label to enable