### PR TITLE
feat(backend): add request duration logging for streaming requests

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/log/Logging.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/log/Logging.kt
@@ -12,6 +12,8 @@ import org.springframework.web.servlet.HandlerMapping
 
 private val log = KotlinLogging.logger {}
 
+const val ORGANISM_MDC_KEY = "organism"
+
 @Component
 class OrganismMdcInterceptor : HandlerInterceptor {
     override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
@@ -26,7 +28,7 @@ class OrganismMdcInterceptor : HandlerInterceptor {
         }
 
         if (organism != null) {
-            MDC.put("organism", organism)
+            MDC.put(ORGANISM_MDC_KEY, organism)
         }
 
         return true


### PR DESCRIPTION
In https://github.com/loculus-project/loculus/pull/5242 we added duration logging for requests, but for streamed requests the "200" response is sent immediately, but the actual data can take quite a bit longer.

This PR adds timing output for streamed requests. I'm also passing the name of the endpoint to the function, so it's easy to spot when among the long running requests there is one that usually shouldn't be there.

(I'm suspecting that `extract-unprocessed-data` is sometimes taking very long to respond, but the logs are not definitive yet)

**manual testing** - I tested this in GenSpectrum and it's running fine and I can see the numbers.

### PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by appropriate, automated tests.~~
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://backend-time-streamed.loculus.org