### PR TITLE
fix(website): stop mobile nav search from triggering keyboard

### DIFF
--- a/website/src/components/Navigation/AccessionSearchBox.spec.tsx
+++ b/website/src/components/Navigation/AccessionSearchBox.spec.tsx
@@ -45,6 +45,13 @@ describe('AccessionSearchBox', () => {
         expect(input).toHaveClass('opacity-100');
     });
 
+    it('does not auto focus the input when defaultOpen is true', () => {
+        render(<AccessionSearchBox defaultOpen={true} />);
+
+        const input = screen.getByPlaceholderText('Search by accession');
+        expect(input).not.toHaveFocus();
+    });
+
     it('opens the input field when the search button is clicked', async () => {
         render(<AccessionSearchBox />);
 

--- a/website/src/components/Navigation/AccessionSearchBox.tsx
+++ b/website/src/components/Navigation/AccessionSearchBox.tsx
@@ -16,12 +16,18 @@ export const AccessionSearchBox: FC<Props> = ({ className, onSubmitSuccess, defa
     const [open, setOpen] = useState(!!defaultOpen);
     const inputRef = useRef<HTMLInputElement | null>(null);
     const [error, setError] = useState<string | null>(null);
+    const hasUserOpenedRef = useRef(false);
 
     useEffect(() => {
-        if (open) {
+        if (open && (!defaultOpen || hasUserOpenedRef.current)) {
             inputRef.current?.focus();
         }
-    }, [open]);
+    }, [open, defaultOpen]);
+
+    const openSearch = () => {
+        hasUserOpenedRef.current = true;
+        setOpen(true);
+    };
 
     // Only allow alphanumeric, dot, dash, underscore - this is for security to prevent injection into URLs, rather than for UX
     function isValidAccession(input: string): boolean {
@@ -32,7 +38,7 @@ export const AccessionSearchBox: FC<Props> = ({ className, onSubmitSuccess, defa
         e.preventDefault();
         const v = value.trim();
         if (!v) {
-            setOpen(true);
+            openSearch();
             setError(null);
             return;
         }
@@ -56,7 +62,7 @@ export const AccessionSearchBox: FC<Props> = ({ className, onSubmitSuccess, defa
             <div className='relative flex items-center'>
                 <Button
                     type='submit'
-                    onClick={() => setOpen(true)}
+                    onClick={openSearch}
                     className='flex items-center justify-center text-primary-600 hover:text-primary-700 transition-colors'
                     aria-label={open ? 'Search' : 'Open accession search'}
                     data-testid='nav-accession-search-button'


### PR DESCRIPTION
hopefully fixes #5433 

## Summary
- ensure the navigation accession search input no longer auto-focuses on mount when the off-canvas menu keeps it expanded, preventing the mobile keyboard from opening during page navigation
- capture whether the user explicitly opened the search box so that the field still receives focus when it is intentionally toggled open, and update the blank-submit path to use the same helper
- add a regression test confirming that a default-open search box does not grab focus automatically

## Testing
- CI=1 npm run test
- npm run check-types
- npm run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691734b2ab24832596ec18005e241e64)
🚀 Preview: https://codex-fix-mobile-keyboard.loculus.org/