### PR TITLE
fix(website): details page, sequences viewer: correctly show which tab is active for multi-segmented organism

### DIFF
--- a/website/src/components/SequenceDetailsPage/SequencesDisplay/SequencesContainer.tsx
+++ b/website/src/components/SequenceDetailsPage/SequencesDisplay/SequencesContainer.tsx
@@ -182,7 +182,9 @@ const UnalignedNucleotideSequenceTabs: FC<NucleotideSequenceTabsProps> = ({
             {segments.map((segmentName) => (
                 <BoxWithTabsTab
                     key={segmentName.lapisName}
-                    isActive={isActive && isUnalignedSequence(sequenceType) && segmentName === sequenceType.name}
+                    isActive={
+                        isActive && isUnalignedSequence(sequenceType) && segmentName.label === sequenceType.name.label
+                    }
                     onClick={() => {
                         setType(unalignedSequenceSegment(segmentName));
                         setActiveTab('unaligned');
@@ -221,7 +223,9 @@ const AlignmentSequenceTabs: FC<NucleotideSequenceTabsProps> = ({
             {segments.map((segmentName) => (
                 <BoxWithTabsTab
                     key={segmentName.lapisName}
-                    isActive={isActive && isAlignedSequence(sequenceType) && segmentName === sequenceType.name}
+                    isActive={
+                        isActive && isAlignedSequence(sequenceType) && segmentName.label === sequenceType.name.label
+                    }
                     onClick={() => {
                         setType(alignedSequenceSegment(segmentName));
                         setActiveTab('aligned');


### PR DESCRIPTION
It was comparing objects (by reference), but it should have compared them deeply. Comparing the label is also enough. likely broke in #4995

### Screenshot

Before:
<img width="1113" height="311" alt="grafik" src="https://github.com/user-attachments/assets/6ef95d1d-034c-4d75-8a79-a1494aa5667a" />


After:
<img width="1113" height="311" alt="grafik" src="https://github.com/user-attachments/assets/7f460479-e84f-4705-a845-e719925eca1e" />


### PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by appropriate, automated tests.~~
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
  - See screenshots

🚀 Preview: Add `preview` label to enable