### PR TITLE
feat(prepro): remove --max-target-seqs param

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/nextclade.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/nextclade.py
@@ -228,8 +228,6 @@ def run_diamond(
             "blastx",
             "--query",
             input_file,
-            "--max-target-seqs",
-            "1",
             "--db",
             dataset_dir + "/diamond/diamond.dmnd",
             "--out",


### PR DESCRIPTION
See https://loculus.slack.com/archives/C0A2N1Y9WDC/p1771827625400529 for details

According to the docs: https://github.com/bbuchfink/diamond/wiki/3.-Command-line-options

## --max-target-seqs/-k

The maximum number of target sequences per query to report alignments for (default=25). Setting this to -k0 will report all targets for which alignments were found.

Note that this parameter does not only affect the reporting, but also the algorithm as it is taken into account for heuristics that eliminate hits prior to full gapped extension.

-> this was causing sequences with a large number of Ns to be misassigned to the wrong subtype. Instead we should keep all and then choose the reference with the highest `pident` (number of matches): we already do this

🚀 Preview: Add `preview` label to enable