### PR TITLE
feat(ingest, config, actions): add datasets assembly download to mirror and allow creation of override groups in ingest

### DIFF
--- a/.github/workflows/datasets-assembly-mirror.yml
+++ b/.github/workflows/datasets-assembly-mirror.yml
@@ -1,0 +1,58 @@
+name: Mirror NCBI Assemblies to Object Storage
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '12 2 * * *' # Runs daily at 02:12 UTC
+jobs:
+  download-and-upload:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        taxon_id:
+          - 11520   # Influenza B
+          - 197911  # Influenza A
+          - 3052518  # CCHFV
+      fail-fast: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-name: datasets
+          create-args: ncbi-datasets-cli s3cmd
+      - name: Download NCBI Dataset
+        shell: bash -l {0}
+        run: |
+          datasets download genome taxon ${{ matrix.taxon_id }} --no-progressbar --assembly-source refseq --dehydrated --filename ${{ matrix.taxon_id }}-refseq.zip
+          unzip -o ${{ matrix.taxon_id }}-refseq.zip
+          tar -I 'zstd -T0 -18' -cvf ${{ matrix.taxon_id }}-refseq.tar.zst ncbi_dataset
+          datasets download genome taxon ${{ matrix.taxon_id }} --no-progressbar --assembly-source genbank --dehydrated --filename ${{ matrix.taxon_id }}-genbank.zip
+          unzip -o ${{ matrix.taxon_id }}-genbank.zip
+          tar -I 'zstd -T0 -18' -cvf ${{ matrix.taxon_id }}-genbank.tar.zst ncbi_dataset
+      - name: Create S3cmd config
+        run: |
+          cat <<EOF > ~/.s3cfg
+          access_key = ${{ secrets.HETZNER_S3_ACCESS_KEY }}
+          secret_key = ${{ secrets.HETZNER_S3_SECRET_KEY }}
+          host_base = hel1.your-objectstorage.com
+          host_bucket = %(bucket)s.hel1.your-objectstorage.com
+          verbosity = DEBUG
+          EOF
+      - name: Upload to Object Storage
+        shell: bash -l {0}
+        run: |
+          for file in ${{ matrix.taxon_id }}-refseq.zip ${{ matrix.taxon_id }}-genbank.zip ${{ matrix.taxon_id }}-refseq.tar.zst ${{ matrix.taxon_id }}-genbank.tar.zst ; do
+            s3cmd put "${file}" s3://loculus-public/mirror/"${file}"
+          done
+  notify_on_failure:  # Runs only if 'build' job fails
+    needs: download-and-upload
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - name: Send Slack Notification
+        env:
+          SLACK_HOOK: ${{ secrets.SLACK_HOOK }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data '{
+            "text": "🚨 Failed to mirror NCBI assemblies: ${{ github.repository }}\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Details>"
+          }' $SLACK_HOOK

--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -38,9 +38,12 @@ MIRROR_BUCKET = config.get("mirror_bucket", "")
 APPROVE_TIMEOUT_MIN = config.get("approve_timeout_min")  # time in minutes
 CHECK_ENA_DEPOSITION = config.get("check_ena_deposition", False)
 FILTER = config.get("metadata_filter", None)
-GROUPS_OVERRIDE_JSON = config.get(
-    "grouping_override", None
-)  # JSON map from group to segments' insdcAccessionFull
+CALCULATE_GROUPS_OVERRIDE_JSON = config.get(
+    "calculate_groups_override_json", False
+)  # Calculate the groups override JSON based on assembly report data.
+GROUPS_OVERRIDE_JSON = CALCULATE_GROUPS_OVERRIDE_JSON or config.get(
+    "grouping_override_url", False
+)
 
 
 if SEGMENTED:
