### PR TITLE
fix(deployment): add exponential backoff retry for helm repo add

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -509,8 +509,23 @@ def install_secret_generator():
         "mittwald",
         "https://helm.mittwald.de",
     ]
-    run_command(add_helm_repo_command)
-    print("Mittwald repository added to Helm.")
+
+    # Retry logic for helm repo add with exponential backoff
+    max_retries = 5
+    retry_delay = 5
+    for attempt in range(max_retries + 1):
+        try:
+            run_command(add_helm_repo_command)
+            print("Mittwald repository added to Helm.")
+            break
+        except subprocess.SubprocessError as e:
+            if attempt < max_retries:
+                print(f"Failed to add Mittwald repository (attempt {attempt + 1}/{max_retries + 1}). Retrying in {retry_delay} seconds...")
+                time.sleep(retry_delay)
+                retry_delay = min(retry_delay * 2, 60)
+            else:
+                print(f"Failed to add Mittwald repository after {max_retries + 1} attempts.")
+                raise e
 
     update_helm_repo_command = ["helm", "repo", "update"]
     run_command(update_helm_repo_command)


### PR DESCRIPTION
Fixes #5588

We are seeing intermittent timeouts when adding the mittwald helm repo (at least twice today, I noticed it on just a few runs and I remember seeing it last week as well).

This PR adds an exponential backoff retry mechanism to the `helm repo add` command in `deploy.py`.
It will retry up to 5 times (6 attempts total) with a delay starting at 5 seconds and doubling up to 60 seconds.

🚀 Preview: Add `preview` label to enable