### PR TITLE
fix(workflows): correct filepath in ena-submission-image workflow

### DIFF
--- a/.github/workflows/ena-submission-image.yaml
+++ b/.github/workflows/ena-submission-image.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Generate files hash
         id: files-hash
         run: |
-          DIR_HASH=$(echo -n ${{ hashFiles('ena-submission/**', '.github/workflows/ena-submission-image.yml') }})
+          DIR_HASH=$(echo -n ${{ hashFiles('ena-submission/**', '.github/workflows/ena-submission-image.yaml') }})
           echo "DIR_HASH=$DIR_HASH${{ env.BUILD_ARM == 'true' && '-arm' || '' }}" >> $GITHUB_ENV
       - name: Setup Docker metadata
         id: dockerMetadata


### PR DESCRIPTION
An incorrect filepath was passed to `hashFiles()` in the ena-submission-image workflow. 

As far as I can tell, `hashFiles()` will just compute the hash using the other files that were correctly specified, silently ignoring the incorrect path. This means the image was not being rebuilt when the workflow file changed.

(I did a quick pass of other places we use `hashFiles()`, there the paths seem to be in order)

### PR Checklist
~- [ ] All necessary documentation has been adapted.~
~- [ ] The implemented feature is covered by appropriate, automated tests.~
~- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~

🚀 Preview: Add `preview` label to enable