### PR TITLE
doc(website): Add live host to README

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -9,7 +9,7 @@ This website uses [Astro](https://astro.build/) for static site generation and
 
 -   Set up your `.env` file, e.g. by copying `.env.example` with `cp .env.example .env`
 -   Install packages: `npm ci` (`ci` as opposed to `install` makes sure to install the exact versions specified in `package-lock.json`)
--   Generate config files for local testing (requires Helm installed): `../generate_local_test_config.sh`. If you are not running the backend locally, run `../generate_local_test_config.sh --from-live` to point to the backend from the live server (preview of the `main` branch) or `../generate_local_test_config.sh --from-live --live-host main.loculus.org` to specify a particular host which can be a preview.
+-   Generate config files for local testing (requires Helm installed): `../generate_local_test_config.sh`. If you are not running the backend locally, run `../generate_local_test_config.sh --from-live` to point to the backend from the live server (preview of the `main` branch) or `../generate_local_test_config.sh --from-live --live-host main.loculus.org` to specify a particular host which can also be a preview.
 -   Run `npm run start` to start a local development server with hot reloading.
 -   Run `npm run format-fast` to format the code.
 


### PR DESCRIPTION
Added to readme the pattern to specify a particular host for local website testing.


🚀 Preview: Add `preview` label to enable