### PR TITLE
fix(website): preserve pagination when opening/closing sequence modals

### DIFF
--- a/website/src/utils/search.ts
+++ b/website/src/utils/search.ts
@@ -23,6 +23,10 @@ export const NULL_QUERY_VALUE = '_null_';
 
 export const MUTATION_KEY = 'mutation';
 
+// UI-only parameters that don't affect search results
+export const SELECTED_SEQ_PARAM = 'selectedSeq';
+export const HALF_SCREEN_PARAM = 'halfScreen';
+
 export type SearchResponse = {
     data: TableSequenceData[];
     totalCount: number;


### PR DESCRIPTION
When opening a sequence detail modal from a paginated browse URL (e.g., 
page 3), the pagination state was being lost and reset to page 1.

The root cause was that setSomeFieldValues unconditionally called 
setPage(1) whenever any URL parameter changed, including UI-only 
parameters like selectedSeq that don't affect search results.

This fix introduces a centralized UI_ONLY_PARAMS set that identifies 
parameters that shouldn't trigger pagination reset. The setSomeFieldValues 
function now only resets pagination when non-UI parameters are modified.

Based on copilot session: https://github.com/loculus-project/loculus/pull/5784
Manually tested and verified the fix works correctly.

Related work:
- #5788: Add vitest unit tests for sequence details modal (including 
  regression test for this fix)

Fixes #5783

🚀 Preview: https://fix-website-pagination-mo.loculus.org