### PR TITLE
feat(deposition): use typed dicts for all sql read and write query conditions 

### DIFF
--- a/ena-submission/scripts/get_ena_submission_list.py
+++ b/ena-submission/scripts/get_ena_submission_list.py
@@ -52,7 +52,11 @@ def fetch_suppressed_accessions(config: Config) -> set[AccessionVersion]:
             f"Failed to retrieve list of suppressed sequences due to requests exception: {e}"
         )
         raise e
-    return {line.strip() for line in response.text.splitlines() if line.strip()}
+    return {
+        AccessionVersion(line.strip().split(".")[0], int(line.strip().split(".")[1]))
+        for line in response.text.splitlines()
+        if line.strip()
+    }
 
 
 def filter_for_submission(

--- a/ena-submission/scripts/get_ena_submission_list.py
+++ b/ena-submission/scripts/get_ena_submission_list.py
@@ -53,7 +53,9 @@ def fetch_suppressed_accessions(config: Config) -> set[AccessionVersion]:
         )
         raise e
     return {
-        AccessionVersion(line.strip().split(".")[0], int(line.strip().split(".")[1]))
+        AccessionVersion(
+            accession=line.strip().split(".")[0], version=int(line.strip().split(".")[1])
+        )
         for line in response.text.splitlines()
         if line.strip()
     }

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -34,6 +34,7 @@ from ena_deposition.ena_types import (
     default_sample_set_type,
 )
 from ena_deposition.loculus_models import Group
+from ena_deposition.submission_db_helper import SeqKey
 
 logger = logging.getLogger(__name__)
 
@@ -234,7 +235,7 @@ class AssemblyCreationTests(unittest.TestCase):
         self.unaligned_sequences = {
             "main": "CTTAACTTTGAGAGAGTGAATT",
         }
-        self.seq_key = {"accession": "LOC_0001TLY", "version": "1"}
+        self.seq_key = SeqKey("LOC_0001TLY", 1)
 
     def test_format_authors(self):
         authors = "Xi,L.;Smith, Anna Maria; Perez Gonzalez, Anthony J.;Doe,;von Doe, John"

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -34,7 +34,7 @@ from ena_deposition.ena_types import (
     default_sample_set_type,
 )
 from ena_deposition.loculus_models import Group
-from ena_deposition.submission_db_helper import SeqKey
+from ena_deposition.submission_db_helper import AccessionVersion
 
 logger = logging.getLogger(__name__)
 
@@ -235,7 +235,7 @@ class AssemblyCreationTests(unittest.TestCase):
         self.unaligned_sequences = {
             "main": "CTTAACTTTGAGAGAGTGAATT",
         }
-        self.seq_key = SeqKey("LOC_0001TLY", 1)
+        self.seq_key = AccessionVersion("LOC_0001TLY", 1)
 
     def test_format_authors(self):
         authors = "Xi,L.;Smith, Anna Maria; Perez Gonzalez, Anthony J.;Doe,;von Doe, John"

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -6,7 +6,7 @@ import json
 import logging
 import unittest
 from pathlib import Path
-from typing import Any, Final
+from typing import Final
 from unittest import mock
 
 import xmltodict
@@ -34,7 +34,11 @@ from ena_deposition.ena_types import (
     default_sample_set_type,
 )
 from ena_deposition.loculus_models import Group
