### PR TITLE
chore(backend): Improve logging around get-released-data components

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -76,6 +76,7 @@ open class ReleasedDataModel(
             null
         }
 
+        log.info { "Starting to stream released submissions for organism $organism" }
         return submissionDatabaseService.streamReleasedSubmissions(organism)
             .map {
                 computeAdditionalMetadataFields(


### PR DESCRIPTION
Just adding a bit of logging for get-released-data timings.

I'm curious what the timings are related of various get-released-data call components.

Should be helpful for monitoring #5727 etc.