### PR TITLE
chore(ci): in integration-test action, only install browser that's used

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -79,10 +79,9 @@ jobs:
         run: cd cli && uv sync && uv build && uv pip install --system dist/*.whl
       - name: Install keyring backend for CLI
         run: uv pip install --system keyrings.alt
-      # Caching is not recommended: https://playwright.dev/docs/ci#caching-browsers
-      # We only install the browser that's actually needed
+      # Firefox's readonly-setup is also done with Chromium
       - name: Install Playwright Browsers and System Dependencies
-        run: cd integration-tests && npx playwright install --with-deps --only-shell ${{ matrix.browser == 'cli' && 'chromium' || matrix.browser }}
+        run: cd integration-tests && npx playwright install --with-deps --only-shell chromium ${{ matrix.browser == 'firefox' && 'firefox' || '' }}
       - name: Wait for the pods to be ready
         run: ./.github/scripts/wait_for_pods_to_be_ready.py --timeout ${{ env.wait_timeout }}
       - name: Sleep for 10 secs

--- a/integration-tests/playwright.config.ts
+++ b/integration-tests/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
 const browser = process.env.BROWSER;
+const readonlySetupName = 'readonly-setup';
 
 /**
  * Read environment variables from file.
@@ -44,13 +45,14 @@ const config = {
     projects: [
         // Dependent project setup
         {
-            name: 'readonly setup',
+            name: readonlySetupName,
+            use: { ...devices['Desktop Chrome'] },
             testMatch: /readonly\.setup\.ts/,
         },
         {
             name: 'chromium-with-dep',
             use: { ...devices['Desktop Chrome'] },
-            dependencies: ['readonly setup'],
+            dependencies: [readonlySetupName],
             testMatch: /.*\.dependent\.spec\.ts/,
         },
         {
@@ -58,7 +60,7 @@ const config = {
             use: {
                 ...devices['Desktop Firefox'],
             },
-            dependencies: ['readonly setup'],
+            dependencies: [readonlySetupName],
             testMatch: /.*\.dependent\.spec\.ts/,
         },
 
@@ -93,13 +95,15 @@ if (testSuite === 'cli') {
     if (testSuite === 'browser') {
         // Run only browser tests (exclude CLI)
         config.projects = config.projects.filter(
-            (p) => p.name.startsWith(browser) || p.name === 'readonly setup',
+            (p) => p.name.startsWith(browser) || p.name === readonlySetupName,
         );
     } else {
         // Default 'all': run both browser and CLI tests
         config.projects = config.projects.filter(
             (p) =>
-                p.name.startsWith(browser) || p.name === 'readonly setup' || p.name === 'cli-tests',
+                p.name.startsWith(browser) ||
+                p.name === readonlySetupName ||
+                p.name === 'cli-tests',
         );
     }
 }


### PR DESCRIPTION
Caching is discouraged by Playwright (https://playwright.dev/docs/ci#caching-browsers) and was using wrong directory anyways (website not integration-test, likely copy/paste error) causing potential divergence in playwright versions/stale cache.

Now it's faster also because we only install the browser that's actually used per matrix job - though pod setup is rate limiting anyways.

<img width="1605" height="48" alt="Google Chrome 2025-11-23 17 15 47" src="https://github.com/user-attachments/assets/8672c7e1-e127-4942-bf8b-b1c4c556c376" />

🚀 Preview: Add `preview` label to enable