@@ -365,17 +368,110 @@ rule prepare_metadata:
         """
 
 
-if GROUPS_OVERRIDE_JSON:
+if GROUPS_OVERRIDE_JSON and not CALCULATE_GROUPS_OVERRIDE_JSON:
 
     rule download_groups:
         output:
             results="results/groups.json",
         params:
-            grouping=config.get("grouping_override"),
+            grouping=config.get("grouping_override_url"),
         shell:
             """
             curl -L -o {output.results} {params.grouping}
             """
+
+
+if CALCULATE_GROUPS_OVERRIDE_JSON:
+
+    rule download_ignore_list:
+        output:
+            ignore_list="results/grouping_ignore_list.txt",
+        params:
+            grouping_ignore_list_url=config.get("grouping_ignore_list_url", ""),
+        shell:
+            """
+            if [[  -n "{params.grouping_ignore_list_url}" ]]; then
+                curl -L -o {output.ignore_list} {params.grouping_ignore_list_url}
+            else
+                touch {output.ignore_list}
+            fi
+            """
+
+    rule fetch_inflate_assemblies:
+        output:
+            marker="results/{source}_assembly/.fetch_inflate_complete",
+        params:
+            taxon_id=TAXON_ID,
+            api_key=f"--api-key {NCBI_API_KEY}" if NCBI_API_KEY else "",
+            gateway=f"--gateway-url {NCBI_GATEWAY_URL}" if NCBI_GATEWAY_URL else "",
+            use_mirror=bool(MIRROR_BUCKET),
+            mirror_url=lambda wc: f"{MIRROR_BUCKET.strip('/')}/{TAXON_ID}-{wc.source}.tar.zst",
+            unzip=unzip,
+            compressed_package_tzst="results/{source}_assembly.tar.zst",
+            compressed_package_zip="results/{source}_assembly.zip",
+            package=directory("results/{source}_assembly"),
+        shell:
+            """
+            if [[ "{params.use_mirror}" == "True" ]]; then
+                curl {params.mirror_url} -o {params.compressed_package_tzst}
+                tar xvf {params.compressed_package_tzst} -C {params.package}
+            else
+                datasets download genome taxon {params.taxon_id} \
+                    --assembly-source {wildcards.source} \
+                    --no-progressbar \
+                    --filename {params.compressed_package_zip} \
+                    {params.api_key} \
+                    {params.gateway} \
+                && {params.unzip} \
+                    -o {params.compressed_package_zip} \
+                    -d {params.package}
+            fi
+            touch {output.marker}
+            """
+
+    rule rehydrate_assemblies:
+        """
+        Unzips the downloaded, dehydrated assembly, and then rehydrates it. The rehydration can take quite a bit,
+        but it can be restarted. Run this rule with --rerun-incomplete to let snakemake know that it can be safely restarted.
+        """
+        input:
+            marker="results/{source}_assembly/.fetch_inflate_complete",
+        output:
+            marker="results/{source}_assembly/.rehydration_complete",
+        params:
+            assembly_dir="results/{source}_assembly",
+        shell:
+            """
+            datasets rehydrate \
+                --directory {params.assembly_dir} \
+                --no-progressbar \
+            && touch {output.marker}
+            """
+
+    rule get_assembly_groups:
+        input:
+            script="scripts/calculate_assembly_groups.py",
+            rehydration_genbank="results/genbank_assembly/.rehydration_complete",
+            rehydration_refseq="results/refseq_assembly/.rehydration_complete",
+            ignore_list="results/grouping_ignore_list.txt",
+            config_file="results/config.yaml",
+        output:
+            groups_json="results/groups.json",
+        params:
+            genbank_dir="results/genbank_assembly/ncbi_dataset/data",
+            refseq_dir="results/refseq_assembly/ncbi_dataset/data",
+        shell:
+            """
+            python {input.script} \
+            --dataset-dir {params.genbank_dir} \
+            --dataset-dir {params.refseq_dir} \
+            --output-file {output.groups_json} \
+            --ignore-list {input.ignore_list} \
+            --config-file {input.config_file}
+            """
+
+
+if GROUPS_OVERRIDE_JSON:
 
     rule override_group_segments:
         """Group segments based on JSON map"""

--- a/ingest/scripts/calculate_assembly_groups.py
+++ b/ingest/scripts/calculate_assembly_groups.py
@@ -1,0 +1,131 @@
+import json
+import logging
+import os
+import pathlib
+from collections import Counter
+from dataclasses import dataclass
+
+import click
+import yaml
+from Bio import SeqIO
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    encoding="utf-8",
+    level=logging.DEBUG,
+    format="%(asctime)s %(levelname)8s (%(filename)20s:%(lineno)4d) - %(message)s ",
+    datefmt="%H:%M:%S",
+)
+
+
+@dataclass(frozen=True)
+class Config:
+    nucleotide_sequences: list[str]
+    segmented: bool
+    organism: str
+
+
+def calculate_assembly_groups(  # noqa: C901
+    dataset_dir: list[str],
+    ignore: set[str],
+    config: Config,
+) -> dict[str, list[str]]:
+    assembly_segment_dict: dict[str, list[str]] = {}
+    records = set()
+    segment_count_counter = Counter()
+
+    for dir in dataset_dir:
+        for gca_folder in os.listdir(dir):
+            gca_path = os.path.join(dir, gca_folder)
+            if not os.path.isdir(gca_path):
+                # The 'assembly_data_report.jsonl' and 'dataset_catalog.json' are also in the dir; skip.
+                continue
+            for file in os.listdir(gca_path):
+                if not file.endswith(".fna"):
+                    continue
+                # Certain assemblies contain two files, one of which we want to ignore because it has CDS info
+                # Examples: GCA_052462815.1, GCA_052463665.1, GCA_052463295.1, GCA_052464535.1
+                if "cds_from_genomic" in file:
+                    continue
+                assembly_id = file.split(".")[0]
+                if assembly_id in assembly_segment_dict:
+                    msg = f"Duplicate assembly found: {assembly_id}"
+                    logger.error(msg)
+                    raise ValueError(msg)
+
+                segments = []
+                with open(os.path.join(gca_path, file), encoding="utf-8") as f:
+                    segments = [
+                        record.id for record in SeqIO.parse(f, "fasta") if record.id not in ignore
+                    ]
+                if set(segments) & records:
+                    msg = f"Duplicate INSDC accessions found in assembly {assembly_id}"
+                    logger.error(msg)
+                    raise ValueError(msg)
+                if len(segments) > len(config.nucleotide_sequences):
+                    msg = (
+                        f"Assembly {assembly_id} has more segments ({len(segments)}) "
+                        f"than expected ({len(config.nucleotide_sequences)}), ignoring assembly."
+                    )
+                    logger.warning(msg)
+                    continue
+                segment_count_counter[len(segments)] += 1
+                assembly_segment_dict[assembly_id] = segments
+                records.update(segments)
+
+    logger.info(f"Found {len(assembly_segment_dict)} assemblies")
+    for segment_count in sorted(segment_count_counter):
+        logger.info(
+            f"Number of assemblies with {segment_count} segments: {segment_count_counter[segment_count]:7}"
+        )
+    return assembly_segment_dict
+
+
+@click.command()
+@click.option("--config-file", required=True, type=click.Path(exists=True))
+@click.option(
+    "--dataset-dir",
+    required=True,
+    type=click.Path(exists=True),
+    multiple=True,
+    help=(
+        "The dataset dir is the 'data' directory you get from an NCBI datasets download. "
+        "It has individual directories inside, per assembly (named e.g. GCF_0002342342.1)."
+    ),
+)
+@click.option(
+    "--output-file",
+    required=True,
+    type=click.Path(exists=False),
+    help="The file to be generated, containing the groupings in JSON format.",
+)
+@click.option(
+    "--ignore-list",
+    required=True,
+    type=click.Path(exists=False),
+    help="A file with one segment ID per line to be ignored.",
+)
+def main(config_file: str, dataset_dir: list[str], output_file: str, ignore_list: str) -> None:
+    full_config = yaml.safe_load(pathlib.Path(config_file).read_text(encoding="utf-8"))
+    relevant_config = {key: full_config[key] for key in Config.__annotations__}
+    config = Config(**relevant_config)
+
+    if not config.segmented:
+        raise ValueError({"ERROR: You are running a function that was built for segmented data"})
+
+    with open(ignore_list, encoding="utf-8") as file:
+        ignore = [line.strip() for line in file]
+    logger.info(f"Ignoring {len(ignore)} segments")
+
+    assembly_segment_dict = calculate_assembly_groups(
+        dataset_dir=dataset_dir,
+        ignore=set(ignore),
+        config=config,
+    )
+
+    with open(output_file, "w", encoding="utf-8") as outfile:
+        json.dump(assembly_segment_dict, outfile, indent=4)
+
+
+if __name__ == "__main__":
+    main()

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1897,6 +1897,7 @@ defaultOrganisms:
       <<: *ingest
       configFile:
         taxon_id: 3052518
+        calculate_groups_override_json: true
         segment_identification:
           method: "align"
           nextclade_dataset_name: community/pathoplexus/cchfv


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/5905

Uses code from https://github.com/GenSpectrum/influenza-override-groups now that the dataset command has become fast enough to run during ingest (also helps for GCAs and nuccore accessions to not get out of sync e.g. for new submissions).

It takes 6min to download dehydrated (hypercompressed) + zipped GCA files.
Hydration takes 50min for influenza-a:
<img width="548" height="108" alt="image" src="https://github.com/user-attachments/assets/474e51f4-7bdb-4612-9c03-1f7261a23064" />

The dehydrated files are 19M, unzipped 260M and 2.3G unzipped and dehydrated. 
(I can even zip the dehydrated + zipped files once more with zstd.zip and get them down to 9.7M). 

The unzipped and dehydrated file when rezipped with zst.zip is 79M but takes minutes to unzip.

This PR adds the GCA files to the mirror in dehydrated, zipped state and let ingest perform rehydration.


### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable