### PR TITLE
fix(website): replace unsafe typecasts with runtime typeof checks

### DIFF
--- a/website/src/components/SearchPage/ReferenceSelector.tsx
+++ b/website/src/components/SearchPage/ReferenceSelector.tsx
@@ -4,7 +4,7 @@ import type { LapisSearchParameters } from './DownloadDialog/SequenceFilters.tsx
 import { SingleChoiceAutoCompleteField } from './fields/SingleChoiceAutoCompleteField.tsx';
 import type { FieldValues, MetadataFilter, SetSomeFieldValues } from '../../types/config.ts';
 import { type ReferenceGenomesInfo } from '../../types/referencesGenomes.ts';
-import { getReferenceIdentifier } from '../../utils/referenceSelection.ts';
+import { expectStringOrNull, getReferenceIdentifier } from '../../utils/referenceSelection.ts';
 import type { MetadataFilterSchema } from '../../utils/search.ts';
 import { getSegmentNames, segmentsWithMultipleReferences } from '../../utils/sequenceTypeHelpers.ts';
 
@@ -78,7 +78,7 @@ export const ReferenceSelector: FC<ReferenceSelectorProps> = ({
                                 fieldName,
                             }}
                             setSomeFieldValues={setSomeFieldValues}
-                            fieldValue={(fieldValues[fieldName] as string | undefined) ?? ''}
+                            fieldValue={expectStringOrNull(fieldValues[fieldName], fieldName) ?? ''}
                         />
 
                         <p className='text-xs text-gray-600 mt-2'>

--- a/website/src/utils/referenceSelection.ts
+++ b/website/src/utils/referenceSelection.ts
@@ -7,6 +7,12 @@ export function getReferenceIdentifier(identifier: string, segmentName: string, 
     return multipleSegments ? `${identifier}_${segmentName}` : identifier;
 }
 
+export function expectStringOrNull(value: unknown, label: string): string | null {
+    if (value === undefined || value === null) return null;
+    if (typeof value === 'string') return value;
+    throw new Error(`Expected string or null for ${label}, got ${typeof value}`);
+}
+
 type GetSegmentSelectionsOpts = {
     segments: string[];
     referenceIdentifierField: string;
@@ -24,8 +30,7 @@ export function getSegmentReferenceSelections({
 
     for (const segmentName of segments) {
         const referenceIdentifier = getReferenceIdentifier(referenceIdentifierField, segmentName, isMultiSegmented);
-        // TODO(5891): it would be better to avoid this typecast
-        result[segmentName] = (state[referenceIdentifier] as string | null | undefined) ?? null;
+        result[segmentName] = expectStringOrNull(state[referenceIdentifier], referenceIdentifier);
     }
 
     return result;


### PR DESCRIPTION
## Summary

- Replaces the unsafe `as string | null | undefined` typecast in `referenceSelection.ts` with a runtime `typeof value === 'string'` check, and removes the `TODO(5891)` comment
- Applies the same pattern to a similar typecast in `ReferenceSelector.tsx` (`as string | undefined`)
- The `state` parameter is `Record<string, unknown>` because callers pass fundamentally different types (`QueryState` with `string | string[] | undefined` values, and `Details` with `string | number | boolean | null` values), so narrowing the type at the signature level would break callers. The `typeof` check is the minimal correct fix — it removes the unsafe cast while adding runtime safety for non-string values.

Closes #5891

## Test plan

- [x] TypeScript compiles with no errors (`npx tsc --noEmit`)
- [x] All 525 website tests pass (`CI=1 npm run test`)
- [ ] Verify reference selection still works correctly in the search UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable