### PR TITLE
ci(backend): use explicit tasks to separate test and lint jobs

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
       - name: Run tests
-        run: ./gradlew assemble test
+        run: ./gradlew test
         working-directory: ./backend
 
   lint:


### PR DESCRIPTION
Fixes #5345

Fixes the separation between test and lint jobs in the Kotlin CI workflow by using explicit Gradle tasks instead of exclusion flags.

The previous attempt to separate test and lint (PR #5343) used `./gradlew build -x ktlintCheck`, but this didn't work as intended. The `build` task includes the `check` task, which depends on individual ktlint source set tasks:
- `ktlintKotlinScriptCheck`
- `ktlintMainSourceSetCheck`  
- `ktlintTestSourceSetCheck`

Even though `-x ktlintCheck` excluded the umbrella task, the individual source set tasks were still running as dependencies of `check`, causing the test job to run linting unnecessarily.

Instead of using exclusions, use explicit tasks that are symmetric and mutually exclusive:
- **Test job**: `./gradlew assemble test` - builds the project and runs tests only
- **Lint job**: `./gradlew ktlintCheck` - runs all ktlint checks only

## Test plan

- [x] Verified locally that `./gradlew assemble test` doesn't run any ktlint tasks
- [x] Verified locally that `./gradlew ktlintCheck` runs all ktlint checks
- [x] CI will verify the fix works as intended

Lint tasks no longer run as part of test job:

<img width="920" height="508" alt="Google Chrome 2025-10-30 10 16 40" src="https://github.com/user-attachments/assets/96de3a30-3639-4c94-aa21-1bd7e213846b" />

🚀 Preview: Add `preview` label to enable