### PR TITLE
fix(website): redirect seqset URLs without version to latest version

### DIFF
--- a/website/src/pages/seqsets/[seqSetId].astro
+++ b/website/src/pages/seqsets/[seqSetId].astro
@@ -1,6 +1,9 @@
 ---
 import { getRuntimeConfig, seqSetsAreEnabled } from '../../config';
+import { getInstanceLogger } from '../../logger';
 import { seqSets } from '../../types/seqSetCitation';
+
+const logger = getInstanceLogger('seqSetRedirect');
 
 if (!seqSetsAreEnabled()) {
     return Astro.rewrite('/404');
@@ -18,8 +21,8 @@ try {
             return Astro.redirect(`/seqsets/${seqSetId}.${latestVersion}`);
         }
     }
-} catch {
-    // Fall through to 404
+} catch (error) {
+    logger.error(`Failed to fetch versions for seqset ${seqSetId}: ${error}`);
 }
 
 return Astro.rewrite('/404');


### PR DESCRIPTION
## Summary

Fixes #2602

When visiting a SeqSet URL without a version (e.g. `/seqsets/LOC_SS_1`), the page previously always redirected to version 1 (`/seqsets/LOC_SS_1.1`). This change fetches all versions from the backend (by omitting the `version` query parameter) and redirects to the latest one. If the seqset doesn't exist, it returns a 404.

## Test plan

Verified on preview:

| Test | URL | Expected | Result |
|---|---|---|---|
| Redirect to latest | [/seqsets/LOC_SS_1](https://fix-seqset-redirect-lates.loculus.org/seqsets/LOC_SS_1) | Redirect to `.2` | Redirects to `/seqsets/LOC_SS_1.2` |
| Direct versioned URL | [/seqsets/LOC_SS_1.1](https://fix-seqset-redirect-lates.loculus.org/seqsets/LOC_SS_1.1) | Stay on `.1` | Stays on `/seqsets/LOC_SS_1.1` |
| Non-existent seqset | [/seqsets/LOC_SS_DOESNOTEXIST](https://fix-seqset-redirect-lates.loculus.org/seqsets/LOC_SS_DOESNOTEXIST) | 404 | Shows 404 page |

🚀 Preview: Add `preview` label to enable