### PR TITLE
feat(config): update values.schema.json for multi path

### DIFF
--- a/docs/src/content/docs/for-administrators/my-first-loculus.md
+++ b/docs/src/content/docs/for-administrators/my-first-loculus.md
@@ -153,7 +153,7 @@ organisms:
         configFile:
           log_level: DEBUG
           batch_size: 100
-          nucleotideSequences:
+          nextclade_sequence_and_datasets:
             - name: 'main'
               genes: []
     referenceGenomes:

--- a/docs/src/content/docs/for-administrators/setup-with-k3d-and-nginx.mdx
+++ b/docs/src/content/docs/for-administrators/setup-with-k3d-and-nginx.mdx
@@ -170,7 +170,7 @@ organisms:
         configFile:
           log_level: DEBUG
           batch_size: 100
-          nucleotideSequences:
+          nextclade_sequence_and_datasets:
             - name: 'main'
               genes: []
     referenceGenomes:

--- a/docs/src/content/docs/for-administrators/setup-with-kubernetes.md
+++ b/docs/src/content/docs/for-administrators/setup-with-kubernetes.md
@@ -144,7 +144,7 @@ preprocessing:
       - 'prepro'
     configFile:
       log_level: DEBUG
-      nucleotideSequences:
+      nextclade_sequence_and_datasets:
         - name: 'main'
           nextclade_dataset_name: nextstrain/ebola/zaire
           genes: [NP, VP35, VP40, GP, sGP, ssGP, VP30, VP24, L]

--- a/docs/src/content/docs/reference/helm-chart-config.mdx
+++ b/docs/src/content/docs/reference/helm-chart-config.mdx
@@ -134,6 +134,10 @@ The values for `args` and `configFile` depend on the used preprocessing pipeline
 
 <SchemaDocs group='nextcladePipelineConfigFile' fieldColumnClass='w-28' />
 
+##### Nextclade Preprocessing Pipeline Sequence and Dataset Objects (type)
+
+<SchemaDocs group='nextcladeSequenceAndDataset' fieldColumnClass='w-28' />
+
 For more details on the Nextclade preprocessing pipeline, please see
 [here](../../for-administrators/existing-preprocessing-pipelines/#nextclade-based-pipeline).
 

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -593,16 +593,72 @@
                     "enum": ["ALL", "ANY"],
                     "description": "If multi-segmented viruses should require ALL segments (that the user provides) align or ANY segment aligns"
                   },
