### PR TITLE
refactor(kubernetes): add indent to Helm template function

### DIFF
--- a/kubernetes/loculus/templates/_preprocessingFromValues.tpl
+++ b/kubernetes/loculus/templates/_preprocessingFromValues.tpl
@@ -56,17 +56,17 @@
 {{- $segments := .nucleotideSequences}}
 {{- $is_segmented := gt (len $segments) 1 }}
 {{- range $metadata }}
-{{- $currentItem := . }}
-{{- if and $is_segmented .perSegment }}
-{{- range $segment := $segments }}
-{{- with $currentItem }}
-{{- $args := deepCopy . | merge (dict "segment" $segment "key" (printf "%s_%s" .name $segment)) }}
-{{- include "loculus.sharedPreproSpecs" $args }}
-{{- end }}
-{{- end }}
-{{- else }}
-{{- $args := deepCopy . | merge (dict "segment" "" "key" .name) }}
-{{- include "loculus.sharedPreproSpecs" $args }}
-{{- end }}
+    {{- $currentItem := . }}
+    {{- if and $is_segmented .perSegment }}
+        {{- range $segment := $segments }}
+            {{- with $currentItem }}
+            {{- $args := deepCopy . | merge (dict "segment" $segment "key" (printf "%s_%s" .name $segment)) }}
+            {{- include "loculus.sharedPreproSpecs" $args }}
+            {{- end }}
+        {{- end }}
+    {{- else }}
+        {{- $args := deepCopy . | merge (dict "segment" "" "key" .name) }}
+        {{- include "loculus.sharedPreproSpecs" $args }}
+    {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
`{{- ` eats the indent anyway.

🚀 Preview: Add `preview` label to enable