### PR TITLE
fix(website): also display icons for extra top nav items

### DIFF
--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -25,20 +25,12 @@ const extraItems = extraSequenceRelatedTopNavigationItems(currentOrganism);
                     {currentOrganismObject?.displayName || currentOrganism}
                 </span>
                 <span class='text-gray-300 mr-2'>|</span>
-                {sequenceRelatedItems.map(({ text, path, icon }) => {
+                {[...sequenceRelatedItems, ...extraItems].map(({ text, path, icon }) => {
                     const Icon = icon;
                     const isActive = currentPath.startsWith(path);
                     return (
                         <SubmenuLink href={path} isActive={isActive}>
                             {Icon && <Icon className='w-4 h-4' />}
-                            {text}
-                        </SubmenuLink>
-                    );
-                })}
-                {extraItems.map(({ text, path }) => {
-                    const isActive = currentPath.startsWith(path);
-                    return (
-                        <SubmenuLink href={path} isActive={isActive}>
                             {text}
                         </SubmenuLink>
                     );


### PR DESCRIPTION
With this PR, icons for extra organism-specific top navigation items will also be displayed. This is relevant for e.g. https://github.com/pathoplexus/pathoplexus/pull/641. For a pure Loculus instance/previews, nothing changes.

### PR Checklist
- ~[ ] All necessary documentation has been adapted.~
- ~[ ] The implemented feature is covered by appropriate, automated tests.~
- ~[ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~

🚀 Preview: Add `preview` label to enable