### PR TITLE
test: quiet successful CLI integration logs

### DIFF
--- a/integration-tests/tests/pages/CliPage.ts
+++ b/integration-tests/tests/pages/CliPage.ts
@@ -365,6 +365,15 @@ export class CliPage {
      * Log CLI result for debugging (always includes stderr if present)
      */
     logCliResult(operation: string, result: CliResult, logStdout: boolean = false): void {
+        const shouldLog =
+            result.exitCode !== 0 ||
+            (result.stderr?.length ?? 0) > 0 ||
+            process.env.CLI_TEST_LOGS === '1';
+
+        if (!shouldLog) {
+            return;
+        }
+
         const parts = [`${operation}:`];
 
         if (result.exitCode !== 0) {


### PR DESCRIPTION
## Summary
- skip logging for successful CLI integration commands to reduce noisy output
- expose a CLI_TEST_LOGS escape hatch for developers who want to re-enable the logs

## Testing
- npm run format *(fails: missing dev dependency @eslint/js in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f93e16cda08325a32d132c0b2d9c08

🚀 Preview: Add `preview` label to enable