### PR TITLE
feat(backend): handle race conditions in extract-unprocessed-data

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1440,7 +1440,6 @@ defaultOrganisms:
     preprocessing:
       - <<: *preprocessing
         version: 1
-        replicas: 4
         configFile:
           <<: *preprocessingConfigFile
           segments:


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/5955

### Description
This change addresses a race condition that can occur when multiple pipeline instances attempt to process the same sequence entries simultaneously. 

Now we:

- ignore errors when inserting and violating unique key constraints (which might happen due to race conditions, which will now lead to silently not inserting)
- but then check with a second query to the db to see if we actually managed to insert and don't return stuff we didn't manage to insert

### PR Checklist
Anya ran some tests and it seemed to work

https://claude.ai/code/session_01NLtTbkoUK9ZPNBWSEgLHzh


https://claude-fix-preprocessing.loculus.org/

🚀 Preview: https://claude-fix-preprocessing.loculus.org