### PR TITLE
chore: add gradle.lockfile to codespell excludes and run codespell (no typos found)

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
-skip = */node_modules,*.jsonl,*.tsv,*.json,*/dist_keycloak,*/playwright-report,*.properties,*/dist,./backend/build,yarn.lock,i18n.ts
+skip = */node_modules,*.jsonl,*.tsv,*.json,*/dist_keycloak,*/playwright-report,*.properties,*/dist,./backend/build,yarn.lock,i18n.ts,*/gradle.lockfile
 exclude-file = .config/codespell/exclude-file
 ignore-words = .config/codespell/ignore-words


### PR DESCRIPTION
🚀 Preview: Add `preview` label to enable