### PR TITLE
fix(website): fix backend URL configuration to use server-side config in get-file route

### DIFF
--- a/website/src/pages/seq/[accessionVersion]/[fileCategory]/[fileName].ts
+++ b/website/src/pages/seq/[accessionVersion]/[fileCategory]/[fileName].ts
@@ -9,7 +9,7 @@ async function proxyToBackend({ params, locals }: Parameters<APIRoute>[0], metho
     const { accessionVersion, fileCategory, fileName } = params;
     const { accession, version } = parseAccessionVersionFromString(accessionVersion!);
 
-    const backendUrl = `${runtimeConfig.public.backendUrl}/files/get/${accession}/${version}/${encodeURIComponent(fileCategory!)}/${encodeURIComponent(fileName!)}`;
+    const backendUrl = `${runtimeConfig.serverSide.backendUrl}/files/get/${accession}/${version}/${encodeURIComponent(fileCategory!)}/${encodeURIComponent(fileName!)}`;
 
     const accessToken = getAccessToken(locals.session)!;
 


### PR DESCRIPTION
I was having trouble running the integration tests locally to pass and claude identified this as the bug, correctly I think. I guess in our CI env (and in previews) it doesn't matter, but it seems technically wrong and to be causing problems here.

### Description
Changed the backend URL configuration source from `runtimeConfig.public.backendUrl` to `runtimeConfig.serverSide.backendUrl` in the file proxy endpoint. This ensures the backend URL is retrieved from server-side configuration instead of public configuration, which is more secure and appropriate for server-only operations.

### Changes
- Updated `[fileName].ts` to use `runtimeConfig.serverSide.backendUrl` instead of `runtimeConfig.public.backendUrl`
