### PR TITLE
ci: Add GitHub Action for automatic component labels with claude

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -14,108 +14,78 @@ jobs:
     permissions:
       contents: read
       issues: write
+      id-token: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Create issue triage prompt
-        run: |
-          mkdir -p /tmp/claude-prompts
-          cat > /tmp/claude-prompts/triage-prompt.txt << 'EOF'
-          You're an issue triage assistant for the Loculus project. Your tasks are to:
-          1. Analyze the issue and apply appropriate component labels
-          2. Search for duplicate issues and comment if found
-
-          Issue Information:
-          - REPO: ${{ github.repository }}
-          - ISSUE_NUMBER: ${{ github.event.issue.number }}
-
-          COMPONENT LABELS TO USE:
-          The following labels should be applied based on which component(s) the issue relates to:
-          - `website` - Issues related to the web frontend (website/ directory)
-          - `backend` - Issues related to the backend API/server (backend/ directory)
-          - `deposition` - Issues related to ENA submission/deposition (ena-submission/ directory)
-          - `preprocessing` - Issues related to data preprocessing (preprocessing/ directory)
-          - `deployment` - Issues related to Kubernetes deployment/infrastructure (kubernetes/ directory)
-          - `ingest` - Issues related to data ingestion (ingest/ directory)
-
-          TASK STEPS:
-
-          1. First, fetch the list of available labels in this repository:
-             Run: `gh label list`
-
-          2. Get context about the issue:
-             - Use mcp__github__get_issue to retrieve the issue's title, description, and existing labels
-             - Use mcp__github__get_issue_comments if there are comments that might provide additional context
-
-          3. Analyze the issue content to determine:
-             - Which component(s) are affected based on:
-               - Explicit mentions of components (website, backend, API, frontend, etc.)
-               - File paths or directories mentioned
-               - Feature areas described (UI issues -> website, API issues -> backend, etc.)
-               - Error messages or stack traces that indicate the component
-             - The type of issue (bug, feature request, question, etc.)
-
-          4. Search for potential duplicate issues:
-             - Use mcp__github__search_issues to find similar issues by searching for key terms from the title and description
-             - Look for issues with similar error messages, feature requests, or problem descriptions
-             - Focus on OPEN issues when identifying duplicates
-
-          5. Apply component labels:
-             - Use mcp__github__update_issue to apply the appropriate component labels
-             - You can apply multiple component labels if the issue spans multiple components
-             - If no component is clearly identifiable, do not apply component labels
-
-          6. If potential duplicates are found:
-             - Use `gh issue comment` to post a helpful comment like:
-               "This issue may be related to existing issues: #X, #Y. Please check if your issue is already being tracked."
-             - Only comment if you find genuinely similar issues (not just any issue with a common word)
-             - Include issue numbers as links
-
-          IMPORTANT GUIDELINES:
-          - Be thorough in your analysis
-          - Only apply labels that exist in the repository
-          - When in doubt about duplicates, err on the side of not commenting
-          - Keep duplicate comments brief and helpful
-          EOF
-
-      - name: Setup GitHub MCP Server
-        run: |
-          mkdir -p /tmp/mcp-config
-          cat > /tmp/mcp-config/mcp-servers.json << 'EOF'
-          {
-            "mcpServers": {
-              "github": {
-                "command": "docker",
-                "args": [
-                  "run",
-                  "-i",
-                  "--rm",
-                  "-e",
-                  "GITHUB_PERSONAL_ACCESS_TOKEN",
-                  "ghcr.io/github/github-mcp-server:sha-7aced2b"
-                ],
-                "env": {
-                  "GITHUB_PERSONAL_ACCESS_TOKEN": "${{ secrets.GITHUB_TOKEN }}"
-                }
-              }
-            }
-          }
-          EOF
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
 
       - name: Run Claude Code for Issue Triage
-        timeout-minutes: 5
-        uses: anthropics/claude-code-base-action@v1
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: anthropics/claude-code-action@v1
         with:
