### PR TITLE
feat!(k8s): make silo-import refresh and poll intervals configurable

### DIFF
--- a/kubernetes/loculus/templates/silo-deployment.yaml
+++ b/kubernetes/loculus/templates/silo-deployment.yaml
@@ -81,7 +81,11 @@ spec:
               value: {{ index $.Values.lineageSystemDefinitions $lineageSystem | toJson | quote }}
             {{- end }}
             - name: SILO_RUN_TIMEOUT_SECONDS
-              value: {{ $.Values.siloImportLimitSeconds | quote }}
+              value: {{ $.Values.siloImport.siloTimeoutSeconds | quote }}
+            - name: HARD_REFRESH_INTERVAL
+              value: {{ $.Values.siloImport.hardRefreshIntervalSeconds | quote }}
+            - name: SILO_IMPORT_POLL_INTERVAL_SECONDS
+              value: {{ $.Values.siloImport.pollIntervalSeconds | quote }}
           volumeMounts:
             - name: lapis-silo-database-config-processed
               mountPath: /preprocessing/input/reference_genomes.json

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1593,10 +1593,35 @@
       "description": "TODO",
       "default": "You must agree to the <a href=\"http://main.loculus.org/terms\">terms of use</a>."
     },
-    "siloImportLimitSeconds": {
-      "type": "integer",
-      "description": "TODO",
-      "default": 3600
+    "siloImport": {
+      "type": "object",
+      "description": "Configuration for SILO import process",
+      "properties": {
+        "siloTimeoutSeconds": {
+          "type": "integer",
+          "description": "Timeout for SILO preprocessing runs in seconds",
+          "default": 3600,
+          "minimum": 1
+        },
+        "hardRefreshIntervalSeconds": {
+          "type": "integer",
+          "description": "Interval in seconds for forcing a hard refresh (re-download) of data, regardless of ETag",
+          "default": 3600,
+          "minimum": 1
+        },
+        "pollIntervalSeconds": {
+          "type": "integer",
+          "description": "Interval in seconds between checking for new data",
+          "default": 30,
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false,
+      "default": {
+        "siloTimeoutSeconds": 3600,
+        "hardRefreshIntervalSeconds": 3600,
+        "pollIntervalSeconds": 30
+      }
     },
     "gitHubEditLink": {
       "type": "string",

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -24,7 +24,10 @@ website:
     enableLoginNavigationItem: true
     enableSubmissionNavigationItem: true
     enableSubmissionPages: true
-siloImportLimitSeconds: 3600
+siloImport:
+  siloTimeoutSeconds: 3600
+  hardRefreshIntervalSeconds: 3600
+  pollIntervalSeconds: 30
 ingestLimitSeconds: 1800
 getSubmissionListLimitSeconds: 600
 preprocessingTimeout: 600

--- a/kubernetes/loculus/values_e2e_and_dev.yaml
+++ b/kubernetes/loculus/values_e2e_and_dev.yaml
@@ -13,3 +13,5 @@ disableEnaSubmission: true
 auth:
   verifyEmail: false
 host: localhost:3000
+siloImport:
+  pollIntervalSeconds: 5


### PR DESCRIPTION
Makes the silo-import refresh and polling intervals configurable through `values.yaml`, consolidating timing configuration under a new `siloImport` section.

For e2e/dev deployments reduce poll interval to 5s to speed up tests.

**Breaking change**: The `siloImportLimitSeconds` top-level field has been moved to `siloImport.siloTimeoutSeconds`.

### Before
```yaml
siloImportLimitSeconds: 3600  # Top-level field
# hardRefreshInterval: hardcoded to 3600 in Python
# pollInterval: hardcoded to 30 in Python
```

### After
```yaml
siloImport:
  siloTimeoutSeconds: 3600           # Timeout for SILO preprocessing
  hardRefreshIntervalSeconds: 3600   # Now configurable! Forces re-download regardless of ETag
  pollIntervalSeconds: 30            # Now configurable! Check interval for new data
```

## Motivation

Previously, the hard refresh interval (how often to force a full re-download ignoring ETags) and poll interval (how often to check for new data) were hardcoded in the Python code with defaults of 3600s and 30s respectively. This made it impossible to tune these values for different deployment scenarios without modifying code.

For example:
- Preview environments might want more frequent hard refreshes to catch issues
- Production environments might want longer poll intervals to reduce load
- Testing environments might want very short intervals for faster iteration

## Changes

1. **values.yaml**: Restructured to nest all silo-import timing configs under `siloImport`:
   - `siloImport.siloTimeoutSeconds` (renamed from `siloImportLimitSeconds`)
   - `siloImport.hardRefreshIntervalSeconds` (newly configurable)
   - `siloImport.pollIntervalSeconds` (newly configurable)

2. **values.schema.json**: Added validation schema for the new `siloImport` object with:
   - Proper descriptions for each field
   - Minimum value validation (`minimum: 1`)
   - Default values matching current behavior

3. **silo-deployment.yaml**: Updated to pass all three configuration values as environment variables to the silo-importer container

## Migration Guide

If you have customized `siloImportLimitSeconds` in your helm overrides, update:

```yaml
# Old
siloImportLimitSeconds: 7200

# New
siloImport:
  siloTimeoutSeconds: 7200
```

Default values remain unchanged, so deployments without overrides will continue to work as before.

🚀 Preview: Add `preview` label to enable