### PR TITLE
Add OAuth-style authorization flow for external applications

### DIFF
--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -204,6 +204,9 @@ welcomeMessageHTML: {{ quote $.Values.welcomeMessageHTML }}
 {{ if $.Values.additionalHeadHTML }}
 additionalHeadHTML: {{ quote $.Values.additionalHeadHTML }}
 {{end}}
+{{ if $.Values.allowedExternalRedirectDomains }}
+allowedExternalRedirectDomains: {{ $.Values.allowedExternalRedirectDomains | toJson }}
+{{ end }}
 
 enableLoginNavigationItem: {{ $.Values.website.websiteConfig.enableLoginNavigationItem }}
 enableSubmissionNavigationItem: {{ $.Values.website.websiteConfig.enableSubmissionNavigationItem }}

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -204,8 +204,8 @@ welcomeMessageHTML: {{ quote $.Values.welcomeMessageHTML }}
 {{ if $.Values.additionalHeadHTML }}
 additionalHeadHTML: {{ quote $.Values.additionalHeadHTML }}
 {{end}}
-{{ if $.Values.allowedExternalRedirectDomains }}
-allowedExternalRedirectDomains: {{ $.Values.allowedExternalRedirectDomains | toJson }}
+{{ if $.Values.allowedExternalRedirectUrls }}
+allowedExternalRedirectUrls: {{ $.Values.allowedExternalRedirectUrls | toJson }}
 {{ end }}
 
 enableLoginNavigationItem: {{ $.Values.website.websiteConfig.enableLoginNavigationItem }}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1242,6 +1242,12 @@
       "type": "string",
       "description": "Email address that users can submit issues to"
     },
