### PR TITLE
feat(website): improve reference selection text in dropdown

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx
@@ -398,7 +398,7 @@ describe('DownloadDialog', () => {
 
             expect(
                 screen.getByText(
-                    'Select a genotype for the segment: L (segment) with the search UI to enable download of more aligned sequences.',
+                    'No genotype has been selected for the segment: L (segment). Select one in the search UI to enable download of aligned sequences for these segments.',
                     { exact: false },
                 ),
             ).toBeVisible();

--- a/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
@@ -263,8 +263,8 @@ export const DownloadForm: FC<DownloadFormProps> = ({
                     !allReferencesSelected(referenceGenomesInfo, selectedReferenceNames) &&
                     referenceIdentifierField !== undefined && (
                         <div className='text-sm text-gray-400 mt-4 max-w-60'>
-                            No {referenceIdentifierField} has been selected for the {notSelectedSegmentsText}. Select one in the search UI to
-                            enable download of aligned sequences for these segments.
+                            No {referenceIdentifierField} has been selected for the {notSelectedSegmentsText}. Select
+                            one in the search UI to enable download of aligned sequences for these segments.
                         </div>
                     )}
             </div>


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/6046

### Screenshot
Old:
<img width="704" height="436" alt="image" src="https://github.com/user-attachments/assets/93ed19a5-491f-4dbd-b305-68c1c2e0d529" />
New:
<img width="704" height="436" alt="image" src="https://github.com/user-attachments/assets/134222e1-fd3a-4acf-b625-170fc23f1e93" />
when only one left to select:
<img width="704" height="494" alt="image" src="https://github.com/user-attachments/assets/14cc0dca-8163-44cb-a643-51cde2aa973a" />



### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://improve-dropdown.loculus.org