### PR TITLE
feat(prepro): fix stop codons

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -82,19 +82,21 @@ def add_nextclade_metadata(
         or unprocessed.nextcladeMetadata[segment] is None
     ):
         return InputData(datum=None)
-    result: str | None = str(
-        dpath.get(
-            unprocessed.nextcladeMetadata[segment],
-            nextclade_path,
-            separator=".",
-            default=None,
-        )
+    raw = dpath.get(
+        unprocessed.nextcladeMetadata[segment],
+        nextclade_path,
+        separator=".",
+        default=None,
     )
+    result = None if raw is None else str(raw)
     if nextclade_path == "frameShifts":
         try:
             result = format_frameshift(result)
         except Exception:
-            msg = "Was unable to format frameshift - this is likely an internal error. Please contact the administrator."
+            msg = (
+                "Was unable to format frameshift - this is likely an internal error. "
+                "Please contact the administrator."
+            )
             logger.error(msg)
             errors = [
                 ProcessingAnnotation.from_single(
@@ -108,7 +110,10 @@ def add_nextclade_metadata(
         try:
             result = format_stop_codon(result)
         except Exception:
-            msg = "Was unable to format stop codon - this is likely an internal error. Please contact the administrator."
+            msg = (
+                "Was unable to format stop codon - this is likely an internal error. "
+                "Please contact the administrator."
+            )
             logger.error(msg)
             errors = [
                 ProcessingAnnotation.from_single(


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/5543

### Screenshot
The EV nextclade datasets do not all have stop codons defined. In this case dpath converted None to the string "None" leading the stop codon formatter to fail. This PR ensures dpath does not convert None to "None".

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://fix-stop-codons.loculus.org