### PR TITLE
Refactor autocomplete fields to share common logic

### DIFF
--- a/website/src/components/SearchPage/fields/AutoCompleteBase.tsx
+++ b/website/src/components/SearchPage/fields/AutoCompleteBase.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useMemo } from 'react';
+
+import { createOptionsProviderHook, type Option, type OptionsProvider } from './AutoCompleteOptions.ts';
+import { getClientLogger } from '../../../clientLogger.ts';
+import { formatNumberWithDefaultLocale } from '../../../utils/formatNumber.tsx';
+import { ComboboxOption, ComboboxOptions } from '../../common/headlessui/Combobox';
+import MdiTick from '~icons/mdi/tick';
+
+const logger = getClientLogger('AutoCompleteField');
+
+type UseAutoCompleteOptionsParams = {
+    optionsProvider: OptionsProvider;
+    query: string;
+    maxDisplayedOptions?: number;
+};
+
+type UseAutoCompleteOptionsResult = {
+    options: Option[];
+    filteredOptions: Option[];
+    isPending: boolean;
+    error: Error | null;
+    load: () => void;
+};
+
+/**
+ * Hook to load and filter autocomplete options with error logging.
+ * Shared between SingleChoiceAutoCompleteField and MultiChoiceAutoCompleteField.
+ */
+export const useAutoCompleteOptions = ({
+    optionsProvider,
+    query,
+    maxDisplayedOptions = 1000,
+}: UseAutoCompleteOptionsParams): UseAutoCompleteOptionsResult => {
+    const hook = createOptionsProviderHook(optionsProvider);
+    const { options, isPending, error, load } = hook();
+
+    useEffect(() => {
+        if (error) {
+            void logger.error(`Error while loading autocomplete options: ${error.message} - ${error.stack}`);
+        }
+    }, [error]);
+
+    const filteredOptions = useMemo(() => {
+        const allMatchedOptions =
+            query === ''
+                ? options
+                : options.filter((option) => option.option.toLowerCase().includes(query.toLowerCase()));
+        return allMatchedOptions.slice(0, maxDisplayedOptions);
+    }, [options, query, maxDisplayedOptions]);
+
+    return { options, filteredOptions, isPending, error, load };
+};
+
+type AutoCompleteOptionsListProps = {
+    filteredOptions: Option[];
+    isPending: boolean;
+    headerContent?: React.ReactNode;
+};
+
+/**
+ * Shared dropdown options list component for autocomplete fields.
+ * Renders loading state, empty state, or the list of options.
+ */
+export const AutoCompleteOptionsList = ({ filteredOptions, isPending, headerContent }: AutoCompleteOptionsListProps) => {
+    return (
+        <ComboboxOptions
+            modal={false}
+            className='absolute z-20 w-full py-1 mt-1 overflow-auto text-base bg-white rounded-md shadow-lg max-h-60 ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm min-h-32'
+        >
+            {isPending ? (
+                <div className='px-4 py-2 text-gray-500'>Loading...</div>
+            ) : filteredOptions.length === 0 ? (
+                <div className='px-4 py-2 text-gray-500'>No options available</div>
+            ) : (
+                <>
+                    {headerContent}
+                    {filteredOptions.map((option) => (
+                        <AutoCompleteOptionItem key={option.option} option={option} />
+                    ))}
+                </>
+            )}
+        </ComboboxOptions>
+    );
+};
+
+type AutoCompleteOptionItemProps = {
+    option: Option;
+};
+
+/**
+ * Individual option item in the autocomplete dropdown.
+ */
+const AutoCompleteOptionItem = ({ option }: AutoCompleteOptionItemProps) => {
+    return (
+        <ComboboxOption
+            className={({ focus }) =>
+                `relative cursor-default select-none py-2 pl-10 pr-4 ${
+                    focus ? 'bg-blue-500 text-white' : 'text-gray-900'
+                }`
+            }
+            value={option.value}
+        >
+            {({ focus, selected }) => (
+                <>
+                    <span
+                        className={`inline-block ${selected ? 'font-medium' : 'font-normal'} ${
+                            option.option === '(blank)' ? 'italic' : ''
+                        }`}
+                    >
+                        {option.option}
+                    </span>
+                    {option.count !== undefined && (
+                        <span className='inline-block ml-1'>({formatNumberWithDefaultLocale(option.count)})</span>
+                    )}
+                    {selected && (
+                        <span
+                            className={`absolute inset-y-0 left-0 flex items-center pl-3 ${
+                                focus ? 'text-white' : 'text-blue-500'
+                            }`}
+                        >
+                            <MdiTick className='w-5 h-5' />
+                        </span>
+                    )}
+                </>
+            )}
+        </ComboboxOption>
+    );
+};

