### PR TITLE
feat(prepro): provide request ID in backend requests to allow tracing requests

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/__main__.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/__main__.py
@@ -7,11 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 def cli_entry() -> None:
-    logging.basicConfig(
-        level=logging.INFO,
-        format='[%(request_id)s] %(levelname)s - %(name)s - %(message)s',
-        defaults={'request_id': 'N/A'}
-    )
+    logging.basicConfig(level=logging.INFO)
 
     config = get_config()
 


### PR DESCRIPTION
When a prepro Pod crashes with a timeout, we don't know what happened to the request in the backend, or we can only correlate it by looking at the time the Pod crashed.

The backend already reads the `x-request-id` header and uses the request ID in it, if given.

This PR sets a UUID as a request ID in the requests sent to the backend.

**Manual testing** - I deployed this to GenSpectrum staging and looked in loki and found a request successfully correlated.

(integration test failures seem unrelated?)

🚀 Preview: https://prepro-provide-request-id.loculus.org