### PR TITLE
fix(ci): Update Claude Code action to v1 and fix CLAUDE.md references

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 1
 
       - name: PR Review with Progress Tracking
-        uses: anthropics/claude-code-action@v1.0.88
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1.0.88
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Code for Issue Triage
-        uses: anthropics/claude-code-action@v1.0.88
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -104,7 +104,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Claude Code for PR Labeling
-        uses: anthropics/claude-code-action@v1.0.88
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/ena-submission/CLAUDE.md
+++ b/ena-submission/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/integration-tests/CLAUDE.md
+++ b/integration-tests/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/kubernetes/CLAUDE.md
+++ b/kubernetes/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/website/codemods/CLAUDE.md
+++ b/website/codemods/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md


### PR DESCRIPTION

This PR updates the Claude Code action version from `v1.0.88` to `v1` across all GitHub workflows, and uses the CLAUDE special format  with text of [`@path`](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#02107) used to include files, rather than a symlink which was breaking recent versions of the action.

<img width="890" height="478" alt="image" src="https://github.com/user-attachments/assets/58f3a306-81f7-4b51-afd8-5203df3d2a64" />



🚀 Preview: Add `preview` label to enable