### PR TITLE
chore(website): log something when the `details.json` endpoint fails

### DIFF
--- a/website/src/pages/seq/[accessionVersion]/details.json.ts
+++ b/website/src/pages/seq/[accessionVersion]/details.json.ts
@@ -3,7 +3,10 @@ import { type APIRoute } from 'astro';
 import { findOrganismAndData } from './findOrganismAndData';
 import { SequenceDetailsTableResultType } from './getSequenceDetailsTableData';
 import { getRuntimeConfig, getSchema } from '../../../config';
+import { getInstanceLogger } from '../../../logger.ts';
 import type { DetailsJson } from '../../../types/detailsJson';
+
+const logger = getInstanceLogger('details.json');
 
 export const GET: APIRoute = async (req) => {
     const params = req.params as { accessionVersion: string; accessToken?: string };
@@ -11,6 +14,9 @@ export const GET: APIRoute = async (req) => {
     const sequenceDetailsTableData = await findOrganismAndData(accessionVersion);
 
     if (sequenceDetailsTableData.isErr()) {
+        logger.warn(
+            `Could not find sequence details for accessionVersion ${accessionVersion}: ${sequenceDetailsTableData.error.message}`,
+        );
         return new Response(`Error detected`, {
             status: 404,
         });

--- a/website/src/pages/seq/[accessionVersion]/getSequenceDetailsTableData.ts
+++ b/website/src/pages/seq/[accessionVersion]/getSequenceDetailsTableData.ts
@@ -14,7 +14,6 @@ import { parseAccessionVersionFromString } from '../../../utils/extractAccession
 export enum SequenceDetailsTableResultType {
     TABLE_DATA = 'tableData',
     REDIRECT = 'redirect',
-    ERROR = 'error',
 }
 
 export type TableData = {


### PR DESCRIPTION
For EV, there is an error on the branch, but I didn't find anything in the logs -> this will write something like:
```
{"instance":"details.json","level":"warn","message":"Could not find sequence details for accessionVersion LOC_001LMDD.1: cchf: 'No data found for accession version LOC_001LMDD.1', dummy-organism: 'No data found for accession version LOC_001LMDD.1', dummy-organism-with-files: 'No data found for accession version LOC_001LMDD.1', ebola-sudan: 'No data found for accession version LOC_001LMDD.1', enteroviruses: 'Value 'null' of field 'genotype' is not a valid string.', not-aligned-organism: 'No data found for accession version LOC_001LMDD.1', west-nile: 'No data found for accession version LOC_001LMDD.1'","timestamp":"2025-11-26T15:23:21.036Z"}
```

### Screenshot

### PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by appropriate, automated tests.~~
~~- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~~

🚀 Preview: Add `preview` label to enable