### PR TITLE
feat(website): show sequence specific filters without requiring an associated segment

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1863,7 +1863,6 @@ defaultOrganisms:
       metadataAdd:
         - name: hostNameScientific
           displayName: Host name - scientific
-          isSequenceFilter: true # revert after testing
           generateIndex: true
           autocomplete: true
           customDisplay:


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/5993

### Screenshot
<img width="580" height="514" alt="image" src="https://github.com/user-attachments/assets/754b8f1c-73f4-4f36-93f5-6f342ed396f5" />

tested on preview, integration tests are failing due to issues with pulling the docker images - I will restart them

🚀 Preview: https://allowsequencedatawithouts.loculus.org