### PR TITLE
fix: Remove symlink for `CLAUDE.md`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,22 @@
-AGENTS.md
+The `backend`, `website`, and `integration-tests` directories each contain their own `AGENTS.md` files with additional specific instructions.
+
+Use conventional commits as titles for PRs, e.g. feat(deployment):xx, fix!(website):xx, chore(backend):xx.
+Components include: website, backend, deployment, preprocessing, ingest, deposition.
+
+Write detailed PR summaries, not just short bullet points. When creating PRs, you should generally create them as a draft PR. If you have access to https://github.com/loculus-project/agent_store/ you can upload screenshots (which you might take using `playwright-cli` there to be able to use in PR descriptions, and maybe issue descriptions).
+
+## Preventing flaky Playwright tests (website)
+
+When adding or modifying interactive components in the website, ensure they are disabled until React hydration completes to prevent race conditions in Playwright tests:
+
+- **For buttons**: Use `Button` from `src/components/common/Button.tsx` instead of native `<button>`
+- **For Headless UI Combobox**: Import from `src/components/common/headlessui/Combobox.tsx` instead of `@headlessui/react`
+- **For other interactive elements**: Wrap with `DisabledUntilHydrated` or use the `useClientFlag` hook
+
+These wrappers automatically disable components until client-side hydration is complete, preventing Playwright from interacting with them before they're ready.
+
+## Updating Conda Environment Dependencies
+
+Conda dependencies in `environment.yml` files are not automatically updated by dependabot.
+The `maintenance-scripts/` folder contains utilities to help update conda environment versions.
+

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -1,1 +1,0 @@
-AGENTS.md


### PR DESCRIPTION
There's a [bug](https://github.com/anthropics/claude-code-action/issues/1187) in the claude action above version `1.0.88`, triggered when the `CLAUDE.md` file is a symlink. 

This was addressed here by pinning the version: https://github.com/loculus-project/loculus/pull/6246 however subsequent dependabot updates show no issues, leading to it potentially being reverted while still broken.

A simple fix for now is to just make the file not a symlink, as this prevents the bug.

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable