### PR TITLE
refactor(website): remove redundant state from FieldSelectorModal

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
@@ -43,7 +43,7 @@ export const DownloadDialog: FC<DownloadDialogProps> = ({
 
     const [downloadOption, setDownloadOption] = useState<DownloadOption | undefined>();
     const [agreedToDataUseTerms, setAgreedToDataUseTerms] = useState(dataUseTermsEnabled ? false : true);
-    const [selectedFields, setSelectedFields] = useState<string[]>(getDefaultSelectedFields(metadata));
+    const [selectedFields, setSelectedFields] = useState<Set<string>>(getDefaultSelectedFields(metadata)); // This is here so that the state is persisted across closing and reopening the dialog
 
     return (
         <>

--- a/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useMemo, useState } from 'react';
+import { type Dispatch, type FC, type SetStateAction, useEffect, useMemo, useState } from 'react';
 
 import type { DownloadDataType } from './DownloadDataType.ts';
 import type { DownloadOption } from './DownloadUrlGenerator.ts';
@@ -26,16 +26,16 @@ type DownloadFormProps = {
     allowSubmissionOfConsensusSequences: boolean;
     dataUseTermsEnabled: boolean;
     metadata: Metadata[];
-    selectedFields: string[];
-    onSelectedFieldsChange: (fields: string[]) => void;
+    selectedFields: Set<string>;
+    onSelectedFieldsChange: Dispatch<SetStateAction<Set<string>>>;
     richFastaHeaderFields: Schema['richFastaHeaderFields'];
     selectedSuborganism: string | null;
     suborganismIdentifierField: string | undefined;
 };
 
 // Sort fields by their order in the search table and ensure accessionVersion is the first field
-function orderFieldsForDownload(fields: string[], metadata: Metadata[]): string[] {
-    const fieldsWithoutAccessionVersion = fields.filter((field) => field !== ACCESSION_VERSION_FIELD);
+function orderFieldsForDownload(fields: Set<string>, metadata: Metadata[]): string[] {
+    const fieldsWithoutAccessionVersion = [...fields].filter((field) => field !== ACCESSION_VERSION_FIELD);
     const orderMap = new Map<string, number>();
     for (const m of metadata) {
         orderMap.set(m.name, m.order ?? Number.MAX_SAFE_INTEGER);
@@ -144,7 +144,7 @@ export const DownloadForm: FC<DownloadFormProps> = ({
                     <span>Metadata</span>
                     <FieldSelectorButton
                         onClick={() => setIsFieldSelectorOpen(true)}
-                        selectedFieldsCount={selectedFields.length}
+                        selectedFieldsCount={selectedFields.size}
                         disabled={dataType !== 0}
                     />
                 </div>
@@ -280,8 +280,8 @@ export const DownloadForm: FC<DownloadFormProps> = ({
                 isOpen={isFieldSelectorOpen}
                 onClose={() => setIsFieldSelectorOpen(false)}
                 metadata={metadata}
-                initialSelectedFields={selectedFields}
-                onSave={onSelectedFieldsChange}
+                selectedFields={selectedFields}
+                onSelectedFieldsChange={onSelectedFieldsChange}
             />
         </div>
     );

--- a/website/src/components/SearchPage/DownloadDialog/FieldSelector/FieldSelectorModal.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/FieldSelector/FieldSelectorModal.tsx
@@ -1,34 +1,26 @@
-import { useState, type FC } from 'react';
+import { type Dispatch, type FC, type SetStateAction } from 'react';
 
 import { ACCESSION_VERSION_FIELD } from '../../../../settings.ts';
 import { type Metadata } from '../../../../types/config.ts';
-import { FieldSelectorModal as CommonFieldSelectorModal, type FieldItem } from '../../../common/FieldSelectorModal.tsx';
+import { type FieldItem, FieldSelectorModal as CommonFieldSelectorModal } from '../../../common/FieldSelectorModal.tsx';
 
 type FieldSelectorProps = {
     isOpen: boolean;
     onClose: () => void;
     metadata: Metadata[];
-    initialSelectedFields?: string[];
-    onSave: (selectedFields: string[]) => void;
+    selectedFields: Set<string>;
+    onSelectedFieldsChange: Dispatch<SetStateAction<Set<string>>>;
 };
 
 export const FieldSelectorModal: FC<FieldSelectorProps> = ({
     isOpen,
     onClose,
     metadata,
-    initialSelectedFields,
-    onSave,
+    selectedFields,
+    onSelectedFieldsChange,
 }) => {
-    const getInitialSelectedFields = () => {
-        const fields = new Set(initialSelectedFields ?? getDefaultSelectedFields(metadata));
-        fields.add(ACCESSION_VERSION_FIELD);
-        return fields;
-    };
-
-    const [selectedFields, setSelectedFields] = useState<Set<string>>(getInitialSelectedFields());
-
     const handleFieldSelection = (fieldName: string, selected: boolean) => {
-        setSelectedFields((prevSelectedFields) => {
+        onSelectedFieldsChange((prevSelectedFields) => {
             const newSelectedFields = new Set(prevSelectedFields);
 
             if (selected) {
@@ -37,7 +29,6 @@ export const FieldSelectorModal: FC<FieldSelectorProps> = ({
                 newSelectedFields.delete(fieldName);
             }
 
-            onSave(Array.from(newSelectedFields));
             return newSelectedFields;
         });
     };
@@ -66,13 +57,10 @@ export const FieldSelectorModal: FC<FieldSelectorProps> = ({
  * Gets the default list of field names that should be selected
  * based on the includeInDownloadsByDefault flag
  */
-export function getDefaultSelectedFields(metadata: Metadata[]): string[] {
-    const defaultFields = metadata.filter((field) => field.includeInDownloadsByDefault).map((field) => field.name);
-
-    // Ensure ACCESSION_VERSION_FIELD is always included
-    if (!defaultFields.includes(ACCESSION_VERSION_FIELD)) {
-        defaultFields.push(ACCESSION_VERSION_FIELD);
-    }
-
+export function getDefaultSelectedFields(metadata: Metadata[]): Set<string> {
+    const defaultFields = new Set(
+        metadata.filter((field) => field.includeInDownloadsByDefault).map((field) => field.name),
+    );
+    defaultFields.add(ACCESSION_VERSION_FIELD);
     return defaultFields;
 }


### PR DESCRIPTION
The inner state is not necessary. We can simply use the outer state instead. Also adapt the test accordingly and refactor a bit.



### Screenshot

### PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [x ] The implemented feature is covered by appropriate, automated tests.
~~- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~~

🚀 Preview: https://removeredundantstate.loculus.org