### PR TITLE
fix(website): fix selection bug in Table when vertical shift

### DIFF
--- a/website/src/components/SearchPage/Table.spec.tsx
+++ b/website/src/components/SearchPage/Table.spec.tsx
@@ -41,10 +41,12 @@ describe('Table', () => {
     test('allows selecting multiple checkboxes by dragging', () => {
         render(<TestWrapper />);
         const checkboxes = screen.getAllByRole('checkbox');
+        // Events are handled on the parent td, not the checkbox itself
+        const checkboxCells = checkboxes.map((cb) => cb.parentElement!);
 
-        fireEvent.mouseDown(checkboxes[0], { clientY: 100 });
-        fireEvent.mouseEnter(checkboxes[1], { clientY: 150 });
-        fireEvent.mouseEnter(checkboxes[2], { clientY: 200 });
+        fireEvent.mouseDown(checkboxCells[0], { clientY: 100 });
+        fireEvent.mouseEnter(checkboxCells[1], { clientY: 150 });
+        fireEvent.mouseEnter(checkboxCells[2], { clientY: 200 });
         fireEvent.mouseUp(document.body);
 
         checkboxes.forEach((cb) => {

--- a/website/src/components/SearchPage/Table.tsx
+++ b/website/src/components/SearchPage/Table.tsx
@@ -125,7 +125,6 @@ export const Table: FC<TableProps> = ({
 
     const mouseDownSelection = useRef('');
     const dragSelecting = useRef({ active: false, value: false, startY: 0 });
-    const checkboxMouseDownFired = useRef(false);
 
     useEffect(() => {
         const handleMouseUp = () => {
@@ -242,15 +241,18 @@ export const Table: FC<TableProps> = ({
                                     data-testid='sequence-row'
                                 >
                                     <td
-                                        className='px-2 whitespace-nowrap text-primary-900 md:pl-6'
+                                        className='px-2 whitespace-nowrap text-primary-900 md:pl-6 select-none'
                                         onClick={(e) => {
                                             e.stopPropagation();
-                                            if (checkboxMouseDownFired.current) {
-                                                checkboxMouseDownFired.current = false;
-                                                return;
-                                            }
+                                        }}
+                                        onMouseDown={(e) => {
                                             const seqId = row[primaryKey] as string;
                                             const newValue = !selectedSeqs.has(seqId);
+                                            dragSelecting.current = {
+                                                active: false,
+                                                value: newValue,
+                                                startY: e.clientY,
+                                            };
                                             setRowSelected(seqId, newValue);
                                         }}
                                         onMouseEnter={(e) => {
@@ -272,19 +274,11 @@ export const Table: FC<TableProps> = ({
                                     >
                                         <input
                                             type='checkbox'
-                                            className='text-primary-900 hover:text-primary-800 hover:no-underline'
-                                            onClick={(e) => e.stopPropagation()}
+                                            className='text-primary-900 hover:text-primary-800 hover:no-underline pointer-events-none'
                                             checked={selectedSeqs.has(row[primaryKey] as string)}
-                                            onMouseDown={(e) => {
+                                            onChange={() => {
                                                 const seqId = row[primaryKey] as string;
-                                                const newValue = !selectedSeqs.has(seqId);
-                                                checkboxMouseDownFired.current = true;
-                                                dragSelecting.current = {
-                                                    active: false,
-                                                    value: newValue,
-                                                    startY: e.clientY,
-                                                };
-                                                setRowSelected(seqId, newValue);
+                                                setRowSelected(seqId, !selectedSeqs.has(seqId));
                                             }}
                                         />
                                     </td>


### PR DESCRIPTION
resolves #5849

This fixes the selection problem when there is a vertical shift in the Table by only activating the drag-selection if the cursor is actually being moved vertically.

### Screenshot

https://github.com/user-attachments/assets/1c902b3e-7005-4325-bc96-a62c79ab0705

### PR Checklist
- ~[ ] All necessary documentation has been adapted.~
- ~[ ] The implemented feature is covered by appropriate, automated tests.~
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
    - See video

🚀 Preview: Add `preview` label to enable