### PR TITLE
fix(ingest): add pytz as dependency for ingest

### DIFF
--- a/ingest/environment.yml
+++ b/ingest/environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - orjsonl=1.0.0
   - pandas=3.0.0
   - psycopg2=2.9.10
+  - pytz=2025.2
   - PyYAML=6.0.3
   - requests=2.32.5
   - seqkit=2.10.1


### PR DESCRIPTION
resolves #
Needed because update to pandas 3.0 meant pytz was no longer pulled in as a sub dependency

🚀 Preview: https://add-pytz-dep.loculus.org