### PR TITLE
ci: Disable claude review for dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Disable the Claude code review GitHub Action for dependabot PRs since we don't have a dependabot secret set up.

🚀 Preview: Add `preview` label to enable