### PR TITLE
Fix wording for multi-segmented which should read `id` not `submissionId` as we renamed this for user facing stuff prior to submission

### DIFF
--- a/website/src/components/Submission/FileUpload/SequenceEntryUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/SequenceEntryUploadComponent.tsx
@@ -99,7 +99,7 @@ export const SequenceEntryUpload: FC<SequenceEntryUploadProps> = ({
                     <p className='text-gray-400 text-xs mt-3'>
                         {organism.toUpperCase()} has a multi-segmented genome. Please submit one metadata entry with a
                         unique <i>id</i> for the full multi-segmented sample, e.g. <b>sample1</b>. Sequence
-                        data should be a FASTA file with each header indicating the <i>submissionId</i> and the segment,
+                        data should be a FASTA file with each header indicating the <i>id</i> and the segment,
                         i.e.{' '}
                         {getFirstLightweightSchema(referenceGenomeLightweightSchema).nucleotideSegmentNames.map(
                             (name, index) => (


### PR DESCRIPTION
🚀 Preview: Add `preview` label to enable