### PR TITLE
fix(website): Surface error details from revision responses better

### DIFF
--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -32,7 +32,10 @@ const logger = getClientLogger('EditPage');
  * Extracts the detail field from a backend error response
  */
 function getErrorDetail(error: unknown): string {
-    if (isErrorFromAlias(backendApi, 'revise', error) || isErrorFromAlias(backendApi, 'submitReviewedSequence', error)) {
+    if (
+        isErrorFromAlias(backendApi, 'revise', error) ||
+        isErrorFromAlias(backendApi, 'submitReviewedSequence', error)
+    ) {
         return error.response.data.detail;
     }
     return JSON.stringify(error);


### PR DESCRIPTION
resolves #4850

Surface more readable error messages on revision

<img width="416" height="192" alt="image" src="https://github.com/user-attachments/assets/b2534b56-cfc8-4646-8b3e-91c59a2d6507" />

vs the horrible long error messages Anya has been screenshotting recently which don't actually capture the salient info.

🚀 Preview: https://claude-surface-revise-err.loculus.org