### PR TITLE
feat(backend, website): download of original data for revisions

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -287,7 +287,7 @@ data class EditedSequenceEntryData(
 data class UnprocessedData(
     @Schema(example = "LOC_000S01D") override val accession: Accession,
     @Schema(example = "1") override val version: Version,
-    val data: OriginalDataWithFileUrls<GeneticSequence>,
+    val data: UnprocessedDataContentWithFileUrls<GeneticSequence>,
     @Schema(description = "The submission id that was used in the upload to link metadata and sequences")
     val submissionId: String,
     @Schema(description = "The username of the submitter")
@@ -298,7 +298,7 @@ data class UnprocessedData(
     val submittedAt: Long,
 ) : AccessionVersionInterface
 
-data class OriginalDataInternal<SequenceType, FilesType>(
+data class UnprocessedDataContentInternal<SequenceType, FilesType>(
     @Schema(
         example = "{\"date\": \"2020-01-01\", \"country\": \"Germany\"}",
         description = "Key value pairs of metadata, as submitted in the metadata file",
@@ -316,9 +316,10 @@ data class OriginalDataInternal<SequenceType, FilesType>(
     val files: Map<String, List<FilesType>>? = null,
 )
 
-typealias OriginalData<SequenceType> = OriginalDataInternal<SequenceType, FileIdAndName>
-typealias OriginalDataWithFileUrls<SequenceType> =
-    OriginalDataInternal<SequenceType, FileIdAndNameAndReadUrl>
+typealias UnprocessedDataContent<SequenceType> = UnprocessedDataContentInternal<SequenceType, FileIdAndName>
+typealias OriginalData<SequenceType> = UnprocessedDataContent<SequenceType>
+typealias UnprocessedDataContentWithFileUrls<SequenceType> =
+    UnprocessedDataContentInternal<SequenceType, FileIdAndNameAndReadUrl>
 
 data class AccessionVersionUnprocessedMetadata(
     override val accession: Accession,
@@ -326,6 +327,24 @@ data class AccessionVersionUnprocessedMetadata(
     val submitter: String,
     val isRevocation: Boolean,
     val unprocessedMetadata: Map<String, String?>?,
+) : AccessionVersionInterface
+
+data class GetOriginalDataRequest(
+    @Schema(
+        description = "The group ID to download data for.",
+    )
+    val groupId: Int,
+    @Schema(
+        description = "Filter by specific accessions. If not provided, all accessions for the group are returned.",
+    )
+    val accessionsFilter: List<Accession>? = null,
+)
+
+data class UnprocessedDataDownloadEntry(
+    override val accession: Accession,
+    override val version: Version,
+    val submissionId: String,
+    val unprocessedData: UnprocessedDataContent<GeneticSequence>,
 ) : AccessionVersionInterface
 
 enum class Status {

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -24,6 +24,7 @@ import org.loculus.backend.api.DataUseTerms
 import org.loculus.backend.api.DataUseTermsType
 import org.loculus.backend.api.EditedSequenceEntryData
 import org.loculus.backend.api.ExternalSubmittedData
+import org.loculus.backend.api.GetOriginalDataRequest
 import org.loculus.backend.api.GetSequenceResponse
 import org.loculus.backend.api.Organism
 import org.loculus.backend.api.ProcessedData
@@ -41,6 +42,10 @@ import org.loculus.backend.controller.LoculusCustomHeaders.X_TOTAL_RECORDS
 import org.loculus.backend.log.ORGANISM_MDC_KEY
 import org.loculus.backend.log.REQUEST_ID_MDC_KEY
 import org.loculus.backend.log.RequestIdContext
+import org.loculus.backend.model.ACCESSION_HEADER
+import org.loculus.backend.model.FASTA_IDS_HEADER
+import org.loculus.backend.model.FASTA_IDS_SEPARATOR
+import org.loculus.backend.model.METADATA_ID_HEADER
 import org.loculus.backend.model.RELEASED_DATA_RELATED_TABLES
 import org.loculus.backend.model.ReleasedDataModel
 import org.loculus.backend.model.SubmissionParams
@@ -49,7 +54,12 @@ import org.loculus.backend.service.datauseterms.DataUseTermsPreconditionValidato
 import org.loculus.backend.service.groupmanagement.GroupManagementPreconditionValidator
 import org.loculus.backend.service.submission.SubmissionDatabaseService
 import org.loculus.backend.utils.Accession
+import org.loculus.backend.utils.FastaEntry
+import org.loculus.backend.utils.FastaWriter
+import org.loculus.backend.utils.GetOriginalDataHelpers
 import org.loculus.backend.utils.IteratorStreamer
+import org.loculus.backend.utils.TsvWriter
+import org.loculus.backend.utils.makeUniqueIds
 import org.slf4j.MDC
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
@@ -69,10 +79,16 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 import io.swagger.v3.oas.annotations.parameters.RequestBody as SwaggerRequestBody
 
 private val log = KotlinLogging.logger { }
+private val ORIGINAL_DATA_DOWNLOAD_TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'")
+
+const val MAX_ORIGINAL_DATA_DOWNLOAD_ENTRIES = 500
 
 @RestController
 @RequestMapping("/{organism}")
@@ -456,6 +472,112 @@ open class SubmissionController(
         }
 
         return ResponseEntity(streamBody, headers, HttpStatus.OK)
+    }
+
+    @Operation(
+        description = "Download original data (metadata and sequences) as a zip file, suitable for revisions. " +
+            "It is limited to $MAX_ORIGINAL_DATA_DOWNLOAD_ENTRIES entries.",
+    )
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping(
+        "/get-original-data",
+        consumes = [MediaType.APPLICATION_JSON_VALUE],
+        produces = ["application/zip"],
+    )
+    fun getOriginalData(
+        @PathVariable @Valid organism: Organism,
+        @HiddenParam authenticatedUser: AuthenticatedUser,
+        @RequestBody body: GetOriginalDataRequest,
+    ): ResponseEntity<StreamingResponseBody> {
+        groupManagementPreconditionValidator.validateUserIsAllowedToModifyGroup(body.groupId, authenticatedUser)
+
+        val entryCount = transaction {
+            submissionDatabaseService.countOriginalDataDownloadEntries(
+                organism,
+                body.groupId,
+                body.accessionsFilter,
+            )
+        }
+
+        if (entryCount > MAX_ORIGINAL_DATA_DOWNLOAD_ENTRIES) {
+            throw UnprocessableEntityException(
+                "Download is limited to $MAX_ORIGINAL_DATA_DOWNLOAD_ENTRIES entries. " +
+                    "Requested download would include $entryCount entries. " +
+                    "Please filter fewer sequences.",
+            )
+        }
+
+        val headers = HttpHeaders()
+        headers.contentType = MediaType.parseMediaType("application/zip")
+        headers.set(
+            HttpHeaders.CONTENT_DISPOSITION,
+            "attachment; filename=\"${originalDataDownloadFilename(organism)}\"",
+        )
+
+        val instanceConfig = backendConfig.getInstanceConfig(organism)
+        val hasConsensusSequences = instanceConfig.schema.submissionDataTypes.consensusSequences
+        val isMultiSegmented = instanceConfig.referenceGenome.nucleotideSequences.size > 1
+
+        val streamBody = StreamingResponseBody { responseBodyStream ->
+            val startTime = System.currentTimeMillis()
+            MDC.put(REQUEST_ID_MDC_KEY, requestIdContext.requestId)
+            MDC.put(ORGANISM_MDC_KEY, organism.name)
+
+            try {
+                java.util.zip.ZipOutputStream(responseBodyStream).use { zipOut ->
+                    transaction {
+                        val data = submissionDatabaseService.streamUnprocessedDataForOriginalDataDownload(
+                            organism,
+                            body.groupId,
+                            body.accessionsFilter,
+                        ).toList()
+
+                        val metadataIds = makeUniqueIds(data.map { it.submissionId })
+                        val uniqueFastaIdsByEntry =
+                            GetOriginalDataHelpers.uniqueFastaIdsByEntry(data, isMultiSegmented)
+
+                        zipOut.putNextEntry(java.util.zip.ZipEntry("metadata.tsv"))
+                        GetOriginalDataHelpers.writeMetadataTsv(
+                            data,
+                            metadataIds,
+                            uniqueFastaIdsByEntry,
+                            zipOut,
+                            isMultiSegmented,
+                        )
+                        zipOut.closeEntry()
+
+                        if (hasConsensusSequences) {
+                            zipOut.putNextEntry(java.util.zip.ZipEntry("sequences.fasta"))
+                            GetOriginalDataHelpers.writeSequencesFasta(
+                                data,
+                                metadataIds,
+                                uniqueFastaIdsByEntry,
+                                zipOut,
+                                isMultiSegmented,
+                            )
+                            zipOut.closeEntry()
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                val duration = System.currentTimeMillis() - startTime
+                log.error(e) { "[get-original-data] Error after ${duration}ms: $e" }
+                throw e
+            } finally {
+                MDC.remove(REQUEST_ID_MDC_KEY)
+                MDC.remove(ORGANISM_MDC_KEY)
+            }
+
+            val duration = System.currentTimeMillis() - startTime
+            log.info { "[get-original-data] Completed in ${duration}ms" }
+        }
+
+        return ResponseEntity(streamBody, headers, HttpStatus.OK)
+    }
+
+    private fun originalDataDownloadFilename(organism: Organism): String {
+        val timestamp = OffsetDateTime.now(ZoneOffset.UTC).format(ORIGINAL_DATA_DOWNLOAD_TIMESTAMP_FORMAT)
+        return "${organism.name}_original_data_$timestamp.zip"
     }
 
     @Operation(description = APPROVE_PROCESSED_DATA_DESCRIPTION)

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -532,6 +532,9 @@ open class SubmissionController(
                             body.accessionsFilter,
                         ).toList()
 
+                        // metadataIds: the unique metadata ids in the same order as the original submission ids.
+                        // uniqueFastaIdsByEntry: per entry (in the same order), a map from the original FASTA id to
+                        // the unique FASTA id used in the download.
                         val metadataIds = makeUniqueIds(data.map { it.submissionId })
                         val uniqueFastaIdsByEntry =
                             GetOriginalDataHelpers.uniqueFastaIdsByEntry(data, isMultiSegmented)

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -14,6 +14,8 @@ import org.jetbrains.exposed.sql.LongColumnType
 import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.QueryParameter
 import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.inList
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.less
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.plus
 import org.jetbrains.exposed.sql.Transaction
@@ -54,7 +56,6 @@ import org.loculus.backend.api.GeneticSequence
 import org.loculus.backend.api.GetSequenceResponse
 import org.loculus.backend.api.Organism
 import org.loculus.backend.api.OriginalData
-import org.loculus.backend.api.OriginalDataWithFileUrls
 import org.loculus.backend.api.PreprocessingStatus.IN_PROCESSING
 import org.loculus.backend.api.PreprocessingStatus.PROCESSED
 import org.loculus.backend.api.ProcessedData
@@ -69,6 +70,8 @@ import org.loculus.backend.api.Status.APPROVED_FOR_RELEASE
 import org.loculus.backend.api.SubmissionIdMapping
 import org.loculus.backend.api.SubmittedProcessedData
 import org.loculus.backend.api.UnprocessedData
+import org.loculus.backend.api.UnprocessedDataContentWithFileUrls
+import org.loculus.backend.api.UnprocessedDataDownloadEntry
 import org.loculus.backend.api.fileIds
 import org.loculus.backend.api.getFileId
 import org.loculus.backend.auth.AuthenticatedUser
@@ -194,13 +197,13 @@ class SubmissionDatabaseService(
             .chunked(streamBatchSize)
             .map { chunk ->
                 val chunkOfUnprocessedData = chunk.map {
-                    val originalData = compressionService.decompressSequencesInOriginalData(
+                    val unprocessedData = compressionService.decompressSequencesInOriginalData(
                         it[table.unprocessedDataColumn]!!,
                     )
-                    val originalDataWithFileUrls = OriginalDataWithFileUrls(
-                        originalData.metadata,
-                        originalData.unalignedNucleotideSequences,
-                        originalData.files?.let {
+                    val unprocessedDataWithFileUrls = UnprocessedDataContentWithFileUrls(
+                        unprocessedData.metadata,
+                        unprocessedData.unalignedNucleotideSequences,
+                        unprocessedData.files?.let {
                             it.mapValues {
                                 it.value.map { f ->
                                     val presignedUrl = s3Service.createUrlToReadPrivateFile(f.fileId)
@@ -212,7 +215,7 @@ class SubmissionDatabaseService(
                     UnprocessedData(
                         accession = it[table.accessionColumn],
                         version = it[table.versionColumn],
-                        data = originalDataWithFileUrls,
+                        data = unprocessedDataWithFileUrls,
                         submissionId = it[table.submissionIdColumn],
                         submitter = it[table.submitterColumn],
                         groupId = it[table.groupIdColumn],
@@ -1300,6 +1303,70 @@ class SubmissionDatabaseService(
                     it[SequenceEntriesView.submitterColumn],
                     it[SequenceEntriesView.isRevocationColumn],
                     selectedMetadata,
+                )
+            }
+    }
+
+    private fun originalDataDownloadConditions(
+        organism: Organism,
+        groupId: Int,
+        accessionsFilter: List<String>?,
+    ): Op<Boolean> {
+        val accessionsCondition = if (!accessionsFilter.isNullOrEmpty()) {
+            SequenceEntriesView.accessionColumn inList accessionsFilter
+        } else {
+            Op.TRUE
+        }
+
+        return SequenceEntriesView.organismIs(organism) and
+            (SequenceEntriesView.groupIdColumn eq groupId) and
+            SequenceEntriesView.statusIs(APPROVED_FOR_RELEASE) and
+            SequenceEntriesView.isMaxVersion and
+            (SequenceEntriesView.isRevocationColumn eq false) and
+            accessionsCondition
+    }
+
+    fun countOriginalDataDownloadEntries(organism: Organism, groupId: Int, accessionsFilter: List<String>?): Long =
+        SequenceEntriesView
+            .select(SequenceEntriesView.accessionColumn)
+            .where(originalDataDownloadConditions(organism, groupId, accessionsFilter))
+            .count()
+
+    fun streamUnprocessedDataForOriginalDataDownload(
+        organism: Organism,
+        groupId: Int,
+        accessionsFilter: List<String>?,
+    ): Sequence<UnprocessedDataDownloadEntry> {
+        val unprocessedDataQuery = SequenceEntriesView.join(
+            SequenceEntriesTable,
+            JoinType.INNER,
+            additionalConstraint = {
+                (SequenceEntriesView.accessionColumn eq SequenceEntriesTable.accessionColumn) and
+                    (SequenceEntriesView.versionColumn eq SequenceEntriesTable.versionColumn)
+            },
+        )
+
+        return unprocessedDataQuery
+            .select(
+                SequenceEntriesView.accessionColumn,
+                SequenceEntriesView.versionColumn,
+                SequenceEntriesView.submissionIdColumn,
+                SequenceEntriesTable.unprocessedDataColumn,
+            )
+            .where(originalDataDownloadConditions(organism, groupId, accessionsFilter))
+            .orderBy(SequenceEntriesView.accessionColumn to SortOrder.ASC)
+            .fetchSize(streamBatchSize)
+            .asSequence()
+            .map {
+                val compressedUnprocessedData = it[SequenceEntriesTable.unprocessedDataColumn]!!
+                val decompressedUnprocessedData = compressionService.decompressSequencesInOriginalData(
+                    compressedUnprocessedData,
+                )
+                UnprocessedDataDownloadEntry(
+                    it[SequenceEntriesView.accessionColumn],
+                    it[SequenceEntriesView.versionColumn],
+                    it[SequenceEntriesView.submissionIdColumn],
+                    decompressedUnprocessedData,
                 )
             }
     }

--- a/backend/src/main/kotlin/org/loculus/backend/utils/FastaWriter.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/FastaWriter.kt
@@ -1,0 +1,25 @@
+package org.loculus.backend.utils
+
+import java.io.OutputStream
+
+class FastaWriter(outputStream: OutputStream) : AutoCloseable {
+    private val writer = outputStream.bufferedWriter()
+
+    fun write(entry: FastaEntry) {
+        writer.write(">")
+        writer.write(entry.fastaId)
+        writer.newLine()
+        writer.write(entry.sequence)
+        writer.newLine()
+    }
+
+    fun writeAll(entries: Iterable<FastaEntry>) {
+        for (entry in entries) {
+            write(entry)
+        }
+    }
+
+    override fun close() {
+        writer.flush()
+    }
+}

--- a/backend/src/main/kotlin/org/loculus/backend/utils/GetOriginalDataHelpers.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/GetOriginalDataHelpers.kt
@@ -12,7 +12,7 @@ import kotlin.collections.iterator
 import kotlin.collections.orEmpty
 
 /**
- * In the Map, each entry is a segment.
+ * Map from original FastaId to unique FastaId for each segment in an entry.
  */
 data class UniqueFastaIdsForEntry(val uniqueFastaIdByOriginalFastaId: Map<FastaId, FastaId>) {
     fun joinedUniqueFastaIds(separator: String): String = uniqueFastaIdByOriginalFastaId.values.joinToString(separator)

--- a/backend/src/main/kotlin/org/loculus/backend/utils/GetOriginalDataHelpers.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/GetOriginalDataHelpers.kt
@@ -1,0 +1,94 @@
+package org.loculus.backend.utils
+
+import org.loculus.backend.api.UnprocessedDataDownloadEntry
+import org.loculus.backend.model.ACCESSION_HEADER
+import org.loculus.backend.model.FASTA_IDS_HEADER
+import org.loculus.backend.model.FASTA_IDS_SEPARATOR
+import org.loculus.backend.model.FastaId
+import org.loculus.backend.model.METADATA_ID_HEADER
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.iterator
+import kotlin.collections.orEmpty
+
+/**
+ * In the Map, each entry is a segment.
+ */
+data class UniqueFastaIdsForEntry(val uniqueFastaIdByOriginalFastaId: Map<FastaId, FastaId>) {
+    fun joinedUniqueFastaIds(separator: String): String = uniqueFastaIdByOriginalFastaId.values.joinToString(separator)
+
+    fun getUniqueFastaId(originalFastaId: FastaId): FastaId = uniqueFastaIdByOriginalFastaId.getValue(originalFastaId)
+}
+
+object GetOriginalDataHelpers {
+
+    fun uniqueFastaIdsByEntry(
+        data: List<UnprocessedDataDownloadEntry>,
+        isMultiSegmented: Boolean,
+    ): List<UniqueFastaIdsForEntry> {
+        if (!isMultiSegmented) {
+            return data.map { UniqueFastaIdsForEntry(emptyMap()) }
+        }
+
+        val originalFastaIds = data.flatMapIndexed { entryIndex, entry ->
+            entry.unprocessedData.unalignedNucleotideSequences.keys.map { entryIndex to it }
+        }
+        val fastaIdsByEntryIndex = originalFastaIds
+            .zip(makeUniqueIds(originalFastaIds.map { it.second }))
+            .groupBy({ it.first.first }, { it.first.second to it.second })
+            .mapValues { (_, ids) -> ids.toMap() }
+
+        return data.indices.map { UniqueFastaIdsForEntry(fastaIdsByEntryIndex[it].orEmpty()) }
+    }
+
+    fun writeMetadataTsv(
+        data: List<UnprocessedDataDownloadEntry>,
+        metadataIds: List<String>,
+        fastaIdsByEntry: List<UniqueFastaIdsForEntry>,
+        outputStream: java.io.OutputStream,
+        isMultiSegmented: Boolean,
+    ) {
+        val metadataKeys = data.flatMapTo(mutableSetOf()) { it.unprocessedData.metadata.keys }.sorted()
+        val headers = if (isMultiSegmented) {
+            listOf(METADATA_ID_HEADER, ACCESSION_HEADER, FASTA_IDS_HEADER) + metadataKeys
+        } else {
+            listOf(METADATA_ID_HEADER, ACCESSION_HEADER) + metadataKeys
+        }
+
+        TsvWriter(outputStream, headers).use { writer ->
+            for ((index, entry) in data.withIndex()) {
+                val metadataValues = metadataKeys.map { entry.unprocessedData.metadata[it] ?: "" }
+                val row = if (isMultiSegmented) {
+                    val fastaIds = fastaIdsByEntry[index].joinedUniqueFastaIds(FASTA_IDS_SEPARATOR)
+                    listOf(metadataIds[index], entry.accession, fastaIds) + metadataValues
+                } else {
+                    listOf(metadataIds[index], entry.accession) + metadataValues
+                }
+                writer.writeRow(row)
+            }
+        }
+    }
+
+    fun writeSequencesFasta(
+        data: List<UnprocessedDataDownloadEntry>,
+        metadataIds: List<String>,
+        fastaIdsByEntry: List<UniqueFastaIdsForEntry>,
+        outputStream: java.io.OutputStream,
+        isMultiSegmented: Boolean,
+    ) {
+        FastaWriter(outputStream).use { writer ->
+            for ((index, entry) in data.withIndex()) {
+                for ((originalFastaId, sequence) in entry.unprocessedData.unalignedNucleotideSequences) {
+                    if (sequence != null) {
+                        val header = if (isMultiSegmented) {
+                            fastaIdsByEntry[index].getUniqueFastaId(originalFastaId)
+                        } else {
+                            metadataIds[index]
+                        }
+                        writer.write(FastaEntry(header, sequence))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/backend/src/main/kotlin/org/loculus/backend/utils/TsvWriter.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/TsvWriter.kt
@@ -1,0 +1,21 @@
+package org.loculus.backend.utils
+
+import org.apache.commons.csv.CSVFormat
+import org.apache.commons.csv.CSVPrinter
+import java.io.OutputStream
+
+class TsvWriter(outputStream: OutputStream, headers: List<String>) : AutoCloseable {
+    private val writer = outputStream.bufferedWriter()
+    private val printer: CSVPrinter = CSVFormat.TDF.builder()
+        .setHeader(*headers.toTypedArray())
+        .get()
+        .print(writer)
+
+    fun writeRow(values: List<String?>) {
+        printer.printRecord(values)
+    }
+
+    override fun close() {
+        printer.flush()
+    }
+}

--- a/backend/src/main/kotlin/org/loculus/backend/utils/UniqueIds.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/UniqueIds.kt
@@ -1,0 +1,25 @@
+package org.loculus.backend.utils
+
+fun makeUniqueIds(ids: List<String>): List<String> {
+    val originalIds = ids.toSet()
+    val usedIds = mutableSetOf<String>()
+
+    return ids.map { id ->
+        if (usedIds.add(id)) {
+            id
+        } else {
+            nextUniqueId(id, originalIds, usedIds)
+        }
+    }
+}
+
+private fun nextUniqueId(id: String, originalIds: Set<String>, usedIds: MutableSet<String>): String {
+    var suffix = 1
+    while (true) {
+        val candidate = "${id}_$suffix"
+        if (candidate !in originalIds && usedIds.add(candidate)) {
+            return candidate
+        }
+        suffix++
+    }
+}

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ExtractUnprocessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ExtractUnprocessedDataEndpointTest.kt
@@ -19,10 +19,10 @@ import org.junit.jupiter.api.Test
 import org.loculus.backend.api.FileIdAndNameAndReadUrl
 import org.loculus.backend.api.GeneticSequence
 import org.loculus.backend.api.OriginalData
-import org.loculus.backend.api.OriginalDataWithFileUrls
 import org.loculus.backend.api.Status.IN_PROCESSING
 import org.loculus.backend.api.Status.RECEIVED
 import org.loculus.backend.api.UnprocessedData
+import org.loculus.backend.api.UnprocessedDataContentWithFileUrls
 import org.loculus.backend.config.BackendSpringProperty
 import org.loculus.backend.controller.DEFAULT_ORGANISM
 import org.loculus.backend.controller.DEFAULT_SIMPLE_FILE_CONTENT
@@ -246,7 +246,7 @@ class ExtractUnprocessedDataEndpointTest(
             everyItem(
                 hasProperty(
                     "data",
-                    hasProperty<OriginalDataWithFileUrls<GeneticSequence>>(
+                    hasProperty<UnprocessedDataContentWithFileUrls<GeneticSequence>>(
                         "files",
                         hasEntry<String, List<FileIdAndNameAndReadUrl>>(
                             `is`("myFileCategory"),

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetOriginalDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetOriginalDataEndpointTest.kt
@@ -183,7 +183,7 @@ class GetOriginalDataEndpointTest(
     }
 
     @Test
-    fun `GIVEN data exists THEN FASTA headers match metadata ids`() {
+    fun `GIVEN single-segmented data exists THEN FASTA headers match metadata ids`() {
         val submissionResult = convenienceClient.submitDefaultFiles()
         val accessionVersions = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
             groupId = submissionResult.groupId,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetOriginalDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetOriginalDataEndpointTest.kt
@@ -74,7 +74,7 @@ class GetOriginalDataEndpointTest(
         val fileNames = getZipFileNames(zipContent)
         assertThat(fileNames, containsInAnyOrder("metadata.tsv", "sequences.fasta"))
 
-        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+        val (metadataTsv, sequencesFasta) = extractOriginalDataZipContents(zipContent)
 
         assertThat(metadataTsv, containsString("id\taccession"))
         val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
@@ -105,7 +105,7 @@ class GetOriginalDataEndpointTest(
         await().until { response.isCommitted }
 
         val zipContent = response.contentAsByteArray
-        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+        val (metadataTsv, sequencesFasta) = extractOriginalDataZipContents(zipContent)
 
         assertThat(metadataTsv, containsString("id\taccession"))
         val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
@@ -148,7 +148,7 @@ class GetOriginalDataEndpointTest(
         await().until { response.isCommitted }
 
         val zipContent = response.contentAsByteArray
-        val (metadataTsv, _) = extractZipContents(zipContent)
+        val (metadataTsv, _) = extractOriginalDataZipContents(zipContent)
 
         assertThat(metadataTsv, containsString("authors"))
         assertThat(metadataTsv, containsString("Corrected Author"))
@@ -169,7 +169,7 @@ class GetOriginalDataEndpointTest(
         await().until { response.isCommitted }
 
         val zipContent = response.contentAsByteArray
-        val (metadataTsv, _) = extractZipContents(zipContent)
+        val (metadataTsv, _) = extractOriginalDataZipContents(zipContent)
 
         val lines = metadataTsv.lines().filter { it.isNotBlank() }
         val header = lines[0].split("\t")
@@ -197,7 +197,7 @@ class GetOriginalDataEndpointTest(
         await().until { response.isCommitted }
 
         val zipContent = response.contentAsByteArray
-        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+        val (metadataTsv, sequencesFasta) = extractOriginalDataZipContents(zipContent)
 
         val metadataIds = metadataTsv.lines()
             .filter { it.isNotBlank() }
@@ -232,7 +232,7 @@ class GetOriginalDataEndpointTest(
         await().until { response.isCommitted }
 
         val zipContent = response.contentAsByteArray
-        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+        val (metadataTsv, sequencesFasta) = extractOriginalDataZipContents(zipContent)
 
         val metadataIds = metadataTsv.lines()
             .filter { it.isNotBlank() }
@@ -268,7 +268,7 @@ class GetOriginalDataEndpointTest(
         await().until { response.isCommitted }
 
         val zipContent = response.contentAsByteArray
-        val (metadataTsv, _) = extractZipContents(zipContent)
+        val (metadataTsv, _) = extractOriginalDataZipContents(zipContent)
 
         val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
         assertThat(metadataLines, hasSize(3))
@@ -293,7 +293,7 @@ class GetOriginalDataEndpointTest(
         await().until { response.isCommitted }
 
         val zipContent = response.contentAsByteArray
-        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+        val (metadataTsv, sequencesFasta) = extractOriginalDataZipContents(zipContent)
 
         val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
         assertThat(metadataLines, hasSize(1))
@@ -336,7 +336,7 @@ class GetOriginalDataEndpointTest(
         await().until { response.isCommitted }
 
         val zipContent = response.contentAsByteArray
-        val (metadataTsv, _) = extractZipContents(zipContent)
+        val (metadataTsv, _) = extractOriginalDataZipContents(zipContent)
 
         val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
         assertThat(metadataLines, hasSize(1))
@@ -361,7 +361,7 @@ class GetOriginalDataEndpointTest(
         await().until { response.isCommitted }
 
         val zipContent = response.contentAsByteArray
-        val (metadataTsv, _) = extractZipContents(zipContent)
+        val (metadataTsv, _) = extractOriginalDataZipContents(zipContent)
 
         val lines = metadataTsv.lines().filter { it.isNotBlank() }
         val header = lines[0].split("\t")
@@ -390,7 +390,7 @@ class GetOriginalDataEndpointTest(
         await().until { response.isCommitted }
 
         val zipContent = response.contentAsByteArray
-        val (metadataTsv, _) = extractZipContents(zipContent)
+        val (metadataTsv, _) = extractOriginalDataZipContents(zipContent)
 
         val lines = metadataTsv.lines().filter { it.isNotBlank() }
         val header = lines[0].split("\t")
@@ -421,7 +421,7 @@ class GetOriginalDataEndpointTest(
         await().until { response.isCommitted }
 
         val zipContent = response.contentAsByteArray
-        val (_, sequencesFasta) = extractZipContents(zipContent)
+        val (_, sequencesFasta) = extractOriginalDataZipContents(zipContent)
 
         val fastaHeaders = sequencesFasta.lines().filter { it.startsWith(">") }
         val matchingHeaders = fastaHeaders.filter { it.contains("${SubmitFiles.DefaultFiles.submissionIds[0]}_") }
@@ -447,7 +447,7 @@ class GetOriginalDataEndpointTest(
         await().until { response.isCommitted }
 
         val zipContent = response.contentAsByteArray
-        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+        val (metadataTsv, sequencesFasta) = extractOriginalDataZipContents(zipContent)
 
         val lines = metadataTsv.lines().filter { it.isNotBlank() }
         val header = lines[0].split("\t")
@@ -463,25 +463,6 @@ class GetOriginalDataEndpointTest(
             .toSet()
 
         assertThat(fastaHeaderIds, `is`(allFastaIdsFromMetadata))
-    }
-
-    private fun extractZipContents(zipContent: ByteArray): Pair<String, String> {
-        var metadataTsv = ""
-        var sequencesFasta = ""
-
-        ZipInputStream(ByteArrayInputStream(zipContent)).use { zis ->
-            var entry = zis.nextEntry
-            while (entry != null) {
-                val content = zis.readBytes().decodeToString()
-                when (entry.name) {
-                    "metadata.tsv" -> metadataTsv = content
-                    "sequences.fasta" -> sequencesFasta = content
-                }
-                entry = zis.nextEntry
-            }
-        }
-
-        return Pair(metadataTsv, sequencesFasta)
     }
 
     private fun submitAndApproveSingleSegmentSequences(submissionIds: List<String>, groupId: Int) {

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetOriginalDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetOriginalDataEndpointTest.kt
@@ -1,0 +1,519 @@
+package org.loculus.backend.controller.submission
+
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsInAnyOrder
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.matchesPattern
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import org.junit.jupiter.api.Test
+import org.loculus.backend.api.AccessionVersion
+import org.loculus.backend.controller.DEFAULT_ORGANISM
+import org.loculus.backend.controller.DUMMY_ORGANISM_MAIN_SEQUENCE
+import org.loculus.backend.controller.EndpointTest
+import org.loculus.backend.controller.ORGANISM_WITHOUT_CONSENSUS_SEQUENCES
+import org.loculus.backend.controller.OTHER_ORGANISM
+import org.loculus.backend.controller.expectUnauthorizedResponse
+import org.loculus.backend.controller.generateJwtFor
+import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
+import org.loculus.backend.controller.groupmanagement.andGetGroupId
+import org.loculus.backend.controller.jwtForDefaultUser
+import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles
+import org.loculus.backend.service.submission.SequenceEntriesTable
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.shaded.org.awaitility.Awaitility.await
+import java.io.ByteArrayInputStream
+import java.util.zip.ZipInputStream
+
+@EndpointTest
+class GetOriginalDataEndpointTest(
+    @Autowired val convenienceClient: SubmissionConvenienceClient,
+    @Autowired val submissionControllerClient: SubmissionControllerClient,
+    @Autowired val groupManagementClient: GroupManagementControllerClient,
+) {
+    @Test
+    fun `GIVEN invalid authorization token THEN returns 401 Unauthorized`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        expectUnauthorizedResponse(isModifyingRequest = true) {
+            submissionControllerClient.getOriginalData(groupId = groupId, jwt = it)
+        }
+    }
+
+    @Test
+    fun `GIVEN user not in group THEN returns 403 Forbidden`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        val otherUserJwt = generateJwtFor("otherUser")
+        groupManagementClient.createNewGroup(jwt = otherUserJwt)
+
+        submissionControllerClient.getOriginalData(groupId = groupId, jwt = otherUserJwt)
+            .andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `GIVEN no sequence entries in database THEN returns zip with header-only metadata and empty sequences`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+
+        val response = submissionControllerClient.getOriginalData(groupId = groupId)
+            .andExpect(status().isOk)
+            .andExpect(content().contentType("application/zip"))
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val fileNames = getZipFileNames(zipContent)
+        assertThat(fileNames, containsInAnyOrder("metadata.tsv", "sequences.fasta"))
+
+        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+
+        assertThat(metadataTsv, containsString("id\taccession"))
+        val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
+        assertThat("metadata should only contain header row", metadataLines, hasSize(1))
+        assertThat(sequencesFasta, `is`(""))
+    }
+
+    @Test
+    fun `GIVEN data exists THEN returns zip with metadata TSV and sequences FASTA`() {
+        val submissionResult = convenienceClient.submitDefaultFiles()
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(groupId = submissionResult.groupId)
+
+        val response = submissionControllerClient.getOriginalData(groupId = submissionResult.groupId)
+            .andExpect(status().isOk)
+            .andExpect(content().contentType("application/zip"))
+            .andExpect(
+                header().string(
+                    HttpHeaders.CONTENT_DISPOSITION,
+                    matchesPattern(
+                        "attachment; filename=\"$DEFAULT_ORGANISM" +
+                            "_original_data_[0-9]{8}T[0-9]{6}Z\\.zip\"",
+                    ),
+                ),
+            )
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+
+        assertThat(metadataTsv, containsString("id\taccession"))
+        val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
+        assertThat(metadataLines, hasSize(DefaultFiles.NUMBER_OF_SEQUENCES + 1))
+        assertThat(sequencesFasta, containsString(">"))
+    }
+
+    @Test
+    fun `GIVEN unprocessed data was corrected after submission THEN returns corrected data`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        val accessionVersions = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(groupId = groupId)
+        val correctedAccession = accessionVersions.first()
+
+        transaction {
+            val unprocessedData = SequenceEntriesTable
+                .select(SequenceEntriesTable.unprocessedDataColumn)
+                .where {
+                    (SequenceEntriesTable.accessionColumn eq correctedAccession.accession) and
+                        (SequenceEntriesTable.versionColumn eq correctedAccession.version)
+                }
+                .single()[SequenceEntriesTable.unprocessedDataColumn]!!
+
+            SequenceEntriesTable.update(
+                where = {
+                    (SequenceEntriesTable.accessionColumn eq correctedAccession.accession) and
+                        (SequenceEntriesTable.versionColumn eq correctedAccession.version)
+                },
+            ) {
+                it[unprocessedDataColumn] = unprocessedData.copy(
+                    metadata = unprocessedData.metadata + ("authors" to "Corrected Author"),
+                )
+            }
+        }
+
+        val response = submissionControllerClient.getOriginalData(groupId = groupId)
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, _) = extractZipContents(zipContent)
+
+        assertThat(metadataTsv, containsString("authors"))
+        assertThat(metadataTsv, containsString("Corrected Author"))
+    }
+
+    @Test
+    fun `GIVEN data exists THEN metadata TSV contains id and accession columns`() {
+        val submissionResult = convenienceClient.submitDefaultFiles()
+        val accessionVersions = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+            groupId = submissionResult.groupId,
+        )
+
+        val response = submissionControllerClient.getOriginalData(groupId = submissionResult.groupId)
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, _) = extractZipContents(zipContent)
+
+        val lines = metadataTsv.lines().filter { it.isNotBlank() }
+        val header = lines[0].split("\t")
+
+        assertThat(header[0], `is`("id"))
+        assertThat(header[1], `is`("accession"))
+
+        val firstDataRow = lines[1].split("\t")
+        assertThat(firstDataRow[0], `is`(SubmitFiles.DefaultFiles.submissionIds[0]))
+        assertThat(firstDataRow[1], `is`(accessionVersions[0].accession))
+    }
+
+    @Test
+    fun `GIVEN data exists THEN FASTA headers match metadata ids`() {
+        val submissionResult = convenienceClient.submitDefaultFiles()
+        val accessionVersions = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+            groupId = submissionResult.groupId,
+        )
+
+        val response = submissionControllerClient.getOriginalData(groupId = submissionResult.groupId)
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+
+        val metadataIds = metadataTsv.lines()
+            .filter { it.isNotBlank() }
+            .drop(1)
+            .map { it.split("\t")[0] }
+            .toSet()
+
+        val fastaIds = sequencesFasta.lines()
+            .filter { it.startsWith(">") }
+            .map { it.removePrefix(">") }
+            .toSet()
+
+        assertThat(fastaIds, `is`(metadataIds))
+
+        val expectedIds = SubmitFiles.DefaultFiles.submissionIds.toSet()
+        assertThat(metadataIds, `is`(expectedIds))
+    }
+
+    @Test
+    fun `GIVEN duplicate original ids THEN downloaded ids are made unique without new clashes`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        submitAndApproveSingleSegmentSequences(
+            listOf("sample", "sample", "sample_1", "sample"),
+            groupId,
+        )
+
+        val response = submissionControllerClient.getOriginalData(groupId = groupId)
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+
+        val metadataIds = metadataTsv.lines()
+            .filter { it.isNotBlank() }
+            .drop(1)
+            .map { it.split("\t")[0] }
+
+        val fastaIds = sequencesFasta.lines()
+            .filter { it.startsWith(">") }
+            .map { it.removePrefix(">") }
+
+        assertThat(metadataIds, containsInAnyOrder("sample", "sample_1", "sample_2", "sample_3"))
+        assertThat(metadataIds.toSet(), hasSize(metadataIds.size))
+        assertThat(fastaIds.toSet(), `is`(metadataIds.toSet()))
+    }
+
+    @Test
+    fun `WHEN filtering by accessions THEN returns only those accessions`() {
+        val submissionResult = convenienceClient.submitDefaultFiles()
+        val accessionVersions = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+            groupId = submissionResult.groupId,
+        )
+
+        val selectedAccessions = accessionVersions.take(2).map { it.accession }
+
+        val response = submissionControllerClient.getOriginalData(
+            groupId = submissionResult.groupId,
+            accessionsFilter = selectedAccessions,
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, _) = extractZipContents(zipContent)
+
+        val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
+        assertThat(metadataLines, hasSize(3))
+
+        val returnedAccessions = metadataLines.drop(1).map { it.split("\t")[1] }
+        assertThat(returnedAccessions, containsInAnyOrder(*selectedAccessions.toTypedArray()))
+    }
+
+    @Test
+    fun `WHEN filtering by non-existent accessions THEN returns empty data`() {
+        val submissionResult = convenienceClient.submitDefaultFiles()
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(groupId = submissionResult.groupId)
+
+        val response = submissionControllerClient.getOriginalData(
+            groupId = submissionResult.groupId,
+            accessionsFilter = listOf("NON_EXISTENT", "ALSO_NOT_THERE"),
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+
+        val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
+        assertThat(metadataLines, hasSize(1))
+        assertThat(sequencesFasta, `is`(""))
+    }
+
+    @Test
+    fun `GIVEN organism without consensus sequences THEN zip contains only metadata TSV`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+            organism = ORGANISM_WITHOUT_CONSENSUS_SEQUENCES,
+            groupId = groupId,
+        )
+
+        val response = submissionControllerClient.getOriginalData(
+            organism = ORGANISM_WITHOUT_CONSENSUS_SEQUENCES,
+            groupId = groupId,
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val fileNames = getZipFileNames(zipContent)
+
+        assertThat(fileNames, containsInAnyOrder("metadata.tsv"))
+    }
+
+    @Test
+    fun `GIVEN only non-released sequences THEN returns empty data`() {
+        val submissionResult = convenienceClient.submitDefaultFiles()
+
+        val response = submissionControllerClient.getOriginalData(groupId = submissionResult.groupId)
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, _) = extractZipContents(zipContent)
+
+        val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
+        assertThat(metadataLines, hasSize(1))
+    }
+
+    @Test
+    fun `GIVEN multi-segmented organism THEN metadata TSV has fastaIds column`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+            organism = OTHER_ORGANISM,
+            groupId = groupId,
+        )
+
+        val response = submissionControllerClient.getOriginalData(
+            organism = OTHER_ORGANISM,
+            groupId = groupId,
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, _) = extractZipContents(zipContent)
+
+        val lines = metadataTsv.lines().filter { it.isNotBlank() }
+        val header = lines[0].split("\t")
+
+        assertThat(header[0], `is`("id"))
+        assertThat(header[1], `is`("accession"))
+        assertThat(header[2], `is`("fastaIds"))
+    }
+
+    @Test
+    fun `GIVEN multi-segmented organism THEN fastaIds contain original fasta ids`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+            organism = OTHER_ORGANISM,
+            groupId = groupId,
+        )
+
+        val response = submissionControllerClient.getOriginalData(
+            organism = OTHER_ORGANISM,
+            groupId = groupId,
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, _) = extractZipContents(zipContent)
+
+        val lines = metadataTsv.lines().filter { it.isNotBlank() }
+        val header = lines[0].split("\t")
+        val fastaIdsIndex = header.indexOf("fastaIds")
+
+        val firstDataRow = lines[1].split("\t")
+        val fastaIds = firstDataRow[fastaIdsIndex]
+
+        assertThat(fastaIds, containsString("${SubmitFiles.DefaultFiles.submissionIds[0]}_"))
+    }
+
+    @Test
+    fun `GIVEN multi-segmented organism THEN FASTA headers contain original fasta ids`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+            organism = OTHER_ORGANISM,
+            groupId = groupId,
+        )
+
+        val response = submissionControllerClient.getOriginalData(
+            organism = OTHER_ORGANISM,
+            groupId = groupId,
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (_, sequencesFasta) = extractZipContents(zipContent)
+
+        val fastaHeaders = sequencesFasta.lines().filter { it.startsWith(">") }
+        val matchingHeaders = fastaHeaders.filter { it.contains("${SubmitFiles.DefaultFiles.submissionIds[0]}_") }
+        assertThat(matchingHeaders.size, org.hamcrest.Matchers.greaterThan(0))
+    }
+
+    @Test
+    fun `GIVEN multi-segmented organism THEN fastaIds in metadata match FASTA headers`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+            organism = OTHER_ORGANISM,
+            groupId = groupId,
+        )
+
+        val response = submissionControllerClient.getOriginalData(
+            organism = OTHER_ORGANISM,
+            groupId = groupId,
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+
+        val lines = metadataTsv.lines().filter { it.isNotBlank() }
+        val header = lines[0].split("\t")
+        val fastaIdsIndex = header.indexOf("fastaIds")
+
+        val allFastaIdsFromMetadata = lines.drop(1)
+            .flatMap { it.split("\t")[fastaIdsIndex].split(" ") }
+            .toSet()
+
+        val fastaHeaderIds = sequencesFasta.lines()
+            .filter { it.startsWith(">") }
+            .map { it.removePrefix(">") }
+            .toSet()
+
+        assertThat(fastaHeaderIds, `is`(allFastaIdsFromMetadata))
+    }
+
+    private fun extractZipContents(zipContent: ByteArray): Pair<String, String> {
+        var metadataTsv = ""
+        var sequencesFasta = ""
+
+        ZipInputStream(ByteArrayInputStream(zipContent)).use { zis ->
+            var entry = zis.nextEntry
+            while (entry != null) {
+                val content = zis.readBytes().decodeToString()
+                when (entry.name) {
+                    "metadata.tsv" -> metadataTsv = content
+                    "sequences.fasta" -> sequencesFasta = content
+                }
+                entry = zis.nextEntry
+            }
+        }
+
+        return Pair(metadataTsv, sequencesFasta)
+    }
+
+    private fun submitAndApproveSingleSegmentSequences(submissionIds: List<String>, groupId: Int) {
+        for (submissionId in submissionIds) {
+            submissionControllerClient.submit(
+                metadataFile = SubmitFiles.metadataFileWith(
+                    content = "submissionId\tfirstColumn\n$submissionId\tvalue-$submissionId",
+                ),
+                sequencesFile = SubmitFiles.sequenceFileWith(
+                    content = ">$submissionId\n$DUMMY_ORGANISM_MAIN_SEQUENCE",
+                ),
+                groupId = groupId,
+            ).andExpect(status().isOk)
+        }
+
+        val accessionVersions = convenienceClient.extractUnprocessedData(numberOfSequenceEntries = submissionIds.size)
+            .map { AccessionVersion(it.accession, it.version) }
+        convenienceClient.submitProcessedData(
+            accessionVersions.map { PreparedProcessedData.successfullyProcessed(it.accession, it.version) },
+        )
+        convenienceClient.approveProcessedSequenceEntries(accessionVersions)
+    }
+
+    private fun getZipFileNames(zipContent: ByteArray): List<String> {
+        val fileNames = mutableListOf<String>()
+        ZipInputStream(ByteArrayInputStream(zipContent)).use { zis ->
+            var entry = zis.nextEntry
+            while (entry != null) {
+                fileNames.add(entry.name)
+                entry = zis.nextEntry
+            }
+        }
+        return fileNames
+    }
+}

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/OriginalDataDownloadTestHelpers.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/OriginalDataDownloadTestHelpers.kt
@@ -1,0 +1,28 @@
+package org.loculus.backend.controller.submission
+
+import java.io.ByteArrayInputStream
+import java.util.zip.ZipInputStream
+
+/**
+ * Extracts the metadata.tsv and sequences.fasta contents from a downloaded original-data zip.
+ *
+ * @return a pair of (metadata.tsv content, sequences.fasta content)
+ */
+fun extractOriginalDataZipContents(zipContent: ByteArray): Pair<String, String> {
+    var metadataTsv = ""
+    var sequencesFasta = ""
+
+    ZipInputStream(ByteArrayInputStream(zipContent)).use { zis ->
+        var entry = zis.nextEntry
+        while (entry != null) {
+            val content = zis.readBytes().decodeToString()
+            when (entry.name) {
+                "metadata.tsv" -> metadataTsv = content
+                "sequences.fasta" -> sequencesFasta = content
+            }
+            entry = zis.nextEntry
+        }
+    }
+
+    return Pair(metadataTsv, sequencesFasta)
+}

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/OriginalDataRevisionWorkflowTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/OriginalDataRevisionWorkflowTest.kt
@@ -16,8 +16,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.testcontainers.shaded.org.awaitility.Awaitility.await
-import java.io.ByteArrayInputStream
-import java.util.zip.ZipInputStream
 
 @EndpointTest
 class OriginalDataRevisionWorkflowTest(
@@ -43,7 +41,7 @@ class OriginalDataRevisionWorkflowTest(
         await().until { response.isCommitted }
 
         val zipContent = response.contentAsByteArray
-        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+        val (metadataTsv, sequencesFasta) = extractOriginalDataZipContents(zipContent)
 
         val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
         val headers = metadataLines[0].split("\t")
@@ -116,7 +114,7 @@ class OriginalDataRevisionWorkflowTest(
         await().until { response.isCommitted }
 
         val zipContent = response.contentAsByteArray
-        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+        val (metadataTsv, sequencesFasta) = extractOriginalDataZipContents(zipContent)
 
         val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
         assertThat(metadataLines.size, `is`(2))
@@ -183,24 +181,5 @@ class OriginalDataRevisionWorkflowTest(
         }
 
         return resultLines.joinToString("\n")
-    }
-
-    private fun extractZipContents(zipContent: ByteArray): Pair<String, String> {
-        var metadataTsv = ""
-        var sequencesFasta = ""
-
-        ZipInputStream(ByteArrayInputStream(zipContent)).use { zis ->
-            var entry = zis.nextEntry
-            while (entry != null) {
-                val content = zis.readBytes().decodeToString()
-                when (entry.name) {
-                    "metadata.tsv" -> metadataTsv = content
-                    "sequences.fasta" -> sequencesFasta = content
-                }
-                entry = zis.nextEntry
-            }
-        }
-
-        return Pair(metadataTsv, sequencesFasta)
     }
 }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/OriginalDataRevisionWorkflowTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/OriginalDataRevisionWorkflowTest.kt
@@ -1,0 +1,206 @@
+package org.loculus.backend.controller.submission
+
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.greaterThan
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.Test
+import org.loculus.backend.controller.EndpointTest
+import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
+import org.loculus.backend.controller.groupmanagement.andGetGroupId
+import org.loculus.backend.controller.jwtForDefaultUser
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.shaded.org.awaitility.Awaitility.await
+import java.io.ByteArrayInputStream
+import java.util.zip.ZipInputStream
+
+@EndpointTest
+class OriginalDataRevisionWorkflowTest(
+    @Autowired val convenienceClient: SubmissionConvenienceClient,
+    @Autowired val submissionControllerClient: SubmissionControllerClient,
+    @Autowired val groupManagementClient: GroupManagementControllerClient,
+) {
+
+    @Test
+    fun `GIVEN released sequences WHEN downloading and modifying original data THEN can submit revision`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        val accessionVersions = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(groupId = groupId)
+
+        assertThat(accessionVersions, hasSize(greaterThan(0)))
+        val firstAccession = accessionVersions[0].accession
+
+        val response = submissionControllerClient.getOriginalData(groupId = groupId)
+            .andExpect(status().isOk)
+            .andExpect(content().contentType("application/zip"))
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+
+        val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
+        val headers = metadataLines[0].split("\t")
+
+        assertThat(headers.contains("id"), `is`(true))
+        assertThat(headers.contains("accession"), `is`(true))
+        assertThat(headers.contains("date"), `is`(true))
+
+        val idIndex = headers.indexOf("id")
+        val accessionIndex = headers.indexOf("accession")
+        val dateIndex = headers.indexOf("date")
+
+        val firstDataRow = metadataLines[1].split("\t")
+        assertThat(firstDataRow[idIndex], `is`(SubmitFiles.DefaultFiles.submissionIds[0]))
+        assertThat(firstDataRow[accessionIndex], `is`(firstAccession))
+        assertThat(sequencesFasta.contains(">${SubmitFiles.DefaultFiles.submissionIds[0]}"), `is`(true))
+
+        val originalDate = firstDataRow[dateIndex]
+        val newDate = "2099-01-01"
+        assertThat(newDate, `is`(org.hamcrest.Matchers.not(originalDate)))
+
+        val revisedMetadataContent = buildRevisedMetadata(metadataLines, headers, dateIndex, newDate)
+        val revisedMetadataFile = MockMultipartFile(
+            "metadataFile",
+            "metadata.tsv",
+            MediaType.TEXT_PLAIN_VALUE,
+            revisedMetadataContent.toByteArray(),
+        )
+
+        val revisedSequencesFile = MockMultipartFile(
+            "sequenceFile",
+            "sequences.fasta",
+            MediaType.TEXT_PLAIN_VALUE,
+            sequencesFasta.toByteArray(),
+        )
+
+        submissionControllerClient.reviseSequenceEntries(
+            metadataFile = revisedMetadataFile,
+            sequencesFile = revisedSequencesFile,
+            jwt = jwtForDefaultUser,
+        )
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("\$.length()").value(accessionVersions.size))
+            .andExpect(jsonPath("\$[0].accession").value(firstAccession))
+            .andExpect(jsonPath("\$[0].version").value(2))
+
+        val revisedEntry = convenienceClient.getSequenceEntry(accession = firstAccession, version = 2)
+        assertThat(revisedEntry.accession, `is`(firstAccession))
+        assertThat(revisedEntry.version, `is`(2L))
+    }
+
+    @Test
+    fun `GIVEN filtered download WHEN modifying and submitting revision THEN only selected sequences are revised`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        val accessionVersions = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(groupId = groupId)
+
+        assertThat(accessionVersions, hasSize(greaterThan(1)))
+
+        val selectedAccession = accessionVersions[0].accession
+
+        val response = submissionControllerClient.getOriginalData(
+            groupId = groupId,
+            accessionsFilter = listOf(selectedAccession),
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+
+        val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
+        assertThat(metadataLines.size, `is`(2))
+
+        val headers = metadataLines[0].split("\t")
+        val dateIndex = headers.indexOf("date")
+
+        val revisedMetadataContent = buildRevisedMetadata(metadataLines, headers, dateIndex, "2099-12-31")
+        val revisedMetadataFile = MockMultipartFile(
+            "metadataFile",
+            "metadata.tsv",
+            MediaType.TEXT_PLAIN_VALUE,
+            revisedMetadataContent.toByteArray(),
+        )
+
+        val revisedSequencesFile = MockMultipartFile(
+            "sequenceFile",
+            "sequences.fasta",
+            MediaType.TEXT_PLAIN_VALUE,
+            sequencesFasta.toByteArray(),
+        )
+
+        submissionControllerClient.reviseSequenceEntries(
+            metadataFile = revisedMetadataFile,
+            sequencesFile = revisedSequencesFile,
+            jwt = jwtForDefaultUser,
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("\$.length()").value(1))
+            .andExpect(jsonPath("\$[0].accession").value(selectedAccession))
+            .andExpect(jsonPath("\$[0].version").value(2))
+
+        val revisedEntry = convenienceClient.getSequenceEntry(accession = selectedAccession, version = 2)
+        assertThat(revisedEntry.version, `is`(2L))
+
+        val otherAccession = accessionVersions[1].accession
+        val otherEntry = convenienceClient.getSequenceEntry(accession = otherAccession, version = 1)
+        assertThat(otherEntry.version, `is`(1L))
+    }
+
+    private fun buildRevisedMetadata(
+        metadataLines: List<String>,
+        headers: List<String>,
+        dateIndex: Int,
+        newDate: String,
+    ): String {
+        val idIndex = headers.indexOf("id")
+
+        val newHeaders = headers.toMutableList()
+        newHeaders[idIndex] = "submissionId"
+
+        val resultLines = mutableListOf<String>()
+        resultLines.add(newHeaders.joinToString("\t"))
+
+        for (i in 1 until metadataLines.size) {
+            val row = metadataLines[i].split("\t").toMutableList()
+            while (row.size < headers.size) {
+                row.add("")
+            }
+            if (dateIndex >= 0 && dateIndex < row.size) {
+                row[dateIndex] = newDate
+            }
+            resultLines.add(row.joinToString("\t"))
+        }
+
+        return resultLines.joinToString("\n")
+    }
+
+    private fun extractZipContents(zipContent: ByteArray): Pair<String, String> {
+        var metadataTsv = ""
+        var sequencesFasta = ""
+
+        ZipInputStream(ByteArrayInputStream(zipContent)).use { zis ->
+            var entry = zis.nextEntry
+            while (entry != null) {
+                val content = zis.readBytes().decodeToString()
+                when (entry.name) {
+                    "metadata.tsv" -> metadataTsv = content
+                    "sequences.fasta" -> sequencesFasta = content
+                }
+                entry = zis.nextEntry
+            }
+        }
+
+        return Pair(metadataTsv, sequencesFasta)
+    }
+}

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
@@ -323,6 +323,25 @@ class SubmissionControllerClient(private val mockMvc: MockMvc, private val objec
             .param("fields", fields?.joinToString(",")),
     )
 
+    fun getOriginalData(
+        organism: String = DEFAULT_ORGANISM,
+        jwt: String? = jwtForDefaultUser,
+        groupId: Int,
+        accessionsFilter: List<String>? = null,
+    ): ResultActions = mockMvc.perform(
+        post(addOrganismToPath("/get-original-data", organism = organism))
+            .withAuth(jwt)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+                objectMapper.writeValueAsString(
+                    mapOf(
+                        "groupId" to groupId,
+                        "accessionsFilter" to accessionsFilter,
+                    ),
+                ),
+            ),
+    )
+
     private fun serialize(listOfSequencesToApprove: List<AccessionVersionInterface>? = null): String =
         if (listOfSequencesToApprove != null) {
             objectMapper.writeValueAsString(

--- a/backend/src/test/kotlin/org/loculus/backend/utils/FastaWriterTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/utils/FastaWriterTest.kt
@@ -1,0 +1,115 @@
+package org.loculus.backend.utils
+
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+
+class FastaWriterTest {
+
+    @Test
+    fun `write multiple entries`() {
+        val outputStream = ByteArrayOutputStream()
+        FastaWriter(outputStream).use { writer ->
+            writer.write(FastaEntry("seq1", "AAATTT"))
+            writer.write(FastaEntry("seq2", "TTTCCC"))
+            writer.write(FastaEntry("seq3", "CCCGGG"))
+        }
+
+        val result = outputStream.toString()
+        val expected = """
+            >seq1
+            AAATTT
+            >seq2
+            TTTCCC
+            >seq3
+            CCCGGG
+        """.trimIndent() + "\n"
+
+        assert(result == expected)
+    }
+
+    @Test
+    fun `write single entry`() {
+        val outputStream = ByteArrayOutputStream()
+        FastaWriter(outputStream).use { writer ->
+            writer.write(FastaEntry("seq1", "AAATTT"))
+        }
+
+        val result = outputStream.toString()
+        val expected = """
+            >seq1
+            AAATTT
+        """.trimIndent() + "\n"
+
+        assert(result == expected)
+    }
+
+    @Test
+    fun `write empty entries`() {
+        val outputStream = ByteArrayOutputStream()
+        FastaWriter(outputStream).use { writer ->
+            writer.writeAll(emptyList())
+        }
+
+        val result = outputStream.toString()
+        assert(result.isEmpty())
+    }
+
+    @Test
+    fun `writeAll writes multiple entries`() {
+        val outputStream = ByteArrayOutputStream()
+        FastaWriter(outputStream).use { writer ->
+            writer.writeAll(
+                listOf(
+                    FastaEntry("seq1", "AAATTT"),
+                    FastaEntry("seq2", "TTTCCC"),
+                ),
+            )
+        }
+
+        val result = outputStream.toString()
+        val expected = """
+            >seq1
+            AAATTT
+            >seq2
+            TTTCCC
+        """.trimIndent() + "\n"
+
+        assert(result == expected)
+    }
+
+    @Test
+    fun `round-trip with FastaReader`() {
+        val entries = listOf(
+            FastaEntry("seq1", "AAATTT"),
+            FastaEntry("seq2", "TTTCCC"),
+            FastaEntry("seq3", "CCCGGG"),
+        )
+
+        val outputStream = ByteArrayOutputStream()
+        FastaWriter(outputStream).use { writer ->
+            writer.writeAll(entries)
+        }
+
+        val parsed = FastaReader(outputStream.toByteArray().inputStream()).toList()
+
+        assert(parsed.size == entries.size)
+        for (i in entries.indices) {
+            assert(parsed[i].fastaId == entries[i].fastaId)
+            assert(parsed[i].sequence == entries[i].sequence)
+        }
+    }
+
+    @Test
+    fun `handles special characters in fasta id`() {
+        val outputStream = ByteArrayOutputStream()
+        FastaWriter(outputStream).use { writer ->
+            writer.write(FastaEntry("seq1|segment_L", "AAATTT"))
+        }
+
+        val result = outputStream.toString()
+        assert(result.contains(">seq1|segment_L"))
+
+        val parsed = FastaReader(result.byteInputStream()).toList()
+        assert(parsed[0].fastaId == "seq1|segment_L")
+    }
+}

--- a/backend/src/test/kotlin/org/loculus/backend/utils/TsvWriterTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/utils/TsvWriterTest.kt
@@ -1,0 +1,121 @@
+package org.loculus.backend.utils
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+
+class TsvWriterTest {
+
+    @Test
+    fun `write multiple rows`() {
+        val outputStream = ByteArrayOutputStream()
+        TsvWriter(outputStream, listOf("id", "name", "value")).use { writer ->
+            writer.writeRow(listOf("1", "Alice", "100"))
+            writer.writeRow(listOf("2", "Bob", "200"))
+            writer.writeRow(listOf("3", "Charlie", "300"))
+        }
+
+        val result = outputStream.toString()
+        val lines = result.lines().filter { it.isNotBlank() }
+
+        assertThat(lines.size, `is`(4))
+        assertThat(lines[0], `is`("id\tname\tvalue"))
+        assertThat(lines[1], `is`("1\tAlice\t100"))
+        assertThat(lines[2], `is`("2\tBob\t200"))
+        assertThat(lines[3], `is`("3\tCharlie\t300"))
+    }
+
+    @Test
+    fun `write single row`() {
+        val outputStream = ByteArrayOutputStream()
+        TsvWriter(outputStream, listOf("id", "name")).use { writer ->
+            writer.writeRow(listOf("1", "Alice"))
+        }
+
+        val result = outputStream.toString()
+        val lines = result.lines().filter { it.isNotBlank() }
+
+        assertThat(lines.size, `is`(2))
+        assertThat(lines[0], `is`("id\tname"))
+        assertThat(lines[1], `is`("1\tAlice"))
+    }
+
+    @Test
+    fun `write headers only when no rows`() {
+        val outputStream = ByteArrayOutputStream()
+        TsvWriter(outputStream, listOf("id", "name", "value")).use { }
+
+        val result = outputStream.toString()
+        val lines = result.lines().filter { it.isNotBlank() }
+
+        assertThat(lines.size, `is`(1))
+        assertThat(lines[0], `is`("id\tname\tvalue"))
+    }
+
+    @Test
+    fun `handle null values`() {
+        val outputStream = ByteArrayOutputStream()
+        TsvWriter(outputStream, listOf("id", "name", "value")).use { writer ->
+            writer.writeRow(listOf("1", null, "100"))
+            writer.writeRow(listOf("2", "Bob", null))
+        }
+
+        val result = outputStream.toString()
+        val lines = result.lines().filter { it.isNotBlank() }
+
+        assertThat(lines.size, `is`(3))
+        assertThat(lines[0], `is`("id\tname\tvalue"))
+        assertThat(lines[1], `is`("1\t\t100"))
+        assertThat(lines[2], `is`("2\tBob\t"))
+    }
+
+    @Test
+    fun `handle empty string values`() {
+        val outputStream = ByteArrayOutputStream()
+        TsvWriter(outputStream, listOf("id", "name")).use { writer ->
+            writer.writeRow(listOf("1", ""))
+            writer.writeRow(listOf("", "Bob"))
+        }
+
+        val result = outputStream.toString()
+        val lines = result.lines().filter { it.isNotBlank() }
+
+        assertThat(lines.size, `is`(3))
+        assertThat(lines[1].startsWith("1\t"), `is`(true))
+        assertThat(lines[2].endsWith("Bob"), `is`(true))
+    }
+
+    @Test
+    fun `handle values containing special characters`() {
+        val outputStream = ByteArrayOutputStream()
+        TsvWriter(outputStream, listOf("id", "description")).use { writer ->
+            writer.writeRow(listOf("1", "value with \"quotes\""))
+            writer.writeRow(listOf("2", "value with\nnewline"))
+        }
+
+        val result = outputStream.toString()
+
+        // Values with special characters should be quoted by CSV library
+        assertThat(result.contains("1"), `is`(true))
+        assertThat(result.contains("quotes"), `is`(true))
+        assertThat(result.contains("newline"), `is`(true))
+    }
+
+    @Test
+    fun `handle single column`() {
+        val outputStream = ByteArrayOutputStream()
+        TsvWriter(outputStream, listOf("id")).use { writer ->
+            writer.writeRow(listOf("1"))
+            writer.writeRow(listOf("2"))
+        }
+
+        val result = outputStream.toString()
+        val lines = result.lines().filter { it.isNotBlank() }
+
+        assertThat(lines.size, `is`(3))
+        assertThat(lines[0], `is`("id"))
+        assertThat(lines[1], `is`("1"))
+        assertThat(lines[2], `is`("2"))
+    }
+}

--- a/backend/src/test/kotlin/org/loculus/backend/utils/UniqueIdsTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/utils/UniqueIdsTest.kt
@@ -1,0 +1,39 @@
+package org.loculus.backend.utils
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Test
+
+class UniqueIdsTest {
+
+    @Test
+    fun `keeps unique ids unchanged`() {
+        val ids = listOf("sample", "sample_1", "other")
+
+        assertThat(makeUniqueIds(ids), `is`(ids))
+    }
+
+    @Test
+    fun `adds suffixes to duplicate ids`() {
+        assertThat(
+            makeUniqueIds(listOf("sample", "sample", "sample")),
+            `is`(listOf("sample", "sample_1", "sample_2")),
+        )
+    }
+
+    @Test
+    fun `skips suffixes that would clash with original ids`() {
+        assertThat(
+            makeUniqueIds(listOf("sample", "sample", "sample_1", "sample")),
+            `is`(listOf("sample", "sample_2", "sample_1", "sample_3")),
+        )
+    }
+
+    @Test
+    fun `deduplicates independently per original id`() {
+        assertThat(
+            makeUniqueIds(listOf("sample", "other", "sample", "other")),
+            `is`(listOf("sample", "other", "sample_1", "other_1")),
+        )
+    }
+}

--- a/docs/src/content/docs/for-users/revise-sequences.md
+++ b/docs/src/content/docs/for-users/revise-sequences.md
@@ -6,6 +6,21 @@ Sequences can be corrected or updated after they have been submitted to Loculus.
 
 The process of submitting revisions is very similar to original submission. The main difference is that you must provide an `accession` column in the metadata file, which contains the Loculus [accession number(s)](../../reference/glossary/#accession) assigned when the sequences were submitted originally.
 
+## Downloading original data for revision
+
+If you no longer have the original files you submitted, you can download them from Loculus. Note that Loculus stores your originally submitted data separately from the processed data shown on the website, so this download gives you the exact data you need for revisions.
+
+1. Navigate to your group's **Released sequences** page
+2. Filter or select specific sequences you want to revise
+3. Click the **Download original data** button on the top-right.
+
+This downloads a zip file containing:
+
+- `metadata.tsv` - your original metadata with an `accession` column already included
+- `sequences.fasta` - your original unaligned sequences (if the organism supports sequence files)
+
+You can then edit these files as needed and resubmit them as a revision. The download is limited to 500 sequences at a time.
+
 ## Preparing the metadata file
 
 The metadata file should include all the metadata fields that were originally included, **both** those that you wish to update and that should remain the same. (Not including a metadata column will set its value to 'empty'.)

--- a/integration-tests/tests/specs/features/download-original-data.spec.ts
+++ b/integration-tests/tests/specs/features/download-original-data.spec.ts
@@ -80,6 +80,10 @@ test.describe('Download Original Data', () => {
             expect(header).toContain('id');
             expect(header).toContain('accession');
 
+            expect(metadataContent).toContain('Switzerland');
+            expect(metadataContent).toContain('2021-01-15');
+            expect(metadataContent).toContain('Test Institute');
+
             const idIndex = header.indexOf('id');
             const accessionIndex = header.indexOf('accession');
 

--- a/integration-tests/tests/specs/features/download-original-data.spec.ts
+++ b/integration-tests/tests/specs/features/download-original-data.spec.ts
@@ -1,0 +1,177 @@
+import { expect } from '@playwright/test';
+import { test } from '../../fixtures/group.fixture';
+import { SearchPage } from '../../pages/search.page';
+import { ReviewPage } from '../../pages/review.page';
+import { SingleSequenceSubmissionPage } from '../../pages/submission.page';
+import { createTestMetadata, createTestSequenceData } from '../../test-helpers/test-data';
+import fs from 'fs';
+import { execSync } from 'child_process';
+import path from 'path';
+import os from 'os';
+
+const TEST_ORGANISM = 'ebola-sudan';
+const SEARCH_INDEXING_TIMEOUT = 60000;
+
+test.describe('Download Original Data', () => {
+    test('can download original data for all sequences on released sequences page', async ({
+        page,
+        groupId,
+    }) => {
+        test.setTimeout(200_000);
+
+        const submissionPage = new SingleSequenceSubmissionPage(page);
+        const timestamp = Date.now();
+        const submissionIds = Array.from(
+            { length: 2 },
+            (_, i) => `download-test-${timestamp}-${i}`,
+        );
+
+        for (const submissionId of submissionIds) {
+            await submissionPage.completeSubmission(
+                createTestMetadata({ submissionId }),
+                createTestSequenceData(),
+            );
+        }
+
+        const reviewPage = new ReviewPage(page);
+        await reviewPage.goto(groupId);
+        await reviewPage.waitForZeroProcessing();
+        await reviewPage.releaseValidSequences();
+
+        const searchPage = new SearchPage(page);
+        await searchPage.goToReleasedSequences(TEST_ORGANISM, groupId);
+        const accessionVersions = await searchPage.waitForSequencesInSearch(
+            2,
+            SEARCH_INDEXING_TIMEOUT,
+        );
+
+        expect(accessionVersions).toHaveLength(2);
+
+        const downloadPromise = page.waitForEvent('download');
+        await page.getByRole('button', { name: /Download original data/ }).click();
+        const download = await downloadPromise;
+
+        const downloadPath = await download.path();
+        expect(downloadPath).toBeTruthy();
+
+        // Verify ZIP magic number (PK = 0x50 0x4B)
+        const fileBuffer = fs.readFileSync(downloadPath);
+        expect(fileBuffer[0]).toBe(0x50);
+        expect(fileBuffer[1]).toBe(0x4b);
+
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'download-test-'));
+        try {
+            execSync(`unzip -o "${downloadPath}" -d "${tmpDir}"`);
+
+            const metadataPath = path.join(tmpDir, 'metadata.tsv');
+            expect(fs.existsSync(metadataPath)).toBe(true);
+
+            const sequencesPath = path.join(tmpDir, 'sequences.fasta');
+            expect(fs.existsSync(sequencesPath)).toBe(true);
+
+            const metadataContent = fs.readFileSync(metadataPath, 'utf8');
+            const metadataLines = metadataContent
+                .split('\n')
+                .filter((line) => line.trim().length > 0);
+
+            expect(metadataLines.length).toBe(3);
+
+            const header = metadataLines[0].split('\t');
+            expect(header).toContain('id');
+            expect(header).toContain('accession');
+
+            const idIndex = header.indexOf('id');
+            const accessionIndex = header.indexOf('accession');
+
+            const downloadedIds = metadataLines.slice(1).map((line) => line.split('\t')[idIndex]);
+            const downloadedAccessions = metadataLines
+                .slice(1)
+                .map((line) => line.split('\t')[accessionIndex]);
+
+            for (const submissionId of submissionIds) {
+                expect(downloadedIds).toContain(submissionId);
+            }
+
+            for (const av of accessionVersions) {
+                expect(downloadedAccessions).toContain(av.accession);
+            }
+
+            const fastaContent = fs.readFileSync(sequencesPath, 'utf8');
+            const fastaHeaders = fastaContent.split('\n').filter((line) => line.startsWith('>'));
+
+            expect(fastaHeaders.length).toBe(2);
+
+            for (const submissionId of submissionIds) {
+                expect(fastaHeaders.some((h) => h.includes(submissionId))).toBe(true);
+            }
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    test('can download original data for selected sequences only', async ({ page, groupId }) => {
+        test.setTimeout(200_000);
+
+        const submissionPage = new SingleSequenceSubmissionPage(page);
+        const timestamp = Date.now();
+
+        for (let i = 0; i < 3; i++) {
+            await submissionPage.completeSubmission(
+                createTestMetadata({ submissionId: `select-download-${timestamp}-${i}` }),
+                createTestSequenceData(),
+            );
+        }
+
+        const reviewPage = new ReviewPage(page);
+        await reviewPage.goto(groupId);
+        await reviewPage.waitForZeroProcessing();
+        await reviewPage.releaseValidSequences();
+
+        const searchPage = new SearchPage(page);
+        await searchPage.goToReleasedSequences(TEST_ORGANISM, groupId);
+        const accessionVersions = await searchPage.waitForSequencesInSearch(
+            3,
+            SEARCH_INDEXING_TIMEOUT,
+        );
+
+        expect(accessionVersions).toHaveLength(3);
+
+        const rows = searchPage.getSequenceRows();
+        for (let i = 0; i < 2; i++) {
+            const checkboxCell = rows.nth(i).locator('td').first();
+            await checkboxCell.click();
+        }
+
+        await expect(
+            page.getByRole('button', { name: /Download original data \(2 selected\)/ }),
+        ).toBeVisible();
+
+        const downloadPromise = page.waitForEvent('download');
+        await page.getByRole('button', { name: /Download original data/ }).click();
+        const download = await downloadPromise;
+
+        const downloadPath = await download.path();
+        expect(downloadPath).toBeTruthy();
+
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'select-download-test-'));
+        try {
+            execSync(`unzip -o "${downloadPath}" -d "${tmpDir}"`);
+
+            const metadataPath = path.join(tmpDir, 'metadata.tsv');
+            const metadataContent = fs.readFileSync(metadataPath, 'utf8');
+            const metadataLines = metadataContent
+                .split('\n')
+                .filter((line) => line.trim().length > 0);
+
+            expect(metadataLines.length).toBe(3);
+
+            const sequencesPath = path.join(tmpDir, 'sequences.fasta');
+            const fastaContent = fs.readFileSync(sequencesPath, 'utf8');
+            const fastaHeaders = fastaContent.split('\n').filter((line) => line.startsWith('>'));
+
+            expect(fastaHeaders.length).toBe(2);
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/website/src/components/SearchPage/DownloadDialog/DownloadOriginalDataButton.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadOriginalDataButton.tsx
@@ -1,0 +1,140 @@
+import { type FC, useState, useCallback } from 'react';
+
+import { type SequenceFilter } from './SequenceFilters';
+import { getOriginalData } from '../../../services/backendClientSideApi';
+import { downloadBlob } from '../../../utils/downloadBlob';
+import { parseAccessionVersionFromString } from '../../../utils/extractAccessionVersion';
+import { formatNumberWithDefaultLocale } from '../../../utils/formatNumber';
+import { Button } from '../../common/Button';
+
+export const MAX_ORIGINAL_DATA_DOWNLOAD_ENTRIES = 500;
+
+type DownloadOriginalDataButtonProps = {
+    sequenceFilter: SequenceFilter;
+    backendUrl: string;
+    accessToken: string;
+    organism: string;
+    groupId: number;
+    totalSequences?: number;
+    fetchAccessions: () => Promise<string[]>;
+};
+
+const extractAccessions = (accessionVersions: string[]): string[] => {
+    const accessions = accessionVersions.map((av) => parseAccessionVersionFromString(av).accession);
+    return [...new Set(accessions)];
+};
+
+export const DownloadOriginalDataButton: FC<DownloadOriginalDataButtonProps> = ({
+    sequenceFilter,
+    backendUrl,
+    accessToken,
+    organism,
+    groupId,
+    totalSequences,
+    fetchAccessions,
+}) => {
+    const [isDownloading, setIsDownloading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const sequenceCount = sequenceFilter.sequenceCount();
+    const effectiveCount = sequenceCount ?? totalSequences;
+    const exceedsLimit = effectiveCount !== undefined && effectiveCount > MAX_ORIGINAL_DATA_DOWNLOAD_ENTRIES;
+
+    let buttonText: string;
+    if (sequenceCount === undefined) {
+        const formattedCount = totalSequences !== undefined ? formatNumberWithDefaultLocale(totalSequences) : 'all';
+        buttonText = `Download original data (${formattedCount})`;
+    } else {
+        const formattedCount = formatNumberWithDefaultLocale(sequenceCount);
+        buttonText = `Download original data (${formattedCount} selected)`;
+    }
+
+    const handleDownload = useCallback(async () => {
+        setIsDownloading(true);
+        setError(null);
+
+        try {
+            let accessionVersions: string[];
+
+            if (sequenceCount !== undefined) {
+                const apiParams = sequenceFilter.toApiParams();
+                const selectedVersions = apiParams.accessionVersion;
+                if (!Array.isArray(selectedVersions)) {
+                    throw new Error('No accessions selected');
+                }
+                accessionVersions = selectedVersions;
+            } else {
+                accessionVersions = await fetchAccessions();
+            }
+
+            const accessions = extractAccessions(accessionVersions);
+            if (accessions.length === 0) {
+                throw new Error('No sequences to download');
+            }
+            if (accessions.length > MAX_ORIGINAL_DATA_DOWNLOAD_ENTRIES) {
+                throw new Error(
+                    `Download is limited to ${formatNumberWithDefaultLocale(MAX_ORIGINAL_DATA_DOWNLOAD_ENTRIES)} entries. Please select fewer.`,
+                );
+            }
+
+            const result = await getOriginalData(backendUrl, organism, accessToken, {
+                groupId,
+                accessionsFilter: accessions,
+            });
+
+            if (!result.ok) {
+                throw new Error(
+                    `Download failed: ${result.error.status} ${result.error.statusText}. ${result.error.detail}`,
+                );
+            }
+
+            if (result.blob.size === 0) {
+                throw new Error('No data to download');
+            }
+
+            const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+            const filename = `${organism}_original_data_${timestamp}.zip`;
+            downloadBlob(result.blob, filename);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'Download failed';
+            setError(message);
+        } finally {
+            setIsDownloading(false);
+        }
+    }, [sequenceFilter, backendUrl, accessToken, organism, groupId, sequenceCount, fetchAccessions]);
+
+    const isDisabled = isDownloading || exceedsLimit;
+
+    return (
+        <div className='relative'>
+            <div className='group relative inline-block'>
+                <Button
+                    className={`w-[18rem] outlineButton ${exceedsLimit ? 'opacity-50 cursor-not-allowed hover:bg-white hover:text-primary-600' : ''}`}
+                    onClick={() => void handleDownload()}
+                    disabled={isDisabled}
+                >
+                    {isDownloading ? 'Downloading...' : buttonText}
+                </Button>
+                {exceedsLimit && (
+                    <div className='invisible group-hover:visible absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 text-sm text-white bg-gray-800 rounded-md shadow-lg whitespace-nowrap z-20'>
+                        Limited to {formatNumberWithDefaultLocale(MAX_ORIGINAL_DATA_DOWNLOAD_ENTRIES)} entries. Please
+                        select fewer.
+                        <div className='absolute left-1/2 -translate-x-1/2 top-full w-0 h-0 border-x-8 border-x-transparent border-t-8 border-t-gray-800' />
+                    </div>
+                )}
+            </div>
+            {error !== null && (
+                <div className='absolute top-full left-0 mt-1 text-sm text-red-600 bg-white p-2 rounded shadow-md z-10 max-w-xs'>
+                    {error}
+                    <Button
+                        className='ml-2 text-gray-500 hover:text-gray-700'
+                        onClick={() => setError(null)}
+                        aria-label='Dismiss error'
+                    >
+                        x
+                    </Button>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/website/src/components/SearchPage/SearchFullUI.spec.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.spec.tsx
@@ -104,6 +104,7 @@ function renderSearchFullUI({
         initialCount: 0,
         initialQueryDict: {},
         hiddenFieldValues,
+        isReleasedPage: true,
     } satisfies InnerSearchFullUIProps;
 
     render(

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -1,8 +1,12 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Button } from '../common/Button';
 import { DownloadDialog } from './DownloadDialog/DownloadDialog.tsx';
+import {
+    DownloadOriginalDataButton,
+    MAX_ORIGINAL_DATA_DOWNLOAD_ENTRIES,
+} from './DownloadDialog/DownloadOriginalDataButton.tsx';
 import { DownloadUrlGenerator } from './DownloadDialog/DownloadUrlGenerator.ts';
 import { LinkOutMenu } from './DownloadDialog/LinkOutMenu.tsx';
 import { FieldFilterSet, SequenceEntrySelection, type SequenceFilter } from './DownloadDialog/SequenceFilters.tsx';
@@ -15,6 +19,7 @@ import { TableColumnSelectorModal } from './TableColumnSelectorModal.tsx';
 import { useSearchPageState } from './useSearchPageState.ts';
 import { type QueryState } from './useStateSyncedWithUrlQueryParams.ts';
 import { getLapisUrl } from '../../config.ts';
+import { fetchDetailsFromLapis } from '../../services/lapisClientSideApi.ts';
 import { lapisClientHooks } from '../../services/serviceHooks.ts';
 import { DATA_USE_TERMS_FIELD, pageSize } from '../../settings';
 import type { Group } from '../../types/backend.ts';
@@ -53,6 +58,8 @@ export interface InnerSearchFullUIProps {
     sequenceFlaggingConfig?: SequenceFlaggingConfig;
     linkOuts?: LinkOut[];
     contactConfig?: ContactConfig;
+    groupId?: number;
+    isReleasedPage: boolean;
 }
 
 const buildSequenceCountText = (totalSequences: number | undefined, oldCount: number | null, initialCount: number) => {
@@ -82,6 +89,8 @@ export const InnerSearchFullUI = ({
     sequenceFlaggingConfig,
     linkOuts,
     contactConfig,
+    groupId,
+    isReleasedPage,
 }: InnerSearchFullUIProps) => {
     hiddenFieldValues ??= {};
 
@@ -205,6 +214,15 @@ export const InnerSearchFullUI = ({
 
     const totalSequences = aggregatedHook.data?.data[0].count ?? undefined;
     const linkOutSequenceCount = downloadFilter.sequenceCount() ?? totalSequences;
+
+    const fetchAccessions = useCallback(async (): Promise<string[]> => {
+        const response = await fetchDetailsFromLapis(lapisUrl, {
+            ...lapisSearchParameters,
+            fields: [schema.primaryKey],
+            limit: MAX_ORIGINAL_DATA_DOWNLOAD_ENTRIES + 1,
+        });
+        return response.data.map((item) => String(item[schema.primaryKey]));
+    }, [lapisUrl, lapisSearchParameters, schema.primaryKey]);
 
     const [oldData, setOldData] = useState<TableSequenceData[] | null>(null);
     const [oldCount, setOldCount] = useState<number | null>(null);
@@ -369,6 +387,19 @@ export const InnerSearchFullUI = ({
                                 selectedReferenceNames={referenceSelection?.selectedReferences}
                                 referenceIdentifierField={schema.referenceIdentifierField}
                             />
+                            {isReleasedPage && accessToken !== undefined && groupId !== undefined && (
+                                <div className='ml-2'>
+                                    <DownloadOriginalDataButton
+                                        sequenceFilter={downloadFilter}
+                                        backendUrl={clientConfig.backendUrl}
+                                        accessToken={accessToken}
+                                        organism={organism}
+                                        groupId={groupId}
+                                        totalSequences={totalSequences}
+                                        fetchAccessions={fetchAccessions}
+                                    />
+                                </div>
+                            )}
                             {linkOuts !== undefined && linkOuts.length > 0 && (
                                 <LinkOutMenu
                                     downloadUrlGenerator={downloadUrlGenerator}

--- a/website/src/pages/[organism]/search/index.astro
+++ b/website/src/pages/[organism]/search/index.astro
@@ -74,5 +74,6 @@ const contactConfig = getContactConfig(websiteConfig);
         sequenceFlaggingConfig={sequenceFlaggingConfig}
         linkOuts={schema.linkOuts}
         contactConfig={contactConfig}
+        isReleasedPage={false}
     />
 </BaseLayout>

--- a/website/src/pages/[organism]/submission/[groupId]/released.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/released.astro
@@ -75,5 +75,7 @@ const contactConfig = getContactConfig(websiteConfig);
         sequenceFlaggingConfig={sequenceFlaggingConfig}
         contactConfig={contactConfig}
         showEditDataUseTermsControls
+        groupId={group.groupId}
+        isReleasedPage={true}
     />
 </SubmissionPageWrapper>

--- a/website/src/services/backendClientSideApi.ts
+++ b/website/src/services/backendClientSideApi.ts
@@ -1,0 +1,63 @@
+import { createAuthorizationHeader } from '../utils/createAuthorizationHeader.ts';
+
+export type GetOriginalDataRequest = {
+    groupId: number;
+    accessionsFilter: string[];
+};
+
+export type GetOriginalDataError = {
+    status: number;
+    statusText: string;
+    detail: string;
+};
+
+export type GetOriginalDataResult = { ok: true; blob: Blob } | { ok: false; error: GetOriginalDataError };
+
+function extractErrorDetail(errorText: string) {
+    try {
+        const errorJson = JSON.parse(errorText) as { message?: unknown; detail?: unknown };
+        if (typeof errorJson.message === 'string') {
+            return errorJson.message;
+        }
+        if (typeof errorJson.detail === 'string') {
+            return errorJson.detail;
+        }
+    } catch {
+        return errorText;
+    }
+
+    return errorText;
+}
+
+export async function getOriginalData(
+    backendUrl: string,
+    organism: string,
+    accessToken: string,
+    request: GetOriginalDataRequest,
+): Promise<GetOriginalDataResult> {
+    const url = `${backendUrl}/${organism}/get-original-data`;
+
+    const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+            ...createAuthorizationHeader(accessToken),
+            'Content-Type': 'application/json', // eslint-disable-line @typescript-eslint/naming-convention
+        },
+        body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        return {
+            ok: false,
+            error: {
+                status: response.status,
+                statusText: response.statusText,
+                detail: extractErrorDetail(errorText),
+            },
+        };
+    }
+
+    const blob = await response.blob();
+    return { ok: true, blob };
+}

--- a/website/src/services/lapisClientSideApi.ts
+++ b/website/src/services/lapisClientSideApi.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+import type { DetailsResponse } from '../types/lapis.ts';
+
+export async function fetchDetailsFromLapis(
+    lapisUrl: string,
+    request: Record<string, unknown>,
+): Promise<DetailsResponse> {
+    const response = await axios.post<DetailsResponse>(`${lapisUrl}/sample/details`, {
+        ...request,
+        dataFormat: 'json',
+    });
+    return response.data;
+}

--- a/website/src/utils/downloadBlob.ts
+++ b/website/src/utils/downloadBlob.ts
@@ -1,0 +1,10 @@
+export function downloadBlob(blob: Blob, filename: string): void {
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
resolves #3167, resolves https://github.com/loculus-project/loculus/issues/5296

This PR adds the feature to download original submission data (metadata and sequences) for released sequences, making it easier to prepare revisions in bulk. Previously, users could only download processed data from the website, but revisions require the original submitted data format.

A new backend endpoint `POST /{organism}/get-original-data` returns a zip file containing metadata.tsv and sequences.fasta in the same format expected for submissions. The download is limited to 500 entries as it has not been optimized for memory efficiency (no streaming or out-of-memory storage). On the website, a new button has been added to the released sequences page for downloading the file.

The design of providing a zip download would be compatible with @theosanderson's proposal in https://github.com/loculus-project/loculus/issues/5821#issuecomment-3731045121 to "provide a zip download which has the whole directory structure to upload in order to put in the existing sequences -- except that instead of each file actually containing the contents it just contains the text `md5:da23ef` or whatever, and that's used as a pointer to the existing file". 

### Screenshot

<img width="1441" height="521" alt="image" src="https://github.com/user-attachments/assets/49feff24-4bd8-4a0c-96a2-be14e4a34691" />

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
  - Workflow of downloading original data (test organism and CCHF), changing something, and using the files for revision

🚀 Preview: https://download-original-data.loculus.org