### PR TITLE
chore(preprocessing): fix spelling in embl file error message

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -570,7 +570,8 @@ def upload_flatfiles(processed: Sequence[SubmissionData], config: Config) -> Non
                     processedFields=[
                         AnnotationSource(name="embl_upload", type=AnnotationSourceType.METADATA)
                     ],
-                    message="Failed to create or upload EMBL file. Please contact your administrator.",
+                    message="Failed to create or upload EMBL file. "
+                    "Please contact your administrator.",
                 )
             )
 


### PR DESCRIPTION
It looked weird before:
`embl_upload: Failed to create or upload EMBL file please contact your administrator.`

<img width="665" height="40" alt="grafik" src="https://github.com/user-attachments/assets/d658d08a-a3cd-41cb-872a-dac5f2331031" />

🚀 Preview: Add `preview` label to enable