### PR TITLE
chore(website): tell agents to run 'npm run test' with 'CI=1' envvar to not get stuck (mostly gemini bug)

### DIFF
--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -1,3 +1,3 @@
 ## Checklist before committing code
 
-Run `npm run test`, `npm run check-types`, `npm run format`.
+Run `CI=1 npm run test`, `npm run check-types`, `npm run format`.


### PR DESCRIPTION
Already reported to Gemini, but CI=1 doesn't harm anyways: https://github.com/google-gemini/gemini-cli/issues/12213