### PR TITLE
feat!(prepro): allow ordinals in author names and allow names to start with an apostrophe (e.g. 't Hooft)

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -68,7 +68,10 @@ def valid_name() -> str:
         r"\u0180-\u024F"  # Latin Extended-B
     )
 
-    ordinal = r"\d+(?:st|nd|rd|th)"
+    # Ordinal must be a separate "word":
+    # - preceded only by start-of-string or whitespace
+    # - ends at a word boundary
+    ordinal = r"(?<!\S)\d+(?:st|nd|rd|th)\b"
     alpha_or_ord = rf"\s*(?:[{chars}']|{ordinal})"  # First character: letter or ordinal
     name_chars = rf"(?:[{chars}\s.\-']|{ordinal})*"
 

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -619,6 +619,7 @@ not_accepted_authors = [
     "Anna Maria Smith",
     "Smith9, Anna;",
     "Anna Smith, Cameron Tucker, and Jose Perez",
+    "Count4th, EwanMcGregor, Count4th",
 ]
 
 


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/5546

### Screenshot
We should reprocess all data again when rolling this out to production

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable