### PR TITLE
fix(prepro): fix bug in processing the output of nextclade sort

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1922,6 +1922,7 @@ defaultOrganisms:
       <<: *ingest
       configFile:
         taxon_id: 12059
+        subsample_fraction: 0.2
     referenceGenomes:
       CV-A16:
         nucleotideSequences:


### PR DESCRIPTION
fixes https://github.com/loculus-project/loculus/issues/5671

Merge conflict: parsing of sort results didn't groupby seqName (=index) before taking the top hit resulting in incorrect answers.

### Numbers:

2,729  CV-A10
9,432  CV-A16
15,676 EV-A71
5,877  EV-D68

33,714 total

### Screenshot
<img width="1118" height="634" alt="image" src="https://github.com/user-attachments/assets/efc48c60-eb06-4250-8218-2114c15740fd" />


### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://test-eves.loculus.org