### PR TITLE
feat(kubernetes): correctly type submission and release dates

### DIFF
--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -67,10 +67,8 @@ fields:
     header: Submission details
     orderOnDetailsPage: 5040
   - name: submittedDate
-    type: string
+    type: date
     hideOnSequenceDetailsPage: true
-    generateIndex: true
-    autocomplete: true
     displayName: Date submitted (exact)
     orderOnDetailsPage: 5050
   - name: releasedAtTimestamp
@@ -80,10 +78,8 @@ fields:
     columnWidth: 100
     orderOnDetailsPage: 5060
   - name: releasedDate
-    type: string
+    type: date
     hideOnSequenceDetailsPage: true
-    generateIndex: true
-    autocomplete: true
     displayName: Date released (exact)
     columnWidth: 100
     orderOnDetailsPage: 5070


### PR DESCRIPTION
resolves #5665

This changes the typing of the fields `submittedDate` and `releasedDate` in SILO/LAPIS to type instead of string.

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable