### PR TITLE
refactor(backend): move revocation versionComment from dedicated column to metadata

### DIFF
--- a/backend/docs/db/schema.sql
+++ b/backend/docs/db/schema.sql
@@ -427,7 +427,6 @@ CREATE TABLE public.sequence_entries (
     released_at timestamp without time zone,
     is_revocation boolean DEFAULT false NOT NULL,
     original_data jsonb,
-    version_comment text,
     unprocessed_data jsonb
 );
 
@@ -469,11 +468,11 @@ CREATE VIEW public.sequence_entries_view AS
     se.released_at,
     se.is_revocation,
     se.unprocessed_data,
-    se.version_comment,
     sepd.started_processing_at,
     sepd.finished_processing_at,
     sepd.processed_data,
         CASE
+            WHEN se.is_revocation THEN jsonb_build_object('metadata', COALESCE((se.unprocessed_data -> 'metadata'::text), '{}'::jsonb), 'unalignedNucleotideSequences', '{}'::jsonb, 'alignedNucleotideSequences', '{}'::jsonb, 'nucleotideInsertions', '{}'::jsonb, 'alignedAminoAcidSequences', '{}'::jsonb, 'aminoAcidInsertions', '{}'::jsonb, 'files', 'null'::jsonb)
             WHEN (aem.external_metadata IS NULL) THEN sepd.processed_data
             ELSE (sepd.processed_data || jsonb_build_object('metadata', ((sepd.processed_data -> 'metadata'::text) || aem.external_metadata)))
         END AS joint_metadata,

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -166,14 +166,6 @@ open class ReleasedDataModel(
                 },
             ) +
             conditionalMetadata(
-                rawProcessedData.isRevocation,
-                {
-                    mapOf(
-                        "versionComment" to TextNode(rawProcessedData.versionComment),
-                    )
-                },
-            ) +
-            conditionalMetadata(
                 earliestReleaseDate != null,
                 {
                     mapOf(

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -52,6 +52,7 @@ import org.loculus.backend.api.FileIdAndNameAndReadUrl
 import org.loculus.backend.api.GeneticSequence
 import org.loculus.backend.api.GetSequenceResponse
 import org.loculus.backend.api.Organism
+import org.loculus.backend.api.OriginalData
 import org.loculus.backend.api.OriginalDataWithFileUrls
 import org.loculus.backend.api.PreprocessingStatus.IN_PROCESSING
 import org.loculus.backend.api.PreprocessingStatus.PROCESSED
@@ -743,7 +744,6 @@ class SubmissionDatabaseService(
             SequenceEntriesView.accessionColumn,
             SequenceEntriesView.versionColumn,
             SequenceEntriesView.isRevocationColumn,
-            SequenceEntriesView.versionCommentColumn,
             SequenceEntriesView.jointDataColumn,
             SequenceEntriesView.submitterColumn,
             SequenceEntriesView.groupIdColumn,
@@ -786,7 +786,6 @@ class SubmissionDatabaseService(
                     DataUseTermsType.fromString(it[DataUseTermsTable.dataUseTermsTypeColumn]),
                     it[DataUseTermsTable.restrictedUntilColumn],
                 ),
-                versionComment = it[SequenceEntriesView.versionCommentColumn],
                 dataUseTermsChangeDate = it[DataUseTermsTable.changeDateColumn],
             )
         }
@@ -962,16 +961,14 @@ class SubmissionDatabaseService(
 
         SequenceEntriesTable.insert(
             SequenceEntriesTable.select(
-                SequenceEntriesTable.accessionColumn, SequenceEntriesTable.versionColumn.plus(1),
-                when (versionComment) {
-                    null -> Op.nullOp()
-                    else -> stringParam(versionComment)
-                },
+                SequenceEntriesTable.accessionColumn,
+                SequenceEntriesTable.versionColumn.plus(1),
                 SequenceEntriesTable.submissionIdColumn,
                 stringParam(authenticatedUser.username),
                 SequenceEntriesTable.groupIdColumn,
                 dateTimeParam(dateProvider.getCurrentDateTime()),
-                booleanParam(true), SequenceEntriesTable.organismColumn,
+                booleanParam(true),
+                SequenceEntriesTable.organismColumn,
             ).where {
                 (
                     SequenceEntriesTable.accessionColumn inList
@@ -982,7 +979,6 @@ class SubmissionDatabaseService(
             columns = listOf(
                 SequenceEntriesTable.accessionColumn,
                 SequenceEntriesTable.versionColumn,
-                SequenceEntriesTable.versionCommentColumn,
                 SequenceEntriesTable.submissionIdColumn,
                 SequenceEntriesTable.submitterColumn,
                 SequenceEntriesTable.groupIdColumn,
@@ -991,6 +987,28 @@ class SubmissionDatabaseService(
                 SequenceEntriesTable.organismColumn,
             ),
         )
+
+        if (versionComment != null) {
+            log.debug { "Adding version comment for revocation: $versionComment" }
+            val metadata = mapOf("versionComment" to versionComment)
+            val originalData = compressionService.compressSequencesInOriginalData(
+                OriginalData(
+                    metadata = metadata,
+                    unalignedNucleotideSequences = emptyMap(),
+                ),
+                organism,
+            )
+            SequenceEntriesTable.update(
+                where = {
+                    (SequenceEntriesTable.accessionColumn inList accessions) and
+                        SequenceEntriesTable.isMaxVersion and
+                        (SequenceEntriesTable.isRevocationColumn eq true)
+                },
+            ) {
+                it[originalDataColumn] = originalData
+                it[unprocessedDataColumn] = originalData
+            }
+        }
 
         auditLogger.log(
             authenticatedUser.username,
@@ -1532,7 +1550,6 @@ data class RawProcessedData(
     override val accession: Accession,
     override val version: Version,
     val isRevocation: Boolean,
-    val versionComment: String?,
     val submitter: String,
     val groupId: Int,
     val groupName: String,

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -12,6 +12,7 @@ import org.jetbrains.exposed.sql.Count
 import org.jetbrains.exposed.sql.JoinType
 import org.jetbrains.exposed.sql.LongColumnType
 import org.jetbrains.exposed.sql.Op
+import org.jetbrains.exposed.sql.QueryParameter
 import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.less
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.plus
@@ -959,6 +960,13 @@ class SubmissionDatabaseService(
                 .andThatOrganismIs(organism)
         }
 
+        val metadata = versionComment?.let { mapOf("versionComment" to it) } ?: emptyMap()
+        val originalData = compressionService.compressSequencesInOriginalData(
+            OriginalData(metadata = metadata, unalignedNucleotideSequences = emptyMap()),
+            organism,
+        )
+        val originalDataParam = QueryParameter(originalData, SequenceEntriesTable.originalDataColumn.columnType)
+
         SequenceEntriesTable.insert(
             SequenceEntriesTable.select(
                 SequenceEntriesTable.accessionColumn,
@@ -969,6 +977,8 @@ class SubmissionDatabaseService(
                 dateTimeParam(dateProvider.getCurrentDateTime()),
                 booleanParam(true),
                 SequenceEntriesTable.organismColumn,
+                originalDataParam,
+                originalDataParam,
             ).where {
                 (
                     SequenceEntriesTable.accessionColumn inList
@@ -985,30 +995,10 @@ class SubmissionDatabaseService(
                 SequenceEntriesTable.submittedAtTimestampColumn,
                 SequenceEntriesTable.isRevocationColumn,
                 SequenceEntriesTable.organismColumn,
+                SequenceEntriesTable.originalDataColumn,
+                SequenceEntriesTable.unprocessedDataColumn,
             ),
         )
-
-        if (versionComment != null) {
-            log.debug { "Adding version comment for revocation: $versionComment" }
-            val metadata = mapOf("versionComment" to versionComment)
-            val originalData = compressionService.compressSequencesInOriginalData(
-                OriginalData(
-                    metadata = metadata,
-                    unalignedNucleotideSequences = emptyMap(),
-                ),
-                organism,
-            )
-            SequenceEntriesTable.update(
-                where = {
-                    (SequenceEntriesTable.accessionColumn inList accessions) and
-                        SequenceEntriesTable.isMaxVersion and
-                        (SequenceEntriesTable.isRevocationColumn eq true)
-                },
-            ) {
-                it[originalDataColumn] = originalData
-                it[unprocessedDataColumn] = originalData
-            }
-        }
 
         auditLogger.log(
             authenticatedUser.username,

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/dbtables/SequenceEntriesTable.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/dbtables/SequenceEntriesTable.kt
@@ -24,7 +24,6 @@ object SequenceEntriesTable : Table(SEQUENCE_ENTRIES_TABLE_NAME) {
 
     val accessionColumn = varchar("accession", 255)
     val versionColumn = long("version")
-    val versionCommentColumn = varchar("version_comment", 255).nullable()
     val organismColumn = varchar("organism", 255)
     val submissionIdColumn = varchar("submission_id", 255)
     val submitterColumn = varchar("submitter", 255)

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/dbtables/SequenceEntriesView.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/dbtables/SequenceEntriesView.kt
@@ -45,7 +45,6 @@ object SequenceEntriesView : Table(SEQUENCE_ENTRIES_VIEW_NAME) {
     val statusColumn = varchar("status", 255)
     val processingResultColumn = varchar("processing_result", 255).nullable()
     val isRevocationColumn = bool("is_revocation").default(false)
-    val versionCommentColumn = varchar("version_comment", 255).nullable()
     val errorsColumn = jacksonSerializableJsonb<List<PreprocessingAnnotation>>("errors").nullable()
     val warningsColumn = jacksonSerializableJsonb<List<PreprocessingAnnotation>>("warnings").nullable()
     val pipelineVersionColumn = long("pipeline_version").nullable()

--- a/backend/src/main/resources/db/migration/V1.27__move_version_comment_to_metadata.sql
+++ b/backend/src/main/resources/db/migration/V1.27__move_version_comment_to_metadata.sql
@@ -1,0 +1,108 @@
+-- Moves revocation versionComment from the dedicated version_comment column
+-- into the unprocessed_data JSONB metadata, and updates the view to automatically
+-- construct joint_metadata for revocations from unprocessed_data.
+-- This unifies how versionComment is stored for both revisions and revocations.
+
+-- Step 1: For existing revocations with non-null version_comment and no unprocessed_data,
+-- create unprocessed_data with versionComment in metadata
+UPDATE sequence_entries
+SET unprocessed_data = jsonb_build_object(
+    'metadata', jsonb_build_object('versionComment', version_comment),
+    'unalignedNucleotideSequences', '{}'::jsonb
+)
+WHERE is_revocation = true AND version_comment IS NOT NULL AND unprocessed_data IS NULL;
+
+-- For revocations that already have unprocessed_data (unlikely but safe),
+-- merge versionComment into existing metadata
+UPDATE sequence_entries
+SET unprocessed_data = jsonb_set(
+    unprocessed_data,
+    '{metadata}',
+    COALESCE(unprocessed_data -> 'metadata', '{}'::jsonb) || jsonb_build_object('versionComment', version_comment)
+)
+WHERE is_revocation = true AND version_comment IS NOT NULL AND unprocessed_data IS NOT NULL;
+
+-- Step 1b: Ensure all revocations have unprocessed_data (even those without version_comment)
+UPDATE sequence_entries
+SET unprocessed_data = jsonb_build_object(
+    'metadata', '{}'::jsonb,
+    'unalignedNucleotideSequences', '{}'::jsonb
+)
+WHERE is_revocation = true AND unprocessed_data IS NULL;
+
+-- Step 2: Drop the view (must be done before dropping the column)
+DROP VIEW IF EXISTS sequence_entries_view;
+
+-- Step 3: Drop the version_comment column
+ALTER TABLE sequence_entries DROP COLUMN version_comment;
+
+-- Step 4: Recreate the view without version_comment.
+-- For revocations, joint_metadata is constructed from unprocessed_data
+-- so versionComment survives pipeline version changes.
+CREATE VIEW sequence_entries_view AS
+SELECT
+    se.accession,
+    se.version,
+    se.organism,
+    se.submission_id,
+    se.submitter,
+    se.approver,
+    se.group_id,
+    se.submitted_at,
+    se.released_at,
+    se.is_revocation,
+    se.unprocessed_data,
+    sepd.started_processing_at,
+    sepd.finished_processing_at,
+    sepd.processed_data,
+    CASE
+        WHEN se.is_revocation THEN
+            jsonb_build_object(
+                'metadata', COALESCE(se.unprocessed_data -> 'metadata', '{}'::jsonb),
+                'unalignedNucleotideSequences', '{}'::jsonb,
+                'alignedNucleotideSequences', '{}'::jsonb,
+                'nucleotideInsertions', '{}'::jsonb,
+                'alignedAminoAcidSequences', '{}'::jsonb,
+                'aminoAcidInsertions', '{}'::jsonb,
+                'files', 'null'::jsonb
+            )
+        WHEN aem.external_metadata IS NULL THEN sepd.processed_data
+        ELSE sepd.processed_data ||
+            jsonb_build_object('metadata', (sepd.processed_data -> 'metadata') || aem.external_metadata)
+    END AS joint_metadata,
+    CASE
+        WHEN se.is_revocation THEN cpp.version
+        ELSE sepd.pipeline_version
+    END AS pipeline_version,
+    sepd.errors,
+    sepd.warnings,
+    CASE
+        WHEN se.released_at IS NOT NULL THEN 'APPROVED_FOR_RELEASE'
+        WHEN se.is_revocation THEN 'PROCESSED'
+        WHEN sepd.processing_status = 'IN_PROCESSING' THEN 'IN_PROCESSING'
+        WHEN sepd.processing_status = 'PROCESSED' THEN 'PROCESSED'
+        ELSE 'RECEIVED'
+    END AS status,
+    CASE
+        WHEN sepd.processing_status = 'IN_PROCESSING' THEN NULL
+        WHEN sepd.errors IS NOT NULL AND jsonb_array_length(sepd.errors) > 0 THEN 'HAS_ERRORS'
+        WHEN sepd.warnings IS NOT NULL AND jsonb_array_length(sepd.warnings) > 0 THEN 'HAS_WARNINGS'
+        ELSE 'NO_ISSUES'
+    END AS processing_result
+FROM sequence_entries se
+LEFT JOIN current_processing_pipeline cpp
+    ON se.organism = cpp.organism
+LEFT JOIN sequence_entries_preprocessed_data sepd
+    ON se.accession = sepd.accession
+    AND se.version = sepd.version
+    AND sepd.pipeline_version = cpp.version
+LEFT JOIN (
+    SELECT
+        em.accession,
+        em.version,
+        jsonb_merge_agg(em.external_metadata) AS external_metadata
+    FROM external_metadata em
+    GROUP BY em.accession, em.version
+) aem
+    ON aem.accession = se.accession
+    AND aem.version = se.version;

--- a/backend/src/test/kotlin/org/loculus/backend/utils/EarliestReleaseDateFinderTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/utils/EarliestReleaseDateFinderTest.kt
@@ -66,7 +66,6 @@ fun row(
         files = null,
     ),
     isRevocation = false,
-    versionComment = null,
     submitter = "foo",
     submissionId = "foo",
     submittedAtTimestamp = releasedAt,


### PR DESCRIPTION
## Summary

This PR unifies how `versionComment` is stored for revisions and revocations, addressing #3135.

**Problem:** Previously, `versionComment` was stored differently depending on the type of version entry:
- For **revisions**, it was stored as a metadata field in `originalData`, processed through the preprocessing pipeline, and ended up in `processedData.metadata`
- For **revocations**, it was stored in a dedicated `version_comment` column on the `sequence_entries` table, then manually merged into released data via special-case code in `ReleasedDataModel`

This inconsistency made the codebase harder to understand and maintain.

**Solution:** Following the approach suggested in #3135, this PR:

1. **Stores revocation `versionComment` in `originalData.metadata`** — When creating a revocation with a version comment, the comment is stored in the `originalData` JSONB column as a metadata entry, compressed using the standard compression service

2. **Automatically constructs `processedData` for revocations in the database view** — The `sequence_entries_view` is updated to build `joint_metadata` for revocations directly from `originalData.metadata`. This approach is pipeline-version-independent, meaning the versionComment survives processing pipeline version changes without needing to reprocess revocations

3. **Removes the dedicated `version_comment` column** — A migration (V1.26) copies existing `version_comment` values into `originalData.metadata` for all affected revocations, then drops the column

4. **Removes special-case code** — The `versionComment` field is removed from `RawProcessedData`, and the conditional metadata merging in `ReleasedDataModel` is removed. The versionComment now flows through the same path for both revisions and revocations

### Files changed

- **Migration `V1.26`**: Migrates existing data and recreates the view
- **`SubmissionDatabaseService.kt`**: `revoke()` now stores versionComment in `originalData`; `streamReleasedSubmissions()` no longer reads `versionCommentColumn`; `RawProcessedData` no longer has `versionComment` field
- **`SequenceEntriesTable.kt` / `SequenceEntriesView.kt`**: Remove `versionCommentColumn`
- **`ReleasedDataModel.kt`**: Remove conditional versionComment addition for revocations
- **`EarliestReleaseDateFinderTest.kt`**: Remove `versionComment` field from test data

### Key design decision

Rather than inserting into `sequence_entries_preprocessed_data` for revocations (which would be tied to a specific pipeline version and lost when the pipeline version changes), the view constructs `joint_metadata` directly from `originalData` for revocations. This means the versionComment is always available regardless of pipeline version changes, without needing to reprocess revocations.

## Test plan

- [x] Verify compilation passes (confirmed locally)
- [x] Verify lint passes (confirmed locally)
- [x] Run full backend test suite (requires PostgreSQL infrastructure)
- [x] Verify revocation with versionComment shows correctly in released data on preview
<img width="1592" height="315" alt="image" src="https://github.com/user-attachments/assets/b209a582-009a-467e-9bfe-cad196803b57" />

- [x] Verify revocation without versionComment still works
<img width="1348" height="276" alt="image" src="https://github.com/user-attachments/assets/9dc52101-40c1-4a5a-b37c-d498d1fb0575" />

(currently on main we also see None if this is empty - I think this is probably an issue with the website I assume it submits revocations with an empty string and not None, this isnt too important atm)
- [x] Verify revision versionComment is unaffected
<img width="651" height="784" alt="image" src="https://github.com/user-attachments/assets/439e9515-2eb1-4008-a763-2c35fcd0cbdb" />

- [x] Verify migration correctly moves existing version_comment values


🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: https://refactor-version-comment.loculus.org