### PR TITLE
fix(deposition): fix type comparison in is_revision()

### DIFF
--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -678,7 +678,7 @@ def add_to_submission_table(
 def is_revision(db_config: SimpleConnectionPool, seq_key: AccessionVersion) -> bool:
     """Check if the entry is a revision"""
     version = seq_key.version
-    if version == "1":
+    if version == 1:
         return False
     accession = {"accession": seq_key.accession}
     sample_data_in_submission_table = find_conditions_in_db(


### PR DESCRIPTION
## Summary

- Fixes the remaining type mismatch in `is_revision()` where `version` (an `int`, via `type Version = int`) was compared to the string `"1"`, which always evaluates to `False` in Python
- The early return for version 1 was dead code — the function would fall through to the database query unnecessarily
- One-character fix: `"1"` -> `1`

Closes #5279

## Test plan

- [x] Verify `AccessionVersion.version` is typed as `Version = int`
- [ ] Existing tests pass (the behavior for version 1 was already correct since the DB query path handled it, this just restores the intended fast path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable