### PR TITLE
test: add integration test for Edit account button

### DIFF
--- a/integration-tests/tests/pages/my-account.page.ts
+++ b/integration-tests/tests/pages/my-account.page.ts
@@ -9,6 +9,26 @@ export class MyAccountPage {
         await this.page.waitForURL(/\/user/);
     }
 
+    getEditAccountInformationLink() {
+        return this.page.getByRole('link', { name: 'Edit account information' });
+    }
+
+    async expectEditAccountLinkHasCorrectHref() {
+        const link = this.getEditAccountInformationLink();
+        await expect(link).toBeVisible();
+        await expect(link).toHaveAttribute('target', '_blank');
+        await expect(link).toHaveAttribute('href', /\/realms\/loculus\/account$/);
+    }
+
+    async clickEditAccountAndGetKeycloakPage() {
+        const link = this.getEditAccountInformationLink();
+        const popupPromise = this.page.waitForEvent('popup');
+        await link.click();
+        const keycloakPage = await popupPromise;
+        await keycloakPage.waitForLoadState();
+        return keycloakPage;
+    }
+
     private groupListItem(groupName: string) {
         return this.page.locator('li').filter({ hasText: groupName });
     }

--- a/integration-tests/tests/specs/auth/edit-account.spec.ts
+++ b/integration-tests/tests/specs/auth/edit-account.spec.ts
@@ -1,0 +1,25 @@
+import { expect } from '@playwright/test';
+import { test } from '../../fixtures/auth.fixture';
+import { MyAccountPage } from '../../pages/my-account.page';
+
+test.describe('Test redirect to Edit Account page', () => {
+    test('Edit account information link has correct href', async ({ page, authenticatedUser }) => {
+        void authenticatedUser;
+        const myAccountPage = new MyAccountPage(page);
+        await myAccountPage.goto();
+        await myAccountPage.expectEditAccountLinkHasCorrectHref();
+    });
+
+    test('Edit account information opens Keycloak account management page', async ({
+        page,
+        authenticatedUser,
+    }) => {
+        void authenticatedUser;
+        const myAccountPage = new MyAccountPage(page);
+        await myAccountPage.goto();
+
+        const keycloakPage = await myAccountPage.clickEditAccountAndGetKeycloakPage();
+        await expect(keycloakPage).toHaveTitle('Keycloak Account Management');
+        await keycloakPage.close();
+    });
+});


### PR DESCRIPTION
Based on @corneliusroemer's suggestion in https://github.com/loculus-project/loculus/pull/5797#pullrequestreview-3626686799, this adds integration tests to check that the "Edit account information" button redirects to Keycloak.

(Unfortunately, it's not that easy to actually test the case that #5797 resolves with the integration tests as it requires a different set of configs. I'll propose a few unit tests later in a separate PR.)