### PR TITLE
chore(kubernetes): LAPIS 0.6.3 -> 0.6.8

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2364,7 +2364,7 @@ images:
     pullPolicy: Always
   lapis:
     repository: "ghcr.io/genspectrum/lapis"
-    tag: "v0.6.7@sha256:81907c25d22ae34da467a022c7e2e3c3e30131a189f701196584f181cced3b25"
+    tag: "v0.6.8@sha256:6a18b82d554ea05ba58ff8630cc74cba17d07d798665f41a8a87edc9402987a2"
     pullPolicy: Always
   website:
     repository: "ghcr.io/loculus-project/website"


### PR DESCRIPTION
There is nothing that really affects Loculus, but some nice new features:
* new endpoint `/llms.txt` that provides a markdown file that LLM agents can use to understand how to use that LAPIS instance (feedback is appreciated if this is useful and whether we can improve it!)
* new endpoint `/query/parse` that can be used to validate advanced queries
* allow configuring an OAuth provider to protect access to LAPIS (requires a JWT then). I tested this with the Loculus Keycloak of the main deployment and it seemed to work.

# LAPIS changelog

## [0.6.8](https://github.com/GenSpectrum/LAPIS/compare/v0.6.7...v0.6.8) (2026-03-05)


### Bug Fixes

* **lapis:** reliably serve whole llms.txt - only flush the response when it did compress ([#1576](https://github.com/GenSpectrum/LAPIS/issues/1576)) ([5745897](https://github.com/GenSpectrum/LAPIS/commit/574589716cc48cdf18420aaba9cbf57734357992))


## [0.6.7](https://github.com/GenSpectrum/LAPIS/compare/v0.6.6...v0.6.7) (2026-03-03)


### Features

* **lapis-e2e:** add more testing for advanced variant queries ([#1558](https://github.com/GenSpectrum/LAPIS/issues/1558)) ([192b634](https://github.com/GenSpectrum/LAPIS/commit/192b634b8e0f0a56410ddba81cbda3afd6ad6250))
* **lapis:** add `llms.txt` - instructions for LLM agents that use a LAPIS instance ([#1553](https://github.com/GenSpectrum/LAPIS/issues/1553)) ([ef6494c](https://github.com/GenSpectrum/LAPIS/commit/ef6494c4e25e278292b3608a3efc5a7670c34eb3))


### Bug Fixes

* **lapis:** advanced queries: allow ambiguous mutation symbols in "mutation from", disallow `.` and `-` in insertions ([#1549](https://github.com/GenSpectrum/LAPIS/issues/1549)) ([244a289](https://github.com/GenSpectrum/LAPIS/commit/244a28993dbd185be94f522ea4e11d404fb64147))

## [0.6.6](https://github.com/GenSpectrum/LAPIS/compare/v0.6.5...v0.6.6) (2026-02-18)


### Features

* new query parse endpoint ([#1531](https://github.com/GenSpectrum/LAPIS/issues/1531)) ([03cdd6a](https://github.com/GenSpectrum/LAPIS/commit/03cdd6a519242be6ccf61ed45a114493351cf09b))

## [0.6.5](https://github.com/GenSpectrum/LAPIS/compare/v0.6.4...v0.6.5) (2026-02-17)


### Features

* **lapis:** make it possible to protect a LAPIS instance by OAuth to require user login before accessing the data ([#1521](https://github.com/GenSpectrum/LAPIS/issues/1521)) ([5f9d764](https://github.com/GenSpectrum/LAPIS/commit/5f9d76414ae1f34d29fc0bf177ca2b582a240067)), closes [#251](https://github.com/GenSpectrum/LAPIS/issues/251)
* **lapis:** support `filename*` with UTF-8 character encoding ([#1532](https://github.com/GenSpectrum/LAPIS/issues/1532)) ([b375e8a](https://github.com/GenSpectrum/LAPIS/commit/b375e8ae39f95da310d059dcc615b765755d99e0))


### Bug Fixes

* **lapis:** throw 'bad request' error when queries are malformed ([#1534](https://github.com/GenSpectrum/LAPIS/issues/1534)) ([786a6ca](https://github.com/GenSpectrum/LAPIS/commit/786a6caab6b383b21a3c32743f7e932bbf653034))

## [0.6.4](https://github.com/GenSpectrum/LAPIS/compare/v0.6.3...v0.6.4) (2026-01-14)


### Features

* **lapis:** add new endpoint `/component/queriesOverTime` ([#1496](https://github.com/GenSpectrum/LAPIS/issues/1496)) ([6a9597c](https://github.com/GenSpectrum/LAPIS/commit/6a9597cda9a114568e020336ad6549abef9b3c2d))
* **lapis:** remove `protected` OpennessLevel ([#1499](https://github.com/GenSpectrum/LAPIS/issues/1499)) ([f1d24c5](https://github.com/GenSpectrum/LAPIS/commit/f1d24c585a45c5c45013bc9dd231e1b0e0ded244))

### PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
  - I clicked around on the search and details pages, everything seems to work
  - Downloading files works

🚀 Preview: https://lapis0-6-7.loculus.org