### PR TITLE
refactor(website): remove unnecessary useEffect as setting is static

### DIFF
--- a/website/src/components/SequenceDetailsPage/SequencesDisplay/SequencesContainer.tsx
+++ b/website/src/components/SequenceDetailsPage/SequencesDisplay/SequencesContainer.tsx
@@ -42,7 +42,7 @@ export const InnerSequencesContainer: FC<SequenceContainerProps> = ({
         suborganism,
     );
 
-    const [loadSequences, setLoadSequences] = useState<boolean>(() => loadSequencesAutomatically);
+    const [loadSequences, setLoadSequences] = useState(() => loadSequencesAutomatically);
     const [sequenceType, setSequenceType] = useState<SequenceType>(unalignedSequenceSegment(nucleotideSegmentInfos[0]));
 
     if (!loadSequences) {


### PR DESCRIPTION
On first render it'd always flash the button unnecessarily - this caused a flake. That's how I came across this code.

Originally introduced in https://github.com/loculus-project/loculus/pull/1677

We might even remove the load sequences altogether eventually - by default we always load now on all organisms.

🚀 Preview: https://remove-unnecessary-use-ef.loculus.org