### PR TITLE
refactor(website): remove redundant and unused code

### DIFF
--- a/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.tsx
@@ -58,14 +58,14 @@ export const SequenceEntryHistoryMenu: React.FC<Props> = ({
                         );
                     })}
                     <li className='border-t mt-1 pt-1'>
-                        <a href={routes.versionPage(accessionVersion)} className='hover:no-underline'>
+                        <a href={routes.sequenceEntryVersionsPage(accessionVersion)} className='hover:no-underline'>
                             All versions
                         </a>
                     </li>
                 </ul>
             </div>
             <div className='sm:hidden inline-block mr-2'>
-                <a href={routes.versionPage(accessionVersion)} className='text-xl'>
+                <a href={routes.sequenceEntryVersionsPage(accessionVersion)} className='text-xl'>
                     <IcBaselineHistory />
                 </a>
             </div>

--- a/website/src/routes/routes.ts
+++ b/website/src/routes/routes.ts
@@ -11,8 +11,6 @@ export type ContinueSubmissionIntent = {
 };
 
 export const approxMaxAcceptableUrlLength = 1900;
-export const SEARCH = 'SEARCH';
-export const MY_SEQUENCES = 'MY_SEQUENCES';
 
 export const routes = {
     apiDocumentationPage: () => '/api-documentation',
@@ -60,7 +58,6 @@ export const routes = {
     editGroupPage: (groupId: number) => `/group/${groupId}/edit`,
     userSequenceReviewPage: (organism: string, groupId: number) =>
         SubmissionRouteUtils.toUrl({ name: 'review', organism, groupId }),
-    versionPage: (accession: string) => `/seq/${accession}/versions`,
     seqSetsPage: (username?: string) => {
         const seqSetPagePath = `/seqsets`;
         return username === undefined ? seqSetPagePath : seqSetPagePath + `?user=${username}`;


### PR DESCRIPTION
This is removing a few lines of redundant / unused code in `routes.ts`.

### PR Checklist
- ~[ ] All necessary documentation has been adapted.~
- ~[ ] The implemented feature is covered by appropriate, automated tests.~
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
    - I checked locally that the link to the version history works.

🚀 Preview: Add `preview` label to enable