### PR TITLE
fix(docs): Updated NDJSON link as ndjson.org site is domain squatted

### DIFF
--- a/preprocessing/specification.md
+++ b/preprocessing/specification.md
@@ -34,7 +34,7 @@ Also see the Swagger UI available in the backend at `<backendUrl>/swagger-ui/ind
 
 ### Pulling unpreprocessed data
 
-To retrieve unpreprocessed data, the preprocessing pipeline sends a POST request to the backend's `/extract-unprocessed-data` with the request parameter `numberOfSequenceEntries` (integer) and `pipelineVersion` (integer). This returns a response in [NDJSON](http://ndjson.org/) containing at most the specified number of sequence entries. If there are no entries that require preprocessing, an empty file is returned.
+To retrieve unpreprocessed data, the preprocessing pipeline sends a POST request to the backend's `/extract-unprocessed-data` with the request parameter `numberOfSequenceEntries` (integer) and `pipelineVersion` (integer). This returns a response in [NDJSON](https://github.com/ndjson/ndjson-spec) containing at most the specified number of sequence entries. If there are no entries that require preprocessing, an empty file is returned.
 
 In the unprocessed NDJSON, each line contains a sequence entry represented as a JSON object and looks as follows:
 


### PR DESCRIPTION
The `ndjson.org` website domain expired, and is now being domain squatted (mentioned here: https://github.com/ndjson/ndjson.github.io/issues/24)

This PR changes the link to the GitHub page for the specification: https://github.com/ndjson/ndjson-spec 

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable