### PR TITLE
chore(e2e): try deflaking revise button click by waiting for sequence to be visible first

### DIFF
--- a/integration-tests/tests/pages/revision.page.ts
+++ b/integration-tests/tests/pages/revision.page.ts
@@ -19,6 +19,10 @@ export class RevisionPage {
      * Clicks the "Revise this sequence" link
      */
     async clickReviseSequenceLink() {
+        // Sometimes clicking revise button doesn't register, so let's wait for sequence viewer to be visible first
+        // See #5447
+        await expect(this.page.getByTestId('fixed-length-text-viewer')).toBeVisible();
+
         await this.page
             .getByRole('link', { name: 'Revise this sequence' })
             .click({ timeout: 15000 });

--- a/integration-tests/tests/pages/search.page.ts
+++ b/integration-tests/tests/pages/search.page.ts
@@ -114,6 +114,10 @@ export class SearchPage {
     }
 
     async reviseSequence() {
+        // Sometimes clicking revise button doesn't register, so let's wait for sequence viewer to be visible first
+        // See #5447
+        await expect(this.page.getByTestId('fixed-length-text-viewer')).toBeVisible();
+
         const reviseButton = this.page.getByRole('link', { name: 'Revise this sequence' });
         await expect(reviseButton).toBeVisible();
         await reviseButton.click();

--- a/integration-tests/tests/specs/features/revise-sequence.spec.ts
+++ b/integration-tests/tests/specs/features/revise-sequence.spec.ts
@@ -37,8 +37,7 @@ sequenceTest(
 
         await searchPage.clickOnSequence(0);
 
-        await page.getByRole('link', { name: 'Revise this sequence' }).click({ timeout: 15000 });
-        await expect(page.getByRole('heading', { name: 'Create new revision from' })).toBeVisible();
+        await searchPage.reviseSequence();
 
         await page.getByTestId(/^discard_edited_L/).click();
         await page.getByTestId(/^discard_edited_S/).click();

--- a/integration-tests/tests/specs/features/search/override-hidden-fields.spec.ts
+++ b/integration-tests/tests/specs/features/search/override-hidden-fields.spec.ts
@@ -59,7 +59,7 @@ test('Override hidden fields', async ({ page, groupId }) => {
     await search.fill('Author affiliations', uuid);
 
     await page.getByRole('cell', { name: 'France' }).click();
-    await page.getByRole('link', { name: 'Revise this sequence' }).click();
+    await search.reviseSequence();
     await page.getByLabel('Collection date').fill('2012-12-13');
     await page.getByRole('button', { name: 'Submit' }).click();
     await page.getByRole('button', { name: 'Confirm' }).click();

--- a/integration-tests/tests/specs/features/sequence-version-banners.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-version-banners.spec.ts
@@ -80,7 +80,7 @@ test.describe('Sequence version banners', () => {
 
         // Click on the sequence and revise it
         await page.getByRole('cell', { name: 'France' }).click();
-        await page.getByRole('link', { name: 'Revise this sequence' }).click();
+        await search.reviseSequence();
         await page.getByLabel('Collection date').fill('2023-06-15');
         await page.getByRole('button', { name: 'Submit' }).click();
         await page.getByRole('button', { name: 'Confirm' }).click();
@@ -184,7 +184,7 @@ test.describe('Sequence version banners', () => {
 
         // Revise the sequence
         await page.getByRole('cell', { name: 'Spain' }).click();
-        await page.getByRole('link', { name: 'Revise this sequence' }).click();
+        await search.reviseSequence();
         await page.getByLabel('Collection date').fill('2023-09-20');
         await page.getByRole('button', { name: 'Submit' }).click();
         await page.getByRole('button', { name: 'Confirm' }).click();


### PR DESCRIPTION
Attempt to mitigate #5447

Also centralize clicking of revise button click on page for better maintainability.

Testing: CI passes, so at least not breaking anything. Whether or not it resolves the issue we'll see over time.

🚀 Preview: Add `preview` label to enable