### PR TITLE
feat(deposition): use unittest instead of pytest to test the cronjob that uses the backend's get-released-data format

### DIFF
--- a/ena-submission/scripts/test_get_ena_submission_list.py
+++ b/ena-submission/scripts/test_get_ena_submission_list.py
@@ -56,7 +56,7 @@ class GetSubmissionListTests(unittest.TestCase):
 
         mock_upload_file_with_comment.return_value = {"ok": True}
         mock_fetch_released_entries.side_effect = fake_fetch_released_entries
-        mock_fetch_suppressed_accessions.return_value = "LOC01.1"
+        mock_fetch_suppressed_accessions.return_value = {"LOC01.1"}
 
         get_ena_submission_list.get_ena_submission_list.callback(config_file=str(CONFIG_FILE))  # type: ignore
         mock_upload_file_with_comment.assert_called()


### PR DESCRIPTION
resolves #

This PR only switches out which testing framework is used for testing `scripts/get_ena_submission_list.py`. Instead of using pytest (as in https://github.com/loculus-project/loculus/pull/5226), we now use unittest. This is more convenient since unittest Mock objects keep track of how often and with what arguments they are called, whereas this needed to be implemented manually under pytest.

### Screenshot

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [ ] ~Any manual testing that has been done is documented (i.e. what exactly was tested?)~ This PR only adds tests, not functionality. The test runs fine using both `pytest ./path/to/test.py` or `python ./path/to/test.py`

🚀 Preview: Add `preview` label to enable