### PR TITLE
fix(deposition): correct version type

### DIFF
--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -127,7 +127,7 @@ def validate_column_name(table_name: str, column_name: str):
 @dataclass
 class SubmissionTableEntry:
     accession: str
-    version: str
+    version: int
     organism: str
     group_id: int
     errors: str | None = None
@@ -588,7 +588,7 @@ def add_to_assembly_table(
         db_conn_pool.putconn(con)
 
 
-def in_submission_table(db_conn_pool: SimpleConnectionPool, conditions) -> bool:
+def in_submission_table(db_conn_pool: SimpleConnectionPool, conditions: dict[str, Any]) -> bool:
     con = db_conn_pool.getconn()
     try:
         with con, con.cursor() as cur:

--- a/ena-submission/src/ena_deposition/trigger_submission_to_ena.py
+++ b/ena-submission/src/ena_deposition/trigger_submission_to_ena.py
@@ -24,22 +24,23 @@ logger = logging.getLogger(__name__)
 def upload_sequences(db_config: SimpleConnectionPool, sequences_to_upload: dict[str, Any]):
     for full_accession, data in sequences_to_upload.items():
         accession, version = full_accession.split(".")
-        if in_submission_table(db_config, {"accession": accession, "version": version}):
+        if in_submission_table(db_config, {"accession": accession, "version": int(version)}):
             continue
-        entry = {
-            "accession": accession,
-            "version": version,
-            "group_id": data["metadata"]["groupId"],
-            "organism": data["organism"],
-            "metadata": json.dumps(data["metadata"]),
-            "unaligned_nucleotide_sequences": json.dumps(data["unalignedNucleotideSequences"]),
-        }
-        submission_table_entry = SubmissionTableEntry(**entry)
-        add_to_submission_table(db_config, submission_table_entry)
+        entry = SubmissionTableEntry(
+            accession=accession,
+            version=int(version),
+            group_id=data["metadata"]["groupId"],
+            organism=data["organism"],
+            metadata=json.dumps(data["metadata"]),
+            unaligned_nucleotide_sequences=json.dumps(data["unalignedNucleotideSequences"]),
+        )
+        add_to_submission_table(db_config, entry)
         logger.info(f"Inserted {full_accession} into submission_table")
 
 
-def trigger_submission_to_ena(config: Config, stop_event: threading.Event, input_file=None):
+def trigger_submission_to_ena(
+    config: Config, stop_event: threading.Event, input_file: str | None = None
+):
     db_config = db_init(config.db_password, config.db_username, config.db_url)
 
     if input_file:


### PR DESCRIPTION
part of https://github.com/loculus-project/loculus/issues/5646

Version is an int in the db (see https://github.com/loculus-project/loculus/blob/main/ena-submission/flyway/sql/V1__Initial_Schema.sql#L3)- this was incorrectly annotated in the code (python doesn't care) - this is a step towards improving typing in python (we will later introduce pydantic or typeddicts which will validate all entries in the db are the correct specified types. 

### PR Checklist
- ~All necessary documentation has been adapted.~
- [x] The implemented feature is covered by appropriate, automated tests.
- ~Any manual testing that has been done is documented (i.e. what exactly was tested?)~ not required as integration tests will submit to ENA dev

🚀 Preview: Add `preview` label to enable