-                  "nextclade_dataset_server": {
-                    "groups": ["nextcladePipelineConfigFile"],
-                    "docsIncludePrefix": false,
-                    "type": "string"
-                  },
-                  "nextclade_dataset_name": {
+                  "segment_classification_method": {
                     "groups": ["nextcladePipelineConfigFile"],
                     "docsIncludePrefix": false,
                     "type": "string",
-                    "description": "Required if sequences should be aligned"
+                    "enum": ["minimizer", "align"],
+                    "description": "Method to classify segments for multi-segmented viruses"
+                  },
+                  "nextclade_dataset_server": {
+                    "groups": ["nextcladePipelineConfigFile"],
+                    "docsIncludePrefix": false,
+                    "type": "string",
+                    "description": "Server from which to download nextclade datasets."
+                  },
+                  "nextclade_sequence_and_datasets": {
+                    "groups": ["nextcladePipelineConfigFile"],
+                    "docsIncludePrefix": false,
+                    "type": "array",
+                    "description": "Array of [nextcladeSequenceAndDataset](#nextclade-preprocessing-pipeline-sequence-and-dataset-objects-type) objects containing nucleotide sequence names and datasets.",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "groups": ["nextcladeSequenceAndDataset"],
+                          "docsIncludePrefix": false,
+                          "type": "string",
+                          "description": "Name of the nucleotide sequence to which this dataset applies - defaults to 'main'."
+                        },
+                        "nextclade_dataset_name": {
+                          "groups": ["nextcladeSequenceAndDataset"],
+                          "docsIncludePrefix": false,
+                          "type": "string",
+                          "description": "Name of the nextclade dataset to use to align the sequence - required if this sequence should be aligned."
+                        },
+                        "nextclade_dataset_tag": {
+                          "groups": ["nextcladeSequenceAndDataset"],
+                          "docsIncludePrefix": false,
+                          "type": "string",
+                          "description": "Optional. Tag of the nextclade dataset to use to align the sequence."
+                        },
+                        "nextclade_dataset_server": {
+                          "groups": ["nextcladeSequenceAndDataset"],
+                          "docsIncludePrefix": false,
+                          "type": "string",
+                          "description": "Optional. Server from which to download the nextclade dataset to use to align the sequence. If not specified, use the global nextclade_dataset_server."
+                        },
+                        "accepted_sort_matches": {
+                          "groups": ["nextcladeSequenceAndDataset"],
+                          "docsIncludePrefix": false,
+                          "type": "array",
+                          "description": "Optional. Array of strings. The dataset names that are accepted as matches when using nextclade sort, if not specified use only accept matches with the same name or nextclade_dataset_name."
+                        },
+                        "genes": {
+                          "groups": ["nextcladeSequenceAndDataset"],
+                          "docsIncludePrefix": false,
+                          "type": "array",
+                          "description": "Array of strings. The names of the genes to be extracted from the sequence alignment results (should correspond to gene names in the nextclade dataset)."
+                        },
+                        "gene_prefix": {
+                          "groups": ["nextcladeSequenceAndDataset"],
+                          "docsIncludePrefix": false,
+                          "type": "string",
+                          "description": "Optional. Prefix to add to extracted gene names when sending the processing results to the backend. For example, if the nucleotide sequence is for segment (or subtype) A of a multi-segmented virus, then setting gene_prefix to 'A_' will result in gene names 'A_gene1', 'A_gene2', etc."
+                        }
+                      }
+                    }
                   },
                   "require_nextclade_sort_match": {
                     "groups": ["nextcladePipelineConfigFile"],
@@ -614,13 +670,7 @@
                     "groups": ["nextcladePipelineConfigFile"],
                     "docsIncludePrefix": false,
                     "type": "string",
-                    "description": "Minimizer used for nextclade sort (if require_nextclade_sort_match is true), if not specified use default nextclade server minimizer"
-                  },
-                  "accepted_dataset_matches": {
-                    "groups": ["nextcladePipelineConfigFile"],
-                    "docsIncludePrefix": false,
-                    "type": "array",
-                    "description": "Array of strings. The dataset names that are accepted as matches when using nextclade sort, if not specified use nextclade_dataset_name."
+                    "description": "Minimizer used for nextclade sort (if require_nextclade_sort_match or if segments are to be assigned using nextclade sort)"
                   },
                   "backend_request_timeout_seconds": {
                     "groups": ["nextcladePipelineConfigFile"],
@@ -628,7 +678,8 @@
                     "type": "integer",
                     "description": "Timeout in seconds for requests to the backend server for data to process"
                   }
-                }
+                },
+                "required": ["nextclade_sequence_and_datasets"]
               }
             },
             "required": ["version", "image"]

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1329,7 +1329,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         log_level: DEBUG
         batch_size: 100
         create_embl_file: true
-        nucleotideSequences:
+        nextclade_sequence_and_datasets:
           - name: "main"
             genes: []
         nextclade_dataset_server: https://data.clades.nextstrain.org/v3
@@ -1351,7 +1351,7 @@ defaultOrganisms:
         version: [1, 2]
         configFile:
           <<: *preprocessingConfigFile
-          nucleotideSequences:
+          nextclade_sequence_and_datasets:
             - nextclade_dataset_name: nextstrain/ebola/sudan
               genes: [NP, VP35, VP40, GP, sGP, ssGP, VP30, VP24, L]
           nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/ebola/data_output
@@ -1428,7 +1428,7 @@ defaultOrganisms:
         version: 1
         configFile:
           <<: *preprocessingConfigFile
