### PR TITLE
feat(website): for fields of type float and int only allow single choice

### DIFF
--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -432,6 +432,7 @@ const SearchField = ({ field, lapisUrl, fieldValues, setSomeFieldValues, lapisSe
                     return (
                         <SingleChoiceAutoCompleteField
                             field={field}
+                            fieldValue={validateSingleValue(fieldValues[field.name], field.name)}
                             setSomeFieldValues={setSomeFieldValues}
                             optionsProvider={{
                                 type: 'generic',


### PR DESCRIPTION
resolves issue found on slack: https://loculus.slack.com/archives/C05G172HL6L/p1773316824073099

do not allow selection of multiple options for int and float fields as LAPIS does not allow multiple choices for these fields, leading the page to show an ugly failure message

### Screenshot
<img width="528" height="438" alt="image" src="https://github.com/user-attachments/assets/ba39b1b2-2f75-4074-962f-e0fc4ad19c1c" />

🚀 Preview: https://singlechoicenumberfields.loculus.org