### PR TITLE
fix(backend): use joinToString(", ") instead of joinToString { ", " } in error messages

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/AccessionPreconditionValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/AccessionPreconditionValidator.kt
@@ -163,7 +163,7 @@ class AccessionPreconditionValidator(
                     "Accession versions have errors: " +
                         sequenceEntriesWithErrors.map {
                             "${it[SequenceEntriesView.accessionColumn]}.${it[SequenceEntriesView.versionColumn]}"
-                        }.joinToString { ", " },
+                        }.joinToString(", "),
                 )
             }
             return this

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ApproveProcessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ApproveProcessedDataEndpointTest.kt
@@ -337,7 +337,7 @@ class ApproveProcessedDataEndpointTest(
     }
 
     @Test
-    fun `WHEN approving sequences with errors THEN an error is raised`() {
+    fun `WHEN approving sequences with errors THEN an error is raised with the accession version in the message`() {
         val submittedSequences =
             convenienceClient.prepareDefaultSequenceEntriesToInProcessing()
         val accessionOfDataWithErrors = submittedSequences[0].accession
@@ -350,6 +350,13 @@ class ApproveProcessedDataEndpointTest(
             accessionVersionsFilter = listOf(AccessionVersion(accessionOfDataWithErrors, 1)),
         )
             .andExpect(status().isUnprocessableEntity)
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(
+                jsonPath(
+                    "$.detail",
+                    containsString("$accessionOfDataWithErrors.1"),
+                ),
+            )
 
         convenienceClient.getSequenceEntry(accession = accessionOfDataWithErrors, version = 1)
             .assertStatusIs(PROCESSED)


### PR DESCRIPTION
## Summary

`joinToString { ", " }` in `AccessionPreconditionValidator.andThatSequenceEntriesHaveNoErrors()` used Kotlin trailing lambda syntax, which passes the lambda as the **transform** parameter — replacing every accession version string with the literal `", "`. This made the error message `"Accession versions have errors: , "` instead of listing the actual accession versions.

The one-character fix changes `{ ", " }` (curly braces = transform lambda) to `(", ")` (parentheses = separator argument).

The existing test only checked for `isUnprocessableEntity` status. The updated test now also asserts that the error response body contains the actual accession version, which fails before the fix and passes after.

**Before:** `"Accession versions have errors: , "`  
**After:** `"Accession versions have errors: LOC_000001Y.1"`

## Test plan

- [x] Added assertion to existing test `WHEN approving sequences with errors THEN an error is raised` that verifies the accession version appears in the error message
- [x] Confirmed the test fails before the fix (error message was `", "`)
- [x] Confirmed the test passes after the fix
- [x] ktlintFormat passes

Resolves #6140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable