### PR TITLE
refactor(ingest): slight code changes, typing and documentation in `override_group_segments.py`

### DIFF
--- a/ingest/scripts/override_group_segments.py
+++ b/ingest/scripts/override_group_segments.py
@@ -68,11 +68,11 @@ class Config:
 
 @dataclass
 class Groups:
-    """Group override definitions, showing which accessions belong to a given group."""
+    # Group override definitions, showing which accessions belong to a given group.
     override_groups: dict[GroupName, list[InsdcAccession]]
 
-    """Map of nucleotide sequence accessions to their group/assembly names.
-    Basically the reverse map of `override_groups`."""
+    # Map of nucleotide sequence accessions to their group/assembly names.
+    # Basically the reverse map of `override_groups`.
     accession_to_group: dict[InsdcAccession, GroupName]
 
 
@@ -247,7 +247,7 @@ def write_grouped_metadata(
     logger.info(f"No override group definitions found for {count_ungrouped} records")
 
     count_incomplete_groups = len(found_groups)
-    count_empty_groups = len([name for name, records in found_groups if len(records) == 0])
+    count_empty_groups = len([name for name, records in found_groups.items() if len(records) == 0])
 
     # Write out remaining, only partially found groups - even if incomplete
     for name, records in found_groups.items():
@@ -307,7 +307,7 @@ def get_groups_object(groups_json_path: str) -> Groups:
         for accession in metadata:
             accession_to_group[accession] = group
 
-    return Groups(accession_to_group, override_groups)
+    return Groups(override_groups, accession_to_group)
 
 
 @click.command()


### PR DESCRIPTION
Hey Loculus folks!

I went through this file today because I wanted to understand better what was happening, and I wanted to share some edits I made while I was reading the file to help me understand how it works. Maybe this "outside perspective" from someone not as familiar with the ingest code is useful to you.

- Made type hints more specific in certain places (for example `str` -> `Accession`)
- Added some doc strings to certain properties
- Added help text to two input arguments, with more detail about what files are expected to be given here.
- moved the `found_groups` dictionary out of the `Groups` type into the function `write_grouped_metadata`, because it was only used there, and can thus be more narrowly scoped be created and kept in that function.
- Changed some log messages, mostly to be more elaborate (for example "input metadata records" instead of just "records")
- In one place, separate the counting of items and the writing of groups into two different code blocks, to help understand both easier (separation of concerns).

### Testing

**TODO** - Will test on GS staging and report back

### PR Checklist
- [x] All necessary documentation has been adapted.
- ~~The implemented feature is covered by appropriate, automated tests.~~
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable