### PR TITLE
fix(silo-import): correct RecordCountMismatchError message

### DIFF
--- a/loculus-silo/src/silo_import/errors.py
+++ b/loculus-silo/src/silo_import/errors.py
@@ -26,7 +26,7 @@ class RecordCountMismatchError(SkipRunError):
     """Mismatch between expected and actual record count."""
 
     def __init__(self, new_etag: str | None = None) -> None:
-        super().__init__("New payload matches the previous run's hash.")
+        super().__init__("Mismatch between expected and actual record count.")
         self.new_etag = new_etag
 
 


### PR DESCRIPTION
## Bug

fixes https://github.com/loculus-project/loculus/issues/6141

[Issue #6141](https://github.com/loculus-project/loculus/issues/6141) — RecordCountMismatchError has copy-pasted error message from HashUnchangedError

## Fix
Changed the error message in RecordCountMismatchError from "New payload matches the previous run's hash." to "Mismatch between expected and actual record count." to match the class docstring and actual error condition.

## Testing
Verified the error message now correctly describes the actual error condition when record count mismatches occur in the SILO importer.

Happy to address any feedback.

Greetings, saschabuehrle

🚀 Preview: Add `preview` label to enable