-          prompt_file: /tmp/claude-prompts/triage-prompt.txt
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          model: claude-sonnet-4-5-20250929
+
+          prompt: |
+            You're an issue triage assistant for the Loculus project. Your tasks are to:
+            1. Analyze the issue and apply appropriate component labels
+            2. Search for duplicate issues and comment if found
+
+            Issue Information:
+            - REPO: ${{ github.repository }}
+            - ISSUE_NUMBER: ${{ github.event.issue.number }}
+
+            COMPONENT LABELS TO USE:
+            The following labels should be applied based on which component(s) the issue relates to:
+            - `website` - Issues related to the web frontend (website/ directory)
+            - `backend` - Issues related to the backend API/server (backend/ directory)
+            - `deposition` - Issues related to ENA submission/deposition (ena-submission/ directory)
+            - `preprocessing` - Issues related to data preprocessing (preprocessing/ directory)
+            - `deployment` - Issues related to Kubernetes deployment/infrastructure (kubernetes/ directory)
+            - `ingest` - Issues related to data ingestion (ingest/ directory)
+
+            TASK STEPS:
+
+            1. First, fetch the list of available labels in this repository:
+               Run: `gh label list`
+
+            2. Get the issue details using: `gh issue view ${{ github.event.issue.number }}`
+
+            3. Analyze the issue content to determine:
+               - Which component(s) are affected based on:
+                 - Explicit mentions of components (website, backend, API, frontend, etc.)
+                 - File paths or directories mentioned
+                 - Feature areas described (UI issues -> website, API issues -> backend, etc.)
+                 - Error messages or stack traces that indicate the component
+               - The type of issue (bug, feature request, question, etc.)
+
+            4. Search for potential duplicate issues:
+               - Run: `gh issue list --state open --limit 50` to see recent open issues
+               - Search for similar issues: `gh issue list --search "keywords from title" --state open`
+               - Look for issues with similar error messages, feature requests, or problem descriptions
+
+            5. Apply component labels:
+               - Run: `gh issue edit ${{ github.event.issue.number }} --add-label "label1,label2"`
+               - You can apply multiple component labels if the issue spans multiple components
+               - Only apply labels that exist in the repository
+               - If no component is clearly identifiable, do not apply component labels
+
+            6. If potential duplicates are found:
+               - Post a helpful comment using: `gh issue comment ${{ github.event.issue.number }} --body "message"`
+               - Format: "This issue may be related to existing issues: #X, #Y. Please check if your issue is already being tracked."
+               - Only comment if you find genuinely similar issues (not just any issue with a common word)
+
+            IMPORTANT GUIDELINES:
+            - Be thorough in your analysis
+            - Only apply labels that exist in the repository
+            - When in doubt about duplicates, err on the side of not commenting
+            - Keep duplicate comments brief and helpful
+
           claude_args: |
-            --model claude-sonnet-4-5-20250929
-            --mcp-config /tmp/mcp-config/mcp-servers.json
-            --allowedTools "Bash(gh label list),Bash(gh issue comment:*),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__search_issues,mcp__github__list_issues"
+            --allowedTools "Bash(gh issue:*),Bash(gh label list)"
 
   label-pr:
     if: github.event_name == 'pull_request'