-from ena_deposition.submission_db_helper import AccessionVersion
+from ena_deposition.submission_db_helper import (
+    AccessionVersion,
+    ProjectTableEntry,
+    SubmissionTableEntry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -99,28 +103,25 @@ with open("test/approved_ena_submission_list_test.json", encoding="utf-8") as f:
     loculus_sample: dict = json.load(f)
 
 
-def sample_data_in_submission_table() -> dict[str, Any]:
+def sample_data_in_submission_table() -> SubmissionTableEntry:
     """Returns a sample data structure that mimics the one used in the submission table."""
-    return {
-        "accession": "LOC_0001TLY",
-        "version": "1",
-        "group_id": 2,
-        "organism": "Test organism",
-        "metadata": loculus_sample["LOC_0001TLY.1"]["metadata"],
-        "unaligned_nucleotide_sequences": {
+    return SubmissionTableEntry(
+        accession="LOC_0001TLY",
+        version=1,
+        group_id=2,
+        organism="Test organism",
+        metadata=loculus_sample["LOC_0001TLY.1"]["metadata"],
+        unaligned_nucleotide_sequences={
             "seg1": None,
             "seg2": "GCGGCACGTCAGTACGTAAGTGTATCTCAAAGAAATACTTAACTTTGAGAGAGTGAATT",
             "seg3": "CTTAACTTTGAGAGAGTGAATT",
         },
-        "center_name": "Fake center name",
-    }
+        center_name="Fake center name",
+    )
 
 
-project_table_entry = {"group_id": "2", "organism": "Test organism"}
-sample_table_entry = {
-    "accession": "LOC_0001TLY",
-    "version": "1",
-}
+project_table_entry = ProjectTableEntry(group_id=2, organism="Test organism")
+accession_version = AccessionVersion(accession="LOC_0001TLY", version=1)
 
 
 # Mock requests
@@ -196,7 +197,7 @@ class TestCreateSample:
         sample_set = construct_sample_set_object(
             config,
             sample_data_in_submission_table(),
-            sample_table_entry,
+            accession_version,
         )
         assert xmltodict.parse(
             dataclass_to_xml(sample_set, root_name="SAMPLE_SET")
@@ -205,11 +206,11 @@ class TestCreateSample:
     def test_sample_set_with_gisaid(self):
         config = mock_config()
         sample_data = sample_data_in_submission_table()
-        sample_data["metadata"]["gisaidIsolateId"] = "EPI_ISL_12345"
+        sample_data.metadata["gisaidIsolateId"] = "EPI_ISL_12345"
         sample_set = construct_sample_set_object(
             config,
             sample_data,
-            sample_table_entry,
+            accession_version,
         )
         assert xmltodict.parse(
             dataclass_to_xml(sample_set, root_name="SAMPLE_SET")
@@ -220,7 +221,7 @@ class TestCreateSample:
         sample_set = construct_sample_set_object(
             config,
             sample_data_in_submission_table(),
-            sample_table_entry,
+            accession_version,
         )
         files = get_sample_xml(sample_set, revision=True)
         revision = files["SUBMISSION"]
@@ -229,13 +230,13 @@ class TestCreateSample:
 
 class AssemblyCreationTests(unittest.TestCase):
     def setUp(self):
-        self.unaligned_sequences_multi = sample_data_in_submission_table()[
-            "unaligned_nucleotide_sequences"
-        ]
-        self.unaligned_sequences = {
+        self.unaligned_sequences_multi = (
+            sample_data_in_submission_table().unaligned_nucleotide_sequences
+        )
+        self.unaligned_sequences: dict[str, str | None] = {
             "main": "CTTAACTTTGAGAGAGTGAATT",
         }
-        self.seq_key = AccessionVersion("LOC_0001TLY", 1)
+        self.seq_key = AccessionVersion(accession="LOC_0001TLY", version=1)
 
     def test_format_authors(self):
         authors = "Xi,L.;Smith, Anna Maria; Perez Gonzalez, Anthony J.;Doe,;von Doe, John"

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 
 
 def create_chromosome_list_object(
-    unaligned_sequences: dict[str, str], seq_key: dict[str, str], organism_metadata: dict[str, str]
+    unaligned_sequences: dict[str, str], seq_key: dict[str, Any], organism_metadata: dict[str, str]
 ) -> AssemblyChromosomeListFile:
     # Use https://www.ebi.ac.uk/ena/browser/view/GCA_900094155.1?show=chromosomes as a template
     # Use https://www.ebi.ac.uk/ena/browser/view/GCA_000854165.1?show=chromosomes for multi-segment
@@ -320,7 +320,7 @@ def submission_table_update(db_config: SimpleConnectionPool) -> None:
 def update_assembly_error(
     db_config: SimpleConnectionPool,
     error: str | list[str],
-    seq_key: dict[str, str],
+    seq_key: dict[str, Any],
     update_type: Literal["revision"] | Literal["creation"],
 ) -> None:
     logger.error(

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -1,12 +1,12 @@
-import json
 import logging
 import random
 import string
 import threading
 import time
 import traceback
+from collections.abc import Sequence
 from datetime import datetime, timedelta
-from typing import Any, Literal
+from typing import Literal
 
 import pytz
 from psycopg2.pool import SimpleConnectionPool
@@ -39,23 +39,30 @@ from .submission_db_helper import (
     AssemblyTableEntry,
     Status,
     StatusAll,
+    SubmissionTableEntry,
     TableName,
     add_to_assembly_table,
     db_init,
-    find_conditions_in_db,
+    find_conditions_in_assembly_db,
+    find_conditions_in_project_db,
+    find_conditions_in_sample_db,
+    find_conditions_in_submission_db,
     find_errors_in_db,
-    find_waiting_in_db,
+    find_waiting_in_assembly_db,
     is_revision,
     last_version,
-    update_db_where_conditions,
-    update_with_retry,
+    update_assembly_db_where_conditions,
+    update_assembly_with_retry,
+    update_submission_db_where_conditions,
 )
 
 logger = logging.getLogger(__name__)
 
 
 def create_chromosome_list_object(
-    unaligned_sequences: dict[str, str], seq_key: AccessionVersion, organism_metadata: dict[str, str]
+    unaligned_sequences: dict[str, str | None],
+    seq_key: AccessionVersion,
+    organism_metadata: dict[str, str],
 ) -> AssemblyChromosomeListFile:
     # Use https://www.ebi.ac.uk/ena/browser/view/GCA_900094155.1?show=chromosomes as a template
     # Use https://www.ebi.ac.uk/ena/browser/view/GCA_000854165.1?show=chromosomes for multi-segment
@@ -70,7 +77,7 @@ def create_chromosome_list_object(
         topology = Topology(organism_metadata.get("topology", "linear"))
         if multi_segment:
             entry = AssemblyChromosomeListFileObject(
-                object_name=f"{seq_key.accession}_{segment_name}",
+                object_name=f"{seq_key['accession']}_{segment_name}",
                 chromosome_name=segment_name,
                 chromosome_type=ChromosomeType.SEGMENTED,
                 topology=topology,
@@ -78,7 +85,7 @@ def create_chromosome_list_object(
             entries.append(entry)
             continue
         entry = AssemblyChromosomeListFileObject(
-            object_name=f"{seq_key.accession}",
+            object_name=f"{seq_key['accession']}",
             chromosome_name="genome",
             chromosome_type=ChromosomeType.MONOPARTITE,
             topology=topology,
@@ -88,8 +95,10 @@ def create_chromosome_list_object(
     return AssemblyChromosomeListFile(chromosomes=entries)
 
 
-def get_segment_order(unaligned_sequences: dict[str, str]) -> list[str]:
+def get_segment_order(unaligned_sequences: dict[str, str | None] | None) -> list[str]:
     """Order in which we put the segments in the chromosome list file"""
+    if not unaligned_sequences:
+        return []
     segment_order = []
     for segment_name, item in unaligned_sequences.items():
         if item:  # Only list sequenced segments
@@ -97,24 +106,21 @@ def get_segment_order(unaligned_sequences: dict[str, str]) -> list[str]:
     return sorted(segment_order)
 
 
-def get_address(config: Config, entry: dict[str, Any]) -> str | None:
+def get_address(config: Config, entry: SubmissionTableEntry) -> str | None:
     if not config.is_broker:
         return None
     try:
-        group_details = call_loculus.get_group_info(config, entry["metadata"]["groupId"])
+        group_details = call_loculus.get_group_info(config, entry.metadata["groupId"])
     except Exception as e:
         logger.error(
-            f"Failed to fetch group info for groupId={entry['metadata']['groupId']}\n"
+            f"Failed to fetch group info for groupId={entry.metadata['groupId']}\n"
             f"{traceback.format_exc()}"
         )
-        msg = (
-            "Failed to fetch group info from Loculus for group: "
-            f"{entry['metadata']['groupId']}, {e}"
-        )
+        msg = f"Failed to fetch group info from Loculus for group: {entry.metadata['groupId']}, {e}"
         raise RuntimeError(msg) from e
     address = group_details.address
     address_list = [
-        entry["center_name"],  # corresponds to Loculus' "Institution" group field
+        entry.center_name,  # corresponds to Loculus' "Institution" group field
         address.city,
         address.state,
         address.country,
@@ -125,7 +131,7 @@ def get_address(config: Config, entry: dict[str, Any]) -> str | None:
 
 
 def get_assembly_values_in_metadata(config: Config, metadata: dict[str, str]) -> dict[str, str]:
-    assembly_values = {}
+    assembly_values: dict[str, str] = {}
     for key in config.manifest_fields_mapping:
         default = config.manifest_fields_mapping[key].get("default")
         loculus_fields = config.manifest_fields_mapping[key]["loculus_fields"]
@@ -141,23 +147,23 @@ def get_assembly_values_in_metadata(config: Config, metadata: dict[str, str]) ->
             try:
                 value = str(int(metadata.get(loculus_fields[0])))  # type: ignore
             except TypeError:
-                value = default  # type: ignore
+                value = default
         else:
-            values = [
+            values: list[str] = [
                 metadata.get(loculus_field)
                 for loculus_field in loculus_fields
                 if metadata.get(loculus_field)
-            ]
-            value = default or None if not values else ", ".join(values)  # type: ignore
+            ]  # type: ignore
+            value = default or None if not values else ", ".join(values)
         if function == "reformat_authors":
             value = get_authors(str(value))
         if not config.is_broker and key == "authors":
             continue
-        assembly_values[key] = value
+        assembly_values[key] = value  # type: ignore
     return assembly_values
 
 
-def make_assembly_name(accession: str, version: str, test: bool = False) -> str:
+def make_assembly_name(accession: str, version: int, test: bool = False) -> str:
     """
     Create a unique assembly name based on accession and version.
     If test=True, add a timestamp to the alias suffix to allow for multiple submissions of the same
@@ -176,7 +182,7 @@ def create_manifest_object(
     config: Config,
     sample_accession: str,
     study_accession: str,
-    submission_table_entry: dict[str, Any],
+    submission_table_entry: SubmissionTableEntry,
     test=False,
     dir: str | None = None,
 ) -> AssemblyManifest:
@@ -191,19 +197,19 @@ def create_manifest_object(
     If test=True add a timestamp to the alias suffix to allow for multiple submissions of the same
     manifest for testing.
     """
-    metadata = submission_table_entry["metadata"]
+    metadata = submission_table_entry.metadata
 
     assembly_name = make_assembly_name(
-        submission_table_entry["accession"],
-        submission_table_entry["version"],
+        submission_table_entry.accession,
+        submission_table_entry.version,
         test=test,
     )
 
-    unaligned_nucleotide_sequences = submission_table_entry["unaligned_nucleotide_sequences"]
-    organism_metadata = config.organisms[submission_table_entry["organism"]]["enaDeposition"]
+    unaligned_nucleotide_sequences = submission_table_entry.unaligned_nucleotide_sequences
+    organism_metadata = config.organisms[submission_table_entry.organism]["enaDeposition"]
     chromosome_list_object = create_chromosome_list_object(
         unaligned_nucleotide_sequences,
-        AccessionVersion(submission_table_entry["accession"], submission_table_entry["version"]),
+        submission_table_entry._get_primary_key(),
         organism_metadata,
     )
     chromosome_list_file = create_chromosome_list(list_object=chromosome_list_object, dir=dir)
@@ -230,9 +236,7 @@ def create_manifest_object(
     except Exception as e:
         # log traceback for better debugging
         logger.error(f"Error creating AssemblyManifest: {e}. Traceback: {traceback.format_exc()}")
-        msg = (
-            f"Failed to create AssemblyManifest for accession {submission_table_entry['accession']}"
-        )
+        msg = f"Failed to create AssemblyManifest for accession {submission_table_entry.accession}"
         raise RuntimeError(msg) from e
 
     return manifest
@@ -246,35 +250,32 @@ def submission_table_start(db_config: SimpleConnectionPool) -> None:
     b.      Else update state to SUBMITTING_ASSEMBLY
     3. Else create corresponding entry in assembly_table
     """
-    conditions = {"status_all": StatusAll.SUBMITTED_SAMPLE}
-    ready_to_submit = find_conditions_in_db(
-        db_config, table_name=TableName.SUBMISSION_TABLE, conditions=conditions
+    ready_to_submit = find_conditions_in_submission_db(
+        db_config, conditions={"status_all": StatusAll.SUBMITTED_SAMPLE}
     )
     if len(ready_to_submit) > 0:
         logger.debug(
             f"Found {len(ready_to_submit)} entries in submission_table in status SUBMITTED_SAMPLE"
         )
     for row in ready_to_submit:
-        seq_key = {"accession": row["accession"], "version": row["version"]}
-
         # 1. check if there exists an entry in the assembly_table for seq_key
-        corresponding_assembly = find_conditions_in_db(
-            db_config, table_name=TableName.ASSEMBLY_TABLE, conditions=seq_key
-        )
+        seq_key = row._get_primary_key()
+        corresponding_assembly = find_conditions_in_assembly_db(db_config, conditions=seq_key)
         status_all = None
         if len(corresponding_assembly) == 1:
-            if corresponding_assembly[0]["status"] == str(Status.SUBMITTED):
+            if corresponding_assembly[0].status == Status.SUBMITTED:
                 status_all = StatusAll.SUBMITTED_ALL
             else:
                 status_all = StatusAll.SUBMITTING_ASSEMBLY
         else:
             # If not: create assembly_entry, change status to SUBMITTING_ASSEMBLY
-            if not add_to_assembly_table(db_config, AssemblyTableEntry(**seq_key)):
+            if not add_to_assembly_table(
+                db_config, AssemblyTableEntry(accession=row.accession, version=row.version)
+            ):
                 continue
             status_all = StatusAll.SUBMITTING_ASSEMBLY
-        update_db_where_conditions(
+        update_submission_db_where_conditions(
             db_config,
-            table_name=TableName.SUBMISSION_TABLE,
             conditions=seq_key,
             update_values={"status_all": status_all},
         )
@@ -287,9 +288,8 @@ def submission_table_update(db_config: SimpleConnectionPool) -> None:
     a.      If (in state SUBMITTED) update state in submission_table to SUBMITTED_ALL
     3. Else throw Error
     """
-    conditions = {"status_all": StatusAll.SUBMITTING_ASSEMBLY}
-    submitting_assembly = find_conditions_in_db(
-        db_config, table_name=TableName.SUBMISSION_TABLE, conditions=conditions
+    submitting_assembly = find_conditions_in_submission_db(
+        db_config, conditions={"status_all": StatusAll.SUBMITTING_ASSEMBLY}
     )
     if len(submitting_assembly) > 0:
         logger.debug(
@@ -297,20 +297,16 @@ def submission_table_update(db_config: SimpleConnectionPool) -> None:
             f"in status SUBMITTING_ASSEMBLY"
         )
     for row in submitting_assembly:
-        seq_key = {"accession": row["accession"], "version": row["version"]}
-
-        corresponding_assembly = find_conditions_in_db(
-            db_config, table_name=TableName.ASSEMBLY_TABLE, conditions=seq_key
-        )
-        if len(corresponding_assembly) == 1 and corresponding_assembly[0]["status"] == str(
-            Status.SUBMITTED
+        seq_key = row._get_primary_key()
+        corresponding_assembly = find_conditions_in_assembly_db(db_config, conditions=seq_key)
+        if (
+            len(corresponding_assembly) == 1
+            and corresponding_assembly[0].status == Status.SUBMITTED
         ):
-            update_values = {"status_all": StatusAll.SUBMITTED_ALL}
-            update_db_where_conditions(
+            update_submission_db_where_conditions(
                 db_config,
-                table_name=TableName.SUBMISSION_TABLE,
                 conditions=seq_key,
-                update_values=update_values,
+                update_values={"status_all": StatusAll.SUBMITTED_ALL},
             )
         if len(corresponding_assembly) == 0:
             error_msg = (
@@ -327,22 +323,24 @@ def update_assembly_error(
     update_type: Literal["revision"] | Literal["creation"],
 ) -> None:
     logger.error(
-        f"Assembly {update_type} failed for accession {seq_key.accession} "
-        f"version {seq_key.version}. Propagating to db. Error: {error}"
+        f"Assembly {update_type} failed for accession {seq_key['accession']} "
+        f"version {seq_key['version']}. Propagating to db. Error: {error}"
     )
-    update_with_retry(
+    errors = error if isinstance(error, list) else [error]
+    update_assembly_with_retry(
         db_config=db_config,
-        conditions=seq_key.to_dict(),
+        conditions=seq_key,
         update_values={
             "status": Status.HAS_ERRORS,
-            "errors": json.dumps(error),
+            "errors": errors,
             "started_at": datetime.now(tz=pytz.utc),
         },
-        table_name=TableName.ASSEMBLY_TABLE,
     )
 
 
-def can_be_revised(config: Config, db_config: SimpleConnectionPool, entry: dict[str, Any]) -> bool:
+def can_be_revised(
+    config: Config, db_config: SimpleConnectionPool, entry: SubmissionTableEntry
+) -> bool:
     """
     Check if assembly can be revised
     1. Check if last version exists in submission_table -> internal error
@@ -351,14 +349,16 @@ def can_be_revised(config: Config, db_config: SimpleConnectionPool, entry: dict[
     3. Check if metadata fields in manifest have changed since previous version ->
        requires manual revision
     """
-    seq_key = AccessionVersion(entry["accession"], entry["version"])
+    seq_key = entry._get_primary_key()
     if not is_revision(db_config, seq_key):
         return False
     version_to_revise = last_version(db_config, seq_key)
-    last_version_data = find_conditions_in_db(
+    if not version_to_revise:
+        error_msg = f"Could not determine last version to revise for {seq_key}"
+        raise RuntimeError(error_msg)
+    last_version_data = find_conditions_in_submission_db(
         db_config,
-        table_name=TableName.SUBMISSION_TABLE,
-        conditions={"accession": entry["accession"], "version": version_to_revise},
+        conditions={"accession": entry.accession, "version": version_to_revise},
     )
     if len(last_version_data) == 0:
         error_msg = f"Last version {version_to_revise} not found in submission_table"
@@ -371,8 +371,8 @@ def can_be_revised(config: Config, db_config: SimpleConnectionPool, entry: dict[
         f"Previous sample accession: {previous_sample_accession}, "
         f"previous study accession: {previous_study_accession}"
     )
-    if entry["metadata"].get("biosampleAccession"):
-        new_sample_accession = entry["metadata"]["biosampleAccession"]
+    if entry.metadata.get("biosampleAccession"):
+        new_sample_accession = entry.metadata["biosampleAccession"]
         if previous_sample_accession != new_sample_accession:
             error = (
                 "Assembly cannot be revised because biosampleAccession in new version: "
@@ -381,8 +381,8 @@ def can_be_revised(config: Config, db_config: SimpleConnectionPool, entry: dict[
             logger.error(error)
             update_assembly_error(db_config, error, seq_key=seq_key, update_type="revision")
             return False
-    if entry["metadata"].get("bioprojectAccession"):
-        new_project_accession = entry["metadata"]["bioprojectAccession"]
+    if entry.metadata.get("bioprojectAccession"):
+        new_project_accession = entry.metadata["bioprojectAccession"]
         if new_project_accession != previous_study_accession:
             error = (
                 "Assembly cannot be revised because bioprojectAccession in new version: "
@@ -395,8 +395,8 @@ def can_be_revised(config: Config, db_config: SimpleConnectionPool, entry: dict[
     differing_fields = []
     for value in config.manifest_fields_mapping.values():
         for field in value.get("loculus_fields", []):
-            last_entry = last_version_data[0]["metadata"].get(field)
-            new_entry = entry["metadata"].get(field)
+            last_entry = last_version_data[0].metadata.get(field)
+            new_entry = entry.metadata.get(field)
             if last_entry != new_entry:
                 differing_fields.append(field)
     if differing_fields:
@@ -410,28 +410,27 @@ def can_be_revised(config: Config, db_config: SimpleConnectionPool, entry: dict[
     return True
 
 
-def is_flatfile_data_changed(db_config: SimpleConnectionPool, entry: dict[str, Any]) -> bool:
+def is_flatfile_data_changed(db_config: SimpleConnectionPool, entry: SubmissionTableEntry) -> bool:
     """
     Check if change in sequence or flatfile metadata has occurred since last version.
     """
-    seq_key = AccessionVersion(entry["accession"], entry["version"])
+    seq_key = entry._get_primary_key()
     version_to_revise = last_version(db_config, seq_key)
-    last_version_data = find_conditions_in_db(
+    if not version_to_revise:
+        error_msg = f"Could not determine last version to revise for {seq_key}"
+        raise RuntimeError(error_msg)
+    last_version_data = find_conditions_in_submission_db(
         db_config,
-        table_name=TableName.SUBMISSION_TABLE,
-        conditions={"accession": entry["accession"], "version": version_to_revise},
+        conditions={"accession": entry.accession, "version": version_to_revise},
     )
     if len(last_version_data) == 0:
         error_msg = f"Last version {version_to_revise} not found in submission_table"
         raise RuntimeError(error_msg)
 
-    if (
-        entry["unaligned_nucleotide_sequences"]
-        != last_version_data[0]["unaligned_nucleotide_sequences"]
-    ):
+    if entry.unaligned_nucleotide_sequences != last_version_data[0].unaligned_nucleotide_sequences:
         logger.debug(
-            f"Unaligned nucleotide sequences have changed for {entry['accession']}, "
-            f"from {version_to_revise} to {entry['version']} - should be revised"
+            f"Unaligned nucleotide sequences have changed for {seq_key['accession']}, "
+            f"from {version_to_revise} to {seq_key['version']} - should be revised"
             "(Metadata maybe also changed.)"
         )
         return True
@@ -443,28 +442,32 @@ def is_flatfile_data_changed(db_config: SimpleConnectionPool, entry: dict[str, A
         *DEFAULT_EMBL_PROPERTY_FIELDS.admin_level_properties,
     ]
     for field in fields:
-        last_entry = last_version_data[0]["metadata"].get(field)
-        new_entry = entry["metadata"].get(field)
+        last_entry = last_version_data[0].metadata.get(field)
+        new_entry = entry.metadata.get(field)
         if last_entry != new_entry:
             logger.debug(
                 f"Field {field} has changed from {last_entry} to {new_entry} "
-                f"for {entry['accession']}. (Maybe other fields changed as well)"
+                f"for {seq_key['accession']}. (Maybe other fields changed as well)"
             )
             return True
     logger.debug(
-        f"No changes detected for {entry['accession']} from version {version_to_revise} "
-        f"to {entry['version']}"
+        f"No changes detected for {seq_key['accession']} from version {version_to_revise} "
+        f"to {seq_key['version']}"
     )
     return False
 
 
-def update_assembly_results_with_latest_version(db_config: SimpleConnectionPool, seq_key: AccessionVersion):
+def update_assembly_results_with_latest_version(
+    db_config: SimpleConnectionPool, seq_key: AccessionVersion
+):
     version_to_revise = last_version(db_config, seq_key)
-    last_version_data = find_conditions_in_db(
+    if not version_to_revise:
+        error_msg = f"Could not determine last version to revise for {seq_key}"
+        raise RuntimeError(error_msg)
+    last_version_data = find_conditions_in_assembly_db(
         db_config,
-        table_name=TableName.ASSEMBLY_TABLE,
         conditions={
-            "accession": seq_key.accession,
+            "accession": seq_key["accession"],
             "version": version_to_revise,
         },
     )
@@ -472,44 +475,43 @@ def update_assembly_results_with_latest_version(db_config: SimpleConnectionPool,
         error_msg = f"Last version {version_to_revise} not found in assembly_table"
         raise RuntimeError(error_msg)
     logger.info(
-        f"Updating assembly results for accession {seq_key.accession} version "
-        f"{seq_key.version} using results from version {version_to_revise} as there was no"
+        f"Updating assembly results for accession {seq_key['accession']} version "
+        f"{seq_key['version']} using results from version {version_to_revise} as there was no"
         "change in flatfile data."
     )
-    update_with_retry(
+    update_assembly_with_retry(
         db_config=db_config,
-        conditions=seq_key.to_dict(),
+        conditions={"accession": seq_key["accession"], "version": seq_key["version"]},
         update_values={
             "status": Status.SUBMITTED,
-            "result": json.dumps(last_version_data[0]["result"]),
+            "result": last_version_data[0].result,
         },
-        table_name=TableName.ASSEMBLY_TABLE,
         reraise=False,
     )
 
 
 def get_project_and_sample_results(
-    db_config: SimpleConnectionPool, entry: dict[str, str]
+    db_config: SimpleConnectionPool, entry: SubmissionTableEntry
 ) -> tuple[str, str]:
-    seq_key = {"accession": entry["accession"], "version": entry["version"]}
-
-    results_in_sample_table = find_conditions_in_db(
-        db_config, table_name=TableName.SAMPLE_TABLE, conditions=seq_key
+    sample_accession, study_accession = "", ""
+    results_in_sample_table = find_conditions_in_sample_db(
+        db_config, conditions={"accession": entry.accession, "version": entry.version}
     )
     if len(results_in_sample_table) == 0:
-        error_msg = f"Entry {entry['accession']} not found in sample_table"
+        error_msg = f"Entry {entry.accession} not found in sample_table"
         raise RuntimeError(error_msg)
 
-    results_in_project_table = find_conditions_in_db(
+    results_in_project_table = find_conditions_in_project_db(
         db_config,
-        table_name=TableName.PROJECT_TABLE,
-        conditions={"project_id": entry["project_id"]},
+        conditions={"project_id": entry.project_id},
     )
     if len(results_in_project_table) == 0:
-        error_msg = f"Entry {entry['accession']} not found in project_table"
+        error_msg = f"Entry {entry.accession} not found in project_table"
         raise RuntimeError(error_msg)
-    sample_accession = results_in_sample_table[0]["result"]["ena_sample_accession"]
-    study_accession = results_in_project_table[0]["result"]["bioproject_accession"]
+    if results_in_sample_table[0].result:
+        sample_accession: str = results_in_sample_table[0].result["ena_sample_accession"]  # type: ignore
+    if results_in_project_table[0].result:
+        study_accession: str = results_in_project_table[0].result["bioproject_accession"]  # type: ignore
     return sample_accession, study_accession
 
 
@@ -524,30 +526,29 @@ def assembly_table_create(db_config: SimpleConnectionPool, config: Config, test:
     If test=True: add a timestamp to the alias suffix to allow for multiple submissions of the same
     manifest for testing AND use the test ENA webin-cli endpoint for submission.
     """
-    conditions = {"status": Status.READY}
-    ready_to_submit_assembly = find_conditions_in_db(
-        db_config, table_name=TableName.ASSEMBLY_TABLE, conditions=conditions
+    ready_to_submit_assembly = find_conditions_in_assembly_db(
+        db_config, conditions={"status": Status.READY}
     )
     if len(ready_to_submit_assembly) > 0:
         logger.debug(
             f"Found {len(ready_to_submit_assembly)} entries in assembly_table in status READY"
         )
     for row in ready_to_submit_assembly:
-        seq_key = AccessionVersion(row["accession"], row["version"])
-        sample_data_in_submission_table = find_conditions_in_db(
-            db_config, table_name=TableName.SUBMISSION_TABLE, conditions=seq_key.to_dict()
+        seq_key = row._get_primary_key()
+        sample_data_in_submission_table = find_conditions_in_submission_db(
+            db_config, conditions=seq_key
         )
         if len(sample_data_in_submission_table) == 0:
-            error_msg = f"Entry {row['accession']} not found in submitting_table"
+            error_msg = f"Entry {row.accession} not found in submitting_table"
             raise RuntimeError(error_msg)
-        center_name = sample_data_in_submission_table[0]["center_name"]
+        center_name = sample_data_in_submission_table[0].center_name
 
         sample_accession, study_accession = get_project_and_sample_results(
             db_config, sample_data_in_submission_table[0]
         )
 
         if is_revision(db_config, seq_key):
-            logger.debug(f"Entry {row['accession']} is a revision, checking if it can be revised")
+            logger.debug(f"Entry {row.accession} is a revision, checking if it can be revised")
             if not can_be_revised(config, db_config, sample_data_in_submission_table[0]):
                 continue
             if not is_flatfile_data_changed(db_config, sample_data_in_submission_table[0]):
@@ -564,17 +565,13 @@ def assembly_table_create(db_config: SimpleConnectionPool, config: Config, test:
             )
             manifest_file = create_manifest(manifest_object, is_broker=config.is_broker)
         except Exception as e:
-            logger.error(
-                f"Manifest creation failed for accession {row['accession']} with error {e}"
-            )
+            logger.error(f"Manifest creation failed for accession {row.accession} with error {e}")
             continue
 
-        update_values: dict[str, Any] = {"status": Status.SUBMITTING}
-        number_rows_updated = update_db_where_conditions(
+        number_rows_updated = update_assembly_db_where_conditions(
             db_config,
-            table_name=TableName.ASSEMBLY_TABLE,
-            conditions=seq_key.to_dict(),
-            update_values=update_values,
+            conditions=seq_key,
+            update_values={"status": Status.SUBMITTING},
         )
         if number_rows_updated != 1:
             # state not correctly updated - do not start submission
@@ -583,9 +580,9 @@ def assembly_table_create(db_config: SimpleConnectionPool, config: Config, test:
                 "not starting submission."
             )
             continue
-        logger.info(f"Starting assembly creation for accession {row['accession']}")
+        logger.info(f"Starting assembly creation for accession {row.accession}")
         segment_order = get_segment_order(
-            sample_data_in_submission_table[0]["unaligned_nucleotide_sequences"]
+            sample_data_in_submission_table[0].unaligned_nucleotide_sequences
         )
 
         # Actual webin-cli command is run here
@@ -597,18 +594,14 @@ def assembly_table_create(db_config: SimpleConnectionPool, config: Config, test:
         )
         if assembly_creation_results.result:
             assembly_creation_results.result["segment_order"] = segment_order
-            update_values = {
-                "status": Status.WAITING,
-                "result": json.dumps(assembly_creation_results.result),
-            }
-            logger.info(
-                f"Assembly creation succeeded for {seq_key.accession} version {seq_key.version}"
-            )
-            update_with_retry(
+            logger.info(f"Assembly creation succeeded for {row.accession} version {row.version}")
+            update_assembly_with_retry(
                 db_config=db_config,
-                conditions=seq_key.to_dict(),
-                update_values=update_values,
-                table_name=TableName.ASSEMBLY_TABLE,
+                conditions=seq_key,
+                update_values={
+                    "status": Status.WAITING,
+                    "result": assembly_creation_results.result,
+                },
             )
         else:
             update_assembly_error(
@@ -630,10 +623,7 @@ def assembly_table_update(db_config: SimpleConnectionPool, config: Config, time_
     3. If (exists): update state to SUBMITTED with results
     """
     global _last_ena_check  # noqa: PLW0603
-    conditions = {"status": Status.WAITING}
-    waiting = find_conditions_in_db(
-        db_config, table_name=TableName.ASSEMBLY_TABLE, conditions=conditions
-    )
+    waiting = find_conditions_in_assembly_db(db_config, conditions={"status": Status.WAITING})
     if len(waiting) > 0:
         logger.debug(f"Found {len(waiting)} entries in assembly_table in status WAITING")
     # Check if ENA has assigned an accession, don't do this too frequently
@@ -641,12 +631,19 @@ def assembly_table_update(db_config: SimpleConnectionPool, config: Config, time_
     if not _last_ena_check or time - timedelta(minutes=time_threshold) > _last_ena_check:
         logger.debug("Checking state in ENA")
         for row in waiting:
-            seq_key = {"accession": row["accession"], "version": row["version"]}
+            seq_key = row._get_primary_key()
             # Previous means from the last time the entry was checked, from db
-            previous_result = row["result"]
-            segment_order = previous_result["segment_order"]
+            previous_result = row.result
+            if not previous_result:
+                msg = (
+                    f"No previous result found in assembly_table for "
+                    f"{seq_key['accession']} version {seq_key['version']}"
+                )
+                raise RuntimeError(msg)
+            segment_order: Sequence[str] = previous_result["segment_order"]
+            erz_accession: str = previous_result.get("erz_accession")  # type: ignore
             new_result: CreationResult = get_ena_analysis_process(
-                config, previous_result["erz_accession"], segment_order
+                config, erz_accession, segment_order
             )
             _last_ena_check = time
 
@@ -672,15 +669,14 @@ def assembly_table_update(db_config: SimpleConnectionPool, config: Config, time_
                     f"Assembly accessioned by ENA for {seq_key['accession']} version "
                     f"{seq_key['version']}"
                 )
-            update_with_retry(
+            update_assembly_with_retry(
                 db_config=db_config,
                 conditions=seq_key,
                 update_values={
                     "status": status,
-                    "result": json.dumps(new_result.result),
+                    "result": new_result.result,
                     "finished_at": datetime.now(tz=pytz.utc),
                 },
-                table_name=TableName.ASSEMBLY_TABLE,
                 reraise=False,
             )
 
@@ -718,9 +714,7 @@ def assembly_table_handle_errors(
         # TODO: Query ENA to check if assembly has in fact been created
         # If created update assembly_table
         # If not retry 3 times, then raise for manual intervention
-    entries_waiting = find_waiting_in_db(
-        db_config, TableName.ASSEMBLY_TABLE, time_threshold=time_threshold_waiting
-    )
+    entries_waiting = find_waiting_in_assembly_db(db_config, time_threshold=time_threshold_waiting)
     if len(entries_waiting) > 0:
         error_msg = (
             f"{config.backend_url}: ENA Submission pipeline found "

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -332,7 +332,7 @@ def update_assembly_error(
     )
     update_with_retry(
         db_config=db_config,
-        conditions={"accession": seq_key.accession, "version": seq_key.version},
+        conditions=seq_key.to_dict(),
         update_values={
             "status": Status.HAS_ERRORS,
             "errors": json.dumps(error),

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import threading
 import time
@@ -14,8 +13,8 @@ from .config import Config
 from .ena_submission_helper import (
     CreationResult,
     create_ena_project,
+    ena_accession_exists,
     get_alias,
-    set_error_if_accession_not_exists,
 )
 from .ena_types import (
     OrganismType,
@@ -30,15 +29,21 @@ from .ena_types import (
 from .notifications import SlackConfig, send_slack_notification, slack_conn_init
 from .submission_db_helper import (
     ProjectTableEntry,
+    ProjectTableEntryDict,
     Status,
     StatusAll,
+    SubmissionTableEntry,
+    SubmissionTableEntryDict,
     TableName,
     add_to_project_table,
     db_init,
-    find_conditions_in_db,
+    find_conditions_in_project_db,
+    find_conditions_in_submission_db,
     find_errors_in_db,
-    update_db_where_conditions,
-    update_with_retry,
+    set_bioproject_error,
+    update_project_db_where_conditions,
+    update_project_with_retry,
+    update_submission_db_where_conditions,
 )
 
 logger = logging.getLogger(__name__)
@@ -47,7 +52,7 @@ logger = logging.getLogger(__name__)
 def construct_project_set_object(
     group_info: Group,
     config: Config,
-    entry: dict[str, str],
+    entry: ProjectTableEntry,
     test=False,
 ) -> ProjectSet:
     """
@@ -60,9 +65,9 @@ def construct_project_set_object(
     submissions of the same project for testing.
     (ENA blocks multiple submissions with the same alias)
     """
-    metadata_dict = config.organisms[entry["organism"]]["enaDeposition"]
+    metadata_dict = config.organisms[entry.organism]["enaDeposition"]
     alias = get_alias(
-        f"{entry['group_id']}:{entry['organism']}:{config.unique_project_suffix}",
+        f"{entry.group_id}:{entry.organism}:{config.unique_project_suffix}",
         test,
         config.set_alias_suffix,
     )
@@ -94,85 +99,75 @@ def construct_project_set_object(
             )
         ),
         project_links=ProjectLinks(
-            project_link=[ProjectLink(xref_link=XrefType(db=config.db_name, id=entry["group_id"]))]
+            project_link=[
+                ProjectLink(xref_link=XrefType(db=config.db_name, id=str(entry.group_id)))
+            ]
         ),
     )
     return ProjectSet(project=[project_type])
 
 
-def set_project_table_entry(db_config, config, row):
+def set_project_table_entry(
+    db_config: SimpleConnectionPool, config: Config, row: SubmissionTableEntry, bioproject: str
+):
     """Set bioprojectAccession for entry with custom bioprojectAccession"""
-    logger.debug(f"Accession {row['accession']} already has bioprojectAccession in metadata")
-    group_key = {"group_id": row["group_id"], "organism": row["organism"]}
-    seq_key = {"accession": row["accession"], "version": row["version"]}
-    bioproject = row["metadata"]["bioprojectAccession"]
+    logger.debug(f"Accession {row.accession} already has bioprojectAccession in metadata")
+    seq_key = row._get_primary_key()
+    group_key = ProjectTableEntryDict(group_id=row.group_id, organism=row.organism)
 
-    corresponding_group = find_conditions_in_db(
-        db_config, table_name=TableName.PROJECT_TABLE, conditions=group_key
-    )
+    corresponding_group = find_conditions_in_project_db(db_config, conditions=group_key)
     corresponding_project = [
         project
         for project in corresponding_group
-        if project["result"].get("bioproject_accession") == bioproject
+        if project.result and project.result.get("bioproject_accession") == bioproject
     ]
     if len(corresponding_project) == 1:
         logger.debug(
             "bioprojectAccession is already in project_table - adding id to submission_table"
         )
-        update_values = {
-            "status_all": StatusAll.SUBMITTED_PROJECT,
-            "center_name": corresponding_project[0]["center_name"],
-            "project_id": corresponding_project[0]["project_id"],
-        }
-        update_db_where_conditions(
+        update_submission_db_where_conditions(
             db_config,
-            table_name=TableName.SUBMISSION_TABLE,
             conditions=seq_key,
-            update_values=update_values,
+            update_values={
+                "status_all": StatusAll.SUBMITTED_PROJECT,
+                "center_name": corresponding_project[0].center_name,
+                "project_id": corresponding_project[0].project_id,
+            },
         )
         return
 
     logger.info("Checking if bioproject actually exists and is public")
-    if (
-        set_error_if_accession_not_exists(
-            conditions=group_key,
-            accession=bioproject,
-            accession_type="BIOPROJECT",
-            db_pool=db_config,
-            config=config,
-        )
-        is False
-    ):
+    if not ena_accession_exists(bioproject, config):
+        error_text = f"Accession {bioproject} of type BIOPROJECT does not exist in ENA."
+        logger.error(error_text)
+        set_bioproject_error(db_config, group_key, error_text, bioproject)
         return
 
     logger.info("Adding bioprojectAccession to project_table")
     try:
-        group_details = call_loculus.get_group_info(config, row["group_id"])
+        group_details = call_loculus.get_group_info(config, row.group_id)
     except Exception as e:
-        logger.error(f"Was unable to get group info for group: {row['group_id']}, {e}")
+        logger.error(f"Was unable to get group info for group: {row.group_id}, {e}")
         return
     center_name = group_details.institution
-    entry = {
-        "group_id": row["group_id"],
-        "organism": row["organism"],
-        "result": {"bioproject_accession": bioproject},
-        "status": Status.SUBMITTED,
-        "center_name": center_name,
-    }
-    project_table_entry = ProjectTableEntry(**entry)
+    project_table_entry = ProjectTableEntry(
+        group_id=row.group_id,
+        organism=row.organism,
+        result={"bioproject_accession": bioproject},
+        status=Status.SUBMITTED,
+        center_name=center_name,
+    )
     succeeded = add_to_project_table(db_config, project_table_entry)
     if succeeded:
         logger.debug("Succeeding in adding bioprojectAccession to project_table")
-        update_values = {
-            "status_all": StatusAll.SUBMITTED_PROJECT,
-            "center_name": center_name,
-            "project_id": succeeded,
-        }
-        update_db_where_conditions(
+        update_submission_db_where_conditions(
             db_config,
-            table_name=TableName.SUBMISSION_TABLE,
             conditions=seq_key,
-            update_values=update_values,
+            update_values={
+                "status_all": StatusAll.SUBMITTED_PROJECT,
+                "center_name": center_name,
+                "project_id": succeeded,
+            },
         )
 
 
@@ -190,49 +185,47 @@ def submission_table_start(db_config: SimpleConnectionPool, config: Config):
     b.      Else update state to SUBMITTING_PROJECT
     4. Else create corresponding entry in project_table
     """
-    conditions = {"status_all": StatusAll.READY_TO_SUBMIT}
-    ready_to_submit = find_conditions_in_db(
-        db_config, table_name=TableName.SUBMISSION_TABLE, conditions=conditions
+    ready_to_submit = find_conditions_in_submission_db(
+        db_config, conditions={"status_all": StatusAll.READY_TO_SUBMIT}
     )
     logger.debug(
         f"Found {len(ready_to_submit)} entries in submission_table in status READY_TO_SUBMIT"
     )
     for row in ready_to_submit:
-        group_key = {"group_id": row["group_id"], "organism": row["organism"]}
-        seq_key = {"accession": row["accession"], "version": row["version"]}
+        seq_key = row._get_primary_key()
 
         # Use custom bioprojectAccession if it exists
-        if "bioprojectAccession" in row["metadata"] and row["metadata"]["bioprojectAccession"]:
-            set_project_table_entry(db_config, config, row)
+        bioproject_accession = row.metadata.get("bioprojectAccession") if row.metadata else None
+        if bioproject_accession:
+            set_project_table_entry(db_config, config, row, bioproject_accession)
             continue
 
         # Create a default project entry for (group_id, organism)
         # Check if there exists an entry in the project table for (group_id, organism)
-        corresponding_project = find_conditions_in_db(
-            db_config, table_name=TableName.PROJECT_TABLE, conditions=group_key
+        corresponding_project = find_conditions_in_project_db(
+            db_config, conditions={"group_id": row.group_id, "organism": row.organism}
         )
         if len(corresponding_project) == 1:
-            if corresponding_project[0]["status"] == str(Status.SUBMITTED):
-                update_values = {
-                    "status_all": StatusAll.SUBMITTED_PROJECT,
-                    "center_name": corresponding_project[0]["center_name"],
-                    "project_id": corresponding_project[0]["project_id"],
-                }
+            if corresponding_project[0].status == Status.SUBMITTED:
+                update_values = SubmissionTableEntryDict(
+                    status_all=StatusAll.SUBMITTED_PROJECT,
+                    center_name=corresponding_project[0].center_name,
+                    project_id=corresponding_project[0].project_id,
+                )
             else:
-                update_values = {"status_all": StatusAll.SUBMITTING_PROJECT}
+                update_values = SubmissionTableEntryDict(status_all=StatusAll.SUBMITTING_PROJECT)
         else:
             project_id = add_to_project_table(
-                db_config, ProjectTableEntry(group_id=row["group_id"], organism=row["organism"])
+                db_config, ProjectTableEntry(group_id=row.group_id, organism=row.organism)
             )
             if not project_id:
                 continue
-            update_values = {
-                "status_all": StatusAll.SUBMITTING_PROJECT,
-                "project_id": project_id,
-            }
-        update_db_where_conditions(
+            update_values = SubmissionTableEntryDict(
+                status_all=StatusAll.SUBMITTING_PROJECT,
+                project_id=project_id,
+            )
+        update_submission_db_where_conditions(
             db_config,
-            table_name=TableName.SUBMISSION_TABLE,
             conditions=seq_key,
             update_values=update_values,
         )
@@ -245,34 +238,28 @@ def submission_table_update(db_config: SimpleConnectionPool):
     a.      If (in state SUBMITTED) update state in submission_table to SUBMITTED_PROJECT
     3. Else throw Error
     """
-    conditions = {"status_all": StatusAll.SUBMITTING_PROJECT}
-    submitting_project = find_conditions_in_db(
-        db_config, table_name=TableName.SUBMISSION_TABLE, conditions=conditions
+    submitting_project = find_conditions_in_submission_db(
+        db_config, conditions={"status_all": StatusAll.SUBMITTING_PROJECT}
     )
     logger.debug(
         f"Found {len(submitting_project)} entries in submission_table in status SUBMITTING_PROJECT"
     )
     for row in submitting_project:
-        group_key = {"group_id": row["group_id"], "organism": row["organism"]}
-        seq_key = {"accession": row["accession"], "version": row["version"]}
-
         # 1. check if there exists an entry in the project table for (group_id, organism)
-        corresponding_project = find_conditions_in_db(
-            db_config, table_name=TableName.PROJECT_TABLE, conditions=group_key
+        corresponding_project = find_conditions_in_project_db(
+            db_config, conditions={"group_id": row.group_id, "organism": row.organism}
         )
-        if len(corresponding_project) == 1 and corresponding_project[0]["status"] == str(
+        if len(corresponding_project) == 1 and corresponding_project[0].status == str(
             Status.SUBMITTED
         ):
-            update_values = {
-                "status_all": StatusAll.SUBMITTED_PROJECT,
-                "center_name": corresponding_project[0]["center_name"],
-                "project_id": corresponding_project[0]["project_id"],
-            }
-            update_db_where_conditions(
+            update_submission_db_where_conditions(
                 db_config,
-                table_name=TableName.SUBMISSION_TABLE,
-                conditions=seq_key,
-                update_values=update_values,
+                conditions=row._get_primary_key(),
+                update_values={
+                    "status_all": StatusAll.SUBMITTED_PROJECT,
+                    "center_name": corresponding_project[0].center_name,
+                    "project_id": corresponding_project[0].project_id,
+                },
             )
         if len(corresponding_project) == 0:
             error_msg = (
@@ -298,31 +285,30 @@ def project_table_create(
     If test=True add a timestamp to the alias suffix to allow for multiple submissions of the same
     project for testing.
     """
-    conditions = {"status": Status.READY}
-    ready_to_submit_project = find_conditions_in_db(
-        db_config, table_name=TableName.PROJECT_TABLE, conditions=conditions
+    ready_to_submit_project = find_conditions_in_project_db(
+        db_config, conditions={"status": Status.READY}
     )
     logger.debug(f"Found {len(ready_to_submit_project)} entries in project_table in status READY")
     for row in ready_to_submit_project:
-        group_key = {"group_id": row["group_id"], "organism": row["organism"]}
-
+        group_key = ProjectTableEntryDict(
+            group_id=row.group_id,
+            organism=row.organism,
+        )
         try:
-            group_info = call_loculus.get_group_info(config, row["group_id"])
+            group_info = call_loculus.get_group_info(config, row.group_id)
         except Exception as e:
-            logger.error(f"Was unable to get group info for group: {row['group_id']}, {e}")
+            logger.error(f"Was unable to get group info for group: {group_key}, {e}")
             continue
 
         project_set = construct_project_set_object(group_info, config, row, test)
-        update_values = {
-            "status": Status.SUBMITTING,
-            "started_at": datetime.now(tz=pytz.utc),
-            "center_name": group_info.institution,
-        }
-        number_rows_updated = update_db_where_conditions(
+        number_rows_updated = update_project_db_where_conditions(
             db_config,
-            table_name=TableName.PROJECT_TABLE,
             conditions=group_key,
-            update_values=update_values,
+            update_values={
+                "status": Status.SUBMITTING,
+                "started_at": datetime.now(tz=pytz.utc),
+                "center_name": group_info.institution,
+            },
         )
         if number_rows_updated != 1:
             # state not correctly updated - do not start submission
@@ -334,34 +320,32 @@ def project_table_create(
             )
             continue
         logger.info(
-            f"Starting Project creation for group_id {row['group_id']} organism {row['organism']}"
+            f"Starting Project creation for group_id {row.group_id} organism {row.organism}"
         )
         # Actual HTTP request to ENA happens here
         project_creation_results: CreationResult = create_ena_project(config, project_set)
         if project_creation_results.result:
-            update_values = {
-                "status": Status.SUBMITTED,
-                "result": json.dumps(project_creation_results.result),
-                "finished_at": datetime.now(tz=pytz.utc),
-            }
+            update_values = ProjectTableEntryDict(
+                status=Status.SUBMITTED,
+                result=project_creation_results.result,
+                finished_at=datetime.now(tz=pytz.utc),
+            )
             logger.info(
-                f"Project creation succeeded for group_id {row['group_id']} "
-                f"organism {row['organism']}"
+                f"Project creation succeeded for group_id {row.group_id} organism {row.organism}"
             )
         else:
-            update_values = {
-                "status": Status.HAS_ERRORS,
-                "errors": json.dumps(project_creation_results.errors),
-                "started_at": datetime.now(tz=pytz.utc),
-            }
-            logger.error(
-                f"Project creation failed for group_id {row['group_id']} organism {row['organism']}"
+            update_values = ProjectTableEntryDict(
+                status=Status.HAS_ERRORS,
+                errors=project_creation_results.errors,
+                started_at=datetime.now(tz=pytz.utc),
             )
-        update_with_retry(
+            logger.error(
+                f"Project creation failed for group_id {row.group_id} organism {row.organism}"
+            )
+        update_project_with_retry(
             db_config=db_config,
             conditions=group_key,
             update_values=update_values,
-            table_name=TableName.PROJECT_TABLE,
         )
 
 

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -295,7 +295,7 @@ def submission_table_update(db_config: SimpleConnectionPool):
             raise RuntimeError(error_msg)
 
 
-def is_old_version(db_config: SimpleConnectionPool, seq_key: dict[str, str]):
+def is_old_version(db_config: SimpleConnectionPool, seq_key: dict[str, Any]):
     """Check if entry is incorrectly added older version - error and do not submit"""
     version = int(seq_key["version"])
     accession = {"accession": seq_key["accession"]}

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -30,8 +30,8 @@ from .ena_types import (
 )
 from .notifications import SlackConfig, send_slack_notification, slack_conn_init
 from .submission_db_helper import (
+    AccessionVersion,
     SampleTableEntry,
-    SeqKey,
     Status,
     StatusAll,
     TableName,
@@ -296,7 +296,7 @@ def submission_table_update(db_config: SimpleConnectionPool):
             raise RuntimeError(error_msg)
 
 
-def is_old_version(db_config: SimpleConnectionPool, seq_key: SeqKey) -> bool:
+def is_old_version(db_config: SimpleConnectionPool, seq_key: AccessionVersion) -> bool:
     """Check if entry is incorrectly added older version - error and do not submit"""
     version = int(seq_key.version)
     accession = {"accession": seq_key.accession}
@@ -344,7 +344,7 @@ def sample_table_create(db_config: SimpleConnectionPool, config: Config, test: b
     )
     logger.debug(f"Found {len(ready_to_submit_sample)} entries in sample_table in status READY")
     for row in ready_to_submit_sample:
-        seq_key = SeqKey(row["accession"], row["version"])
+        seq_key = AccessionVersion(row["accession"], row["version"])
         if is_old_version(db_config, seq_key):
             logger.warning(f"Skipping submission for {seq_key} as it is not the latest version.")
             continue

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import re
 import threading
@@ -14,8 +13,8 @@ from .config import Config
 from .ena_submission_helper import (
     CreationResult,
     create_ena_sample,
+    ena_accession_exists,
     get_alias,
-    set_error_if_accession_not_exists,
 )
 from .ena_types import (
     ProjectLink,
@@ -32,16 +31,21 @@ from .notifications import SlackConfig, send_slack_notification, slack_conn_init
 from .submission_db_helper import (
     AccessionVersion,
     SampleTableEntry,
+    SampleTableEntryDict,
     Status,
     StatusAll,
+    SubmissionTableEntry,
     TableName,
     add_to_sample_table,
     db_init,
-    find_conditions_in_db,
+    find_conditions_in_sample_db,
+    find_conditions_in_submission_db,
     find_errors_in_db,
     is_revision,
-    update_db_where_conditions,
-    update_with_retry,
+    set_biosample_error,
+    update_sample_db_where_conditions,
+    update_sample_with_retry,
+    update_submission_db_where_conditions,
 )
 
 logger = logging.getLogger(__name__)
@@ -119,8 +123,8 @@ def get_sample_attributes(
 
 def construct_sample_set_object(
     config: Config,
-    sample_data_in_submission_table: dict[str, str | dict[str, str]],
-    entry: dict[str, str],
+    sample_data_in_submission_table: SubmissionTableEntry,
+    accession_version: AccessionVersion,
     test: bool = False,
 ):
     """
@@ -132,12 +136,12 @@ def construct_sample_set_object(
     submissions of the same project for testing.
     (ENA blocks multiple submissions with the same alias)
     """
-    sample_metadata: dict[str, str] = sample_data_in_submission_table["metadata"]  # type: ignore
-    center_name = sample_data_in_submission_table["center_name"]
-    organism: str = sample_data_in_submission_table["organism"]  # type: ignore
+    sample_metadata: dict[str, str] = sample_data_in_submission_table.metadata
+    center_name = sample_data_in_submission_table.center_name
+    organism: str = sample_data_in_submission_table.organism
     organism_metadata = config.organisms[organism]["enaDeposition"]
     alias = get_alias(
-        f"{entry['accession']}:{organism}:{config.unique_project_suffix}",
+        f"{accession_version['accession']}:{organism}:{config.unique_project_suffix}",
         test,
         config.set_alias_suffix,
     )
@@ -162,52 +166,48 @@ def construct_sample_set_object(
             scientific_name=organism_metadata["scientific_name"],
         ),
         sample_links=SampleLinks(
-            sample_link=[ProjectLink(xref_link=XrefType(db=config.db_name, id=entry["accession"]))]
+            sample_link=[
+                ProjectLink(
+                    xref_link=XrefType(db=config.db_name, id=accession_version["accession"])
+                )
+            ]
         ),
         sample_attributes=SampleAttributes(sample_attribute=sample_attributes),
     )
     return SampleSetType(sample=[sample_type])
 
 
-def set_sample_table_entry(db_config, row, seq_key, config: Config):
+def set_sample_table_entry(
+    db_config: SimpleConnectionPool, row: SubmissionTableEntry, config: Config, biosample: str
+):
     """Set sample_table entry for entry with biosampleAccession"""
     logger.debug(
-        f"Accession: {row['accession']} already has biosampleAccession, adding to sample_table"
+        f"Accession: {row.accession} already has biosampleAccession, adding to sample_table"
     )
-    biosample = row["metadata"]["biosampleAccession"]
 
     logger.info("Checking if biosample actually exists and is public")
-    seq_key = {"accession": row["accession"], "version": row["version"]}
-    if (
-        set_error_if_accession_not_exists(
-            conditions=seq_key,
-            accession=biosample,
-            accession_type="BIOSAMPLE",
-            db_pool=db_config,
-            config=config,
-        )
-        is False
-    ):
+    seq_key = row._get_primary_key()
+    if not ena_accession_exists(biosample, config):
+        error_text = f"Accession {biosample} of type BIOSAMPLE does not exist in ENA."
+        logger.error(error_text)
+        set_biosample_error(db_config, seq_key, error_text, biosample)
         return
 
-    entry = {
-        "accession": row["accession"],
-        "version": row["version"],
-        "result": {"ena_sample_accession": biosample, "biosample_accession": biosample},
-        "status": Status.SUBMITTED,
-    }
-    sample_table_entry = SampleTableEntry(**entry)
+    sample_table_entry = SampleTableEntry(
+        accession=row.accession,
+        version=row.version,
+        result={"ena_sample_accession": biosample, "biosample_accession": biosample},
+        status=Status.SUBMITTED,
+    )
     succeeded = add_to_sample_table(db_config, sample_table_entry)
     if succeeded:
         logger.debug("Succeeding in adding biosampleAccession to sample_table")
-        update_values = {
-            "status_all": StatusAll.SUBMITTED_SAMPLE,
-        }
-        update_db_where_conditions(
+        update_submission_db_where_conditions(
             db_config,
-            table_name=TableName.SUBMISSION_TABLE,
             conditions=seq_key,
-            update_values=update_values,
+            update_values={
+                "status_all": StatusAll.SUBMITTED_SAMPLE,
+            },
         )
 
 
@@ -222,36 +222,33 @@ def submission_table_start(db_config: SimpleConnectionPool, config: Config):
     4. Else create corresponding entry in sample_table
     """
     # Check submission_table for newly added sequences
-    conditions = {"status_all": StatusAll.SUBMITTED_PROJECT}
-    ready_to_submit = find_conditions_in_db(
-        db_config, table_name=TableName.SUBMISSION_TABLE, conditions=conditions
+    ready_to_submit = find_conditions_in_submission_db(
+        db_config, conditions={"status_all": StatusAll.SUBMITTED_PROJECT}
     )
     logger.debug(
         f"Found {len(ready_to_submit)} entries in submission_table in status SUBMITTED_PROJECT"
     )
     for row in ready_to_submit:
-        seq_key = {"accession": row["accession"], "version": row["version"]}
+        seq_key = row._get_primary_key()
 
         # 1. check if there exists an entry in the sample table for seq_key
-        corresponding_sample = find_conditions_in_db(
-            db_config, table_name=TableName.SAMPLE_TABLE, conditions=seq_key
-        )
+        corresponding_sample = find_conditions_in_sample_db(db_config, conditions=seq_key)
         if len(corresponding_sample) == 1:
-            if corresponding_sample[0]["status"] == str(Status.SUBMITTED):
+            if corresponding_sample[0].status == Status.SUBMITTED:
                 status_all = StatusAll.SUBMITTED_SAMPLE
             else:
                 status_all = StatusAll.SUBMITTING_SAMPLE
         else:
             # If not: create sample_entry, change status to SUBMITTING_SAMPLE
-            if "biosampleAccession" in row["metadata"] and row["metadata"]["biosampleAccession"]:
-                set_sample_table_entry(db_config, row, seq_key, config)
+            biosample_accession = row.metadata.get("biosampleAccession") if row.metadata else None
+            if biosample_accession:
+                set_sample_table_entry(db_config, row, config, biosample_accession)
                 continue
             if not add_to_sample_table(db_config, SampleTableEntry(**seq_key)):
                 continue
             status_all = StatusAll.SUBMITTING_SAMPLE
-        update_db_where_conditions(
+        update_submission_db_where_conditions(
             db_config,
-            table_name=TableName.SUBMISSION_TABLE,
             conditions=seq_key,
             update_values={"status_all": status_all},
         )
@@ -264,29 +261,22 @@ def submission_table_update(db_config: SimpleConnectionPool):
     a.      If (in state SUBMITTED) update state in submission_table to SUBMITTED_SAMPLE
     3. Else throw Error
     """
-    conditions = {"status_all": StatusAll.SUBMITTING_SAMPLE}
-    submitting_sample = find_conditions_in_db(
-        db_config, table_name=TableName.SUBMISSION_TABLE, conditions=conditions
+    submitting_sample = find_conditions_in_submission_db(
+        db_config, conditions={"status_all": StatusAll.SUBMITTING_SAMPLE}
     )
     logger.debug(
         f"Found {len(submitting_sample)} entries in submission_table in status SUBMITTING_SAMPLE"
     )
     for row in submitting_sample:
-        seq_key = {"accession": row["accession"], "version": row["version"]}
+        seq_key = row._get_primary_key()
 
         # 1. check if there exists an entry in the sample table for seq_key
-        corresponding_sample = find_conditions_in_db(
-            db_config, table_name=TableName.SAMPLE_TABLE, conditions=seq_key
-        )
-        if len(corresponding_sample) == 1 and corresponding_sample[0]["status"] == str(
-            Status.SUBMITTED
-        ):
-            update_values = {"status_all": StatusAll.SUBMITTED_SAMPLE}
-            update_db_where_conditions(
+        corresponding_sample = find_conditions_in_sample_db(db_config, conditions=seq_key)
+        if len(corresponding_sample) == 1 and corresponding_sample[0].status == Status.SUBMITTED:
+            update_submission_db_where_conditions(
                 db_config,
-                table_name=TableName.SUBMISSION_TABLE,
                 conditions=seq_key,
-                update_values=update_values,
+                update_values={"status_all": StatusAll.SUBMITTED_SAMPLE},
             )
         if len(corresponding_sample) == 0:
             error_msg = (
@@ -298,28 +288,25 @@ def submission_table_update(db_config: SimpleConnectionPool):
 
 def is_old_version(db_config: SimpleConnectionPool, seq_key: AccessionVersion) -> bool:
     """Check if entry is incorrectly added older version - error and do not submit"""
-    version = int(seq_key.version)
-    accession = {"accession": seq_key.accession}
-    sample_data_in_submission_table = find_conditions_in_db(
-        db_config, table_name=TableName.SUBMISSION_TABLE, conditions=accession
+    version = seq_key["version"]
+    sample_data_in_submission_table = find_conditions_in_submission_db(
+        db_config, conditions={"accession": seq_key["accession"]}
     )
-    all_versions = sorted([int(entry["version"]) for entry in sample_data_in_submission_table])
+    all_versions = sorted([int(entry.version) for entry in sample_data_in_submission_table])
 
     if version < all_versions[-1]:
-        update_values = {
-            "status": Status.HAS_ERRORS,
-            "errors": json.dumps(["Revision version is not the latest version"]),
-            "started_at": datetime.now(tz=pytz.utc),
-        }
         logger.error(
-            f"Sample creation failed for {seq_key.accession} version {version} "
+            f"Sample creation failed for {seq_key['accession']} version {version} "
             "as it is not the latest version."
         )
-        update_with_retry(
+        update_sample_with_retry(
             db_config=db_config,
-            conditions=seq_key.to_dict(),
-            update_values=update_values,
-            table_name=TableName.SAMPLE_TABLE,
+            conditions=seq_key,
+            update_values={
+                "status": Status.HAS_ERRORS,
+                "errors": ["Revision version is not the latest version"],
+                "started_at": datetime.now(tz=pytz.utc),
+            },
             reraise=False,
         )
         return True
@@ -338,33 +325,31 @@ def sample_table_create(db_config: SimpleConnectionPool, config: Config, test: b
     If test=True add a timestamp to the alias suffix to allow for multiple submissions of the same
     sample for testing.
     """
-    conditions = {"status": Status.READY}
-    ready_to_submit_sample = find_conditions_in_db(
-        db_config, table_name=TableName.SAMPLE_TABLE, conditions=conditions
+    ready_to_submit_sample = find_conditions_in_sample_db(
+        db_config, conditions={"status": Status.READY}
     )
     logger.debug(f"Found {len(ready_to_submit_sample)} entries in sample_table in status READY")
     for row in ready_to_submit_sample:
-        seq_key = AccessionVersion(row["accession"], row["version"])
+        seq_key = row._get_primary_key()
         if is_old_version(db_config, seq_key):
             logger.warning(f"Skipping submission for {seq_key} as it is not the latest version.")
             continue
 
         logger.info(f"Processing sample_table entry for {seq_key}")
-        sample_data_in_submission_table = find_conditions_in_db(
-            db_config, table_name=TableName.SUBMISSION_TABLE, conditions=seq_key.to_dict()
+        sample_data_in_submission_table = find_conditions_in_submission_db(
+            db_config, conditions=seq_key
         )
 
         sample_set = construct_sample_set_object(
-            config, sample_data_in_submission_table[0], row, test
+            config, sample_data_in_submission_table[0], seq_key, test
         )
-        update_values = {
-            "status": Status.SUBMITTING,
-            "started_at": datetime.now(tz=pytz.utc),
-        }
-        number_rows_updated = update_db_where_conditions(
+        update_values = SampleTableEntryDict(
+            status=Status.SUBMITTING,
+            started_at=datetime.now(tz=pytz.utc),
+        )
+        number_rows_updated = update_sample_db_where_conditions(
             db_config,
-            table_name=TableName.SAMPLE_TABLE,
-            conditions=seq_key.to_dict(),
+            conditions=seq_key,
             update_values=update_values,
         )
         if number_rows_updated != 1:
@@ -374,33 +359,32 @@ def sample_table_create(db_config: SimpleConnectionPool, config: Config, test: b
                 "- not starting submission."
             )
             continue
-        logger.info(f"Starting sample creation for accession {row['accession']}")
+        logger.info(f"Starting sample creation for accession {row.accession}")
         sample_creation_results: CreationResult = create_ena_sample(
             config, sample_set, revision=is_revision(db_config, seq_key)
         )
         if sample_creation_results.result:
-            update_values = {
-                "status": Status.SUBMITTED,
-                "result": json.dumps(sample_creation_results.result),
-                "finished_at": datetime.now(tz=pytz.utc),
-            }
+            update_values = SampleTableEntryDict(
+                status=Status.SUBMITTED,
+                result=sample_creation_results.result,
+                finished_at=datetime.now(tz=pytz.utc),
+            )
             logger.info(
-                f"Sample creation succeeded for {seq_key.accession} version {seq_key.version}"
+                f"Sample creation succeeded for {seq_key['accession']} version {seq_key['version']}"
             )
         else:
-            update_values = {
-                "status": Status.HAS_ERRORS,
-                "errors": json.dumps(sample_creation_results.errors),
-                "started_at": datetime.now(tz=pytz.utc),
-            }
-            logger.error(
-                f"Sample creation failed for {seq_key.accession} version {seq_key.version}"
+            update_values = SampleTableEntryDict(
+                status=Status.HAS_ERRORS,
+                errors=sample_creation_results.errors,
+                started_at=datetime.now(tz=pytz.utc),
             )
-        update_with_retry(
+            logger.error(
+                f"Sample creation failed for {seq_key['accession']} version {seq_key['version']}"
+            )
+        update_sample_with_retry(
             db_config=db_config,
-            conditions=seq_key.to_dict(),
+            conditions=seq_key,
             update_values=update_values,
-            table_name=TableName.SAMPLE_TABLE,
         )
 
 

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -124,13 +124,13 @@ def validate_column_name(table_name: str, column_name: str):
         raise ValueError(msg)
 
 
-@dataclass
-class SeqKey:
+@dataclass(frozen=True)  # Immutable so that it is hashable
+class AccessionVersion:
     accession: str
     version: int
 
     def to_dict(self) -> dict:
-        """Convert SeqKey instance to a dictionary."""
+        """Convert AccessionVersion instance to a dictionary."""
         return {"accession": self.accession, "version": self.version}
 
 
@@ -199,7 +199,6 @@ class AssemblyTableEntry:
 
 
 type Accession = str
-type AccessionVersion = str
 type Version = int
 
 
@@ -657,7 +656,7 @@ def add_to_submission_table(
         db_conn_pool.putconn(con)
 
 
-def is_revision(db_config: SimpleConnectionPool, seq_key: SeqKey) -> bool:
+def is_revision(db_config: SimpleConnectionPool, seq_key: AccessionVersion) -> bool:
     """Check if the entry is a revision"""
     version = seq_key.version
     if version == 1:
@@ -670,7 +669,7 @@ def is_revision(db_config: SimpleConnectionPool, seq_key: SeqKey) -> bool:
     return len(all_versions) > 1 and version == all_versions[-1]
 
 
-def last_version(db_config: SimpleConnectionPool, seq_key: SeqKey) -> int | None:
+def last_version(db_config: SimpleConnectionPool, seq_key: AccessionVersion) -> int | None:
     if not is_revision(db_config, seq_key):
         return None
     accession = {"accession": seq_key.accession}

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -125,6 +125,16 @@ def validate_column_name(table_name: str, column_name: str):
 
 
 @dataclass
+class SeqKey:
+    accession: str
+    version: int
+
+    def to_dict(self) -> dict:
+        """Convert SeqKey instance to a dictionary."""
+        return {"accession": self.accession, "version": self.version}
+
+
+@dataclass
 class SubmissionTableEntry:
     accession: str
     version: str
@@ -647,12 +657,12 @@ def add_to_submission_table(
         db_conn_pool.putconn(con)
 
 
-def is_revision(db_config: SimpleConnectionPool, seq_key: dict[str, Any]):
+def is_revision(db_config: SimpleConnectionPool, seq_key: SeqKey) -> bool:
     """Check if the entry is a revision"""
-    version = int(seq_key["version"])
+    version = seq_key.version
     if version == 1:
         return False
-    accession = {"accession": seq_key["accession"]}
+    accession = {"accession": seq_key.accession}
     sample_data_in_submission_table = find_conditions_in_db(
         db_config, table_name=TableName.SUBMISSION_TABLE, conditions=accession
     )
@@ -660,10 +670,10 @@ def is_revision(db_config: SimpleConnectionPool, seq_key: dict[str, Any]):
     return len(all_versions) > 1 and version == all_versions[-1]
 
 
-def last_version(db_config: SimpleConnectionPool, seq_key: dict[str, Any]) -> int | None:
+def last_version(db_config: SimpleConnectionPool, seq_key: SeqKey) -> int | None:
     if not is_revision(db_config, seq_key):
         return None
-    accession = {"accession": seq_key["accession"]}
+    accession = {"accession": seq_key.accession}
     sample_data_in_submission_table = find_conditions_in_db(
         db_config, table_name=TableName.SUBMISSION_TABLE, conditions=accession
     )

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -2,10 +2,11 @@ import json
 import logging
 import os
 import re
-from dataclasses import dataclass
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from enum import Enum, StrEnum
-from typing import Any, Final
+from enum import StrEnum
+from typing import Any, Final, TypedDict
 
 import psycopg2
 import pytz
@@ -63,33 +64,27 @@ def db_init(
     )
 
 
-class StatusAll(Enum):
-    READY_TO_SUBMIT = 0
-    SUBMITTING_PROJECT = 1
-    SUBMITTED_PROJECT = 2
-    SUBMITTING_SAMPLE = 3
-    SUBMITTED_SAMPLE = 4
-    SUBMITTING_ASSEMBLY = 5
-    SUBMITTED_ALL = 6
-    SENT_TO_LOCULUS = 7
-    HAS_ERRORS_PROJECT = 8
-    HAS_ERRORS_ASSEMBLY = 9
-    HAS_ERRORS_SAMPLE = 10
-    HAS_ERRORS_EXT_METADATA_UPLOAD = 11
-
-    def __str__(self):
-        return self.name
+class StatusAll(StrEnum):
+    READY_TO_SUBMIT = "READY_TO_SUBMIT"
+    SUBMITTING_PROJECT = "SUBMITTING_PROJECT"
+    SUBMITTED_PROJECT = "SUBMITTED_PROJECT"
+    SUBMITTING_SAMPLE = "SUBMITTING_SAMPLE"
+    SUBMITTED_SAMPLE = "SUBMITTED_SAMPLE"
+    SUBMITTING_ASSEMBLY = "SUBMITTING_ASSEMBLY"
+    SUBMITTED_ALL = "SUBMITTED_ALL"
+    SENT_TO_LOCULUS = "SENT_TO_LOCULUS"
+    HAS_ERRORS_PROJECT = "HAS_ERRORS_PROJECT"
+    HAS_ERRORS_ASSEMBLY = "HAS_ERRORS_ASSEMBLY"
+    HAS_ERRORS_SAMPLE = "HAS_ERRORS_SAMPLE"
+    HAS_ERRORS_EXT_METADATA_UPLOAD = "HAS_ERRORS_EXT_METADATA_UPLOAD"
 
 
-class Status(Enum):
-    READY = 0
-    SUBMITTING = 1
-    SUBMITTED = 2
-    HAS_ERRORS = 3
-    WAITING = 4  # Only for assembly creation
-
-    def __str__(self):
-        return self.name
+class Status(StrEnum):
+    READY = "READY"
+    SUBMITTING = "SUBMITTING"
+    SUBMITTED = "SUBMITTED"
+    HAS_ERRORS = "HAS_ERRORS"
+    WAITING = "WAITING"  # Only for assembly creation
 
 
 class TableName(StrEnum):
@@ -124,32 +119,50 @@ def validate_column_name(table_name: str, column_name: str):
         raise ValueError(msg)
 
 
-@dataclass(frozen=True)  # Immutable so that it is hashable
-class AccessionVersion:
+@dataclass(frozen=True)
+class AccessionVersion(TypedDict):
     accession: str
     version: int
 
-    def to_dict(self) -> dict:
-        """Convert AccessionVersion instance to a dictionary."""
-        return {"accession": self.accession, "version": self.version}
+
+class ProjectId(TypedDict):
+    project_id: int | None
 
 
 @dataclass
 class SubmissionTableEntry:
     accession: str
-    version: str
+    version: int
     organism: str
     group_id: int
-    errors: str | None = None
-    warnings: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    errors: list[str] | None = None
+    warnings: list[str] | None = None
     status_all: StatusAll = StatusAll.READY_TO_SUBMIT
     started_at: datetime | None = None
     finished_at: datetime | None = None
-    metadata: str | None = None
-    unaligned_nucleotide_sequences: str | None = None
+    unaligned_nucleotide_sequences: dict[str, str | None] = field(default_factory=dict)
     center_name: str | None = None
-    external_metadata: str | None = None
+    external_metadata: dict[str, str | Sequence[str]] | None = None
     project_id: int | None = None
+
+    def _get_primary_key(self) -> AccessionVersion:
+        return AccessionVersion(accession=self.accession, version=self.version)
+
+
+class SubmissionTableEntryDict(TypedDict, total=False):
+    accession: str
+    version: int
+    organism: str
+    group_id: int
+    errors: list[str] | None
+    warnings: list[str] | None
+    status_all: StatusAll
+    started_at: datetime | None
+    finished_at: datetime | None
+    external_metadata: dict[str, str | Sequence[str]] | None
+    center_name: str | None
+    project_id: int | None
 
 
 @dataclass(kw_only=True)
@@ -157,45 +170,97 @@ class ProjectTableEntry:
     group_id: int
     organism: str
     project_id: int | None = None
-    errors: str | None = None
-    warnings: str | None = None
+    errors: list[str] | None = None
+    warnings: list[str] | None = None
     status: Status = Status.READY
     started_at: datetime | None = None
     finished_at: datetime | None = None
     center_name: str | None = None
-    result: dict[str, str] | str | None = None
+    result: dict[str, str | Sequence[str]] | None = None
     ena_first_publicly_visible: datetime | None = None
     ncbi_first_publicly_visible: datetime | None = None
+
+    def _get_primary_key(self) -> ProjectId:
+        return ProjectId(project_id=self.project_id)
+
+
+class ProjectTableEntryDict(TypedDict, total=False):
+    group_id: int
+    organism: str
+    project_id: int | None
+    errors: list[str] | None
+    warnings: list[str] | None
+    status: Status
+    started_at: datetime | None
+    finished_at: datetime | None
+    center_name: str | None
+    result: dict[str, str | Sequence[str]] | None
+    ena_first_publicly_visible: datetime | None
+    ncbi_first_publicly_visible: datetime | None
 
 
 @dataclass(kw_only=True)
 class SampleTableEntry:
     accession: str
     version: int
-    errors: str | None = None
-    warnings: str | None = None
+    errors: list[str] | None = None
+    warnings: list[str] | None = None
     status: Status = Status.READY
     started_at: datetime | None = None
     finished_at: datetime | None = None
-    result: dict[str, str] | str | None = None
+    result: dict[str, str | Sequence[str]] | None = None
     ena_first_publicly_visible: datetime | None = None
     ncbi_first_publicly_visible: datetime | None = None
+
+    def _get_primary_key(self) -> AccessionVersion:
+        return AccessionVersion(accession=self.accession, version=self.version)
+
+
+class SampleTableEntryDict(TypedDict, total=False):
+    accession: str
+    version: int
+    errors: list[str] | None
+    warnings: list[str] | None
+    status: Status
+    started_at: datetime | None
+    finished_at: datetime | None
+    result: dict[str, str | Sequence[str]] | None
+    ena_first_publicly_visible: datetime | None
+    ncbi_first_publicly_visible: datetime | None
 
 
 @dataclass(kw_only=True)
 class AssemblyTableEntry:
     accession: str
     version: int
-    errors: str | None = None
-    warnings: str | None = None
+    errors: list[str] | None = None
+    warnings: list[str] | None = None
     status: Status = Status.READY
     started_at: datetime | None = None
     finished_at: datetime | None = None
-    result: str | None = None
+    result: dict[str, str | Sequence[str]] | None = None
     ena_nucleotide_first_publicly_visible: datetime | None = None
     ncbi_nucleotide_first_publicly_visible: datetime | None = None
     ena_gca_first_publicly_visible: datetime | None = None
     ncbi_gca_first_publicly_visible: datetime | None = None
+
+    def _get_primary_key(self) -> AccessionVersion:
+        return AccessionVersion(accession=self.accession, version=self.version)
+
+
+class AssemblyTableEntryDict(TypedDict, total=False):
+    accession: str
+    version: int
+    errors: list[str] | None
+    warnings: list[str] | None
+    status: Status
+    started_at: datetime | None
+    finished_at: datetime | None
+    result: dict[str, str | Sequence[str]] | None
+    ena_nucleotide_first_publicly_visible: datetime | None
+    ncbi_nucleotide_first_publicly_visible: datetime | None
+    ena_gca_first_publicly_visible: datetime | None
+    ncbi_gca_first_publicly_visible: datetime | None
 
 
 type Accession = str
@@ -223,6 +288,14 @@ def highest_version_in_submission_table(
     finally:
         db_conn_pool.putconn(con)
     return {row["accession"]: int(row["version"]) for row in results}
+
+
+def type_conversion(value: Any) -> Any:
+    if isinstance(value, (Status, StatusAll)):
+        return str(value)
+    if isinstance(value, (dict, list)):
+        return json.dumps(value)
+    return value
 
 
 def delete_records_in_db(
@@ -256,10 +329,7 @@ def delete_records_in_db(
 
             cur.execute(
                 query,
-                tuple(
-                    str(value) if isinstance(value, (Status, StatusAll)) else value
-                    for value in conditions.values()
-                ),
+                tuple(type_conversion(value) for value in conditions.values()),
             )
 
             deleted_rows = cur.rowcount  # Get number of affected rows
@@ -272,17 +342,17 @@ def delete_records_in_db(
     return deleted_rows
 
 
-def find_conditions_in_db(
-    db_conn_pool: SimpleConnectionPool, table_name: TableName, conditions: dict[str, Any]
+def _find_conditions_in_db(
+    db_conn_pool: SimpleConnectionPool, table_name: TableName, conditions: Mapping[str, Any]
 ) -> list[dict[str, Any]]:
     """
     Return all records from the specified table that match all the conditions
     Args:
         db_conn_pool (SimpleConnectionPool): Connection pool for PostgreSQL.
         table_name (TableName): The table to search in.
-        conditions (dict[str, str]): A dictionary of column names and values for filtering.
+        conditions (dict[str, Any]): A dictionary of column names and values for filtering.
     Returns:
-        list[dict[str, str]]: A list of dictionaries representing the records that
+        list[dict[str, Any]]: A list of dictionaries representing the records that
             match the conditions. Each dictionary contains column names as keys and
             their corresponding values.
     """
@@ -303,10 +373,7 @@ def find_conditions_in_db(
                     where_conditions.append(f"{key} IS NULL")
                 else:
                     where_conditions.append(f"{key} = %s")
-                    if isinstance(value, (Status, StatusAll)):
-                        params.append(str(value))
-                    else:
-                        params.append(value)
+                    params.append(type_conversion(value))
             if where_conditions:
                 query += " WHERE " + " AND ".join(where_conditions)
 
@@ -316,6 +383,70 @@ def find_conditions_in_db(
         db_conn_pool.putconn(con)
 
     return results
+
+
+def find_conditions_in_submission_db(
+    db_conn_pool: SimpleConnectionPool, conditions: SubmissionTableEntryDict | AccessionVersion
+) -> list[SubmissionTableEntry]:
+    entries = [
+        SubmissionTableEntry(**row)
+        for row in _find_conditions_in_db(
+            db_conn_pool, table_name=TableName.SUBMISSION_TABLE, conditions=conditions
+        )
+    ]
+    if conditions is AccessionVersion and len(entries) > 1:
+        msg = f"Multiple entries found in submission_db for AccessionVersion: {conditions}"
+        logger.error(msg)
+        raise ValueError(msg)
+    return entries
+
+
+def find_conditions_in_sample_db(
+    db_conn_pool: SimpleConnectionPool, conditions: SampleTableEntryDict | AccessionVersion
+) -> list[SampleTableEntry]:
+    entries = [
+        SampleTableEntry(**row)
+        for row in _find_conditions_in_db(
+            db_conn_pool, table_name=TableName.SAMPLE_TABLE, conditions=conditions
+        )
+    ]
+    if conditions is AccessionVersion and len(entries) > 1:
+        msg = f"Multiple entries found in sample_db for AccessionVersion: {conditions}"
+        logger.error(msg)
+        raise ValueError(msg)
+    return entries
+
+
+def find_conditions_in_project_db(
+    db_conn_pool: SimpleConnectionPool, conditions: ProjectTableEntryDict | ProjectId
+) -> list[ProjectTableEntry]:
+    entries = [
+        ProjectTableEntry(**row)
+        for row in _find_conditions_in_db(
+            db_conn_pool, table_name=TableName.PROJECT_TABLE, conditions=conditions
+        )
+    ]
+    if conditions is ProjectId and len(entries) > 1:
+        msg = f"Multiple entries found in project_db for ProjectId: {conditions}"
+        logger.error(msg)
+        raise ValueError(msg)
+    return entries
+
+
+def find_conditions_in_assembly_db(
+    db_conn_pool: SimpleConnectionPool, conditions: AssemblyTableEntryDict | AccessionVersion
+) -> list[AssemblyTableEntry]:
+    entries = [
+        AssemblyTableEntry(**row)
+        for row in _find_conditions_in_db(
+            db_conn_pool, table_name=TableName.ASSEMBLY_TABLE, conditions=conditions
+        )
+    ]
+    if conditions is AccessionVersion and len(entries) > 1:
+        msg = f"Multiple entries found in assembly_db for AccessionVersion: {conditions}"
+        logger.error(msg)
+        raise ValueError(msg)
+    return entries
 
 
 def find_errors_in_db(
@@ -366,17 +497,15 @@ def find_stuck_in_submission_db(
     return results
 
 
-def find_waiting_in_db(
-    db_conn_pool: SimpleConnectionPool, table_name: TableName, time_threshold: int = 48
+def find_waiting_in_assembly_db(
+    db_conn_pool: SimpleConnectionPool, time_threshold: int = 48
 ) -> list[dict[str, str]]:
     con = db_conn_pool.getconn()
     try:
         with con, con.cursor(cursor_factory=RealDictCursor) as cur:
             min_start_time = datetime.now(tz=pytz.utc) + timedelta(hours=-time_threshold)
-            # Prevent sql-injection with table_name validation
-            TableName.validate(table_name)
 
-            query = f"SELECT * FROM {table_name} WHERE status = 'WAITING' AND started_at < %s"  # noqa: S608
+            query = "SELECT * FROM assembly_table WHERE status = 'WAITING' AND started_at < %s"
 
             cur.execute(query, (min_start_time,))
 
@@ -387,11 +516,11 @@ def find_waiting_in_db(
     return results
 
 
-def update_db_where_conditions(
+def _update_db_where_conditions(
     db_conn_pool: SimpleConnectionPool,
     table_name: TableName,
-    conditions: dict[str, str | int],
-    update_values: dict[str, Any],
+    conditions: Mapping[str, Any],
+    update_values: Mapping[str, Any],
 ) -> int:
     updated_row_count = 0
     con = db_conn_pool.getconn()
@@ -418,18 +547,9 @@ def update_db_where_conditions(
             )
             query += f" WHERE {where_clause} AND ( {where_not_equal_clause} )"
             parameters = (
-                tuple(
-                    str(value) if (isinstance(value, (Status, StatusAll))) else value
-                    for value in update_values.values()
-                )
-                + tuple(
-                    str(value) if (isinstance(value, (Status, StatusAll))) else value
-                    for value in conditions.values()
-                )
-                + tuple(
-                    str(value) if (isinstance(value, (Status, StatusAll))) else value
-                    for value in update_values.values()
-                )
+                tuple(type_conversion(value) for value in update_values.values())
+                + tuple(type_conversion(value) for value in conditions.values())
+                + tuple(type_conversion(value) for value in update_values.values())
             )
 
             cur.execute(query, parameters)
@@ -447,11 +567,63 @@ def update_db_where_conditions(
     return updated_row_count
 
 
-def update_with_retry(
+def update_submission_db_where_conditions(
+    db_conn_pool: SimpleConnectionPool,
+    conditions: SubmissionTableEntryDict | AccessionVersion,
+    update_values: SubmissionTableEntryDict,
+) -> int:
+    return _update_db_where_conditions(
+        db_conn_pool,
+        table_name=TableName.SUBMISSION_TABLE,
+        conditions=conditions,
+        update_values=update_values,
+    )
+
+
+def update_sample_db_where_conditions(
+    db_conn_pool: SimpleConnectionPool,
+    conditions: SampleTableEntryDict | AccessionVersion,
+    update_values: SampleTableEntryDict,
+) -> int:
+    return _update_db_where_conditions(
+        db_conn_pool,
+        table_name=TableName.SAMPLE_TABLE,
+        conditions=conditions,
+        update_values=update_values,
+    )
+
+
+def update_project_db_where_conditions(
+    db_conn_pool: SimpleConnectionPool,
+    conditions: ProjectTableEntryDict | ProjectId,
+    update_values: ProjectTableEntryDict,
+) -> int:
+    return _update_db_where_conditions(
+        db_conn_pool,
+        table_name=TableName.PROJECT_TABLE,
+        conditions=conditions,
+        update_values=update_values,
+    )
+
+
+def update_assembly_db_where_conditions(
+    db_conn_pool: SimpleConnectionPool,
+    conditions: AssemblyTableEntryDict | AccessionVersion,
+    update_values: AssemblyTableEntryDict,
+) -> int:
+    return _update_db_where_conditions(
+        db_conn_pool,
+        table_name=TableName.ASSEMBLY_TABLE,
+        conditions=conditions,
+        update_values=update_values,
+    )
+
+
+def _update_with_retry(
     db_config: SimpleConnectionPool,
-    conditions: dict[str, str | int],
+    conditions: Mapping[str, Any],
     table_name: TableName,
-    update_values: dict[str, Any],
+    update_values: Mapping[str, Any],
     reraise: bool = True,
 ) -> int:
     """Update the database with retry logic.
@@ -460,7 +632,7 @@ def update_with_retry(
     they will be added to the log message."""
 
     def _do_update():
-        number_rows_updated = update_db_where_conditions(
+        number_rows_updated = _update_db_where_conditions(
             db_config,
             table_name=table_name,
             conditions=conditions,
@@ -497,6 +669,66 @@ def update_with_retry(
             logger.error("Raising exception after retries failed")
             raise ValueError(error_msg) from e
         return 0
+
+
+def update_submission_with_retry(
+    db_config: SimpleConnectionPool,
+    conditions: SubmissionTableEntryDict | AccessionVersion,
+    update_values: SubmissionTableEntryDict,
+    reraise: bool = True,
+) -> int:
+    return _update_with_retry(
+        db_config,
+        table_name=TableName.SUBMISSION_TABLE,
+        conditions=conditions,
+        update_values=update_values,
+        reraise=reraise,
+    )
+
+
+def update_project_with_retry(
+    db_config: SimpleConnectionPool,
+    conditions: ProjectTableEntryDict | ProjectId,
+    update_values: ProjectTableEntryDict,
+    reraise: bool = True,
+) -> int:
+    return _update_with_retry(
+        db_config,
+        table_name=TableName.PROJECT_TABLE,
+        conditions=conditions,
+        update_values=update_values,
+        reraise=reraise,
+    )
+
+
+def update_assembly_with_retry(
+    db_config: SimpleConnectionPool,
+    conditions: AssemblyTableEntryDict | AccessionVersion,
+    update_values: AssemblyTableEntryDict,
+    reraise: bool = True,
+) -> int:
+    return _update_with_retry(
+        db_config,
+        table_name=TableName.ASSEMBLY_TABLE,
+        conditions=conditions,
+        update_values=update_values,
+        reraise=reraise,
+    )
+
+
+def update_sample_with_retry(
+    db_config: SimpleConnectionPool,
+    conditions: SampleTableEntryDict | AccessionVersion,
+    update_values: SampleTableEntryDict,
+    reraise: bool = True,
+) -> int:
+    return _update_with_retry(
+        db_config,
+        table_name=TableName.SAMPLE_TABLE,
+        conditions=conditions,
+        update_values=update_values,
+        reraise=reraise,
+    )
 
 
 def add_to_project_table(
@@ -597,7 +829,9 @@ def add_to_assembly_table(
         db_conn_pool.putconn(con)
 
 
-def in_submission_table(db_conn_pool: SimpleConnectionPool, conditions) -> bool:
+def in_submission_table(
+    db_conn_pool: SimpleConnectionPool, conditions: SubmissionTableEntryDict
+) -> bool:
     con = db_conn_pool.getconn()
     try:
         with con, con.cursor() as cur:
@@ -641,8 +875,8 @@ def add_to_submission_table(
                     str(submission_table_entry.status_all),
                     submission_table_entry.started_at,
                     submission_table_entry.finished_at,
-                    submission_table_entry.metadata,
-                    submission_table_entry.unaligned_nucleotide_sequences,
+                    json.dumps(submission_table_entry.metadata),
+                    json.dumps(submission_table_entry.unaligned_nucleotide_sequences),
                     json.dumps(submission_table_entry.external_metadata),
                 ),
             )
@@ -658,23 +892,64 @@ def add_to_submission_table(
 
 def is_revision(db_config: SimpleConnectionPool, seq_key: AccessionVersion) -> bool:
     """Check if the entry is a revision"""
-    version = seq_key.version
+    version = seq_key["version"]
     if version == 1:
         return False
-    accession = {"accession": seq_key.accession}
-    sample_data_in_submission_table = find_conditions_in_db(
-        db_config, table_name=TableName.SUBMISSION_TABLE, conditions=accession
+    sample_data_in_submission_table = find_conditions_in_submission_db(
+        db_config, conditions={"accession": seq_key["accession"]}
     )
-    all_versions = sorted([int(entry["version"]) for entry in sample_data_in_submission_table])
+    all_versions = sorted([int(entry.version) for entry in sample_data_in_submission_table])
     return len(all_versions) > 1 and version == all_versions[-1]
 
 
 def last_version(db_config: SimpleConnectionPool, seq_key: AccessionVersion) -> int | None:
     if not is_revision(db_config, seq_key):
         return None
-    accession = {"accession": seq_key.accession}
-    sample_data_in_submission_table = find_conditions_in_db(
-        db_config, table_name=TableName.SUBMISSION_TABLE, conditions=accession
+    sample_data_in_submission_table = find_conditions_in_submission_db(
+        db_config, conditions={"accession": seq_key["accession"]}
     )
-    all_versions = sorted([int(entry["version"]) for entry in sample_data_in_submission_table])
+    all_versions = sorted([int(entry.version) for entry in sample_data_in_submission_table])
     return all_versions[-2]
+
+
+def set_biosample_error(
+    db_pool: SimpleConnectionPool,
+    seq_key: AccessionVersion,
+    error_msg: str,
+    biosample_accession: str,
+) -> bool:
+    sample_table_entry = SampleTableEntry(
+        accession=seq_key["accession"],
+        version=seq_key["version"],
+        status=Status.HAS_ERRORS,
+        errors=[error_msg],
+        result={
+            "ena_sample_accession": biosample_accession,
+            "biosample_accession": biosample_accession,
+        },
+    )
+    succeeded = add_to_sample_table(db_pool, sample_table_entry)
+
+    if not succeeded:
+        logger.warning("Biosample creation failed and DB update failed.")
+    return False
+
+
+def set_bioproject_error(
+    db_pool: SimpleConnectionPool,
+    conditions: ProjectTableEntryDict,
+    error_msg: str,
+    bioproject_accession: str,
+) -> bool:
+    conditions["status"] = Status.HAS_ERRORS
+    conditions["errors"] = [error_msg]
+    conditions["result"] = {"bioproject_accession": bioproject_accession}
+
+    project_table_entry = ProjectTableEntry(
+        **conditions,  # type: ignore
+    )
+    succeeded = add_to_project_table(db_pool, project_table_entry)
+
+    if not succeeded:
+        logger.warning("Bioproject creation failed and DB update failed.")
+    return False

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -440,7 +440,7 @@ def update_db_where_conditions(
 
 def update_with_retry(
     db_config: SimpleConnectionPool,
-    conditions: dict[str, str],
+    conditions: dict[str, str | int],
     table_name: TableName,
     update_values: dict[str, Any],
     reraise: bool = True,
@@ -647,10 +647,10 @@ def add_to_submission_table(
         db_conn_pool.putconn(con)
 
 
-def is_revision(db_config: SimpleConnectionPool, seq_key: dict[str, str]):
+def is_revision(db_config: SimpleConnectionPool, seq_key: dict[str, Any]):
     """Check if the entry is a revision"""
-    version = seq_key["version"]
-    if version == "1":
+    version = int(seq_key["version"])
+    if version == 1:
         return False
     accession = {"accession": seq_key["accession"]}
     sample_data_in_submission_table = find_conditions_in_db(
@@ -660,7 +660,7 @@ def is_revision(db_config: SimpleConnectionPool, seq_key: dict[str, str]):
     return len(all_versions) > 1 and version == all_versions[-1]
 
 
-def last_version(db_config: SimpleConnectionPool, seq_key: dict[str, str]) -> int | None:
+def last_version(db_config: SimpleConnectionPool, seq_key: dict[str, Any]) -> int | None:
     if not is_revision(db_config, seq_key):
         return None
     accession = {"accession": seq_key["accession"]}

--- a/ena-submission/src/ena_deposition/trigger_submission_to_ena.py
+++ b/ena-submission/src/ena_deposition/trigger_submission_to_ena.py
@@ -24,17 +24,16 @@ logger = logging.getLogger(__name__)
 def upload_sequences(db_config: SimpleConnectionPool, sequences_to_upload: dict[str, Any]):
     for full_accession, data in sequences_to_upload.items():
         accession, version = full_accession.split(".")
-        if in_submission_table(db_config, {"accession": accession, "version": version}):
+        if in_submission_table(db_config, {"accession": accession, "version": int(version)}):
             continue
-        entry = {
-            "accession": accession,
-            "version": version,
-            "group_id": data["metadata"]["groupId"],
-            "organism": data["organism"],
-            "metadata": json.dumps(data["metadata"]),
-            "unaligned_nucleotide_sequences": json.dumps(data["unalignedNucleotideSequences"]),
-        }
-        submission_table_entry = SubmissionTableEntry(**entry)
+        submission_table_entry = SubmissionTableEntry(
+            accession=accession,
+            version=int(version),
+            group_id=data["metadata"]["groupId"],
+            organism=data["organism"],
+            metadata=data["metadata"],
+            unaligned_nucleotide_sequences=data["unalignedNucleotideSequences"],
+        )
         add_to_submission_table(db_config, submission_table_entry)
         logger.info(f"Inserted {full_accession} into submission_table")
 


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/5279

1. TypedDicts are made for all table entry values and each table's primary keys, e.g. `AccessionVersion`.
2. The `update_db_where_conditions`, `update_with_retry` and `find_conditions_in_db` are now all made internal to the `submission_db_helper` script and can only be called using the exact table name e.g. `update_submission_db_where_conditions`. These calls now assert conditions are properly typed and additional throw ValueErrors if there are ever multiple entries with the same primary key.
3. The `set_error_if_accession_not_exists` is split up into one function that calls ENA to check if an accession exists and another call to update the table with an error state.
4. `_get_results_of_single_db_record` is removed as it no longer required (`find_conditions_in_db` asserts on uniqueness of primary key and entry type)

### Screenshot

When attempting to switch from using the barebones [pyscopg](https://www.psycopg.org/docs/) library to the sqlAlchemy ORM I realized that SQLAlchemy alone cannot offer typing of database entry updates where the values to update are given as a dictionary.

For example the example below offers no type protection:
```
submission = session.get(Submission, (accession, version))
if not submission:
    raise Exception
for key, value in update_values.items():
    setattr(submission, key, value)
session.commit()
```

In my understanding the only way to use a dictionary of update values and offer type protection is to explicitly write out each out each update e.g. 
```
submission = session.get(Submission, (accession, version))
if not submission:
    raise Exception
submission.results =...
submission.errors =...
session.commit()
```
or use [TypedDicts](https://peps.python.org/pep-0589/). 

Writing out all update values each time seems very tedious and like a regression from the current state, therefore I decided to switch to using TypedDicts. I don't need to switch to using SQLAlchemy to do this and thus just refactored the current set up to use TypedDicts. The IDE will now flag if we attempt to update a db table entry with a column that does not exist in the table, or with the wrong type: 
<img width="724" height="220" alt="image" src="https://github.com/user-attachments/assets/d994dcba-377e-4ff0-8a3d-4dc6212dd2e3" />
<img width="724" height="220" alt="image" src="https://github.com/user-attachments/assets/6accad99-6927-45de-991b-19cd21302658" />


### PR Checklist
- [ ] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable