### PR TITLE
feat(deposition): fix type in is_revision

### DIFF
--- a/ena-submission/scripts/get_ena_submission_list.py
+++ b/ena-submission/scripts/get_ena_submission_list.py
@@ -134,9 +134,7 @@ def filter_for_submission(
     entries_with_external_metadata: set[Accession] = set()
     revoked_entries: set[Accession] = set()
     logger.debug("Querying ENA db for latest version of submissions")
-    highest_submitted_version = highest_version_in_submission_table(
-        db_conn_pool=db_pool
-    )
+    highest_submitted_version = highest_version_in_submission_table(db_conn_pool=db_pool)
     logger.debug("Starting processing of data from Loculus backend")
     suppressed_accessions = fetch_suppressed_accessions(config)
     for idx, entry in enumerate(entries_iterator):
@@ -155,7 +153,7 @@ def filter_for_submission(
             continue
 
         # Ignore if a higher version of this entry is already to be submitted
-        version_already_to_submit = int(
+        version_already_to_submit = (
             entries_to_submit.get(accession_version.accession, {})
             .get("metadata", {})
             .get("version", -1)

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -285,7 +285,7 @@ def is_old_version(db_config: SimpleConnectionPool, seq_key: AccessionVersion) -
     sample_data_in_submission_table = find_conditions_in_db(
         db_config, table_name=TableName.SUBMISSION_TABLE, conditions=accession
     )
-    all_versions = sorted([int(entry["version"]) for entry in sample_data_in_submission_table])
+    all_versions = sorted([entry["version"] for entry in sample_data_in_submission_table])
 
     if version < all_versions[-1]:
         update_values = {

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -143,7 +143,10 @@ class AccessionVersion:
         )
 
     def __post_init__(self):
-        object.__setattr__(self, "version", int(self.version))
+        if not isinstance(self.version, int):
+            msg = "version must be an int"
+            logger.error(msg)
+            raise TypeError(msg)
 
 
 @dataclass(frozen=True)
@@ -258,7 +261,7 @@ def highest_version_in_submission_table(
             results = cur.fetchall()
     finally:
         db_conn_pool.putconn(con)
-    return {row["accession"]: int(row["version"]) for row in results}
+    return {row["accession"]: row["version"] for row in results}
 
 
 def delete_records_in_db(
@@ -687,7 +690,7 @@ def is_revision(db_config: SimpleConnectionPool, seq_key: AccessionVersion) -> b
     sample_data_in_submission_table = find_conditions_in_db(
         db_config, table_name=TableName.SUBMISSION_TABLE, conditions=accession
     )
-    all_versions = sorted([int(entry["version"]) for entry in sample_data_in_submission_table])
+    all_versions = sorted([entry["version"] for entry in sample_data_in_submission_table])
     return len(all_versions) > 1 and version == all_versions[-1]
 
 
@@ -698,5 +701,5 @@ def last_version(db_config: SimpleConnectionPool, seq_key: AccessionVersion) -> 
     sample_data_in_submission_table = find_conditions_in_db(
         db_config, table_name=TableName.SUBMISSION_TABLE, conditions=accession
     )
-    all_versions = sorted([int(entry["version"]) for entry in sample_data_in_submission_table])
+    all_versions = sorted([entry["version"] for entry in sample_data_in_submission_table])
     return all_versions[-2]

--- a/ena-submission/src/ena_deposition/trigger_submission_to_ena.py
+++ b/ena-submission/src/ena_deposition/trigger_submission_to_ena.py
@@ -12,6 +12,7 @@ from psycopg2.pool import SimpleConnectionPool
 
 from .config import Config
 from .submission_db_helper import (
+    AccessionVersion,
     SubmissionTableEntry,
     add_to_submission_table,
     db_init,
@@ -23,12 +24,15 @@ logger = logging.getLogger(__name__)
 
 def upload_sequences(db_config: SimpleConnectionPool, sequences_to_upload: dict[str, Any]):
     for full_accession, data in sequences_to_upload.items():
-        accession, version = full_accession.split(".")
-        if in_submission_table(db_config, {"accession": accession, "version": int(version)}):
+        accession_version = AccessionVersion.from_string(full_accession)
+        if in_submission_table(
+            db_config,
+            {"accession": accession_version.accession, "version": accession_version.version},
+        ):
             continue
         entry = SubmissionTableEntry(
-            accession=accession,
-            version=int(version),
+            accession=accession_version.accession,
+            version=accession_version.version,
             group_id=data["metadata"]["groupId"],
             organism=data["organism"],
             metadata=data["metadata"],


### PR DESCRIPTION
resolves #5279

### Screenshot
https://github.com/loculus-project/loculus/pull/5652/changes#r2804431536, assert AccessionVersion is created with version of type int - this is validated by the class code after creation, this removes the need to typecase version objects. I confirmed the json given to the pod has version of type int, and from a spot check of entries in the PPX submission DB type is also an int there

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable