### PR TITLE
fix(deposition): dont call get on a value that could be None or a dict

### DIFF
--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -112,7 +112,7 @@ def set_project_table_entry(db_config, config, row):
     corresponding_project = [
         project
         for project in corresponding_group
-        if project["result"].get("bioproject_accession") == bioproject
+        if project["result"] and project["result"].get("bioproject_accession") == bioproject
     ]
     if len(corresponding_project) == 1:
         logger.debug(

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -914,7 +914,7 @@ def retry_failed_submissions_for_matching_errors(
             "status": Status.READY,
             "errors": None,
             "finished_at": None,
-            "result": None,
+            "result": {},
         }
         try:
             update_with_retry(


### PR DESCRIPTION
Another reason to do: https://github.com/loculus-project/loculus/issues/5646

### Screenshot
We finally get to test my re-try code in full on prod, and sadly it is crashlooping due to a type error:
```

2026-04-10 17:11:12.831 | Traceback (most recent call last): |  
-- | -- | --
  |   | 2026-04-10 17:11:12.831 | File "/opt/conda/lib/python3.12/site-packages/ena_deposition/__main__.py", line 66, in run |  
  |   | 2026-04-10 17:11:12.831 | future.result() |  
  |   | 2026-04-10 17:11:12.831 | File "/opt/conda/lib/python3.12/concurrent/futures/_base.py", line 449, in result |  
  |   | 2026-04-10 17:11:12.831 | return self.__get_result() |  
  |   | 2026-04-10 17:11:12.831 | ^^^^^^^^^^^^^^^^^^^ |  
  |   | 2026-04-10 17:11:12.831 | File "/opt/conda/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result |  
  |   | 2026-04-10 17:11:12.831 | raise self._exception |  
  |   | 2026-04-10 17:11:12.831 | File "/opt/conda/lib/python3.12/concurrent/futures/thread.py", line 59, in run |  
  |   | 2026-04-10 17:11:12.831 | result = self.fn(*self.args, **self.kwargs) |  
  |   | 2026-04-10 17:11:12.831 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ |  
  |   | 2026-04-10 17:11:12.831 | File "/opt/conda/lib/python3.12/site-packages/ena_deposition/create_project.py", line 418, in create_project |  
  |   | 2026-04-10 17:11:12.831 | submission_table_start(db_config, config) |  
  |   | 2026-04-10 17:11:12.831 | File "/opt/conda/lib/python3.12/site-packages/ena_deposition/create_project.py", line 202, in submission_table_start |  
  |   | 2026-04-10 17:11:12.831 | set_project_table_entry(db_config, config, row) |  
  |   | 2026-04-10 17:11:12.831 | File "/opt/conda/lib/python3.12/site-packages/ena_deposition/create_project.py", line 115, in set_project_table_entry |  
  |   | 2026-04-10 17:11:12.831 | if project["result"].get("bioproject_accession") == bioproject |  
  |   | 2026-04-10 17:11:12.831 | ^^^^^^^^^^^^^^^^^^^^^ |  
  |   | 2026-04-10 17:11:12.831 | AttributeError: 'NoneType' object has no attribute 'get'


```

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable