### PR TITLE
feat(website): search page: don't make `accessionVersion` selectable as a search field

### DIFF
--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -15,7 +15,7 @@ import { MutationField } from './fields/MutationField.tsx';
 import { NormalTextField } from './fields/NormalTextField';
 import { searchFormHelpDocsUrl } from './searchFormHelpDocsUrl.ts';
 import { useOffCanvas } from '../../hooks/useOffCanvas.ts';
-import { ACCESSION_FIELD, IS_REVOCATION_FIELD, VERSION_STATUS_FIELD } from '../../settings.ts';
+import { ACCESSION_FIELD, ACCESSION_VERSION_FIELD, IS_REVOCATION_FIELD, VERSION_STATUS_FIELD } from '../../settings.ts';
 import type { FieldValues, GroupedMetadataFilter, MetadataFilter, SetSomeFieldValues } from '../../types/config.ts';
 import { type ReferenceGenomesLightweightSchema } from '../../types/referencesGenomes.ts';
 import type { ClientConfig } from '../../types/runtimeConfig.ts';
@@ -92,7 +92,8 @@ export const SearchForm = ({
     }, [filterSchema]);
 
     const fieldItems: FieldItem[] = filterSchema.filters
-        .filter((filter) => filter.name !== ACCESSION_FIELD) // Exclude accession field
+        .filter((filter) => filter.name !== ACCESSION_FIELD)
+        .filter((filter) => filter.name !== ACCESSION_VERSION_FIELD)
         .filter((filter) => filter.name !== suborganismIdentifierField)
         .map((filter) => ({
             name: filter.name,


### PR DESCRIPTION
On current main:
<img width="1348" height="745" alt="image" src="https://github.com/user-attachments/assets/3844c38f-a566-43ca-b387-19f7124aaa57" />

I found it weird that `accession` is excluded, but `accessionVersion` isn't. The "Accession"  search field (that always exists) covers both.

resolves #

### Screenshot

### PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by appropriate, automated tests.~~
~~- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~~

🚀 Preview: Add `preview` label to enable