### PR TITLE
feat(backend): restrict allowed filenames

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
@@ -111,6 +111,7 @@ class SubmitModel(
         }
 
         submissionIdFilesMappingPreconditionValidator
+            .validateFilenameCharacters(submissionParams.files)
             .validateFilenamesAreUnique(submissionParams.files)
             .validateCategoriesMatchSchema(submissionParams.files, submissionParams.organism)
             .validateMultipartUploads(submissionParams.files)

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -243,6 +243,7 @@ class SubmissionDatabaseService(
             }
             submittedProcessedData.data.files?.let { fileMapping ->
                 fileMappingPreconditionValidator
+                    .validateFilenameCharacters(fileMapping)
                     .validateFilenamesAreUnique(fileMapping)
                     .validateCategoriesMatchOutputSchema(fileMapping, organism)
                     .validateMultipartUploads(fileMapping.fileIds)
@@ -1076,6 +1077,7 @@ class SubmissionDatabaseService(
 
         editedSequenceEntryData.data.files?.let { fileMapping ->
             fileMappingPreconditionValidator
+                .validateFilenameCharacters(fileMapping)
                 .validateFilenamesAreUnique(fileMapping)
                 .validateCategoriesMatchSubmissionSchema(fileMapping, organism)
                 .validateMultipartUploads(fileMapping.fileIds)

--- a/backend/src/test/kotlin/org/loculus/backend/service/submission/ValidateFileNameTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/submission/ValidateFileNameTest.kt
@@ -1,0 +1,193 @@
+package org.loculus.backend.service.submission
+
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.loculus.backend.api.FileCategory
+import org.loculus.backend.api.FileCategoryFilesMap
+import org.loculus.backend.api.FileIdAndName
+import org.loculus.backend.config.BackendConfig
+import org.loculus.backend.controller.UnprocessableEntityException
+import org.loculus.backend.service.files.FilesDatabaseService
+import org.loculus.backend.service.files.S3Service
+import java.util.UUID
+
+class ValidateFileNameTest {
+    private val backendConfig: BackendConfig = mockk()
+    private val s3Service: S3Service = mockk()
+    private val filesDatabaseService: FilesDatabaseService = mockk()
+    private val validator = FileMappingPreconditionValidator(backendConfig, s3Service, filesDatabaseService)
+
+    private fun createFileMapping(category: FileCategory, filenames: List<String>): FileCategoryFilesMap {
+        val files = filenames.map { FileIdAndName(UUID.randomUUID(), it) }
+        return mapOf(category to files)
+    }
+
+    @Test
+    fun `valid filenames should pass validation`() {
+        val fileMapping = createFileMapping(
+            "sequences",
+            listOf(
+                "file.txt",
+                "my_file.fasta",
+                "data-2024.csv",
+                "results_final_v2.xlsx",
+                "file123.json",
+                "UPPERCASE.TXT",
+            ),
+        )
+        validator.validateFilenameCharacters(fileMapping)
+    }
+
+    @Test
+    fun `unicode filenames should pass validation`() {
+        val fileMapping = createFileMapping(
+            "sequences",
+            listOf(
+                "文件.txt",
+                "データ.csv",
+                "файл.json",
+                "αρχείο.xml",
+                "ملف.fasta",
+            ),
+        )
+        validator.validateFilenameCharacters(fileMapping)
+    }
+
+    @Test
+    fun `filenames with leading periods should pass validation`() {
+        val fileMapping = createFileMapping("sequences", listOf(".gitignore", ".hidden_file.txt"))
+        validator.validateFilenameCharacters(fileMapping)
+    }
+
+    @Test
+    fun `empty filename should fail validation`() {
+        val fileMapping = createFileMapping("sequences", listOf(""))
+        assertThrows<UnprocessableEntityException> {
+            validator.validateFilenameCharacters(fileMapping)
+        }
+    }
+
+    @Test
+    fun `filename exceeding 255 characters should fail validation`() {
+        val longFilename = "a".repeat(256) + ".txt"
+        val fileMapping = createFileMapping("sequences", listOf(longFilename))
+        assertThrows<UnprocessableEntityException> {
+            validator.validateFilenameCharacters(fileMapping)
+        }
+    }
+
+    @Test
+    fun `filename with less than sign should fail validation`() {
+        val fileMapping = createFileMapping("sequences", listOf("file<test.txt"))
+        assertThrows<UnprocessableEntityException> {
+            validator.validateFilenameCharacters(fileMapping)
+        }
+    }
+
+    @Test
+    fun `filename with greater than sign should fail validation`() {
+        val fileMapping = createFileMapping("sequences", listOf("file>test.txt"))
+        assertThrows<UnprocessableEntityException> {
+            validator.validateFilenameCharacters(fileMapping)
+        }
+    }
+
+    @Test
+    fun `filename with colon should fail validation`() {
+        val fileMapping = createFileMapping("sequences", listOf("file:test.txt"))
+        assertThrows<UnprocessableEntityException> {
+            validator.validateFilenameCharacters(fileMapping)
+        }
+    }
+
+    @Test
+    fun `filename with double quote should fail validation`() {
+        val fileMapping = createFileMapping("sequences", listOf("file\"test.txt"))
+        assertThrows<UnprocessableEntityException> {
+            validator.validateFilenameCharacters(fileMapping)
+        }
+    }
+
+    @Test
+    fun `filename with forward slash should fail validation`() {
+        val fileMapping = createFileMapping("sequences", listOf("file/test.txt"))
+        assertThrows<UnprocessableEntityException> {
+            validator.validateFilenameCharacters(fileMapping)
+        }
+    }
+
+    @Test
+    fun `filename with backslash should fail validation`() {
+        val fileMapping = createFileMapping("sequences", listOf("file\\test.txt"))
+        assertThrows<UnprocessableEntityException> {
+            validator.validateFilenameCharacters(fileMapping)
+        }
+    }
+
+    @Test
+    fun `filename with pipe should fail validation`() {
+        val fileMapping = createFileMapping("sequences", listOf("file|test.txt"))
+        assertThrows<UnprocessableEntityException> {
+            validator.validateFilenameCharacters(fileMapping)
+        }
+    }
+
+    @Test
+    fun `filename with question mark should fail validation`() {
+        val fileMapping = createFileMapping("sequences", listOf("file?.txt"))
+        assertThrows<UnprocessableEntityException> {
+            validator.validateFilenameCharacters(fileMapping)
+        }
+    }
+
+    @Test
+    fun `filename with asterisk should fail validation`() {
+        val fileMapping = createFileMapping("sequences", listOf("file*.txt"))
+        assertThrows<UnprocessableEntityException> {
+            validator.validateFilenameCharacters(fileMapping)
+        }
+    }
+
+    @Test
+    fun `filename with NUL should fail validation`() {
+        val fileMapping = createFileMapping("sequences", listOf("file\u0000test.txt"))
+        assertThrows<UnprocessableEntityException> {
+            validator.validateFilenameCharacters(fileMapping)
+        }
+    }
+
+    @Test
+    fun `filename with ASCII control character should fail validation`() {
+        val fileMapping = createFileMapping("sequences", listOf("file\u0001test.txt"))
+        assertThrows<UnprocessableEntityException> {
+            validator.validateFilenameCharacters(fileMapping)
+        }
+    }
+
+    @Test
+    fun `null file mapping should pass validation`() {
+        validator.validateFilenameCharacters(null)
+    }
+
+    @Test
+    fun `empty file mapping should pass validation`() {
+        validator.validateFilenameCharacters(emptyMap())
+    }
+
+    @Test
+    fun `multiple files with mixed valid and invalid names should fail validation`() {
+        val fileMapping = createFileMapping(
+            "sequences",
+            listOf(
+                "valid_file1.txt",
+                "valid_file2.txt",
+                "invalid|file.txt",
+                "another_valid.txt",
+            ),
+        )
+        assertThrows<UnprocessableEntityException> {
+            validator.validateFilenameCharacters(fileMapping)
+        }
+    }
+}

--- a/docs/src/content/docs/for-users/submit-extra-files.md
+++ b/docs/src/content/docs/for-users/submit-extra-files.md
@@ -170,3 +170,12 @@ And the `mapping JSON` has this structure:
 - The `fileCategory` needs to be a predefined category which is organism specific.
 - The `fileId` is the ID received in the previous step, which identifies the actual file.
 - The `fileName` can be chosen freely, but depending on configuration it might become an identifier for the file later on.
+
+## Filename restrictions
+
+The filenames may contain any UTF-8 characters except:
+
+- Forbidden characters: `< > : " / \ | ? *`
+- ASCII control characters (character codes 0-31)
+
+Filenames may not be empty or contain more than 255 characters.


### PR DESCRIPTION
resolves #3999

This PR adds backend validation to prevent filenames to contain characters that are not allowed in some of the major operating systems, ASCII control characters and be longer than 255 characters. For the reason mentioned in https://github.com/loculus-project/loculus/issues/3999#issuecomment-3700741717, this is not taking the restrictions of `Content-Disposition`'s `filename=` into account.

### Screenshot

<img width="926" height="349" alt="image" src="https://github.com/user-attachments/assets/0e20bcc5-7579-4b30-8221-7d724c97c225" />

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
    - The upload of a file with a `*` in the name.

🚀 Preview: https://filename-restriction.loculus.org