--- a/website/src/components/SearchPage/fields/MultiChoiceAutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/MultiChoiceAutoCompleteField.tsx
@@ -1,24 +1,14 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
-import { createOptionsProviderHook, type OptionsProvider } from './AutoCompleteOptions.ts';
+import { AutoCompleteOptionsList, useAutoCompleteOptions } from './AutoCompleteBase.tsx';
+import { type OptionsProvider } from './AutoCompleteOptions.ts';
 import { FloatingLabelContainer } from './FloatingLabelContainer.tsx';
-import { getClientLogger } from '../../../clientLogger.ts';
 import { type GroupedMetadataFilter, type MetadataFilter, type SetSomeFieldValues } from '../../../types/config.ts';
-import { formatNumberWithDefaultLocale } from '../../../utils/formatNumber.tsx';
 import { NULL_QUERY_VALUE } from '../../../utils/search.ts';
 import { Button } from '../../common/Button';
-import {
-    Combobox,
-    ComboboxButton,
-    ComboboxInput,
-    ComboboxOption,
-    ComboboxOptions,
-} from '../../common/headlessui/Combobox';
+import { Combobox, ComboboxButton, ComboboxInput } from '../../common/headlessui/Combobox';
 import MaterialSymbolsClose from '~icons/material-symbols/close';
 import MdiChevronUpDown from '~icons/mdi/chevron-up-down';
