### PR TITLE
chore(website): fix Astro glob deprecation warning by using recommended migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ __pycache__/
 
 
 .venv*
+
+.claude/

--- a/website/.prettierignore
+++ b/website/.prettierignore
@@ -1,2 +1,3 @@
 /dist
 /playwright-report
+.claude/

--- a/website/src/components/Navigation/DocsMenu.tsx
+++ b/website/src/components/Navigation/DocsMenu.tsx
@@ -1,26 +1,24 @@
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react';
-import type { MDXInstance } from 'astro';
 import { type FC } from 'react';
 
+import type { MdxPage } from '../../types/mdxTypes';
 import XIcon from '~icons/material-symbols/close';
 import MenuIcon from '~icons/material-symbols/menu';
 
-type Page = MDXInstance<Record<string, any>>; // eslint-disable-line @typescript-eslint/no-explicit-any -- TODO(#3451) use a proper type
-
 interface DocsMenuProps {
-    docsPages: Page[];
+    docsPages: MdxPage[];
     currentPageUrl: string;
     title: string;
 }
 
 interface GroupedPages {
-    groupedPages: Record<string, Page[]>;
-    indexPages: Record<string, Page>;
+    groupedPages: Record<string, MdxPage[]>;
+    indexPages: Record<string, MdxPage>;
 }
 
-const groupPagesByDirectory = (pages: Page[]): GroupedPages => {
-    const groupedPages: Record<string, Page[]> = {};
-    const indexPages: Record<string, Page> = {};
+const groupPagesByDirectory = (pages: MdxPage[]): GroupedPages => {
+    const groupedPages: Record<string, MdxPage[]> = {};
+    const indexPages: Record<string, MdxPage> = {};
 
     pages.forEach((page) => {
         const fileParts = page.file.split('/');
@@ -54,7 +52,7 @@ const groupPagesByDirectory = (pages: Page[]): GroupedPages => {
 const toTitleCase = (str: string): string => str.replace(/\b\w/g, (char) => char.toUpperCase());
 
 interface MenuItemProps {
-    page: Page;
+    page: MdxPage;
     currentPageUrl: string;
 }
 
@@ -73,8 +71,8 @@ const MenuItem: FC<MenuItemProps> = ({ page, currentPageUrl }) => (
 
 interface MenuSectionProps {
     dir: string;
-    pages: Page[];
-    indexPage?: Page;
+    pages: MdxPage[];
+    indexPage?: MdxPage;
     currentPageUrl: string;
 }
 

--- a/website/src/layouts/AboutLayout.astro
+++ b/website/src/layouts/AboutLayout.astro
@@ -2,16 +2,17 @@
 import '../styles/mdcontainer.scss';
 import BaseLayout from './BaseLayout.astro';
 import DocsMenu from '../components/Navigation/DocsMenu';
+import type { MdxPage } from '../types/mdxTypes';
 
 const { frontmatter } = Astro.props;
-const docsPages = await Astro.glob('../pages/about/**/*.mdx');
+const aboutPages = Object.values(import.meta.glob<MdxPage>('../pages/about/**/*.mdx', { eager: true }));
 const activeTopNavigationItem = frontmatter?.activeTopNavigationItem ?? '/about';
 const currentPageUrl = Astro.url.pathname;
 ---
 
 <BaseLayout title={frontmatter.title} activeTopNavigationItem={activeTopNavigationItem}>
     <div class='md:flex md:justify-between max-w-5xl mx-auto items-start gap-10'>
-        <DocsMenu docsPages={docsPages} currentPageUrl={currentPageUrl} title='About' client:load />
+        <DocsMenu docsPages={aboutPages} currentPageUrl={currentPageUrl} title='About' client:load />
         <div class='mdContainer mdContainerItself text-gray-700 leading-relaxed'>
             <h1>{frontmatter.title}</h1>
 

--- a/website/src/layouts/DocLayout.astro
+++ b/website/src/layouts/DocLayout.astro
@@ -3,6 +3,7 @@ import '../styles/mdcontainer.scss';
 import BaseLayout from './BaseLayout.astro';
 import DocsMenu from '../components/Navigation/DocsMenu';
 import { getWebsiteConfig } from '../config';
+import type { MdxPage } from '../types/mdxTypes';
 import MdiGithub from '~icons/mdi/github';
 
 const { frontmatter } = Astro.props;
@@ -10,7 +11,7 @@ const activeTopNavigationItem = frontmatter?.activeTopNavigationItem ?? '/docs/'
 const file = Astro.props.file;
 const FILE_BEGINNING = 'src/pages/';
 const fileLocation = file.slice(file.indexOf(FILE_BEGINNING), file.length);
-const docsPages = await Astro.glob('../pages/docs/**/*.mdx');
+const docsPages = Object.values(import.meta.glob<MdxPage>('../pages/docs/**/*.mdx', { eager: true }));
 const currentPageUrl = Astro.url.pathname;
 const { gitHubEditLink } = getWebsiteConfig();
 const editUrl = `${gitHubEditLink}${fileLocation}`;

--- a/website/src/types/mdxTypes.ts
+++ b/website/src/types/mdxTypes.ts
@@ -1,0 +1,4 @@
+import type { MDXInstance } from 'astro';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO(#3451) use content collections for proper types
+export type MdxPage = MDXInstance<Record<string, any>>;


### PR DESCRIPTION
Fixes deprecation warnings on each `npm run check`:

```
> loculus-website@0.0.1 check-types
> astro check && tsc --noEmit

14:43:40 [@astrojs/node] Enabling sessions with filesystem storage
14:43:40 [content] Syncing content
14:43:40 [content] Synced content
14:43:40 [types] Generated 22ms
14:43:40 [check] Getting diagnostics for Astro files in /Users/cr/code/loculus/website...
src/layouts/AboutLayout.astro:7:31 - warning ts(6387): The signature '(globStr: `${any}.mdx`): Promise<MDXInstance<Record<string, any>>[]>' of 'Astro.glob' is deprecated.

7 const docsPages = await Astro.glob('../pages/about/**/*.mdx');
                                ~~~~
src/layouts/AboutLayout.astro:7:31 - warning ts(6385): 'glob' is deprecated.

7 const docsPages = await Astro.glob('../pages/about/**/*.mdx');
                                ~~~~

src/layouts/DocLayout.astro:13:31 - warning ts(6387): The signature '(globStr: `${any}.mdx`): Promise<MDXInstance<Record<string, any>>[]>' of 'Astro.glob' is deprecated.

13 const docsPages = await Astro.glob('../pages/docs/**/*.mdx');
                                 ~~~~
src/layouts/DocLayout.astro:13:31 - warning ts(6385): 'glob' is deprecated.

13 const docsPages = await Astro.glob('../pages/docs/**/*.mdx');
                                 ~~~~
```

Also ensure .claude settings are ignored by prettier.

🚀 Preview: https://fix-glob-depr.loculus.org