### PR TITLE
fix(deployment): give backend 30min to come live not 3min to avoid it being killed during migrations

### DIFF
--- a/kubernetes/loculus/templates/loculus-backend.yaml
+++ b/kubernetes/loculus/templates/loculus-backend.yaml
@@ -34,7 +34,7 @@ spec:
               path: "/actuator/health/liveness"
               port: 8079
             periodSeconds: 5
-            failureThreshold: 36 # 3 minutes to start
+            failureThreshold: 360 # 30 minutes to start
           livenessProbe:
             httpGet:
               path: "/actuator/health/liveness"


### PR DESCRIPTION
Helps with #5613

3min is too short when backend flyway needs to get a lock on tables. Let's extend to 30min for now to not run into this termination loop.

I've discussed this with @anna-parker before.

🚀 Preview: Add `preview` label to enable