### PR TITLE
docs: add funding section

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -62,6 +62,20 @@ import members from '../../team.json';
   small={true}
 />
 
+## Funding
+
+This project has received funding from NIH<span class="align-super text-xs">1</span> through the [Pathogen Data Network](https://pathogendatanetwork.org/) and [swissuniversities](https://www.swissuniversities.ch/) through the Programme Open Science.
+
+<p>
+  <small>
+    <span class='align-super'>1</span> This resource is supported by the National Institute Of Allergy And Infectious
+    Diseases of the National Institutes of Health under Award Number
+    [U24AI183840](https://reporter.nih.gov/search/JHbtQB-XeUu8wvs3vUlFFw/project-details/10913643). The content is
+    solely the responsibility of the authors and does not necessarily represent the official views of the National
+    Institutes of Health.
+  </small>
+</p>
+
 ## Contact
 
 If you found a bug or would like to suggest a feature, you are very welcome to [open an issue on GitHub](https://github.com/loculus-project/loculus/issues). For other inquiries, please reach out to one of the [team members](#team).


### PR DESCRIPTION
This adds a funding section to the landing page. Please feel free to directly add additional funding sources!

### Screenshot

<img width="1102" height="193" alt="image" src="https://github.com/user-attachments/assets/f75b97d5-29ca-4e9f-a066-d2ee9c67b969" />

🚀 Preview: Add `preview` label to enable