### PR TITLE
fix(website): Fix display names for fasta download on multi-reference 

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx
@@ -419,6 +419,23 @@ describe('DownloadDialog', () => {
             expect(query).contains('fastaHeaderTemplate=%7BaccessionVersion%7D');
         });
 
+        test('should use display name fasta header template when display name is selected on multi-ref organism', async () => {
+            await renderDialog({
+                referenceGenomesInfo: SINGLE_SEG_MULTI_REF_REFERENCEGENOMES,
+                referenceIdentifierField: 'genotype',
+                richFastaHeaderFields: ['displayName'],
+            });
+
+            await checkAgreement();
+            await userEvent.click(screen.getByLabelText(rawNucleotideSequencesLabel));
+            await userEvent.click(screen.getByLabelText(displayNameFastaHeaderStyleLabel));
+
+            const { path, query } = parseDownloadHref();
+            expectRouteInPathMatches(path, `/sample/unalignedNucleotideSequences`);
+            expect(query).contains('fastaHeaderTemplate=%7BdisplayName%7D');
+            expect(query).not.contains('fastaHeaderTemplate=%7BaccessionVersion%7D');
+        });
+
         test('should download all unaligned segments when no reference is selected for multi-segmented reference genomes', async () => {
             await renderDialog({
                 referenceGenomesInfo: MULTI_SEG_MULTI_REF_REFERENCEGENOMES,

--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
@@ -213,10 +213,11 @@ function getDownloadOption({
                     segmentLapisNames: useMultiSegmentEndpoint
                         ? downloadFormState.unalignedNucleotideSequence
                         : undefined,
-                    richFastaHeaders:
-                        defaultFastaHeaderTemplate !== undefined
-                            ? { include: true, fastaHeaderOverride: defaultFastaHeaderTemplate }
-                            : { include: downloadFormState.includeRichFastaHeaders },
+                    richFastaHeaders: downloadFormState.includeRichFastaHeaders
+                        ? { include: true }
+                        : defaultFastaHeaderTemplate !== undefined
+                          ? { include: true, fastaHeaderOverride: defaultFastaHeaderTemplate }
+                          : { include: false },
                 };
             case 'alignedNucleotideSequences':
                 return {


### PR DESCRIPTION
Previously when downloading unaligned sequences, if a `defaultFastaHeaderTemplate` was set (which if the organism is multi-reference, it is set as `accessionVersion`), then this would still be used even if the user chooses 'Display name' for the fasta header style. 

This fix switches to only using the `defaultFastaHeaderTemplate` when the user has selected 'Accession' for the fasta header style.

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://fix-fasta-download-displa.loculus.org