### PR TITLE
chore(config): use standardized silo lineage hierarchy definition paths

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -53,7 +53,7 @@ lineageSystemDefinitions:
   alternativeLineage:
     4: https://raw.githubusercontent.com/loculus-project/loculus/fe3b2974071acc9a25856d650350f8a952040a7c/preprocessing/dummy/lineage-alternative.yaml
   cchfS:
-    1: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/cchf/S/2025-09-12/lineages.yaml
+    1: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/cchf/S/2025-09-24--07-29-03Z/lineages.yaml
 defaultOrganismConfig: &defaultOrganismConfig
   schema: &schema
     loadSequencesAutomatically: true


### PR DESCRIPTION
Only path changes, file remains the same, see https://github.com/pathoplexus/silo-lineage-hierarchy-definitions

🚀 Preview: https://timestamped-lineage-defin.loculus.org