### PR TITLE
fix(website): convert null field values to empty strings in GET URL p…

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.spec.ts
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.spec.ts
@@ -2,6 +2,45 @@ import { describe, expect, it } from 'vitest';
 
 import { DownloadUrlGenerator } from './DownloadUrlGenerator';
 import { FieldFilterSet } from './SequenceFilters';
+import type { FieldValues, Metadata } from '../../../types/config.ts';
+import { MetadataFilterSchema } from '../../../utils/search.ts';
+
+const makeFieldFilterSet = (fieldValues: FieldValues, metadataFields: Metadata[]) => {
+    return new FieldFilterSet(
+        new MetadataFilterSchema(metadataFields),
+        fieldValues,
+        {},
+        { nucleotideSegmentInfos: [], geneInfos: [] },
+        {
+            isMultiSegmented: false,
+            segmentReferenceGenomes: {},
+            segmentDisplayNames: {},
+            useLapisMultiSegmentedEndpoint: false,
+        },
+    );
+};
+
+describe('FieldFilterSet.toUrlSearchParams', () => {
+    it('converts null single values to empty strings', () => {
+        const filter = makeFieldFilterSet({ field1: null }, [{ name: 'field1', type: 'string' as const }]);
+        const params = filter.toUrlSearchParams();
+        expect(params).toContainEqual(['field1', '']);
+    });
+
+    it('converts null values in arrays to empty strings', () => {
+        const filter = makeFieldFilterSet({ field1: ['value1', null, 'value2'] }, [
+            { name: 'field1', type: 'string' as const },
+        ]);
+        const params = filter.toUrlSearchParams();
+        expect(params).toContainEqual(['field1', ['value1', '', 'value2']]);
+    });
+
+    it('does not convert regular string values', () => {
+        const filter = makeFieldFilterSet({ field1: 'someValue' }, [{ name: 'field1', type: 'string' as const }]);
+        const params = filter.toUrlSearchParams();
+        expect(params).toContainEqual(['field1', 'someValue']);
+    });
+});
 
 describe('DownloadUrlGenerator', () => {
     const organism = 'test-organism';
@@ -42,5 +81,18 @@ describe('DownloadUrlGenerator', () => {
         });
 
         expect(result.params.has('fields')).toBe(false);
+    });
+
+    it('includes null field values as empty string params in download URL', () => {
+        const generator = new DownloadUrlGenerator(organism, lapisUrl, dataUseTermsEnabled);
+        const filter = makeFieldFilterSet({ field1: null }, [{ name: 'field1', type: 'string' as const }]);
+
+        const result = generator.generateDownloadUrl(filter, {
+            dataType: { type: 'metadata', fields: [] },
+            includeRestricted: false,
+            compression: undefined,
+        });
+
+        expect(result.params.get('field1')).toBe('');
     });
 });

--- a/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadUrlGenerator.ts
@@ -93,11 +93,9 @@ export class DownloadUrlGenerator {
             .forEach(([name, value]) => {
                 if (Array.isArray(value)) {
                     value.forEach((val) => {
-                        if (val && val.length > 0) {
-                            params.append(name, val);
-                        }
+                        params.append(name, val);
                     });
-                } else if (value && value.length > 0) {
+                } else {
                     params.append(name, value);
                 }
             });

--- a/website/src/components/SearchPage/DownloadDialog/SequenceFilters.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/SequenceFilters.tsx
@@ -172,8 +172,10 @@ export class FieldFilterSet implements SequenceFilter {
 
             if (Array.isArray(value)) {
                 if (value.length > 0) {
-                    result.push([key, value]);
+                    result.push([key, value.map((v: any) => (v === null ? '' : v))]);
                 }
+            } else if (value === null) {
+                result.push([key, '']);
             } else {
                 const stringValue = String(value);
                 const trimmedValue = stringValue.trim();


### PR DESCRIPTION
…arams

When building GET request URLs (e.g. LAPIS download URLs), null field values were being converted to the literal string "null" via String(null) instead of empty strings. LAPIS interprets empty string params as "field is null" for GET requests, whereas the string "null" would search for the literal text "null".

The fix converts null values to empty strings in
FieldFilterSet.toUrlSearchParams() and updates DownloadUrlGenerator to allow empty string values through (previously filtered by truthiness check).

https://claude.ai/code/session_017kbxfHYZZzyhUvVgEfyEeG

resolves #

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://claude-fix-null-get-param.loculus.org