### PR TITLE
feat(backend): add date became open to DUT metadata fields

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -746,6 +746,7 @@ class SubmissionDatabaseService(
             SequenceEntriesView.pipelineVersionColumn,
             DataUseTermsTable.dataUseTermsTypeColumn,
             DataUseTermsTable.restrictedUntilColumn,
+            DataUseTermsTable.changeDateColumn,
         )
         .where {
             SequenceEntriesView.statusIs(Status.APPROVED_FOR_RELEASE) and SequenceEntriesView.organismIs(
@@ -779,6 +780,7 @@ class SubmissionDatabaseService(
                     it[DataUseTermsTable.restrictedUntilColumn],
                 ),
                 versionComment = it[SequenceEntriesView.versionCommentColumn],
+                dataUseTermsChangeDate = it[DataUseTermsTable.changeDateColumn],
             )
         }
 
@@ -1533,4 +1535,5 @@ data class RawProcessedData(
     val processedData: ProcessedData<GeneticSequence>,
     val pipelineVersion: Long,
     val dataUseTerms: DataUseTerms,
+    val dataUseTermsChangeDate: LocalDateTime?,
 ) : AccessionVersionInterface

--- a/backend/src/test/kotlin/org/loculus/backend/utils/EarliestReleaseDateFinderTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/utils/EarliestReleaseDateFinderTest.kt
@@ -74,6 +74,7 @@ fun row(
     groupName = "foo",
     dataUseTerms = DataUseTerms.Open,
     pipelineVersion = 0,
+    dataUseTermsChangeDate = releasedAt,
 )
 
 // Notes:

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -104,6 +104,12 @@ fields:
     hideOnSequenceDetailsPage: true
     header: Data use terms
     orderOnDetailsPage: 620
+  - name: dataBecameOpenAt
+    type: date
+    displayName: Date data became open
+    hideOnSequenceDetailsPage: true
+    header: Data use terms
+    orderOnDetailsPage: 625
   {{- if $.Values.dataUseTerms.urls }}
   - name: dataUseTermsUrl
     displayName: Data use terms URL


### PR DESCRIPTION
resolves #

### Screenshot

### PR Checklist
- [x] The implemented feature is covered by appropriate, automated tests.

@anna-parker Testing Notes:
- [x] confirmed date became open is submission date for sequences submitted as OPEN
- [x] submitted LOC_001H5KN.1 and LOC_001H5LL.1 with restricted access until tomorrow (11th of Feb)
- [x] confirmed date_became_open is null for restricted use sequences
- [x] set LOC_001H5KN.1 to open and confirmed date is today (10th) -> yup! `2026-02-10`
- [x] waited until 11th and confirmed LOC_001H5LL.1 is open and has date_became_open 11th

🚀 Preview: https://data-open-at.loculus.org