### PR TITLE
refactor(website): edit page - remove side effect from rows getter

### DIFF
--- a/website/src/components/Edit/EditableSequences.spec.ts
+++ b/website/src/components/Edit/EditableSequences.spec.ts
@@ -37,10 +37,10 @@ describe('EditableSequences', () => {
         const MAX_SEQUENCES_PER_ENTRY = 1;
         let editableSequences = EditableSequences.empty(MAX_SEQUENCES_PER_ENTRY);
         const initialRows = editableSequences.rows;
-        expect(initialRows).toEqual([
-            { label: 'Add a segment', value: null, initialValue: null, fastaHeader: null, key: expect.any(String) },
-        ]);
         const firstKey = initialRows[0].key;
+        expect(initialRows).toEqual([
+            { label: 'Add a segment', value: null, initialValue: null, fastaHeader: null, key: firstKey },
+        ]);
         {
             editableSequences = editableSequences.update(firstKey, SEQUENCE, LABEL, FASTAHEADER);
             const fasta = editableSequences.getSequenceFasta();
@@ -59,13 +59,12 @@ describe('EditableSequences', () => {
             'Maximum limit reached — you can add up to 1 sequence file(s) only.',
         );
         editableSequences = editableSequences.update(firstKey, null, null, null);
+        const secondKey = String(Number(firstKey) + 1);
         expect(editableSequences.rows).toEqual([
-            { label: 'Add a segment', value: null, fastaHeader: null, initialValue: null, key: expect.any(String) },
+            { label: 'Add a segment', value: null, fastaHeader: null, initialValue: null, key: secondKey },
         ]);
-        const rowsAfterDeletion = editableSequences.rows;
-        const newFirstKey = rowsAfterDeletion[0].key;
         {
-            editableSequences = editableSequences.update(newFirstKey, SEQUENCE, LABEL, FASTAHEADER);
+            editableSequences = editableSequences.update(secondKey, SEQUENCE, LABEL, FASTAHEADER);
             const fasta = editableSequences.getSequenceFasta();
             expect(fasta).not.toBeUndefined();
             const fastaText = await fasta!.text();
@@ -78,7 +77,7 @@ describe('EditableSequences', () => {
                     label: LABEL,
                     value: SEQUENCE,
                     initialValue: null,
-                    key: newFirstKey,
+                    key: secondKey,
                     fastaHeader: FASTAHEADER,
                 },
             ]);
@@ -91,12 +90,12 @@ describe('EditableSequences', () => {
         let editableSequences = EditableSequences.empty(MAX_SEQUENCES_PER_ENTRY);
 
         const initialRows = editableSequences.rows;
-        expect(initialRows).toEqual([
-            { label: 'Add a segment', value: null, initialValue: null, fastaHeader: null, key: expect.any(String) },
-        ]);
         const firstKey = initialRows[0].key;
+        expect(initialRows).toEqual([
+            { label: 'Add a segment', value: null, initialValue: null, fastaHeader: null, key: firstKey },
+        ]);
 
-        let secondKey;
+        const secondKey = String(Number(firstKey) + 1);
         {
             editableSequences = editableSequences.update(firstKey, SEQUENCE, LABEL, FASTAHEADER);
             const fasta = editableSequences.getSequenceFasta();
@@ -114,9 +113,8 @@ describe('EditableSequences', () => {
                     fastaHeader: FASTAHEADER,
                     key: firstKey,
                 },
-                { label: 'Add a segment', value: null, initialValue: null, fastaHeader: null, key: expect.any(String) },
+                { label: 'Add a segment', value: null, initialValue: null, fastaHeader: null, key: secondKey },
             ]);
-            secondKey = rows[1].key;
         }
 
         {
@@ -160,14 +158,13 @@ describe('EditableSequences', () => {
         let editableSequences = EditableSequences.empty(MAX_SEQUENCES_PER_ENTRY);
 
         const initialRows = editableSequences.rows;
-        expect(initialRows).toEqual([
-            { label: 'Add a segment', value: null, initialValue: null, fastaHeader: null, key: expect.any(String) },
-        ]);
         const firstKey = initialRows[0].key;
+        expect(initialRows).toEqual([
+            { label: 'Add a segment', value: null, initialValue: null, fastaHeader: null, key: firstKey },
+        ]);
 
         editableSequences = editableSequences.update(firstKey, SEQUENCE, LABEL, FASTAHEADER);
-        const rowsAfterFirstUpdate = editableSequences.rows;
-        const secondKey = rowsAfterFirstUpdate[1].key;
+        const secondKey = String(Number(firstKey) + 1);
 
         editableSequences = editableSequences.update(
             secondKey,
@@ -192,10 +189,10 @@ describe('EditableSequences', () => {
         let editableSequences = EditableSequences.empty(MAX_SEQUENCES_PER_ENTRY);
 
         const initialRows = editableSequences.rows;
-        expect(initialRows).toEqual([
-            { label: 'Add a segment', value: null, initialValue: null, fastaHeader: null, key: expect.any(String) },
-        ]);
         const key = initialRows[0].key;
+        expect(initialRows).toEqual([
+            { label: 'Add a segment', value: null, initialValue: null, key: key, fastaHeader: null },
+        ]);
 
         editableSequences = editableSequences.update(key, SEQUENCE, key, FASTAHEADER);
         const fasta = editableSequences.getSequenceFasta();
@@ -216,10 +213,10 @@ describe('EditableSequences', () => {
         let editableSequences = EditableSequences.empty(MAX_SEQUENCES_PER_ENTRY);
 
         const initialRows = editableSequences.rows;
-        expect(initialRows).toEqual([
-            { label: 'Add a segment', value: null, initialValue: null, fastaHeader: null, key: expect.any(String) },
-        ]);
         const key = initialRows[0].key;
+        expect(initialRows).toEqual([
+            { label: 'Add a segment', value: null, initialValue: null, fastaHeader: null, key: key },
+        ]);
 
         editableSequences = editableSequences.update(key, SEQUENCE, LABEL, null);
         const fasta = editableSequences.getSequenceFasta();
@@ -242,14 +239,16 @@ describe('EditableSequences', () => {
         const key = editableSequences.rows[0].key;
 
         editableSequences = editableSequences.update(key, SEQUENCE, key, key);
+        const secondKey = String(Number(key) + 1);
         expect(editableSequences.rows).toEqual([
             { label: key, value: SEQUENCE, initialValue: null, key, fastaHeader: key },
-            { label: 'Add a segment', value: null, initialValue: null, fastaHeader: null, key: expect.any(String) },
+            { label: 'Add a segment', value: null, initialValue: null, fastaHeader: null, key: secondKey },
         ]);
 
         editableSequences = editableSequences.update(key, null, null, null);
+        const thirdKey = String(Number(secondKey) + 1);
         expect(editableSequences.rows).toEqual([
-            { label: 'Add a segment', value: null, initialValue: null, fastaHeader: null, key: expect.any(String) },
+            { label: 'Add a segment', value: null, initialValue: null, fastaHeader: null, key: thirdKey },
         ]);
         expect(editableSequences.getFastaIds()).toEqual('');
     });

--- a/website/src/components/Edit/EditableSequences.spec.ts
+++ b/website/src/components/Edit/EditableSequences.spec.ts
@@ -56,7 +56,7 @@ describe('EditableSequences', () => {
         }
 
         expect(() => editableSequences.update('another key', 'GG', 'another key', 'FASTAHEADER_anotherkey')).toThrow(
-            'Maximum limit reached — you can add up to 1 sequence file(s) only.',
+            "Attempting to update sequence with key 'another key' that does not exist.",
         );
         editableSequences = editableSequences.update(firstKey, null, null, null);
         const secondKey = String(Number(firstKey) + 1);
@@ -148,7 +148,7 @@ describe('EditableSequences', () => {
         }
 
         expect(() => editableSequences.update('another key', 'GG', 'another key', 'anything')).toThrow(
-            'Maximum limit reached — you can add up to 2 sequence file(s) only.',
+            "Attempting to update sequence with key 'another key' that does not exist.",
         );
         expect(editableSequences.getFastaIds()).toEqual(`${FASTAHEADER} ${OTHER_FASTAHEADER}`);
     });
@@ -204,7 +204,7 @@ describe('EditableSequences', () => {
         const rows = editableSequences.rows;
         expect(rows).deep.equals([{ label: key, value: SEQUENCE, initialValue: null, fastaHeader: FASTAHEADER, key }]);
         expect(() => editableSequences.update('another key', OTHER_SEQUENCE, OTHER_LABEL, OTHER_FASTAHEADER)).toThrow(
-            'Maximum limit reached — you can add up to 1 sequence file(s) only.',
+            "Attempting to update sequence with key 'another key' that does not exist.",
         );
     });
 
@@ -228,7 +228,7 @@ describe('EditableSequences', () => {
         const rows = editableSequences.rows;
         expect(rows).deep.equals([{ label: LABEL, value: SEQUENCE, initialValue: null, fastaHeader: key, key }]);
         expect(() => editableSequences.update('another key', OTHER_SEQUENCE, OTHER_LABEL, OTHER_FASTAHEADER)).toThrow(
-            'Maximum limit reached — you can add up to 1 sequence file(s) only.',
+            "Attempting to update sequence with key 'another key' that does not exist.",
         );
     });
 

--- a/website/src/components/Edit/EditableSequences.ts
+++ b/website/src/components/Edit/EditableSequences.ts
@@ -24,7 +24,8 @@ export class EditableSequences {
     private readonly maxNumberOfRows: number;
 
     public get rows(): Required<EditableSequenceFile>[] {
-        return this.editableSequenceFiles;
+        // Return a copy so callers cannot mutate the internal list.
+        return [...this.editableSequenceFiles];
     }
 
     private constructor(rows: EditableSequenceFile[], maxNumberOfRows: number) {
@@ -122,17 +123,15 @@ export class EditableSequences {
      */
     update(key: string, value: string | null, label: string | null, fastaHeader: string | null): EditableSequences {
         const rows = this.editableSequenceFiles;
-        const rowsWithoutPlaceholders = rows.filter((row) => row.value !== null);
         const existingFileIndex = rows.findIndex((file) => file.key === key);
         if (existingFileIndex === -1) {
             throw new Error(`Attempting to update sequence with key '${key}' that does not exist.`);
         }
         fastaHeader ??= value == null ? null : key; // Ensure fastaHeader is never null if a sequence exists
-        if (
-            rowsWithoutPlaceholders.some(
-                (seq, index) => index !== existingFileIndex && getFastaId(seq.fastaHeader) === getFastaId(fastaHeader),
-            )
-        ) {
+        const collidesWithAnotherRow = rows.some(
+            (row) => row.key !== key && row.value !== null && getFastaId(row.fastaHeader) === getFastaId(fastaHeader),
+        );
+        if (collidesWithAnotherRow) {
             toast.error(`A sequence with the fastaID ${getFastaId(fastaHeader)} already exists.`);
             return this;
         }

--- a/website/src/components/Edit/EditableSequences.ts
+++ b/website/src/components/Edit/EditableSequences.ts
@@ -66,7 +66,7 @@ export class EditableSequences {
         ];
     }
 
-    static invertRecordMulti(obj: Record<string, string | null>): Record<string, string[]> {
+    private static invertRecordMulti(obj: Record<string, string | null>): Record<string, string[]> {
         const inverted: Record<string, string[]> = {};
 
         for (const key in obj) {


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/5637

get rows() had a side effect (it calls getNextKey()) this leads to the key of each newly submitted sequence increasing by an undefined amount as React is calling that getter multiple times per “one” user action - this currently doesnt break anything but it is unintended and would be nice to clean up.

### Screenshot

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable