### PR TITLE
feat(website): Add organism switch button to navigation submenu

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1306,7 +1306,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1339,7 +1338,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1372,7 +1370,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2838,7 +2835,6 @@
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.0.tgz",
             "integrity": "sha512-i0GV1yJnm2n3Yq1qw6QrUrd/LI9bE8WEBOTtOkpCXHHdyN3TAGgqAK/DAT05z4fq2x04cARXt2pDmjWjL92iTQ==",
-            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -2878,7 +2874,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2899,7 +2894,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2920,7 +2914,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2941,7 +2934,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2962,7 +2954,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2983,7 +2974,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3004,7 +2994,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3025,7 +3014,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3046,7 +3034,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3067,7 +3054,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3088,7 +3074,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3109,7 +3094,6 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3130,7 +3114,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3148,7 +3131,6 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
             "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-            "dev": true,
             "license": "MIT",
             "optional": true
         },
@@ -7024,7 +7006,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
             "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "bin": {
@@ -15955,7 +15936,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -15972,7 +15952,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -15989,7 +15968,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16006,7 +15984,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16023,7 +16000,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16040,7 +16016,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16057,7 +16032,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16074,7 +16048,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16091,7 +16064,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16108,7 +16080,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16125,7 +16096,6 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16142,7 +16112,6 @@
             "cpu": [
                 "loong64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16159,7 +16128,6 @@
             "cpu": [
                 "mips64el"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16176,7 +16144,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16193,7 +16160,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16210,7 +16176,6 @@
             "cpu": [
                 "s390x"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16227,7 +16192,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16244,7 +16208,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16261,7 +16224,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16278,7 +16240,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16295,7 +16256,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16312,7 +16272,6 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16329,7 +16288,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16385,7 +16343,6 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1306,6 +1306,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1338,6 +1339,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1370,6 +1372,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2835,6 +2838,7 @@
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.0.tgz",
             "integrity": "sha512-i0GV1yJnm2n3Yq1qw6QrUrd/LI9bE8WEBOTtOkpCXHHdyN3TAGgqAK/DAT05z4fq2x04cARXt2pDmjWjL92iTQ==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -2874,6 +2878,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2894,6 +2899,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2914,6 +2920,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2934,6 +2941,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2954,6 +2962,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2974,6 +2983,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2994,6 +3004,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3014,6 +3025,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3034,6 +3046,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3054,6 +3067,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3074,6 +3088,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3094,6 +3109,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3114,6 +3130,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3131,6 +3148,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
             "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+            "dev": true,
             "license": "MIT",
             "optional": true
         },
@@ -7006,6 +7024,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
             "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "bin": {
@@ -15936,6 +15955,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -15952,6 +15972,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -15968,6 +15989,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -15984,6 +16006,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16000,6 +16023,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16016,6 +16040,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16032,6 +16057,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16048,6 +16074,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16064,6 +16091,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16080,6 +16108,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16096,6 +16125,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16112,6 +16142,7 @@
             "cpu": [
                 "loong64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16128,6 +16159,7 @@
             "cpu": [
                 "mips64el"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16144,6 +16176,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16160,6 +16193,7 @@
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16176,6 +16210,7 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16192,6 +16227,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16208,6 +16244,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16224,6 +16261,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16240,6 +16278,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16256,6 +16295,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16272,6 +16312,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16288,6 +16329,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -16343,6 +16385,7 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,

--- a/website/src/components/Navigation/OrganismNavigation.tsx
+++ b/website/src/components/Navigation/OrganismNavigation.tsx
@@ -16,7 +16,7 @@ export const OrganismNavigation: React.FC<OrganismNavigationProps> = ({ currentO
 
     return (
         <Menu as='div' className='relative'>
-            <MenuButton as={NavigationTab} isActive={!!currentOrganism} className='group'>
+            <MenuButton as={NavigationTab} isActive={!!currentOrganism} className='group' data-organism-menu-button>
                 <span>{displayName}</span>
                 {currentOrganism && (
                     <span className='hidden lg:inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full bg-primary-50 text-primary-700 border border-primary-200'>

--- a/website/src/components/Navigation/OrganismNavigation.tsx
+++ b/website/src/components/Navigation/OrganismNavigation.tsx
@@ -15,8 +15,8 @@ export const OrganismNavigation: React.FC<OrganismNavigationProps> = ({ currentO
     const displayName = 'Organisms';
 
     return (
-        <Menu as='div' className='relative'>
-            <MenuButton as={NavigationTab} isActive={!!currentOrganism} className='group' data-organism-menu-button>
+        <Menu as='div' className='relative' id='organism-menu'>
+            <MenuButton as={NavigationTab} isActive={!!currentOrganism} className='group'>
                 <span>{displayName}</span>
                 {currentOrganism && (
                     <span className='hidden lg:inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full bg-primary-50 text-primary-700 border border-primary-200'>

--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -1,10 +1,10 @@
 ---
 import { SubmenuLink } from './SubmenuLink.tsx';
+import { mainTailwindColor } from '../../../colors.json';
 import type { Organism } from '../../config';
 import { extraSequenceRelatedTopNavigationItems } from '../../routes/extraTopNavigationItems';
 import { getSequenceRelatedItems } from '../../routes/navigationItems';
 import FaExchangeAlt from '~icons/fa-solid/exchange-alt';
-import { mainTailwindColor } from '../../../colors.json';
 
 interface Props {
     currentOrganism?: string;

--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -108,32 +108,72 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
                 height: ${from.height}px;
                 left: ${from.left}px;
                 top: ${from.top}px;
-                transition: all 350ms cubic-bezier(0.4, 0, 0.2, 1);
-                filter: drop-shadow(0 0 4px ${primaryColor}) drop-shadow(0 0 8px ${primaryColor});
                 color: ${primaryColor};
+                filter: drop-shadow(0 0 3px ${primaryColor});
             `;
             wrapper.appendChild(flyingIcon);
             document.body.appendChild(wrapper);
 
-            requestAnimationFrame(() => {
-                wrapper.style.left = `${to.left + to.width / 2 - from.width / 2}px`;
-                wrapper.style.top = `${to.top + to.height / 2 - from.height / 2}px`;
-                wrapper.style.opacity = '0';
-                wrapper.style.filter = `drop-shadow(0 0 6px ${primaryColor}) drop-shadow(0 0 14px ${primaryColor})`;
-            });
+            // Animate using requestAnimationFrame for trail particles
+            const startX = from.left;
+            const startY = from.top;
+            const endX = to.left + to.width / 2 - from.width / 2;
+            const endY = to.top + to.height / 2 - from.height / 2;
+            const duration = 350;
+            const startTime = performance.now();
+            const trailInterval = 25;
+            let lastTrailTime = 0;
 
-            setTimeout(() => {
-                wrapper.remove();
-                menuButton.style.transition = 'box-shadow 150ms ease-in';
-                menuButton.style.boxShadow = `0 0 0 3px ${primaryColor}, 0 0 12px ${primaryColor}`;
-                setTimeout(() => {
-                    menuButton.style.boxShadow = '';
+            function animate(now: number) {
+                const elapsed = now - startTime;
+                const t = Math.min(elapsed / duration, 1);
+                // ease-out cubic
+                const ease = 1 - Math.pow(1 - t, 3);
+
+                const x = startX + (endX - startX) * ease;
+                const y = startY + (endY - startY) * ease;
+                wrapper.style.left = `${x}px`;
+                wrapper.style.top = `${y}px`;
+
+                // Spawn trail ghost
+                if (now - lastTrailTime > trailInterval && t < 0.95) {
+                    lastTrailTime = now;
+                    const ghost = document.createElement('div');
+                    ghost.innerHTML = icon!.outerHTML;
+                    ghost.style.cssText = `
+                        position: fixed;
+                        z-index: 2147483646;
+                        pointer-events: none;
+                        width: ${from.width}px;
+                        height: ${from.height}px;
+                        left: ${x}px;
+                        top: ${y}px;
+                        color: ${primaryColor};
+                        opacity: 0.5;
+                        transition: opacity 200ms ease-out;
+                    `;
+                    document.body.appendChild(ghost);
+                    requestAnimationFrame(() => { ghost.style.opacity = '0'; });
+                    setTimeout(() => ghost.remove(), 220);
+                }
+
+                if (t < 1) {
+                    requestAnimationFrame(animate);
+                } else {
+                    wrapper.remove();
+                    menuButton!.style.transition = 'box-shadow 150ms ease-in';
+                    menuButton!.style.boxShadow = `0 0 0 3px ${primaryColor}, 0 0 12px ${primaryColor}`;
                     setTimeout(() => {
-                        menuButton.style.transition = '';
-                        menuButton.click();
-                    }, 150);
-                }, 200);
-            }, 350);
+                        menuButton!.style.boxShadow = '';
+                        setTimeout(() => {
+                            menuButton!.style.transition = '';
+                            menuButton!.click();
+                        }, 150);
+                    }, 200);
+                }
+            }
+
+            requestAnimationFrame(animate);
         } else {
             window.dispatchEvent(new Event('open-sandwich-menu'));
         }

--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -90,6 +90,14 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
             const from = icon.getBoundingClientRect();
             const to = menuButton.getBoundingClientRect();
 
+            // Read the primary color from Tailwind for the trail and flash
+            const probe = document.createElement('span');
+            probe.className = 'text-primary';
+            probe.style.display = 'none';
+            document.body.appendChild(probe);
+            const primaryColor = getComputedStyle(probe).color;
+            probe.remove();
+
             const flyingIcon = icon.cloneNode(true) as SVGElement;
             const wrapper = document.createElement('div');
             wrapper.style.cssText = `
@@ -100,7 +108,9 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
                 height: ${from.height}px;
                 left: ${from.left}px;
                 top: ${from.top}px;
-                transition: all 300ms cubic-bezier(0.4, 0, 0.2, 1);
+                transition: all 350ms cubic-bezier(0.4, 0, 0.2, 1);
+                filter: drop-shadow(0 0 4px ${primaryColor}) drop-shadow(0 0 8px ${primaryColor});
+                color: ${primaryColor};
             `;
             wrapper.appendChild(flyingIcon);
             document.body.appendChild(wrapper);
@@ -109,15 +119,8 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
                 wrapper.style.left = `${to.left + to.width / 2 - from.width / 2}px`;
                 wrapper.style.top = `${to.top + to.height / 2 - from.height / 2}px`;
                 wrapper.style.opacity = '0';
+                wrapper.style.filter = `drop-shadow(0 0 6px ${primaryColor}) drop-shadow(0 0 14px ${primaryColor})`;
             });
-
-            // Read the primary color from Tailwind for the flash effect
-            const probe = document.createElement('span');
-            probe.className = 'text-primary';
-            probe.style.display = 'none';
-            document.body.appendChild(probe);
-            const primaryColor = getComputedStyle(probe).color;
-            probe.remove();
 
             setTimeout(() => {
                 wrapper.remove();
@@ -130,7 +133,7 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
                         menuButton.click();
                     }, 150);
                 }, 200);
-            }, 300);
+            }, 350);
         } else {
             window.dispatchEvent(new Event('open-sandwich-menu'));
         }

--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -31,12 +31,12 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
                     {/* eslint-disable-next-line no-restricted-syntax -- Server-rendered Astro component, wired via vanilla <script>, no React hydration needed */}
                     <button
                         type='button'
-                        class='inline-flex items-center justify-center w-6 h-6 text-gray-400 hover:text-gray-600 hover:bg-gray-200 rounded transition-colors sm:mr-3'
+                        class='inline-flex items-center justify-center w-5 h-5 text-gray-400 hover:text-gray-600 hover:bg-gray-200 rounded transition-colors self-end mb-px sm:mr-3'
                         title='Switch organism'
                         aria-label='Switch organism'
                         data-organism-switch-button
                     >
-                        <FaExchangeAlt className='w-3.5 h-3.5' />
+                        <FaExchangeAlt className='w-2.5 h-2.5' />
                     </button>
                     <span class='hidden sm:inline text-gray-300 mr-2'>|</span>
                     <div class='hidden sm:flex items-center gap-2 flex-wrap'>
@@ -78,7 +78,7 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
 
 <script>
     document.querySelector('[data-organism-switch-button]')?.addEventListener('click', () => {
-        const menuButton = document.querySelector<HTMLElement>('[data-organism-menu-button]');
+        const menuButton = document.querySelector<HTMLElement>('#organism-menu button');
         menuButton?.click();
         menuButton?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     });

--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -30,12 +30,12 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
                          {/* eslint-disable-next-line no-restricted-syntax -- Server-rendered Astro component, wired via vanilla <script>, no React hydration needed */}
                     <button
                         type='button'
-                        class='inline-flex items-center justify-center w-5 h-5 text-gray-400 hover:text-gray-600 hover:bg-gray-200 rounded transition-colors self-end mb-px sm:mr-3'
+                        class='inline-flex items-center justify-center w-5 h-5 text-gray-400 hover:text-gray-600 hover:bg-gray-200 rounded transition-colors self-end mb-px mr-2 ml-2'
                         title='Switch organism'
                         aria-label='Switch organism'
                         data-organism-switch-button
                     >
-                        <FaExchangeAlt className='w-2.5 h-2.5 ml-1' />
+                        <FaExchangeAlt className='w-2.5 h-2.5 ' />
                     </button>
                     </span>
                     <span class='hidden sm:inline text-gray-300 mr-2'>|</span>

--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -27,16 +27,16 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
                 <div class='flex items-center gap-2 w-full sm:flex-1 flex-wrap sm:flex-nowrap'>
                     <span class='text-gray-700 font-medium'>
                         {currentOrganismObject?.displayName || currentOrganism}
-                         {/* eslint-disable-next-line no-restricted-syntax -- Server-rendered Astro component, wired via vanilla <script>, no React hydration needed */}
-                    <button
-                        type='button'
-                        class='inline-flex items-center justify-center w-5 h-5 text-gray-400 hover:text-gray-600 hover:bg-gray-200 rounded transition-colors self-end mb-px mr-2 ml-2'
-                        title='Switch organism'
-                        aria-label='Switch organism'
-                        data-organism-switch-button
-                    >
-                        <FaExchangeAlt className='w-2.5 h-2.5 ' />
-                    </button>
+                        {/* eslint-disable-next-line no-restricted-syntax -- Server-rendered Astro component, wired via vanilla <script>, no React hydration needed */}
+                        <button
+                            type='button'
+                            class='inline-flex items-center justify-center w-5 h-5 text-gray-400 hover:text-gray-600 hover:bg-gray-200 rounded transition-colors self-end mb-px mr-2 ml-2'
+                            title='Switch organism'
+                            aria-label='Switch organism'
+                            data-organism-switch-button
+                        >
+                            <FaExchangeAlt className='w-2.5 h-2.5 ' />
+                        </button>
                     </span>
                     <span class='hidden sm:inline text-gray-300 mr-2'>|</span>
                     <div class='hidden sm:flex items-center gap-2 flex-wrap'>

--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -24,9 +24,20 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
         <nav class='bg-gray-50 border-gray-200 border-b-[1.5px]' aria-label='Organism navigation'>
             <div class='flex flex-col sm:flex-row sm:items-center gap-2 px-4 py-2 mx-4'>
                 <div class='flex items-center gap-2 w-full sm:flex-1 flex-wrap sm:flex-nowrap'>
-                    <span class='text-gray-700 font-medium sm:mr-3'>
+                    <span class='text-gray-700 font-medium'>
                         {currentOrganismObject?.displayName || currentOrganism}
                     </span>
+                    <button
+                        type='button'
+                        class='inline-flex items-center justify-center w-6 h-6 text-gray-400 hover:text-gray-600 hover:bg-gray-200 rounded transition-colors sm:mr-3'
+                        title='Switch organism'
+                        aria-label='Switch organism'
+                        data-organism-switch-button
+                    >
+                        <svg class='w-3.5 h-3.5' viewBox='0 0 512 512' fill='currentColor' aria-hidden='true'>
+                            <path d='M0 168v-16c0-13.255 10.745-24 24-24h360V80c0-21.367 25.899-32.042 40.971-16.971l80 80c9.372 9.373 9.372 24.569 0 33.941l-80 80C409.956 271.982 384 261.456 384 240v-48H24c-13.255 0-24-10.745-24-24zm488 152H128v-48c0-21.314-25.862-32.08-40.971-16.971l-80 80c-9.372 9.373-9.372 24.569 0 33.941l80 80C102.057 463.997 128 453.437 128 432v-48h360c13.255 0 24-10.745 24-24v-16c0-13.255-10.745-24-24-24z'/>
+                        </svg>
+                    </button>
                     <span class='hidden sm:inline text-gray-300 mr-2'>|</span>
                     <div class='hidden sm:flex items-center gap-2 flex-wrap'>
                         {navigationItems.map(({ text, path, icon }) => {
@@ -64,3 +75,11 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
         </nav>
     )
 }
+
+<script>
+    document.querySelector('[data-organism-switch-button]')?.addEventListener('click', () => {
+        const menuButton = document.querySelector<HTMLElement>('[data-organism-menu-button]');
+        menuButton?.click();
+        menuButton?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    });
+</script>

--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -84,33 +84,36 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
             if (!menuButton) return;
 
             const btn = e.currentTarget as HTMLElement;
-            const from = btn.getBoundingClientRect();
+            const icon = btn.querySelector('svg');
+            if (!icon) return;
+
+            const from = icon.getBoundingClientRect();
             const to = menuButton.getBoundingClientRect();
 
-            const dot = document.createElement('div');
-            dot.style.cssText = `
+            const flyingIcon = icon.cloneNode(true) as SVGElement;
+            const wrapper = document.createElement('div');
+            wrapper.style.cssText = `
                 position: fixed;
-                z-index: 9999;
-                width: 10px;
-                height: 10px;
-                border-radius: 50%;
+                z-index: 2147483647;
                 pointer-events: none;
-                left: ${from.left + from.width / 2 - 5}px;
-                top: ${from.top + from.height / 2 - 5}px;
+                width: ${from.width}px;
+                height: ${from.height}px;
+                left: ${from.left}px;
+                top: ${from.top}px;
                 transition: all 300ms cubic-bezier(0.4, 0, 0.2, 1);
-                opacity: 1;
+                color: var(--color-primary-500);
             `;
-            dot.className = 'bg-primary-500';
-            document.body.appendChild(dot);
+            wrapper.appendChild(flyingIcon);
+            document.body.appendChild(wrapper);
 
             requestAnimationFrame(() => {
-                dot.style.left = `${to.left + to.width / 2 - 5}px`;
-                dot.style.top = `${to.top + to.height / 2 - 5}px`;
-                dot.style.opacity = '0';
+                wrapper.style.left = `${to.left + to.width / 2 - from.width / 2}px`;
+                wrapper.style.top = `${to.top + to.height / 2 - from.height / 2}px`;
+                wrapper.style.opacity = '0';
             });
 
             setTimeout(() => {
-                dot.remove();
+                wrapper.remove();
                 menuButton.click();
             }, 300);
         } else {

--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -4,6 +4,7 @@ import type { Organism } from '../../config';
 import { extraSequenceRelatedTopNavigationItems } from '../../routes/extraTopNavigationItems';
 import { getSequenceRelatedItems } from '../../routes/navigationItems';
 import FaExchangeAlt from '~icons/fa-solid/exchange-alt';
+import { mainTailwindColor } from '../../../colors.json';
 
 interface Props {
     currentOrganism?: string;
@@ -12,6 +13,7 @@ interface Props {
 }
 
 const { currentOrganism, currentOrganismObject, currentPath } = Astro.props;
+const primaryColor = mainTailwindColor[400];
 
 // Get the navigation items for this organism
 const sequenceRelatedItems = getSequenceRelatedItems(currentOrganism);
@@ -34,6 +36,7 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
                             title='Switch organism'
                             aria-label='Switch organism'
                             data-organism-switch-button
+                            data-primary-color={primaryColor}
                         >
                             <FaExchangeAlt className='w-2.5 h-2.5 ' />
                         </button>
@@ -90,13 +93,8 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
             const from = icon.getBoundingClientRect();
             const to = menuButton.getBoundingClientRect();
 
-            // Read the primary color from Tailwind for the trail and flash
-            const probe = document.createElement('span');
-            probe.className = 'text-primary';
-            probe.style.display = 'none';
-            document.body.appendChild(probe);
-            const primaryColor = getComputedStyle(probe).color;
-            probe.remove();
+            // Read the primary color from the data attribute (set from colors.json in frontmatter)
+            const primaryColor = btn.dataset.primaryColor ?? '#88a1d2';
 
             const flyingIcon = icon.cloneNode(true) as SVGElement;
             const wrapper = document.createElement('div');

--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -153,7 +153,9 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
                         transition: opacity 200ms ease-out;
                     `;
                     document.body.appendChild(ghost);
-                    requestAnimationFrame(() => { ghost.style.opacity = '0'; });
+                    requestAnimationFrame(() => {
+                        ghost.style.opacity = '0';
+                    });
                     setTimeout(() => ghost.remove(), 220);
                 }
 

--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -3,6 +3,7 @@ import { SubmenuLink } from './SubmenuLink.tsx';
 import type { Organism } from '../../config';
 import { extraSequenceRelatedTopNavigationItems } from '../../routes/extraTopNavigationItems';
 import { getSequenceRelatedItems } from '../../routes/navigationItems';
+import FaExchangeAlt from '~icons/fa-solid/exchange-alt';
 
 interface Props {
     currentOrganism?: string;
@@ -34,9 +35,7 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
                         aria-label='Switch organism'
                         data-organism-switch-button
                     >
-                        <svg class='w-3.5 h-3.5' viewBox='0 0 512 512' fill='currentColor' aria-hidden='true'>
-                            <path d='M0 168v-16c0-13.255 10.745-24 24-24h360V80c0-21.367 25.899-32.042 40.971-16.971l80 80c9.372 9.373 9.372 24.569 0 33.941l-80 80C409.956 271.982 384 261.456 384 240v-48H24c-13.255 0-24-10.745-24-24zm488 152H128v-48c0-21.314-25.862-32.08-40.971-16.971l-80 80c-9.372 9.373-9.372 24.569 0 33.941l80 80C102.057 463.997 128 453.437 128 432v-48h360c13.255 0 24-10.745 24-24v-16c0-13.255-10.745-24-24-24z'/>
-                        </svg>
+                        <FaExchangeAlt className='w-3.5 h-3.5' />
                     </button>
                     <span class='hidden sm:inline text-gray-300 mr-2'>|</span>
                     <div class='hidden sm:flex items-center gap-2 flex-wrap'>

--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -90,14 +90,6 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
             const from = icon.getBoundingClientRect();
             const to = menuButton.getBoundingClientRect();
 
-            // Read the primary color from Tailwind via a temporary element
-            const probe = document.createElement('span');
-            probe.className = 'text-primary';
-            probe.style.display = 'none';
-            document.body.appendChild(probe);
-            const primaryColor = getComputedStyle(probe).color;
-            probe.remove();
-
             const flyingIcon = icon.cloneNode(true) as SVGElement;
             const wrapper = document.createElement('div');
             wrapper.style.cssText = `
@@ -109,7 +101,6 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
                 left: ${from.left}px;
                 top: ${from.top}px;
                 transition: all 300ms cubic-bezier(0.4, 0, 0.2, 1);
-                color: ${primaryColor};
             `;
             wrapper.appendChild(flyingIcon);
             document.body.appendChild(wrapper);
@@ -119,6 +110,14 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
                 wrapper.style.top = `${to.top + to.height / 2 - from.height / 2}px`;
                 wrapper.style.opacity = '0';
             });
+
+            // Read the primary color from Tailwind for the flash effect
+            const probe = document.createElement('span');
+            probe.className = 'text-primary';
+            probe.style.display = 'none';
+            document.body.appendChild(probe);
+            const primaryColor = getComputedStyle(probe).color;
+            probe.remove();
 
             setTimeout(() => {
                 wrapper.remove();

--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -80,7 +80,11 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
 }
 
 <script>
+    let isAnimating = false;
+
     document.querySelector('[data-organism-switch-button]')?.addEventListener('click', (e) => {
+        if (isAnimating) return;
+
         const desktopMenu = document.querySelector<HTMLElement>('#organism-menu');
         if (desktopMenu && desktopMenu.offsetParent !== null) {
             const menuButton = desktopMenu.querySelector<HTMLElement>('button');
@@ -89,6 +93,8 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
             const btn = e.currentTarget as HTMLElement;
             const icon = btn.querySelector('svg');
             if (!icon) return;
+
+            isAnimating = true;
 
             const from = icon.getBoundingClientRect();
             const to = menuButton.getBoundingClientRect();
@@ -168,6 +174,7 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
                         setTimeout(() => {
                             menuButton!.style.transition = '';
                             menuButton!.click();
+                            isAnimating = false;
                         }, 150);
                     }, 200);
                 }

--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -27,8 +27,7 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
                 <div class='flex items-center gap-2 w-full sm:flex-1 flex-wrap sm:flex-nowrap'>
                     <span class='text-gray-700 font-medium'>
                         {currentOrganismObject?.displayName || currentOrganism}
-                    </span>
-                    {/* eslint-disable-next-line no-restricted-syntax -- Server-rendered Astro component, wired via vanilla <script>, no React hydration needed */}
+                         {/* eslint-disable-next-line no-restricted-syntax -- Server-rendered Astro component, wired via vanilla <script>, no React hydration needed */}
                     <button
                         type='button'
                         class='inline-flex items-center justify-center w-5 h-5 text-gray-400 hover:text-gray-600 hover:bg-gray-200 rounded transition-colors self-end mb-px sm:mr-3'
@@ -36,8 +35,9 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
                         aria-label='Switch organism'
                         data-organism-switch-button
                     >
-                        <FaExchangeAlt className='w-2.5 h-2.5' />
+                        <FaExchangeAlt className='w-2.5 h-2.5 mx-1' />
                     </button>
+                    </span>
                     <span class='hidden sm:inline text-gray-300 mr-2'>|</span>
                     <div class='hidden sm:flex items-center gap-2 flex-wrap'>
                         {navigationItems.map(({ text, path, icon }) => {

--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -90,6 +90,14 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
             const from = icon.getBoundingClientRect();
             const to = menuButton.getBoundingClientRect();
 
+            // Read the primary color from Tailwind via a temporary element
+            const probe = document.createElement('span');
+            probe.className = 'text-primary';
+            probe.style.display = 'none';
+            document.body.appendChild(probe);
+            const primaryColor = getComputedStyle(probe).color;
+            probe.remove();
+
             const flyingIcon = icon.cloneNode(true) as SVGElement;
             const wrapper = document.createElement('div');
             wrapper.style.cssText = `
@@ -101,7 +109,7 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
                 left: ${from.left}px;
                 top: ${from.top}px;
                 transition: all 300ms cubic-bezier(0.4, 0, 0.2, 1);
-                color: var(--color-primary-500);
+                color: ${primaryColor};
             `;
             wrapper.appendChild(flyingIcon);
             document.body.appendChild(wrapper);
@@ -114,7 +122,15 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
 
             setTimeout(() => {
                 wrapper.remove();
-                menuButton.click();
+                menuButton.style.transition = 'box-shadow 150ms ease-in';
+                menuButton.style.boxShadow = `0 0 0 3px ${primaryColor}, 0 0 12px ${primaryColor}`;
+                setTimeout(() => {
+                    menuButton.style.boxShadow = '';
+                    setTimeout(() => {
+                        menuButton.style.transition = '';
+                        menuButton.click();
+                    }, 150);
+                }, 200);
             }, 300);
         } else {
             window.dispatchEvent(new Event('open-sandwich-menu'));

--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -78,8 +78,13 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
 
 <script>
     document.querySelector('[data-organism-switch-button]')?.addEventListener('click', () => {
-        const menuButton = document.querySelector<HTMLElement>('#organism-menu button');
-        menuButton?.click();
-        menuButton?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        const desktopMenu = document.querySelector<HTMLElement>('#organism-menu');
+        if (desktopMenu && desktopMenu.offsetParent !== null) {
+            const menuButton = desktopMenu.querySelector<HTMLElement>('button');
+            menuButton?.click();
+            menuButton?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        } else {
+            window.dispatchEvent(new Event('open-sandwich-menu'));
+        }
     });
 </script>

--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -28,6 +28,7 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
                     <span class='text-gray-700 font-medium'>
                         {currentOrganismObject?.displayName || currentOrganism}
                     </span>
+                    {/* eslint-disable-next-line no-restricted-syntax -- Server-rendered Astro component, wired via vanilla <script>, no React hydration needed */}
                     <button
                         type='button'
                         class='inline-flex items-center justify-center w-6 h-6 text-gray-400 hover:text-gray-600 hover:bg-gray-200 rounded transition-colors sm:mr-3'

--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -35,7 +35,7 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
                         aria-label='Switch organism'
                         data-organism-switch-button
                     >
-                        <FaExchangeAlt className='w-2.5 h-2.5 mx-1' />
+                        <FaExchangeAlt className='w-2.5 h-2.5 ml-1' />
                     </button>
                     </span>
                     <span class='hidden sm:inline text-gray-300 mr-2'>|</span>

--- a/website/src/components/Navigation/OrganismSubmenu.astro
+++ b/website/src/components/Navigation/OrganismSubmenu.astro
@@ -77,12 +77,42 @@ const selectId = currentOrganism ? `organism-navigation-${currentOrganism}` : 'o
 }
 
 <script>
-    document.querySelector('[data-organism-switch-button]')?.addEventListener('click', () => {
+    document.querySelector('[data-organism-switch-button]')?.addEventListener('click', (e) => {
         const desktopMenu = document.querySelector<HTMLElement>('#organism-menu');
         if (desktopMenu && desktopMenu.offsetParent !== null) {
             const menuButton = desktopMenu.querySelector<HTMLElement>('button');
-            menuButton?.click();
-            menuButton?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+            if (!menuButton) return;
+
+            const btn = e.currentTarget as HTMLElement;
+            const from = btn.getBoundingClientRect();
+            const to = menuButton.getBoundingClientRect();
+
+            const dot = document.createElement('div');
+            dot.style.cssText = `
+                position: fixed;
+                z-index: 9999;
+                width: 10px;
+                height: 10px;
+                border-radius: 50%;
+                pointer-events: none;
+                left: ${from.left + from.width / 2 - 5}px;
+                top: ${from.top + from.height / 2 - 5}px;
+                transition: all 300ms cubic-bezier(0.4, 0, 0.2, 1);
+                opacity: 1;
+            `;
+            dot.className = 'bg-primary-500';
+            document.body.appendChild(dot);
+
+            requestAnimationFrame(() => {
+                dot.style.left = `${to.left + to.width / 2 - 5}px`;
+                dot.style.top = `${to.top + to.height / 2 - 5}px`;
+                dot.style.opacity = '0';
+            });
+
+            setTimeout(() => {
+                dot.remove();
+                menuButton.click();
+            }, 300);
         } else {
             window.dispatchEvent(new Event('open-sandwich-menu'));
         }

--- a/website/src/components/Navigation/SandwichMenu.tsx
+++ b/website/src/components/Navigation/SandwichMenu.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import { type FC, useEffect } from 'react';
 
 import AccessionSearchBox from './AccessionSearchBox';
 import type { Organism } from '../../config';
@@ -28,7 +28,13 @@ export const SandwichMenu: FC<SandwichMenuProps> = ({
     siteName,
     activeTopNavigationItem,
 }) => {
-    const { isOpen, toggle: toggleMenu, close: closeMenu } = useOffCanvas();
+    const { isOpen, open: openMenu, toggle: toggleMenu, close: closeMenu } = useOffCanvas();
+
+    useEffect(() => {
+        const handler = () => openMenu();
+        window.addEventListener('open-sandwich-menu', handler);
+        return () => window.removeEventListener('open-sandwich-menu', handler);
+    }, [openMenu]);
 
     return (
         <div className='relative'>


### PR DESCRIPTION
Adds a button to help people confused about how to switch organism to find the organism menu.

<img width="373" height="136" alt="image" src="https://github.com/user-attachments/assets/7ef120de-60c9-4c77-9d3f-25b7caab6812" />

The rationale for this somewhat odd design is that it's confusing to have two totally different UI elements to do the same thing as part of the main UI, but it's also confusing that people expect there to be a way to change organism from the left hand UI and that they can't atm.

Because the elements are in Astro not React the code is a bit different to our normal style, and generally it probably looks quite hacky. In my view it's basically fine though.

Discussion in https://loculus.slack.com/archives/C061ZQQM3N1/p1775646115881829

🚀 Preview: https://claude-organism-menu-butt.loculus.org