### PR TITLE
feat(deposition): refactor to use SQLAlchemy

### DIFF
--- a/ena-submission/FAQ.md
+++ b/ena-submission/FAQ.md
@@ -30,7 +30,7 @@ def test_submit(self, mock_get_group_info, mock_submit_external_metadata):
     Test the full ENA submission pipeline with accurate data - this should succeed
     """
     simple_submission(
-        self.db_config, self.config, mock_get_group_info, mock_submit_external_metadata
+        self.db_engine, self.config, mock_get_group_info, mock_submit_external_metadata
     )
 ```
 
@@ -42,7 +42,7 @@ The behavior is specified in the test function itself in this case, inside `simp
 
 ```py
 def simple_submission(
-    db_config: SimpleConnectionPool,
+    db_engine: SimpleConnectionPool,
     config: Config,
     mock_get_group_info,
     mock_submit_external_metadata,

--- a/ena-submission/environment.yml
+++ b/ena-submission/environment.yml
@@ -19,6 +19,7 @@ dependencies:
   - requests=2.32.5
   - unzip=6.0
   - psycopg2=2.9.10
+  - sqlalchemy=2.0.40
   - slack_sdk=3.37.0
   - xmltodict=1.0.2
   - biopython=1.85

--- a/ena-submission/scripts/deposition_dry_run.py
+++ b/ena-submission/scripts/deposition_dry_run.py
@@ -103,7 +103,7 @@ def local_ena_submission_generator(
             group_id=data["metadata"]["groupId"],
             organism=data["organism"],
             result={"bioproject_accession": bioproject} if bioproject else None,
-            center_name=center_name
+            center_name=center_name,
         )
         sample_entry = SampleTableEntry(
             accession=accession,

--- a/ena-submission/scripts/deposition_dry_run.py
+++ b/ena-submission/scripts/deposition_dry_run.py
@@ -18,6 +18,11 @@ from ena_deposition.create_assembly import create_manifest_object
 from ena_deposition.create_project import construct_project_set_object
 from ena_deposition.create_sample import construct_sample_set_object
 from ena_deposition.ena_submission_helper import create_manifest, get_project_xml, get_sample_xml
+from ena_deposition.submission_db_helper import (
+    ProjectTableEntry,
+    SampleTableEntry,
+    SubmissionTableEntry,
+)
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(
@@ -86,18 +91,29 @@ def local_ena_submission_generator(
 
     for full_accession, data in sequences_to_upload.items():
         accession, version = full_accession.split(".")
-        entry = {
-            "accession": accession,
-            "version": version,
-            "group_id": data["metadata"]["groupId"],
-            "organism": data["organism"],
-            "metadata": data["metadata"],
-            "unaligned_nucleotide_sequences": data["unalignedNucleotideSequences"],
-        }
+        entry = SubmissionTableEntry(
+            accession=accession,
+            version=int(version),
+            group_id=data["metadata"]["groupId"],
+            organism=data["organism"],
+            seq_metadata=data["metadata"],
+            unaligned_nucleotide_sequences=data["unalignedNucleotideSequences"],
+        )
+        project_entry = ProjectTableEntry(
+            group_id=data["metadata"]["groupId"],
+            organism=data["organism"],
+            result={"bioproject_accession": bioproject} if bioproject else None,
+            center_name=center_name
+        )
+        sample_entry = SampleTableEntry(
+            accession=accession,
+            version=int(version),
+            result={"biosample_accession": biosample} if biosample else None,
+        )
 
     if mode == "project":
-        group_info = get_group_info(config, entry["group_id"])
-        project_set = construct_project_set_object(group_info, config, entry)
+        group_info = get_group_info(config, entry.group_id)
+        project_set = construct_project_set_object(group_info, config, project_entry)
         project_xml = get_project_xml(project_set)
 
         directory = "project"
@@ -121,8 +137,7 @@ def local_ena_submission_generator(
         )
 
     if mode == "sample":
-        entry["center_name"] = center_name
-        sample_set = construct_sample_set_object(config, entry, entry)
+        sample_set = construct_sample_set_object(config, entry, sample_entry)
         sample_xml = get_sample_xml(sample_set, revision=revision)
 
         directory = "sample"
@@ -145,8 +160,6 @@ def local_ena_submission_generator(
         )
 
     if mode == "assembly":
-        entry["center_name"] = center_name
-
         directory = "assembly"
         os.makedirs(directory, exist_ok=True)
         logger.info(f"Writing results to {directory}")

--- a/ena-submission/scripts/get_ena_submission_list.py
+++ b/ena-submission/scripts/get_ena_submission_list.py
@@ -113,7 +113,7 @@ def assign_ena_organism(
 
 def filter_for_submission(
     config: Config,
-    db_pool: Engine,
+    db_engine: Engine,
     entries_iterator: Iterator[dict[str, Any]],
     ena_organisms: list[ENAOrganism],
 ) -> SubmissionResults:
@@ -134,7 +134,7 @@ def filter_for_submission(
     entries_with_external_metadata: set[Accession] = set()
     revoked_entries: set[Accession] = set()
     logger.debug("Querying ENA db for latest version of submissions")
-    highest_submitted_version = highest_version_in_submission_table(db_pool)
+    highest_submitted_version = highest_version_in_submission_table(db_engine)
     logger.debug("Starting processing of data from Loculus backend")
     suppressed_accessions = fetch_suppressed_accessions(config)
     for idx, entry in enumerate(entries_iterator):
@@ -257,7 +257,7 @@ def get_ena_submission_list(config_file) -> None:
 
     output_file_suffix = "ena_submission_list.json"
 
-    db_pool = db_init(
+    db_engine = db_init(
         db_password_default=config.db_password,
         db_username_default=config.db_username,
         db_url_default=config.db_url,
@@ -276,7 +276,7 @@ def get_ena_submission_list(config_file) -> None:
         released_entries = fetch_released_entries(config, loculus_organism)
         logger.info("Starting to stream released entries. Filtering for submission...")
         submission_results = filter_for_submission(
-            config, db_pool, released_entries, input_map[loculus_organism]
+            config, db_engine, released_entries, input_map[loculus_organism]
         )
         if submission_results.entries_to_submit:
             logger.info(

--- a/ena-submission/scripts/get_ena_submission_list.py
+++ b/ena-submission/scripts/get_ena_submission_list.py
@@ -22,7 +22,7 @@ from ena_deposition.submission_db_helper import (
     db_init,
     highest_version_in_submission_table,
 )
-from psycopg2.pool import SimpleConnectionPool
+from sqlalchemy import Engine
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(
@@ -113,7 +113,7 @@ def assign_ena_organism(
 
 def filter_for_submission(
     config: Config,
-    db_pool: SimpleConnectionPool,
+    db_pool: Engine,
     entries_iterator: Iterator[dict[str, Any]],
     ena_organisms: list[ENAOrganism],
 ) -> SubmissionResults:
@@ -134,7 +134,7 @@ def filter_for_submission(
     entries_with_external_metadata: set[Accession] = set()
     revoked_entries: set[Accession] = set()
     logger.debug("Querying ENA db for latest version of submissions")
-    highest_submitted_version = highest_version_in_submission_table(db_conn_pool=db_pool)
+    highest_submitted_version = highest_version_in_submission_table(db_pool)
     logger.debug("Starting processing of data from Loculus backend")
     suppressed_accessions = fetch_suppressed_accessions(config)
     for idx, entry in enumerate(entries_iterator):

--- a/ena-submission/scripts/test_api.py
+++ b/ena-submission/scripts/test_api.py
@@ -28,7 +28,7 @@ config_file = "./test/test_config.yaml"
 class ApiTest(unittest.TestCase):
     def setUp(self) -> None:
         self.config: Config = get_config(config_file)
-        self.db_config = db_init(
+        self.db_engine = db_init(
             self.config.db_password, self.config.db_username, self.config.db_url
         )
 
@@ -44,7 +44,7 @@ class ApiTest(unittest.TestCase):
         mock_get_insdc_accessions.return_value = mock_insdc_accessions
 
         app.state.config = self.config
-        app.state.engine = self.db_config
+        app.state.engine = self.db_engine
 
         response = client.get("/submitted")
 

--- a/ena-submission/scripts/test_api.py
+++ b/ena-submission/scripts/test_api.py
@@ -44,6 +44,7 @@ class ApiTest(unittest.TestCase):
         mock_get_insdc_accessions.return_value = mock_insdc_accessions
 
         app.state.config = self.config
+        app.state.engine = self.db_config
 
         response = client.get("/submitted")
 

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -7,7 +7,7 @@ import logging
 import os
 import unittest
 from pathlib import Path
-from typing import Any, Final
+from typing import Final
 from unittest import mock
 
 import xmltodict
@@ -19,6 +19,11 @@ from ena_deposition.create_assembly import (
 )
 from ena_deposition.create_project import construct_project_set_object
 from ena_deposition.create_sample import construct_sample_set_object
+from ena_deposition.submission_db_helper import (
+    ProjectTableEntry,
+    SampleTableEntry,
+    SubmissionTableEntry,
+)
 from ena_deposition.ena_submission_helper import (
     create_chromosome_list,
     create_ena_project,
@@ -123,28 +128,25 @@ with open("test/approved_ena_submission_list_test.json", encoding="utf-8") as f:
     loculus_sample: dict = json.load(f)
 
 
-def sample_data_in_submission_table() -> dict[str, Any]:
-    """Returns a sample data structure that mimics the one used in the submission table."""
-    return {
-        "accession": "LOC_0001TLY",
-        "version": "1",
-        "group_id": 2,
-        "organism": "Test organism",
-        "metadata": loculus_sample["LOC_0001TLY.1"]["metadata"],
-        "unaligned_nucleotide_sequences": {
+def sample_data_in_submission_table() -> SubmissionTableEntry:
+    """Returns a SubmissionTableEntry that mimics a row from the submission table."""
+    return SubmissionTableEntry(
+        accession="LOC_0001TLY",
+        version=1,
+        group_id=2,
+        organism="Test organism",
+        seq_metadata=loculus_sample["LOC_0001TLY.1"]["metadata"],
+        unaligned_nucleotide_sequences={
             "seg1": None,
             "seg2": "GCGGCACGTCAGTACGTAAGTGTATCTCAAAGAAATACTTAACTTTGAGAGAGTGAATT",
             "seg3": "CTTAACTTTGAGAGAGTGAATT",
         },
-        "center_name": "Fake center name",
-    }
+        center_name="Fake center name",
+    )
 
 
-project_table_entry = {"group_id": "2", "organism": "Test organism"}
-sample_table_entry = {
-    "accession": "LOC_0001TLY",
-    "version": "1",
-}
+project_table_entry = ProjectTableEntry(group_id=2, organism="Test organism")
+sample_table_entry = SampleTableEntry(accession="LOC_0001TLY", version=1)
 
 
 # Mock requests
@@ -229,7 +231,7 @@ class TestCreateSample:
     def test_sample_set_with_gisaid(self):
         config = mock_config()
         sample_data = sample_data_in_submission_table()
-        sample_data["metadata"]["gisaidIsolateId"] = "EPI_ISL_12345"
+        sample_data.seq_metadata["gisaidIsolateId"] = "EPI_ISL_12345"
         sample_set = construct_sample_set_object(
             config,
             sample_data,
@@ -253,13 +255,13 @@ class TestCreateSample:
 
 class AssemblyCreationTests(unittest.TestCase):
     def setUp(self):
-        self.unaligned_sequences_multi = sample_data_in_submission_table()[
-            "unaligned_nucleotide_sequences"
-        ]
+        self.unaligned_sequences_multi = (
+            sample_data_in_submission_table().unaligned_nucleotide_sequences
+        )
         self.unaligned_sequences = {
             "main": "CTTAACTTTGAGAGAGTGAATT",
         }
-        self.seq_key = {"accession": "LOC_0001TLY", "version": "1"}
+        self.seq_key = "LOC_0001TLY"
 
     def test_format_authors(self):
         authors = "Xi,L.;Smith, Anna Maria; Perez Gonzalez, Anthony J.;Doe,;von Doe, John"

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -258,7 +258,7 @@ class AssemblyCreationTests(unittest.TestCase):
         self.unaligned_sequences_multi = (
             sample_data_in_submission_table().unaligned_nucleotide_sequences
         )
-        self.unaligned_sequences = {
+        self.unaligned_sequences: dict[str, str | None] = {
             "main": "CTTAACTTTGAGAGAGTGAATT",
         }
         self.seq_key = "LOC_0001TLY"
@@ -290,7 +290,7 @@ class AssemblyCreationTests(unittest.TestCase):
             "sampleCollectionDate": "2024-01-01",
             "geoLocCountry": "Italy",
         }
-        unaligned_sequences = {
+        unaligned_sequences: dict[str, str | None] = {
             "main": "ATCGATCGATCG",
         }
 

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -19,11 +19,6 @@ from ena_deposition.create_assembly import (
 )
 from ena_deposition.create_project import construct_project_set_object
 from ena_deposition.create_sample import construct_sample_set_object
-from ena_deposition.submission_db_helper import (
-    ProjectTableEntry,
-    SampleTableEntry,
-    SubmissionTableEntry,
-)
 from ena_deposition.ena_submission_helper import (
     create_chromosome_list,
     create_ena_project,
@@ -43,6 +38,11 @@ from ena_deposition.ena_types import (
     default_sample_set_type,
 )
 from ena_deposition.loculus_models import Group
+from ena_deposition.submission_db_helper import (
+    ProjectTableEntry,
+    SampleTableEntry,
+    SubmissionTableEntry,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/ena-submission/scripts/test_ena_submission_integration.py
+++ b/ena-submission/scripts/test_ena_submission_integration.py
@@ -593,7 +593,6 @@ class TestFirstPublicUpdate(TestSubmission):
         "base_entry": {
             "group_id": 1,
             "organism": "test_organism",
-            "project_id": 0,
             "status": Status.SUBMITTED,
         },
         "add_function": add_to_project_table,

--- a/ena-submission/scripts/test_ena_submission_integration.py
+++ b/ena-submission/scripts/test_ena_submission_integration.py
@@ -694,7 +694,7 @@ class TestFirstPublicUpdate(TestSubmission):
             # Single key (like project_id)
             conditions = {"project_id": entity_id}
         else:
-            conditions = asdict(entry.primary_key)
+            conditions = asdict(entry.pkey)
 
         # Run visibility check with invalid accessions
         check_and_update_visibility_for_column(

--- a/ena-submission/scripts/test_ena_submission_integration.py
+++ b/ena-submission/scripts/test_ena_submission_integration.py
@@ -90,6 +90,7 @@ def assert_biosample_accession(
 ) -> None:
     assert len(rows) == 1, f"Sample for {full_accession} not found in sample table."
     if biosample_accession:
+        assert rows[0].result, f"No result for sample {full_accession} in sample table."
         assert rows[0].result.get("biosample_accession") == biosample_accession, (
             "Incorrect biosample accession in sample table."
         )
@@ -100,6 +101,7 @@ def assert_bioproject_accession(
 ) -> None:
     assert len(rows) == 1, f"Project {group_id} for {full_accession} not found in project table."
     if bioproject_accession:
+        assert rows[0].result, f"No result for project {group_id} in project table."
         assert rows[0].result.get("bioproject_accession") == bioproject_accession, (
             "Incorrect bioproject accession in project table."
         )
@@ -198,6 +200,7 @@ def check_assembly_submission_waiting(
             conditions={"accession": accession, "version": version, "status": "WAITING"},
         )
         assert len(rows) == 1, f"Assembly for {full_accession} not found in assembly table."
+        assert rows[0].result, f"No result for assembly {full_accession} in assembly table."
         assert "erz_accession" in rows[0].result, "Incorrect assembly result in assembly table."
         assert "segment_order" in rows[0].result, "Incorrect assembly result in assembly table."
 
@@ -268,6 +271,7 @@ def check_assembly_submission_with_nuc_without_gca(
         assert len(rows) == 1, (
             f"Assembly for {full_accession} not in state 'WAITING' in assembly table."
         )
+        assert rows[0].result, f"No result for assembly {full_accession} in assembly table."
         assert rows[0].result.get("insdc_accession_full_L") is not None
         assert rows[0].result.get("insdc_accession_full_M") is None
         assert rows[0].result.get("gca_accession") is None

--- a/ena-submission/scripts/test_ena_submission_integration.py
+++ b/ena-submission/scripts/test_ena_submission_integration.py
@@ -107,7 +107,7 @@ def assert_bioproject_accession(
         )
 
 
-def delete_all_records(db_config: Engine) -> None:
+def delete_all_records(db_engine: Engine) -> None:
     logger.debug("Deleting all records from all deposition tables except flyway")
     for model_class in [
         SubmissionTableEntry,
@@ -115,19 +115,19 @@ def delete_all_records(db_config: Engine) -> None:
         SampleTableEntry,
         AssemblyTableEntry,
     ]:
-        delete_records_in_db(db_config, model_class, {})
+        delete_records_in_db(db_engine, model_class, {})
 
 
-def check_sequences_uploaded(db_config: Engine, sequences_to_upload: dict[str, Any]) -> None:
+def check_sequences_uploaded(db_engine: Engine, sequences_to_upload: dict[str, Any]) -> None:
     for full_accession in sequences_to_upload:
         accession, version = full_accession.split(".")
         assert in_submission_table(
-            db_config, {"accession": accession, "version": version, "status_all": "READY_TO_SUBMIT"}
+            db_engine, {"accession": accession, "version": version, "status_all": "READY_TO_SUBMIT"}
         ), f"Sequence {accession}.{version} not found in submission table."
 
 
 def check_project_submission_started(
-    db_config: Engine, sequences_to_upload: dict[str, Any]
+    db_engine: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession, data in sequences_to_upload.items():
         group_id = data["metadata"]["groupId"]
@@ -135,7 +135,7 @@ def check_project_submission_started(
         assert (
             len(
                 find_conditions_in_db(
-                    db_config,
+                    db_engine,
                     ProjectTableEntry,
                     conditions={"group_id": group_id, "organism": organism, "status": "READY"},
                 )
@@ -144,13 +144,13 @@ def check_project_submission_started(
         ), f"Project {group_id} for {full_accession} not found in project table."
 
 
-def check_sample_submission_started(db_config: Engine, sequences_to_upload: dict[str, Any]) -> None:
+def check_sample_submission_started(db_engine: Engine, sequences_to_upload: dict[str, Any]) -> None:
     for full_accession in sequences_to_upload:
         accession, version = full_accession.split(".")
         assert (
             len(
                 find_conditions_in_db(
-                    db_config,
+                    db_engine,
                     SampleTableEntry,
                     conditions={"accession": accession, "version": version, "status": "READY"},
                 )
@@ -160,29 +160,29 @@ def check_sample_submission_started(db_config: Engine, sequences_to_upload: dict
 
 
 def check_sample_submission_submitted(
-    db_config: Engine, sequences_to_upload: dict[str, Any]
+    db_engine: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession, data in sequences_to_upload.items():
         accession, version = full_accession.split(".")
         rows = find_conditions_in_db(
-            db_config,
+            db_engine,
             SampleTableEntry,
             conditions={"accession": accession, "version": version, "status": "SUBMITTED"},
         )
         assert_biosample_accession(rows, data["metadata"]["biosampleAccession"], full_accession)
         assert in_submission_table(
-            db_config,
+            db_engine,
             {"accession": accession, "version": version, "status_all": StatusAll.SUBMITTED_SAMPLE},
         ), f"Sequence {accession}.{version} not in state SUBMITTED_SAMPLE submission table."
 
 
 def check_sample_submission_has_errors(
-    db_config: Engine, sequences_to_upload: dict[str, Any]
+    db_engine: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession, data in sequences_to_upload.items():
         accession, version = full_accession.split(".")
         rows = find_conditions_in_db(
-            db_config,
+            db_engine,
             SampleTableEntry,
             conditions={"accession": accession, "version": version, "status": "HAS_ERRORS"},
         )
@@ -190,12 +190,12 @@ def check_sample_submission_has_errors(
 
 
 def check_assembly_submission_waiting(
-    db_config: Engine, sequences_to_upload: dict[str, Any]
+    db_engine: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession in sequences_to_upload:
         accession, version = full_accession.split(".")
         rows = find_conditions_in_db(
-            db_config,
+            db_engine,
             AssemblyTableEntry,
             conditions={"accession": accession, "version": version, "status": "WAITING"},
         )
@@ -206,12 +206,12 @@ def check_assembly_submission_waiting(
 
 
 def check_assembly_submission_has_errors(
-    db_config: Engine, sequences_to_upload: dict[str, Any]
+    db_engine: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession in sequences_to_upload:
         accession, version = full_accession.split(".")
         rows = find_conditions_in_db(
-            db_config,
+            db_engine,
             AssemblyTableEntry,
             conditions={"accession": accession, "version": version, "status": "HAS_ERRORS"},
         )
@@ -219,12 +219,12 @@ def check_assembly_submission_has_errors(
 
 
 def check_assembly_submission_started(
-    db_config: Engine, sequences_to_upload: dict[str, Any]
+    db_engine: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession in sequences_to_upload:
         accession, version = full_accession.split(".")
         rows = find_conditions_in_db(
-            db_config,
+            db_engine,
             AssemblyTableEntry,
             conditions={"accession": accession, "version": version, "status": "READY"},
         )
@@ -232,12 +232,12 @@ def check_assembly_submission_started(
 
 
 def check_assembly_submission_submitted(
-    db_config: Engine, sequences_to_upload: dict[str, Any]
+    db_engine: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession in sequences_to_upload:
         accession, version = full_accession.split(".")
         rows = find_conditions_in_db(
-            db_config,
+            db_engine,
             AssemblyTableEntry,
             conditions={"accession": accession, "version": version, "status": "SUBMITTED"},
         )
@@ -245,7 +245,7 @@ def check_assembly_submission_submitted(
             f"Assembly for {full_accession} not in state 'SUBMITTED' in assembly table."
         )
         assert in_submission_table(
-            db_config,
+            db_engine,
             {
                 "accession": accession,
                 "version": version,
@@ -255,12 +255,12 @@ def check_assembly_submission_submitted(
 
 
 def check_assembly_submission_with_nuc_without_gca(
-    db_config: Engine, sequences_to_upload: dict[str, Any]
+    db_engine: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession in sequences_to_upload:
         accession, version = full_accession.split(".")
         rows = find_conditions_in_db(
-            db_config,
+            db_engine,
             AssemblyTableEntry,
             conditions={
                 "accession": accession,
@@ -277,11 +277,11 @@ def check_assembly_submission_with_nuc_without_gca(
         assert rows[0].result.get("gca_accession") is None
 
 
-def check_sent_to_loculus(db_config: Engine, sequences_to_upload: dict[str, Any]) -> None:
+def check_sent_to_loculus(db_engine: Engine, sequences_to_upload: dict[str, Any]) -> None:
     for full_accession in sequences_to_upload:
         accession, version = full_accession.split(".")
         assert in_submission_table(
-            db_config,
+            db_engine,
             {
                 "accession": accession,
                 "version": version,
@@ -291,14 +291,14 @@ def check_sent_to_loculus(db_config: Engine, sequences_to_upload: dict[str, Any]
 
 
 def check_project_submission_submitted(
-    db_config: Engine, sequences_to_upload: dict[str, Any]
+    db_engine: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession, data in sequences_to_upload.items():
         accession, version = full_accession.split(".")
         group_id = data["metadata"]["groupId"]
         organism = data["organism"]
         rows = find_conditions_in_db(
-            db_config,
+            db_engine,
             ProjectTableEntry,
             conditions={"group_id": group_id, "organism": organism, "status": "SUBMITTED"},
         )
@@ -306,19 +306,19 @@ def check_project_submission_submitted(
             rows, data["metadata"]["bioprojectAccession"], group_id, full_accession
         )
         assert in_submission_table(
-            db_config,
+            db_engine,
             {"accession": accession, "version": version, "status_all": StatusAll.SUBMITTED_PROJECT},
         ), f"Sequence {accession}.{version} not in state SUBMITTED_PROJECT submission table."
 
 
 def check_project_submission_has_errors(
-    db_config: Engine, sequences_to_upload: dict[str, Any]
+    db_engine: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession, data in sequences_to_upload.items():
         group_id = data["metadata"]["groupId"]
         organism = data["organism"]
         rows = find_conditions_in_db(
-            db_config,
+            db_engine,
             ProjectTableEntry,
             conditions={"group_id": group_id, "organism": organism, "status": "HAS_ERRORS"},
         )
@@ -328,7 +328,7 @@ def check_project_submission_has_errors(
 
 
 def set_db_to_known_erz_accession(
-    db_config: Engine, sequences_to_upload: dict[str, Any], single_segment: bool
+    db_engine: Engine, sequences_to_upload: dict[str, Any], single_segment: bool
 ) -> None:
     """
     Sets erz-accession to known previous values that have received accession