-import MdiTick from '~icons/mdi/tick';
-
-const logger = getClientLogger('MultiChoiceAutoCompleteField');
 
 type MultiChoiceAutoCompleteFieldProps = {
     field: MetadataFilter | GroupedMetadataFilter;
@@ -42,25 +32,14 @@ export const MultiChoiceAutoCompleteField = ({
     // Maximum number of badges to show before switching to summary
     const MAX_VISIBLE_BADGES = 2;
 
-    const hook = createOptionsProviderHook(optionsProvider);
-    const { options, isPending: isOptionListPending, error, load } = hook();
+    const { filteredOptions, isPending, load } = useAutoCompleteOptions({
+        optionsProvider,
+        query,
+        maxDisplayedOptions,
+    });
 
     // Track selected values as a Set (NULL_QUERY_VALUE for nulls)
     const selectedValues = useMemo(() => new Set<string>(fieldValues.map((v) => v ?? NULL_QUERY_VALUE)), [fieldValues]);
-
-    useEffect(() => {
-        if (error) {
-            void logger.error(`Error while loading autocomplete options: ${error.message} - ${error.stack}`);
-        }
-    }, [error]);
-
-    const filteredOptions = useMemo(() => {
-        const allMatchedOptions =
-            query === ''
-                ? options
-                : options.filter((option) => option.option.toLowerCase().includes(query.toLowerCase()));
-        return allMatchedOptions.slice(0, maxDisplayedOptions);
-    }, [options, query, maxDisplayedOptions]);
 
     const handleChange = (value: string[] | null) => {
         if (!value || value.length === 0) {
@@ -78,6 +57,34 @@ export const MultiChoiceAutoCompleteField = ({
 
     // Convert selectedValues Set to array for Combobox value
     const multiSelectValue = useMemo(() => Array.from(selectedValues), [selectedValues]);
+
+    const headerContent = (
+        <div className='flex justify-between px-4 py-2 text-xs text-gray-600 border-b border-gray-200'>
+            <Button
+                type='button'
+                className='hover:text-blue-600 hover:underline'
+                onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    const allValues = filteredOptions.map((opt) => opt.value);
+                    handleChange(allValues);
+                }}
+            >
+                Select all
+            </Button>
+            <Button
+                type='button'
+                className='hover:text-blue-600 hover:underline'
+                onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    handleChange([]);
+                }}
+            >
+                Select none
+            </Button>
+        </div>
+    );
 
     return (
         <div className='w-full'>
@@ -171,83 +178,11 @@ export const MultiChoiceAutoCompleteField = ({
                         </ComboboxButton>
                     </FloatingLabelContainer>
 
-                    <ComboboxOptions
-                        modal={false}
-                        className='absolute z-20 w-full py-1 mt-1 overflow-auto text-base bg-white rounded-md shadow-lg max-h-60 ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm min-h-32'
-                    >
-                        {isOptionListPending ? (
-                            <div className='px-4 py-2 text-gray-500'>Loading...</div>
-                        ) : filteredOptions.length === 0 ? (
-                            <div className='px-4 py-2 text-gray-500'>No options available</div>
-                        ) : (
-                            <>
-                                <div className='flex justify-between px-4 py-2 text-xs text-gray-600 border-b border-gray-200'>
-                                    <Button
-                                        type='button'
-                                        className='hover:text-blue-600 hover:underline'
-                                        onClick={(e) => {
-                                            e.preventDefault();
-                                            e.stopPropagation();
-                                            const allValues = filteredOptions.map((opt) => opt.value);
-                                            handleChange(allValues);
-                                        }}
-                                    >
-                                        Select all
-                                    </Button>
-                                    <Button
-                                        type='button'
-                                        className='hover:text-blue-600 hover:underline'
-                                        onClick={(e) => {
-                                            e.preventDefault();
-                                            e.stopPropagation();
-                                            handleChange([]);
-                                        }}
-                                    >
-                                        Select none
-                                    </Button>
-                                </div>
-                                {filteredOptions.map((option) => (
-                                    <ComboboxOption
-                                        key={option.option}
-                                        className={({ focus }) =>
-                                            `relative cursor-default select-none py-2 pl-10 pr-4 ${
-                                                focus ? 'bg-blue-500 text-white' : 'text-gray-900'
-                                            }`
-                                        }
-                                        value={option.value}
-                                    >
-                                        {({ focus, selected }) => {
-                                            return (
-                                                <>
-                                                    <span
-                                                        className={`inline-block ${selected ? 'font-medium' : 'font-normal'} ${
-                                                            option.option === '(blank)' ? 'italic' : ''
-                                                        }`}
-                                                    >
-                                                        {option.option}
-                                                    </span>
-                                                    {option.count !== undefined && (
-                                                        <span className='inline-block ml-1'>
-                                                            ({formatNumberWithDefaultLocale(option.count)})
-                                                        </span>
-                                                    )}
-                                                    {selected && (
-                                                        <span
-                                                            className={`absolute inset-y-0 left-0 flex items-center pl-3 ${
-                                                                focus ? 'text-white' : 'text-blue-500'
-                                                            }`}
-                                                        >
-                                                            <MdiTick className='w-5 h-5' />
-                                                        </span>
-                                                    )}
-                                                </>
-                                            );
-                                        }}
-                                    </ComboboxOption>
-                                ))}
-                            </>
-                        )}
-                    </ComboboxOptions>
+                    <AutoCompleteOptionsList
+                        filteredOptions={filteredOptions}
+                        isPending={isPending}
+                        headerContent={headerContent}
+                    />
                 </div>
             </Combobox>
         </div>

--- a/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
@@ -1,22 +1,14 @@
-import { type InputHTMLAttributes, useEffect, useMemo, useState, forwardRef } from 'react';
+import { type InputHTMLAttributes, useState, forwardRef } from 'react';
 
-import { createOptionsProviderHook, type OptionsProvider } from './AutoCompleteOptions.ts';
+import { AutoCompleteOptionsList, useAutoCompleteOptions } from './AutoCompleteBase.tsx';
+import { type OptionsProvider } from './AutoCompleteOptions.ts';
 import { TextField } from './TextField.tsx';
-import { getClientLogger } from '../../../clientLogger.ts';
 import { type GroupedMetadataFilter, type MetadataFilter, type SetSomeFieldValues } from '../../../types/config.ts';
-import { formatNumberWithDefaultLocale } from '../../../utils/formatNumber.tsx';
 import { NULL_QUERY_VALUE } from '../../../utils/search.ts';
 import { Button } from '../../common/Button';
-import {
-    Combobox,
-    ComboboxButton,
-    ComboboxInput,
-    ComboboxOption,
-    ComboboxOptions,
-} from '../../common/headlessui/Combobox';
+import { Combobox, ComboboxButton, ComboboxInput } from '../../common/headlessui/Combobox';
 import MaterialSymbolsClose from '~icons/material-symbols/close';
 import MdiChevronUpDown from '~icons/mdi/chevron-up-down';
-import MdiTick from '~icons/mdi/tick';
 
 const CustomInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>((props, ref) => (
     <TextField
@@ -30,8 +22,6 @@ const CustomInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputEl
         label={props.placeholder ?? ''}
     />
 ));
-
-const logger = getClientLogger('SingleChoiceAutoCompleteField');
 
 type SingleChoiceAutoCompleteFieldProps = {
     field: MetadataFilter | GroupedMetadataFilter;
@@ -50,22 +40,11 @@ export const SingleChoiceAutoCompleteField = ({
 }: SingleChoiceAutoCompleteFieldProps) => {
     const [query, setQuery] = useState('');
 
-    const hook = createOptionsProviderHook(optionsProvider);
-    const { options, isPending: isOptionListPending, error, load } = hook();
-
-    useEffect(() => {
-        if (error) {
-            void logger.error(`Error while loading autocomplete options: ${error.message} - ${error.stack}`);
-        }
-    }, [error]);
-
-    const filteredOptions = useMemo(() => {
-        const allMatchedOptions =
-            query === ''
-                ? options
-                : options.filter((option) => option.option.toLowerCase().includes(query.toLowerCase()));
-        return allMatchedOptions.slice(0, maxDisplayedOptions);
-    }, [options, query, maxDisplayedOptions]);
+    const { filteredOptions, isPending, load } = useAutoCompleteOptions({
+        optionsProvider,
+        query,
+        maxDisplayedOptions,
+    });
 
     const handleChange = (value: string | null) => {
         const finalValue = value === NULL_QUERY_VALUE ? null : (value ?? '');
@@ -109,58 +88,7 @@ export const SingleChoiceAutoCompleteField = ({
                         </ComboboxButton>
                     </>
 
-                    <ComboboxOptions
-                        modal={false}
-                        className='absolute z-20 w-full py-1 mt-1 overflow-auto text-base bg-white rounded-md shadow-lg max-h-60 ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm min-h-32'
-                    >
-                        {isOptionListPending ? (
-                            <div className='px-4 py-2 text-gray-500'>Loading...</div>
-                        ) : filteredOptions.length === 0 ? (
-                            <div className='px-4 py-2 text-gray-500'>No options available</div>
-                        ) : (
-                            <>
-                                {filteredOptions.map((option) => (
-                                    <ComboboxOption
-                                        key={option.option}
-                                        className={({ focus }) =>
-                                            `relative cursor-default select-none py-2 pl-10 pr-4 ${
-                                                focus ? 'bg-blue-500 text-white' : 'text-gray-900'
-                                            }`
-                                        }
-                                        value={option.value}
-                                    >
-                                        {({ focus, selected }) => {
-                                            return (
-                                                <>
-                                                    <span
-                                                        className={`inline-block ${selected ? 'font-medium' : 'font-normal'} ${
-                                                            option.option === '(blank)' ? 'italic' : ''
-                                                        }`}
-                                                    >
-                                                        {option.option}
-                                                    </span>
-                                                    {option.count !== undefined && (
-                                                        <span className='inline-block ml-1'>
-                                                            ({formatNumberWithDefaultLocale(option.count)})
-                                                        </span>
-                                                    )}
-                                                    {selected && (
-                                                        <span
-                                                            className={`absolute inset-y-0 left-0 flex items-center pl-3 ${
-                                                                focus ? 'text-white' : 'text-blue-500'
-                                                            }`}
-                                                        >
-                                                            <MdiTick className='w-5 h-5' />
-                                                        </span>
-                                                    )}
-                                                </>
-                                            );
-                                        }}
-                                    </ComboboxOption>
-                                ))}
-                            </>
-                        )}
-                    </ComboboxOptions>
+                    <AutoCompleteOptionsList filteredOptions={filteredOptions} isPending={isPending} />
                 </div>
             </Combobox>
         </div>


### PR DESCRIPTION
### Description
Extracts shared autocomplete functionality from `SingleChoiceAutoCompleteField` and `MultiChoiceAutoCompleteField` into a new `AutoCompleteBase.tsx` module. This reduces code duplication and improves maintainability.

### Changes
- **New file**: `AutoCompleteBase.tsx` containing:
  - `useAutoCompleteOptions` hook: Handles loading, filtering, and error logging of autocomplete options
  - `AutoCompleteOptionsList` component: Renders the dropdown options list with loading/empty states
  - `AutoCompleteOptionItem` component: Renders individual option items with selection indicators and counts

- **Modified files**:
  - `SingleChoiceAutoCompleteField.tsx`: Refactored to use shared hook and components, removed ~55 lines of duplicated code
  - `MultiChoiceAutoCompleteField.tsx`: Refactored to use shared hook and components, moved "Select all/none" buttons to `headerContent` prop, removed ~80 lines of duplicated code

### Benefits
- Eliminates code duplication between single and multi-choice autocomplete fields
- Centralizes error handling and logging logic
- Makes it easier to maintain and update autocomplete behavior consistently
- Allows future autocomplete fields to reuse the same components and hooks

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

https://claude.ai/code/session_01NF3N8suEkc5KYGZ2ETbERY

🚀 Preview: Add `preview` label to enable