### PR TITLE
feat(website): improve linkout menu

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
@@ -132,7 +132,7 @@ export const LinkOutMenu: FC<LinkOutMenuProps> = ({
                     <IwwaArrowDown className='ml-2 h-5 w-5' aria-hidden='true' />
                 </MenuButton>
 
-                <MenuItems className='absolute right-0 mt-2 w-64 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none'>
+                <MenuItems className='absolute right-0 mt-2 w-64  origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none'>
                     <div className='py-1'>
                         <div className='px-4 py-2 text-sm text-gray-500'>
                             Analyze {sequenceCount !== undefined ? formatNumberWithDefaultLocale(sequenceCount) : '...'}{' '}


### PR DESCRIPTION
Make clearer what sequences will go to external tools by showing a number

<img width="992" height="372" alt="image" src="https://github.com/user-attachments/assets/7dd3023b-780c-472b-92ef-22b8067152a4" />



<img width="982" height="397" alt="image" src="https://github.com/user-attachments/assets/068f7c3f-169c-457c-ab07-9e01763fd2b0" />

🚀 Preview: Add `preview` label to enable