@@ -124,108 +94,79 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: write
+      issues: read
+      id-token: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Create PR labeling prompt
-        run: |
-          mkdir -p /tmp/claude-prompts
-          cat > /tmp/claude-prompts/pr-label-prompt.txt << 'EOF'
-          You're a PR triage assistant for the Loculus project. Your tasks are to:
-          1. Analyze the changed files and apply appropriate component labels
-          2. Search for duplicate or related issues/PRs and comment if found
-
-          PR Information:
-          - REPO: ${{ github.repository }}
-          - PR_NUMBER: ${{ github.event.pull_request.number }}
-          - PR_TITLE: ${{ github.event.pull_request.title }}
-
-          COMPONENT LABEL MAPPING:
-          Apply labels based on which directories have changed files:
-          - `website` - Changes in website/ directory
-          - `backend` - Changes in backend/ directory
-          - `deposition` - Changes in ena-submission/ directory
-          - `preprocessing` - Changes in preprocessing/ directory
-          - `deployment` - Changes in kubernetes/ directory
-          - `ingest` - Changes in ingest/ directory
-
-          TASK STEPS:
-
-          1. Get the list of changed files in this PR:
-             Run: `gh pr diff ${{ github.event.pull_request.number }} --name-only`
-
-          2. Fetch the list of available labels:
-             Run: `gh label list`
-
-          3. Analyze changed files and determine component labels:
-             - website/* -> apply "website" label
-             - backend/* -> apply "backend" label
-             - ena-submission/* -> apply "deposition" label
-             - preprocessing/* -> apply "preprocessing" label
-             - kubernetes/* -> apply "deployment" label
-             - ingest/* -> apply "ingest" label
-             - Multiple directories -> apply multiple labels
-
-          4. Apply the component labels:
-             Run: `gh pr edit ${{ github.event.pull_request.number }} --add-label "label1,label2"`
-             Only add labels that exist in the repository.
-
-          5. Search for related issues that this PR might address:
-             - Use mcp__github__search_issues to find issues with similar keywords
-             - Look for issues that describe the bug being fixed or feature being added
-             - Check the PR title and description for issue references
-
-          6. If related issues are found that aren't already linked:
-             - Use `gh pr comment` to post a helpful comment like:
-               "This PR may be related to: #X, #Y"
-             - Only comment if genuinely related issues are found
-             - Skip if issues are already linked in the PR description
-
-          IMPORTANT GUIDELINES:
-          - Always apply component labels based on changed files
-          - Only apply labels that exist in the repository
-          - Be conservative when suggesting related issues
-          - Do not duplicate information already in the PR description
-          EOF
-
-      - name: Setup GitHub MCP Server
-        run: |
-          mkdir -p /tmp/mcp-config
-          cat > /tmp/mcp-config/mcp-servers.json << 'EOF'
-          {
-            "mcpServers": {
-              "github": {
-                "command": "docker",
-                "args": [
-                  "run",
-                  "-i",
-                  "--rm",
-                  "-e",
-                  "GITHUB_PERSONAL_ACCESS_TOKEN",
-                  "ghcr.io/github/github-mcp-server:sha-7aced2b"
-                ],
-                "env": {
-                  "GITHUB_PERSONAL_ACCESS_TOKEN": "${{ secrets.GITHUB_TOKEN }}"
-                }
-              }
-            }
-          }
-          EOF
-
       - name: Run Claude Code for PR Labeling
-        timeout-minutes: 5
-        uses: anthropics/claude-code-base-action@v1
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: anthropics/claude-code-action@v1
         with:
-          prompt_file: /tmp/claude-prompts/pr-label-prompt.txt
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          model: claude-sonnet-4-5-20250929
+
+          prompt: |
+            You're a PR triage assistant for the Loculus project. Your tasks are to:
+            1. Analyze the changed files and apply appropriate component labels
+            2. Search for related issues that this PR might address
+
+            PR Information:
+            - REPO: ${{ github.repository }}
+            - PR_NUMBER: ${{ github.event.pull_request.number }}
+            - PR_TITLE: ${{ github.event.pull_request.title }}
+
+            COMPONENT LABEL MAPPING:
+            Apply labels based on which directories have changed files:
+            - `website` - Changes in website/ directory
+            - `backend` - Changes in backend/ directory
+            - `deposition` - Changes in ena-submission/ directory
+            - `preprocessing` - Changes in preprocessing/ directory
+            - `deployment` - Changes in kubernetes/ directory
+            - `ingest` - Changes in ingest/ directory
+
+            TASK STEPS:
+
+            1. Get the list of changed files in this PR:
+               Run: `gh pr diff ${{ github.event.pull_request.number }} --name-only`
+
+            2. Fetch the list of available labels:
+               Run: `gh label list`
+
+            3. Analyze changed files and determine component labels:
+               - website/* -> apply "website" label
+               - backend/* -> apply "backend" label
+               - ena-submission/* -> apply "deposition" label
+               - preprocessing/* -> apply "preprocessing" label
+               - kubernetes/* -> apply "deployment" label
+               - ingest/* -> apply "ingest" label
+               - Multiple directories -> apply multiple labels
+
+            4. Apply the component labels:
+               Run: `gh pr edit ${{ github.event.pull_request.number }} --add-label "label1,label2"`
+               Only add labels that exist in the repository.
+
+            5. Search for related issues that this PR might address:
+               - Run: `gh issue list --state open --limit 30` to see recent issues
+               - Search for related issues: `gh issue list --search "keywords" --state open`
+               - Look for issues that describe the bug being fixed or feature being added
+               - Check the PR title and description for issue references
+
+            6. If related issues are found that aren't already linked:
+               - Post a comment: `gh pr comment ${{ github.event.pull_request.number }} --body "message"`
+               - Format: "This PR may be related to: #X, #Y"
+               - Only comment if genuinely related issues are found
+               - Skip if issues are already linked in the PR description
+
+            IMPORTANT GUIDELINES:
+            - Always apply component labels based on changed files
+            - Only apply labels that exist in the repository
+            - Be conservative when suggesting related issues
+            - Do not duplicate information already in the PR description
+
           claude_args: |
-            --model claude-sonnet-4-5-20250929
-            --mcp-config /tmp/mcp-config/mcp-servers.json
-            --allowedTools "Bash(gh pr diff:*),Bash(gh pr edit:*),Bash(gh pr comment:*),Bash(gh label list),mcp__github__search_issues,mcp__github__list_issues,mcp__github__get_issue"
+            --allowedTools "Bash(gh pr:*),Bash(gh issue list:*),Bash(gh label list)"


### PR DESCRIPTION
let's try this for a bit and we can always turn it off


Add a new GitHub Actions workflow that uses Claude Code to:

1. Automatically label issues and PRs based on affected components:
   - website: Changes in website/ directory
   - backend: Changes in backend/ directory
   - deposition: Changes in ena-submission/ directory
   - preprocessing: Changes in preprocessing/ directory
   - deployment: Changes in kubernetes/ directory
   - ingest: Changes in ingest/ directory

2. Search for duplicate/related issues and comment suggestions:
   - For issues: Searches for similar open issues and comments if duplicates found
   - For PRs: Searches for related issues that the PR might address

The workflow uses Claude Code with the GitHub MCP server to:
- Analyze issue content to determine relevant components
- Parse changed files in PRs to automatically apply component labels
- Search for and identify potential duplicate issues
- Post helpful comments when duplicates are detected

🚀 Preview: Add `preview` label to enable