### PR TITLE
feat(website): add blockquote styling to MdLayout

### DIFF
--- a/website/src/pages/-testpage/index.mdx
+++ b/website/src/pages/-testpage/index.mdx
@@ -19,3 +19,5 @@ are great
 and `commands`
 
 [Link](http://google.com)
+
+> This is a blockquote example for testing styling.

--- a/website/src/styles/mdcontainer.scss
+++ b/website/src/styles/mdcontainer.scss
@@ -134,6 +134,10 @@
     @apply text-lg font-semibold text-main my-3 border-t border-gray-300 mt-7 pt-5 mb-0;
 }
 
+.mdContainer blockquote {
+    @apply my-4 pl-4 border-l-4 border-gray-300 text-gray-600 italic;
+}
+
 .astro-code {
     @apply p-2;
 }


### PR DESCRIPTION
[Note from Theo: no strong feelings on italic or not]

## Summary

Blockquotes in markdown pages rendered with MdLayout previously had no styling, making them visually indistinct from regular text. This adds styling to `.mdContainer blockquote` in `mdcontainer.scss`:

- **Left border**: 4px solid gray left border (`border-l-4 border-gray-300`), consistent with gray tones used for tables and other elements
- **Text color**: Muted gray (`text-gray-600`) to visually distinguish from body text
- **Italic**: Standard blockquote convention
- **Spacing**: Vertical margin and left padding for readability

Also adds a blockquote example to the `-testpage` so the styling can be previewed.

### Screenshot

![Blockquote styling on test page](https://raw.githubusercontent.com/loculus-project/agent_store/main/blockquote-styling-pr6113.png)

## Test plan

- [ ] Visit `/-testpage` and verify the blockquote renders with the left border, muted color, and italic styling
- [ ] Verify existing elements on the page (headings, lists, code blocks, links) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)