+    "allowedExternalRedirectDomains": {
+      "groups": ["general"],
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "List of external domains allowed to receive authentication tokens via /auth/authorize. If not set, any domain is allowed (with user consent)."
+    },
     "sequenceFlagging": {
       "type": "object",
       "properties": {

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1242,11 +1242,11 @@
       "type": "string",
       "description": "Email address that users can submit issues to"
     },
-    "allowedExternalRedirectDomains": {
+    "allowedExternalRedirectUrls": {
       "groups": ["general"],
       "type": "array",
       "items": { "type": "string" },
-      "description": "List of external domains allowed to receive authentication tokens via /auth/authorize. If not set, any domain is allowed (with user consent)."
+      "description": "List of URL prefixes allowed to receive authentication tokens via /auth/authorize (e.g. 'https://evolve.org/auth'). Redirect URLs must start with one of these prefixes. If not set, any URL is allowed (with user consent)."
     },
     "sequenceFlagging": {
       "type": "object",

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2536,7 +2536,7 @@ gitHubEditLink: "https://github.com/loculus-project/loculus/edit/main/monorepo/w
 gitHubMainUrl: https://github.com/loculus-project/loculus
 gitHubIssuesUrl: https://github.com/loculus-project/loculus/issues
 issuesEmail: noreply@loculus.org
-# allowedExternalRedirectDomains: []
+# allowedExternalRedirectUrls: []
 resources:
   website:
     requests:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2536,6 +2536,7 @@ gitHubEditLink: "https://github.com/loculus-project/loculus/edit/main/monorepo/w
 gitHubMainUrl: https://github.com/loculus-project/loculus
 gitHubIssuesUrl: https://github.com/loculus-project/loculus/issues
 issuesEmail: noreply@loculus.org
+# allowedExternalRedirectDomains: []
 resources:
   website:
     requests:

--- a/kubernetes/loculus/values_preview_server.yaml
+++ b/kubernetes/loculus/values_preview_server.yaml
@@ -134,6 +134,8 @@ resources:
       cpu: "2m"
     limits:
       memory: "1Gi"
+allowedExternalRedirectUrls:
+  - "https://evolve.org/"
 defaultResources:
   requests:
     memory: "200Mi"

--- a/website/src/pages/auth/authorize.astro
+++ b/website/src/pages/auth/authorize.astro
@@ -9,7 +9,7 @@ const websiteConfig = getWebsiteConfig();
 const runtimeConfig = getRuntimeConfig();
 const instanceName = websiteConfig.name;
 const allowInsecure = runtimeConfig.insecureCookies;
-const allowedDomains = websiteConfig.allowedExternalRedirectDomains ?? null;
+const allowedPrefixes = websiteConfig.allowedExternalRedirectUrls ?? null;
 
 const redirectParam = Astro.url.searchParams.get('redirect');
 
@@ -18,20 +18,22 @@ if (!redirectParam) {
     return Astro.redirect('/user');
 }
 
-const validation = validateRedirectUrl(redirectParam, { allowInsecure, allowedDomains });
+const validation = validateRedirectUrl(redirectParam, { allowInsecure, allowedPrefixes });
 
-// Handle POST (user confirmed consent)
+// Handle POST (user confirmed consent) — render an auto-submitting form that POSTs the token to the target
+let postRedirectTarget: string | null = null;
+let accessToken: string | null = null;
+
 if (Astro.request.method === 'POST') {
     const formData = await Astro.request.formData();
     const postRedirect = formData.get('redirect') as string | null;
 
-    const postValidation = validateRedirectUrl(postRedirect, { allowInsecure, allowedDomains });
+    const postValidation = validateRedirectUrl(postRedirect, { allowInsecure, allowedPrefixes });
     if (postValidation.valid && postRedirect) {
-        const accessToken = getAccessToken(session);
-        if (accessToken) {
-            const targetUrl = new URL(postRedirect);
-            targetUrl.searchParams.set('loculusToken', accessToken);
-            return Astro.redirect(targetUrl.toString());
+        const token = getAccessToken(session);
+        if (token) {
+            postRedirectTarget = postRedirect;
+            accessToken = token;
         }
     }
     // If validation fails on POST, fall through to render page with error
@@ -43,51 +45,66 @@ const error = !isValid ? validation.error : null;
 const username = session.user?.username ?? session.user?.name ?? 'your account';
 ---
 
-<BaseLayout title='Authorize External Application'>
-    <div class='max-w-xl mx-auto mt-12 p-6'>
-        {
-            !isValid && (
-                <div>
-                    <h1 class='text-2xl font-bold mb-4'>Invalid Request</h1>
-                    <p class='mb-6 text-red-600'>{error}</p>
-                    <a href='/' class='btn loculusColor text-white hover:bg-primary-700'>
-                        Return to homepage
-                    </a>
-                </div>
-            )
-        }
-
-        {
-            isValid && (
-                <div>
-                    <h1 class='text-2xl font-bold mb-4'>Authorize External Application</h1>
-                    <div class='bg-gray-50 border border-gray-200 rounded-lg p-4 mb-6'>
-                        <p class='text-lg mb-2'>
-                            <strong>{hostname}</strong> is requesting access to your
-                            <strong>{instanceName}</strong> account.
-                        </p>
-                        <p class='text-sm text-gray-600'>
-                            Signed in as <strong>{username}</strong>
-                        </p>
+{
+    postRedirectTarget && accessToken ? (
+        <html lang='en'>
+            <head>
+                <title>Redirecting...</title>
+            </head>
+            <body>
+                <noscript>
+                    <p>JavaScript is required to complete the authorization. Please enable JavaScript and try again.</p>
+                </noscript>
+                <form id='redirect-form' method='POST' action={postRedirectTarget}>
+                    <input type='hidden' name='loculusToken' value={accessToken} />
+                </form>
+                <script is:inline>document.getElementById('redirect-form').submit();</script>
+            </body>
+        </html>
+    ) : (
+        <BaseLayout title='Authorize External Application'>
+            <div class='max-w-xl mx-auto mt-12 p-6'>
+                {!isValid && (
+                    <div>
+                        <h1 class='text-2xl font-bold mb-4'>Invalid Request</h1>
+                        <p class='mb-6 text-red-600'>{error}</p>
+                        <a href='/' class='btn loculusColor text-white hover:bg-primary-700'>
+                            Return to homepage
+                        </a>
                     </div>
-                    <p class='mb-6 text-gray-600'>
-                        If you authorize, you will be redirected to <strong>{hostname}</strong> with your authentication
-                        token. Only continue if you trust this site.
-                    </p>
-                    <form method='POST'>
-                        <input type='hidden' name='redirect' value={redirectParam} />
-                        <div class='flex gap-4'>
-                            {/* eslint-disable-next-line no-restricted-syntax -- Plain HTML form, no hydration needed */}
-                            <button type='submit' class='btn loculusColor text-white hover:bg-primary-700'>
-                                Authorize
-                            </button>
-                            <a href='/' class='btn btn-outline'>
-                                Deny
-                            </a>
+                )}
+
+                {isValid && (
+                    <div>
+                        <h1 class='text-2xl font-bold mb-4'>Authorize External Application</h1>
+                        <div class='bg-gray-50 border border-gray-200 rounded-lg p-4 mb-6'>
+                            <p class='text-lg mb-2'>
+                                <strong>{hostname}</strong> is requesting access to your
+                                <strong>{instanceName}</strong> account.
+                            </p>
+                            <p class='text-sm text-gray-600'>
+                                Signed in as <strong>{username}</strong>
+                            </p>
                         </div>
-                    </form>
-                </div>
-            )
-        }
-    </div>
-</BaseLayout>
+                        <p class='mb-6 text-gray-600'>
+                            If you authorize, you will be redirected to <strong>{hostname}</strong> with your
+                            authentication token. Only continue if you trust this site.
+                        </p>
+                        <form method='POST'>
+                            <input type='hidden' name='redirect' value={redirectParam} />
+                            <div class='flex gap-4'>
+                                {/* eslint-disable-next-line no-restricted-syntax -- Plain HTML form, no hydration needed */}
+                                <button type='submit' class='btn loculusColor text-white hover:bg-primary-700'>
+                                    Authorize
+                                </button>
+                                <a href='/' class='btn btn-outline'>
+                                    Deny
+                                </a>
+                            </div>
+                        </form>
+                    </div>
+                )}
+            </div>
+        </BaseLayout>
+    )
+}

--- a/website/src/pages/auth/authorize.astro
+++ b/website/src/pages/auth/authorize.astro
@@ -1,0 +1,93 @@
+---
+import { getRuntimeConfig, getWebsiteConfig } from '../../config';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { getAccessToken } from '../../utils/getAccessToken';
+import { validateRedirectUrl } from '../../utils/validateRedirectUrl';
+
+const session = Astro.locals.session!;
+const websiteConfig = getWebsiteConfig();
+const runtimeConfig = getRuntimeConfig();
+const instanceName = websiteConfig.name;
+const allowInsecure = runtimeConfig.insecureCookies;
+const allowedDomains = websiteConfig.allowedExternalRedirectDomains ?? null;
+
+const redirectParam = Astro.url.searchParams.get('redirect');
+
+// No redirect param → just go to user page (user is logged in due to enforced login)
+if (!redirectParam) {
+    return Astro.redirect('/user');
+}
+
+const validation = validateRedirectUrl(redirectParam, { allowInsecure, allowedDomains });
+
+// Handle POST (user confirmed consent)
+if (Astro.request.method === 'POST') {
+    const formData = await Astro.request.formData();
+    const postRedirect = formData.get('redirect') as string | null;
+
+    const postValidation = validateRedirectUrl(postRedirect, { allowInsecure, allowedDomains });
+    if (postValidation.valid && postRedirect) {
+        const accessToken = getAccessToken(session);
+        if (accessToken) {
+            const targetUrl = new URL(postRedirect);
+            targetUrl.searchParams.set('loculusToken', accessToken);
+            return Astro.redirect(targetUrl.toString());
+        }
+    }
+    // If validation fails on POST, fall through to render page with error
+}
+
+const isValid = validation.valid;
+const hostname = isValid ? validation.hostname : null;
+const error = !isValid ? validation.error : null;
+const username = session.user?.username ?? session.user?.name ?? 'your account';
+---
+
+<BaseLayout title='Authorize External Application'>
+    <div class='max-w-xl mx-auto mt-12 p-6'>
+        {
+            !isValid && (
+                <div>
+                    <h1 class='text-2xl font-bold mb-4'>Invalid Request</h1>
+                    <p class='mb-6 text-red-600'>{error}</p>
+                    <a href='/' class='btn loculusColor text-white hover:bg-primary-700'>
+                        Return to homepage
+                    </a>
+                </div>
+            )
+        }
+
+        {
+            isValid && (
+                <div>
+                    <h1 class='text-2xl font-bold mb-4'>Authorize External Application</h1>
+                    <div class='bg-gray-50 border border-gray-200 rounded-lg p-4 mb-6'>
+                        <p class='text-lg mb-2'>
+                            <strong>{hostname}</strong> is requesting access to your
+                            <strong>{instanceName}</strong> account.
+                        </p>
+                        <p class='text-sm text-gray-600'>
+                            Signed in as <strong>{username}</strong>
+                        </p>
+                    </div>
+                    <p class='mb-6 text-gray-600'>
+                        If you authorize, you will be redirected to <strong>{hostname}</strong> with your authentication
+                        token. Only continue if you trust this site.
+                    </p>
+                    <form method='POST'>
+                        <input type='hidden' name='redirect' value={redirectParam} />
+                        <div class='flex gap-4'>
+                            {/* eslint-disable-next-line no-restricted-syntax -- Plain HTML form, no hydration needed */}
+                            <button type='submit' class='btn loculusColor text-white hover:bg-primary-700'>
+                                Authorize
+                            </button>
+                            <a href='/' class='btn btn-outline'>
+                                Deny
+                            </a>
+                        </div>
+                    </form>
+                </div>
+            )
+        }
+    </div>
+</BaseLayout>

--- a/website/src/routes/routes.ts
+++ b/website/src/routes/routes.ts
@@ -65,6 +65,7 @@ export const routes = {
     seqSetPage: (seqSetAccessionVersion: AccessionVersion | string) => {
         return `/seqsets/${getAccessionVersionString(seqSetAccessionVersion)}`;
     },
+    authAuthorize: (redirect: string) => `/auth/authorize?redirect=${encodeURIComponent(redirect)}`,
     logout: () => '/logout',
     datauseTermsPage: () => '/about/terms-of-use/data-use-terms',
 };

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -259,6 +259,7 @@ export const websiteConfig = z.object({
     enableSubmissionPages: z.boolean(),
     enableDataUseTerms: z.boolean(),
     sequenceFlagging: sequenceFlaggingConfig.optional(),
+    allowedExternalRedirectDomains: z.array(z.string()).nullable().optional(),
 });
 export type WebsiteConfig = z.infer<typeof websiteConfig>;
 

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -259,7 +259,7 @@ export const websiteConfig = z.object({
     enableSubmissionPages: z.boolean(),
     enableDataUseTerms: z.boolean(),
     sequenceFlagging: sequenceFlaggingConfig.optional(),
-    allowedExternalRedirectDomains: z.array(z.string()).nullable().optional(),
+    allowedExternalRedirectUrls: z.array(z.string()).nullable().optional(),
 });
 export type WebsiteConfig = z.infer<typeof websiteConfig>;
 

--- a/website/src/utils/shouldMiddlewareEnforceLogin.ts
+++ b/website/src/utils/shouldMiddlewareEnforceLogin.ts
@@ -8,7 +8,11 @@ function getEnforcedLoginRoutes(configuredOrganisms: string[]) {
             new RegExp(`^/${organism}/my_sequences`),
         ]);
 
-        enforcedLoginRoutesCache[cacheKey] = [new RegExp('^/user/?'), ...organismSpecificRoutes];
+        enforcedLoginRoutesCache[cacheKey] = [
+            new RegExp('^/user/?'),
+            new RegExp('^/auth/authorize'),
+            ...organismSpecificRoutes,
+        ];
     }
     return enforcedLoginRoutesCache[cacheKey];
 }

--- a/website/src/utils/validateRedirectUrl.ts
+++ b/website/src/utils/validateRedirectUrl.ts
@@ -2,7 +2,7 @@ type RedirectValidation = { valid: true; hostname: string } | { valid: false; er
 
 export function validateRedirectUrl(
     url: string | null | undefined,
-    options: { allowInsecure?: boolean; allowedDomains?: string[] | null } = {},
+    options: { allowInsecure?: boolean; allowedPrefixes?: string[] | null } = {},
 ): RedirectValidation {
     if (!url || url.trim() === '') {
         return { valid: false, error: 'No redirect URL provided.' };
@@ -26,9 +26,13 @@ export function validateRedirectUrl(
         }
     }
 
-    if (options.allowedDomains && options.allowedDomains.length > 0) {
-        if (!options.allowedDomains.includes(hostname)) {
-            return { valid: false, error: `The domain "${hostname}" is not in the list of allowed redirect domains.` };
+    if (options.allowedPrefixes && options.allowedPrefixes.length > 0) {
+        const matches = options.allowedPrefixes.some((prefix) => url.startsWith(prefix));
+        if (!matches) {
+            return {
+                valid: false,
+                error: `"${hostname}" is not in the list of allowed redirect targets.`,
+            };
         }
     }
 

--- a/website/src/utils/validateRedirectUrl.ts
+++ b/website/src/utils/validateRedirectUrl.ts
@@ -19,6 +19,10 @@ export function validateRedirectUrl(
         return { valid: false, error: 'The redirect URL must use HTTPS.' };
     }
 
+    if (parsed.username || parsed.password || url.includes('@')) {
+        return { valid: false, error: 'The redirect URL must not contain credentials.' };
+    }
+
     const { hostname } = parsed;
     if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') {
         if (!options.allowInsecure) {

--- a/website/src/utils/validateRedirectUrl.ts
+++ b/website/src/utils/validateRedirectUrl.ts
@@ -1,0 +1,36 @@
+type RedirectValidation = { valid: true; hostname: string } | { valid: false; error: string };
+
+export function validateRedirectUrl(
+    url: string | null | undefined,
+    options: { allowInsecure?: boolean; allowedDomains?: string[] | null } = {},
+): RedirectValidation {
+    if (!url || url.trim() === '') {
+        return { valid: false, error: 'No redirect URL provided.' };
+    }
+
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return { valid: false, error: 'The redirect URL is not a valid URL.' };
+    }
+
+    if (parsed.protocol !== 'https:' && !(options.allowInsecure && parsed.protocol === 'http:')) {
+        return { valid: false, error: 'The redirect URL must use HTTPS.' };
+    }
+
+    const { hostname } = parsed;
+    if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') {
+        if (!options.allowInsecure) {
+            return { valid: false, error: 'The redirect URL must not point to localhost.' };
+        }
+    }
+
+    if (options.allowedDomains && options.allowedDomains.length > 0) {
+        if (!options.allowedDomains.includes(hostname)) {
+            return { valid: false, error: `The domain "${hostname}" is not in the list of allowed redirect domains.` };
+        }
+    }
+
+    return { valid: true, hostname };
+}


### PR DESCRIPTION
resolves #

### Description

This PR implements an OAuth-style authorization flow that allows external applications to request access to user accounts with explicit user consent.

#### Changes

- **New authorization page** (`/auth/authorize`): Displays a consent screen where logged-in users can authorize or deny external applications requesting access to their account
- **Redirect URL validation** (`validateRedirectUrl.ts`): Utility function that validates redirect URLs with configurable security options:
  - Enforces HTTPS by default (with optional insecure HTTP support)
  - Prevents redirects to localhost unless explicitly allowed
  - Supports allowlist of permitted redirect domains
- **Access token generation**: Upon user consent, generates an access token and appends it as a `loculusToken` query parameter to the redirect URL
- **Configuration**: Added `allowedExternalRedirectDomains` config option to specify which external domains are permitted to receive redirects
- **Route enforcement**: Added `/auth/authorize` to enforced login routes to ensure only authenticated users can access the authorization flow
- **Route helper**: Added `authAuthorize()` route builder for generating authorization URLs

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

### Manual Testing

The authorization flow should be tested by:
1. Accessing `/auth/authorize?redirect=<valid-https-url>` while logged in
2. Verifying the consent screen displays the requesting domain and current user
3. Confirming authorization redirects to the specified URL with a `loculusToken` parameter
4. Verifying denial redirects to the homepage
5. Testing validation with invalid URLs (non-HTTPS, localhost, unlisted domains)

https://claude.ai/code/session_01CDtqNur1hfYmKDdUXJZDkH

🚀 Preview: Add `preview` label to enable