### PR TITLE
fix(config): increase frequency of deposition cronjob runs

### DIFF
--- a/kubernetes/loculus/templates/ena-submission-deployment.yaml
+++ b/kubernetes/loculus/templates/ena-submission-deployment.yaml
@@ -117,7 +117,8 @@ kind: CronJob
 metadata:
   name: loculus-get-ena-submission-list-cronjob
 spec:
-  schedule: "0 1,13 * * *" # run twice a day at 1am and 1pm
+   # run twice a day to ensure at least once no overlap with argo cd refresh
+  schedule: "0 1,13 * * *"
   startingDeadlineSeconds: 60
   concurrencyPolicy: Forbid
   jobTemplate:


### PR DESCRIPTION
Bug is that we currently restart all pods every 24 at the time we merged. If this happens at midnight then cronjob will always fail because it only runs once a day.

Running twice a day solves this.

related to https://github.com/loculus-project/loculus/issues/5755

🚀 Preview: Add `preview` label to enable