### PR TITLE
feat(ingest): update curated warning to include hash

### DIFF
--- a/ingest/scripts/compare_hashes.py
+++ b/ingest/scripts/compare_hashes.py
@@ -118,7 +118,8 @@ def process_hashes(
         notification = (
             f"Ingest: Sequence {corresponding_loculus_accession} with INSDC "
             f"accession {ingested_insdc_accession} has been curated before "
-            "- do not know how to proceed"
+            f"- do not know how to proceed. New hash: {newly_ingested_hash}, "
+            f"old hash: {previously_submitted_entry.hash}."
         )
         logger.warning(notification)
         notify(update_manager.config, notification)


### PR DESCRIPTION
Improves the error message when ingest wants to revise curated sequences, we decided for now to "hack the DB" by just doing db surgery to set the old hash to the new hash calculated by ingest to get rid of this warning for now. This message will let me do that.

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable