### PR TITLE
chore(website): remove unused second test group

### DIFF
--- a/website/vitest.setup.ts
+++ b/website/vitest.setup.ts
@@ -330,18 +330,6 @@ export const testGroups: Group[] = [
             country: 'Switzerland',
         },
     },
-    {
-        groupId: 1,
-        groupName: 'Group2',
-        institution: 'Institution 2',
-        contactEmail: 'group2@institution2.org',
-        address: {
-            line1: '',
-            city: '',
-            postalCode: '',
-            country: 'Switzerland',
-        },
-    },
 ];
 
 export const mockRequest = {


### PR DESCRIPTION
This was unused and had a "bug" in that it duplicated the id of the first test group

🚀 Preview: Add `preview` label to enable