### PR TITLE
fix(website): Fix notSearchable appearing in search entries

### DIFF
--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -97,7 +97,7 @@ export const SearchForm = ({
     const fieldItems: FieldItem[] = filterSchema.filters
         .filter((filter) => filter.name !== ACCESSION_FIELD) // Exclude accession field
         .filter((filter) => filter.name !== suborganismIdentifierField)
-        .filter((filter) => filter.notSearchable !== true) // Don't show notSearchable fields in selector
+        .filter((filter) => filter.notSearchable !== true)
         .map((filter) => ({
             name: filter.name,
             displayName: filter.displayName ?? sentenceCase(filter.name),


### PR DESCRIPTION
Fields with `notSearchable: true` (like version and pipelineVersion) were appearing in the "Add search fields" selector modal, but clicking their checkboxes had no effect because searchVisibilities did not track them.

This fix filters out notSearchable fields from the field selector, aligning the selector's contents with what searchVisibilities actually tracks.

Fixes #5761


### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://claude-fix-version-select.loculus.org