### PR TITLE
docs(ingest): document grouping_override in README

### DIFF
--- a/ingest/README.md
+++ b/ingest/README.md
@@ -56,7 +56,7 @@ We group segments by adding a `jointAccession` field to the metadata which consi
 
 Using the config `grouping_override` you can provide a URL to a JSON file containing grouping overrides. The file should contain a dictionary mapping group names to lists of accessions.
 
-During grouping, this file will be used first to group segments together into a sequence entry. Only the remaining segments will be grouped in the way described above.
+During grouping, this file will be used first to group segments together into a sequence entry. Only the remaining segments will be grouped using heuristic grouping (as described above).
 
 ### Getting status and hashes of previously submitted sequences and triaging
 


### PR DESCRIPTION
The README describes the ingest steps, and there is a step about grouping segments as well, but it doesn't mention that an override is possible. 

This PR adds a sub-section about manual overrides of groupings.

See here: https://github.com/loculus-project/loculus/blob/3e5a8ca3cbb19dca2b43747b0f2fb9ce7ead0672/ingest/README.md#manual-grouping-override

### PR Checklist
- [x] All necessary documentation has been adapted.
- ~~The implemented feature is covered by appropriate, automated tests.~~
- ~~Any manual testing that has been done is documented (i.e. what exactly was tested?)~~

🚀 Preview: Add `preview` label to enable