### PR TITLE
chore(ci): Revert `helm repo add` retry code and log ip instead

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -59,6 +59,8 @@ jobs:
     steps:
       - name: Shorten sha
         run: echo "sha=${sha::7}" >> $GITHUB_ENV
+      - name: Get runner IP
+        run: curl -4 ifconfig.me
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@v2
       - name: Checkout repository

--- a/deploy.py
+++ b/deploy.py
@@ -509,23 +509,8 @@ def install_secret_generator():
         "mittwald",
         "https://helm.mittwald.de",
     ]
-
-    # Retry logic for helm repo add with exponential backoff
-    max_retries = 5
-    retry_delay = 5
-    for attempt in range(max_retries + 1):
-        try:
-            run_command(add_helm_repo_command)
-            print("Mittwald repository added to Helm.")
-            break
-        except subprocess.SubprocessError as e:
-            if attempt < max_retries:
-                print(f"Failed to add Mittwald repository (attempt {attempt + 1}/{max_retries + 1}). Retrying in {retry_delay} seconds...")
-                time.sleep(retry_delay)
-                retry_delay = min(retry_delay * 2, 60)
-            else:
-                print(f"Failed to add Mittwald repository after {max_retries + 1} attempts.")
-                raise e
+    run_command(add_helm_repo_command)
+    print("Mittwald repository added to Helm.")
 
     update_helm_repo_command = ["helm", "repo", "update"]
     run_command(update_helm_repo_command)


### PR DESCRIPTION
Retrying (#5590) didn't help.

Getting IP will help Mittwald debug the problem if it comes back, see https://github.com/mittwald/kubernetes-secret-generator/issues/115#issuecomment-3607716359

🚀 Preview: Add `preview` label to enable