### PR TITLE
fix: Disable query refetch on window focus and improve error handling

### DIFF
--- a/website/src/components/SequenceDetailsPage/SequencesDisplay/SequenceViewer.tsx
+++ b/website/src/components/SequenceDetailsPage/SequencesDisplay/SequenceViewer.tsx
@@ -30,7 +30,7 @@ export const SequencesViewer: FC<Props> = ({
         useLapisMultiSegmentedEndpoint,
     );
 
-    if (error !== null && data === undefined) {
+    if (error !== null) {
         return (
             <div className='text-error'>
                 Failed to load {noCase(sequenceType.type)} sequence {sequenceType.name.lapisName}:{' '}


### PR DESCRIPTION
### Description

Relates to https://loculus.slack.com/archives/C05G172HL6L/p1771013766207329

This PR makes two improvements to query handling and error display:

1. **Disable refetch on window focus**: Configures React Query's `QueryClient` to not automatically refetch queries when the window regains focus. 



### Testing

I did some trials with turning off my internet and behaviour seems better

🚀 Preview: https://claude-fix-offline-connec.loculus.org