### PR TITLE
chore(silo-import): better logging of failed downloads

### DIFF
--- a/silo-import/src/silo_import/download_manager.py
+++ b/silo-import/src/silo_import/download_manager.py
@@ -161,7 +161,6 @@ class DownloadManager:
 
             # Extract and validate ETag
             etag_value = response.headers.get("etag")
-            
             if not etag_value:
                 safe_remove(download_dir)
                 msg = f"Response headers: {response.headers} did not contain an ETag header"


### PR DESCRIPTION
The error was cryptic when backend errored. This should be better.

Previously this was the error (instead of reporting bad status code):

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/silo_import/runner.py", line 105, in run_forever
    runner.run_once()
  File "/usr/local/lib/python3.11/site-packages/silo_import/runner.py", line 54, in run_once
    download = self.download_manager.download_release(self.config, self.paths, last_etag)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/silo_import/download_manager.py", line 155, in download_release
    raise RuntimeError(msg)
RuntimeError: Response headers: {'x-request-id': '62954dca-fda1-48a8-9c2d-2ba40f8b8b2c', 'vary': 'Origin, Access-Control-Request-Method, Access-Control-Request-Headers', 'x-content-type-options': 'nosniff', 'x-xss-protection': '0', 'cache-control': 'no-cache, no-store, max-age=0, must-revalidate', 'pragma': 'no-cache', 'expires': '0', 'x-frame-options': 'DENY', 'content-type': 'application/problem+json', 'transfer-encoding': 'chunked', 'date': 'Tue, 16 Dec 2025 18:54:54 GMT', 'connection': 'close'} did not contain an ETag header
```

🚀 Preview: Add `preview` label to enable