### PR TITLE
feat(deployment): give silo-importer silo-preprocessing resource limits

### DIFF
--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1728,7 +1728,7 @@
         "keycloak": { "$ref": "#/definitions/resourceSpec" },
         "silo": { "$ref": "#/definitions/resourceSpec" },
         "lapis": { "$ref": "#/definitions/resourceSpec" },
-        "silo-preprocessing": { "$ref": "#/definitions/resourceSpec" },
+        "silo-importer": { "$ref": "#/definitions/resourceSpec" },
         "backend": { "$ref": "#/definitions/resourceSpec" },
         "preprocessing": { "$ref": "#/definitions/resourceSpec" },
         "organismSpecific": {
@@ -1746,7 +1746,7 @@
                 "keycloak": { "$ref": "#/definitions/resourceSpec" },
                 "silo": { "$ref": "#/definitions/resourceSpec" },
                 "lapis": { "$ref": "#/definitions/resourceSpec" },
-                "silo-preprocessing": { "$ref": "#/definitions/resourceSpec" },
+                "silo-importer": { "$ref": "#/definitions/resourceSpec" },
                 "backend": { "$ref": "#/definitions/resourceSpec" },
                 "preprocessing": { "$ref": "#/definitions/resourceSpec" }
               },

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2427,7 +2427,7 @@ resources:
       cpu: "100m"
     limits:
       memory: "5Gi"
-  silo-preprocessing:
+  silo-importer:
     requests:
       memory: "20Mi"
       cpu: "20m"

--- a/kubernetes/loculus/values_preview_server.yaml
+++ b/kubernetes/loculus/values_preview_server.yaml
@@ -110,7 +110,7 @@ resources:
       cpu: "30m"
     limits:
       memory: "5Gi"
-  silo-preprocessing:
+  silo-importer:
     requests:
       memory: "10Mi"
       cpu: "5m"


### PR DESCRIPTION
I realized we removed the silo-preprocessing pod but didnt update our resource limits

PPX pr: https://github.com/pathoplexus/pathoplexus/pull/829

🚀 Preview: Add `preview` label to enable