### PR TITLE
Revert "chore(deps): bump pandas from 2.3.3 to 3.0.0 in /ingest"

### DIFF
--- a/ingest/environment.yml
+++ b/ingest/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - ncbi-datasets-cli=18.9.0
   - nextclade=3.18.0
   - orjsonl=1.0.0
-  - pandas=3.0.0
+  - pandas=2.3.3
   - psycopg2=2.9.10
   - PyYAML=6.0.3
   - requests=2.32.5


### PR DESCRIPTION
Reverts loculus-project/loculus#5921

see discussion https://loculus.slack.com/archives/C05G172HL6L/p1770200787718059

🚀 Preview: https://revert-5921-dependabot-co.loculus.org