### PR TITLE
feat(website): Warning banner when an earlier version of a seqset is being viewed

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -98,9 +98,8 @@ const lastTimeBannerWasClosed = Astro.cookies.get('lastTimeBannerWasClosed')?.va
                     currentOrganismObject={currentOrganismObject}
                     currentPath={currentPath}
                 />
-
-                <slot name='banner' />
             </header>
+            <slot name='banner' />
 
             <div
                 class:list={[

--- a/website/src/pages/seqsets/[seqSetId].[version].astro
+++ b/website/src/pages/seqsets/[seqSetId].[version].astro
@@ -7,6 +7,7 @@ import { SeqSetItemActions } from '../../components/SeqSetCitations/SeqSetItemAc
 import { getSeqSetStatistics } from '../../components/SeqSetCitations/getSeqSetStatistics.ts';
 import { getRuntimeConfig, seqSetsAreEnabled, getWebsiteConfig } from '../../config';
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import { routes } from '../../routes/routes';
 import { SeqSetCitationClient } from '../../services/seqSetCitationClient.ts';
 import type { ProblemDetail } from '../../types/backend';
 import type { SeqSet } from '../../types/seqSetCitation';
@@ -31,8 +32,7 @@ if (!seqSetsAreEnabled()) {
 }
 
 const seqSetClient = SeqSetCitationClient.create();
-
-const seqSetVersionsResponse = await seqSetClient.call('getSeqSet', { params: { seqSetId, version } });
+const seqSetVersionsResponse = await seqSetClient.call('getSeqSetVersions', { params: { seqSetId } });
 const seqSetRecordsResponse = await seqSetClient.call('getSeqSetRecords', { params: { seqSetId, version } });
 const seqSetCitedByResponse = await seqSetClient.call('getSeqSetCitedBy', { params: { seqSetId, version } });
 
@@ -47,6 +47,9 @@ const getSeqSetByVersion = (seqSetVersions: SeqSet[], version: string) => {
 };
 
 const seqSetResponse = seqSetVersionsResponse.map((seqSetVersions) => getSeqSetByVersion(seqSetVersions, version));
+const latestSeqSetVersion = seqSetVersionsResponse.isOk()
+    ? Math.max(...seqSetVersionsResponse.value.map((s) => s.seqSetVersion))
+    : undefined;
 const seqSetAuthorResponse = seqSetResponse.isOk()
     ? await seqSetClient.getAuthor(seqSetResponse.value.createdBy)
     : err();
@@ -77,6 +80,19 @@ const secondaryErrors = (
     data-testid='seqSets-item-container'
     activeTopNavigationItem='seqsets'
 >
+    {
+        seqSetResponse.isOk() && latestSeqSetVersion && seqSetResponse.value.seqSetVersion < latestSeqSetVersion && (
+            <div class='bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-3 space-y-2' role='alert'>
+                <p class='font-bold'>This is not the latest version of this SeqSet entry.</p>
+                <p>
+                    The latest version is:
+                    <a href={routes.seqSetPage(`${seqSetId}.${latestSeqSetVersion}`)} class='font-bold underline mx-1'>
+                        {`${seqSetId}.${latestSeqSetVersion}`}
+                    </a>
+                </p>
+            </div>
+        )
+    }
     {
         seqSetResponse.isOk() && seqSetRecordsResponse.isOk() ? (
             <div class='mt-12'>

--- a/website/src/pages/seqsets/[seqSetId].[version].astro
+++ b/website/src/pages/seqsets/[seqSetId].[version].astro
@@ -82,18 +82,21 @@ const secondaryErrors = (
 >
     {
         seqSetResponse.isOk() && latestSeqSetVersion && seqSetResponse.value.seqSetVersion < latestSeqSetVersion && (
-            <div
-                slot='banner'
-                class='bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-3 space-y-2'
-                role='alert'
-            >
-                <p class='font-bold'>This is not the latest version of this SeqSet entry.</p>
-                <p>
-                    The latest version is:
-                    <a href={routes.seqSetPage(`${seqSetId}.${latestSeqSetVersion}`)} class='font-bold underline mx-1'>
-                        {`${seqSetId}.${latestSeqSetVersion}`}
-                    </a>
-                </p>
+            <div slot='banner'>
+                <div class='pt-3'>
+                    <div class='bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-3' role='alert'>
+                        <p class='font-bold'>This is not the latest version of this SeqSet entry.</p>
+                        <p>
+                            The latest version is:
+                            <a
+                                href={routes.seqSetPage(`${seqSetId}.${latestSeqSetVersion}`)}
+                                class='font-bold underline mx-1'
+                            >
+                                {`${seqSetId}.${latestSeqSetVersion}`}
+                            </a>
+                        </p>
+                    </div>
+                </div>
             </div>
         )
     }

--- a/website/src/pages/seqsets/[seqSetId].[version].astro
+++ b/website/src/pages/seqsets/[seqSetId].[version].astro
@@ -95,7 +95,7 @@ const secondaryErrors = (
     }
     {
         seqSetResponse.isOk() && seqSetRecordsResponse.isOk() ? (
-            <div class='mt-12'>
+            <div class='mt-8'>
                 {secondaryErrors.length > 0 && (
                     <ErrorFeedback message={secondaryErrors.join(', ')} client:only='react' />
                 )}

--- a/website/src/pages/seqsets/[seqSetId].[version].astro
+++ b/website/src/pages/seqsets/[seqSetId].[version].astro
@@ -82,7 +82,11 @@ const secondaryErrors = (
 >
     {
         seqSetResponse.isOk() && latestSeqSetVersion && seqSetResponse.value.seqSetVersion < latestSeqSetVersion && (
-            <div class='bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-3 space-y-2' role='alert'>
+            <div
+                slot='banner'
+                class='bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-3 space-y-2'
+                role='alert'
+            >
                 <p class='font-bold'>This is not the latest version of this SeqSet entry.</p>
                 <p>
                     The latest version is:

--- a/website/src/services/seqSetCitationApi.ts
+++ b/website/src/services/seqSetCitationApi.ts
@@ -38,6 +38,14 @@ const getSeqSetEndpoint = makeEndpoint({
     errors: [notAuthorizedError],
 });
 
+const getSeqSetVersionsEndpoint = makeEndpoint({
+    method: 'get',
+    path: '/get-seqset?seqSetId=:seqSetId',
+    alias: 'getSeqSetVersions',
+    response: seqSets,
+    errors: [notAuthorizedError],
+});
+
 const getSeqSetRecordsEndpoint = makeEndpoint({
     method: 'get',
     path: '/get-seqset-records?seqSetId=:seqSetId&version=:version',
@@ -167,6 +175,7 @@ export const seqSetCitationApi = makeApi([
     getUserCitedByEndpoint,
     getSeqSetCitedByEndpoint,
     getSeqSetEndpoint,
+    getSeqSetVersionsEndpoint,
     getSeqSetRecordsEndpoint,
     validateSeqSetRecords,
     createSeqSetEndpoint,


### PR DESCRIPTION
If the SeqSet being viewed is an earlier version, a warning banner is now added with a link to the latest version.

### Screenshot

<img width="1699" height="673" alt="image" src="https://github.com/user-attachments/assets/bc796827-9a7d-4272-b5f5-5c3b554d746e" />

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://latest-seqset-banner.loculus.org