### PR TITLE
fix: correct joinToString usage in error messages

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/AccessionPreconditionValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/AccessionPreconditionValidator.kt
@@ -163,7 +163,7 @@ class AccessionPreconditionValidator(
                     "Accession versions have errors: " +
                         sequenceEntriesWithErrors.map {
                             "${it[SequenceEntriesView.accessionColumn]}.${it[SequenceEntriesView.versionColumn]}"
-                        }.joinToString { ", " },
+                        }.joinToString(", "),
                 )
             }
             return this


### PR DESCRIPTION
## Bug
[Issue #6140](https://github.com/loculus-project/loculus/issues/6140) — joinToString misuse in SubmissionDatabaseService discards accession versions in error messages

## Fix
Changed `joinToString { ", " }` to `joinToString(", ")` in AccessionPreconditionValidator. The curly brace syntax passes the lambda as a transform parameter, replacing each element with the literal string ", ", instead of using it as the separator.

## Testing
Error messages will now correctly display accession versions like "LOC_00001.1, LOC_00002.1" instead of just ", , , ".

Happy to address any feedback.

Greetings, saschabuehrle

🚀 Preview: Add `preview` label to enable