### PR TITLE
feat(deployment): validate nextclade preprocessing configFile schema

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1756,7 +1756,7 @@ defaultOrganisms:
         configFile:
           <<: *preprocessingConfigFile
           log_level: DEBUG
-          minimizer_index: https://loculus-project.github.io/nextclade-sort-minimizers/data/CCHF/minimizer.json
+          minimizer_url: https://loculus-project.github.io/nextclade-sort-minimizers/data/CCHF/minimizer.json
           nextclade_sequence_and_datasets:
             - name: L
               nextclade_dataset_name: community/pathoplexus/cchfv/L


### PR DESCRIPTION
Adds a bit of the values.yaml JSON schema that checks that the config settings applied to the nextclade-preprocessing pipeline are valid. This is quite vibe-coded but the fact that it passes suggests it's mostly good. The alternative implementation would be to build this into the preprocessing pipeline itself. That would be more consistent with how custom user pipelines would need to work, but less consistent with our other validation. For now, merging this PR probably makes sense to me.

### Claude's description

Add conditional JSON schema validation for the nextclade preprocessing pipeline configFile. Validation is only applied when the image contains "preprocessing-nextclade", allowing other pipelines to have flexible configuration.

For nextclade pipelines:
- Add `additionalProperties: false` to configFile to reject unexpected keys and catch typos
- Add `additionalProperties: false` to nextclade_sequence_and_datasets items
- Add `items.type: string` to `accepted_sort_matches` and `genes` arrays
- Add missing config properties: `batch_size` (with minimum: 1)
- Add EMBL file generation options: `create_embl_file`, `scientific_name`, `molecule_type` (enum), `topology` (enum), `db_name`, and `embl` object
- Require `nextclade_sequence_and_datasets` field

For other pipelines (e.g., preprocessing-dummy):
- No strict validation applied, allowing flexible configuration

🚀 Preview: Add `preview` label to enable