### PR TITLE
fix(prepro): bug in stop codon and frameshift formatting

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -145,9 +145,11 @@ def add_nextclade_metadata(
 
     match nextclade_path:
         case "frameShifts":
-            return process_frameshifts(raw)
+            result = None if raw is None else str(raw)
+            return process_frameshifts(result)
         case "qc.stopCodons.stopCodons":
-            return process_stop_codons(raw)
+            result = None if raw is None else str(raw)
+            return process_stop_codons(result)
         case _:
             return InputData(datum=str(raw))
 


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/5686

### Screenshot
https://github.com/loculus-project/loculus/pull/5634/files changed the name of the paths in nextclade - I didnt realize while reviewing. It also stopped converting list and dict objects to strings (without which formatting fails)

Example sequence: https://fix-formatting.loculus.org/seq/LOC_000W9HX.1 fix from top to bottom

<img width="1490" height="762" alt="image" src="https://github.com/user-attachments/assets/5dd6d991-58f9-49e6-85e5-fe955de3f301" />

<img width="1490" height="762" alt="image" src="https://github.com/user-attachments/assets/aecc35e7-6c6c-43c9-b67c-64a2dc72c25a" />


### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://fix-formatting.loculus.org