### PR TITLE
ci: Update github workflow for integration tests to save pod descriptions…

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -121,7 +121,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           mkdir -p pod_descriptions
-          kubectl describe pods -l app=loculus > pod_descriptions/describe_pods.txt
+          kubectl describe pods -l app=loculus | tee pod_descriptions/describe_pods.txt
       - name: Upload pod descriptions
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v5


### PR DESCRIPTION
… to file rather than logging out directly. (Because otherwise it's hard to get the full file, e.g. to copy and paste into an LLM, as GitHub loads logs lazily)

🚀 Preview: Add `preview` label to enable