@@ -345,14 +345,14 @@ def set_db_to_known_erz_accession(
             segment_order = ["L"] if single_segment else ["L", "M"]
             erz_accession = "ERZ24985816" if single_segment else "ERZ24784470"
             update_db_where_conditions(
-                db_config,
+                db_engine,
                 AssemblyTableEntry,
                 {"accession": accession, "version": version},
                 {"result": {"erz_accession": erz_accession, "segment_order": segment_order}},
             )
         if organism == "west-nile":
             update_db_where_conditions(
-                db_config,
+                db_engine,
                 AssemblyTableEntry,
                 {"accession": accession, "version": version},
                 {"result": {"erz_accession": "ERZ24908522", "segment_order": ["main"]}},
@@ -360,57 +360,57 @@ def set_db_to_known_erz_accession(
 
 
 def _test_successful_assembly_submission(
-    db_config: Engine,
+    db_engine: Engine,
     config: Config,
     sequences_to_upload: dict[str, Any],
     single_segment: bool = False,
 ) -> None:
-    create_assembly_submission_table_start(db_config, config)
-    check_assembly_submission_started(db_config, sequences_to_upload)
+    create_assembly_submission_table_start(db_engine, config)
+    check_assembly_submission_started(db_engine, sequences_to_upload)
 
     assert config.test, "Not submitting to dev - stopping"
-    assembly_table_create(db_config, config)
-    check_assembly_submission_waiting(db_config, sequences_to_upload)
+    assembly_table_create(db_engine, config)
+    check_assembly_submission_waiting(db_engine, sequences_to_upload)
 
     # Hack: ENA never processed on dev, so we set erz_accession to known public accessions
     # So we can test the rest of the pipeline
-    set_db_to_known_erz_accession(db_config, sequences_to_upload, single_segment=single_segment)
-    assembly_table_update(db_config, config, time_threshold=0)
-    create_assembly_submission_table_update(db_config)
+    set_db_to_known_erz_accession(db_engine, sequences_to_upload, single_segment=single_segment)
+    assembly_table_update(db_engine, config, time_threshold=0)
+    create_assembly_submission_table_update(db_engine)
     if single_segment:
-        check_assembly_submission_with_nuc_without_gca(db_config, sequences_to_upload)
+        check_assembly_submission_with_nuc_without_gca(db_engine, sequences_to_upload)
     else:
-        check_assembly_submission_submitted(db_config, sequences_to_upload)
+        check_assembly_submission_submitted(db_engine, sequences_to_upload)
 
 
 def _test_successful_assembly_submission_no_wait(
-    db_config: Engine, config: Config, sequences_to_upload: dict[str, Any]
+    db_engine: Engine, config: Config, sequences_to_upload: dict[str, Any]
 ) -> None:
-    create_assembly_submission_table_start(db_config, config)
-    check_assembly_submission_started(db_config, sequences_to_upload)
+    create_assembly_submission_table_start(db_engine, config)
+    check_assembly_submission_started(db_engine, sequences_to_upload)
 
     assert config.test, "Not submitting to dev - stopping"
-    assembly_table_create(db_config, config)
-    create_assembly_submission_table_update(db_config)
-    check_assembly_submission_submitted(db_config, sequences_to_upload)
+    assembly_table_create(db_engine, config)
+    create_assembly_submission_table_update(db_engine)
+    check_assembly_submission_submitted(db_engine, sequences_to_upload)
 
 
 def _test_assembly_submission_errored(
-    db_config: Engine,
+    db_engine: Engine,
     config: Config,
     slack_config: SlackConfig,
     sequences_to_upload: dict[str, Any],
     mock_notify: Mock,
 ) -> None:
-    create_assembly_submission_table_start(db_config, config)
-    check_assembly_submission_started(db_config, sequences_to_upload)
+    create_assembly_submission_table_start(db_engine, config)
+    check_assembly_submission_started(db_engine, sequences_to_upload)
 
     assert config.test, "Not submitting to dev - stopping"
-    assembly_table_create(db_config, config)
-    check_assembly_submission_has_errors(db_config, sequences_to_upload)
+    assembly_table_create(db_engine, config)
+    check_assembly_submission_has_errors(db_engine, sequences_to_upload)
 
     assembly_table_handle_errors(
-        db_config,
+        db_engine,
         config,
         slack_config,
         last_retry_time=datetime.now(tz=pytz.utc),
@@ -423,25 +423,25 @@ def _test_assembly_submission_errored(
 
 
 def _test_successful_sample_submission(
-    db_config: Engine, config: Config, sequences_to_upload: dict[str, Any]
+    db_engine: Engine, config: Config, sequences_to_upload: dict[str, Any]
 ) -> None:
-    create_sample_sync_state_with_submission_table(db_config, config=config)
-    check_sample_submission_started(db_config, sequences_to_upload)
+    create_sample_sync_state_with_submission_table(db_engine, config=config)
+    check_sample_submission_started(db_engine, sequences_to_upload)
 
-    sample_table_create(db_config, config, test=config.test)
-    create_sample_sync_state_with_submission_table(db_config, config)
-    check_sample_submission_submitted(db_config, sequences_to_upload)
+    sample_table_create(db_engine, config, test=config.test)
+    create_sample_sync_state_with_submission_table(db_engine, config)
+    check_sample_submission_submitted(db_engine, sequences_to_upload)
 
 
 def _test_successful_project_submission(
-    db_config: Engine, config: Config, sequences_to_upload: dict[str, Any]
+    db_engine: Engine, config: Config, sequences_to_upload: dict[str, Any]
 ) -> None:
-    create_project_sync_state_with_submission_table(db_config, config)
-    check_project_submission_started(db_config, sequences_to_upload)
+    create_project_sync_state_with_submission_table(db_engine, config)
+    check_project_submission_started(db_engine, sequences_to_upload)
 
-    project_table_create(db_config, config, test=config.test)
-    create_project_sync_state_with_submission_table(db_config, config)
-    check_project_submission_submitted(db_config, sequences_to_upload)
+    project_table_create(db_engine, config, test=config.test)
+    create_project_sync_state_with_submission_table(db_engine, config)
+    check_project_submission_submitted(db_engine, sequences_to_upload)
 
 
 def get_sequences() -> dict[str, Any]:
@@ -478,7 +478,7 @@ def mock_requests_post() -> Mock:
 
 
 def multi_segment_submission(
-    db_config: Engine,
+    db_engine: Engine,
     config: Config,
     mock_get_group_info: Mock,
     mock_submit_external_metadata: Mock,
@@ -495,16 +495,16 @@ def multi_segment_submission(
         # Set segment M to None so we have only one segment in the assembly
         sequences_to_upload["LOC_0001TLY.1"]["unalignedNucleotideSequences"]["M"] = None
 
-    get_external_metadata_and_send_to_loculus(db_config, config)
+    get_external_metadata_and_send_to_loculus(db_engine, config)
     mock_submit_external_metadata.assert_not_called()
 
-    upload_sequences(db_config, sequences_to_upload)
-    check_sequences_uploaded(db_config, sequences_to_upload)
-    get_external_metadata_and_send_to_loculus(db_config, config)
+    upload_sequences(db_engine, sequences_to_upload)
+    check_sequences_uploaded(db_engine, sequences_to_upload)
+    get_external_metadata_and_send_to_loculus(db_engine, config)
     mock_submit_external_metadata.assert_not_called()
 
-    _test_successful_project_submission(db_config, config, sequences_to_upload)
-    get_external_metadata_and_send_to_loculus(db_config, config)
+    _test_successful_project_submission(db_engine, config, sequences_to_upload)
+    get_external_metadata_and_send_to_loculus(db_engine, config)
     args = mock_submit_external_metadata.call_args_list
 
     assert len(args) == 1
@@ -514,8 +514,8 @@ def multi_segment_submission(
     assert set(payload["externalMetadata"]) == {"bioprojectAccession"}
     assert payload["externalMetadata"]["bioprojectAccession"].startswith("PRJEB")
 
-    _test_successful_sample_submission(db_config, config, sequences_to_upload)
-    get_external_metadata_and_send_to_loculus(db_config, config)
+    _test_successful_sample_submission(db_engine, config, sequences_to_upload)
+    get_external_metadata_and_send_to_loculus(db_engine, config)
     args = mock_submit_external_metadata.call_args_list
     assert len(args) == 2  # noqa: PLR2004
     payload = args[1][0][0]  # first positional argument of second call
@@ -525,11 +525,11 @@ def multi_segment_submission(
     assert payload["externalMetadata"]["bioprojectAccession"].startswith("PRJEB")
     assert payload["externalMetadata"]["biosampleAccession"].startswith("SAMEA")
 
-    _test_successful_assembly_submission(db_config, config, sequences_to_upload, single_segment)
-    get_external_metadata_and_send_to_loculus(db_config, config)
+    _test_successful_assembly_submission(db_engine, config, sequences_to_upload, single_segment)
+    get_external_metadata_and_send_to_loculus(db_engine, config)
     if not single_segment:
         # Only complete in case of multi-segment submission
-        check_sent_to_loculus(db_config, sequences_to_upload)
+        check_sent_to_loculus(db_engine, sequences_to_upload)
     args = mock_submit_external_metadata.call_args_list
     assert len(args) == 3  # noqa: PLR2004
     payload = args[2][0][0]  # first positional argument of third call
@@ -571,10 +571,10 @@ class TestSubmission:
     def setup_method(self) -> None:
         self.config: Config = get_config(CONFIG_FILE)
         self.config.submitting_time_threshold_min = 0
-        self.db_config = db_init(
+        self.db_engine = db_init(
             self.config.db_password, self.config.db_username, self.config.db_url
         )
-        delete_all_records(self.db_config)
+        delete_all_records(self.db_engine)
         # for testing set last_notification_sent to 1 day ago
         self.slack_config = SlackConfig(
             slack_hook=self.config.slack_hook or "",
@@ -681,7 +681,7 @@ class TestFirstPublicUpdate(TestSubmission):
 
         # Insert into the database
         add_function = test_data["add_function"]
-        entity_id = add_function(self.db_config, entry)
+        entity_id = add_function(self.db_engine, entry)
         if entity_id is None:
             msg = f"Failed to add {entity_type.value} entry to the database."
             raise ValueError(msg)
@@ -698,12 +698,12 @@ class TestFirstPublicUpdate(TestSubmission):
 
         # Run visibility check with invalid accessions
         check_and_update_visibility_for_column(
-            self.config, self.db_config, entity_type, column_name
+            self.config, self.db_engine, entity_type, column_name
         )
 
         # Check that visibility column is None
         rows = find_conditions_in_db(
-            self.db_config,
+            self.db_engine,
             config.entry_class,
             conditions=conditions,
         )
@@ -717,7 +717,7 @@ class TestFirstPublicUpdate(TestSubmission):
 
         # Update the entry to have valid accessions
         update_db_where_conditions(
-            self.db_config,
+            self.db_engine,
             config.entry_class,
             conditions=conditions,
             update_values={"result": test_data["valid_result"]},
@@ -725,12 +725,12 @@ class TestFirstPublicUpdate(TestSubmission):
 
         # Run the visibility check again with valid accessions
         check_and_update_visibility_for_column(
-            self.config, self.db_config, entity_type, column_name
+            self.config, self.db_engine, entity_type, column_name
         )
 
         # Check that visibility column is now updated
         rows = find_conditions_in_db(
-            self.db_config,
+            self.db_engine,
             config.entry_class,
             conditions=conditions,
         )
@@ -753,7 +753,7 @@ class TestSimpleSubmission(TestSubmission):
         Test the full ENA submission pipeline with accurate data - this should succeed
         """
         multi_segment_submission(
-            self.db_config, self.config, mock_get_group_info, mock_submit_external_metadata
+            self.db_engine, self.config, mock_get_group_info, mock_submit_external_metadata
         )
 
 
@@ -764,7 +764,7 @@ class TestSingleSegmentOfMultiSegmentOrganismWithoutGCA(TestSubmission):
     @patch("ena_deposition.call_loculus.get_group_info", autospec=True)
     def test_submit(self, mock_get_group_info: Mock, mock_submit_external_metadata: Mock) -> None:
         multi_segment_submission(
-            self.db_config,
+            self.db_engine,
             self.config,
             mock_get_group_info,
             mock_submit_external_metadata,
@@ -789,18 +789,18 @@ class TestKnownBioproject(TestSubmission):
             entry["metadata"]["bioprojectAccession"] = "PRJNA231221"
 
         # upload sequences
-        upload_sequences(self.db_config, sequences_to_upload)
-        check_sequences_uploaded(self.db_config, sequences_to_upload)
+        upload_sequences(self.db_engine, sequences_to_upload)
+        check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # submit
-        create_project_sync_state_with_submission_table(self.db_config, self.config)
-        check_project_submission_submitted(self.db_config, sequences_to_upload)
-        _test_successful_sample_submission(self.db_config, self.config, sequences_to_upload)
-        _test_successful_assembly_submission(self.db_config, self.config, sequences_to_upload)
+        create_project_sync_state_with_submission_table(self.db_engine, self.config)
+        check_project_submission_submitted(self.db_engine, sequences_to_upload)
+        _test_successful_sample_submission(self.db_engine, self.config, sequences_to_upload)
+        _test_successful_assembly_submission(self.db_engine, self.config, sequences_to_upload)
 
         # send to loculus
-        get_external_metadata_and_send_to_loculus(self.db_config, self.config)
-        check_sent_to_loculus(self.db_config, sequences_to_upload)
+        get_external_metadata_and_send_to_loculus(self.db_engine, self.config)
+        check_sent_to_loculus(self.db_engine, sequences_to_upload)
 
 
 class TestIncorrectBioprojectPassed(TestSubmission):
@@ -816,14 +816,14 @@ class TestIncorrectBioprojectPassed(TestSubmission):
             entry["metadata"]["bioprojectAccession"] = "INVALID_ACCESSION"
 
         # upload sequences
-        upload_sequences(self.db_config, sequences_to_upload)
-        check_sequences_uploaded(self.db_config, sequences_to_upload)
+        upload_sequences(self.db_engine, sequences_to_upload)
+        check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # check project submission fails and sends notification
-        create_project_sync_state_with_submission_table(self.db_config, self.config)
-        check_project_submission_has_errors(self.db_config, sequences_to_upload)
+        create_project_sync_state_with_submission_table(self.db_engine, self.config)
+        check_project_submission_has_errors(self.db_engine, sequences_to_upload)
         project_table_handle_errors(
-            self.db_config,
+            self.db_engine,
             self.config,
             self.slack_config,
             last_retry_time=datetime.now(tz=pytz.utc),
@@ -853,19 +853,19 @@ class TestKnownBioprojectAndBioSample(TestSubmission):
             entry["metadata"]["biosampleAccession"] = "SAMN11077987"
 
         # upload
-        upload_sequences(self.db_config, sequences_to_upload)
-        check_sequences_uploaded(self.db_config, sequences_to_upload)
+        upload_sequences(self.db_engine, sequences_to_upload)
+        check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # submit
-        create_project_sync_state_with_submission_table(self.db_config, self.config)
-        check_project_submission_submitted(self.db_config, sequences_to_upload)
-        create_sample_sync_state_with_submission_table(self.db_config, config=self.config)
-        check_sample_submission_submitted(self.db_config, sequences_to_upload)
-        _test_successful_assembly_submission(self.db_config, self.config, sequences_to_upload)
+        create_project_sync_state_with_submission_table(self.db_engine, self.config)
+        check_project_submission_submitted(self.db_engine, sequences_to_upload)
+        create_sample_sync_state_with_submission_table(self.db_engine, config=self.config)
+        check_sample_submission_submitted(self.db_engine, sequences_to_upload)
+        _test_successful_assembly_submission(self.db_engine, self.config, sequences_to_upload)
 
         # send to loculus
-        get_external_metadata_and_send_to_loculus(self.db_config, self.config)
-        check_sent_to_loculus(self.db_config, sequences_to_upload)
+        get_external_metadata_and_send_to_loculus(self.db_engine, self.config)
+        check_sent_to_loculus(self.db_engine, sequences_to_upload)
 
 
 class TestKnownBioprojectAndIncorrectBioSample(TestSubmission):
@@ -890,18 +890,18 @@ class TestKnownBioprojectAndIncorrectBioSample(TestSubmission):
             entry["metadata"]["biosampleAccession"] = "INVALID_ACCESSION"
 
         # upload
-        upload_sequences(self.db_config, sequences_to_upload)
-        check_sequences_uploaded(self.db_config, sequences_to_upload)
+        upload_sequences(self.db_engine, sequences_to_upload)
+        check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # submit project
-        create_project_sync_state_with_submission_table(self.db_config, self.config)
-        check_project_submission_submitted(self.db_config, sequences_to_upload)
+        create_project_sync_state_with_submission_table(self.db_engine, self.config)
+        check_project_submission_submitted(self.db_engine, sequences_to_upload)
 
         # check sample submission fails and sends notification
-        create_sample_sync_state_with_submission_table(self.db_config, config=self.config)
-        check_sample_submission_has_errors(self.db_config, sequences_to_upload)
+        create_sample_sync_state_with_submission_table(self.db_engine, config=self.config)
+        check_sample_submission_has_errors(self.db_engine, sequences_to_upload)
         sample_table_handle_errors(
-            self.db_config,
+            self.db_engine,
             self.config,
             self.slack_config,
             last_retry_time=datetime.now(tz=pytz.utc) - timedelta(hours=5),
@@ -922,7 +922,7 @@ class TestRevisionAssemblyModificationTests(TestSubmission):
     def test_revise(self, mock_get_group_info: Mock, mock_submit_external_metadata: Mock) -> None:
         self.config.set_alias_suffix = "revision" + str(uuid.uuid4())
         multi_segment_submission(
-            self.db_config, self.config, mock_get_group_info, mock_submit_external_metadata
+            self.db_engine, self.config, mock_get_group_info, mock_submit_external_metadata
         )
 
         # get data
@@ -931,18 +931,18 @@ class TestRevisionAssemblyModificationTests(TestSubmission):
         sequences_to_upload = get_revisions()
 
         # upload sequences
-        upload_sequences(self.db_config, sequences_to_upload)
-        check_sequences_uploaded(self.db_config, sequences_to_upload)
+        upload_sequences(self.db_engine, sequences_to_upload)
+        check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # submit
-        create_project_sync_state_with_submission_table(self.db_config, self.config)
-        check_project_submission_submitted(self.db_config, sequences_to_upload)
-        _test_successful_sample_submission(self.db_config, self.config, sequences_to_upload)
-        _test_successful_assembly_submission(self.db_config, self.config, sequences_to_upload)
+        create_project_sync_state_with_submission_table(self.db_engine, self.config)
+        check_project_submission_submitted(self.db_engine, sequences_to_upload)
+        _test_successful_sample_submission(self.db_engine, self.config, sequences_to_upload)
+        _test_successful_assembly_submission(self.db_engine, self.config, sequences_to_upload)
 
         # send to loculus
-        get_external_metadata_and_send_to_loculus(self.db_config, self.config)
-        check_sent_to_loculus(self.db_config, sequences_to_upload)
+        get_external_metadata_and_send_to_loculus(self.db_engine, self.config)
+        check_sent_to_loculus(self.db_engine, sequences_to_upload)
 
 
 class TestRevisionNoAssemblyModificationTests(TestSubmission):
@@ -953,7 +953,7 @@ class TestRevisionNoAssemblyModificationTests(TestSubmission):
     def test_revise(self, mock_get_group_info: Mock, mock_submit_external_metadata: Mock) -> None:
         self.config.set_alias_suffix = "revision" + str(uuid.uuid4())
         multi_segment_submission(
-            self.db_config, self.config, mock_get_group_info, mock_submit_external_metadata
+            self.db_engine, self.config, mock_get_group_info, mock_submit_external_metadata
         )
 
         # get data
@@ -962,20 +962,20 @@ class TestRevisionNoAssemblyModificationTests(TestSubmission):
         sequences_to_upload = get_revisions(modify_assembly=False)
 
         # upload sequences
-        upload_sequences(self.db_config, sequences_to_upload)
-        check_sequences_uploaded(self.db_config, sequences_to_upload)
+        upload_sequences(self.db_engine, sequences_to_upload)
+        check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # submit
-        create_project_sync_state_with_submission_table(self.db_config, self.config)
-        check_project_submission_submitted(self.db_config, sequences_to_upload)
-        _test_successful_sample_submission(self.db_config, self.config, sequences_to_upload)
+        create_project_sync_state_with_submission_table(self.db_engine, self.config)
+        check_project_submission_submitted(self.db_engine, sequences_to_upload)
+        _test_successful_sample_submission(self.db_engine, self.config, sequences_to_upload)
         _test_successful_assembly_submission_no_wait(
-            self.db_config, self.config, sequences_to_upload
+            self.db_engine, self.config, sequences_to_upload
         )
 
         # send to loculus
-        get_external_metadata_and_send_to_loculus(self.db_config, self.config)
-        check_sent_to_loculus(self.db_config, sequences_to_upload)
+        get_external_metadata_and_send_to_loculus(self.db_engine, self.config)
+        check_sent_to_loculus(self.db_engine, sequences_to_upload)
 
 
 class TestRevisionWithManifestChangeTests(TestSubmission):
@@ -992,7 +992,7 @@ class TestRevisionWithManifestChangeTests(TestSubmission):
     ) -> None:
         self.config.set_alias_suffix = "revision" + str(uuid.uuid4())
         multi_segment_submission(
-            self.db_config, self.config, mock_get_group_info, mock_submit_external_metadata
+            self.db_engine, self.config, mock_get_group_info, mock_submit_external_metadata
         )
         # get data
         mock_get_group_info.return_value = TEST_GROUP
@@ -1000,17 +1000,17 @@ class TestRevisionWithManifestChangeTests(TestSubmission):
         sequences_to_upload = get_revisions(modify_manifest=True)
 
         # upload sequences
-        upload_sequences(self.db_config, sequences_to_upload)
-        check_sequences_uploaded(self.db_config, sequences_to_upload)
+        upload_sequences(self.db_engine, sequences_to_upload)
+        check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # submit
-        create_project_sync_state_with_submission_table(self.db_config, self.config)
-        check_project_submission_submitted(self.db_config, sequences_to_upload)
-        _test_successful_sample_submission(self.db_config, self.config, sequences_to_upload)
+        create_project_sync_state_with_submission_table(self.db_engine, self.config)
+        check_project_submission_submitted(self.db_engine, sequences_to_upload)
+        _test_successful_sample_submission(self.db_engine, self.config, sequences_to_upload)
 
         # check notified cannot submit assembly
         _test_assembly_submission_errored(
-            self.db_config, self.config, self.slack_config, sequences_to_upload, mock_notify
+            self.db_engine, self.config, self.slack_config, sequences_to_upload, mock_notify
         )
 
 

--- a/ena-submission/scripts/test_ena_submission_integration.py
+++ b/ena-submission/scripts/test_ena_submission_integration.py
@@ -107,13 +107,16 @@ def assert_bioproject_accession(
 
 def delete_all_records(db_config: Engine) -> None:
     logger.debug("Deleting all records from all deposition tables except flyway")
-    for model_class in [SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry]:
+    for model_class in [
+        SubmissionTableEntry,
+        ProjectTableEntry,
+        SampleTableEntry,
+        AssemblyTableEntry,
+    ]:
         delete_records_in_db(db_config, model_class, {})
 
 
-def check_sequences_uploaded(
-    db_config: Engine, sequences_to_upload: dict[str, Any]
-) -> None:
+def check_sequences_uploaded(db_config: Engine, sequences_to_upload: dict[str, Any]) -> None:
     for full_accession in sequences_to_upload:
         accession, version = full_accession.split(".")
         assert in_submission_table(
@@ -139,9 +142,7 @@ def check_project_submission_started(
         ), f"Project {group_id} for {full_accession} not found in project table."
 
 
-def check_sample_submission_started(
-    db_config: Engine, sequences_to_upload: dict[str, Any]
-) -> None:
+def check_sample_submission_started(db_config: Engine, sequences_to_upload: dict[str, Any]) -> None:
     for full_accession in sequences_to_upload:
         accession, version = full_accession.split(".")
         assert (
@@ -272,9 +273,7 @@ def check_assembly_submission_with_nuc_without_gca(
         assert rows[0].result.get("gca_accession") is None
 
 
-def check_sent_to_loculus(
-    db_config: Engine, sequences_to_upload: dict[str, Any]
-) -> None:
+def check_sent_to_loculus(db_config: Engine, sequences_to_upload: dict[str, Any]) -> None:
     for full_accession in sequences_to_upload:
         accession, version = full_accession.split(".")
         assert in_submission_table(
@@ -345,9 +344,7 @@ def set_db_to_known_erz_accession(
                 db_config,
                 AssemblyTableEntry,
                 {"accession": accession, "version": version},
-                {
-                    "result": {"erz_accession": erz_accession, "segment_order": segment_order}
-                },
+                {"result": {"erz_accession": erz_accession, "segment_order": segment_order}},
             )
         if organism == "west-nile":
             update_db_where_conditions(

--- a/ena-submission/scripts/test_ena_submission_integration.py
+++ b/ena-submission/scripts/test_ena_submission_integration.py
@@ -55,9 +55,12 @@ from ena_deposition.create_sample import (
 from ena_deposition.loculus_models import Group
 from ena_deposition.notifications import SlackConfig
 from ena_deposition.submission_db_helper import (
+    AssemblyTableEntry,
+    ProjectTableEntry,
+    SampleTableEntry,
     Status,
     StatusAll,
-    TableName,
+    SubmissionTableEntry,
     add_to_assembly_table,
     add_to_project_table,
     add_to_sample_table,
@@ -71,7 +74,7 @@ from ena_deposition.trigger_submission_to_ena import upload_sequences
 from ena_deposition.upload_external_metadata_to_loculus import (
     get_external_metadata_and_send_to_loculus,
 )
-from psycopg2.pool import SimpleConnectionPool
+from sqlalchemy import Engine
 
 CONFIG_FILE = "./test/test_config.yaml"
 INPUT_FILE = "./test/approved_ena_submission_list_test.json"
@@ -83,38 +86,33 @@ TEST_GROUP: Final = Group._create_example_for_tests()
 
 
 def assert_biosample_accession(
-    rows: list[dict[str, Any]], biosample_accession: str, full_accession: str
+    rows: list[SampleTableEntry], biosample_accession: str, full_accession: str
 ) -> None:
     assert len(rows) == 1, f"Sample for {full_accession} not found in sample table."
     if biosample_accession:
-        assert rows[0]["result"].get("biosample_accession") == biosample_accession, (
+        assert rows[0].result.get("biosample_accession") == biosample_accession, (
             "Incorrect biosample accession in sample table."
         )
 
 
 def assert_bioproject_accession(
-    rows: list[dict[str, Any]], bioproject_accession: str, group_id: str, full_accession: str
+    rows: list[ProjectTableEntry], bioproject_accession: str, group_id: str, full_accession: str
 ) -> None:
     assert len(rows) == 1, f"Project {group_id} for {full_accession} not found in project table."
     if bioproject_accession:
-        assert rows[0]["result"].get("bioproject_accession") == bioproject_accession, (
+        assert rows[0].result.get("bioproject_accession") == bioproject_accession, (
             "Incorrect bioproject accession in project table."
         )
 
 
-def delete_all_records(db_config: SimpleConnectionPool) -> None:
+def delete_all_records(db_config: Engine) -> None:
     logger.debug("Deleting all records from all deposition tables except flyway")
-    for table_name in [
-        TableName.SUBMISSION_TABLE,
-        TableName.PROJECT_TABLE,
-        TableName.SAMPLE_TABLE,
-        TableName.ASSEMBLY_TABLE,
-    ]:
-        delete_records_in_db(db_config, table_name, {})
+    for model_class in [SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry]:
+        delete_records_in_db(db_config, model_class, {})
 
 
 def check_sequences_uploaded(
-    db_config: SimpleConnectionPool, sequences_to_upload: dict[str, Any]
+    db_config: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession in sequences_to_upload:
         accession, version = full_accession.split(".")
@@ -124,7 +122,7 @@ def check_sequences_uploaded(
 
 
 def check_project_submission_started(
-    db_config: SimpleConnectionPool, sequences_to_upload: dict[str, Any]
+    db_config: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession, data in sequences_to_upload.items():
         group_id = data["metadata"]["groupId"]
@@ -133,7 +131,7 @@ def check_project_submission_started(
             len(
                 find_conditions_in_db(
                     db_config,
-                    TableName.PROJECT_TABLE,
+                    ProjectTableEntry,
                     conditions={"group_id": group_id, "organism": organism, "status": "READY"},
                 )
             )
@@ -142,7 +140,7 @@ def check_project_submission_started(
 
 
 def check_sample_submission_started(
-    db_config: SimpleConnectionPool, sequences_to_upload: dict[str, Any]
+    db_config: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession in sequences_to_upload:
         accession, version = full_accession.split(".")
@@ -150,7 +148,7 @@ def check_sample_submission_started(
             len(
                 find_conditions_in_db(
                     db_config,
-                    TableName.SAMPLE_TABLE,
+                    SampleTableEntry,
                     conditions={"accession": accession, "version": version, "status": "READY"},
                 )
             )
@@ -159,13 +157,13 @@ def check_sample_submission_started(
 
 
 def check_sample_submission_submitted(
-    db_config: SimpleConnectionPool, sequences_to_upload: dict[str, Any]
+    db_config: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession, data in sequences_to_upload.items():
         accession, version = full_accession.split(".")
         rows = find_conditions_in_db(
             db_config,
-            TableName.SAMPLE_TABLE,
+            SampleTableEntry,
             conditions={"accession": accession, "version": version, "status": "SUBMITTED"},
         )
         assert_biosample_accession(rows, data["metadata"]["biosampleAccession"], full_accession)
@@ -176,67 +174,67 @@ def check_sample_submission_submitted(
 
 
 def check_sample_submission_has_errors(
-    db_config: SimpleConnectionPool, sequences_to_upload: dict[str, Any]
+    db_config: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession, data in sequences_to_upload.items():
         accession, version = full_accession.split(".")
         rows = find_conditions_in_db(
             db_config,
-            TableName.SAMPLE_TABLE,
+            SampleTableEntry,
             conditions={"accession": accession, "version": version, "status": "HAS_ERRORS"},
         )
         assert_biosample_accession(rows, data["metadata"]["biosampleAccession"], full_accession)
 
 
 def check_assembly_submission_waiting(
-    db_config: SimpleConnectionPool, sequences_to_upload: dict[str, Any]
+    db_config: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession in sequences_to_upload:
         accession, version = full_accession.split(".")
         rows = find_conditions_in_db(
             db_config,
-            TableName.ASSEMBLY_TABLE,
+            AssemblyTableEntry,
             conditions={"accession": accession, "version": version, "status": "WAITING"},
         )
         assert len(rows) == 1, f"Assembly for {full_accession} not found in assembly table."
-        assert "erz_accession" in rows[0]["result"], "Incorrect assembly result in assembly table."
-        assert "segment_order" in rows[0]["result"], "Incorrect assembly result in assembly table."
+        assert "erz_accession" in rows[0].result, "Incorrect assembly result in assembly table."
+        assert "segment_order" in rows[0].result, "Incorrect assembly result in assembly table."
 
 
 def check_assembly_submission_has_errors(
-    db_config: SimpleConnectionPool, sequences_to_upload: dict[str, Any]
+    db_config: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession in sequences_to_upload:
         accession, version = full_accession.split(".")
         rows = find_conditions_in_db(
             db_config,
-            TableName.ASSEMBLY_TABLE,
+            AssemblyTableEntry,
             conditions={"accession": accession, "version": version, "status": "HAS_ERRORS"},
         )
         assert len(rows) == 1, f"Assembly for {full_accession} not found in assembly table."
 
 
 def check_assembly_submission_started(
-    db_config: SimpleConnectionPool, sequences_to_upload: dict[str, Any]
+    db_config: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession in sequences_to_upload:
         accession, version = full_accession.split(".")
         rows = find_conditions_in_db(
             db_config,
-            TableName.ASSEMBLY_TABLE,
+            AssemblyTableEntry,
             conditions={"accession": accession, "version": version, "status": "READY"},
         )
         assert len(rows) == 1, f"Assembly for {full_accession} not found in assembly table."
 
 
 def check_assembly_submission_submitted(
-    db_config: SimpleConnectionPool, sequences_to_upload: dict[str, Any]
+    db_config: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession in sequences_to_upload:
         accession, version = full_accession.split(".")
         rows = find_conditions_in_db(
             db_config,
-            TableName.ASSEMBLY_TABLE,
+            AssemblyTableEntry,
             conditions={"accession": accession, "version": version, "status": "SUBMITTED"},
         )
         assert len(rows) == 1, (
@@ -253,13 +251,13 @@ def check_assembly_submission_submitted(
 
 
 def check_assembly_submission_with_nuc_without_gca(
-    db_config: SimpleConnectionPool, sequences_to_upload: dict[str, Any]
+    db_config: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession in sequences_to_upload:
         accession, version = full_accession.split(".")
         rows = find_conditions_in_db(
             db_config,
-            TableName.ASSEMBLY_TABLE,
+            AssemblyTableEntry,
             conditions={
                 "accession": accession,
                 "version": version,
@@ -269,13 +267,13 @@ def check_assembly_submission_with_nuc_without_gca(
         assert len(rows) == 1, (
             f"Assembly for {full_accession} not in state 'WAITING' in assembly table."
         )
-        assert rows[0]["result"].get("insdc_accession_full_L") is not None
-        assert rows[0]["result"].get("insdc_accession_full_M") is None
-        assert rows[0]["result"].get("gca_accession") is None
+        assert rows[0].result.get("insdc_accession_full_L") is not None
+        assert rows[0].result.get("insdc_accession_full_M") is None
+        assert rows[0].result.get("gca_accession") is None
 
 
 def check_sent_to_loculus(
-    db_config: SimpleConnectionPool, sequences_to_upload: dict[str, Any]
+    db_config: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession in sequences_to_upload:
         accession, version = full_accession.split(".")
@@ -290,7 +288,7 @@ def check_sent_to_loculus(
 
 
 def check_project_submission_submitted(
-    db_config: SimpleConnectionPool, sequences_to_upload: dict[str, Any]
+    db_config: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession, data in sequences_to_upload.items():
         accession, version = full_accession.split(".")
@@ -298,7 +296,7 @@ def check_project_submission_submitted(
         organism = data["organism"]
         rows = find_conditions_in_db(
             db_config,
-            TableName.PROJECT_TABLE,
+            ProjectTableEntry,
             conditions={"group_id": group_id, "organism": organism, "status": "SUBMITTED"},
         )
         assert_bioproject_accession(
@@ -311,14 +309,14 @@ def check_project_submission_submitted(
 
 
 def check_project_submission_has_errors(
-    db_config: SimpleConnectionPool, sequences_to_upload: dict[str, Any]
+    db_config: Engine, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession, data in sequences_to_upload.items():
         group_id = data["metadata"]["groupId"]
         organism = data["organism"]
         rows = find_conditions_in_db(
             db_config,
-            TableName.PROJECT_TABLE,
+            ProjectTableEntry,
             conditions={"group_id": group_id, "organism": organism, "status": "HAS_ERRORS"},
         )
         assert_bioproject_accession(
@@ -327,7 +325,7 @@ def check_project_submission_has_errors(
 
 
 def set_db_to_known_erz_accession(
-    db_config: SimpleConnectionPool, sequences_to_upload: dict[str, Any], single_segment: bool
+    db_config: Engine, sequences_to_upload: dict[str, Any], single_segment: bool
 ) -> None:
     """
     Sets erz-accession to known previous values that have received accession
@@ -345,25 +343,23 @@ def set_db_to_known_erz_accession(
             erz_accession = "ERZ24985816" if single_segment else "ERZ24784470"
             update_db_where_conditions(
                 db_config,
-                TableName.ASSEMBLY_TABLE,
+                AssemblyTableEntry,
                 {"accession": accession, "version": version},
                 {
-                    "result": json.dumps(
-                        {"erz_accession": erz_accession, "segment_order": segment_order}
-                    )
+                    "result": {"erz_accession": erz_accession, "segment_order": segment_order}
                 },
             )
         if organism == "west-nile":
             update_db_where_conditions(
                 db_config,
-                TableName.ASSEMBLY_TABLE,
+                AssemblyTableEntry,
                 {"accession": accession, "version": version},
-                {"result": json.dumps({"erz_accession": "ERZ24908522", "segment_order": ["main"]})},
+                {"result": {"erz_accession": "ERZ24908522", "segment_order": ["main"]}},
             )
 
 
 def _test_successful_assembly_submission(
-    db_config: SimpleConnectionPool,
+    db_config: Engine,
     config: Config,
     sequences_to_upload: dict[str, Any],
     single_segment: bool = False,
@@ -387,7 +383,7 @@ def _test_successful_assembly_submission(
 
 
 def _test_successful_assembly_submission_no_wait(
-    db_config: SimpleConnectionPool, config: Config, sequences_to_upload: dict[str, Any]
+    db_config: Engine, config: Config, sequences_to_upload: dict[str, Any]
 ) -> None:
     create_assembly_submission_table_start(db_config, config)
     check_assembly_submission_started(db_config, sequences_to_upload)
@@ -399,7 +395,7 @@ def _test_successful_assembly_submission_no_wait(
 
 
 def _test_assembly_submission_errored(
-    db_config: SimpleConnectionPool,
+    db_config: Engine,
     config: Config,
     slack_config: SlackConfig,
     sequences_to_upload: dict[str, Any],
@@ -426,7 +422,7 @@ def _test_assembly_submission_errored(
 
 
 def _test_successful_sample_submission(
-    db_config: SimpleConnectionPool, config: Config, sequences_to_upload: dict[str, Any]
+    db_config: Engine, config: Config, sequences_to_upload: dict[str, Any]
 ) -> None:
     create_sample_sync_state_with_submission_table(db_config, config=config)
     check_sample_submission_started(db_config, sequences_to_upload)
@@ -437,7 +433,7 @@ def _test_successful_sample_submission(
 
 
 def _test_successful_project_submission(
-    db_config: SimpleConnectionPool, config: Config, sequences_to_upload: dict[str, Any]
+    db_config: Engine, config: Config, sequences_to_upload: dict[str, Any]
 ) -> None:
     create_project_sync_state_with_submission_table(db_config, config)
     check_project_submission_started(db_config, sequences_to_upload)
@@ -481,7 +477,7 @@ def mock_requests_post() -> Mock:
 
 
 def multi_segment_submission(
-    db_config: SimpleConnectionPool,
+    db_config: Engine,
     config: Config,
     mock_get_group_info: Mock,
     mock_submit_external_metadata: Mock,
@@ -706,16 +702,15 @@ class TestFirstPublicUpdate(TestSubmission):
         )
 
         # Check that visibility column is None
-        rows: list[dict] = find_conditions_in_db(
+        rows = find_conditions_in_db(
             self.db_config,
-            config.table_name,
+            config.entry_class,
             conditions=conditions,
         )
         logger.debug(f"Rows found after invalid check: {rows}")
         assert len(rows) == 1, f"{entity_type.value} not found in table."
 
-        entry_after_invalid = config.entry_class(**rows[0])
-        visibility_value = getattr(entry_after_invalid, column_name)
+        visibility_value = getattr(rows[0], column_name)
         assert visibility_value is None, (
             f"{column_name} should be None for non-existing accessions. Got: {visibility_value}"
         )
@@ -723,9 +718,9 @@ class TestFirstPublicUpdate(TestSubmission):
         # Update the entry to have valid accessions
         update_db_where_conditions(
             self.db_config,
-            config.table_name,
+            config.entry_class,
             conditions=conditions,
-            update_values={"result": json.dumps(test_data["valid_result"])},
+            update_values={"result": test_data["valid_result"]},
         )
 
         # Run the visibility check again with valid accessions
@@ -736,13 +731,12 @@ class TestFirstPublicUpdate(TestSubmission):
         # Check that visibility column is now updated
         rows = find_conditions_in_db(
             self.db_config,
-            config.table_name,
+            config.entry_class,
             conditions=conditions,
         )
         assert len(rows) == 1, f"{entity_type.value} not found in table after update."
 
-        entry_after_valid = config.entry_class(**rows[0])
-        visibility_value = getattr(entry_after_valid, column_name)
+        visibility_value = getattr(rows[0], column_name)
         assert visibility_value is not None, (
             f"{column_name} should be updated to current timestamp for valid accessions. "
             f"Got: {visibility_value}"

--- a/ena-submission/src/ena_deposition/api.py
+++ b/ena-submission/src/ena_deposition/api.py
@@ -1,5 +1,6 @@
 import logging
 import threading
+from typing import cast
 
 import uvicorn
 from fastapi import FastAPI, HTTPException
@@ -25,7 +26,9 @@ def get_bio_sample_accessions(engine: Engine) -> dict[str, str]:
     with Session(engine) as session:
         stmt = select(SampleTableEntry).where(SampleTableEntry.status == str(Status.SUBMITTED))
         results = list(session.scalars(stmt).all())
-    return {row.accession: row.result["biosample_accession"] for row in results if row.result}
+    return {
+        row.accession: cast(str, row.result["biosample_accession"]) for row in results if row.result
+    }
 
 
 def get_insdc_accessions(engine: Engine) -> dict[str, list[str]]:
@@ -36,7 +39,9 @@ def get_insdc_accessions(engine: Engine) -> dict[str, list[str]]:
         results = list(session.scalars(stmt).all())
     return {
         row.accession: [
-            row.result[key] for key in row.result if key.startswith("insdc_accession_full")
+            cast(str, row.result[key])
+            for key in row.result
+            if key.startswith("insdc_accession_full")
         ]
         for row in results
         if row.result

--- a/ena-submission/src/ena_deposition/api.py
+++ b/ena-submission/src/ena_deposition/api.py
@@ -50,6 +50,7 @@ def get_insdc_accessions(engine: Engine) -> dict[str, list[str]]:
 
 def init_app(config: Config):
     app.state.config = config
+    app.state.engine = db_init(config.db_password, config.db_username, config.db_url)
 
 
 @app.get("/")
@@ -59,8 +60,7 @@ def read_root():
 
 @app.get("/submitted", response_model=SubmittedAccessionsResponse)
 def submitted_insdc_accessions():
-    config = app.state.config
-    engine = db_init(config.db_password, config.db_username, config.db_url)
+    engine = app.state.engine
     try:
         insdc_accessions = get_insdc_accessions(engine)
         all_insdc_accessions = [item for sublist in insdc_accessions.values() for item in sublist]

--- a/ena-submission/src/ena_deposition/api.py
+++ b/ena-submission/src/ena_deposition/api.py
@@ -3,12 +3,12 @@ import threading
 
 import uvicorn
 from fastapi import FastAPI, HTTPException
-from psycopg2.extras import RealDictCursor
-from psycopg2.pool import SimpleConnectionPool
 from pydantic import BaseModel
+from sqlalchemy import Engine, select
+from sqlalchemy.orm import Session
 
 from .config import Config
-from .submission_db_helper import db_init
+from .submission_db_helper import AssemblyTableEntry, SampleTableEntry, Status, db_init
 
 logger = logging.getLogger(__name__)
 
@@ -21,39 +21,33 @@ class SubmittedAccessionsResponse(BaseModel):
     biosampleAccessions: list[str]  # noqa: N815
 
 
-def get_bio_sample_accessions(db_conn_pool: SimpleConnectionPool) -> dict[str, str]:
-    con = db_conn_pool.getconn()
-    try:
-        with con, con.cursor(cursor_factory=RealDictCursor) as cur:
-            query = "SELECT accession, result FROM sample_table WHERE STATUS = 'SUBMITTED'"
-            cur.execute(query)
-            results = cur.fetchall()
-    finally:
-        db_conn_pool.putconn(con)
-
-    return {result["accession"]: result["result"]["biosample_accession"] for result in results}
-
-
-def get_insdc_accessions(db_conn_pool: SimpleConnectionPool) -> dict[str, list[str]]:
-    con = db_conn_pool.getconn()
-    try:
-        with con, con.cursor(cursor_factory=RealDictCursor) as cur:
-            query = (
-                "SELECT accession, result FROM assembly_table "
-                "WHERE STATUS IN ('SUBMITTED', 'WAITING')"
-            )
-            cur.execute(query)
-            results = cur.fetchall()
-    finally:
-        db_conn_pool.putconn(con)
-
+def get_bio_sample_accessions(engine: Engine) -> dict[str, str]:
+    with Session(engine) as session:
+        stmt = select(SampleTableEntry).where(
+            SampleTableEntry.status == str(Status.SUBMITTED)
+        )
+        results = list(session.scalars(stmt).all())
     return {
-        result["accession"]: [
-            result["result"][key]
-            for key in result["result"]
+        row.accession: row.result["biosample_accession"]
+        for row in results
+        if row.result
+    }
+
+
+def get_insdc_accessions(engine: Engine) -> dict[str, list[str]]:
+    with Session(engine) as session:
+        stmt = select(AssemblyTableEntry).where(
+            AssemblyTableEntry.status.in_([str(Status.SUBMITTED), str(Status.WAITING)])
+        )
+        results = list(session.scalars(stmt).all())
+    return {
+        row.accession: [
+            row.result[key]
+            for key in row.result
             if key.startswith("insdc_accession_full")
         ]
-        for result in results
+        for row in results
+        if row.result
     }
 
 
@@ -69,11 +63,11 @@ def read_root():
 @app.get("/submitted", response_model=SubmittedAccessionsResponse)
 def submitted_insdc_accessions():
     config = app.state.config
-    db_conn_pool = db_init(config.db_password, config.db_username, config.db_url)
+    engine = db_init(config.db_password, config.db_username, config.db_url)
     try:
-        insdc_accessions = get_insdc_accessions(db_conn_pool)
+        insdc_accessions = get_insdc_accessions(engine)
         all_insdc_accessions = [item for sublist in insdc_accessions.values() for item in sublist]
-        bio_samples = list(get_bio_sample_accessions(db_conn_pool).values())
+        bio_samples = list(get_bio_sample_accessions(engine).values())
         return {
             "status": "ok",
             "insdcAccessions": all_insdc_accessions,

--- a/ena-submission/src/ena_deposition/api.py
+++ b/ena-submission/src/ena_deposition/api.py
@@ -23,15 +23,9 @@ class SubmittedAccessionsResponse(BaseModel):
 
 def get_bio_sample_accessions(engine: Engine) -> dict[str, str]:
     with Session(engine) as session:
-        stmt = select(SampleTableEntry).where(
-            SampleTableEntry.status == str(Status.SUBMITTED)
-        )
+        stmt = select(SampleTableEntry).where(SampleTableEntry.status == str(Status.SUBMITTED))
         results = list(session.scalars(stmt).all())
-    return {
-        row.accession: row.result["biosample_accession"]
-        for row in results
-        if row.result
-    }
+    return {row.accession: row.result["biosample_accession"] for row in results if row.result}
 
 
 def get_insdc_accessions(engine: Engine) -> dict[str, list[str]]:
@@ -42,9 +36,7 @@ def get_insdc_accessions(engine: Engine) -> dict[str, list[str]]:
         results = list(session.scalars(stmt).all())
     return {
         row.accession: [
-            row.result[key]
-            for key in row.result
-            if key.startswith("insdc_accession_full")
+            row.result[key] for key in row.result if key.startswith("insdc_accession_full")
         ]
         for row in results
         if row.result

--- a/ena-submission/src/ena_deposition/api.py
+++ b/ena-submission/src/ena_deposition/api.py
@@ -24,7 +24,7 @@ class SubmittedAccessionsResponse(BaseModel):
 
 def get_bio_sample_accessions(engine: Engine) -> dict[str, str]:
     with Session(engine) as session:
-        stmt = select(SampleTableEntry).where(SampleTableEntry.status == str(Status.SUBMITTED))
+        stmt = select(SampleTableEntry).where(SampleTableEntry.status == Status.SUBMITTED)
         results = list(session.scalars(stmt).all())
     return {
         row.accession: cast(str, row.result["biosample_accession"]) for row in results if row.result
@@ -34,7 +34,7 @@ def get_bio_sample_accessions(engine: Engine) -> dict[str, str]:
 def get_insdc_accessions(engine: Engine) -> dict[str, list[str]]:
     with Session(engine) as session:
         stmt = select(AssemblyTableEntry).where(
-            AssemblyTableEntry.status.in_([str(Status.SUBMITTED), str(Status.WAITING)])
+            AssemblyTableEntry.status.in_([Status.SUBMITTED, Status.WAITING])
         )
         results = list(session.scalars(stmt).all())
     return {

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -268,7 +268,7 @@ def check_and_update_visibility_for_column(
     )
 
     for entity in entities_needing_check:
-        entity_id = asdict(entity.primary_key)
+        entity_id = asdict(entity.pkey)
         accessions = get_accessions_to_check(entity, column_config)
 
         if not accessions:

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -18,7 +18,7 @@ from http import HTTPStatus
 
 import pytz
 import requests
-from psycopg2.pool import SimpleConnectionPool
+from sqlalchemy import Engine
 
 from ena_deposition.config import Config
 from ena_deposition.submission_db_helper import (
@@ -26,7 +26,6 @@ from ena_deposition.submission_db_helper import (
     ProjectTableEntry,
     SampleTableEntry,
     Status,
-    TableName,
     db_init,
     find_conditions_in_db,
     update_db_where_conditions,
@@ -45,7 +44,6 @@ class EntityType(Enum):
 class ColumnCheckConfig:
     """Configuration for checking a specific table column"""
 
-    table_name: TableName
     entry_class: type[ProjectTableEntry | SampleTableEntry | AssemblyTableEntry]
     visibility_column: str
     accession_field_name_prefix: str  # Field prefix in result dict (e.g. "insdc_accession_full")
@@ -152,28 +150,24 @@ class NCBIVisibilityChecker(VisibilityChecker):
 # Configuration mapping: (EntityType, column_name) -> ColumnCheckConfig
 COLUMN_CONFIGS = {
     (EntityType.PROJECT, "ena_first_publicly_visible"): ColumnCheckConfig(
-        table_name=TableName.PROJECT_TABLE,
         entry_class=ProjectTableEntry,
         visibility_column="ena_first_publicly_visible",
         accession_field_name_prefix="bioproject_accession",
         checker_class=ENAVisibilityChecker,
     ),
     (EntityType.PROJECT, "ncbi_first_publicly_visible"): ColumnCheckConfig(
-        table_name=TableName.PROJECT_TABLE,
         entry_class=ProjectTableEntry,
         visibility_column="ncbi_first_publicly_visible",
         accession_field_name_prefix="bioproject_accession",
         checker_class=NCBIVisibilityChecker,
     ),
     (EntityType.SAMPLE, "ena_first_publicly_visible"): ColumnCheckConfig(
-        table_name=TableName.SAMPLE_TABLE,
         entry_class=SampleTableEntry,
         visibility_column="ena_first_publicly_visible",
         accession_field_name_prefix="biosample_accession",
         checker_class=ENAVisibilityChecker,
     ),
     (EntityType.SAMPLE, "ncbi_first_publicly_visible"): ColumnCheckConfig(
-        table_name=TableName.SAMPLE_TABLE,
         entry_class=SampleTableEntry,
         visibility_column="ncbi_first_publicly_visible",
         accession_field_name_prefix="biosample_accession",
@@ -181,14 +175,12 @@ COLUMN_CONFIGS = {
     ),
     # Assemblies - ENA nucleotide accessions
     (EntityType.ASSEMBLY, "ena_nucleotide_first_publicly_visible"): ColumnCheckConfig(
-        table_name=TableName.ASSEMBLY_TABLE,
         entry_class=AssemblyTableEntry,
         visibility_column="ena_nucleotide_first_publicly_visible",
         accession_field_name_prefix="insdc_accession_full",  # Prefix for multi-segment accessions
         checker_class=ENAVisibilityChecker,
     ),
     (EntityType.ASSEMBLY, "ncbi_nucleotide_first_publicly_visible"): ColumnCheckConfig(
-        table_name=TableName.ASSEMBLY_TABLE,
         entry_class=AssemblyTableEntry,
         visibility_column="ncbi_nucleotide_first_publicly_visible",
         accession_field_name_prefix="insdc_accession_full",  # Prefix for multi-segment accessions
@@ -196,14 +188,12 @@ COLUMN_CONFIGS = {
     ),
     # Assemblies - ENA GCA accessions
     (EntityType.ASSEMBLY, "ena_gca_first_publicly_visible"): ColumnCheckConfig(
-        table_name=TableName.ASSEMBLY_TABLE,
         entry_class=AssemblyTableEntry,
         visibility_column="ena_gca_first_publicly_visible",
         accession_field_name_prefix="gca_accession",
         checker_class=ENAVisibilityChecker,
     ),
     (EntityType.ASSEMBLY, "ncbi_gca_first_publicly_visible"): ColumnCheckConfig(
-        table_name=TableName.ASSEMBLY_TABLE,
         entry_class=AssemblyTableEntry,
         visibility_column="ncbi_gca_first_publicly_visible",
         accession_field_name_prefix="gca_accession",
@@ -213,21 +203,17 @@ COLUMN_CONFIGS = {
 
 
 def get_entities_needing_column_check(
-    pool: SimpleConnectionPool, column_config: ColumnCheckConfig
+    engine: Engine, column_config: ColumnCheckConfig
 ) -> list[SampleTableEntry | ProjectTableEntry | AssemblyTableEntry]:
-    """Get entities (db rows for Project/Sample/Assembly) that don't have a timestamp
-    for a specific visibility column"""
-
-    data_in_submission_table: list[dict] = find_conditions_in_db(
-        pool,
-        table_name=column_config.table_name,
+    """Get entities that don't have a timestamp for a specific visibility column"""
+    return find_conditions_in_db(
+        engine,
+        column_config.entry_class,
         conditions={
             column_config.visibility_column: None,
-            "status": Status.SUBMITTED,
+            "status": str(Status.SUBMITTED),
         },
     )
-
-    return [column_config.entry_class(**row) for row in data_in_submission_table]
 
 
 def get_accessions_to_check(
@@ -258,7 +244,7 @@ def get_accessions_to_check(
 
 def check_and_update_visibility_for_column(
     config: Config,
-    pool: SimpleConnectionPool,
+    engine: Engine,
     entity_type: EntityType,
     column_name: str,
 ):
@@ -276,7 +262,7 @@ def check_and_update_visibility_for_column(
         return
 
     logger.debug(f"Checking {entity_type.value}.{column_name} for visibility")
-    entities_needing_check = get_entities_needing_column_check(pool, column_config)
+    entities_needing_check = get_entities_needing_column_check(engine, column_config)
     logger.info(
         f"Found {len(entities_needing_check)} {entity_type.value}s needing {column_name} check"
     )
@@ -318,8 +304,8 @@ def check_and_update_visibility_for_column(
                 "publicly visible, updating database."
             )
             updated_count = update_db_where_conditions(
-                pool,
-                table_name=column_config.table_name,
+                engine,
+                model_class=column_config.entry_class,
                 conditions=entity_id,
                 update_values={column_config.visibility_column: first_visible_timestamp},
             )
@@ -342,19 +328,19 @@ def check_and_update_visibility_for_column(
             )
 
 
-def check_and_update_visibility_all_columns(config: Config, pool: SimpleConnectionPool):
+def check_and_update_visibility_all_columns(config: Config, engine: Engine):
     """Check and update visibility for all configured (entity_type, column) combinations"""
 
     for entity_type, column_name in COLUMN_CONFIGS:
         try:
-            check_and_update_visibility_for_column(config, pool, entity_type, column_name)
+            check_and_update_visibility_for_column(config, engine, entity_type, column_name)
         except Exception as e:
             logger.error(f"Error checking {entity_type.value}.{column_name}: {e}", exc_info=True)
 
 
 def check_and_update_visibility(config: Config, stop_event: threading.Event):
     """Main loop function"""
-    pool = db_init(config.db_password, config.db_username, config.db_url)
+    engine = db_init(config.db_password, config.db_username, config.db_url)
 
     while True:
         start_time = time.time()
@@ -362,7 +348,7 @@ def check_and_update_visibility(config: Config, stop_event: threading.Event):
             logger.info("check_and_update_visibility stopped due to exception in another task")
             return
 
-        check_and_update_visibility_all_columns(config, pool)
+        check_and_update_visibility_all_columns(config, engine)
         logger.debug("check_and_update_visibility finished, sleeping for a while")
 
         gca_cache.clear()

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -257,9 +257,6 @@ def check_and_update_visibility_for_column(
 
     # Get the appropriate visibility checker
     visibility_checker: VisibilityChecker = column_config.checker_class()
-    if not visibility_checker:
-        logger.error(f"No checker found for {column_config.checker_class}")
-        return
 
     logger.debug(f"Checking {entity_type.value}.{column_name} for visibility")
     entities_needing_check = get_entities_needing_column_check(db_engine, column_config)

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -203,11 +203,11 @@ COLUMN_CONFIGS = {
 
 
 def get_entities_needing_column_check(
-    engine: Engine, column_config: ColumnCheckConfig
+    db_engine: Engine, column_config: ColumnCheckConfig
 ) -> list[SampleTableEntry | ProjectTableEntry | AssemblyTableEntry]:
     """Get entities that don't have a timestamp for a specific visibility column"""
     return find_conditions_in_db(
-        engine,
+        db_engine,
         column_config.entry_class,
         conditions={
             column_config.visibility_column: None,
@@ -244,7 +244,7 @@ def get_accessions_to_check(
 
 def check_and_update_visibility_for_column(
     config: Config,
-    engine: Engine,
+    db_engine: Engine,
     entity_type: EntityType,
     column_name: str,
 ):
@@ -262,7 +262,7 @@ def check_and_update_visibility_for_column(
         return
 
     logger.debug(f"Checking {entity_type.value}.{column_name} for visibility")
-    entities_needing_check = get_entities_needing_column_check(engine, column_config)
+    entities_needing_check = get_entities_needing_column_check(db_engine, column_config)
     logger.info(
         f"Found {len(entities_needing_check)} {entity_type.value}s needing {column_name} check"
     )
@@ -304,7 +304,7 @@ def check_and_update_visibility_for_column(
                 "publicly visible, updating database."
             )
             updated_count = update_db_where_conditions(
-                engine,
+                db_engine,
                 model_class=column_config.entry_class,
                 conditions=entity_id,
                 update_values={column_config.visibility_column: first_visible_timestamp},
@@ -328,19 +328,19 @@ def check_and_update_visibility_for_column(
             )
 
 
-def check_and_update_visibility_all_columns(config: Config, engine: Engine):
+def check_and_update_visibility_all_columns(config: Config, db_engine: Engine):
     """Check and update visibility for all configured (entity_type, column) combinations"""
 
     for entity_type, column_name in COLUMN_CONFIGS:
         try:
-            check_and_update_visibility_for_column(config, engine, entity_type, column_name)
+            check_and_update_visibility_for_column(config, db_engine, entity_type, column_name)
         except Exception as e:
             logger.error(f"Error checking {entity_type.value}.{column_name}: {e}", exc_info=True)
 
 
 def check_and_update_visibility(config: Config, stop_event: threading.Event):
     """Main loop function"""
-    engine = db_init(config.db_password, config.db_username, config.db_url)
+    db_engine = db_init(config.db_password, config.db_username, config.db_url)
 
     while True:
         start_time = time.time()
@@ -348,7 +348,7 @@ def check_and_update_visibility(config: Config, stop_event: threading.Event):
             logger.info("check_and_update_visibility stopped due to exception in another task")
             return
 
-        check_and_update_visibility_all_columns(config, engine)
+        check_and_update_visibility_all_columns(config, db_engine)
         logger.debug("check_and_update_visibility finished, sleeping for a while")
 
         gca_cache.clear()

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -211,7 +211,7 @@ def get_entities_needing_column_check(
         column_config.entry_class,
         conditions={
             column_config.visibility_column: None,
-            "status": str(Status.SUBMITTED),
+            "status": Status.SUBMITTED,
         },
     )
 

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -249,7 +249,7 @@ def submission_table_start(db_engine: Engine, config: Config) -> None:
             f"Found {len(ready_to_submit)} entries in submission_table in status SUBMITTED_SAMPLE"
         )
     for row in ready_to_submit:
-        seq_key = {"accession": row.accession, "version": row.version}
+        seq_key = asdict(row.pkey)
 
         run_ref = row.seq_metadata.get("insdcRawReadsAccession")
         if run_ref and not accession_exists(run_ref, config):
@@ -301,7 +301,7 @@ def submission_table_update(db_engine: Engine) -> None:
             f"in status SUBMITTING_ASSEMBLY"
         )
     for row in submitting_assembly:
-        seq_key = {"accession": row.accession, "version": row.version}
+        seq_key = asdict(row.pkey)
 
         corresponding_assembly = find_conditions_in_db(
             db_engine, AssemblyTableEntry, conditions=seq_key
@@ -675,7 +675,7 @@ def assembly_table_update(db_engine: Engine, config: Config, time_threshold: int
     if not _last_ena_check or now - timedelta(minutes=time_threshold) > _last_ena_check:
         logger.debug("Checking state in ENA")
         for row in waiting:
-            seq_key = {"accession": row.accession, "version": row.version}
+            seq_key = asdict(row.pkey)
             submission_rows = find_conditions_in_db(
                 db_engine, SubmissionTableEntry, conditions=seq_key
             )

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -455,7 +455,7 @@ def is_flatfile_data_changed(db_engine: Engine, submission_row: SubmissionTableE
     last_version_rows = find_conditions_in_db(
         db_engine,
         SubmissionTableEntry,
-        conditions=asdict(seq_key),
+        conditions={"accession": seq_key.accession, "version": version_to_revise},
     )
     if len(last_version_rows) == 0:
         error_msg = f"Last version {version_to_revise} not found in submission_table"

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -257,7 +257,7 @@ def submission_table_start(db_engine: Engine, config: Config) -> None:
                 conditions=seq_key,
                 accession=run_ref,
                 accession_type="RUN_REF",
-                db_pool=db_engine,
+                db_engine=db_engine,
             )
             continue
 

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -716,8 +716,7 @@ def assembly_table_update(db_engine: Engine, config: Config, time_threshold: int
             else:
                 status = Status.SUBMITTED
                 logger.info(
-                    f"Assembly accessioned by ENA for {seq_key.accession} version "
-                    f"{seq_key.version}"
+                    f"Assembly accessioned by ENA for {seq_key.accession} version {seq_key.version}"
                 )
             update_with_retry(
                 db_engine=db_engine,

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -49,8 +49,9 @@ from .submission_db_helper import (
     find_conditions_in_db,
     find_errors_or_stuck_in_db,
     find_waiting_in_db,
+    is_latest_revision,
     is_revision,
-    last_version,
+    previous_version,
     update_db_where_conditions,
     update_with_retry,
 )
@@ -356,9 +357,9 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
        requires manual revision
     """
     seq_key = submission_row.pkey
-    if not is_revision(db_engine, seq_key):
+    if not is_latest_revision(db_engine, seq_key):
         return False
-    version_to_revise = last_version(db_engine, seq_key)
+    version_to_revise = previous_version(db_engine, seq_key)
     last_version_rows = find_conditions_in_db(
         db_engine,
         SubmissionTableEntry,
@@ -450,7 +451,7 @@ def is_flatfile_data_changed(db_engine: Engine, submission_row: SubmissionTableE
     Check if change in sequence or flatfile metadata has occurred since last version.
     """
     seq_key = submission_row.pkey
-    version_to_revise = last_version(db_engine, seq_key)
+    version_to_revise = previous_version(db_engine, seq_key)
     last_version_rows = find_conditions_in_db(
         db_engine,
         SubmissionTableEntry,
@@ -493,7 +494,7 @@ def is_flatfile_data_changed(db_engine: Engine, submission_row: SubmissionTableE
 
 
 def update_assembly_results_with_latest_version(db_engine: Engine, seq_key: AccessionVersion):
-    version_to_revise = last_version(db_engine, seq_key)
+    version_to_revise = previous_version(db_engine, seq_key)
     last_version_rows = find_conditions_in_db(
         db_engine,
         AssemblyTableEntry,

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 from typing import Any, Literal
 
 import pytz
-from psycopg2.pool import SimpleConnectionPool
+from sqlalchemy import Engine
 
 from ena_deposition import call_loculus
 
@@ -39,9 +39,11 @@ from .notifications import SlackConfig, send_slack_notification, slack_conn_init
 from .submission_db_helper import (
     AccessionVersion,
     AssemblyTableEntry,
+    ProjectTableEntry,
+    SampleTableEntry,
     Status,
     StatusAll,
-    TableName,
+    SubmissionTableEntry,
     add_to_assembly_table,
     db_init,
     find_conditions_in_db,
@@ -58,7 +60,7 @@ logger = logging.getLogger(__name__)
 
 def create_chromosome_list_object(
     unaligned_sequences: dict[str, str],
-    seq_key: dict[str, str],
+    accession: str,
     organism_metadata: EnaOrganismDetails,
 ) -> AssemblyChromosomeListFile:
     # Use https://www.ebi.ac.uk/ena/browser/view/GCA_900094155.1?show=chromosomes as a template
@@ -74,7 +76,7 @@ def create_chromosome_list_object(
         topology = organism_metadata.topology
         if multi_segment:
             entry = AssemblyChromosomeListFileObject(
-                object_name=f"{seq_key['accession']}_{segment_name}",
+                object_name=f"{accession}_{segment_name}",
                 chromosome_name=segment_name,
                 chromosome_type=ChromosomeType.SEGMENTED,
                 topology=topology,
@@ -82,7 +84,7 @@ def create_chromosome_list_object(
             entries.append(entry)
             continue
         entry = AssemblyChromosomeListFileObject(
-            object_name=f"{seq_key['accession']}",
+            object_name=f"{accession}",
             chromosome_name="genome",
             chromosome_type=ChromosomeType.MONOPARTITE,
             topology=topology,
@@ -101,24 +103,24 @@ def get_segment_order(unaligned_sequences: dict[str, str]) -> list[str]:
     return sorted(segment_order)
 
 
-def get_address(config: Config, entry: dict[str, Any]) -> str | None:
+def get_address(config: Config, submission_row: SubmissionTableEntry) -> str | None:
     if not config.is_broker:
         return None
     try:
-        group_details = call_loculus.get_group_info(config, entry["metadata"]["groupId"])
+        group_details = call_loculus.get_group_info(config, submission_row.seq_metadata["groupId"])
     except Exception as e:
         logger.error(
-            f"Failed to fetch group info for groupId={entry['metadata']['groupId']}\n"
+            f"Failed to fetch group info for groupId={submission_row.seq_metadata['groupId']}\n"
             f"{traceback.format_exc()}"
         )
         msg = (
             "Failed to fetch group info from Loculus for group: "
-            f"{entry['metadata']['groupId']}, {e}"
+            f"{submission_row.seq_metadata['groupId']}, {e}"
         )
         raise RuntimeError(msg) from e
     address = group_details.address
     address_list = [
-        entry["center_name"],  # corresponds to Loculus' "Institution" group field
+        submission_row.center_name,  # corresponds to Loculus' "Institution" group field
         address.city,
         address.state,
         address.country,
@@ -177,7 +179,7 @@ def create_manifest_object(
     config: Config,
     sample_accession: str,
     study_accession: str,
-    submission_table_entry: dict[str, Any],
+    submission_row: SubmissionTableEntry,
     dir: str | None = None,
 ) -> AssemblyManifest:
     """
@@ -191,17 +193,17 @@ def create_manifest_object(
     If test=True add a timestamp to the alias suffix to allow for multiple submissions of the same
     manifest for testing.
     """
-    metadata = submission_table_entry["metadata"]
+    metadata = submission_row.seq_metadata
 
     assembly_name = make_assembly_name(
-        submission_table_entry["accession"],
-        submission_table_entry["version"],
+        submission_row.accession,
+        str(submission_row.version),
     )
 
-    unaligned_nucleotide_sequences = submission_table_entry["unaligned_nucleotide_sequences"]
-    ena_organism = config.enaOrganisms[submission_table_entry["organism"]]
+    unaligned_nucleotide_sequences = submission_row.unaligned_nucleotide_sequences
+    ena_organism = config.enaOrganisms[submission_row.organism]
     chromosome_list_object = create_chromosome_list_object(
-        unaligned_nucleotide_sequences, submission_table_entry, ena_organism
+        unaligned_nucleotide_sequences, submission_row.accession, ena_organism
     )
     chromosome_list_file = create_chromosome_list(list_object=chromosome_list_object, dir=dir)
     logger.debug("Created chromosome list file")
@@ -220,20 +222,18 @@ def create_manifest_object(
             description=get_description(config, metadata),
             moleculetype=ena_organism.molecule_type,
             **assembly_values,  # type: ignore
-            address=get_address(config, submission_table_entry),
+            address=get_address(config, submission_row),
         )
     except Exception as e:
         # log traceback for better debugging
         logger.error(f"Error creating AssemblyManifest: {e}. Traceback: {traceback.format_exc()}")
-        msg = (
-            f"Failed to create AssemblyManifest for accession {submission_table_entry['accession']}"
-        )
+        msg = f"Failed to create AssemblyManifest for accession {submission_row.accession}"
         raise RuntimeError(msg) from e
 
     return manifest
 
 
-def submission_table_start(db_config: SimpleConnectionPool, config: Config) -> None:
+def submission_table_start(db_config: Engine, config: Config) -> None:
     """
     1. Find all entries in submission_table in state SUBMITTED_SAMPLE
     2. If entry has insdcRawReadsAccession, check it exists in ENA, if not set error and continue
@@ -242,38 +242,32 @@ def submission_table_start(db_config: SimpleConnectionPool, config: Config) -> N
     b.      Else update state to SUBMITTING_ASSEMBLY
     4. Else create corresponding entry in assembly_table
     """
-    conditions = {"status_all": StatusAll.SUBMITTED_SAMPLE}
-    ready_to_submit = find_conditions_in_db(
-        db_config, table_name=TableName.SUBMISSION_TABLE, conditions=conditions
-    )
+    conditions = {"status_all": str(StatusAll.SUBMITTED_SAMPLE)}
+    ready_to_submit = find_conditions_in_db(db_config, SubmissionTableEntry, conditions=conditions)
     if len(ready_to_submit) > 0:
         logger.debug(
             f"Found {len(ready_to_submit)} entries in submission_table in status SUBMITTED_SAMPLE"
         )
     for row in ready_to_submit:
-        seq_key = {"accession": row["accession"], "version": row["version"]}
+        seq_key = {"accession": row.accession, "version": row.version}
 
-        if (
-            "insdcRawReadsAccession" in row["metadata"]
-            and row["metadata"]["insdcRawReadsAccession"]
-        ):
-            run_ref = row["metadata"]["insdcRawReadsAccession"]
-            if not accession_exists(run_ref, config):
-                set_accession_does_not_exist_error(
-                    conditions=seq_key,
-                    accession=run_ref,
-                    accession_type="RUN_REF",
-                    db_pool=db_config,
-                )
-                continue
+        run_ref = row.seq_metadata.get("insdcRawReadsAccession")
+        if run_ref and not accession_exists(run_ref, config):
+            set_accession_does_not_exist_error(
+                conditions=seq_key,
+                accession=run_ref,
+                accession_type="RUN_REF",
+                db_pool=db_config,
+            )
+            continue
 
         # 1. check if there exists an entry in the assembly_table for seq_key
         corresponding_assembly = find_conditions_in_db(
-            db_config, table_name=TableName.ASSEMBLY_TABLE, conditions=seq_key
+            db_config, AssemblyTableEntry, conditions=seq_key
         )
         status_all = None
         if len(corresponding_assembly) == 1:
-            if corresponding_assembly[0]["status"] == str(Status.SUBMITTED):
+            if corresponding_assembly[0].status == str(Status.SUBMITTED):
                 status_all = StatusAll.SUBMITTED_ALL
             else:
                 status_all = StatusAll.SUBMITTING_ASSEMBLY
@@ -284,22 +278,22 @@ def submission_table_start(db_config: SimpleConnectionPool, config: Config) -> N
             status_all = StatusAll.SUBMITTING_ASSEMBLY
         update_db_where_conditions(
             db_config,
-            table_name=TableName.SUBMISSION_TABLE,
+            model_class=SubmissionTableEntry,
             conditions=seq_key,
             update_values={"status_all": status_all},
         )
 
 
-def submission_table_update(db_config: SimpleConnectionPool) -> None:
+def submission_table_update(db_config: Engine) -> None:
     """
     1. Find all entries in submission_table in state SUBMITTING_ASSEMBLY
     2. If (exists an entry in the assembly_table for (accession, version)):
     a.      If (in state SUBMITTED) update state in submission_table to SUBMITTED_ALL
     3. Else throw Error
     """
-    conditions = {"status_all": StatusAll.SUBMITTING_ASSEMBLY}
+    conditions = {"status_all": str(StatusAll.SUBMITTING_ASSEMBLY)}
     submitting_assembly = find_conditions_in_db(
-        db_config, table_name=TableName.SUBMISSION_TABLE, conditions=conditions
+        db_config, SubmissionTableEntry, conditions=conditions
     )
     if len(submitting_assembly) > 0:
         logger.debug(
@@ -307,18 +301,18 @@ def submission_table_update(db_config: SimpleConnectionPool) -> None:
             f"in status SUBMITTING_ASSEMBLY"
         )
     for row in submitting_assembly:
-        seq_key = {"accession": row["accession"], "version": row["version"]}
+        seq_key = {"accession": row.accession, "version": row.version}
 
         corresponding_assembly = find_conditions_in_db(
-            db_config, table_name=TableName.ASSEMBLY_TABLE, conditions=seq_key
+            db_config, AssemblyTableEntry, conditions=seq_key
         )
-        if len(corresponding_assembly) == 1 and corresponding_assembly[0]["status"] == str(
+        if len(corresponding_assembly) == 1 and corresponding_assembly[0].status == str(
             Status.SUBMITTED
         ):
             update_values = {"status_all": StatusAll.SUBMITTED_ALL}
             update_db_where_conditions(
                 db_config,
-                table_name=TableName.SUBMISSION_TABLE,
+                model_class=SubmissionTableEntry,
                 conditions=seq_key,
                 update_values=update_values,
             )
@@ -331,9 +325,9 @@ def submission_table_update(db_config: SimpleConnectionPool) -> None:
 
 
 def update_assembly_error(
-    db_config: SimpleConnectionPool,
+    db_config: Engine,
     error: list[str],
-    seq_key: dict[str, str],
+    seq_key: dict[str, Any],
     update_type: Literal["revision"] | Literal["creation"],
 ) -> None:
     logger.error(
@@ -348,11 +342,11 @@ def update_assembly_error(
             "errors": error,
             "started_at": datetime.now(tz=pytz.utc),
         },
-        table_name=TableName.ASSEMBLY_TABLE,
+        model_class=AssemblyTableEntry,
     )
 
 
-def can_be_revised(config: Config, db_config: SimpleConnectionPool, entry: dict[str, Any]) -> bool:
+def can_be_revised(config: Config, db_config: Engine, submission_row: SubmissionTableEntry) -> bool:
     """
     Check if assembly can be revised
     1. Last version exists in submission_table, otherwise throw RuntimeError
@@ -361,20 +355,20 @@ def can_be_revised(config: Config, db_config: SimpleConnectionPool, entry: dict[
     3. metadata fields in manifest haven't changed since previous version, otherwise
        requires manual revision
     """
-    seq_key = AccessionVersion(accession=entry["accession"], version=entry["version"])
+    seq_key = AccessionVersion(accession=submission_row.accession, version=submission_row.version)
     if not is_revision(db_config, seq_key):
         return False
     version_to_revise = last_version(db_config, seq_key)
-    last_version_data = find_conditions_in_db(
+    last_version_rows = find_conditions_in_db(
         db_config,
-        table_name=TableName.SUBMISSION_TABLE,
-        conditions={"accession": entry["accession"], "version": version_to_revise},
+        SubmissionTableEntry,
+        conditions={"accession": submission_row.accession, "version": version_to_revise},
     )
-    if len(last_version_data) == 0:
+    if len(last_version_rows) == 0:
         error_msg = f"Last version {version_to_revise} not found in submission_table"
         raise RuntimeError(error_msg)
 
-    last_version_entry = last_version_data[0]
+    last_version_entry = last_version_rows[0]
 
     previous_sample_accession, previous_study_accession = get_project_and_sample_results(
         db_config, last_version_entry
@@ -383,33 +377,43 @@ def can_be_revised(config: Config, db_config: SimpleConnectionPool, entry: dict[
         f"Previous sample accession: {previous_sample_accession}, "
         f"previous study accession: {previous_study_accession}"
     )
-    if entry["metadata"].get("biosampleAccession"):
-        new_sample_accession = entry["metadata"]["biosampleAccession"]
+    if submission_row.seq_metadata.get("biosampleAccession"):
+        new_sample_accession = submission_row.seq_metadata["biosampleAccession"]
         if previous_sample_accession != new_sample_accession:
             error = (
                 "Assembly cannot be revised because biosampleAccession in new version: "
                 f"{new_sample_accession} differs from last version: {previous_sample_accession}"
             )
             logger.error(error)
-            update_assembly_error(db_config, [error], seq_key=entry, update_type="revision")
+            update_assembly_error(
+                db_config,
+                [error],
+                seq_key={"accession": submission_row.accession, "version": submission_row.version},
+                update_type="revision",
+            )
             return False
-    if entry["metadata"].get("bioprojectAccession"):
-        new_project_accession = entry["metadata"]["bioprojectAccession"]
+    if submission_row.seq_metadata.get("bioprojectAccession"):
+        new_project_accession = submission_row.seq_metadata["bioprojectAccession"]
         if new_project_accession != previous_study_accession:
             error = (
                 "Assembly cannot be revised because bioprojectAccession in new version: "
                 f"{new_project_accession} differs from last version: {previous_study_accession}"
             )
             logger.error(error)
-            update_assembly_error(db_config, [error], seq_key=entry, update_type="revision")
+            update_assembly_error(
+                db_config,
+                [error],
+                seq_key={"accession": submission_row.accession, "version": submission_row.version},
+                update_type="revision",
+            )
             return False
 
     differing_fields = {}
     for mapping in config.manifest_fields_mapping.values():
         loculus_field_names = mapping.loculus_fields
         for loculus_field_name in loculus_field_names:
-            last_entry = last_version_entry["metadata"].get(loculus_field_name)
-            new_entry = entry["metadata"].get(loculus_field_name)
+            last_entry = last_version_entry.seq_metadata.get(loculus_field_name)
+            new_entry = submission_row.seq_metadata.get(loculus_field_name)
             if loculus_field_name == "authors":
                 try:
                     last_entry = get_authors(last_entry) if last_entry else last_entry
@@ -431,30 +435,34 @@ def can_be_revised(config: Config, db_config: SimpleConnectionPool, entry: dict[
             f"last version: {json.dumps(differing_fields)}"
         )
         logger.error(error)
-        update_assembly_error(db_config, [error], seq_key=entry, update_type="revision")
+        update_assembly_error(
+            db_config,
+            [error],
+            seq_key={"accession": submission_row.accession, "version": submission_row.version},
+            update_type="revision",
+        )
         return False
     return True
 
 
-def is_flatfile_data_changed(db_config: SimpleConnectionPool, entry: dict[str, Any]) -> bool:
+def is_flatfile_data_changed(db_config: Engine, submission_row: SubmissionTableEntry) -> bool:
     """
     Check if change in sequence or flatfile metadata has occurred since last version.
     """
-    seq_key = AccessionVersion(accession=entry["accession"], version=entry["version"])
+    seq_key = AccessionVersion(accession=submission_row.accession, version=submission_row.version)
     version_to_revise = last_version(db_config, seq_key)
-    last_version_data = find_conditions_in_db(
+    last_version_rows = find_conditions_in_db(
         db_config,
-        table_name=TableName.SUBMISSION_TABLE,
+        SubmissionTableEntry,
         conditions={"accession": seq_key.accession, "version": version_to_revise},
     )
-    if len(last_version_data) == 0:
+    if len(last_version_rows) == 0:
         error_msg = f"Last version {version_to_revise} not found in submission_table"
         raise RuntimeError(error_msg)
 
-    if (
-        entry["unaligned_nucleotide_sequences"]
-        != last_version_data[0]["unaligned_nucleotide_sequences"]
-    ):
+    last_entry = last_version_rows[0]
+
+    if submission_row.unaligned_nucleotide_sequences != last_entry.unaligned_nucleotide_sequences:
         logger.debug(
             f"Unaligned nucleotide sequences have changed for {seq_key.accession}, "
             f"from {version_to_revise} to {seq_key.version} - should be revised"
@@ -469,34 +477,32 @@ def is_flatfile_data_changed(db_config: SimpleConnectionPool, entry: dict[str, A
         *DEFAULT_EMBL_PROPERTY_FIELDS.admin_level_properties,
     ]
     for field in fields:
-        last_entry = last_version_data[0]["metadata"].get(field)
-        new_entry = entry["metadata"].get(field)
-        if last_entry != new_entry:
+        last_val = last_entry.seq_metadata.get(field)
+        new_val = submission_row.seq_metadata.get(field)
+        if last_val != new_val:
             logger.debug(
-                f"Field {field} has changed from {last_entry} to {new_entry} "
-                f"for {entry['accession']}. (Maybe other fields changed as well)"
+                f"Field {field} has changed from {last_val} to {new_val} "
+                f"for {submission_row.accession}. (Maybe other fields changed as well)"
             )
             return True
     logger.debug(
-        f"No changes detected for {entry['accession']} from version {version_to_revise} "
-        f"to {entry['version']}"
+        f"No changes detected for {submission_row.accession} from version {version_to_revise} "
+        f"to {submission_row.version}"
     )
     return False
 
 
-def update_assembly_results_with_latest_version(
-    db_config: SimpleConnectionPool, seq_key: AccessionVersion
-):
+def update_assembly_results_with_latest_version(db_config: Engine, seq_key: AccessionVersion):
     version_to_revise = last_version(db_config, seq_key)
-    last_version_data = find_conditions_in_db(
+    last_version_rows = find_conditions_in_db(
         db_config,
-        table_name=TableName.ASSEMBLY_TABLE,
+        AssemblyTableEntry,
         conditions={
             "accession": seq_key.accession,
             "version": version_to_revise,
         },
     )
-    if len(last_version_data) == 0:
+    if len(last_version_rows) == 0:
         error_msg = f"Last version {version_to_revise} not found in assembly_table"
         raise RuntimeError(error_msg)
     logger.info(
@@ -509,39 +515,37 @@ def update_assembly_results_with_latest_version(
         conditions=asdict(seq_key),
         update_values={
             "status": Status.SUBMITTED,
-            "result": last_version_data[0]["result"],
+            "result": last_version_rows[0].result,
         },
-        table_name=TableName.ASSEMBLY_TABLE,
+        model_class=AssemblyTableEntry,
         reraise=False,
     )
 
 
 def get_project_and_sample_results(
-    db_config: SimpleConnectionPool, entry: dict[str, str]
+    db_config: Engine, submission_row: SubmissionTableEntry
 ) -> tuple[str, str]:
-    seq_key = {"accession": entry["accession"], "version": entry["version"]}
+    seq_key = {"accession": submission_row.accession, "version": submission_row.version}
 
-    results_in_sample_table = find_conditions_in_db(
-        db_config, table_name=TableName.SAMPLE_TABLE, conditions=seq_key
-    )
-    if len(results_in_sample_table) == 0:
-        error_msg = f"Entry {entry['accession']} not found in sample_table"
+    sample_rows = find_conditions_in_db(db_config, SampleTableEntry, conditions=seq_key)
+    if len(sample_rows) == 0:
+        error_msg = f"Entry {submission_row.accession} not found in sample_table"
         raise RuntimeError(error_msg)
 
-    results_in_project_table = find_conditions_in_db(
+    project_rows = find_conditions_in_db(
         db_config,
-        table_name=TableName.PROJECT_TABLE,
-        conditions={"project_id": entry["project_id"]},
+        ProjectTableEntry,
+        conditions={"project_id": submission_row.project_id},
     )
-    if len(results_in_project_table) == 0:
-        error_msg = f"Entry {entry['accession']} not found in project_table"
+    if len(project_rows) == 0:
+        error_msg = f"Entry {submission_row.accession} not found in project_table"
         raise RuntimeError(error_msg)
-    sample_accession = results_in_sample_table[0]["result"]["ena_sample_accession"]
-    study_accession = results_in_project_table[0]["result"]["bioproject_accession"]
+    sample_accession = sample_rows[0].result["ena_sample_accession"]
+    study_accession = project_rows[0].result["bioproject_accession"]
     return sample_accession, study_accession
 
 
-def assembly_table_create(db_config: SimpleConnectionPool, config: Config):
+def assembly_table_create(db_config: Engine, config: Config):
     """
     1. Find all entries in assembly_table in state READY
     2. Create temporary files: chromosome_list_file, embl_file, manifest_file
@@ -551,33 +555,34 @@ def assembly_table_create(db_config: SimpleConnectionPool, config: Config):
 
     If config.test=True: use the test ENA webin-cli endpoint for submission.
     """
-    conditions = {"status": Status.READY}
+    conditions = {"status": str(Status.READY)}
     ready_to_submit_assembly = find_conditions_in_db(
-        db_config, table_name=TableName.ASSEMBLY_TABLE, conditions=conditions
+        db_config, AssemblyTableEntry, conditions=conditions
     )
     if len(ready_to_submit_assembly) > 0:
         logger.debug(
             f"Found {len(ready_to_submit_assembly)} entries in assembly_table in status READY"
         )
     for row in ready_to_submit_assembly:
-        seq_key = AccessionVersion(accession=row["accession"], version=row["version"])
-        sample_data_in_submission_table = find_conditions_in_db(
-            db_config, table_name=TableName.SUBMISSION_TABLE, conditions=asdict(seq_key)
+        seq_key = AccessionVersion(accession=row.accession, version=row.version)
+        submission_rows = find_conditions_in_db(
+            db_config, SubmissionTableEntry, conditions=asdict(seq_key)
         )
-        if len(sample_data_in_submission_table) == 0:
-            error_msg = f"Entry {row['accession']} not found in submitting_table"
+        if len(submission_rows) == 0:
+            error_msg = f"Entry {row.accession} not found in submitting_table"
             raise RuntimeError(error_msg)
-        center_name = sample_data_in_submission_table[0]["center_name"]
+        submission_row = submission_rows[0]
+        center_name = submission_row.center_name
 
         sample_accession, study_accession = get_project_and_sample_results(
-            db_config, sample_data_in_submission_table[0]
+            db_config, submission_row
         )
 
         if is_revision(db_config, seq_key):
-            logger.debug(f"Entry {row['accession']} is a revision, checking if it can be revised")
-            if not can_be_revised(config, db_config, sample_data_in_submission_table[0]):
+            logger.debug(f"Entry {row.accession} is a revision, checking if it can be revised")
+            if not can_be_revised(config, db_config, submission_row):
                 continue
-            if not is_flatfile_data_changed(db_config, sample_data_in_submission_table[0]):
+            if not is_flatfile_data_changed(db_config, submission_row):
                 update_assembly_results_with_latest_version(db_config, seq_key)
                 continue
 
@@ -586,19 +591,17 @@ def assembly_table_create(db_config: SimpleConnectionPool, config: Config):
                 config,
                 sample_accession,
                 study_accession,
-                sample_data_in_submission_table[0],
+                submission_row,
             )
             manifest_file = create_manifest(manifest_object, is_broker=config.is_broker)
         except Exception as e:
-            logger.error(
-                f"Manifest creation failed for accession {row['accession']} with error {e}"
-            )
+            logger.error(f"Manifest creation failed for accession {row.accession} with error {e}")
             continue
 
         update_values: dict[str, Any] = {"status": Status.SUBMITTING}
         number_rows_updated = update_db_where_conditions(
             db_config,
-            table_name=TableName.ASSEMBLY_TABLE,
+            model_class=AssemblyTableEntry,
             conditions=asdict(seq_key),
             update_values=update_values,
         )
@@ -609,10 +612,8 @@ def assembly_table_create(db_config: SimpleConnectionPool, config: Config):
                 "not starting submission."
             )
             continue
-        logger.info(f"Starting assembly creation for accession {row['accession']}")
-        segment_order = get_segment_order(
-            sample_data_in_submission_table[0]["unaligned_nucleotide_sequences"]
-        )
+        logger.info(f"Starting assembly creation for accession {row.accession}")
+        segment_order = get_segment_order(submission_row.unaligned_nucleotide_sequences)
 
         # Actual webin-cli command is run here
         assembly_creation_results: CreationResult = create_ena_assembly(
@@ -633,13 +634,13 @@ def assembly_table_create(db_config: SimpleConnectionPool, config: Config):
                 db_config=db_config,
                 conditions=asdict(seq_key),
                 update_values=update_values,
-                table_name=TableName.ASSEMBLY_TABLE,
+                model_class=AssemblyTableEntry,
             )
         else:
             update_assembly_error(
                 db_config,
                 assembly_creation_results.errors,
-                seq_key=row,
+                seq_key={"accession": row.accession, "version": row.version},
                 update_type="creation",
             )
 
@@ -647,7 +648,7 @@ def assembly_table_create(db_config: SimpleConnectionPool, config: Config):
 _last_ena_check: datetime | None = None
 
 
-def assembly_table_update(db_config: SimpleConnectionPool, config: Config, time_threshold: int = 5):
+def assembly_table_update(db_config: Engine, config: Config, time_threshold: int = 5):
     """
     - time_threshold (minutes)
     1. Find all entries in assembly_table in state WAITING
@@ -655,32 +656,30 @@ def assembly_table_update(db_config: SimpleConnectionPool, config: Config, time_
     3. If (exists): update state to SUBMITTED with results
     """
     global _last_ena_check  # noqa: PLW0603
-    conditions = {"status": Status.WAITING}
-    waiting = find_conditions_in_db(
-        db_config, table_name=TableName.ASSEMBLY_TABLE, conditions=conditions
-    )
+    conditions = {"status": str(Status.WAITING)}
+    waiting = find_conditions_in_db(db_config, AssemblyTableEntry, conditions=conditions)
     if len(waiting) > 0:
         logger.debug(f"Found {len(waiting)} entries in assembly_table in status WAITING")
     # Check if ENA has assigned an accession, don't do this too frequently
-    time = datetime.now(tz=pytz.utc)
-    if not _last_ena_check or time - timedelta(minutes=time_threshold) > _last_ena_check:
+    now = datetime.now(tz=pytz.utc)
+    if not _last_ena_check or now - timedelta(minutes=time_threshold) > _last_ena_check:
         logger.debug("Checking state in ENA")
         for row in waiting:
-            seq_key = {"accession": row["accession"], "version": row["version"]}
-            sample_data_in_submission_table = find_conditions_in_db(
-                db_config, table_name=TableName.SUBMISSION_TABLE, conditions=seq_key
+            seq_key = {"accession": row.accession, "version": row.version}
+            submission_rows = find_conditions_in_db(
+                db_config, SubmissionTableEntry, conditions=seq_key
             )
-            if len(sample_data_in_submission_table) == 0:
-                error_msg = f"Entry {row['accession']} not found in submitting_table"
+            if len(submission_rows) == 0:
+                error_msg = f"Entry {row.accession} not found in submitting_table"
                 raise RuntimeError(error_msg)
-            organism = config.enaOrganisms[sample_data_in_submission_table[0]["organism"]]
+            organism = config.enaOrganisms[submission_rows[0].organism]
             # Previous means from the last time the entry was checked, from db
-            previous_result = row["result"]
+            previous_result = row.result
             segment_order = previous_result["segment_order"]
             new_result: CreationResult = get_ena_analysis_process(
                 config, previous_result["erz_accession"], segment_order, organism
             )
-            _last_ena_check = time
+            _last_ena_check = now
 
             if not new_result.result:
                 continue
@@ -712,13 +711,13 @@ def assembly_table_update(db_config: SimpleConnectionPool, config: Config, time_
                     "result": new_result.result,
                     "finished_at": datetime.now(tz=pytz.utc),
                 },
-                table_name=TableName.ASSEMBLY_TABLE,
+                model_class=AssemblyTableEntry,
                 reraise=False,
             )
 
 
 def assembly_table_handle_errors(
-    db_config: SimpleConnectionPool,
+    db_config: Engine,
     config: Config,
     slack_config: SlackConfig,
     last_retry_time: datetime | None,
@@ -730,18 +729,18 @@ def assembly_table_handle_errors(
     3. Trigger retry if time since last retry is over retry_threshold_min
     """
     entries_waiting = find_waiting_in_db(
-        db_config, TableName.ASSEMBLY_TABLE, time_threshold=config.waiting_threshold_hours
+        db_config, AssemblyTableEntry, time_threshold=config.waiting_threshold_hours
     )
     entries_with_errors = find_errors_or_stuck_in_db(
         db_config,
-        TableName.ASSEMBLY_TABLE,
+        AssemblyTableEntry,
         time_threshold=config.submitting_time_threshold_min,
     )
 
     messages = []
 
     if entries_waiting:
-        top3_accessions = [entry.get("accession") for entry in entries_waiting[:3]]
+        top3_accessions = [entry.accession for entry in entries_waiting[:3]]
         msg = (
             f"{config.backend_url}: ENA Submission pipeline found "
             f"{len(entries_waiting)} entries in assembly_table in "
@@ -761,7 +760,7 @@ def assembly_table_handle_errors(
         last_retry_time = retry_failed_submissions_for_matching_errors(
             entries_with_errors,
             db_config,
-            table_name=TableName.ASSEMBLY_TABLE,
+            model_class=AssemblyTableEntry,
             retry_threshold_min=config.retry_threshold_min,
             last_retry=last_retry_time,
             error_substrings=(

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -163,7 +163,7 @@ def get_assembly_values_in_metadata(config: Config, metadata: dict[str, str]) ->
     return assembly_values
 
 
-def make_assembly_name(accession: str, version: str) -> str:
+def make_assembly_name(accession: str, version: int) -> str:
     """
     Create a unique assembly name based on accession, version and timestamp.
     Add a timestamp to the alias suffix.
@@ -197,7 +197,7 @@ def create_manifest_object(
 
     assembly_name = make_assembly_name(
         submission_row.accession,
-        str(submission_row.version),
+        submission_row.version,
     )
 
     unaligned_nucleotide_sequences = submission_row.unaligned_nucleotide_sequences
@@ -355,7 +355,7 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
     3. metadata fields in manifest haven't changed since previous version, otherwise
        requires manual revision
     """
-    seq_key = AccessionVersion(accession=submission_row.accession, version=submission_row.version)
+    seq_key = submission_row.pkey
     if not is_revision(db_engine, seq_key):
         return False
     version_to_revise = last_version(db_engine, seq_key)
@@ -388,7 +388,7 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
             update_assembly_error(
                 db_engine,
                 [error],
-                seq_key={"accession": submission_row.accession, "version": submission_row.version},
+                seq_key=asdict(submission_row.pkey),
                 update_type="revision",
             )
             return False
@@ -403,7 +403,7 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
             update_assembly_error(
                 db_engine,
                 [error],
-                seq_key={"accession": submission_row.accession, "version": submission_row.version},
+                seq_key=asdict(submission_row.pkey),
                 update_type="revision",
             )
             return False
@@ -438,7 +438,7 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
         update_assembly_error(
             db_engine,
             [error],
-            seq_key={"accession": submission_row.accession, "version": submission_row.version},
+            seq_key=asdict(submission_row.pkey),
             update_type="revision",
         )
         return False
@@ -449,12 +449,12 @@ def is_flatfile_data_changed(db_engine: Engine, submission_row: SubmissionTableE
     """
     Check if change in sequence or flatfile metadata has occurred since last version.
     """
-    seq_key = AccessionVersion(accession=submission_row.accession, version=submission_row.version)
+    seq_key = submission_row.pkey
     version_to_revise = last_version(db_engine, seq_key)
     last_version_rows = find_conditions_in_db(
         db_engine,
         SubmissionTableEntry,
-        conditions={"accession": seq_key.accession, "version": version_to_revise},
+        conditions=asdict(seq_key),
     )
     if len(last_version_rows) == 0:
         error_msg = f"Last version {version_to_revise} not found in submission_table"
@@ -574,7 +574,7 @@ def assembly_table_create(db_engine: Engine, config: Config):
             f"Found {len(ready_to_submit_assembly)} entries in assembly_table in status READY"
         )
     for row in ready_to_submit_assembly:
-        seq_key = AccessionVersion(accession=row.accession, version=row.version)
+        seq_key = row.pkey
         submission_rows = find_conditions_in_db(
             db_engine, SubmissionTableEntry, conditions=asdict(seq_key)
         )
@@ -650,7 +650,7 @@ def assembly_table_create(db_engine: Engine, config: Config):
             update_assembly_error(
                 db_engine,
                 assembly_creation_results.errors,
-                seq_key={"accession": row.accession, "version": row.version},
+                seq_key=asdict(row.pkey),
                 update_type="creation",
             )
 

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -242,7 +242,7 @@ def submission_table_start(db_config: Engine, config: Config) -> None:
     b.      Else update state to SUBMITTING_ASSEMBLY
     4. Else create corresponding entry in assembly_table
     """
-    conditions = {"status_all": str(StatusAll.SUBMITTED_SAMPLE)}
+    conditions = {"status_all": StatusAll.SUBMITTED_SAMPLE}
     ready_to_submit = find_conditions_in_db(db_config, SubmissionTableEntry, conditions=conditions)
     if len(ready_to_submit) > 0:
         logger.debug(
@@ -267,7 +267,7 @@ def submission_table_start(db_config: Engine, config: Config) -> None:
         )
         status_all = None
         if len(corresponding_assembly) == 1:
-            if corresponding_assembly[0].status == str(Status.SUBMITTED):
+            if corresponding_assembly[0].status == Status.SUBMITTED:
                 status_all = StatusAll.SUBMITTED_ALL
             else:
                 status_all = StatusAll.SUBMITTING_ASSEMBLY
@@ -291,7 +291,7 @@ def submission_table_update(db_config: Engine) -> None:
     a.      If (in state SUBMITTED) update state in submission_table to SUBMITTED_ALL
     3. Else throw Error
     """
-    conditions = {"status_all": str(StatusAll.SUBMITTING_ASSEMBLY)}
+    conditions = {"status_all": StatusAll.SUBMITTING_ASSEMBLY}
     submitting_assembly = find_conditions_in_db(
         db_config, SubmissionTableEntry, conditions=conditions
     )
@@ -565,7 +565,7 @@ def assembly_table_create(db_config: Engine, config: Config):
 
     If config.test=True: use the test ENA webin-cli endpoint for submission.
     """
-    conditions = {"status": str(Status.READY)}
+    conditions = {"status": Status.READY}
     ready_to_submit_assembly = find_conditions_in_db(
         db_config, AssemblyTableEntry, conditions=conditions
     )
@@ -666,7 +666,7 @@ def assembly_table_update(db_config: Engine, config: Config, time_threshold: int
     3. If (exists): update state to SUBMITTED with results
     """
     global _last_ena_check  # noqa: PLW0603
-    conditions = {"status": str(Status.WAITING)}
+    conditions = {"status": Status.WAITING}
     waiting = find_conditions_in_db(db_config, AssemblyTableEntry, conditions=conditions)
     if len(waiting) > 0:
         logger.debug(f"Found {len(waiting)} entries in assembly_table in status WAITING")

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -233,7 +233,7 @@ def create_manifest_object(
     return manifest
 
 
-def submission_table_start(db_config: Engine, config: Config) -> None:
+def submission_table_start(db_engine: Engine, config: Config) -> None:
     """
     1. Find all entries in submission_table in state SUBMITTED_SAMPLE
     2. If entry has insdcRawReadsAccession, check it exists in ENA, if not set error and continue
@@ -243,7 +243,7 @@ def submission_table_start(db_config: Engine, config: Config) -> None:
     4. Else create corresponding entry in assembly_table
     """
     conditions = {"status_all": StatusAll.SUBMITTED_SAMPLE}
-    ready_to_submit = find_conditions_in_db(db_config, SubmissionTableEntry, conditions=conditions)
+    ready_to_submit = find_conditions_in_db(db_engine, SubmissionTableEntry, conditions=conditions)
     if len(ready_to_submit) > 0:
         logger.debug(
             f"Found {len(ready_to_submit)} entries in submission_table in status SUBMITTED_SAMPLE"
@@ -257,13 +257,13 @@ def submission_table_start(db_config: Engine, config: Config) -> None:
                 conditions=seq_key,
                 accession=run_ref,
                 accession_type="RUN_REF",
-                db_pool=db_config,
+                db_pool=db_engine,
             )
             continue
 
         # 1. check if there exists an entry in the assembly_table for seq_key
         corresponding_assembly = find_conditions_in_db(
-            db_config, AssemblyTableEntry, conditions=seq_key
+            db_engine, AssemblyTableEntry, conditions=seq_key
         )
         status_all = None
         if len(corresponding_assembly) == 1:
@@ -273,18 +273,18 @@ def submission_table_start(db_config: Engine, config: Config) -> None:
                 status_all = StatusAll.SUBMITTING_ASSEMBLY
         else:
             # If not: create assembly_entry, change status to SUBMITTING_ASSEMBLY
-            if not add_to_assembly_table(db_config, AssemblyTableEntry(**seq_key)):
+            if not add_to_assembly_table(db_engine, AssemblyTableEntry(**seq_key)):
                 continue
             status_all = StatusAll.SUBMITTING_ASSEMBLY
         update_db_where_conditions(
-            db_config,
+            db_engine,
             model_class=SubmissionTableEntry,
             conditions=seq_key,
             update_values={"status_all": status_all},
         )
 
 
-def submission_table_update(db_config: Engine) -> None:
+def submission_table_update(db_engine: Engine) -> None:
     """
     1. Find all entries in submission_table in state SUBMITTING_ASSEMBLY
     2. If (exists an entry in the assembly_table for (accession, version)):
@@ -293,7 +293,7 @@ def submission_table_update(db_config: Engine) -> None:
     """
     conditions = {"status_all": StatusAll.SUBMITTING_ASSEMBLY}
     submitting_assembly = find_conditions_in_db(
-        db_config, SubmissionTableEntry, conditions=conditions
+        db_engine, SubmissionTableEntry, conditions=conditions
     )
     if len(submitting_assembly) > 0:
         logger.debug(
@@ -304,14 +304,14 @@ def submission_table_update(db_config: Engine) -> None:
         seq_key = {"accession": row.accession, "version": row.version}
 
         corresponding_assembly = find_conditions_in_db(
-            db_config, AssemblyTableEntry, conditions=seq_key
+            db_engine, AssemblyTableEntry, conditions=seq_key
         )
         if len(corresponding_assembly) == 1 and corresponding_assembly[0].status == str(
             Status.SUBMITTED
         ):
             update_values = {"status_all": StatusAll.SUBMITTED_ALL}
             update_db_where_conditions(
-                db_config,
+                db_engine,
                 model_class=SubmissionTableEntry,
                 conditions=seq_key,
                 update_values=update_values,
@@ -325,7 +325,7 @@ def submission_table_update(db_config: Engine) -> None:
 
 
 def update_assembly_error(
-    db_config: Engine,
+    db_engine: Engine,
     error: list[str],
     seq_key: dict[str, Any],
     update_type: Literal["revision"] | Literal["creation"],
@@ -335,7 +335,7 @@ def update_assembly_error(
         f"version {seq_key['version']}. Propagating to db. Error: {error}"
     )
     update_with_retry(
-        db_config=db_config,
+        db_engine=db_engine,
         conditions={"accession": seq_key["accession"], "version": seq_key["version"]},
         update_values={
             "status": Status.HAS_ERRORS,
@@ -346,7 +346,7 @@ def update_assembly_error(
     )
 
 
-def can_be_revised(config: Config, db_config: Engine, submission_row: SubmissionTableEntry) -> bool:
+def can_be_revised(config: Config, db_engine: Engine, submission_row: SubmissionTableEntry) -> bool:
     """
     Check if assembly can be revised
     1. Last version exists in submission_table, otherwise throw RuntimeError
@@ -356,11 +356,11 @@ def can_be_revised(config: Config, db_config: Engine, submission_row: Submission
        requires manual revision
     """
     seq_key = AccessionVersion(accession=submission_row.accession, version=submission_row.version)
-    if not is_revision(db_config, seq_key):
+    if not is_revision(db_engine, seq_key):
         return False
-    version_to_revise = last_version(db_config, seq_key)
+    version_to_revise = last_version(db_engine, seq_key)
     last_version_rows = find_conditions_in_db(
-        db_config,
+        db_engine,
         SubmissionTableEntry,
         conditions={"accession": submission_row.accession, "version": version_to_revise},
     )
@@ -371,7 +371,7 @@ def can_be_revised(config: Config, db_config: Engine, submission_row: Submission
     last_version_entry = last_version_rows[0]
 
     previous_sample_accession, previous_study_accession = get_project_and_sample_results(
-        db_config, last_version_entry
+        db_engine, last_version_entry
     )
     logger.debug(
         f"Previous sample accession: {previous_sample_accession}, "
@@ -386,7 +386,7 @@ def can_be_revised(config: Config, db_config: Engine, submission_row: Submission
             )
             logger.error(error)
             update_assembly_error(
-                db_config,
+                db_engine,
                 [error],
                 seq_key={"accession": submission_row.accession, "version": submission_row.version},
                 update_type="revision",
@@ -401,7 +401,7 @@ def can_be_revised(config: Config, db_config: Engine, submission_row: Submission
             )
             logger.error(error)
             update_assembly_error(
-                db_config,
+                db_engine,
                 [error],
                 seq_key={"accession": submission_row.accession, "version": submission_row.version},
                 update_type="revision",
@@ -436,7 +436,7 @@ def can_be_revised(config: Config, db_config: Engine, submission_row: Submission
         )
         logger.error(error)
         update_assembly_error(
-            db_config,
+            db_engine,
             [error],
             seq_key={"accession": submission_row.accession, "version": submission_row.version},
             update_type="revision",
@@ -445,14 +445,14 @@ def can_be_revised(config: Config, db_config: Engine, submission_row: Submission
     return True
 
 
-def is_flatfile_data_changed(db_config: Engine, submission_row: SubmissionTableEntry) -> bool:
+def is_flatfile_data_changed(db_engine: Engine, submission_row: SubmissionTableEntry) -> bool:
     """
     Check if change in sequence or flatfile metadata has occurred since last version.
     """
     seq_key = AccessionVersion(accession=submission_row.accession, version=submission_row.version)
-    version_to_revise = last_version(db_config, seq_key)
+    version_to_revise = last_version(db_engine, seq_key)
     last_version_rows = find_conditions_in_db(
-        db_config,
+        db_engine,
         SubmissionTableEntry,
         conditions={"accession": seq_key.accession, "version": version_to_revise},
     )
@@ -492,10 +492,10 @@ def is_flatfile_data_changed(db_config: Engine, submission_row: SubmissionTableE
     return False
 
 
-def update_assembly_results_with_latest_version(db_config: Engine, seq_key: AccessionVersion):
-    version_to_revise = last_version(db_config, seq_key)
+def update_assembly_results_with_latest_version(db_engine: Engine, seq_key: AccessionVersion):
+    version_to_revise = last_version(db_engine, seq_key)
     last_version_rows = find_conditions_in_db(
-        db_config,
+        db_engine,
         AssemblyTableEntry,
         conditions={
             "accession": seq_key.accession,
@@ -511,7 +511,7 @@ def update_assembly_results_with_latest_version(db_config: Engine, seq_key: Acce
         "change in flatfile data."
     )
     update_with_retry(
-        db_config=db_config,
+        db_engine=db_engine,
         conditions=asdict(seq_key),
         update_values={
             "status": Status.SUBMITTED,
@@ -523,17 +523,17 @@ def update_assembly_results_with_latest_version(db_config: Engine, seq_key: Acce
 
 
 def get_project_and_sample_results(
-    db_config: Engine, submission_row: SubmissionTableEntry
+    db_engine: Engine, submission_row: SubmissionTableEntry
 ) -> tuple[str, str]:
     seq_key = {"accession": submission_row.accession, "version": submission_row.version}
 
-    sample_rows = find_conditions_in_db(db_config, SampleTableEntry, conditions=seq_key)
+    sample_rows = find_conditions_in_db(db_engine, SampleTableEntry, conditions=seq_key)
     if len(sample_rows) == 0:
         error_msg = f"Entry {submission_row.accession} not found in sample_table"
         raise RuntimeError(error_msg)
 
     project_rows = find_conditions_in_db(
-        db_config,
+        db_engine,
         ProjectTableEntry,
         conditions={"project_id": submission_row.project_id},
     )
@@ -555,7 +555,7 @@ def get_project_and_sample_results(
     return cast(str, sample_accession), cast(str, study_accession)
 
 
-def assembly_table_create(db_config: Engine, config: Config):
+def assembly_table_create(db_engine: Engine, config: Config):
     """
     1. Find all entries in assembly_table in state READY
     2. Create temporary files: chromosome_list_file, embl_file, manifest_file
@@ -567,7 +567,7 @@ def assembly_table_create(db_config: Engine, config: Config):
     """
     conditions = {"status": Status.READY}
     ready_to_submit_assembly = find_conditions_in_db(
-        db_config, AssemblyTableEntry, conditions=conditions
+        db_engine, AssemblyTableEntry, conditions=conditions
     )
     if len(ready_to_submit_assembly) > 0:
         logger.debug(
@@ -576,7 +576,7 @@ def assembly_table_create(db_config: Engine, config: Config):
     for row in ready_to_submit_assembly:
         seq_key = AccessionVersion(accession=row.accession, version=row.version)
         submission_rows = find_conditions_in_db(
-            db_config, SubmissionTableEntry, conditions=asdict(seq_key)
+            db_engine, SubmissionTableEntry, conditions=asdict(seq_key)
         )
         if len(submission_rows) == 0:
             error_msg = f"Entry {row.accession} not found in submitting_table"
@@ -585,15 +585,15 @@ def assembly_table_create(db_config: Engine, config: Config):
         center_name = submission_row.center_name
 
         sample_accession, study_accession = get_project_and_sample_results(
-            db_config, submission_row
+            db_engine, submission_row
         )
 
-        if is_revision(db_config, seq_key):
+        if is_revision(db_engine, seq_key):
             logger.debug(f"Entry {row.accession} is a revision, checking if it can be revised")
-            if not can_be_revised(config, db_config, submission_row):
+            if not can_be_revised(config, db_engine, submission_row):
                 continue
-            if not is_flatfile_data_changed(db_config, submission_row):
-                update_assembly_results_with_latest_version(db_config, seq_key)
+            if not is_flatfile_data_changed(db_engine, submission_row):
+                update_assembly_results_with_latest_version(db_engine, seq_key)
                 continue
 
         try:
@@ -610,7 +610,7 @@ def assembly_table_create(db_config: Engine, config: Config):
 
         update_values: dict[str, Any] = {"status": Status.SUBMITTING}
         number_rows_updated = update_db_where_conditions(
-            db_config,
+            db_engine,
             model_class=AssemblyTableEntry,
             conditions=asdict(seq_key),
             update_values=update_values,
@@ -641,14 +641,14 @@ def assembly_table_create(db_config: Engine, config: Config):
                 f"Assembly creation succeeded for {seq_key.accession} version {seq_key.version}"
             )
             update_with_retry(
-                db_config=db_config,
+                db_engine=db_engine,
                 conditions=asdict(seq_key),
                 update_values=update_values,
                 model_class=AssemblyTableEntry,
             )
         else:
             update_assembly_error(
-                db_config,
+                db_engine,
                 assembly_creation_results.errors,
                 seq_key={"accession": row.accession, "version": row.version},
                 update_type="creation",
@@ -658,7 +658,7 @@ def assembly_table_create(db_config: Engine, config: Config):
 _last_ena_check: datetime | None = None
 
 
-def assembly_table_update(db_config: Engine, config: Config, time_threshold: int = 5):
+def assembly_table_update(db_engine: Engine, config: Config, time_threshold: int = 5):
     """
     - time_threshold (minutes)
     1. Find all entries in assembly_table in state WAITING
@@ -667,7 +667,7 @@ def assembly_table_update(db_config: Engine, config: Config, time_threshold: int
     """
     global _last_ena_check  # noqa: PLW0603
     conditions = {"status": Status.WAITING}
-    waiting = find_conditions_in_db(db_config, AssemblyTableEntry, conditions=conditions)
+    waiting = find_conditions_in_db(db_engine, AssemblyTableEntry, conditions=conditions)
     if len(waiting) > 0:
         logger.debug(f"Found {len(waiting)} entries in assembly_table in status WAITING")
     # Check if ENA has assigned an accession, don't do this too frequently
@@ -677,7 +677,7 @@ def assembly_table_update(db_config: Engine, config: Config, time_threshold: int
         for row in waiting:
             seq_key = {"accession": row.accession, "version": row.version}
             submission_rows = find_conditions_in_db(
-                db_config, SubmissionTableEntry, conditions=seq_key
+                db_engine, SubmissionTableEntry, conditions=seq_key
             )
             if len(submission_rows) == 0:
                 error_msg = f"Entry {row.accession} not found in submitting_table"
@@ -720,7 +720,7 @@ def assembly_table_update(db_config: Engine, config: Config, time_threshold: int
                     f"{seq_key['version']}"
                 )
             update_with_retry(
-                db_config=db_config,
+                db_engine=db_engine,
                 conditions=seq_key,
                 update_values={
                     "status": status,
@@ -733,7 +733,7 @@ def assembly_table_update(db_config: Engine, config: Config, time_threshold: int
 
 
 def assembly_table_handle_errors(
-    db_config: Engine,
+    db_engine: Engine,
     config: Config,
     slack_config: SlackConfig,
     last_retry_time: datetime | None,
@@ -744,9 +744,9 @@ def assembly_table_handle_errors(
     2. If time since last slack notification is over slack_retry_threshold_min send notification
     3. Trigger retry if time since last retry is over retry_threshold_min
     """
-    entries_waiting = find_waiting_in_db(db_config, time_threshold=config.waiting_threshold_hours)
+    entries_waiting = find_waiting_in_db(db_engine, time_threshold=config.waiting_threshold_hours)
     entries_with_errors = find_errors_or_stuck_in_db(
-        db_config,
+        db_engine,
         AssemblyTableEntry,
         time_threshold=config.submitting_time_threshold_min,
     )
@@ -773,7 +773,7 @@ def assembly_table_handle_errors(
 
         last_retry_time = retry_failed_submissions_for_matching_errors(
             entries_with_errors,
-            db_config,
+            db_engine,
             model_class=AssemblyTableEntry,
             retry_threshold_min=config.retry_threshold_min,
             last_retry=last_retry_time,
@@ -802,7 +802,7 @@ def assembly_table_handle_errors(
 
 
 def create_assembly(config: Config, stop_event: threading.Event):
-    db_config = db_init(config.db_password, config.db_username, config.db_url)
+    db_engine = db_init(config.db_password, config.db_username, config.db_url)
     slack_config = slack_conn_init(
         slack_hook_default=config.slack_hook,
         slack_token_default=config.slack_token,
@@ -815,12 +815,12 @@ def create_assembly(config: Config, stop_event: threading.Event):
             logger.warning("create_assembly stopped due to exception in another task")
             return
         logger.debug("Checking for assemblies to create")
-        submission_table_start(db_config, config)
-        submission_table_update(db_config)
+        submission_table_start(db_engine, config)
+        submission_table_update(db_engine)
 
-        assembly_table_create(db_config, config)
-        assembly_table_update(db_config, config, time_threshold=config.min_between_ena_checks)
+        assembly_table_create(db_engine, config)
+        assembly_table_update(db_engine, config, time_threshold=config.min_between_ena_checks)
         last_retry_time = assembly_table_handle_errors(
-            db_config, config, slack_config, last_retry_time
+            db_engine, config, slack_config, last_retry_time
         )
         time.sleep(config.time_between_iterations)

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -7,7 +7,7 @@ import time
 import traceback
 from dataclasses import asdict
 from datetime import datetime, timedelta
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import pytz
 from sqlalchemy import Engine
@@ -59,7 +59,7 @@ logger = logging.getLogger(__name__)
 
 
 def create_chromosome_list_object(
-    unaligned_sequences: dict[str, str],
+    unaligned_sequences: dict[str, str | None],
     accession: str,
     organism_metadata: EnaOrganismDetails,
 ) -> AssemblyChromosomeListFile:
@@ -94,7 +94,7 @@ def create_chromosome_list_object(
     return AssemblyChromosomeListFile(chromosomes=entries)
 
 
-def get_segment_order(unaligned_sequences: dict[str, str]) -> list[str]:
+def get_segment_order(unaligned_sequences: dict[str, str | None]) -> list[str]:
     """Order in which we put the segments in the chromosome list file"""
     segment_order = []
     for segment_name, item in unaligned_sequences.items():
@@ -540,9 +540,19 @@ def get_project_and_sample_results(
     if len(project_rows) == 0:
         error_msg = f"Entry {submission_row.accession} not found in project_table"
         raise RuntimeError(error_msg)
-    sample_accession = sample_rows[0].result["ena_sample_accession"]
-    study_accession = project_rows[0].result["bioproject_accession"]
-    return sample_accession, study_accession
+    sample_accession = (
+        sample_rows[0].result.get("ena_sample_accession") if sample_rows[0].result else None
+    )
+    study_accession = (
+        project_rows[0].result.get("bioproject_accession") if project_rows[0].result else None
+    )
+    if not sample_accession or not study_accession:
+        error_msg = (
+            f"Missing sample_accession or study_accession for accession {submission_row.accession} "
+            "cannot create manifest"
+        )
+        raise RuntimeError(error_msg)
+    return cast(str, sample_accession), cast(str, study_accession)
 
 
 def assembly_table_create(db_config: Engine, config: Config):
@@ -674,10 +684,16 @@ def assembly_table_update(db_config: Engine, config: Config, time_threshold: int
                 raise RuntimeError(error_msg)
             organism = config.enaOrganisms[submission_rows[0].organism]
             # Previous means from the last time the entry was checked, from db
-            previous_result = row.result
-            segment_order = previous_result["segment_order"]
+            segment_order = row.result.get("segment_order") if row.result else None
+            erz_accession = row.result.get("erz_accession") if row.result else None
+            if not erz_accession or not segment_order:
+                logger.warning(
+                    f"Missing erz_accession or segment_order for {seq_key['accession']} version "
+                    f"{seq_key['version']} - cannot check ENA for accession yet."
+                )
+                continue
             new_result: CreationResult = get_ena_analysis_process(
-                config, previous_result["erz_accession"], segment_order, organism
+                config, cast(str, erz_accession), cast(list[str], segment_order), organism
             )
             _last_ena_check = now
 
@@ -690,7 +706,7 @@ def assembly_table_update(db_config: Engine, config: Config, time_threshold: int
             )
 
             if not (result_contains_gca_accession and result_contains_insdc_accession):
-                if previous_result == new_result.result:
+                if row.result == new_result.result:
                     continue
                 status = Status.WAITING
                 logger.info(
@@ -728,9 +744,7 @@ def assembly_table_handle_errors(
     2. If time since last slack notification is over slack_retry_threshold_min send notification
     3. Trigger retry if time since last retry is over retry_threshold_min
     """
-    entries_waiting = find_waiting_in_db(
-        db_config, AssemblyTableEntry, time_threshold=config.waiting_threshold_hours
-    )
+    entries_waiting = find_waiting_in_db(db_config, time_threshold=config.waiting_threshold_hours)
     entries_with_errors = find_errors_or_stuck_in_db(
         db_config,
         AssemblyTableEntry,

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -675,9 +675,9 @@ def assembly_table_update(db_engine: Engine, config: Config, time_threshold: int
     if not _last_ena_check or now - timedelta(minutes=time_threshold) > _last_ena_check:
         logger.debug("Checking state in ENA")
         for row in waiting:
-            seq_key = asdict(row.pkey)
+            seq_key = row.pkey
             submission_rows = find_conditions_in_db(
-                db_engine, SubmissionTableEntry, conditions=seq_key
+                db_engine, SubmissionTableEntry, conditions=asdict(seq_key)
             )
             if len(submission_rows) == 0:
                 error_msg = f"Entry {row.accession} not found in submitting_table"
@@ -688,8 +688,8 @@ def assembly_table_update(db_engine: Engine, config: Config, time_threshold: int
             erz_accession = row.result.get("erz_accession") if row.result else None
             if not erz_accession or not segment_order:
                 logger.warning(
-                    f"Missing erz_accession or segment_order for {seq_key['accession']} version "
-                    f"{seq_key['version']} - cannot check ENA for accession yet."
+                    f"Missing erz_accession or segment_order for {seq_key.accession} version "
+                    f"{seq_key.version} - cannot check ENA for accession yet."
                 )
                 continue
             new_result: CreationResult = get_ena_analysis_process(
@@ -710,18 +710,18 @@ def assembly_table_update(db_engine: Engine, config: Config, time_threshold: int
                     continue
                 status = Status.WAITING
                 logger.info(
-                    f"Assembly partially accessioned by ENA for {seq_key['accession']} "
-                    f"version {seq_key['version']}"
+                    f"Assembly partially accessioned by ENA for {seq_key.accession} "
+                    f"version {seq_key.version}"
                 )
             else:
                 status = Status.SUBMITTED
                 logger.info(
-                    f"Assembly accessioned by ENA for {seq_key['accession']} version "
-                    f"{seq_key['version']}"
+                    f"Assembly accessioned by ENA for {seq_key.accession} version "
+                    f"{seq_key.version}"
                 )
             update_with_retry(
                 db_engine=db_engine,
-                conditions=seq_key,
+                conditions=asdict(seq_key),
                 update_values={
                     "status": status,
                     "result": new_result.result,

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -245,10 +245,9 @@ def submission_table_start(db_engine: Engine, config: Config) -> None:
     """
     conditions = {"status_all": StatusAll.SUBMITTED_SAMPLE}
     ready_to_submit = find_conditions_in_db(db_engine, SubmissionTableEntry, conditions=conditions)
-    if len(ready_to_submit) > 0:
-        logger.debug(
-            f"Found {len(ready_to_submit)} entries in submission_table in status SUBMITTED_SAMPLE"
-        )
+    logger.debug(
+        f"Found {len(ready_to_submit)} entries in submission_table in status SUBMITTED_SAMPLE"
+    )
     for row in ready_to_submit:
         seq_key = asdict(row.pkey)
 

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -1,7 +1,7 @@
-from dataclasses import asdict
 import logging
 import threading
 import time
+from dataclasses import asdict
 from datetime import datetime
 
 import pytz

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -137,7 +137,7 @@ def set_project_table_entry(db_engine: Engine, config: Config, row: SubmissionTa
             conditions=group_key,
             accession=bioproject,
             accession_type="BIOPROJECT",
-            db_pool=db_engine,
+            db_engine=db_engine,
         )
         return
 

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -93,7 +93,9 @@ def construct_project_set_object(
             )
         ),
         project_links=ProjectLinks(
-            project_link=[ProjectLink(xref_link=XrefType(db=config.db_name, id=entry.group_id))]
+            project_link=[
+                ProjectLink(xref_link=XrefType(db=config.db_name, id=str(entry.group_id)))
+            ]
         ),
     )
     return ProjectSet(project=[project_type])

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -1,7 +1,6 @@
 import logging
 import threading
 import time
-from dataclasses import asdict
 from datetime import datetime
 
 import pytz

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -106,9 +106,7 @@ def set_project_table_entry(db_config: Engine, config: Config, row: SubmissionTa
     seq_key = {"accession": row.accession, "version": row.version}
     bioproject = row.seq_metadata["bioprojectAccession"]
 
-    corresponding_group = find_conditions_in_db(
-        db_config, ProjectTableEntry, conditions=group_key
-    )
+    corresponding_group = find_conditions_in_db(db_config, ProjectTableEntry, conditions=group_key)
     corresponding_project = [
         project
         for project in corresponding_group
@@ -181,9 +179,7 @@ def sync_state_with_submission_table(db_config: Engine, config: Config):
     4. Else create corresponding entry in project_table
     """
     conditions = {"status_all": str(StatusAll.READY_TO_SUBMIT)}
-    ready_to_submit = find_conditions_in_db(
-        db_config, SubmissionTableEntry, conditions=conditions
-    )
+    ready_to_submit = find_conditions_in_db(db_config, SubmissionTableEntry, conditions=conditions)
     logger.debug(
         f"Found {len(ready_to_submit)} entries in submission_table in status READY_TO_SUBMIT"
     )
@@ -290,8 +286,7 @@ def project_table_create(
                 "finished_at": datetime.now(tz=pytz.utc),
             }
             logger.info(
-                f"Project creation succeeded for group_id {row.group_id} "
-                f"organism {row.organism}"
+                f"Project creation succeeded for group_id {row.group_id} organism {row.organism}"
             )
         else:
             update_values = {

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -4,7 +4,7 @@ import time
 from datetime import datetime
 
 import pytz
-from psycopg2.pool import SimpleConnectionPool
+from sqlalchemy import Engine
 
 from ena_deposition import call_loculus
 from ena_deposition.loculus_models import Group
@@ -33,7 +33,7 @@ from .submission_db_helper import (
     ProjectTableEntry,
     Status,
     StatusAll,
-    TableName,
+    SubmissionTableEntry,
     add_to_project_table,
     db_init,
     find_conditions_in_db,
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 def construct_project_set_object(
     group_info: Group,
     config: Config,
-    entry: dict[str, str],
+    entry: ProjectTableEntry,
     test=False,
 ) -> ProjectSet:
     """
@@ -61,9 +61,9 @@ def construct_project_set_object(
     submissions of the same project for testing.
     (ENA blocks multiple submissions with the same alias)
     """
-    metadata_dict = config.enaOrganisms[entry["organism"]]
+    metadata_dict = config.enaOrganisms[entry.organism]
     alias = get_alias(
-        f"{entry['group_id']}:{entry['organism']}:{config.unique_project_suffix}",
+        f"{entry.group_id}:{entry.organism}:{config.unique_project_suffix}",
         test,
         config.set_alias_suffix,
     )
@@ -93,26 +93,26 @@ def construct_project_set_object(
             )
         ),
         project_links=ProjectLinks(
-            project_link=[ProjectLink(xref_link=XrefType(db=config.db_name, id=entry["group_id"]))]
+            project_link=[ProjectLink(xref_link=XrefType(db=config.db_name, id=entry.group_id))]
         ),
     )
     return ProjectSet(project=[project_type])
 
 
-def set_project_table_entry(db_config, config, row):
+def set_project_table_entry(db_config: Engine, config: Config, row: SubmissionTableEntry):
     """Set bioprojectAccession for entry with custom bioprojectAccession"""
-    logger.debug(f"Accession {row['accession']} already has bioprojectAccession in metadata")
-    group_key = {"group_id": row["group_id"], "organism": row["organism"]}
-    seq_key = {"accession": row["accession"], "version": row["version"]}
-    bioproject = row["metadata"]["bioprojectAccession"]
+    logger.debug(f"Accession {row.accession} already has bioprojectAccession in metadata")
+    group_key = {"group_id": row.group_id, "organism": row.organism}
+    seq_key = {"accession": row.accession, "version": row.version}
+    bioproject = row.seq_metadata["bioprojectAccession"]
 
     corresponding_group = find_conditions_in_db(
-        db_config, table_name=TableName.PROJECT_TABLE, conditions=group_key
+        db_config, ProjectTableEntry, conditions=group_key
     )
     corresponding_project = [
         project
         for project in corresponding_group
-        if project["result"] and project["result"].get("bioproject_accession") == bioproject
+        if project.result and project.result.get("bioproject_accession") == bioproject
     ]
     if len(corresponding_project) == 1:
         logger.debug(
@@ -120,12 +120,12 @@ def set_project_table_entry(db_config, config, row):
         )
         update_values = {
             "status_all": StatusAll.SUBMITTED_PROJECT,
-            "center_name": corresponding_project[0]["center_name"],
-            "project_id": corresponding_project[0]["project_id"],
+            "center_name": corresponding_project[0].center_name,
+            "project_id": corresponding_project[0].project_id,
         }
         update_db_where_conditions(
             db_config,
-            table_name=TableName.SUBMISSION_TABLE,
+            model_class=type(row),
             conditions=seq_key,
             update_values=update_values,
         )
@@ -143,19 +143,18 @@ def set_project_table_entry(db_config, config, row):
 
     logger.info("Adding bioprojectAccession to project_table")
     try:
-        group_details = call_loculus.get_group_info(config, row["group_id"])
+        group_details = call_loculus.get_group_info(config, row.group_id)
     except Exception as e:
-        logger.error(f"Was unable to get group info for group: {row['group_id']}, {e}")
+        logger.error(f"Was unable to get group info for group: {row.group_id}, {e}")
         return
     center_name = group_details.institution
-    entry = {
-        "group_id": row["group_id"],
-        "organism": row["organism"],
-        "result": {"bioproject_accession": bioproject},
-        "status": Status.SUBMITTED,
-        "center_name": center_name,
-    }
-    project_table_entry = ProjectTableEntry(**entry)
+    project_table_entry = ProjectTableEntry(
+        group_id=row.group_id,
+        organism=row.organism,
+        result={"bioproject_accession": bioproject},
+        status=str(Status.SUBMITTED),
+        center_name=center_name,
+    )
     succeeded = add_to_project_table(db_config, project_table_entry)
     if succeeded:
         logger.debug("Succeeding in adding bioprojectAccession to project_table")
@@ -166,13 +165,13 @@ def set_project_table_entry(db_config, config, row):
         }
         update_db_where_conditions(
             db_config,
-            table_name=TableName.SUBMISSION_TABLE,
+            model_class=type(row),
             conditions=seq_key,
             update_values=update_values,
         )
 
 
-def sync_state_with_submission_table(db_config: SimpleConnectionPool, config: Config):
+def sync_state_with_submission_table(db_config: Engine, config: Config):
     """
     1. Find all entries in submission_table in state READY_TO_SUBMIT
     2. If (exists "bioproject" in "metadata"):
@@ -181,39 +180,39 @@ def sync_state_with_submission_table(db_config: SimpleConnectionPool, config: Co
     a.      If (in state SUBMITTED) update state in submission_table to SUBMITTED_PROJECT
     4. Else create corresponding entry in project_table
     """
-    conditions = {"status_all": StatusAll.READY_TO_SUBMIT}
+    conditions = {"status_all": str(StatusAll.READY_TO_SUBMIT)}
     ready_to_submit = find_conditions_in_db(
-        db_config, table_name=TableName.SUBMISSION_TABLE, conditions=conditions
+        db_config, SubmissionTableEntry, conditions=conditions
     )
     logger.debug(
         f"Found {len(ready_to_submit)} entries in submission_table in status READY_TO_SUBMIT"
     )
     for row in ready_to_submit:
-        group_key = {"group_id": row["group_id"], "organism": row["organism"]}
-        seq_key = {"accession": row["accession"], "version": row["version"]}
+        group_key = {"group_id": row.group_id, "organism": row.organism}
+        seq_key = {"accession": row.accession, "version": row.version}
 
         # Use custom bioprojectAccession if it exists
-        if "bioprojectAccession" in row["metadata"] and row["metadata"]["bioprojectAccession"]:
+        if row.seq_metadata.get("bioprojectAccession"):
             set_project_table_entry(db_config, config, row)
             continue
 
         # Create a default project entry for (group_id, organism)
         # Check if there exists an entry in the project table for (group_id, organism)
         corresponding_project = find_conditions_in_db(
-            db_config, table_name=TableName.PROJECT_TABLE, conditions=group_key
+            db_config, ProjectTableEntry, conditions=group_key
         )
         if len(corresponding_project) == 1:
-            if corresponding_project[0]["status"] == str(Status.SUBMITTED):
+            if corresponding_project[0].status == str(Status.SUBMITTED):
                 update_values = {
                     "status_all": StatusAll.SUBMITTED_PROJECT,
-                    "center_name": corresponding_project[0]["center_name"],
-                    "project_id": corresponding_project[0]["project_id"],
+                    "center_name": corresponding_project[0].center_name,
+                    "project_id": corresponding_project[0].project_id,
                 }
             else:
                 continue
         else:
             project_id = add_to_project_table(
-                db_config, ProjectTableEntry(group_id=row["group_id"], organism=row["organism"])
+                db_config, ProjectTableEntry(group_id=row.group_id, organism=row.organism)
             )
             if not project_id:
                 continue
@@ -222,7 +221,7 @@ def sync_state_with_submission_table(db_config: SimpleConnectionPool, config: Co
             }
         update_db_where_conditions(
             db_config,
-            table_name=TableName.SUBMISSION_TABLE,
+            model_class=SubmissionTableEntry,
             conditions=seq_key,
             update_values=update_values,
         )
@@ -230,7 +229,7 @@ def sync_state_with_submission_table(db_config: SimpleConnectionPool, config: Co
 
 # TODO Allow propagating updated group info https://github.com/loculus-project/loculus/issues/2939
 def project_table_create(
-    db_config: SimpleConnectionPool,
+    db_config: Engine,
     config: Config,
     test: bool = False,
 ):
@@ -244,18 +243,18 @@ def project_table_create(
     If test=True add a timestamp to the alias suffix to allow for multiple submissions of the same
     project for testing.
     """
-    conditions = {"status": Status.READY}
+    conditions = {"status": str(Status.READY)}
     ready_to_submit_project = find_conditions_in_db(
-        db_config, table_name=TableName.PROJECT_TABLE, conditions=conditions
+        db_config, ProjectTableEntry, conditions=conditions
     )
     logger.debug(f"Found {len(ready_to_submit_project)} entries in project_table in status READY")
     for row in ready_to_submit_project:
-        group_key = {"group_id": row["group_id"], "organism": row["organism"]}
+        group_key = {"group_id": row.group_id, "organism": row.organism}
 
         try:
-            group_info = call_loculus.get_group_info(config, row["group_id"])
+            group_info = call_loculus.get_group_info(config, row.group_id)
         except Exception as e:
-            logger.error(f"Was unable to get group info for group: {row['group_id']}, {e}")
+            logger.error(f"Was unable to get group info for group: {row.group_id}, {e}")
             continue
 
         project_set = construct_project_set_object(group_info, config, row, test)
@@ -266,7 +265,7 @@ def project_table_create(
         }
         number_rows_updated = update_db_where_conditions(
             db_config,
-            table_name=TableName.PROJECT_TABLE,
+            model_class=ProjectTableEntry,
             conditions=group_key,
             update_values=update_values,
         )
@@ -280,7 +279,7 @@ def project_table_create(
             )
             continue
         logger.info(
-            f"Starting Project creation for group_id {row['group_id']} organism {row['organism']}"
+            f"Starting Project creation for group_id {row.group_id} organism {row.organism}"
         )
         # Actual HTTP request to ENA happens here
         project_creation_results: CreationResult = create_ena_project(config, project_set)
@@ -291,8 +290,8 @@ def project_table_create(
                 "finished_at": datetime.now(tz=pytz.utc),
             }
             logger.info(
-                f"Project creation succeeded for group_id {row['group_id']} "
-                f"organism {row['organism']}"
+                f"Project creation succeeded for group_id {row.group_id} "
+                f"organism {row.organism}"
             )
         else:
             update_values = {
@@ -301,18 +300,18 @@ def project_table_create(
                 "started_at": datetime.now(tz=pytz.utc),
             }
             logger.error(
-                f"Project creation failed for group_id {row['group_id']} organism {row['organism']}"
+                f"Project creation failed for group_id {row.group_id} organism {row.organism}"
             )
         update_with_retry(
             db_config=db_config,
             conditions=group_key,
             update_values=update_values,
-            table_name=TableName.PROJECT_TABLE,
+            model_class=ProjectTableEntry,
         )
 
 
 def project_table_handle_errors(
-    db_config: SimpleConnectionPool,
+    db_config: Engine,
     config: Config,
     slack_config: SlackConfig,
     last_retry_time: datetime | None,
@@ -324,7 +323,7 @@ def project_table_handle_errors(
     3. Retry entries if time since last retry is over retry_threshold_min
     """
     entries_with_errors = find_errors_or_stuck_in_db(
-        db_config, TableName.PROJECT_TABLE, time_threshold=config.submitting_time_threshold_min
+        db_config, ProjectTableEntry, time_threshold=config.submitting_time_threshold_min
     )
     if len(entries_with_errors) > 0:
         error_msg = (
@@ -341,7 +340,7 @@ def project_table_handle_errors(
         return retry_failed_submissions_for_matching_errors(
             entries_with_errors,
             db_config,
-            table_name=TableName.PROJECT_TABLE,
+            model_class=ProjectTableEntry,
             retry_threshold_min=config.retry_threshold_min,
             last_retry=last_retry_time,
         )

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -152,7 +152,7 @@ def set_project_table_entry(db_config: Engine, config: Config, row: SubmissionTa
         group_id=row.group_id,
         organism=row.organism,
         result={"bioproject_accession": bioproject},
-        status=str(Status.SUBMITTED),
+        status=Status.SUBMITTED,
         center_name=center_name,
     )
     succeeded = add_to_project_table(db_config, project_table_entry)
@@ -180,7 +180,7 @@ def sync_state_with_submission_table(db_config: Engine, config: Config):
     a.      If (in state SUBMITTED) update state in submission_table to SUBMITTED_PROJECT
     4. Else create corresponding entry in project_table
     """
-    conditions = {"status_all": str(StatusAll.READY_TO_SUBMIT)}
+    conditions = {"status_all": StatusAll.READY_TO_SUBMIT}
     ready_to_submit = find_conditions_in_db(db_config, SubmissionTableEntry, conditions=conditions)
     logger.debug(
         f"Found {len(ready_to_submit)} entries in submission_table in status READY_TO_SUBMIT"
@@ -200,7 +200,7 @@ def sync_state_with_submission_table(db_config: Engine, config: Config):
             db_config, ProjectTableEntry, conditions=group_key
         )
         if len(corresponding_project) == 1:
-            if corresponding_project[0].status == str(Status.SUBMITTED):
+            if corresponding_project[0].status == Status.SUBMITTED:
                 update_values = {
                     "status_all": StatusAll.SUBMITTED_PROJECT,
                     "center_name": corresponding_project[0].center_name,
@@ -241,7 +241,7 @@ def project_table_create(
     If test=True add a timestamp to the alias suffix to allow for multiple submissions of the same
     project for testing.
     """
-    conditions = {"status": str(Status.READY)}
+    conditions = {"status": Status.READY}
     ready_to_submit_project = find_conditions_in_db(
         db_config, ProjectTableEntry, conditions=conditions
     )

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict
 import logging
 import threading
 import time
@@ -105,7 +106,7 @@ def set_project_table_entry(db_engine: Engine, config: Config, row: SubmissionTa
     """Set bioprojectAccession for entry with custom bioprojectAccession"""
     logger.debug(f"Accession {row.accession} already has bioprojectAccession in metadata")
     group_key = {"group_id": row.group_id, "organism": row.organism}
-    seq_key = {"accession": row.accession, "version": row.version}
+    seq_key = asdict(row.pkey)
     bioproject = row.seq_metadata["bioprojectAccession"]
 
     corresponding_group = find_conditions_in_db(db_engine, ProjectTableEntry, conditions=group_key)
@@ -187,7 +188,7 @@ def sync_state_with_submission_table(db_engine: Engine, config: Config):
     )
     for row in ready_to_submit:
         group_key = {"group_id": row.group_id, "organism": row.organism}
-        seq_key = {"accession": row.accession, "version": row.version}
+        seq_key = asdict(row.pkey)
 
         # Use custom bioprojectAccession if it exists
         if row.seq_metadata.get("bioprojectAccession"):

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -101,14 +101,14 @@ def construct_project_set_object(
     return ProjectSet(project=[project_type])
 
 
-def set_project_table_entry(db_config: Engine, config: Config, row: SubmissionTableEntry):
+def set_project_table_entry(db_engine: Engine, config: Config, row: SubmissionTableEntry):
     """Set bioprojectAccession for entry with custom bioprojectAccession"""
     logger.debug(f"Accession {row.accession} already has bioprojectAccession in metadata")
     group_key = {"group_id": row.group_id, "organism": row.organism}
     seq_key = {"accession": row.accession, "version": row.version}
     bioproject = row.seq_metadata["bioprojectAccession"]
 
-    corresponding_group = find_conditions_in_db(db_config, ProjectTableEntry, conditions=group_key)
+    corresponding_group = find_conditions_in_db(db_engine, ProjectTableEntry, conditions=group_key)
     corresponding_project = [
         project
         for project in corresponding_group
@@ -124,7 +124,7 @@ def set_project_table_entry(db_config: Engine, config: Config, row: SubmissionTa
             "project_id": corresponding_project[0].project_id,
         }
         update_db_where_conditions(
-            db_config,
+            db_engine,
             model_class=type(row),
             conditions=seq_key,
             update_values=update_values,
@@ -137,7 +137,7 @@ def set_project_table_entry(db_config: Engine, config: Config, row: SubmissionTa
             conditions=group_key,
             accession=bioproject,
             accession_type="BIOPROJECT",
-            db_pool=db_config,
+            db_pool=db_engine,
         )
         return
 
@@ -155,7 +155,7 @@ def set_project_table_entry(db_config: Engine, config: Config, row: SubmissionTa
         status=Status.SUBMITTED,
         center_name=center_name,
     )
-    succeeded = add_to_project_table(db_config, project_table_entry)
+    succeeded = add_to_project_table(db_engine, project_table_entry)
     if succeeded:
         logger.debug("Succeeding in adding bioprojectAccession to project_table")
         update_values = {
@@ -164,14 +164,14 @@ def set_project_table_entry(db_config: Engine, config: Config, row: SubmissionTa
             "project_id": succeeded,
         }
         update_db_where_conditions(
-            db_config,
+            db_engine,
             model_class=type(row),
             conditions=seq_key,
             update_values=update_values,
         )
 
 
-def sync_state_with_submission_table(db_config: Engine, config: Config):
+def sync_state_with_submission_table(db_engine: Engine, config: Config):
     """
     1. Find all entries in submission_table in state READY_TO_SUBMIT
     2. If (exists "bioproject" in "metadata"):
@@ -181,7 +181,7 @@ def sync_state_with_submission_table(db_config: Engine, config: Config):
     4. Else create corresponding entry in project_table
     """
     conditions = {"status_all": StatusAll.READY_TO_SUBMIT}
-    ready_to_submit = find_conditions_in_db(db_config, SubmissionTableEntry, conditions=conditions)
+    ready_to_submit = find_conditions_in_db(db_engine, SubmissionTableEntry, conditions=conditions)
     logger.debug(
         f"Found {len(ready_to_submit)} entries in submission_table in status READY_TO_SUBMIT"
     )
@@ -191,13 +191,13 @@ def sync_state_with_submission_table(db_config: Engine, config: Config):
 
         # Use custom bioprojectAccession if it exists
         if row.seq_metadata.get("bioprojectAccession"):
-            set_project_table_entry(db_config, config, row)
+            set_project_table_entry(db_engine, config, row)
             continue
 
         # Create a default project entry for (group_id, organism)
         # Check if there exists an entry in the project table for (group_id, organism)
         corresponding_project = find_conditions_in_db(
-            db_config, ProjectTableEntry, conditions=group_key
+            db_engine, ProjectTableEntry, conditions=group_key
         )
         if len(corresponding_project) == 1:
             if corresponding_project[0].status == Status.SUBMITTED:
@@ -210,7 +210,7 @@ def sync_state_with_submission_table(db_config: Engine, config: Config):
                 continue
         else:
             project_id = add_to_project_table(
-                db_config, ProjectTableEntry(group_id=row.group_id, organism=row.organism)
+                db_engine, ProjectTableEntry(group_id=row.group_id, organism=row.organism)
             )
             if not project_id:
                 continue
@@ -218,7 +218,7 @@ def sync_state_with_submission_table(db_config: Engine, config: Config):
                 "project_id": project_id,
             }
         update_db_where_conditions(
-            db_config,
+            db_engine,
             model_class=SubmissionTableEntry,
             conditions=seq_key,
             update_values=update_values,
@@ -227,7 +227,7 @@ def sync_state_with_submission_table(db_config: Engine, config: Config):
 
 # TODO Allow propagating updated group info https://github.com/loculus-project/loculus/issues/2939
 def project_table_create(
-    db_config: Engine,
+    db_engine: Engine,
     config: Config,
     test: bool = False,
 ):
@@ -243,7 +243,7 @@ def project_table_create(
     """
     conditions = {"status": Status.READY}
     ready_to_submit_project = find_conditions_in_db(
-        db_config, ProjectTableEntry, conditions=conditions
+        db_engine, ProjectTableEntry, conditions=conditions
     )
     logger.debug(f"Found {len(ready_to_submit_project)} entries in project_table in status READY")
     for row in ready_to_submit_project:
@@ -262,7 +262,7 @@ def project_table_create(
             "center_name": group_info.institution,
         }
         number_rows_updated = update_db_where_conditions(
-            db_config,
+            db_engine,
             model_class=ProjectTableEntry,
             conditions=group_key,
             update_values=update_values,
@@ -300,7 +300,7 @@ def project_table_create(
                 f"Project creation failed for group_id {row.group_id} organism {row.organism}"
             )
         update_with_retry(
-            db_config=db_config,
+            db_engine=db_engine,
             conditions=group_key,
             update_values=update_values,
             model_class=ProjectTableEntry,
@@ -308,7 +308,7 @@ def project_table_create(
 
 
 def project_table_handle_errors(
-    db_config: Engine,
+    db_engine: Engine,
     config: Config,
     slack_config: SlackConfig,
     last_retry_time: datetime | None,
@@ -320,7 +320,7 @@ def project_table_handle_errors(
     3. Retry entries if time since last retry is over retry_threshold_min
     """
     entries_with_errors = find_errors_or_stuck_in_db(
-        db_config, ProjectTableEntry, time_threshold=config.submitting_time_threshold_min
+        db_engine, ProjectTableEntry, time_threshold=config.submitting_time_threshold_min
     )
     if len(entries_with_errors) > 0:
         error_msg = (
@@ -336,7 +336,7 @@ def project_table_handle_errors(
         )
         return retry_failed_submissions_for_matching_errors(
             entries_with_errors,
-            db_config,
+            db_engine,
             model_class=ProjectTableEntry,
             retry_threshold_min=config.retry_threshold_min,
             last_retry=last_retry_time,
@@ -348,7 +348,7 @@ def project_table_handle_errors(
 
 
 def create_project(config: Config, stop_event: threading.Event):
-    db_config = db_init(config.db_password, config.db_username, config.db_url)
+    db_engine = db_init(config.db_password, config.db_username, config.db_url)
     slack_config = slack_conn_init(
         slack_hook_default=config.slack_hook,
         slack_token_default=config.slack_token,
@@ -361,13 +361,13 @@ def create_project(config: Config, stop_event: threading.Event):
             logger.warning("create_project stopped due to exception in another task")
             return
         logger.debug("Checking for projects to create")
-        sync_state_with_submission_table(db_config, config)
+        sync_state_with_submission_table(db_engine, config)
 
-        project_table_create(db_config, config, test=config.test)
+        project_table_create(db_engine, config, test=config.test)
         sync_state_with_submission_table(
-            db_config, config
+            db_engine, config
         )  # update submission_table state after creation
         last_retry_time = project_table_handle_errors(
-            db_config, config, slack_config, last_retry_time
+            db_engine, config, slack_config, last_retry_time
         )
         time.sleep(config.time_between_iterations)

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -106,7 +106,7 @@ def set_project_table_entry(db_engine: Engine, config: Config, row: SubmissionTa
     """Set bioprojectAccession for entry with custom bioprojectAccession"""
     logger.debug(f"Accession {row.accession} already has bioprojectAccession in metadata")
     group_key = {"group_id": row.group_id, "organism": row.organism}
-    seq_key = asdict(row.pkey)
+    seq_key = {"accession": row.accession, "version": row.version}
     bioproject = row.seq_metadata["bioprojectAccession"]
 
     corresponding_group = find_conditions_in_db(db_engine, ProjectTableEntry, conditions=group_key)
@@ -188,7 +188,7 @@ def sync_state_with_submission_table(db_engine: Engine, config: Config):
     )
     for row in ready_to_submit:
         group_key = {"group_id": row.group_id, "organism": row.organism}
-        seq_key = asdict(row.pkey)
+        seq_key = {"accession": row.accession, "version": row.version}
 
         # Use custom bioprojectAccession if it exists
         if row.seq_metadata.get("bioprojectAccession"):

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -115,6 +115,8 @@ def set_project_table_entry(db_engine: Engine, config: Config, row: SubmissionTa
         if project.result and project.result.get("bioproject_accession") == bioproject
     ]
     if len(corresponding_project) == 1:
+        if corresponding_project[0].status != Status.SUBMITTED:
+            return
         logger.debug(
             "bioprojectAccession is already in project_table - adding id to submission_table"
         )

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -182,7 +182,7 @@ def set_sample_table_entry(
             conditions=seq_key,
             accession=biosample,
             accession_type="BIOSAMPLE",
-            db_pool=db_engine,
+            db_engine=db_engine,
         )
         return
 

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -190,7 +190,7 @@ def set_sample_table_entry(
         accession=row.accession,
         version=row.version,
         result={"ena_sample_accession": biosample, "biosample_accession": biosample},
-        status=str(Status.SUBMITTED),
+        status=Status.SUBMITTED,
     )
     succeeded = add_to_sample_table(db_config, sample_table_entry)
     if succeeded:
@@ -216,7 +216,7 @@ def sync_state_with_submission_table(db_config: Engine, config: Config):
     4. Else create corresponding entry in sample_table
     """
     # Check submission_table for newly added sequences
-    conditions = {"status_all": str(StatusAll.SUBMITTED_PROJECT)}
+    conditions = {"status_all": StatusAll.SUBMITTED_PROJECT}
     ready_to_submit = find_conditions_in_db(db_config, SubmissionTableEntry, conditions=conditions)
     logger.debug(
         f"Found {len(ready_to_submit)} entries in submission_table in status SUBMITTED_PROJECT"
@@ -229,7 +229,7 @@ def sync_state_with_submission_table(db_config: Engine, config: Config):
             db_config, SampleTableEntry, conditions=seq_key
         )
         if len(corresponding_sample) == 1:
-            if corresponding_sample[0].status == str(Status.SUBMITTED):
+            if corresponding_sample[0].status == Status.SUBMITTED:
                 update_db_where_conditions(
                     db_config,
                     table_name=TableName.SUBMISSION_TABLE,
@@ -285,7 +285,7 @@ def sample_table_create(db_config: Engine, config: Config, test: bool = False):
     If test=True add a timestamp to the alias suffix to allow for multiple submissions of the same
     sample for testing.
     """
-    conditions = {"status": str(Status.READY)}
+    conditions = {"status": Status.READY}
     ready_to_submit_sample = find_conditions_in_db(
         db_config, SampleTableEntry, conditions=conditions
     )

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -291,7 +291,7 @@ def sample_table_create(db_engine: Engine, config: Config, test: bool = False):
     )
     logger.debug(f"Found {len(ready_to_submit_sample)} entries in sample_table in status READY")
     for row in ready_to_submit_sample:
-        seq_key = AccessionVersion(accession=row.accession, version=row.version)
+        seq_key = row.pkey
         if is_old_version(db_engine, seq_key):
             logger.warning(f"Skipping submission for {seq_key} as it is not the latest version.")
             continue

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -39,7 +39,7 @@ from .submission_db_helper import (
     db_init,
     find_conditions_in_db,
     find_errors_or_stuck_in_db,
-    is_revision,
+    is_latest_revision,
     update_db_where_conditions,
     update_with_retry,
 )
@@ -321,7 +321,7 @@ def sample_table_create(db_engine: Engine, config: Config, test: bool = False):
             continue
         logger.info(f"Starting sample creation for accession {row.accession}")
         sample_creation_results: CreationResult = create_ena_sample(
-            config, sample_set, revision=is_revision(db_engine, seq_key)
+            config, sample_set, revision=is_latest_revision(db_engine, seq_key)
         )
         if sample_creation_results.result:
             update_values = {

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -176,7 +176,7 @@ def set_sample_table_entry(
     biosample = row.seq_metadata["biosampleAccession"]
 
     logger.info("Checking if biosample actually exists and is public")
-    seq_key = {"accession": row.accession, "version": row.version}
+    seq_key = asdict(row.pkey)
     if not accession_exists(biosample, config):
         set_accession_does_not_exist_error(
             conditions=seq_key,
@@ -222,7 +222,7 @@ def sync_state_with_submission_table(db_engine: Engine, config: Config):
         f"Found {len(ready_to_submit)} entries in submission_table in status SUBMITTED_PROJECT"
     )
     for row in ready_to_submit:
-        seq_key = {"accession": row.accession, "version": row.version}
+        seq_key = asdict(row.pkey)
 
         # 1. check if there exists an entry in the sample table for seq_key
         corresponding_sample = find_conditions_in_db(

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -231,8 +231,8 @@ def sync_state_with_submission_table(db_engine: Engine, config: Config):
         if len(corresponding_sample) == 1:
             if corresponding_sample[0].status == Status.SUBMITTED:
                 update_db_where_conditions(
-                    db_config,
-                    table_name=TableName.SUBMISSION_TABLE,
+                    db_engine,
+                    model_class=SubmissionTableEntry,
                     conditions=seq_key,
                     update_values={"status_all": StatusAll.SUBMITTED_SAMPLE},
                 )

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -6,7 +6,7 @@ from dataclasses import asdict
 from datetime import datetime
 
 import pytz
-from psycopg2.pool import SimpleConnectionPool
+from sqlalchemy import Engine
 
 from .config import Config, MetadataMapping
 from .ena_submission_helper import (
@@ -34,7 +34,7 @@ from .submission_db_helper import (
     SampleTableEntry,
     Status,
     StatusAll,
-    TableName,
+    SubmissionTableEntry,
     add_to_sample_table,
     db_init,
     find_conditions_in_db,
@@ -114,25 +114,25 @@ def get_sample_attributes(
 
 def construct_sample_set_object(
     config: Config,
-    sample_data_in_submission_table: dict[str, str | dict[str, str]],
-    entry: dict[str, str],
+    submission_row: SubmissionTableEntry,
+    sample_row: SampleTableEntry,
     test: bool = False,
 ):
     """
     Construct sample set object, using:
-    - entry in sample_table
-    - sample_data_in_submission_table: corresponding entry in submission_table
+    - sample_row: entry in sample_table
+    - submission_row: corresponding entry in submission_table
     - config information, such as enaDeposition metadata for that organism
     If test=True add a timestamp to the alias suffix to allow for multiple
     submissions of the same project for testing.
     (ENA blocks multiple submissions with the same alias)
     """
-    sample_metadata: dict[str, str] = sample_data_in_submission_table["metadata"]  # type: ignore
-    center_name = sample_data_in_submission_table["center_name"]
-    organism: str = sample_data_in_submission_table["organism"]  # type: ignore
+    sample_metadata: dict[str, str] = submission_row.seq_metadata  # type: ignore
+    center_name = submission_row.center_name
+    organism: str = submission_row.organism
     organism_metadata = config.enaOrganisms[organism]
     alias = get_alias(
-        f"{entry['accession']}:{organism}:{config.unique_project_suffix}",
+        f"{sample_row.accession}:{organism}:{config.unique_project_suffix}",
         test,
         config.set_alias_suffix,
     )
@@ -157,22 +157,26 @@ def construct_sample_set_object(
             scientific_name=organism_metadata.scientific_name,
         ),
         sample_links=SampleLinks(
-            sample_link=[ProjectLink(xref_link=XrefType(db=config.db_name, id=entry["accession"]))]
+            sample_link=[
+                ProjectLink(xref_link=XrefType(db=config.db_name, id=sample_row.accession))
+            ]
         ),
         sample_attributes=SampleAttributes(sample_attribute=sample_attributes),
     )
     return SampleSetType(sample=[sample_type])
 
 
-def set_sample_table_entry(db_config, row, seq_key, config: Config):
+def set_sample_table_entry(
+    db_config: Engine, row: SubmissionTableEntry, seq_key: dict, config: Config
+):
     """Set sample_table entry for entry with biosampleAccession"""
     logger.debug(
-        f"Accession: {row['accession']} already has biosampleAccession, adding to sample_table"
+        f"Accession: {row.accession} already has biosampleAccession, adding to sample_table"
     )
-    biosample = row["metadata"]["biosampleAccession"]
+    biosample = row.seq_metadata["biosampleAccession"]
 
     logger.info("Checking if biosample actually exists and is public")
-    seq_key = {"accession": row["accession"], "version": row["version"]}
+    seq_key = {"accession": row.accession, "version": row.version}
     if not accession_exists(biosample, config):
         set_accession_does_not_exist_error(
             conditions=seq_key,
@@ -182,13 +186,12 @@ def set_sample_table_entry(db_config, row, seq_key, config: Config):
         )
         return
 
-    entry = {
-        "accession": row["accession"],
-        "version": row["version"],
-        "result": {"ena_sample_accession": biosample, "biosample_accession": biosample},
-        "status": Status.SUBMITTED,
-    }
-    sample_table_entry = SampleTableEntry(**entry)
+    sample_table_entry = SampleTableEntry(
+        accession=row.accession,
+        version=row.version,
+        result={"ena_sample_accession": biosample, "biosample_accession": biosample},
+        status=str(Status.SUBMITTED),
+    )
     succeeded = add_to_sample_table(db_config, sample_table_entry)
     if succeeded:
         logger.debug("Succeeding in adding biosampleAccession to sample_table")
@@ -197,13 +200,13 @@ def set_sample_table_entry(db_config, row, seq_key, config: Config):
         }
         update_db_where_conditions(
             db_config,
-            table_name=TableName.SUBMISSION_TABLE,
+            model_class=SubmissionTableEntry,
             conditions=seq_key,
             update_values=update_values,
         )
 
 
-def sync_state_with_submission_table(db_config: SimpleConnectionPool, config: Config):
+def sync_state_with_submission_table(db_config: Engine, config: Config):
     """
     1. Find all entries in submission_table in state SUBMITTED_PROJECT
     2. If (exists an entry in the sample_table for (accession, version)):
@@ -213,22 +216,22 @@ def sync_state_with_submission_table(db_config: SimpleConnectionPool, config: Co
     4. Else create corresponding entry in sample_table
     """
     # Check submission_table for newly added sequences
-    conditions = {"status_all": StatusAll.SUBMITTED_PROJECT}
+    conditions = {"status_all": str(StatusAll.SUBMITTED_PROJECT)}
     ready_to_submit = find_conditions_in_db(
-        db_config, table_name=TableName.SUBMISSION_TABLE, conditions=conditions
+        db_config, SubmissionTableEntry, conditions=conditions
     )
     logger.debug(
         f"Found {len(ready_to_submit)} entries in submission_table in status SUBMITTED_PROJECT"
     )
     for row in ready_to_submit:
-        seq_key = {"accession": row["accession"], "version": row["version"]}
+        seq_key = {"accession": row.accession, "version": row.version}
 
         # 1. check if there exists an entry in the sample table for seq_key
         corresponding_sample = find_conditions_in_db(
-            db_config, table_name=TableName.SAMPLE_TABLE, conditions=seq_key
+            db_config, SampleTableEntry, conditions=seq_key
         )
         if len(corresponding_sample) == 1:
-            if corresponding_sample[0]["status"] == str(Status.SUBMITTED):
+            if corresponding_sample[0].status == str(Status.SUBMITTED):
                 update_db_where_conditions(
                     db_config,
                     table_name=TableName.SUBMISSION_TABLE,
@@ -236,21 +239,20 @@ def sync_state_with_submission_table(db_config: SimpleConnectionPool, config: Co
                     update_values={"status_all": StatusAll.SUBMITTED_SAMPLE},
                 )
         else:
-            if "biosampleAccession" in row["metadata"] and row["metadata"]["biosampleAccession"]:
+            if row.seq_metadata.get("biosampleAccession"):
                 set_sample_table_entry(db_config, row, seq_key, config)
                 continue
             if not add_to_sample_table(db_config, SampleTableEntry(**seq_key)):
                 continue
 
 
-def is_old_version(db_config: SimpleConnectionPool, seq_key: AccessionVersion) -> bool:
+def is_old_version(db_config: Engine, seq_key: AccessionVersion) -> bool:
     """Check if entry is incorrectly added older version - error and do not submit"""
     version = seq_key.version
-    accession = {"accession": seq_key.accession}
-    sample_data_in_submission_table = find_conditions_in_db(
-        db_config, table_name=TableName.SUBMISSION_TABLE, conditions=accession
+    rows = find_conditions_in_db(
+        db_config, SubmissionTableEntry, conditions={"accession": seq_key.accession}
     )
-    all_versions = sorted([entry["version"] for entry in sample_data_in_submission_table])
+    all_versions = sorted(row.version for row in rows)
 
     if version < all_versions[-1]:
         update_values = {
@@ -266,14 +268,14 @@ def is_old_version(db_config: SimpleConnectionPool, seq_key: AccessionVersion) -
             db_config=db_config,
             conditions=asdict(seq_key),
             update_values=update_values,
-            table_name=TableName.SAMPLE_TABLE,
+            model_class=SampleTableEntry,
             reraise=False,
         )
         return True
     return False
 
 
-def sample_table_create(db_config: SimpleConnectionPool, config: Config, test: bool = False):
+def sample_table_create(db_config: Engine, config: Config, test: bool = False):
     """
     1. Find all entries in sample_table in state READY
     2. Create sample_set_object: use metadata, center_name, organism, and ingest fields
@@ -285,32 +287,30 @@ def sample_table_create(db_config: SimpleConnectionPool, config: Config, test: b
     If test=True add a timestamp to the alias suffix to allow for multiple submissions of the same
     sample for testing.
     """
-    conditions = {"status": Status.READY}
+    conditions = {"status": str(Status.READY)}
     ready_to_submit_sample = find_conditions_in_db(
-        db_config, table_name=TableName.SAMPLE_TABLE, conditions=conditions
+        db_config, SampleTableEntry, conditions=conditions
     )
     logger.debug(f"Found {len(ready_to_submit_sample)} entries in sample_table in status READY")
     for row in ready_to_submit_sample:
-        seq_key = AccessionVersion(accession=row["accession"], version=row["version"])
+        seq_key = AccessionVersion(accession=row.accession, version=row.version)
         if is_old_version(db_config, seq_key):
             logger.warning(f"Skipping submission for {seq_key} as it is not the latest version.")
             continue
 
         logger.info(f"Processing sample_table entry for {seq_key}")
-        sample_data_in_submission_table = find_conditions_in_db(
-            db_config, table_name=TableName.SUBMISSION_TABLE, conditions=asdict(seq_key)
+        submission_rows = find_conditions_in_db(
+            db_config, SubmissionTableEntry, conditions=asdict(seq_key)
         )
 
-        sample_set = construct_sample_set_object(
-            config, sample_data_in_submission_table[0], row, test
-        )
+        sample_set = construct_sample_set_object(config, submission_rows[0], row, test)
         update_values = {
             "status": Status.SUBMITTING,
             "started_at": datetime.now(tz=pytz.utc),
         }
         number_rows_updated = update_db_where_conditions(
             db_config,
-            table_name=TableName.SAMPLE_TABLE,
+            model_class=SampleTableEntry,
             conditions=asdict(seq_key),
             update_values=update_values,
         )
@@ -321,7 +321,7 @@ def sample_table_create(db_config: SimpleConnectionPool, config: Config, test: b
                 "- not starting submission."
             )
             continue
-        logger.info(f"Starting sample creation for accession {row['accession']}")
+        logger.info(f"Starting sample creation for accession {row.accession}")
         sample_creation_results: CreationResult = create_ena_sample(
             config, sample_set, revision=is_revision(db_config, seq_key)
         )
@@ -347,12 +347,12 @@ def sample_table_create(db_config: SimpleConnectionPool, config: Config, test: b
             db_config=db_config,
             conditions=asdict(seq_key),
             update_values=update_values,
-            table_name=TableName.SAMPLE_TABLE,
+            model_class=SampleTableEntry,
         )
 
 
 def sample_table_handle_errors(
-    db_config: SimpleConnectionPool,
+    db_config: Engine,
     config: Config,
     slack_config: SlackConfig,
     last_retry_time: datetime | None,
@@ -363,7 +363,7 @@ def sample_table_handle_errors(
     2. If time since last slack_notification is over slack_retry_threshold_min send notification
     """
     entries_with_errors = find_errors_or_stuck_in_db(
-        db_config, TableName.SAMPLE_TABLE, time_threshold=config.submitting_time_threshold_min
+        db_config, SampleTableEntry, time_threshold=config.submitting_time_threshold_min
     )
     if len(entries_with_errors) > 0:
         error_msg = (
@@ -380,7 +380,7 @@ def sample_table_handle_errors(
         last_retry_time = retry_failed_submissions_for_matching_errors(
             entries_with_errors,
             db_config,
-            table_name=TableName.SAMPLE_TABLE,
+            model_class=SampleTableEntry,
             retry_threshold_min=config.retry_threshold_min,
             last_retry=last_retry_time,
         )

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -217,9 +217,7 @@ def sync_state_with_submission_table(db_config: Engine, config: Config):
     """
     # Check submission_table for newly added sequences
     conditions = {"status_all": str(StatusAll.SUBMITTED_PROJECT)}
-    ready_to_submit = find_conditions_in_db(
-        db_config, SubmissionTableEntry, conditions=conditions
-    )
+    ready_to_submit = find_conditions_in_db(db_config, SubmissionTableEntry, conditions=conditions)
     logger.debug(
         f"Found {len(ready_to_submit)} entries in submission_table in status SUBMITTED_PROJECT"
     )

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -30,7 +30,6 @@ from .ena_types import (
 )
 from .notifications import SlackConfig, send_slack_notification, slack_conn_init
 from .submission_db_helper import (
-    AccessionVersion,
     SampleTableEntry,
     Status,
     StatusAll,
@@ -40,6 +39,7 @@ from .submission_db_helper import (
     find_conditions_in_db,
     find_errors_or_stuck_in_db,
     is_latest_revision,
+    is_revision,
     update_db_where_conditions,
     update_with_retry,
 )
@@ -244,35 +244,6 @@ def sync_state_with_submission_table(db_engine: Engine, config: Config):
                 continue
 
 
-def is_old_version(db_engine: Engine, seq_key: AccessionVersion) -> bool:
-    """Check if entry is incorrectly added older version - error and do not submit"""
-    version = seq_key.version
-    rows = find_conditions_in_db(
-        db_engine, SubmissionTableEntry, conditions={"accession": seq_key.accession}
-    )
-    all_versions = sorted(row.version for row in rows)
-
-    if version < all_versions[-1]:
-        update_values = {
-            "status": Status.HAS_ERRORS,
-            "errors": ["Revision version is not the latest version"],
-            "started_at": datetime.now(tz=pytz.utc),
-        }
-        logger.error(
-            f"Sample creation failed for {seq_key.accession} version {version} "
-            "as it is not the latest version."
-        )
-        update_with_retry(
-            db_engine=db_engine,
-            conditions=asdict(seq_key),
-            update_values=update_values,
-            model_class=SampleTableEntry,
-            reraise=False,
-        )
-        return True
-    return False
-
-
 def sample_table_create(db_engine: Engine, config: Config, test: bool = False):
     """
     1. Find all entries in sample_table in state READY
@@ -292,7 +263,7 @@ def sample_table_create(db_engine: Engine, config: Config, test: bool = False):
     logger.debug(f"Found {len(ready_to_submit_sample)} entries in sample_table in status READY")
     for row in ready_to_submit_sample:
         seq_key = row.pkey
-        if is_old_version(db_engine, seq_key):
+        if is_revision(db_engine, seq_key) and not is_latest_revision(db_engine, seq_key):
             logger.warning(f"Skipping submission for {seq_key} as it is not the latest version.")
             continue
 

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -167,7 +167,7 @@ def construct_sample_set_object(
 
 
 def set_sample_table_entry(
-    db_config: Engine, row: SubmissionTableEntry, seq_key: dict, config: Config
+    db_engine: Engine, row: SubmissionTableEntry, seq_key: dict, config: Config
 ):
     """Set sample_table entry for entry with biosampleAccession"""
     logger.debug(
@@ -182,7 +182,7 @@ def set_sample_table_entry(
             conditions=seq_key,
             accession=biosample,
             accession_type="BIOSAMPLE",
-            db_pool=db_config,
+            db_pool=db_engine,
         )
         return
 
@@ -192,21 +192,21 @@ def set_sample_table_entry(
         result={"ena_sample_accession": biosample, "biosample_accession": biosample},
         status=Status.SUBMITTED,
     )
-    succeeded = add_to_sample_table(db_config, sample_table_entry)
+    succeeded = add_to_sample_table(db_engine, sample_table_entry)
     if succeeded:
         logger.debug("Succeeding in adding biosampleAccession to sample_table")
         update_values = {
             "status_all": StatusAll.SUBMITTED_SAMPLE,
         }
         update_db_where_conditions(
-            db_config,
+            db_engine,
             model_class=SubmissionTableEntry,
             conditions=seq_key,
             update_values=update_values,
         )
 
 
-def sync_state_with_submission_table(db_config: Engine, config: Config):
+def sync_state_with_submission_table(db_engine: Engine, config: Config):
     """
     1. Find all entries in submission_table in state SUBMITTED_PROJECT
     2. If (exists an entry in the sample_table for (accession, version)):
@@ -217,7 +217,7 @@ def sync_state_with_submission_table(db_config: Engine, config: Config):
     """
     # Check submission_table for newly added sequences
     conditions = {"status_all": StatusAll.SUBMITTED_PROJECT}
-    ready_to_submit = find_conditions_in_db(db_config, SubmissionTableEntry, conditions=conditions)
+    ready_to_submit = find_conditions_in_db(db_engine, SubmissionTableEntry, conditions=conditions)
     logger.debug(
         f"Found {len(ready_to_submit)} entries in submission_table in status SUBMITTED_PROJECT"
     )
@@ -226,7 +226,7 @@ def sync_state_with_submission_table(db_config: Engine, config: Config):
 
         # 1. check if there exists an entry in the sample table for seq_key
         corresponding_sample = find_conditions_in_db(
-            db_config, SampleTableEntry, conditions=seq_key
+            db_engine, SampleTableEntry, conditions=seq_key
         )
         if len(corresponding_sample) == 1:
             if corresponding_sample[0].status == Status.SUBMITTED:
@@ -238,17 +238,17 @@ def sync_state_with_submission_table(db_config: Engine, config: Config):
                 )
         else:
             if row.seq_metadata.get("biosampleAccession"):
-                set_sample_table_entry(db_config, row, seq_key, config)
+                set_sample_table_entry(db_engine, row, seq_key, config)
                 continue
-            if not add_to_sample_table(db_config, SampleTableEntry(**seq_key)):
+            if not add_to_sample_table(db_engine, SampleTableEntry(**seq_key)):
                 continue
 
 
-def is_old_version(db_config: Engine, seq_key: AccessionVersion) -> bool:
+def is_old_version(db_engine: Engine, seq_key: AccessionVersion) -> bool:
     """Check if entry is incorrectly added older version - error and do not submit"""
     version = seq_key.version
     rows = find_conditions_in_db(
-        db_config, SubmissionTableEntry, conditions={"accession": seq_key.accession}
+        db_engine, SubmissionTableEntry, conditions={"accession": seq_key.accession}
     )
     all_versions = sorted(row.version for row in rows)
 
@@ -263,7 +263,7 @@ def is_old_version(db_config: Engine, seq_key: AccessionVersion) -> bool:
             "as it is not the latest version."
         )
         update_with_retry(
-            db_config=db_config,
+            db_engine=db_engine,
             conditions=asdict(seq_key),
             update_values=update_values,
             model_class=SampleTableEntry,
@@ -273,7 +273,7 @@ def is_old_version(db_config: Engine, seq_key: AccessionVersion) -> bool:
     return False
 
 
-def sample_table_create(db_config: Engine, config: Config, test: bool = False):
+def sample_table_create(db_engine: Engine, config: Config, test: bool = False):
     """
     1. Find all entries in sample_table in state READY
     2. Create sample_set_object: use metadata, center_name, organism, and ingest fields
@@ -287,18 +287,18 @@ def sample_table_create(db_config: Engine, config: Config, test: bool = False):
     """
     conditions = {"status": Status.READY}
     ready_to_submit_sample = find_conditions_in_db(
-        db_config, SampleTableEntry, conditions=conditions
+        db_engine, SampleTableEntry, conditions=conditions
     )
     logger.debug(f"Found {len(ready_to_submit_sample)} entries in sample_table in status READY")
     for row in ready_to_submit_sample:
         seq_key = AccessionVersion(accession=row.accession, version=row.version)
-        if is_old_version(db_config, seq_key):
+        if is_old_version(db_engine, seq_key):
             logger.warning(f"Skipping submission for {seq_key} as it is not the latest version.")
             continue
 
         logger.info(f"Processing sample_table entry for {seq_key}")
         submission_rows = find_conditions_in_db(
-            db_config, SubmissionTableEntry, conditions=asdict(seq_key)
+            db_engine, SubmissionTableEntry, conditions=asdict(seq_key)
         )
 
         sample_set = construct_sample_set_object(config, submission_rows[0], row, test)
@@ -307,7 +307,7 @@ def sample_table_create(db_config: Engine, config: Config, test: bool = False):
             "started_at": datetime.now(tz=pytz.utc),
         }
         number_rows_updated = update_db_where_conditions(
-            db_config,
+            db_engine,
             model_class=SampleTableEntry,
             conditions=asdict(seq_key),
             update_values=update_values,
@@ -321,7 +321,7 @@ def sample_table_create(db_config: Engine, config: Config, test: bool = False):
             continue
         logger.info(f"Starting sample creation for accession {row.accession}")
         sample_creation_results: CreationResult = create_ena_sample(
-            config, sample_set, revision=is_revision(db_config, seq_key)
+            config, sample_set, revision=is_revision(db_engine, seq_key)
         )
         if sample_creation_results.result:
             update_values = {
@@ -342,7 +342,7 @@ def sample_table_create(db_config: Engine, config: Config, test: bool = False):
                 f"Sample creation failed for {seq_key.accession} version {seq_key.version}"
             )
         update_with_retry(
-            db_config=db_config,
+            db_engine=db_engine,
             conditions=asdict(seq_key),
             update_values=update_values,
             model_class=SampleTableEntry,
@@ -350,7 +350,7 @@ def sample_table_create(db_config: Engine, config: Config, test: bool = False):
 
 
 def sample_table_handle_errors(
-    db_config: Engine,
+    db_engine: Engine,
     config: Config,
     slack_config: SlackConfig,
     last_retry_time: datetime | None,
@@ -361,7 +361,7 @@ def sample_table_handle_errors(
     2. If time since last slack_notification is over slack_retry_threshold_min send notification
     """
     entries_with_errors = find_errors_or_stuck_in_db(
-        db_config, SampleTableEntry, time_threshold=config.submitting_time_threshold_min
+        db_engine, SampleTableEntry, time_threshold=config.submitting_time_threshold_min
     )
     if len(entries_with_errors) > 0:
         error_msg = (
@@ -377,7 +377,7 @@ def sample_table_handle_errors(
         )
         last_retry_time = retry_failed_submissions_for_matching_errors(
             entries_with_errors,
-            db_config,
+            db_engine,
             model_class=SampleTableEntry,
             retry_threshold_min=config.retry_threshold_min,
             last_retry=last_retry_time,
@@ -389,7 +389,7 @@ def sample_table_handle_errors(
 
 
 def create_sample(config: Config, stop_event: threading.Event):
-    db_config = db_init(config.db_password, config.db_username, config.db_url)
+    db_engine = db_init(config.db_password, config.db_username, config.db_url)
     slack_config = slack_conn_init(
         slack_hook_default=config.slack_hook,
         slack_token_default=config.slack_token,
@@ -402,13 +402,13 @@ def create_sample(config: Config, stop_event: threading.Event):
             logger.warning("create_sample stopped due to exception in another task")
             return
         logger.debug("Checking for samples to create")
-        sync_state_with_submission_table(db_config, config=config)
+        sync_state_with_submission_table(db_engine, config=config)
 
-        sample_table_create(db_config, config, test=config.test)
+        sample_table_create(db_engine, config, test=config.test)
         sync_state_with_submission_table(
-            db_config, config=config
+            db_engine, config=config
         )  # update submission_table state after creation
         last_retry_time = sample_table_handle_errors(
-            db_config, config, slack_config, last_retry_time
+            db_engine, config, slack_config, last_retry_time
         )
         time.sleep(config.time_between_iterations)

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -263,7 +263,8 @@ def sample_table_create(db_engine: Engine, config: Config, test: bool = False):
     logger.debug(f"Found {len(ready_to_submit_sample)} entries in sample_table in status READY")
     for row in ready_to_submit_sample:
         seq_key = row.pkey
-        if is_revision(db_engine, seq_key) and not is_latest_revision(db_engine, seq_key):
+        is_rev = is_revision(db_engine, seq_key)
+        if is_rev and not is_latest_revision(db_engine, seq_key):
             logger.warning(f"Skipping submission for {seq_key} as it is not the latest version.")
             continue
 
@@ -292,7 +293,7 @@ def sample_table_create(db_engine: Engine, config: Config, test: bool = False):
             continue
         logger.info(f"Starting sample creation for accession {row.accession}")
         sample_creation_results: CreationResult = create_ena_sample(
-            config, sample_set, revision=is_latest_revision(db_engine, seq_key)
+            config, sample_set, revision=is_rev
         )
         if sample_creation_results.result:
             update_values = {

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -881,7 +881,7 @@ def retry_failed_submissions_for_matching_errors(
     entries_with_errors: Iterable[ProjectTableEntry]
     | Iterable[SampleTableEntry]
     | Iterable[AssemblyTableEntry],
-    db_config: Engine,
+    db_engine: Engine,
     model_class: type[ProjectTableEntry] | type[SampleTableEntry] | type[AssemblyTableEntry],
     retry_threshold_min: int,
     error_substrings: Sequence[str] = ("does not exist in ENA",),
@@ -911,7 +911,7 @@ def retry_failed_submissions_for_matching_errors(
         }
         try:
             update_with_retry(
-                db_config=db_config,
+                db_engine=db_engine,
                 conditions=asdict(pkey),
                 update_values=update_values,
                 model_class=model_class,

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -436,7 +436,7 @@ def create_flatfile(
     config: Config,
     metadata: dict[str, Any],
     organism_metadata: EnaOrganismDetails,
-    unaligned_nucleotide_sequences: dict[str, str],
+    unaligned_nucleotide_sequences: dict[str, str | None],
     dir: str | None,
 ):
     collection_date = metadata.get(DEFAULT_EMBL_PROPERTY_FIELDS.collection_date_property, "Unknown")
@@ -878,9 +878,11 @@ def set_accession_does_not_exist_error(
 
 
 def retry_failed_submissions_for_matching_errors(
-    entries_with_errors: Iterable[ProjectTableEntry | SampleTableEntry | AssemblyTableEntry],
+    entries_with_errors: Iterable[ProjectTableEntry]
+    | Iterable[SampleTableEntry]
+    | Iterable[AssemblyTableEntry],
     db_config: Engine,
-    model_class: type[ProjectTableEntry | SampleTableEntry | AssemblyTableEntry],
+    model_class: type[ProjectTableEntry] | type[SampleTableEntry] | type[AssemblyTableEntry],
     retry_threshold_min: int,
     error_substrings: Sequence[str] = ("does not exist in ENA",),
     last_retry: datetime | None = None,

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -841,7 +841,7 @@ def set_accession_does_not_exist_error(
     conditions: dict[str, str | dict[str, str]],
     accession: str,
     accession_type: Literal["BIOPROJECT"] | Literal["BIOSAMPLE"] | Literal["RUN_REF"],
-    db_pool: Engine,
+    db_engine: Engine,
 ):
     error_text = f"Accession {accession} of type {accession_type} does not exist in ENA."
     logger.error(error_text)
@@ -855,7 +855,7 @@ def set_accession_does_not_exist_error(
                 errors=[error_text],
                 result={"ena_sample_accession": accession, "biosample_accession": accession},
             )
-            succeeded = add_to_sample_table(db_pool, sample_table_entry)
+            succeeded = add_to_sample_table(db_engine, sample_table_entry)
         case "BIOPROJECT":
             project_table_entry = ProjectTableEntry(
                 **conditions,  # type: ignore
@@ -863,7 +863,7 @@ def set_accession_does_not_exist_error(
                 errors=[error_text],
                 result={"bioproject_accession": accession},
             )
-            succeeded = add_to_project_table(db_pool, project_table_entry)
+            succeeded = add_to_project_table(db_engine, project_table_entry)
         case "RUN_REF":
             assembly_table_entry = AssemblyTableEntry(
                 **conditions,  # type: ignore
@@ -871,7 +871,7 @@ def set_accession_does_not_exist_error(
                 errors=[error_text],
                 result={},  # type: ignore
             )
-            succeeded = add_to_assembly_table(db_pool, assembly_table_entry)
+            succeeded = add_to_assembly_table(db_engine, assembly_table_entry)
 
     if not succeeded:
         logger.warning(f"{accession_type} creation failed and DB update failed.")

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -9,7 +9,7 @@ import string
 import subprocess  # noqa: S404
 import tempfile
 from collections import defaultdict
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import Field, asdict, dataclass, is_dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -23,8 +23,8 @@ from Bio.Seq import Seq
 from Bio.SeqFeature import FeatureLocation, Reference, SeqFeature
 from Bio.SeqRecord import SeqRecord
 from bs4 import BeautifulSoup
-from psycopg2.pool import SimpleConnectionPool
 from requests.auth import HTTPBasicAuth
+from sqlalchemy import Engine
 from tenacity import (
     RetryCallState,
     Retrying,
@@ -55,7 +55,6 @@ from .submission_db_helper import (
     ProjectTableEntry,
     SampleTableEntry,
     Status,
-    TableName,
     add_to_assembly_table,
     add_to_project_table,
     add_to_sample_table,
@@ -842,7 +841,7 @@ def set_accession_does_not_exist_error(
     conditions: dict[str, str | dict[str, str]],
     accession: str,
     accession_type: Literal["BIOPROJECT"] | Literal["BIOSAMPLE"] | Literal["RUN_REF"],
-    db_pool: SimpleConnectionPool,
+    db_pool: Engine,
 ):
     error_text = f"Accession {accession} of type {accession_type} does not exist in ENA."
     logger.error(error_text)
@@ -879,9 +878,9 @@ def set_accession_does_not_exist_error(
 
 
 def retry_failed_submissions_for_matching_errors(
-    entries_with_errors: Iterable[Mapping[str, Any]],
-    db_config: SimpleConnectionPool,
-    table_name: TableName,
+    entries_with_errors: Iterable[ProjectTableEntry | SampleTableEntry | AssemblyTableEntry],
+    db_config: Engine,
+    model_class: type[ProjectTableEntry | SampleTableEntry | AssemblyTableEntry],
     retry_threshold_min: int,
     error_substrings: Sequence[str] = ("does not exist in ENA",),
     last_retry: datetime | None = None,
@@ -892,22 +891,14 @@ def retry_failed_submissions_for_matching_errors(
     ):
         return last_retry
     for entry in entries_with_errors:
-        errors = str(entry.get("errors", ""))
+        errors = str(entry.errors or "")
         if not any(substring in errors for substring in error_substrings):
             continue
-        match table_name:
-            case TableName.PROJECT_TABLE:
-                primary_key = ProjectTableEntry(**entry).primary_key
-            case TableName.SAMPLE_TABLE:
-                primary_key = SampleTableEntry(**entry).primary_key
-            case TableName.ASSEMBLY_TABLE:
-                primary_key = AssemblyTableEntry(**entry).primary_key
-            case _:
-                logger.error(f"Unknown table name: {table_name}")
-                continue
 
+        primary_key = entry.primary_key
         logger.info(
-            f"Retrying submission {primary_key} in {table_name} with error: '{entry.get('errors')}'"
+            f"Retrying submission {primary_key} in {model_class.__tablename__}"
+            f" with error: '{entry.errors}'"
         )
 
         update_values = {
@@ -921,9 +912,9 @@ def retry_failed_submissions_for_matching_errors(
                 db_config=db_config,
                 conditions=asdict(primary_key),
                 update_values=update_values,
-                table_name=table_name,
+                model_class=model_class,
             )
             last_retry = datetime.now(tz=pytz.utc)
         except Exception as e:
-            logger.error(f"Failed to update {table_name} entry for retry: {e!s}")
+            logger.error(f"Failed to update {model_class.__tablename__} entry for retry: {e!s}")
     return last_retry

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -897,9 +897,9 @@ def retry_failed_submissions_for_matching_errors(
         if not any(substring in errors for substring in error_substrings):
             continue
 
-        primary_key = entry.primary_key
+        pkey = entry.pkey
         logger.info(
-            f"Retrying submission {primary_key} in {model_class.__tablename__}"
+            f"Retrying submission {pkey} in {model_class.__tablename__}"
             f" with error: '{entry.errors}'"
         )
 
@@ -912,7 +912,7 @@ def retry_failed_submissions_for_matching_errors(
         try:
             update_with_retry(
                 db_config=db_config,
-                conditions=asdict(primary_key),
+                conditions=asdict(pkey),
                 update_values=update_values,
                 model_class=model_class,
             )

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -9,7 +9,7 @@ from enum import StrEnum
 from typing import Any, Final, TypeVar
 
 import pytz
-from sqlalchemy import Engine, create_engine, delete, func, or_, select, update
+from sqlalchemy import Engine, create_engine, delete, func, make_url, or_, select, update
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import (
     DeclarativeBase,
@@ -47,12 +47,9 @@ def db_init(db_password_default: str, db_username_default: str, db_url_default: 
     db_url = os.getenv("DB_URL") or db_url_default
 
     base_dsn = convert_jdbc_to_psycopg2(db_url)
-    # Insert credentials into the URL: postgresql+psycopg2://user:pass@host:port/db
-    url = base_dsn.replace(
-        "postgresql+psycopg2://",
-        f"postgresql+psycopg2://{db_username}:{db_password}@",
-        1,
-    )
+
+    parsed = make_url(base_dsn)
+    url = parsed.set(username=db_username, password=db_password)
     return create_engine(
         url,
         connect_args={"options": "-c search_path=ena_deposition_schema"},

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -309,9 +309,7 @@ def delete_records_in_db[
     return deleted_rows
 
 
-def find_errors_or_stuck_in_db[
-    T: (SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)
-](
+def find_errors_or_stuck_in_db[T: (ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)](
     engine: Engine,
     model_class: type[T],
     time_threshold: int = 15,
@@ -346,19 +344,16 @@ def find_stuck_in_submission_db(
         return rows
 
 
-def find_waiting_in_db[
-    T: (SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)
-](
+def find_waiting_in_db(
     engine: Engine,
-    model_class: type[T],
     time_threshold: int = 48,
-) -> list[T]:
+) -> list[AssemblyTableEntry]:
     """Return rows stuck in WAITING status for longer than *time_threshold* hours."""
     min_start_time = datetime.now(tz=pytz.utc) - timedelta(hours=time_threshold)
     with Session(engine) as session:
-        status_col = model_class.status
-        started_at_col = model_class.started_at
-        stmt = select(model_class).where(
+        status_col = AssemblyTableEntry.status
+        started_at_col = AssemblyTableEntry.started_at
+        stmt = select(AssemblyTableEntry).where(
             (status_col == str(Status.WAITING)) & (started_at_col < min_start_time)
         )
         rows = list(session.scalars(stmt).all())

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -301,7 +301,9 @@ def delete_records_in_db[
         result = session.execute(stmt)
         session.commit()
         deleted_rows = result.rowcount
-    logger.debug(f"Deleted {deleted_rows} rows from '{model_class.__tablename__}' where {conditions}")
+    logger.debug(
+        f"Deleted {deleted_rows} rows from '{model_class.__tablename__}' where {conditions}"
+    )
     return deleted_rows
 
 

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -246,6 +246,14 @@ class AssemblyTableEntry(Base):
         return AccessionVersion(accession=self.accession, version=self.version)
 
 
+type TableEntry = (
+    SubmissionTableEntry
+    | ProjectTableEntry
+    | SampleTableEntry
+    | AssemblyTableEntry
+)
+
+
 def highest_version_in_submission_table(engine: Engine) -> dict[Accession, Version]:
     """Return the highest version for each accession in submission_table."""
     with Session(engine) as session:
@@ -258,7 +266,7 @@ def highest_version_in_submission_table(engine: Engine) -> dict[Accession, Versi
 
 
 def find_conditions_in_db[
-    T: (SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)
+    T: TableEntry
 ](
     engine: Engine,
     model_class: type[T],
@@ -282,7 +290,7 @@ def find_conditions_in_db[
 
 
 def delete_records_in_db[
-    T: (SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)
+    T: TableEntry
 ](
     engine: Engine,
     model_class: type[T],
@@ -362,7 +370,7 @@ def find_waiting_in_db(
 
 
 def update_db_where_conditions[
-    T: (SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)
+    T: TableEntry
 ](
     engine: Engine,
     model_class: type[T],
@@ -408,7 +416,7 @@ def update_db_where_conditions[
 
 
 def update_with_retry[
-    T: (SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)
+    T: TableEntry
 ](
     db_engine: Engine,
     conditions: Mapping[str, Any],

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -9,7 +9,7 @@ from enum import StrEnum
 from typing import Any, Final, TypeVar
 
 import pytz
-from sqlalchemy import Engine, create_engine, delete, func, make_url, or_, select, update
+from sqlalchemy import Engine, Enum, create_engine, delete, func, make_url, or_, select, update
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import (
     DeclarativeBase,
@@ -151,7 +151,10 @@ class SubmissionTableEntry(Base):
     seq_metadata: Mapped[dict[str, Any]] = mapped_column("metadata", JSONB, default_factory=dict)
     errors: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
     warnings: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
-    status_all: Mapped[str] = mapped_column(default=str(StatusAll.READY_TO_SUBMIT))
+    status_all: Mapped[Status] = mapped_column(
+        Enum(StatusAll, native_enum=False),  # Store enum as string in DB table.
+        default=StatusAll.READY_TO_SUBMIT,
+    )
     started_at: Mapped[datetime | None] = mapped_column(default=None)
     finished_at: Mapped[datetime | None] = mapped_column(default=None)
     unaligned_nucleotide_sequences: Mapped[dict[str, str | None]] = mapped_column(
@@ -182,7 +185,10 @@ class ProjectTableEntry(Base):
     organism: Mapped[str] = mapped_column()
     errors: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
     warnings: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
-    status: Mapped[str] = mapped_column(default=str(Status.READY))
+    status: Mapped[Status] = mapped_column(
+        Enum(Status, native_enum=False),
+        default=Status.READY,
+    )
     started_at: Mapped[datetime | None] = mapped_column(default=None)
     finished_at: Mapped[datetime | None] = mapped_column(default=None)
     center_name: Mapped[str | None] = mapped_column(default=None)
@@ -205,7 +211,10 @@ class SampleTableEntry(Base):
     version: Mapped[int] = mapped_column(primary_key=True)
     errors: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
     warnings: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
-    status: Mapped[str] = mapped_column(default=str(Status.READY))
+    status: Mapped[Status] = mapped_column(
+        Enum(Status, native_enum=False),
+        default=Status.READY,
+    )
     started_at: Mapped[datetime | None] = mapped_column(default=None)
     finished_at: Mapped[datetime | None] = mapped_column(default=None)
     result: Mapped[dict[str, str | Sequence[str]] | None] = mapped_column(JSONB, default=None)
@@ -227,7 +236,10 @@ class AssemblyTableEntry(Base):
     version: Mapped[int] = mapped_column(primary_key=True)
     errors: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
     warnings: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
-    status: Mapped[str] = mapped_column(default=str(Status.READY))
+    status: Mapped[Status] = mapped_column(
+        Enum(Status, native_enum=False),
+        default=Status.READY,
+    )
     started_at: Mapped[datetime | None] = mapped_column(default=None)
     finished_at: Mapped[datetime | None] = mapped_column(default=None)
     result: Mapped[dict[str, str | Sequence[str]] | None] = mapped_column(JSONB, default=None)
@@ -320,8 +332,8 @@ def find_errors_or_stuck_in_db[T: (ProjectTableEntry, SampleTableEntry, Assembly
         status_col = model_class.status
         started_at_col = model_class.started_at
         stmt = select(model_class).where(
-            (status_col == str(Status.HAS_ERRORS))
-            | ((status_col == str(Status.SUBMITTING)) & (started_at_col < min_start_time))
+            (status_col == Status.HAS_ERRORS)
+            | ((status_col == Status.SUBMITTING) & (started_at_col < min_start_time))
         )
         rows = list(session.scalars(stmt).all())
         session.expunge_all()
@@ -336,7 +348,7 @@ def find_stuck_in_submission_db(
     min_start_time = datetime.now(tz=pytz.utc) - timedelta(hours=time_threshold)
     with Session(engine) as session:
         stmt = select(SubmissionTableEntry).where(
-            SubmissionTableEntry.status_all == str(StatusAll.HAS_ERRORS_EXT_METADATA_UPLOAD),
+            SubmissionTableEntry.status_all == StatusAll.HAS_ERRORS_EXT_METADATA_UPLOAD,
             SubmissionTableEntry.started_at < min_start_time,
         )
         rows = list(session.scalars(stmt).all())
@@ -354,7 +366,7 @@ def find_waiting_in_db(
         status_col = AssemblyTableEntry.status
         started_at_col = AssemblyTableEntry.started_at
         stmt = select(AssemblyTableEntry).where(
-            (status_col == str(Status.WAITING)) & (started_at_col < min_start_time)
+            (status_col == Status.WAITING) & (started_at_col < min_start_time)
         )
         rows = list(session.scalars(stmt).all())
         session.expunge_all()

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -558,7 +558,7 @@ def is_revision(engine: Engine, seq_key: AccessionVersion) -> bool:
 
 def previous_version(engine: Engine, seq_key: AccessionVersion) -> int | None:
     """Return the previous version number for *seq_key*, or None if not a revision."""
-    if not is_latest_revision(engine, seq_key):
+    if not is_revision(engine, seq_key):
         return None
     rows = find_conditions_in_db(
         engine,

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -1,14 +1,15 @@
 import logging
 import os
 import re
+import typing
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import StrEnum
-from typing import Any, Final, TypeVar
+from typing import Any, Final
 
 import pytz
-from sqlalchemy import Engine, create_engine, delete, func, or_, select, update
+from sqlalchemy import Engine, create_engine, func, or_, select, update
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import (
     DeclarativeBase,
@@ -140,7 +141,7 @@ class SubmissionTableEntry(Base):
     """Maps to submission_table. Primary key: (accession, version)."""
 
     __tablename__ = "submission_table"
-    __table_args__ = {"schema": "ena_deposition_schema"}
+    __table_args__: typing.ClassVar[dict[str, Any]] = {"schema": "ena_deposition_schema"}
 
     # Required fields (no defaults) must come first for dataclass ordering.
     accession: Mapped[str] = mapped_column(primary_key=True)
@@ -174,7 +175,7 @@ class ProjectTableEntry(Base):
     """Maps to project_table. Primary key: project_id (BIGSERIAL)."""
 
     __tablename__ = "project_table"
-    __table_args__ = {"schema": "ena_deposition_schema"}
+    __table_args__: typing.ClassVar[dict[str, Any]] = {"schema": "ena_deposition_schema"}
 
     # BIGSERIAL primary key — server-generated, excluded from __init__.
     project_id: Mapped[int | None] = mapped_column(
@@ -201,7 +202,7 @@ class SampleTableEntry(Base):
     """Maps to sample_table. Primary key: (accession, version)."""
 
     __tablename__ = "sample_table"
-    __table_args__ = {"schema": "ena_deposition_schema"}
+    __table_args__: typing.ClassVar[dict[str, Any]] = {"schema": "ena_deposition_schema"}
 
     accession: Mapped[str] = mapped_column(primary_key=True)
     version: Mapped[int] = mapped_column(primary_key=True)
@@ -223,7 +224,7 @@ class AssemblyTableEntry(Base):
     """Maps to assembly_table. Primary key: (accession, version)."""
 
     __tablename__ = "assembly_table"
-    __table_args__ = {"schema": "ena_deposition_schema"}
+    __table_args__: typing.ClassVar[dict[str, Any]] = {"schema": "ena_deposition_schema"}
 
     accession: Mapped[str] = mapped_column(primary_key=True)
     version: Mapped[int] = mapped_column(primary_key=True)
@@ -243,21 +244,6 @@ class AssemblyTableEntry(Base):
         return AccessionVersion(accession=self.accession, version=self.version)
 
 
-# TypeVar bound to our ORM base so generic query helpers stay typed.
-T = TypeVar(
-    "T",
-    SubmissionTableEntry,
-    ProjectTableEntry,
-    SampleTableEntry,
-    AssemblyTableEntry,
-)
-
-
-# ---------------------------------------------------------------------------
-# Query helpers
-# ---------------------------------------------------------------------------
-
-
 def highest_version_in_submission_table(engine: Engine) -> dict[Accession, Version]:
     """Return the highest version for each accession in submission_table."""
     with Session(engine) as session:
@@ -269,7 +255,9 @@ def highest_version_in_submission_table(engine: Engine) -> dict[Accession, Versi
     return {row.accession: row.version for row in rows}
 
 
-def find_conditions_in_db(
+def find_conditions_in_db[
+    T: (SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)
+](
     engine: Engine,
     model_class: type[T],
     conditions: dict[str, Any],
@@ -285,14 +273,13 @@ def find_conditions_in_db(
         stmt = select(model_class)
         for col_name, value in conditions.items():
             col = getattr(model_class, col_name)
-            if value is None:
-                stmt = stmt.where(col.is_(None))
-            else:
-                stmt = stmt.where(col == value)
+            stmt = stmt.where(col.is_(None)) if value is None else stmt.where(col == value)
         return list(session.scalars(stmt).all())
 
 
-def find_errors_or_stuck_in_db(
+def find_errors_or_stuck_in_db[
+    T: (SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)
+](
     engine: Engine,
     model_class: type[T],
     time_threshold: int = 15,
@@ -323,7 +310,9 @@ def find_stuck_in_submission_db(
         return list(session.scalars(stmt).all())
 
 
-def find_waiting_in_db(
+def find_waiting_in_db[
+    T: (SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)
+](
     engine: Engine,
     model_class: type[T],
     time_threshold: int = 48,
@@ -339,7 +328,9 @@ def find_waiting_in_db(
         return list(session.scalars(stmt).all())
 
 
-def update_db_where_conditions(
+def update_db_where_conditions[
+    T: (SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)
+](
     engine: Engine,
     model_class: type[T],
     conditions: Mapping[str, Any],
@@ -383,7 +374,9 @@ def update_db_where_conditions(
     return updated_row_count
 
 
-def update_with_retry(
+def update_with_retry[
+    T: (SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)
+](
     db_config: Engine,
     conditions: Mapping[str, Any],
     model_class: type[T],

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -274,7 +274,9 @@ def find_conditions_in_db[
         for col_name, value in conditions.items():
             col = getattr(model_class, col_name)
             stmt = stmt.where(col.is_(None)) if value is None else stmt.where(col == value)
-        return list(session.scalars(stmt).all())
+        rows = list(session.scalars(stmt).all())
+        session.expunge_all()
+        return rows
 
 
 def delete_records_in_db[
@@ -323,7 +325,9 @@ def find_errors_or_stuck_in_db[
             (status_col == str(Status.HAS_ERRORS))
             | ((status_col == str(Status.SUBMITTING)) & (started_at_col < min_start_time))
         )
-        return list(session.scalars(stmt).all())
+        rows = list(session.scalars(stmt).all())
+        session.expunge_all()
+        return rows
 
 
 def find_stuck_in_submission_db(
@@ -337,7 +341,9 @@ def find_stuck_in_submission_db(
             SubmissionTableEntry.status_all == str(StatusAll.HAS_ERRORS_EXT_METADATA_UPLOAD),
             SubmissionTableEntry.started_at < min_start_time,
         )
-        return list(session.scalars(stmt).all())
+        rows = list(session.scalars(stmt).all())
+        session.expunge_all()
+        return rows
 
 
 def find_waiting_in_db[
@@ -355,7 +361,9 @@ def find_waiting_in_db[
         stmt = select(model_class).where(
             (status_col == str(Status.WAITING)) & (started_at_col < min_start_time)
         )
-        return list(session.scalars(stmt).all())
+        rows = list(session.scalars(stmt).all())
+        session.expunge_all()
+        return rows
 
 
 def update_db_where_conditions[

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import StrEnum
-from typing import Any, Final, TypeVar
+from typing import Any, Final
 
 import pytz
 from sqlalchemy import Engine, Enum, create_engine, delete, func, make_url, or_, select, update
@@ -257,16 +257,9 @@ def highest_version_in_submission_table(engine: Engine) -> dict[Accession, Versi
     return {row.accession: row.version for row in rows}
 
 
-T = TypeVar(
-    "T",
-    SubmissionTableEntry,
-    ProjectTableEntry,
-    SampleTableEntry,
-    AssemblyTableEntry,
-)
-
-
-def find_conditions_in_db[T](
+def find_conditions_in_db[
+    T: (SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)
+](
     engine: Engine,
     model_class: type[T],
     conditions: dict[str, Any],
@@ -288,7 +281,9 @@ def find_conditions_in_db[T](
         return rows
 
 
-def delete_records_in_db[T](
+def delete_records_in_db[
+    T: (SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)
+](
     engine: Engine,
     model_class: type[T],
     conditions: dict[str, Any],
@@ -366,7 +361,9 @@ def find_waiting_in_db(
         return rows
 
 
-def update_db_where_conditions[T](
+def update_db_where_conditions[
+    T: (SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)
+](
     engine: Engine,
     model_class: type[T],
     conditions: Mapping[str, Any],
@@ -410,7 +407,9 @@ def update_db_where_conditions[T](
     return updated_row_count
 
 
-def update_with_retry[T](
+def update_with_retry[
+    T: (SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)
+](
     db_engine: Engine,
     conditions: Mapping[str, Any],
     model_class: type[T],

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -167,7 +167,7 @@ class SubmissionTableEntry(Base):
     project_id: Mapped[int | None] = mapped_column(default=None)
 
     @property
-    def primary_key(self) -> AccessionVersion:
+    def pkey(self) -> AccessionVersion:
         return AccessionVersion(accession=self.accession, version=self.version)
 
 
@@ -194,7 +194,7 @@ class ProjectTableEntry(Base):
     ncbi_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
 
     @property
-    def primary_key(self) -> ProjectId:
+    def pkey(self) -> ProjectId:
         return ProjectId(project_id=self.project_id)
 
 
@@ -216,7 +216,7 @@ class SampleTableEntry(Base):
     ncbi_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
 
     @property
-    def primary_key(self) -> AccessionVersion:
+    def pkey(self) -> AccessionVersion:
         return AccessionVersion(accession=self.accession, version=self.version)
 
 
@@ -240,7 +240,7 @@ class AssemblyTableEntry(Base):
     ncbi_gca_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
 
     @property
-    def primary_key(self) -> AccessionVersion:
+    def pkey(self) -> AccessionVersion:
         return AccessionVersion(accession=self.accession, version=self.version)
 
 

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -528,7 +528,7 @@ def add_to_submission_table(engine: Engine, entry: SubmissionTableEntry) -> bool
         return False
 
 
-def is_revision(engine: Engine, seq_key: AccessionVersion) -> bool:
+def is_latest_revision(engine: Engine, seq_key: AccessionVersion) -> bool:
     """Return True if *seq_key* is the latest of multiple versions for its accession."""
     if seq_key.version == 1:
         return False
@@ -541,9 +541,24 @@ def is_revision(engine: Engine, seq_key: AccessionVersion) -> bool:
     return len(all_versions) > 1 and seq_key.version == all_versions[-1]
 
 
-def last_version(engine: Engine, seq_key: AccessionVersion) -> int | None:
+def is_revision(engine: Engine, seq_key: AccessionVersion) -> bool:
+    """Return True if *seq_key* is a revision of an accession submitted to ENA.
+    Note: a sequence with version > 1 is not necessarily a revision as the first version
+    might not have been submitted to ENA yet."""
+    if seq_key.version == 1:
+        return False
+    rows = find_conditions_in_db(
+        engine,
+        SubmissionTableEntry,
+        {"accession": seq_key.accession},
+    )
+    all_versions = sorted(row.version for row in rows)
+    return len(all_versions) > 1
+
+
+def previous_version(engine: Engine, seq_key: AccessionVersion) -> int | None:
     """Return the previous version number for *seq_key*, or None if not a revision."""
-    if not is_revision(engine, seq_key):
+    if not is_latest_revision(engine, seq_key):
         return None
     rows = find_conditions_in_db(
         engine,

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -122,7 +122,7 @@ class ProjectId:
 
 
 # ---------------------------------------------------------------------------
-# SQLAlchemy ORM models — these replace the previous plain dataclasses.
+# SQLAlchemy ORM models
 # Using MappedAsDataclass so they still behave as dataclasses (constructor,
 # field access, asdict, etc.) while giving typed attribute access on query
 # results (row.accession instead of row["accession"]).

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -490,7 +490,7 @@ def add_to_sample_table(engine: Engine, entry: SampleTableEntry) -> bool:
     """Insert *entry* into sample_table. Returns True on success."""
     entry.started_at = datetime.now(tz=pytz.utc)
     try:
-        with Session(engine) as session:
+        with Session(engine, expire_on_commit=False) as session:
             session.add(entry)
             session.commit()
         return True
@@ -503,7 +503,7 @@ def add_to_assembly_table(engine: Engine, entry: AssemblyTableEntry) -> bool:
     """Insert *entry* into assembly_table. Returns True on success."""
     entry.started_at = datetime.now(tz=pytz.utc)
     try:
-        with Session(engine) as session:
+        with Session(engine, expire_on_commit=False) as session:
             session.add(entry)
             session.commit()
         return True
@@ -525,7 +525,7 @@ def add_to_submission_table(engine: Engine, entry: SubmissionTableEntry) -> bool
     """Insert *entry* into submission_table. Returns True on success."""
     entry.started_at = datetime.now(tz=pytz.utc)
     try:
-        with Session(engine) as session:
+        with Session(engine, expire_on_commit=False) as session:
             session.add(entry)
             session.commit()
         return True

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -418,7 +418,7 @@ def update_db_where_conditions[T](
 
 
 def update_with_retry[T](
-    db_config: Engine,
+    db_engine: Engine,
     conditions: Mapping[str, Any],
     model_class: type[T],
     update_values: dict[str, Any],
@@ -432,7 +432,7 @@ def update_with_retry[T](
 
     def _do_update() -> int:
         number_rows_updated = update_db_where_conditions(
-            db_config,
+            db_engine,
             model_class=model_class,
             conditions=conditions,
             update_values=update_values,

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import StrEnum
-from typing import Any, Final
+from typing import Any, Final, TypeVar
 
 import pytz
 from sqlalchemy import Engine, create_engine, delete, func, or_, select, update
@@ -255,9 +255,16 @@ def highest_version_in_submission_table(engine: Engine) -> dict[Accession, Versi
     return {row.accession: row.version for row in rows}
 
 
-def find_conditions_in_db[
-    T: (SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)
-](
+T = TypeVar(
+    "T",
+    SubmissionTableEntry,
+    ProjectTableEntry,
+    SampleTableEntry,
+    AssemblyTableEntry,
+)
+
+
+def find_conditions_in_db[T](
     engine: Engine,
     model_class: type[T],
     conditions: dict[str, Any],
@@ -279,9 +286,7 @@ def find_conditions_in_db[
         return rows
 
 
-def delete_records_in_db[
-    T: (SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)
-](
+def delete_records_in_db[T](
     engine: Engine,
     model_class: type[T],
     conditions: dict[str, Any],
@@ -294,7 +299,7 @@ def delete_records_in_db[
     Returns:
         int: The number of rows deleted.
     """
-    logger.debug(f"Deleting records from '{model_class.__tablename__}' where {conditions}")
+    logger.debug(f"Deleting records from '{model_class.__name__}' where {conditions}")
     with Session(engine) as session:
         stmt = delete(model_class)
         for col_name, value in conditions.items():
@@ -303,9 +308,7 @@ def delete_records_in_db[
         result = session.execute(stmt)
         session.commit()
         deleted_rows = result.rowcount
-    logger.debug(
-        f"Deleted {deleted_rows} rows from '{model_class.__tablename__}' where {conditions}"
-    )
+    logger.debug(f"Deleted {deleted_rows} rows from '{model_class.__name__}' where {conditions}")
     return deleted_rows
 
 
@@ -361,9 +364,7 @@ def find_waiting_in_db(
         return rows
 
 
-def update_db_where_conditions[
-    T: (SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)
-](
+def update_db_where_conditions[T](
     engine: Engine,
     model_class: type[T],
     conditions: Mapping[str, Any],
@@ -377,7 +378,7 @@ def update_db_where_conditions[
     """
     updated_row_count = 0
     logger.debug(
-        f"Updating '{model_class.__tablename__}' with conditions '{conditions}'"
+        f"Updating '{model_class.__name__}' with conditions '{conditions}'"
         f" and values '{update_values}'"
     )
     try:
@@ -401,15 +402,13 @@ def update_db_where_conditions[
     except Exception as e:
         logger.warning(f"update_db_where_conditions errored with: {e}")
     logger.debug(
-        f"Updated {updated_row_count} rows in '{model_class.__tablename__}'"
+        f"Updated {updated_row_count} rows in '{model_class.__name__}'"
         f" for conditions '{conditions}' and update values '{update_values}'"
     )
     return updated_row_count
 
 
-def update_with_retry[
-    T: (SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)
-](
+def update_with_retry[T](
     db_config: Engine,
     conditions: Mapping[str, Any],
     model_class: type[T],
@@ -430,7 +429,7 @@ def update_with_retry[
             update_values=update_values,
         )
         if number_rows_updated != 1:
-            msg = f"{model_class.__tablename__} update failed"
+            msg = f"{model_class.__name__} update failed"
             raise ValueError(msg)
         return number_rows_updated
 
@@ -445,18 +444,17 @@ def update_with_retry[
 
     try:
         logger.debug(
-            f"Updating {model_class.__tablename__} with conditions {conditions}"
+            f"Updating {model_class.__name__} with conditions {conditions}"
             f" and values {update_values}"
         )
         result = retryer(_do_update)
         logger.info(
-            f"{model_class.__tablename__} update succeeded"
-            f" for {conditions} with values {update_values}"
+            f"{model_class.__name__} update succeeded for {conditions} with values {update_values}"
         )
         return result
     except Exception as e:
         error_msg = (
-            f"{model_class.__tablename__} update failed for {conditions}"
+            f"{model_class.__name__} update failed for {conditions}"
             f" with values {update_values} after {number_of_retries} attempts."
         )
         logger.error(error_msg)

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -9,7 +9,7 @@ from enum import StrEnum
 from typing import Any, Final
 
 import pytz
-from sqlalchemy import Engine, create_engine, func, or_, select, update
+from sqlalchemy import Engine, create_engine, delete, func, or_, select, update
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import (
     DeclarativeBase,
@@ -275,6 +275,34 @@ def find_conditions_in_db[
             col = getattr(model_class, col_name)
             stmt = stmt.where(col.is_(None)) if value is None else stmt.where(col == value)
         return list(session.scalars(stmt).all())
+
+
+def delete_records_in_db[
+    T: (SubmissionTableEntry, ProjectTableEntry, SampleTableEntry, AssemblyTableEntry)
+](
+    engine: Engine,
+    model_class: type[T],
+    conditions: dict[str, Any],
+) -> int:
+    """Delete rows from *model_class*'s table matching every condition.
+
+    Each condition whose value is None generates an IS NULL check; others
+    generate an equality check.
+
+    Returns:
+        int: The number of rows deleted.
+    """
+    logger.debug(f"Deleting records from '{model_class.__tablename__}' where {conditions}")
+    with Session(engine) as session:
+        stmt = delete(model_class)
+        for col_name, value in conditions.items():
+            col = getattr(model_class, col_name)
+            stmt = stmt.where(col.is_(None)) if value is None else stmt.where(col == value)
+        result = session.execute(stmt)
+        session.commit()
+        deleted_rows = result.rowcount
+    logger.debug(f"Deleted {deleted_rows} rows from '{model_class.__tablename__}' where {conditions}")
+    return deleted_rows
 
 
 def find_errors_or_stuck_in_db[

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -76,13 +76,6 @@ class Status(StrEnum):
     WAITING = "WAITING"  # Only for assembly creation
 
 
-class TableName(StrEnum):
-    PROJECT_TABLE = "project_table"
-    SAMPLE_TABLE = "sample_table"
-    ASSEMBLY_TABLE = "assembly_table"
-    SUBMISSION_TABLE = "submission_table"
-
-
 type Accession = str
 type Version = int
 

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -1,17 +1,22 @@
-import json
 import logging
 import os
 import re
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import StrEnum
-from typing import Any, Final
+from typing import Any, Final, TypeVar
 
-import psycopg2
 import pytz
-from psycopg2.extras import RealDictCursor
-from psycopg2.pool import SimpleConnectionPool
+from sqlalchemy import Engine, create_engine, delete, func, or_, select, update
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    MappedAsDataclass,
+    Session,
+    mapped_column,
+)
 from tenacity import (
     Retrying,
     before_sleep_log,
@@ -23,44 +28,35 @@ from tenacity import (
 logger = logging.getLogger(__name__)
 
 
-def convert_jdbc_to_psycopg2(jdbc_url):
+def convert_jdbc_to_psycopg2(jdbc_url: str) -> str:
     jdbc_pattern = r"jdbc:postgresql://(?P<host>[^:/]+)(?::(?P<port>\d+))?/(?P<dbname>[^?]+)"
-
     match = re.match(jdbc_pattern, jdbc_url)
-
     if not match:
         msg = "Invalid JDBC URL format."
         raise ValueError(msg)
-
     host = match.group("host")
-    port = match.group("port") or "5432"  # Default to 5432 if no port is provided
+    port = match.group("port") or "5432"
     dbname = match.group("dbname")
+    return f"postgresql+psycopg2://{host}:{port}/{dbname}"
 
-    return f"postgresql://{host}:{port}/{dbname}"
 
+def db_init(db_password_default: str, db_username_default: str, db_url_default: str) -> Engine:
+    db_password = os.getenv("DB_PASSWORD") or db_password_default
+    db_username = os.getenv("DB_USERNAME") or db_username_default
+    db_url = os.getenv("DB_URL") or db_url_default
 
-def db_init(
-    db_password_default: str, db_username_default: str, db_url_default: str
-) -> SimpleConnectionPool:
-    db_password = os.getenv("DB_PASSWORD")
-    if not db_password:
-        db_password = db_password_default
-
-    db_username = os.getenv("DB_USERNAME")
-    if not db_username:
-        db_username = db_username_default
-
-    db_url = os.getenv("DB_URL")
-    if not db_url:
-        db_url = db_url_default
-
-    db_dsn = convert_jdbc_to_psycopg2(db_url) + "?options=-c%20search_path%3Dena_deposition_schema"
-    return SimpleConnectionPool(
-        minconn=1,
-        maxconn=2,  # max 7*2 connections to db allowed
-        user=db_username,
-        password=db_password,
-        dsn=db_dsn,
+    base_dsn = convert_jdbc_to_psycopg2(db_url)
+    # Insert credentials into the URL: postgresql+psycopg2://user:pass@host:port/db
+    url = base_dsn.replace(
+        "postgresql+psycopg2://",
+        f"postgresql+psycopg2://{db_username}:{db_password}@",
+        1,
+    )
+    return create_engine(
+        url,
+        connect_args={"options": "-c search_path=ena_deposition_schema"},
+        pool_size=1,
+        max_overflow=1,  # max 2 connections total; 7 processes * 2 = 14 DB connections
     )
 
 
@@ -87,31 +83,6 @@ class TableName(StrEnum):
     SAMPLE_TABLE = "sample_table"
     ASSEMBLY_TABLE = "assembly_table"
     SUBMISSION_TABLE = "submission_table"
-
-    @classmethod
-    def validate(cls, value: str):
-        if value not in cls._value2member_map_:
-            msg = (
-                f"Invalid table name '{value}'."
-                f" Allowed values are: {', '.join([e.value for e in cls])}"
-            )
-            raise ValueError(msg)
-
-
-def validate_column_name(table_name: str, column_name: str):
-    match table_name:
-        case "project_table":
-            field_names = ProjectTableEntry.__annotations__.keys()
-        case "sample_table":
-            field_names = SampleTableEntry.__annotations__.keys()
-        case "assembly_table":
-            field_names = AssemblyTableEntry.__annotations__.keys()
-        case "submission_table":
-            field_names = SubmissionTableEntry.__annotations__.keys()
-
-    if column_name not in field_names:
-        msg = f"Invalid column name '{column_name}' for {table_name}"
-        raise ValueError(msg)
 
 
 type Accession = str
@@ -149,348 +120,291 @@ class ProjectId:
     project_id: int | None
 
 
-@dataclass
-class SubmissionTableEntry:
-    accession: Accession
-    version: Version
-    organism: str
-    group_id: int
-    metadata: dict[str, Any] = field(default_factory=dict)
-    errors: list[str] | None = None
-    warnings: list[str] | None = None
-    status_all: StatusAll = StatusAll.READY_TO_SUBMIT
-    started_at: datetime | None = None
-    finished_at: datetime | None = None
-    unaligned_nucleotide_sequences: dict[str, str | None] = field(default_factory=dict)
-    center_name: str | None = None
-    external_metadata: dict[str, str | Sequence[str]] | None = None
-    project_id: int | None = None
+# ---------------------------------------------------------------------------
+# SQLAlchemy ORM models — these replace the previous plain dataclasses.
+# Using MappedAsDataclass so they still behave as dataclasses (constructor,
+# field access, asdict, etc.) while giving typed attribute access on query
+# results (row.accession instead of row["accession"]).
+#
+# Note: the 'metadata' field of SubmissionTableEntry is mapped to DB column
+# "metadata" but exposed as the Python attribute 'seq_metadata' to avoid
+# conflicting with SQLAlchemy's DeclarativeBase.metadata class attribute.
+# ---------------------------------------------------------------------------
+
+
+class Base(MappedAsDataclass, DeclarativeBase):
+    pass
+
+
+class SubmissionTableEntry(Base):
+    """Maps to submission_table. Primary key: (accession, version)."""
+
+    __tablename__ = "submission_table"
+    __table_args__ = {"schema": "ena_deposition_schema"}
+
+    # Required fields (no defaults) must come first for dataclass ordering.
+    accession: Mapped[str] = mapped_column(primary_key=True)
+    version: Mapped[int] = mapped_column(primary_key=True)
+    organism: Mapped[str] = mapped_column()
+    group_id: Mapped[int] = mapped_column()
+
+    # Optional fields with defaults.
+    # 'seq_metadata' maps to the DB column "metadata".
+    seq_metadata: Mapped[dict[str, Any]] = mapped_column("metadata", JSONB, default_factory=dict)
+    errors: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
+    warnings: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
+    status_all: Mapped[str] = mapped_column(default=str(StatusAll.READY_TO_SUBMIT))
+    started_at: Mapped[datetime | None] = mapped_column(default=None)
+    finished_at: Mapped[datetime | None] = mapped_column(default=None)
+    unaligned_nucleotide_sequences: Mapped[dict[str, str | None]] = mapped_column(
+        JSONB, default_factory=dict
+    )
+    center_name: Mapped[str | None] = mapped_column(default=None)
+    external_metadata: Mapped[dict[str, str | Sequence[str]] | None] = mapped_column(
+        JSONB, default=None
+    )
+    project_id: Mapped[int | None] = mapped_column(default=None)
 
     @property
     def primary_key(self) -> AccessionVersion:
         return AccessionVersion(accession=self.accession, version=self.version)
 
 
-@dataclass(kw_only=True)
-class ProjectTableEntry:
-    group_id: int
-    organism: str
-    project_id: int | None = None
-    errors: list[str] | None = None
-    warnings: list[str] | None = None
-    status: Status = Status.READY
-    started_at: datetime | None = None
-    finished_at: datetime | None = None
-    center_name: str | None = None
-    result: dict[str, str | Sequence[str]] | None = None
-    ena_first_publicly_visible: datetime | None = None
-    ncbi_first_publicly_visible: datetime | None = None
+class ProjectTableEntry(Base):
+    """Maps to project_table. Primary key: project_id (BIGSERIAL)."""
+
+    __tablename__ = "project_table"
+    __table_args__ = {"schema": "ena_deposition_schema"}
+
+    # BIGSERIAL primary key — server-generated, excluded from __init__.
+    project_id: Mapped[int | None] = mapped_column(
+        primary_key=True, autoincrement=True, init=False, default=None
+    )
+    group_id: Mapped[int] = mapped_column()
+    organism: Mapped[str] = mapped_column()
+    errors: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
+    warnings: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
+    status: Mapped[str] = mapped_column(default=str(Status.READY))
+    started_at: Mapped[datetime | None] = mapped_column(default=None)
+    finished_at: Mapped[datetime | None] = mapped_column(default=None)
+    center_name: Mapped[str | None] = mapped_column(default=None)
+    result: Mapped[dict[str, str | Sequence[str]] | None] = mapped_column(JSONB, default=None)
+    ena_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
+    ncbi_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
 
     @property
     def primary_key(self) -> ProjectId:
         return ProjectId(project_id=self.project_id)
 
 
-@dataclass(kw_only=True)
-class SampleTableEntry:
-    accession: Accession
-    version: Version
-    errors: list[str] | None = None
-    warnings: list[str] | None = None
-    status: Status = Status.READY
-    started_at: datetime | None = None
-    finished_at: datetime | None = None
-    result: dict[str, str | Sequence[str]] | None = None
-    ena_first_publicly_visible: datetime | None = None
-    ncbi_first_publicly_visible: datetime | None = None
+class SampleTableEntry(Base):
+    """Maps to sample_table. Primary key: (accession, version)."""
+
+    __tablename__ = "sample_table"
+    __table_args__ = {"schema": "ena_deposition_schema"}
+
+    accession: Mapped[str] = mapped_column(primary_key=True)
+    version: Mapped[int] = mapped_column(primary_key=True)
+    errors: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
+    warnings: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
+    status: Mapped[str] = mapped_column(default=str(Status.READY))
+    started_at: Mapped[datetime | None] = mapped_column(default=None)
+    finished_at: Mapped[datetime | None] = mapped_column(default=None)
+    result: Mapped[dict[str, str | Sequence[str]] | None] = mapped_column(JSONB, default=None)
+    ena_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
+    ncbi_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
 
     @property
     def primary_key(self) -> AccessionVersion:
         return AccessionVersion(accession=self.accession, version=self.version)
 
 
-@dataclass(kw_only=True)
-class AssemblyTableEntry:
-    accession: Accession
-    version: Version
-    errors: list[str] | None = None
-    warnings: list[str] | None = None
-    status: Status = Status.READY
-    started_at: datetime | None = None
-    finished_at: datetime | None = None
-    result: dict[str, str | Sequence[str]] | None = None
-    ena_nucleotide_first_publicly_visible: datetime | None = None
-    ncbi_nucleotide_first_publicly_visible: datetime | None = None
-    ena_gca_first_publicly_visible: datetime | None = None
-    ncbi_gca_first_publicly_visible: datetime | None = None
+class AssemblyTableEntry(Base):
+    """Maps to assembly_table. Primary key: (accession, version)."""
+
+    __tablename__ = "assembly_table"
+    __table_args__ = {"schema": "ena_deposition_schema"}
+
+    accession: Mapped[str] = mapped_column(primary_key=True)
+    version: Mapped[int] = mapped_column(primary_key=True)
+    errors: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
+    warnings: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
+    status: Mapped[str] = mapped_column(default=str(Status.READY))
+    started_at: Mapped[datetime | None] = mapped_column(default=None)
+    finished_at: Mapped[datetime | None] = mapped_column(default=None)
+    result: Mapped[dict[str, str | Sequence[str]] | None] = mapped_column(JSONB, default=None)
+    ena_nucleotide_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
+    ncbi_nucleotide_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
+    ena_gca_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
+    ncbi_gca_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
 
     @property
     def primary_key(self) -> AccessionVersion:
         return AccessionVersion(accession=self.accession, version=self.version)
 
 
-def type_conversion(value: Any) -> Any:
-    if isinstance(value, (Status, StatusAll)):
-        return str(value)
-    if isinstance(value, (dict, list)):
-        return json.dumps(value)
-    return value
+# TypeVar bound to our ORM base so generic query helpers stay typed.
+T = TypeVar(
+    "T",
+    SubmissionTableEntry,
+    ProjectTableEntry,
+    SampleTableEntry,
+    AssemblyTableEntry,
+)
 
 
-def highest_version_in_submission_table(
-    db_conn_pool: SimpleConnectionPool,
-) -> dict[Accession, Version]:
-    """
-    Returns the highest version for a given accession in the submission table.
-    Does group by, so that only the highest version for each accession is returned.
-    """
-    con = db_conn_pool.getconn()
-    try:
-        with con, con.cursor(cursor_factory=RealDictCursor) as cur:
-            query = f"""
-                SELECT accession, MAX(version) AS version
-                FROM {TableName.SUBMISSION_TABLE}
-                GROUP BY accession
-            """  # noqa: S608
-            cur.execute(query)
-            results = cur.fetchall()
-    finally:
-        db_conn_pool.putconn(con)
-    return {row["accession"]: row["version"] for row in results}
+# ---------------------------------------------------------------------------
+# Query helpers
+# ---------------------------------------------------------------------------
 
 
-def delete_records_in_db(
-    db_conn_pool: SimpleConnectionPool,
-    table_name: TableName,
-    conditions: dict[str, str],
-) -> int:
-    """
-    Deletes records from the specified table based on the given conditions.
-
-    Args:
-        db_conn_pool (SimpleConnectionPool): Connection pool for PostgreSQL.
-        table_name (TableName): The table to delete records from.
-        conditions (dict[str, str]): A dictionary of column names and values for filtering.
-
-    Returns:
-        int: The number of rows deleted.
-    """
-    logger.debug(f"Deleting records from {table_name} where {conditions}")
-    con = db_conn_pool.getconn()
-    try:
-        with con, con.cursor() as cur:
-            # Validate table and column names to prevent SQL injection
-            TableName.validate(table_name)
-            for key in conditions:
-                validate_column_name(table_name, key)
-
-            query = f"DELETE FROM {table_name}"  # noqa: S608
-
-            if conditions:
-                where_clause = " AND ".join([f"{key}=%s" for key in conditions])
-                query += f" WHERE {where_clause}"
-
-            cur.execute(
-                query,
-                tuple(type_conversion(value) for value in conditions.values()),
-            )
-
-            deleted_rows = cur.rowcount  # Get number of affected rows
-
-    finally:
-        db_conn_pool.putconn(con)
-
-    logger.debug(f"Deleted {deleted_rows} rows from {table_name} where {conditions}")
-
-    return deleted_rows
+def highest_version_in_submission_table(engine: Engine) -> dict[Accession, Version]:
+    """Return the highest version for each accession in submission_table."""
+    with Session(engine) as session:
+        stmt = select(
+            SubmissionTableEntry.accession,
+            func.max(SubmissionTableEntry.version).label("version"),
+        ).group_by(SubmissionTableEntry.accession)
+        rows = session.execute(stmt).all()
+    return {row.accession: row.version for row in rows}
 
 
 def find_conditions_in_db(
-    db_conn_pool: SimpleConnectionPool,
-    table_name: TableName,
+    engine: Engine,
+    model_class: type[T],
     conditions: dict[str, Any],
-) -> list[dict[str, Any]]:
+) -> list[T]:
+    """Return all rows from *model_class*'s table matching every condition.
+
+    Each condition whose value is None generates an IS NULL check; others
+    generate an equality check.  Column names are Python attribute names on
+    the model class, so a typo raises AttributeError at import/call time
+    rather than a silent runtime KeyError.
     """
-    Return all records from the specified table that match all the conditions
-    Args:
-        db_conn_pool (SimpleConnectionPool): Connection pool for PostgreSQL.
-        table_name (TableName): The table to search in.
-        conditions (dict[str, str]): A dictionary of column names and values for filtering.
-    Returns:
-        list[dict[str, str]]: A list of dictionaries representing the records that
-            match the conditions. Each dictionary contains column names as keys and
-            their corresponding values.
-    """
-    con = db_conn_pool.getconn()
-    try:
-        with con, con.cursor(cursor_factory=RealDictCursor) as cur:
-            # Prevent sql-injection with table_name and column_name validation
-            TableName.validate(table_name)
-            for key in conditions:
-                validate_column_name(table_name, key)
-
-            query = f"SELECT * FROM {table_name}"  # noqa: S608
-
-            where_conditions, params = [], []
-
-            for key, value in conditions.items():
-                if value is None:
-                    where_conditions.append(f"{key} IS NULL")
-                else:
-                    where_conditions.append(f"{key} = %s")
-                    params.append(type_conversion(value))
-            if where_conditions:
-                query += " WHERE " + " AND ".join(where_conditions)
-
-            cur.execute(query, params)
-            results = cur.fetchall()
-    finally:
-        db_conn_pool.putconn(con)
-
-    return results
+    with Session(engine) as session:
+        stmt = select(model_class)
+        for col_name, value in conditions.items():
+            col = getattr(model_class, col_name)
+            if value is None:
+                stmt = stmt.where(col.is_(None))
+            else:
+                stmt = stmt.where(col == value)
+        return list(session.scalars(stmt).all())
 
 
 def find_errors_or_stuck_in_db(
-    db_conn_pool: SimpleConnectionPool, table_name: TableName, time_threshold: int = 15
-) -> list[dict[str, str]]:
-    con = db_conn_pool.getconn()
-    try:
-        with con, con.cursor(cursor_factory=RealDictCursor) as cur:
-            min_start_time = datetime.now(tz=pytz.utc) + timedelta(minutes=-time_threshold)
-            # Prevent sql-injection with table_name validation
-            TableName.validate(table_name)
-
-            query = f"""
-                SELECT * FROM {table_name}
-                WHERE (status = 'HAS_ERRORS')
-                OR (status = 'SUBMITTING' AND started_at < %s)
-            """  # noqa: S608
-
-            cur.execute(query, (min_start_time,))
-
-            results = cur.fetchall()
-    finally:
-        db_conn_pool.putconn(con)
-
-    return results
+    engine: Engine,
+    model_class: type[T],
+    time_threshold: int = 15,
+) -> list[T]:
+    """Return rows in HAS_ERRORS status or stuck in SUBMITTING > *time_threshold* minutes."""
+    min_start_time = datetime.now(tz=pytz.utc) - timedelta(minutes=time_threshold)
+    with Session(engine) as session:
+        status_col = model_class.status
+        started_at_col = model_class.started_at
+        stmt = select(model_class).where(
+            (status_col == str(Status.HAS_ERRORS))
+            | ((status_col == str(Status.SUBMITTING)) & (started_at_col < min_start_time))
+        )
+        return list(session.scalars(stmt).all())
 
 
 def find_stuck_in_submission_db(
-    db_conn_pool: SimpleConnectionPool, time_threshold: int = 48
-) -> list[dict[str, str]]:
-    con = db_conn_pool.getconn()
-    try:
-        with con, con.cursor(cursor_factory=RealDictCursor) as cur:
-            min_start_time = datetime.now(tz=pytz.utc) + timedelta(hours=-time_threshold)
-
-            query = """
-                SELECT * FROM submission_table
-                WHERE status_all = 'HAS_ERRORS_EXT_METADATA_UPLOAD'
-                AND started_at < %s
-            """
-
-            cur.execute(query, (min_start_time,))
-
-            results = cur.fetchall()
-    finally:
-        db_conn_pool.putconn(con)
-
-    return results
+    engine: Engine,
+    time_threshold: int = 48,
+) -> list[SubmissionTableEntry]:
+    """Return submission_table rows stuck in HAS_ERRORS_EXT_METADATA_UPLOAD."""
+    min_start_time = datetime.now(tz=pytz.utc) - timedelta(hours=time_threshold)
+    with Session(engine) as session:
+        stmt = select(SubmissionTableEntry).where(
+            SubmissionTableEntry.status_all == str(StatusAll.HAS_ERRORS_EXT_METADATA_UPLOAD),
+            SubmissionTableEntry.started_at < min_start_time,
+        )
+        return list(session.scalars(stmt).all())
 
 
 def find_waiting_in_db(
-    db_conn_pool: SimpleConnectionPool, table_name: TableName, time_threshold: int = 48
-) -> list[dict[str, str]]:
-    con = db_conn_pool.getconn()
-    try:
-        with con, con.cursor(cursor_factory=RealDictCursor) as cur:
-            min_start_time = datetime.now(tz=pytz.utc) + timedelta(hours=-time_threshold)
-            # Prevent sql-injection with table_name validation
-            TableName.validate(table_name)
-
-            query = f"SELECT * FROM {table_name} WHERE status = 'WAITING' AND started_at < %s"  # noqa: S608
-
-            cur.execute(query, (min_start_time,))
-
-            results = cur.fetchall()
-    finally:
-        db_conn_pool.putconn(con)
-
-    return results
+    engine: Engine,
+    model_class: type[T],
+    time_threshold: int = 48,
+) -> list[T]:
+    """Return rows stuck in WAITING status for longer than *time_threshold* hours."""
+    min_start_time = datetime.now(tz=pytz.utc) - timedelta(hours=time_threshold)
+    with Session(engine) as session:
+        status_col = model_class.status
+        started_at_col = model_class.started_at
+        stmt = select(model_class).where(
+            (status_col == str(Status.WAITING)) & (started_at_col < min_start_time)
+        )
+        return list(session.scalars(stmt).all())
 
 
 def update_db_where_conditions(
-    db_conn_pool: SimpleConnectionPool,
-    table_name: TableName,
-    conditions: Mapping[str, str | int],
+    engine: Engine,
+    model_class: type[T],
+    conditions: Mapping[str, Any],
     update_values: dict[str, Any],
 ) -> int:
+    """UPDATE rows in *model_class*'s table.
+
+    Only rows that match *conditions* AND where at least one column in
+    *update_values* would actually change are updated (IS DISTINCT FROM).
+    Returns the number of rows updated.
+    """
     updated_row_count = 0
-    con = db_conn_pool.getconn()
     logger.debug(
-        f"Updating '{table_name}' with conditions '{conditions}' and values '{update_values}'"
+        f"Updating '{model_class.__tablename__}' with conditions '{conditions}'"
+        f" and values '{update_values}'"
     )
     try:
-        with con, con.cursor(cursor_factory=RealDictCursor) as cur:
-            # Prevent sql-injection with table_name and column_name validation
-            TableName.validate(table_name)
-            for key in conditions:
-                validate_column_name(table_name, key)
-
-            query = f"UPDATE {table_name} SET "  # noqa: S608
-
-            set_clause = ", ".join([f"{key}=%s" for key in update_values])
-            query += set_clause
-
-            where_clause = " AND ".join([f"{key}=%s" for key in conditions])
-            # Avoid updating rows that would not change so the return value is actually the
-            # number of rows that were changed for real. See bug #4911
-            where_not_equal_clause = " OR ".join(
-                [f"{key} IS DISTINCT FROM %s" for key in update_values]
+        with Session(engine) as session:
+            stmt = update(model_class)
+            for col_name, value in conditions.items():
+                stmt = stmt.where(getattr(model_class, col_name) == value)
+            # Only update when at least one value actually differs (avoids spurious rowcount=0)
+            stmt = stmt.where(
+                or_(
+                    *[
+                        getattr(model_class, col_name).is_distinct_from(value)
+                        for col_name, value in update_values.items()
+                    ]
+                )
             )
-            query += f" WHERE {where_clause} AND ( {where_not_equal_clause} )"
-            parameters = (
-                tuple(type_conversion(value) for value in update_values.values())
-                + tuple(type_conversion(value) for value in conditions.values())
-                + tuple(type_conversion(value) for value in update_values.values())
-            )
-
-            cur.execute(query, parameters)
-            updated_row_count = cur.rowcount
-            con.commit()
-    except (Exception, psycopg2.DatabaseError) as e:
-        con.rollback()
+            stmt = stmt.values(**update_values)
+            result = session.execute(stmt)
+            session.commit()
+            updated_row_count = result.rowcount
+    except Exception as e:
         logger.warning(f"update_db_where_conditions errored with: {e}")
-    finally:
-        db_conn_pool.putconn(con)
     logger.debug(
-        f"Updated {updated_row_count} rows in '{table_name}' for conditions '{conditions}'"
-        f"and update values '{update_values}'"
+        f"Updated {updated_row_count} rows in '{model_class.__tablename__}'"
+        f" for conditions '{conditions}' and update values '{update_values}'"
     )
     return updated_row_count
 
 
 def update_with_retry(
-    db_config: SimpleConnectionPool,
+    db_config: Engine,
     conditions: Mapping[str, Any],
-    table_name: TableName,
+    model_class: type[T],
     update_values: dict[str, Any],
     reraise: bool = True,
 ) -> int:
     """Update the database with retry logic.
-    the conditions and update_values are dictionaries where
-    keys are column names and values are the new values to set.
-    they will be added to the log message."""
 
-    def _do_update():
+    *conditions* and *update_values* map column names to values.
+    They are included in log messages to aid debugging.
+    """
+
+    def _do_update() -> int:
         number_rows_updated = update_db_where_conditions(
             db_config,
-            table_name=table_name,
+            model_class=model_class,
             conditions=conditions,
             update_values=update_values,
         )
         if number_rows_updated != 1:
-            msg = f"{table_name} update failed"
+            msg = f"{model_class.__tablename__} update failed"
             raise ValueError(msg)
         return number_rows_updated
 
@@ -505,15 +419,19 @@ def update_with_retry(
 
     try:
         logger.debug(
-            f"Updating {table_name} with conditions {conditions} and values {update_values}"
+            f"Updating {model_class.__tablename__} with conditions {conditions}"
+            f" and values {update_values}"
         )
         result = retryer(_do_update)
-        logger.info(f"{table_name} update succeeded for {conditions} with values {update_values}")
+        logger.info(
+            f"{model_class.__tablename__} update succeeded"
+            f" for {conditions} with values {update_values}"
+        )
         return result
     except Exception as e:
         error_msg = (
-            f"{table_name} update failed for {conditions} with values {update_values} "
-            f"after {number_of_retries} attempts."
+            f"{model_class.__tablename__} update failed for {conditions}"
+            f" with values {update_values} after {number_of_retries} attempts."
         )
         logger.error(error_msg)
         if reraise:
@@ -522,179 +440,90 @@ def update_with_retry(
         return 0
 
 
-def add_to_project_table(
-    db_conn_pool: SimpleConnectionPool, project_table_entry: ProjectTableEntry
-) -> int | None:
-    con = db_conn_pool.getconn()
+def add_to_project_table(engine: Engine, entry: ProjectTableEntry) -> int | None:
+    """Insert *entry* into project_table and return the generated project_id."""
+    entry.started_at = datetime.now(tz=pytz.utc)
     try:
-        with con, con.cursor() as cur:
-            project_table_entry.started_at = datetime.now(tz=pytz.utc)
-
-            cur.execute(
-                "INSERT INTO project_table VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) "
-                "RETURNING project_id",
-                (
-                    project_table_entry.group_id,
-                    project_table_entry.organism,
-                    json.dumps(project_table_entry.errors),
-                    json.dumps(project_table_entry.warnings),
-                    str(project_table_entry.status),
-                    project_table_entry.started_at,
-                    project_table_entry.finished_at,
-                    json.dumps(project_table_entry.result),
-                    project_table_entry.center_name,
-                ),
-            )
-
-            project_id = cur.fetchone()
-
-            con.commit()
-        return project_id[0] if project_id else None
+        with Session(engine) as session:
+            session.add(entry)
+            session.flush()  # Sends INSERT; project_id is populated via RETURNING.
+            project_id = entry.project_id
+            session.commit()
+        return project_id
     except Exception as e:
-        con.rollback()
         logger.warning(f"add_to_project_table errored with: {e}")
         return None
-    finally:
-        db_conn_pool.putconn(con)
 
 
-def add_to_sample_table(
-    db_conn_pool: SimpleConnectionPool, sample_table_entry: SampleTableEntry
-) -> bool:
-    con = db_conn_pool.getconn()
+def add_to_sample_table(engine: Engine, entry: SampleTableEntry) -> bool:
+    """Insert *entry* into sample_table. Returns True on success."""
+    entry.started_at = datetime.now(tz=pytz.utc)
     try:
-        with con, con.cursor() as cur:
-            sample_table_entry.started_at = datetime.now(tz=pytz.utc)
-
-            cur.execute(
-                "insert into sample_table values(%s,%s,%s,%s,%s,%s,%s,%s)",
-                (
-                    sample_table_entry.accession,
-                    sample_table_entry.version,
-                    json.dumps(sample_table_entry.errors),
-                    json.dumps(sample_table_entry.warnings),
-                    str(sample_table_entry.status),
-                    sample_table_entry.started_at,
-                    sample_table_entry.finished_at,
-                    json.dumps(sample_table_entry.result),
-                ),
-            )
-            con.commit()
+        with Session(engine) as session:
+            session.add(entry)
+            session.commit()
         return True
     except Exception as e:
-        con.rollback()
         logger.warning(f"add_to_sample_table errored with: {e}")
         return False
-    finally:
-        db_conn_pool.putconn(con)
 
 
-def add_to_assembly_table(
-    db_conn_pool: SimpleConnectionPool, assembly_table_entry: AssemblyTableEntry
-) -> bool:
-    con = db_conn_pool.getconn()
+def add_to_assembly_table(engine: Engine, entry: AssemblyTableEntry) -> bool:
+    """Insert *entry* into assembly_table. Returns True on success."""
+    entry.started_at = datetime.now(tz=pytz.utc)
     try:
-        with con, con.cursor() as cur:
-            assembly_table_entry.started_at = datetime.now(tz=pytz.utc)
-
-            cur.execute(
-                "insert into assembly_table values(%s,%s,%s,%s,%s,%s,%s,%s)",
-                (
-                    assembly_table_entry.accession,
-                    assembly_table_entry.version,
-                    json.dumps(assembly_table_entry.errors),
-                    json.dumps(assembly_table_entry.warnings),
-                    str(assembly_table_entry.status),
-                    assembly_table_entry.started_at,
-                    assembly_table_entry.finished_at,
-                    json.dumps(assembly_table_entry.result),
-                ),
-            )
-            con.commit()
+        with Session(engine) as session:
+            session.add(entry)
+            session.commit()
         return True
     except Exception as e:
-        con.rollback()
         logger.warning(f"add_to_assembly_table errored with: {e}")
         return False
-    finally:
-        db_conn_pool.putconn(con)
 
 
-def in_submission_table(db_conn_pool: SimpleConnectionPool, conditions: dict[str, Any]) -> bool:
-    con = db_conn_pool.getconn()
+def in_submission_table(engine: Engine, conditions: dict[str, Any]) -> bool:
+    """Return True if any row in submission_table matches *conditions*."""
+    with Session(engine) as session:
+        stmt = select(SubmissionTableEntry)
+        for col_name, value in conditions.items():
+            stmt = stmt.where(getattr(SubmissionTableEntry, col_name) == value)
+        return session.scalar(stmt) is not None
+
+
+def add_to_submission_table(engine: Engine, entry: SubmissionTableEntry) -> bool:
+    """Insert *entry* into submission_table. Returns True on success."""
+    entry.started_at = datetime.now(tz=pytz.utc)
     try:
-        with con, con.cursor() as cur:
-            for key in conditions:
-                validate_column_name("submission_table", key)
-
-            query = "SELECT * from submission_table"
-
-            where_clause = " AND ".join([f"{key}=%s" for key in conditions])
-            query += f" WHERE {where_clause}"
-            cur.execute(
-                query,
-                tuple(type_conversion(value) for value in conditions.values()),
-            )
-            in_db = bool(cur.rowcount)
-    finally:
-        db_conn_pool.putconn(con)
-    return in_db
-
-
-def add_to_submission_table(
-    db_conn_pool: SimpleConnectionPool, submission_table_entry: SubmissionTableEntry
-) -> bool:
-    con = db_conn_pool.getconn()
-    try:
-        with con, con.cursor() as cur:
-            submission_table_entry.started_at = datetime.now(tz=pytz.utc)
-
-            cur.execute(
-                "insert into submission_table values(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)",
-                (
-                    submission_table_entry.accession,
-                    submission_table_entry.version,
-                    submission_table_entry.organism,
-                    submission_table_entry.group_id,
-                    json.dumps(submission_table_entry.errors),
-                    json.dumps(submission_table_entry.warnings),
-                    str(submission_table_entry.status_all),
-                    submission_table_entry.started_at,
-                    submission_table_entry.finished_at,
-                    json.dumps(submission_table_entry.metadata),
-                    json.dumps(submission_table_entry.unaligned_nucleotide_sequences),
-                    json.dumps(submission_table_entry.external_metadata),
-                ),
-            )
-            con.commit()
+        with Session(engine) as session:
+            session.add(entry)
+            session.commit()
         return True
     except Exception as e:
-        con.rollback()
         logger.warning(f"add_to_submission_table errored with: {e}")
         return False
-    finally:
-        db_conn_pool.putconn(con)
 
 
-def is_revision(db_config: SimpleConnectionPool, seq_key: AccessionVersion) -> bool:
-    """Check if the entry is a revision"""
-    version = seq_key.version
-    if version == 1:
+def is_revision(engine: Engine, seq_key: AccessionVersion) -> bool:
+    """Return True if *seq_key* is the latest of multiple versions for its accession."""
+    if seq_key.version == 1:
         return False
-    accession = {"accession": seq_key.accession}
-    sample_data_in_submission_table = find_conditions_in_db(
-        db_config, table_name=TableName.SUBMISSION_TABLE, conditions=accession
+    rows = find_conditions_in_db(
+        engine,
+        SubmissionTableEntry,
+        {"accession": seq_key.accession},
     )
-    all_versions = sorted([entry["version"] for entry in sample_data_in_submission_table])
-    return len(all_versions) > 1 and version == all_versions[-1]
+    all_versions = sorted(row.version for row in rows)
+    return len(all_versions) > 1 and seq_key.version == all_versions[-1]
 
 
-def last_version(db_config: SimpleConnectionPool, seq_key: AccessionVersion) -> int | None:
-    if not is_revision(db_config, seq_key):
+def last_version(engine: Engine, seq_key: AccessionVersion) -> int | None:
+    """Return the previous version number for *seq_key*, or None if not a revision."""
+    if not is_revision(engine, seq_key):
         return None
-    accession = {"accession": seq_key.accession}
-    sample_data_in_submission_table = find_conditions_in_db(
-        db_config, table_name=TableName.SUBMISSION_TABLE, conditions=accession
+    rows = find_conditions_in_db(
+        engine,
+        SubmissionTableEntry,
+        {"accession": seq_key.accession},
     )
-    all_versions = sorted([entry["version"] for entry in sample_data_in_submission_table])
+    all_versions = sorted(row.version for row in rows)
     return all_versions[-2]

--- a/ena-submission/src/ena_deposition/trigger_submission_to_ena.py
+++ b/ena-submission/src/ena_deposition/trigger_submission_to_ena.py
@@ -22,11 +22,11 @@ from .submission_db_helper import (
 logger = logging.getLogger(__name__)
 
 
-def upload_sequences(db_config: Engine, sequences_to_upload: dict[str, Any]):
+def upload_sequences(db_engine: Engine, sequences_to_upload: dict[str, Any]):
     for full_accession, data in sequences_to_upload.items():
         accession_version = AccessionVersion.from_string(full_accession)
         if in_submission_table(
-            db_config,
+            db_engine,
             {"accession": accession_version.accession, "version": accession_version.version},
         ):
             continue
@@ -38,20 +38,20 @@ def upload_sequences(db_config: Engine, sequences_to_upload: dict[str, Any]):
             seq_metadata=data["metadata"],
             unaligned_nucleotide_sequences=data["unalignedNucleotideSequences"],
         )
-        add_to_submission_table(db_config, entry)
+        add_to_submission_table(db_engine, entry)
         logger.info(f"Inserted {full_accession} into submission_table")
 
 
 def trigger_submission_to_ena(
     config: Config, stop_event: threading.Event, input_file: str | None = None
 ):
-    db_config = db_init(config.db_password, config.db_username, config.db_url)
+    db_engine = db_init(config.db_password, config.db_username, config.db_url)
 
     if input_file:
         # Get sequences to upload from a file
         with open(input_file, encoding="utf-8") as json_file:
             sequences_to_upload: dict[str, Any] = json.load(json_file)
-            upload_sequences(db_config, sequences_to_upload)
+            upload_sequences(db_engine, sequences_to_upload)
             return
 
     while True:
@@ -72,7 +72,7 @@ def trigger_submission_to_ena(
             continue
         try:
             sequences_to_upload = response.json()
-            upload_sequences(db_config, sequences_to_upload)
+            upload_sequences(db_engine, sequences_to_upload)
         except Exception as upload_error:
             logger.error(f"Failed to upload sequences: {upload_error}")
         finally:

--- a/ena-submission/src/ena_deposition/trigger_submission_to_ena.py
+++ b/ena-submission/src/ena_deposition/trigger_submission_to_ena.py
@@ -35,7 +35,7 @@ def upload_sequences(db_config: Engine, sequences_to_upload: dict[str, Any]):
             version=accession_version.version,
             group_id=data["metadata"]["groupId"],
             organism=data["organism"],
-            metadata=data["metadata"],
+            seq_metadata=data["metadata"],
             unaligned_nucleotide_sequences=data["unalignedNucleotideSequences"],
         )
         add_to_submission_table(db_config, entry)

--- a/ena-submission/src/ena_deposition/trigger_submission_to_ena.py
+++ b/ena-submission/src/ena_deposition/trigger_submission_to_ena.py
@@ -8,7 +8,7 @@ import time
 from typing import Any
 
 import requests
-from psycopg2.pool import SimpleConnectionPool
+from sqlalchemy import Engine
 
 from .config import Config
 from .submission_db_helper import (
@@ -22,7 +22,7 @@ from .submission_db_helper import (
 logger = logging.getLogger(__name__)
 
 
-def upload_sequences(db_config: SimpleConnectionPool, sequences_to_upload: dict[str, Any]):
+def upload_sequences(db_config: Engine, sequences_to_upload: dict[str, Any]):
     for full_accession, data in sequences_to_upload.items():
         accession_version = AccessionVersion.from_string(full_accession)
         if in_submission_table(

--- a/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
+++ b/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
@@ -53,9 +53,7 @@ def _get_result_of_single_db_record(
     return result
 
 
-def get_bioproject_accession_from_db(
-    db_config: Engine, project_id: int
-) -> dict[str, str]:
+def get_bioproject_accession_from_db(db_config: Engine, project_id: int) -> dict[str, str]:
     result = _get_result_of_single_db_record(
         db_config, ProjectTableEntry, conditions={"project_id": project_id}
     )
@@ -147,9 +145,7 @@ def get_external_metadata_to_upload(
     }, all([bioproject_accession, biosample_accession, all_assemblies_present])
 
 
-def get_external_metadata_and_send_to_loculus(
-    db_config: Engine, config: Config
-) -> None:
+def get_external_metadata_and_send_to_loculus(db_config: Engine, config: Config) -> None:
     for status in (
         StatusAll.SUBMITTED_PROJECT,
         StatusAll.SUBMITTED_SAMPLE,

--- a/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
+++ b/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
@@ -29,9 +29,9 @@ from .submission_db_helper import (
 logger = logging.getLogger(__name__)
 
 
-def _get_result_of_single_db_record(
+def _get_result_of_single_db_record[T: SampleTableEntry | ProjectTableEntry | AssemblyTableEntry](
     db_engine: Engine,
-    model_class: type,
+    model_class: type[T],
     conditions: dict[str, Any],
 ) -> dict[str, Any]:
     """Helper to get the result field from a single record with validation."""

--- a/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
+++ b/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
@@ -7,15 +7,18 @@ from datetime import datetime
 from typing import Any
 
 import pytz
-from psycopg2.pool import SimpleConnectionPool
+from sqlalchemy import Engine
 
 from ena_deposition.call_loculus import submit_external_metadata
 
 from .config import Config, EnaOrganismDetails
 from .notifications import SlackConfig, send_slack_notification, slack_conn_init
 from .submission_db_helper import (
+    AssemblyTableEntry,
+    ProjectTableEntry,
+    SampleTableEntry,
     StatusAll,
-    TableName,
+    SubmissionTableEntry,
     db_init,
     find_conditions_in_db,
     find_stuck_in_submission_db,
@@ -25,39 +28,36 @@ from .submission_db_helper import (
 logger = logging.getLogger(__name__)
 
 
-def _get_results_of_single_db_record(
-    db_config: SimpleConnectionPool,
-    table_name: TableName,
+def _get_result_of_single_db_record(
+    db_config: Engine,
+    model_class: type,
     conditions: dict[str, Any],
 ) -> dict[str, Any]:
-    """Helper to get a single record from database with validation."""
-    entries = find_conditions_in_db(db_config, table_name=table_name, conditions=conditions)
+    """Helper to get the result field from a single record with validation."""
+    entries = find_conditions_in_db(db_config, model_class, conditions=conditions)
 
     if not entries:
         return {}
 
     if len(entries) > 1:
         msg = (
-            f"Expected 1 record in {table_name} for conditions: {conditions}, "
+            f"Expected 1 record in {model_class.__tablename__} for conditions: {conditions}, "
             f"but found {len(entries)} records."
         )
         raise ValueError(msg)
 
-    if not isinstance(entries[0], dict) or "result" not in entries[0]:
-        msg = (
-            f"Expected a single record with 'result' in {table_name} for conditions: {conditions}, "
-            f"but found: {entries[0]}"
-        )
-        raise ValueError(msg)
+    result = entries[0].result
+    if result is None:
+        return {}
 
-    return entries[0]["result"]
+    return result
 
 
 def get_bioproject_accession_from_db(
-    db_config: SimpleConnectionPool, project_id: str
+    db_config: Engine, project_id: int
 ) -> dict[str, str]:
-    result = _get_results_of_single_db_record(
-        db_config, TableName.PROJECT_TABLE, {"project_id": project_id}
+    result = _get_result_of_single_db_record(
+        db_config, ProjectTableEntry, conditions={"project_id": project_id}
     )
 
     if not result or "bioproject_accession" not in result:
@@ -67,12 +67,12 @@ def get_bioproject_accession_from_db(
 
 
 def get_biosample_accession_from_db(
-    db_config: SimpleConnectionPool, accession: str, version: str
+    db_config: Engine, accession: str, version: int
 ) -> dict[str, str]:
-    result = _get_results_of_single_db_record(
+    result = _get_result_of_single_db_record(
         db_config,
-        TableName.SAMPLE_TABLE,
-        {"accession": accession, "version": version},
+        SampleTableEntry,
+        conditions={"accession": accession, "version": version},
     )
 
     if not result or "biosample_accession" not in result:
@@ -82,15 +82,15 @@ def get_biosample_accession_from_db(
 
 
 def get_assembly_accessions_from_db(
-    db_config: SimpleConnectionPool,
+    db_config: Engine,
     accession: str,
-    version: str,
+    version: int,
     organism: EnaOrganismDetails,
 ) -> tuple[dict[str, str], bool]:
-    result = _get_results_of_single_db_record(
+    result = _get_result_of_single_db_record(
         db_config,
-        TableName.ASSEMBLY_TABLE,
-        {"accession": accession, "version": version},
+        AssemblyTableEntry,
+        conditions={"accession": accession, "version": version},
     )
 
     if not result:
@@ -124,13 +124,13 @@ def get_assembly_accessions_from_db(
 
 
 def get_external_metadata_to_upload(
-    db_config: SimpleConnectionPool, entry: dict[str, Any], config: Config
+    db_config: Engine, entry: SubmissionTableEntry, config: Config
 ) -> tuple[dict[str, Any], bool]:
-    accession = entry["accession"]
-    version = entry["version"]
-    organism = config.enaOrganisms[entry["organism"]]
+    accession = entry.accession
+    version = entry.version
+    organism = config.enaOrganisms[entry.organism]
 
-    bioproject_accession = get_bioproject_accession_from_db(db_config, entry["project_id"])
+    bioproject_accession = get_bioproject_accession_from_db(db_config, entry.project_id)
     biosample_accession = get_biosample_accession_from_db(db_config, accession, version)
     assembly_accession, all_assemblies_present = get_assembly_accessions_from_db(
         db_config, accession, version, organism
@@ -148,7 +148,7 @@ def get_external_metadata_to_upload(
 
 
 def get_external_metadata_and_send_to_loculus(
-    db_config: SimpleConnectionPool, config: Config
+    db_config: Engine, config: Config
 ) -> None:
     for status in (
         StatusAll.SUBMITTED_PROJECT,
@@ -158,16 +158,16 @@ def get_external_metadata_and_send_to_loculus(
     ):
         for entry in find_conditions_in_db(
             db_config,
-            table_name=TableName.SUBMISSION_TABLE,
-            conditions={"status_all": status},
+            SubmissionTableEntry,
+            conditions={"status_all": str(status)},
         ):
-            accession = entry["accession"]
-            version = entry["version"]
+            accession = entry.accession
+            version = entry.version
             accession_version = f"{accession}.{version}"
             data, all_present = get_external_metadata_to_upload(db_config, entry, config)
             seq_key = {"accession": accession, "version": version}
 
-            previously_uploaded: dict[str, Any] = entry.get("external_metadata", {})
+            previously_uploaded: dict[str, Any] = entry.external_metadata or {}
             new_external_metadata: dict[str, Any] = data.get("externalMetadata", {})
 
             if new_external_metadata and (
@@ -181,7 +181,7 @@ def get_external_metadata_and_send_to_loculus(
                     submit_external_metadata(
                         data,
                         config,
-                        entry["organism"],
+                        entry.organism,
                     )
                     logger.info(
                         f"External metadata update for {accession_version} succeeded. "
@@ -201,7 +201,7 @@ def get_external_metadata_and_send_to_loculus(
                         update_values={
                             "external_metadata": new_external_metadata,
                         },
-                        table_name=TableName.SUBMISSION_TABLE,
+                        model_class=SubmissionTableEntry,
                     )
                 except Exception as e:
                     logger.exception(
@@ -218,7 +218,7 @@ def get_external_metadata_and_send_to_loculus(
                             "status_all": StatusAll.SENT_TO_LOCULUS,
                             "finished_at": datetime.now(tz=pytz.utc),
                         },
-                        table_name=TableName.SUBMISSION_TABLE,
+                        model_class=SubmissionTableEntry,
                     )
                 except Exception as e:
                     logger.exception(
@@ -232,12 +232,12 @@ def get_external_metadata_and_send_to_loculus(
                             "status_all": StatusAll.HAS_ERRORS_EXT_METADATA_UPLOAD,
                             "finished_at": datetime.now(tz=pytz.utc),
                         },
-                        table_name=TableName.SUBMISSION_TABLE,
+                        model_class=SubmissionTableEntry,
                     )
 
 
 def upload_handle_errors(
-    db_config: SimpleConnectionPool,
+    db_config: Engine,
     config: Config,
     slack_config: SlackConfig,
     time_threshold: int = 15,

--- a/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
+++ b/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
@@ -3,6 +3,7 @@
 import logging
 import threading
 import time
+from dataclasses import asdict
 from datetime import datetime
 from typing import Any
 
@@ -159,11 +160,8 @@ def get_external_metadata_and_send_to_loculus(db_engine: Engine, config: Config)
             SubmissionTableEntry,
             conditions={"status_all": status},
         ):
-            accession = entry.accession
-            version = entry.version
-            accession_version = f"{accession}.{version}"
             data, all_present = get_external_metadata_to_upload(db_engine, entry, config)
-            seq_key = {"accession": accession, "version": version}
+            seq_key = entry.pkey
 
             previously_uploaded: dict[str, Any] = entry.external_metadata or {}
             new_external_metadata: dict[str, Any] = data.get("externalMetadata", {})
@@ -182,20 +180,19 @@ def get_external_metadata_and_send_to_loculus(db_engine: Engine, config: Config)
                         entry.organism,
                     )
                     logger.info(
-                        f"External metadata update for {accession_version} succeeded. "
+                        f"External metadata update for {seq_key} succeeded. "
                         f"Old data: {previously_uploaded}, "
                         f"new data: {new_external_metadata}"
                     )
                 except Exception as e:
                     logger.exception(
-                        f"Submitting external metadata to backend failed for "
-                        f"{accession_version}: {e}"
+                        f"Submitting external metadata to backend failed for {seq_key}: {e}"
                     )
                     continue
                 try:
                     update_with_retry(
                         db_engine,
-                        conditions=seq_key,
+                        conditions=asdict(seq_key),
                         update_values={
                             "external_metadata": new_external_metadata,
                         },
@@ -204,14 +201,14 @@ def get_external_metadata_and_send_to_loculus(db_engine: Engine, config: Config)
                 except Exception as e:
                     logger.exception(
                         f"Failed to add new state of submitted external metadata to db for "
-                        f"{accession_version}: {e}"
+                        f"{seq_key}: {e}"
                     )
                     continue
             if status == StatusAll.SUBMITTED_ALL and all_present:
                 try:
                     update_with_retry(
                         db_engine,
-                        conditions=seq_key,
+                        conditions=asdict(seq_key),
                         update_values={
                             "status_all": StatusAll.SENT_TO_LOCULUS,
                             "finished_at": datetime.now(tz=pytz.utc),
@@ -220,12 +217,12 @@ def get_external_metadata_and_send_to_loculus(db_engine: Engine, config: Config)
                     )
                 except Exception as e:
                     logger.exception(
-                        f"Failed to update status_all for {accession_version} to "
+                        f"Failed to update status_all for {seq_key} to "
                         f"{StatusAll.SENT_TO_LOCULUS}: {e}"
                     )
                     update_with_retry(
                         db_engine,
-                        conditions=seq_key,
+                        conditions=asdict(seq_key),
                         update_values={
                             "status_all": StatusAll.HAS_ERRORS_EXT_METADATA_UPLOAD,
                             "finished_at": datetime.now(tz=pytz.utc),

--- a/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
+++ b/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
@@ -157,7 +157,7 @@ def get_external_metadata_and_send_to_loculus(db_config: Engine, config: Config)
         for entry in find_conditions_in_db(
             db_config,
             SubmissionTableEntry,
-            conditions={"status_all": str(status)},
+            conditions={"status_all": status},
         ):
             accession = entry.accession
             version = entry.version

--- a/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
+++ b/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
@@ -29,12 +29,12 @@ logger = logging.getLogger(__name__)
 
 
 def _get_result_of_single_db_record(
-    db_config: Engine,
+    db_engine: Engine,
     model_class: type,
     conditions: dict[str, Any],
 ) -> dict[str, Any]:
     """Helper to get the result field from a single record with validation."""
-    entries = find_conditions_in_db(db_config, model_class, conditions=conditions)
+    entries = find_conditions_in_db(db_engine, model_class, conditions=conditions)
 
     if not entries:
         return {}
@@ -53,11 +53,11 @@ def _get_result_of_single_db_record(
     return result
 
 
-def get_bioproject_accession_from_db(db_config: Engine, project_id: int | None) -> dict[str, str]:
+def get_bioproject_accession_from_db(db_engine: Engine, project_id: int | None) -> dict[str, str]:
     if project_id is None:
         return {}
     result = _get_result_of_single_db_record(
-        db_config, ProjectTableEntry, conditions={"project_id": project_id}
+        db_engine, ProjectTableEntry, conditions={"project_id": project_id}
     )
 
     if not result or "bioproject_accession" not in result:
@@ -67,10 +67,10 @@ def get_bioproject_accession_from_db(db_config: Engine, project_id: int | None) 
 
 
 def get_biosample_accession_from_db(
-    db_config: Engine, accession: str, version: int
+    db_engine: Engine, accession: str, version: int
 ) -> dict[str, str]:
     result = _get_result_of_single_db_record(
-        db_config,
+        db_engine,
         SampleTableEntry,
         conditions={"accession": accession, "version": version},
     )
@@ -82,13 +82,13 @@ def get_biosample_accession_from_db(
 
 
 def get_assembly_accessions_from_db(
-    db_config: Engine,
+    db_engine: Engine,
     accession: str,
     version: int,
     organism: EnaOrganismDetails,
 ) -> tuple[dict[str, str], bool]:
     result = _get_result_of_single_db_record(
-        db_config,
+        db_engine,
         AssemblyTableEntry,
         conditions={"accession": accession, "version": version},
     )
@@ -124,16 +124,16 @@ def get_assembly_accessions_from_db(
 
 
 def get_external_metadata_to_upload(
-    db_config: Engine, entry: SubmissionTableEntry, config: Config
+    db_engine: Engine, entry: SubmissionTableEntry, config: Config
 ) -> tuple[dict[str, Any], bool]:
     accession = entry.accession
     version = entry.version
     organism = config.enaOrganisms[entry.organism]
 
-    bioproject_accession = get_bioproject_accession_from_db(db_config, entry.project_id)
-    biosample_accession = get_biosample_accession_from_db(db_config, accession, version)
+    bioproject_accession = get_bioproject_accession_from_db(db_engine, entry.project_id)
+    biosample_accession = get_biosample_accession_from_db(db_engine, accession, version)
     assembly_accession, all_assemblies_present = get_assembly_accessions_from_db(
-        db_config, accession, version, organism
+        db_engine, accession, version, organism
     )
 
     return {
@@ -147,7 +147,7 @@ def get_external_metadata_to_upload(
     }, all([bioproject_accession, biosample_accession, all_assemblies_present])
 
 
-def get_external_metadata_and_send_to_loculus(db_config: Engine, config: Config) -> None:
+def get_external_metadata_and_send_to_loculus(db_engine: Engine, config: Config) -> None:
     for status in (
         StatusAll.SUBMITTED_PROJECT,
         StatusAll.SUBMITTED_SAMPLE,
@@ -155,14 +155,14 @@ def get_external_metadata_and_send_to_loculus(db_config: Engine, config: Config)
         StatusAll.SUBMITTED_ALL,
     ):
         for entry in find_conditions_in_db(
-            db_config,
+            db_engine,
             SubmissionTableEntry,
             conditions={"status_all": status},
         ):
             accession = entry.accession
             version = entry.version
             accession_version = f"{accession}.{version}"
-            data, all_present = get_external_metadata_to_upload(db_config, entry, config)
+            data, all_present = get_external_metadata_to_upload(db_engine, entry, config)
             seq_key = {"accession": accession, "version": version}
 
             previously_uploaded: dict[str, Any] = entry.external_metadata or {}
@@ -194,7 +194,7 @@ def get_external_metadata_and_send_to_loculus(db_config: Engine, config: Config)
                     continue
                 try:
                     update_with_retry(
-                        db_config,
+                        db_engine,
                         conditions=seq_key,
                         update_values={
                             "external_metadata": new_external_metadata,
@@ -210,7 +210,7 @@ def get_external_metadata_and_send_to_loculus(db_config: Engine, config: Config)
             if status == StatusAll.SUBMITTED_ALL and all_present:
                 try:
                     update_with_retry(
-                        db_config,
+                        db_engine,
                         conditions=seq_key,
                         update_values={
                             "status_all": StatusAll.SENT_TO_LOCULUS,
@@ -224,7 +224,7 @@ def get_external_metadata_and_send_to_loculus(db_config: Engine, config: Config)
                         f"{StatusAll.SENT_TO_LOCULUS}: {e}"
                     )
                     update_with_retry(
-                        db_config,
+                        db_engine,
                         conditions=seq_key,
                         update_values={
                             "status_all": StatusAll.HAS_ERRORS_EXT_METADATA_UPLOAD,
@@ -235,7 +235,7 @@ def get_external_metadata_and_send_to_loculus(db_config: Engine, config: Config)
 
 
 def upload_handle_errors(
-    db_config: Engine,
+    db_engine: Engine,
     config: Config,
     slack_config: SlackConfig,
     time_threshold: int = 15,
@@ -250,7 +250,7 @@ def upload_handle_errors(
     2. If time since last slack_notification is over slack_time_threshold send notification
     """
     entries_with_errors = find_stuck_in_submission_db(
-        db_config,
+        db_engine,
         time_threshold=time_threshold,
     )
     if len(entries_with_errors) > 0:
@@ -268,7 +268,7 @@ def upload_handle_errors(
 
 
 def upload_external_metadata(config: Config, stop_event: threading.Event):
-    db_config = db_init(config.db_password, config.db_username, config.db_url)
+    db_engine = db_init(config.db_password, config.db_username, config.db_url)
     slack_config = slack_conn_init(
         slack_hook_default=config.slack_hook,
         slack_token_default=config.slack_token,
@@ -280,9 +280,9 @@ def upload_external_metadata(config: Config, stop_event: threading.Event):
             logger.warning("upload_external_metadata stopped due to exception in another task")
             return
         logger.debug("Checking for external metadata to upload to Loculus")
-        get_external_metadata_and_send_to_loculus(db_config, config)
+        get_external_metadata_and_send_to_loculus(db_engine, config)
         upload_handle_errors(
-            db_config,
+            db_engine,
             config,
             slack_config,
         )

--- a/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
+++ b/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
@@ -53,7 +53,9 @@ def _get_result_of_single_db_record(
     return result
 
 
-def get_bioproject_accession_from_db(db_config: Engine, project_id: int) -> dict[str, str]:
+def get_bioproject_accession_from_db(db_config: Engine, project_id: int | None) -> dict[str, str]:
+    if project_id is None:
+        return {}
     result = _get_result_of_single_db_record(
         db_config, ProjectTableEntry, conditions={"project_id": project_id}
     )


### PR DESCRIPTION
Claude helped me do this!

resolves https://github.com/loculus-project/loculus/issues/5293
partially resolves https://github.com/loculus-project/loculus/issues/5646

[SQLAlchemy](https://docs.sqlalchemy.org/en/20/tutorial/index.html) is a popular python SQL database toolkit, it is comprised of 2 components: the core which uses a database driver (we continue to use psycopg2) to establish and manage database connections and an Object Relational Mapper (ORM) which maps SQL structures and commands into python objects.

Currently the ENA deposition code uses plain `psycopg2` and I manage all connections in the code, writing raw SQL transactions myself. This works quite well but `psycopg2` returns database transactions as dictionaries where the keys are of type str and correspond to column names and the values are of type Any. psycopg2 do not check column names exist or that values are used with correct types in the code. 

### Changes

1. Defines table objects via declarative mapping classes: https://docs.sqlalchemy.org/en/20/tutorial/metadata.html#declaring-mapped-classes and dataclass wrappers: https://docs.sqlalchemy.org/en/21/orm/dataclasses.html#declarative-dataclass-mapping
2. SQLAlchemy now manages the connections to the database via an "engine" (psycopg2 is still the database driver), the engine manages the connection pool (removing the requirement for custom connection pool code that I added before)
3. Database operations are now performed using SQLAlchemy's ORM layer within [sessions](https://docs.sqlalchemy.org/en/20/tutorial/orm_data_manipulation.html) (removing the requirement to open DB connections ourselves and excecute raw SQL statements). (ORM) Objects are added to sessions and the session ensures they are passed to the DB as transactions in an optimized automated manner (can be forced using "flush"). Objects persist in a Session using a "unit of work pattern". Note that although the session manages DB connections, commit operations still need to be added explicitly. SQLAlchemy performs JSONB dumps and validates inserted values to prevent SQL injections. After changes are commited, the objects still persist in the session and are linked to their location in memory via an "identity map", this can be used to retrieve e.g. (generated) primary keys. Note objects stay attached to a session until the session is closed. 
4. The largest improvement over the current state is that return values/rows are mapped into typed dataclasses instead of dictionary objects. This alone woudl have prevent most of the typing error encountered in the codebase.

### Limitations

Note the `update_db_where_conditions` and `find_conditions_in_db` still pass dictionaries. I did this primarily to restrict the changes in this PR to refactoring changes and not logic changes. The dictionaries that are passed are not typed.

To improve the typing of these functions we could move to using typedDicts as suggested in the issue or write out typed ORM queries each time instead of using a dictionary of table columns/values to filter on/ update. 

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
Tested on staging - see notes in https://loculus.slack.com/archives/C05G172HL6L/p1777376294911849

🚀 Preview: Add `preview` label to enable