### PR TITLE
ci: don't claude review draft PRs or dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,10 +2,11 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review, reopened]
+    types: [ready_for_review, reopened]
 
 jobs:
   review-with-tracking:
+    if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -66,6 +67,9 @@ jobs:
             Generally if you have mentioned something in an inline comment you do not need 
             to mention it again in the overall review. The overall review should be brief
             with most points made as inline comments. Keep language simple and to the point.
+
+            Do not add inline comments that are simply praise - inline comments should be
+            actionable.
 
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
We accidentally lost this line in https://github.com/loculus-project/loculus/commit/8aa8dda4ecd5530c74cad0f189c67e8a60406264

Also this PR tweaks the prompt to try to prevent too much noise.

🚀 Preview: Add `preview` label to enable