### PR TITLE
feat(deposition): Distinguish between complete and incomplete (raw read) ENA metadata in notifications

### DIFF
--- a/ena-submission/scripts/get_ena_submission_list.py
+++ b/ena-submission/scripts/get_ena_submission_list.py
@@ -111,7 +111,6 @@ def filter_for_submission(  # noqa: PLR0912
             if entry["metadata"].get(field)
         ]
         if ena_specific_metadata:
-            # Check if all ena_specific_metadata_fields are present
             all_fields_present = all(
                 entry["metadata"].get(field) for field in ena_specific_metadata_fields
             )


### PR DESCRIPTION
## Summary

This PR improves how we handle and notify about sequences with ENA-specific metadata fields.

Previously, all sequences with any ENA-specific metadata were triaged together into a single notification. This made it difficult to distinguish between:
1. Legitimate user submissions linking to raw reads (all fields present)
2. Potential user errors (only some fields present)

### Updated Notifications
- Two separate Slack notifications with clearer, more actionable messages
- Different output filenames to distinguish the two categories
- Complete metadata gets info-level logging, incomplete gets warning-level

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable