### PR TITLE
fix(deployment): hotfix bug in ingest config

### DIFF
--- a/kubernetes/loculus/templates/ingest-config.yaml
+++ b/kubernetes/loculus/templates/ingest-config.yaml
@@ -8,7 +8,7 @@
 {{- $values := $item.contents }}
 {{- if $values.ingest }}
 {{- $metadata := (include "loculus.patchMetadataSchema" $values.schema | fromYaml).metadata }}
-{{- $rawUniqueSegments := (include "loculus.extractUniqueRawNucleotideSequenceNames" .referenceGenomes | fromYaml).segments }}
+{{- $rawUniqueSegments := (include "loculus.extractUniqueRawNucleotideSequenceNames" $values.referenceGenomes | fromYaml).segments }}
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
We were missing the right context for `.referenceGenomes`

Ingest now works:

![Uploading image.png…]()


🚀 Preview: https://fixbug3.loculus.org