-          nucleotideSequences:
+          nextclade_sequence_and_datasets:
             - nextclade_dataset_name: nextstrain/wnv/all-lineages
               genes: [capsid, prM, env, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
           nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/wnv/data_output
@@ -1689,6 +1689,9 @@ defaultOrganisms:
         configFile:
           log_level: DEBUG
           batch_size: 100
+          nextclade_sequence_and_datasets:
+            - name: "main"
+              genes: []
     referenceGenomes:
       singleReference:
         nucleotideSequences:
@@ -1754,7 +1757,7 @@ defaultOrganisms:
           <<: *preprocessingConfigFile
           log_level: DEBUG
           minimizer_index: https://loculus-project.github.io/nextclade-sort-minimizers/data/CCHF/minimizer.json
-          nucleotideSequences:
+          nextclade_sequence_and_datasets:
             - name: L
               nextclade_dataset_name: community/pathoplexus/cchfv/L
               genes: [RdRp]
@@ -1880,7 +1883,7 @@ defaultOrganisms:
           <<: *preprocessingConfigFile
           segment_classification_method: "minimizer"
           minimizer_index: "https://raw.githubusercontent.com/alejandra-gonzalezsanchez/loculus-evs/master/evs_minimizer-index.json"
-          nucleotideSequences:
+          nextclade_sequence_and_datasets:
             - name: CV-A16
               nextclade_dataset_name: enpen/enterovirus/cv-a16
               accepted_sort_matches: ["community/hodcroftlab/enterovirus/cva16", "community/hodcroftlab/enterovirus/enterovirus/linked/CV-A16"]

--- a/preprocessing/nextclade/README.md
+++ b/preprocessing/nextclade/README.md
@@ -185,7 +185,7 @@ To add multiple preprocessing pipelines alter the preprocessing section of the `
          version: 1
          dockerTag: commit-xxxxx
          configFile:
-            nucleotideSequences:
+            nextclade_sequence_and_datasets:
             - name: main # default value, not actually required
                nextclade_dataset_name: nextstrain/wnv/all-lineages
             batch_size: 100
@@ -195,7 +195,7 @@ To add multiple preprocessing pipelines alter the preprocessing section of the `
          version: 2
          dockerTag: commit-yyyyyyy
          configFile:
-            nucleotideSequences:
+            nextclade_sequence_and_datasets:
             - name: main
                nextclade_dataset_name: nextstrain/wnv/all-lineages
             batch_size: 100

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -66,7 +66,7 @@ class Config:
     keycloak_token_path: str = "realms/loculus/protocol/openid-connect/token"  # noqa: S105
 
     organism: str = "mpox"
-    nucleotideSequences: list[NextcladeSequenceAndDataset] = dataclasses.field(  # noqa: N815
+    nextclade_sequence_and_datasets: list[NextcladeSequenceAndDataset] = dataclasses.field(
         default_factory=list
     )
     processing_spec: dict[str, dict[str, Any]] = dataclasses.field(default_factory=dict)
@@ -94,7 +94,7 @@ def assign_nextclade_sequence_and_dataset(
     nuc_seq_values: list[dict[str, Any]], config: Config
 ) -> list[NextcladeSequenceAndDataset]:
     if not isinstance(nuc_seq_values, list):
-        error_msg = f"nucleotideSequences should be a list of dicts, got: {type(nuc_seq_values)}"
+        error_msg = f"nextclade_sequence_and_datasets should be a list of dicts, got: {type(nuc_seq_values)}"
         logger.error(error_msg)
         raise ValueError(error_msg)
     nextclade_sequence_and_dataset_list: list[NextcladeSequenceAndDataset] = []
@@ -113,7 +113,7 @@ def assign_nextclade_sequence_and_dataset(
 
 def set_alignment_requirement(config: Config) -> AlignmentRequirement:
     need_nextclade_dataset: bool = False
-    for sequence in config.nucleotideSequences:
+    for sequence in config.nextclade_sequence_and_datasets:
         if sequence.nextclade_dataset_name:
             need_nextclade_dataset = True
     if not need_nextclade_dataset:
@@ -128,7 +128,7 @@ def load_config_from_yaml(config_file: str, config: Config | None = None) -> Con
         logger.debug(f"Loaded config from {config_file}: {yaml_config}")
     for key, value in yaml_config.items():
         if value is not None and hasattr(config, key):
-            if key == "nucleotideSequences":
+            if key == "nextclade_sequence_and_datasets":
                 setattr(config, key, assign_nextclade_sequence_and_dataset(value, config))
                 continue
             attr = getattr(config, key)
@@ -217,7 +217,7 @@ def get_config(config_file: str | None = None, ignore_args: bool = False) -> Con
 
     config.alignment_requirement = set_alignment_requirement(config)
 
-    if len(config.nucleotideSequences) > 1:
+    if len(config.nextclade_sequence_and_datasets) > 1:
         config.multi_segment = True
 
     return config

--- a/preprocessing/nextclade/src/loculus_preprocessing/nextclade.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/nextclade.py
@@ -324,7 +324,7 @@ def assign_segment(
         best_hit = best_hits[best_hits["seqName"] == seq_id]
 
         not_found = True
-        for segment in config.nucleotideSequences:
+        for segment in config.nextclade_sequence_and_datasets:
             if (
                 config.segment_classification_method == SegmentClassificationMethod.ALIGN
                 and best_hit["segment"].iloc[0] == segment.name
@@ -385,7 +385,7 @@ def assign_segment_with_nextclade_align(
 ) -> SegmentAssignmentBatch:
     """
     Run nextclade align
-    - assert sequence aligns to one of the segments in config.nucleotideSequences
+    - assert sequence aligns to one of the segments in config.nextclade_sequence_and_datasets
     """
     batch = SegmentAssignmentBatch()
 
@@ -394,7 +394,7 @@ def assign_segment_with_nextclade_align(
         input_file = result_dir + "/input.fasta"
         id_map = write_nextclade_input_fasta(unprocessed, input_file)
 
-        for sequence_and_dataset in config.nucleotideSequences:
+        for sequence_and_dataset in config.nextclade_sequence_and_datasets:
             segment = sequence_and_dataset.name
             result_file_seg = f"{result_dir}/sort_output_{segment}.tsv"
 
@@ -527,11 +527,11 @@ def assign_segment_using_header(
 ) -> SegmentAssignment:
     segment_assignment = SegmentAssignment()
     duplicate_segments = set()
-    if not config.nucleotideSequences:
+    if not config.nextclade_sequence_and_datasets:
         return segment_assignment
     if not config.multi_segment:
         return assign_single_segment(input_unaligned_sequences, config)
-    for sequence_and_dataset in config.nucleotideSequences:
+    for sequence_and_dataset in config.nextclade_sequence_and_datasets:
         segment = sequence_and_dataset.name
         unaligned_segment = [
             data
@@ -567,7 +567,7 @@ def assign_segment_using_header(
                 f"{', '.join(remaining_segments)}. "
                 "Each metadata entry can have multiple corresponding fasta sequence "
                 "entries with format <submissionId>_<segmentName> valid segments are: "
-                f"{', '.join([seq.name for seq in config.nucleotideSequences])}."
+                f"{', '.join([seq.name for seq in config.nextclade_sequence_and_datasets])}."
             )
         )
     if len(segment_assignment.unalignedNucleotideSequences) == 0 and not duplicate_segments:
@@ -692,7 +692,7 @@ def enrich_with_nextclade(  # noqa: PLR0914
         AccessionVersion, defaultdict[GeneName, list[AminoAcidInsertion]]
     ] = defaultdict(lambda: defaultdict(list))
     with TemporaryDirectory(delete=not config.keep_tmp_dir) as result_dir:
-        for sequence_and_dataset in config.nucleotideSequences:
+        for sequence_and_dataset in config.nextclade_sequence_and_datasets:
             segment = sequence_and_dataset.name
             result_dir_seg = result_dir + "/" + segment
             input_file = result_dir_seg + "/input.fasta"
@@ -773,7 +773,7 @@ def enrich_with_nextclade(  # noqa: PLR0914
 
 
 def download_nextclade_dataset(dataset_dir: str, config: Config) -> None:
-    for sequence_and_dataset in config.nucleotideSequences:
+    for sequence_and_dataset in config.nextclade_sequence_and_datasets:
         dataset_download_command = [
             "nextclade3",
             "dataset",

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -329,7 +329,7 @@ def get_output_metadata(
             continue
 
         if output_field.startswith("length_") and output_field[7:] in [
-            seq.name for seq in config.nucleotideSequences
+            seq.name for seq in config.nextclade_sequence_and_datasets
         ]:
             segment = output_field[7:]
             output_metadata[output_field] = get_sequence_length(
@@ -402,7 +402,7 @@ def alignment_errors_warnings(
         )
         return (errors, warnings)
     aligned_segments = set()
-    for sequence_and_dataset in config.nucleotideSequences:
+    for sequence_and_dataset in config.nextclade_sequence_and_datasets:
         segment = sequence_and_dataset.name
         if segment not in unprocessed.unalignedNucleotideSequences:
             continue
@@ -445,7 +445,7 @@ def unpack_annotations(config, nextclade_metadata: dict[str, Any] | None) -> dic
     if not config.create_embl_file or not nextclade_metadata:
         return None
     annotations: dict[str, Any] = {}
-    for sequence_and_dataset in config.nucleotideSequences:
+    for sequence_and_dataset in config.nextclade_sequence_and_datasets:
         segment = sequence_and_dataset.name
         if segment in nextclade_metadata:
             annotations[segment] = None

--- a/preprocessing/nextclade/tests/multi_pathogen_config.yaml
+++ b/preprocessing/nextclade/tests/multi_pathogen_config.yaml
@@ -4,7 +4,7 @@ alignment_requirement: ALL
 log_level: DEBUG
 minimizer_index: TEST
 nextclade_dataset_server: TEST
-nucleotideSequences:
+nextclade_sequence_and_datasets:
 - name: ebola-sudan
   nextclade_dataset_name: ebola-dataset/ebola-sudan
   accepted_sort_matches: ebola-sudan

--- a/preprocessing/nextclade/tests/multi_segment_config.yaml
+++ b/preprocessing/nextclade/tests/multi_segment_config.yaml
@@ -3,7 +3,7 @@ alignment_requirement: ALL
 log_level: DEBUG
 minimizer_index: TEST
 segment_classification_method: "minimizer"
-nucleotideSequences:
+nextclade_sequence_and_datasets:
 - name: ebola-sudan
   nextclade_dataset_name: ebola-dataset/ebola-sudan
   genes: [NPEbolaSudan, VP35EbolaSudan, LEbolaSudan]

--- a/preprocessing/nextclade/tests/multi_segment_config_unaligned.yaml
+++ b/preprocessing/nextclade/tests/multi_segment_config_unaligned.yaml
@@ -2,7 +2,7 @@ batch_size: 100
 alignment_requirement: NONE
 log_level: DEBUG
 minimizer_index: TEST
-nucleotideSequences:
+nextclade_sequence_and_datasets:
 - name: ebola-sudan
 - name: ebola-zaire
 organism: multi-ebola-test

--- a/preprocessing/nextclade/tests/single_segment_config.yaml
+++ b/preprocessing/nextclade/tests/single_segment_config.yaml
@@ -6,7 +6,7 @@ molecule_type: "genomic RNA"
 topology: "linear"
 db_name: "Loculus"
 minimizer_index: TEST
-nucleotideSequences:
+nextclade_sequence_and_datasets:
 - nextclade_dataset_name: ebola-sudan
   genes: [NPEbolaSudan, VP35EbolaSudan, LEbolaSudan]
 organism: ebola-sudan-test

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -660,7 +660,7 @@ def test_preprocessing_without_consensus_sequences(config: Config) -> None:
         ),
     )
 
-    config.nucleotideSequences = []
+    config.nextclade_sequence_and_datasets = []
 
     result = process_all([sequence_entry_data], "temp_dataset_dir", config)
     processed_entry = result[0].processed_entry


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/5571

Adds the new config structure to the kubernetes/loculus/values.schema.json. I also renamed `nucleotideSequences` to `nextcladeSequenceAndDatasets` to avoid confusion as preprocessing expects different items in this list of dictionaries. 

### Screenshot
<img width="1096" height="1398" alt="image" src="https://github.com/user-attachments/assets/02041fb7-2e92-4d14-9bc9-3d1feab0c112" />

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable