### PR TITLE
fix(website): allow mobile menu scrolling

### DIFF
--- a/website/src/components/Navigation/SandwichMenu.tsx
+++ b/website/src/components/Navigation/SandwichMenu.tsx
@@ -35,14 +35,14 @@ export const SandwichMenu: FC<SandwichMenuProps> = ({
             </Button>
             {isOpen && <OffCanvasOverlay onClick={closeMenu} />}
             <div
-                className={`fixed top-0 right-0 z-50 w-64 min-h-screen bg-white flex flex-col transition-transform duration-300 ${
+                className={`fixed top-0 right-0 z-50 w-64 h-screen bg-white flex flex-col transition-transform duration-300 ${
                     isOpen ? 'translate-x-0' : 'translate-x-full'
                 }`}
             >
                 <Button className='absolute z-50 right-3 top-4 p-2' onClick={toggleMenu} aria-label='Close main menu'>
                     <SandwichIcon isOpen={isOpen} />
                 </Button>
-                <div className='p-5 flex flex-col justify-between min-h-screen overflow-y-auto'>
+                <div className='p-5 flex flex-col justify-between h-full overflow-y-auto'>
                     <div>
                         <div className='h-10 font-bold'>
                             <a href='/' className='text-gray-900 hover:text-primary-600 transition-colors'>


### PR DESCRIPTION
resolves #5486

Sorry I was vaguely aware of this and intended to fix it differently - by e.g. collapsing the organism list. But for now we should just get some fix in. I tested this in preview.

## Summary
- Ensure the off-canvas sandwich menu spans the full viewport height and keeps an internal scroll container so long navigation lists remain reachable on mobile when body scrolling is locked.
- Keep the menu content layout filling available space while allowing vertical overflow handling for smaller screens.


🚀 Preview: https://codex-make-sidebar-menu-s.loculus.org