### PR TITLE
chore(deployment): update k3d install URL with retries

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -67,7 +67,9 @@ jobs:
         uses: actions/checkout@v6
       - name: Install k3d
         run: |
-          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+          for i in {1..5}; do
+            curl https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | DEBUG=true bash && break || sleep $((i * 2))
+          done
           k3d version
       - uses: azure/setup-helm@v4
         with:

--- a/integration-tests/AGENTS.md
+++ b/integration-tests/AGENTS.md
@@ -16,7 +16,7 @@ Install required tools if not already installed:
 docker --version
 
 # Install k3d (Kubernetes in Docker)
-curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 k3d version
 
 # Install Helm


### PR DESCRIPTION
The rancher/k3d URL failed with 503 in CI. Switch to the official k3d-io URL and add retry logic.

🚀 Preview: Add `preview` label to enable