### PR TITLE
feat(website): add diff view for comparing sequence versions

### DIFF
--- a/website/src/components/VersionDiff/DiffTable.tsx
+++ b/website/src/components/VersionDiff/DiffTable.tsx
@@ -1,0 +1,94 @@
+import type { ComparisonResult, FieldComparison } from './types';
+
+type DiffTableProps = {
+    comparison: ComparisonResult;
+    version1: number;
+    version2: number;
+    showAllFields: boolean;
+};
+
+function groupFieldsByHeader(fields: FieldComparison[]): Map<string, FieldComparison[]> {
+    const grouped = new Map<string, FieldComparison[]>();
+    for (const field of fields) {
+        const header = field.header || 'Other';
+        if (!grouped.has(header)) {
+            grouped.set(header, []);
+        }
+        grouped.get(header)!.push(field);
+    }
+    return grouped;
+}
+
+function FieldRow({ field }: { field: FieldComparison }) {
+    const rowClass = field.isNoisy ? 'text-gray-400' : field.hasChanged ? 'bg-amber-50' : '';
+
+    return (
+        <tr className={rowClass}>
+            <td className='border px-4 py-2 font-medium'>{field.label}</td>
+            <td className='border px-4 py-2'>{String(field.value1)}</td>
+            <td className='border px-4 py-2'>{String(field.value2)}</td>
+        </tr>
+    );
+}
+
+function FieldGroup({ header, fields }: { header: string; fields: FieldComparison[] }) {
+    return (
+        <>
+            <tr>
+                <td colSpan={3} className='bg-gray-100 px-4 py-2 font-semibold'>
+                    {header}
+                </td>
+            </tr>
+            {fields.map((field) => (
+                <FieldRow key={field.name} field={field} />
+            ))}
+        </>
+    );
+}
+
+export function DiffTable({ comparison, version1, version2, showAllFields }: DiffTableProps) {
+    // Prepare fields to display
+    const fieldsToDisplay: FieldComparison[] = [];
+
+    // Always show changed fields (non-noisy)
+    fieldsToDisplay.push(...comparison.changedFields);
+
+    // Show unchanged fields if toggle is on
+    if (showAllFields) {
+        fieldsToDisplay.push(...comparison.unchangedFields);
+    }
+
+    // Add noisy fields at the end
+    fieldsToDisplay.push(...comparison.noisyFields);
+
+    // Group by header
+    const groupedFields = groupFieldsByHeader(fieldsToDisplay);
+
+    // If no fields to display
+    if (fieldsToDisplay.length === 0) {
+        return (
+            <div className='p-4 text-gray-500'>
+                No differences found between version {version1} and version {version2}.
+            </div>
+        );
+    }
+
+    return (
+        <div className='overflow-x-auto'>
+            <table className='table-auto w-full border-collapse border'>
+                <thead>
+                    <tr className='bg-gray-200'>
+                        <th className='border px-4 py-2 text-left'>Field</th>
+                        <th className='border px-4 py-2 text-left'>Version {version1}</th>
+                        <th className='border px-4 py-2 text-left'>Version {version2}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {Array.from(groupedFields.entries()).map(([header, fields]) => (
+                        <FieldGroup key={header} header={header} fields={fields} />
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}

--- a/website/src/components/VersionDiff/VersionsWithDiff.tsx
+++ b/website/src/components/VersionDiff/VersionsWithDiff.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useState } from 'react';
+
+import { DiffTable } from './DiffTable';
+import { compareVersionData } from './compareVersions';
+import type { ComparisonResult } from './types';
+import { routes } from '../../routes/routes';
+import type { DetailsJson } from '../../types/detailsJson';
+import type { SequenceEntryHistoryEntry } from '../../types/lapis';
+import { getAccessionVersionString, extractAccessionVersion } from '../../utils/extractAccessionVersion';
+import { getVersionStatusColor, getVersionStatusLabel } from '../../utils/getVersionStatusColor';
+
+type VersionsWithDiffProps = {
+    versions: SequenceEntryHistoryEntry[];
+    accession: string;
+};
+
+export function VersionsWithDiff({ versions, accession }: VersionsWithDiffProps) {
+    const [selectedVersions, setSelectedVersions] = useState<Set<number>>(new Set());
+    const [showAllFields, setShowAllFields] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [comparisonData, setComparisonData] = useState<{
+        v1: DetailsJson;
+        v2: DetailsJson;
+        result: ComparisonResult;
+    } | null>(null);
+
+    const showCheckboxes = versions.length > 2;
+    const autoCompare = versions.length === 2;
+
+    // Read URL params on mount
+    useEffect(() => {
+        const params = new URLSearchParams(window.location.search);
+        const compareParam = params.get('compare');
+
+        if (compareParam) {
+            const versionNumbers = compareParam
+                .split(',')
+                .map((v) => parseInt(v, 10))
+                .filter((v) => !isNaN(v));
+            if (versionNumbers.length === 2) {
+                setSelectedVersions(new Set(versionNumbers));
+            }
+        } else if (autoCompare) {
+            // Auto-select both versions if only 2 exist
+            const versionNumbers = versions.map((v) => v.version);
+            setSelectedVersions(new Set(versionNumbers));
+        }
+    }, [autoCompare, versions]);
+
+    // Fetch and compare when selection changes
+    useEffect(() => {
+        const selectedArray = Array.from(selectedVersions);
+        if (selectedArray.length !== 2) {
+            setComparisonData(null);
+            return;
+        }
+
+        const [v1, v2] = selectedArray.sort((a, b) => a - b);
+
+        // Update URL
+        const url = new URL(window.location.href);
+        url.searchParams.set('compare', `${v1},${v2}`);
+        window.history.pushState({}, '', url.toString());
+
+        // Fetch data
+        const fetchAndCompare = async () => {
+            setLoading(true);
+            setError(null);
+
+            try {
+                const [data1, data2] = await Promise.all([
+                    fetch(`/seq/${accession}.${v1}/details.json`).then((r) => {
+                        if (!r.ok) throw new Error(`Failed to fetch version ${v1}`);
+                        return r.json() as Promise<DetailsJson>;
+                    }),
+                    fetch(`/seq/${accession}.${v2}/details.json`).then((r) => {
+                        if (!r.ok) throw new Error(`Failed to fetch version ${v2}`);
+                        return r.json() as Promise<DetailsJson>;
+                    }),
+                ]);
+
+                const result = compareVersionData(data1, data2);
+                setComparisonData({ v1: data1, v2: data2, result });
+            } catch (err) {
+                setError(err instanceof Error ? err.message : 'Failed to fetch version data');
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        void fetchAndCompare();
+    }, [selectedVersions, accession]);
+
+    const handleVersionToggle = (version: number) => {
+        const newSelection = new Set(selectedVersions);
+        if (newSelection.has(version)) {
+            newSelection.delete(version);
+        } else {
+            // Only allow 2 selections
+            if (newSelection.size >= 2) {
+                // Remove the oldest selection
+                const oldest = Array.from(newSelection)[0];
+                newSelection.delete(oldest);
+            }
+            newSelection.add(version);
+        }
+        setSelectedVersions(newSelection);
+    };
+
+    const selectedArray = Array.from(selectedVersions).sort((a, b) => a - b);
+    const canCompare = selectedArray.length === 2;
+
+    return (
+        <div>
+            <div className='mb-6'>
+                <h2 className='text-xl font-semibold mb-4'>Version History</h2>
+                {showCheckboxes && (
+                    <p className='text-sm text-gray-600 mb-3'>
+                        Select two versions to compare (selected: {selectedVersions.size}/2)
+                    </p>
+                )}
+                <ul className='p-3'>
+                    {versions.map((version) => (
+                        <li key={version.version} className='mb-4'>
+                            <div className='flex items-start gap-3'>
+                                {showCheckboxes && (
+                                    <input
+                                        type='checkbox'
+                                        checked={selectedVersions.has(version.version)}
+                                        onChange={() => handleVersionToggle(version.version)}
+                                        className='checkbox mt-1'
+                                    />
+                                )}
+                                <div className='flex-1'>
+                                    <div className='font-semibold'>{version.submittedAtTimestamp}</div>
+                                    <div className='flex flex-row gap-3 justify-start'>
+                                        <a
+                                            href={routes.sequenceEntryDetailsPage(
+                                                getAccessionVersionString(extractAccessionVersion(version)),
+                                            )}
+                                            className='hover:no-underline'
+                                        >
+                                            {getAccessionVersionString(extractAccessionVersion(version))}
+                                        </a>
+                                        <p
+                                            className={`${getVersionStatusColor(version.versionStatus, version.isRevocation)} ml-2`}
+                                        >
+                                            {getVersionStatusLabel(version.versionStatus, version.isRevocation)}
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+            </div>
+
+            {(canCompare || autoCompare) && (
+                <div className='mt-8 border-t pt-6'>
+                    <div className='flex justify-between items-center mb-4'>
+                        <h2 className='text-xl font-semibold'>
+                            Comparing Version {selectedArray[0]} vs Version {selectedArray[1]}
+                        </h2>
+                        <label className='flex items-center gap-2 cursor-pointer'>
+                            <span className='text-sm'>Show all fields</span>
+                            <input
+                                type='checkbox'
+                                checked={showAllFields}
+                                onChange={(e) => setShowAllFields(e.target.checked)}
+                                className='toggle toggle-sm'
+                            />
+                        </label>
+                    </div>
+
+                    {loading && (
+                        <div className='flex justify-center items-center py-8'>
+                            <div className='loading loading-spinner loading-lg'></div>
+                        </div>
+                    )}
+
+                    {error && (
+                        <div className='alert alert-error'>
+                            <span>{error}</span>
+                        </div>
+                    )}
+
+                    {!loading && !error && comparisonData && (
+                        <DiffTable
+                            comparison={comparisonData.result}
+                            version1={selectedArray[0]}
+                            version2={selectedArray[1]}
+                            showAllFields={showAllFields}
+                        />
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/website/src/components/VersionDiff/compareVersions.ts
+++ b/website/src/components/VersionDiff/compareVersions.ts
@@ -1,0 +1,111 @@
+import type { ComparisonResult, FieldComparison } from './types';
+import type { DetailsJson } from '../../types/detailsJson';
+import type { TableDataEntry } from '../SequenceDetailsPage/types';
+
+// Fields that are expected to change between versions and should be shown greyed out
+const NOISY_FIELD_NAMES = ['submittedAtTimestamp', 'version', 'versionStatus', 'accessionVersion'];
+const NOISY_FIELD_PATTERNS = [/timestamp/i, /release.*date/i];
+
+function isNoisyField(fieldName: string): boolean {
+    if (NOISY_FIELD_NAMES.includes(fieldName)) {
+        return true;
+    }
+    return NOISY_FIELD_PATTERNS.some((pattern) => pattern.test(fieldName));
+}
+
+function compareValues(value1: string | number | boolean, value2: string | number | boolean): boolean {
+    return value1 !== value2;
+}
+
+export function compareVersionData(v1: DetailsJson, v2: DetailsJson): ComparisonResult {
+    const changedFields: FieldComparison[] = [];
+    const unchangedFields: FieldComparison[] = [];
+    const noisyFields: FieldComparison[] = [];
+
+    // Create a map of fields from version 2 for quick lookup
+    const v2FieldMap = new Map<string, TableDataEntry>();
+    for (const entry of v2.tableData) {
+        v2FieldMap.set(entry.name, entry);
+    }
+
+    // Create a set to track which fields we've already processed
+    const processedFields = new Set<string>();
+
+    // Process all fields from version 1
+    for (const v1Entry of v1.tableData) {
+        const v2Entry = v2FieldMap.get(v1Entry.name);
+
+        // If field doesn't exist in v2, consider it as changed (removed)
+        if (!v2Entry) {
+            const comparison: FieldComparison = {
+                name: v1Entry.name,
+                label: v1Entry.label,
+                header: v1Entry.header,
+                value1: v1Entry.value,
+                value2: '' as string, // Field doesn't exist in v2
+                type: v1Entry.type,
+                hasChanged: true,
+                isNoisy: isNoisyField(v1Entry.name),
+            };
+
+            if (comparison.isNoisy) {
+                noisyFields.push(comparison);
+            } else {
+                changedFields.push(comparison);
+            }
+        } else {
+            // Field exists in both versions
+            const hasChanged = compareValues(v1Entry.value, v2Entry.value);
+            const isNoisy = isNoisyField(v1Entry.name);
+
+            const comparison: FieldComparison = {
+                name: v1Entry.name,
+                label: v1Entry.label,
+                header: v1Entry.header,
+                value1: v1Entry.value,
+                value2: v2Entry.value,
+                type: v1Entry.type,
+                hasChanged,
+                isNoisy,
+            };
+
+            if (isNoisy) {
+                noisyFields.push(comparison);
+            } else if (hasChanged) {
+                changedFields.push(comparison);
+            } else {
+                unchangedFields.push(comparison);
+            }
+        }
+
+        processedFields.add(v1Entry.name);
+    }
+
+    // Process fields that only exist in version 2 (added fields)
+    for (const v2Entry of v2.tableData) {
+        if (!processedFields.has(v2Entry.name)) {
+            const comparison: FieldComparison = {
+                name: v2Entry.name,
+                label: v2Entry.label,
+                header: v2Entry.header,
+                value1: '' as string, // Field doesn't exist in v1
+                value2: v2Entry.value,
+                type: v2Entry.type,
+                hasChanged: true,
+                isNoisy: isNoisyField(v2Entry.name),
+            };
+
+            if (comparison.isNoisy) {
+                noisyFields.push(comparison);
+            } else {
+                changedFields.push(comparison);
+            }
+        }
+    }
+
+    return {
+        changedFields,
+        unchangedFields,
+        noisyFields,
+    };
+}

--- a/website/src/components/VersionDiff/types.ts
+++ b/website/src/components/VersionDiff/types.ts
@@ -1,0 +1,18 @@
+import type { TableDataEntryType } from '../SequenceDetailsPage/types';
+
+export type FieldComparison = {
+    name: string;
+    label: string;
+    header: string;
+    value1: string | number | boolean;
+    value2: string | number | boolean;
+    type: TableDataEntryType;
+    hasChanged: boolean;
+    isNoisy: boolean;
+};
+
+export type ComparisonResult = {
+    changedFields: FieldComparison[];
+    unchangedFields: FieldComparison[];
+    noisyFields: FieldComparison[];
+};

--- a/website/src/pages/seq/[accessionVersion]/versions.astro
+++ b/website/src/pages/seq/[accessionVersion]/versions.astro
@@ -1,14 +1,9 @@
 ---
 import { getVersionsData } from './getVersionsData';
+import { VersionsWithDiff } from '../../../components/VersionDiff/VersionsWithDiff.tsx';
 import ErrorBox from '../../../components/common/ErrorBox.tsx';
 import BaseLayout from '../../../layouts/BaseLayout.astro';
-import { routes } from '../../../routes/routes';
-import {
-    extractAccessionVersion,
-    getAccessionVersionString,
-    parseAccessionVersionFromString,
-} from '../../../utils/extractAccessionVersion';
-import { getVersionStatusColor, getVersionStatusLabel } from '../../../utils/getVersionStatusColor';
+import { parseAccessionVersionFromString } from '../../../utils/extractAccessionVersion';
 
 const accessionVersion = Astro.params.accessionVersion!;
 const { accession } = parseAccessionVersionFromString(accessionVersion);
@@ -20,38 +15,14 @@ const { organism, versionListResult } = await getVersionsData(accession);
         <h1 class='title'>Versions for accession {accession}</h1>
     </div>
 
-    <ul class='p-3'>
-        {
-            versionListResult.match(
-                (list) => {
-                    return list.map((version) => (
-                        <li class='mb-4'>
-                            <div class='mb-2'>
-                                <div class='font-semibold'>{version.submittedAtTimestamp}</div>
-                                <div class='flex flex-row gap-3 justify-start'>
-                                    <a
-                                        href={routes.sequenceEntryDetailsPage(
-                                            getAccessionVersionString(extractAccessionVersion(version)),
-                                        )}
-                                        class='hover:no-underline'
-                                    >
-                                        {getAccessionVersionString(extractAccessionVersion(version))}
-                                    </a>
-
-                                    <p
-                                        class={`${getVersionStatusColor(version.versionStatus, version.isRevocation)} ml-2`}
-                                    >
-                                        {getVersionStatusLabel(version.versionStatus, version.isRevocation)}
-                                    </p>
-                                </div>
-                            </div>
-                        </li>
-                    ));
-                },
-                (error) => {
-                    return <ErrorBox title='Request for sequence history failed'>{error}</ErrorBox>;
-                },
-            )
-        }
-    </ul>
+    {
+        versionListResult.match(
+            (list) => {
+                return <VersionsWithDiff versions={list} accession={accession} client:load />;
+            },
+            (error) => {
+                return <ErrorBox title='Request for sequence history failed'>{error}</ErrorBox>;
+            },
+        )
+    }
 </BaseLayout>


### PR DESCRIPTION
Based on quick vibe code session with @maverbiest

First attempt at offering some diffing between versions - we have nothing so far. This is better than nothing - clearly has room for improvement.

Try it out:
- Sequences with 2 versions show diff automatically: https://diff-versions.loculus.org/seq/LOC_0002GVP.2/versions?compare=1%2C2
- Sequences with more than 2 allow selecting 2 to diff: https://diff-versions.loculus.org/seq/LOC_0002H0D.4/versions?compare=2%2C4

<img width="1710" height="1013" alt="image" src="https://github.com/user-attachments/assets/62503f53-914d-4a36-939f-1e2f8571a7f7" />


## Summary
Add interactive diff view to compare metadata changes between sequence versions on the `/seq/{accession}/versions` page.

### Features
- **Smart defaults**: Auto-compares when only 2 versions exist, shows checkboxes for 3+ versions
- **URL persistence**: Shareable links with `?compare=1,3` format
- **Toggle view**: Show all fields or only changed fields
- **Noisy field handling**: Timestamps and version info displayed greyed out at bottom
- **Visual design**: Changed fields highlighted with amber background, grouped by metadata headers

### Components
- `VersionsWithDiff.tsx` - Main React component with version selection and data fetching
- `DiffTable.tsx` - Table display with field comparisons
- `compareVersions.ts` - Logic to identify changed/unchanged/noisy fields
- `types.ts` - TypeScript types for comparison results

### Test Plan
- [x] Type checking passes (`npm run check-types`)
- [x] Unit tests pass (`CI=1 npm run test`)
- [x] Code formatted (`npm run format`)
- [ ] Manual test: Browse to a sequence with 2 versions on preview, verify auto-compare
- [x] Manual test: Browse to a sequence with 3+ versions, select 2, verify comparison
- [ ] Manual test: Toggle "Show all fields", verify unchanged fields appear
- [x] Manual test: Verify URL params persist and are shareable
- [ ] Manual test: Verify noisy fields (timestamps) are greyed out

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable