### PR TITLE
docs: Update README.md for keycloakify to explicitly contain nvm install

### DIFF
--- a/keycloak/keycloakify/README.md
+++ b/keycloak/keycloakify/README.md
@@ -15,7 +15,7 @@ Based on upstream commit: https://github.com/keycloakify/keycloakify-starter/com
 
 First, ensure [nvm](https://github.com/nvm-sh/nvm) is installed and that corepack is enabled (`corepack enable`).
 If you don't have the version of npm specified in `.nvmrc` installed, do so by running `nvm install` in this directory.
-Then, run the following commands (all together, not as individual commands):
+Then, run the following commands:
 ```bash
 nvm use
 corepack install


### PR DESCRIPTION
instructions

resolves https://github.com/loculus-project/loculus/issues/5608

### Screenshot

### PR Checklist
- [x] All necessary documentation has been adapted.
- [ ] ~The implemented feature is covered by appropriate, automated tests.~
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

Manually tested that the commands I included in the README work on my machine. Storybook output looked good as far as I could tell.

🚀 Preview: Add `preview` label to enable