### PR TITLE
feat(taxonomy): Host organism categories endpoint

### DIFF
--- a/taxonomy/taxonomy_service/README.md
+++ b/taxonomy/taxonomy_service/README.md
@@ -16,6 +16,7 @@ The DB version is configured in `values.yaml` (`taxonomyService.dbVersion`).
 | `GET /` | Health check |
 | `GET /taxa?scientific_name=<string>` | Endpoint used to validate user input. If the input is valid, the details of all associated taxa are returned. Currently only supports validation of scientific names (case-insensitive) through the `scientific_name` query parameter. |
 | `GET /taxa/{tax_id}?find_common_name=<boolean>` |  Endpoint to use once a valid taxon ID is found. Looks up a taxon by NCBI taxon ID and returns it. If find_common_name=true, returns the nearest ancestor (including self) that has a common name. |
+| `GET /taxa/{tax_id}/host-categories` | Returns all organism category labels associated with ancestors of `tax_id`. Labels are specified in the configuration as `organism_categories: dict[int, str]` where keys are NCBI taxon IDs and values are labels |
 
 ## Updating the NCBI database
 

--- a/taxonomy/taxonomy_service/config/defaults.yaml
+++ b/taxonomy/taxonomy_service/config/defaults.yaml
@@ -1,1 +1,4 @@
 log_level: DEBUG
+organism_categories:
+  7175: "mosquito"
+  7174: "mosquitos"

--- a/taxonomy/taxonomy_service/config/defaults.yaml
+++ b/taxonomy/taxonomy_service/config/defaults.yaml
@@ -1,4 +1,1 @@
 log_level: DEBUG
-organism_categories:
-  7175: "mosquito"
-  7174: "mosquitos"

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -135,19 +135,21 @@ def query_taxa(
 
 @app.get("/taxa/{tax_id}")
 def get_taxon(
-    tax_id: int, db: DbConnection, find_common_name: bool = False
+    tax_id: int,
+    db: DbConnection,
+    find_common_name: bool = False,
 ) -> dict[str, str | int | None]:
-    if find_common_name:
-        taxon = fetch_common_name(db, tax_id)
-        if taxon is None:
-            raise HTTPException(
-                status_code=404, detail=f"Unable to find common name for taxon {tax_id}"
-            )
-        return taxon
-
     taxon = fetch_by_id(db, tax_id)
     if taxon is None:
         raise HTTPException(status_code=404, detail=f"'{tax_id}' not found")
+
+    if find_common_name:
+        taxon_with_common_name = fetch_common_name(db, taxon["tax_id"])
+        if taxon_with_common_name is None:
+            raise HTTPException(
+                status_code=404, detail=f"Unable to find common name for taxon {tax_id}"
+            )
+        return taxon_with_common_name
 
     return taxon
 

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -6,6 +6,8 @@ from typing import Annotated
 import uvicorn
 from fastapi import Depends, FastAPI, HTTPException
 
+from taxonomy_service.datatypes import Taxon
+
 from .config import Config
 
 logger = logging.getLogger()
@@ -21,6 +23,7 @@ def get_db_connection() -> Generator[sqlite3.Connection]:
         uri=True,
         check_same_thread=False,  # DB is read-only so this should be fine
     )
+
     conn.row_factory = sqlite3.Row
     try:
         yield conn
@@ -31,9 +34,7 @@ def get_db_connection() -> Generator[sqlite3.Connection]:
 DbConnection = Annotated[sqlite3.Connection, Depends(get_db_connection)]
 
 
-def fetch_by_sci_name(
-    db_conn: sqlite3.Connection, name: str
-) -> list[dict[str, str | int | None]] | None:
+def fetch_by_sci_name(db_conn: sqlite3.Connection, name: str) -> list[Taxon] | None:
     """Check if a scientific name exists in the taxonomy and, if so, return all taxa associated
     with that name
 
@@ -49,12 +50,10 @@ def fetch_by_sci_name(
     if not taxa:
         return None
 
-    return [dict(taxon) for taxon in taxa]
+    return [Taxon.from_row(row) for row in taxa]
 
 
-def fetch_by_id(
-    db_conn: sqlite3.Connection, tax_id: int
-) -> dict[str, str | int | None] | None:
+def fetch_by_id(db_conn: sqlite3.Connection, tax_id: int) -> Taxon | None:
     """Return the taxon associated with `tax_id`. Return None if `tax_id` does not exist in the DB
 
     args:
@@ -66,12 +65,11 @@ def fetch_by_id(
     ).fetchone()
     if not taxon:
         return None
-    return dict(taxon)
+
+    return Taxon.from_row(taxon)
 
 
-def fetch_common_name(
-    db_conn: sqlite3.Connection, tax_id: int
-) -> dict[str, str | int | None] | None:
+def fetch_common_name(db_conn: sqlite3.Connection, taxon: Taxon) -> Taxon | None:
     """Return a taxon with a common name
 
     If the supplied `tax_id` is associated with a common name, return the taxon.
@@ -83,25 +81,59 @@ def fetch_common_name(
         db_conn (sqlite3.Connection):   connection to a database. The caller is responsible for closing it
         tax_id (int):                   NCBI taxon ID of the taxon for which to find a common name
     """
+    if taxon.common_name is not None:
+        return taxon
+
     # creating a reusable cursor here instead of calling `fetch_by_id` in the while loop
     cursor = db_conn.cursor()
+    tax_id = taxon.parent_id
     while tax_id > 1:  # tax_id 1 is the root
-        taxon = cursor.execute(
+        row = cursor.execute(
             "SELECT * FROM taxonomy WHERE tax_id = ?", (tax_id,)
         ).fetchone()
-        if taxon is None or taxon["depth"] == 0:
+        taxon = Taxon.from_row(row)
+
+        if taxon.depth == 0:
             # for safety, break when depth is 0 (in case NCBI decide at some
             # point that the root should no longer be 1)
             break
-        if taxon["common_name"] is not None:
-            return dict(taxon)
-        tax_id = taxon["parent_id"]
+        if taxon.common_name is not None:
+            return taxon
+
+        tax_id = taxon.parent_id
 
     return None
 
 
-def taxon_is_descendant(db_conn: sqlite3.Connection, query: int, target: int) -> bool:
-    return False
+def assign_host_categories(
+    db_conn: sqlite3.Connection, query_taxon: Taxon, host_categories: dict[int, str]
+) -> list[str]:
+    """The recursive CTE builds the ancestor chain from `query_taxon` to the
+    root once, then checks for each of the `target_taxa` whether it is in this ancestor chain.
+
+    A list of `target_taxa` that are in the ancestor chain is returned
+    """
+    if not host_categories:
+        return []
+
+    query = f"""
+    WITH RECURSIVE ancestors(tax_id, parent_id) AS (
+        SELECT tax_id, parent_id FROM taxonomy WHERE tax_id = ?
+        UNION ALL
+        SELECT t.tax_id, t.parent_id
+        FROM taxonomy t
+        JOIN ancestors a ON t.tax_id = a.parent_id
+        WHERE t.tax_id != t.parent_id
+    )
+    SELECT tax_id FROM ancestors WHERE tax_id IN ({",".join(["?"] * len(host_categories))})
+    """
+
+    result = db_conn.execute(
+        query, (query_taxon.tax_id, *host_categories.keys())
+    ).fetchall()
+    ancestor_ids = [row["tax_id"] for row in result]
+
+    return [host_categories[id] for id in ancestor_ids]
 
 
 @app.get("/")
@@ -109,22 +141,9 @@ def read_root() -> dict[str, str]:
     return {"message": "Taxonomy service is running"}
 
 
-@app.get("/ancestors")
-def get_ancestors(query: int, targets: list[int], db: DbConnection) -> list[int]:
-    hits = []
-
-    for t in targets:
-        if taxon_is_descendant(db, query, t):
-            hits.append(t)
-
-    return hits
-
-
 @app.get("/taxa")
-def query_taxa(
-    scientific_name: str, db: DbConnection
-) -> list[dict[str, str | int | None]] | None:
-    """Given a scientific name, try to find all taxa associated with it."""
+def query_taxa(scientific_name: str, db: DbConnection) -> list[Taxon] | None:
+    """Given a scientific name, find all taxa associated with it."""
     taxa = fetch_by_sci_name(db, scientific_name)
 
     if taxa is None:
@@ -138,20 +157,37 @@ def get_taxon(
     tax_id: int,
     db: DbConnection,
     find_common_name: bool = False,
-) -> dict[str, str | int | None]:
+) -> Taxon:
     taxon = fetch_by_id(db, tax_id)
     if taxon is None:
         raise HTTPException(status_code=404, detail=f"'{tax_id}' not found")
 
     if find_common_name:
-        taxon_with_common_name = fetch_common_name(db, taxon["tax_id"])
+        taxon_with_common_name = fetch_common_name(db, taxon)
         if taxon_with_common_name is None:
             raise HTTPException(
-                status_code=404, detail=f"Unable to find common name for taxon {tax_id}"
+                status_code=404,
+                detail=f"Unable to find common name for taxon {tax_id}",
             )
         return taxon_with_common_name
 
     return taxon
+
+
+@app.get("/taxa/{tax_id}/host-categories")
+def get_host_categories(
+    tax_id: int,
+    db: DbConnection,
+) -> list[str]:
+    taxon = fetch_by_id(db, tax_id)
+    if taxon is None:
+        raise HTTPException(status_code=404, detail=f"'{tax_id}' not found")
+
+    assigned_categories = assign_host_categories(
+        db, taxon, app.state.config.organism_categories
+    )
+
+    return assigned_categories
 
 
 def init_app(config: Config):

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -100,6 +100,10 @@ def fetch_common_name(
     return None
 
 
+def taxon_is_descendant(db_conn: sqlite3.Connection, query: int, target: int) -> bool:
+    return False
+
+
 @app.get("/")
 def read_root() -> dict[str, str]:
     return {"message": "Taxonomy service is running"}
@@ -109,9 +113,9 @@ def read_root() -> dict[str, str]:
 def get_ancestors(query: int, targets: list[int], db: DbConnection) -> list[int]:
     hits = []
 
-    # for t in targets:
-    #     if q is_descendent(t):
-    #         hits.append(t)
+    for t in targets:
+        if taxon_is_descendant(db, query, t):
+            hits.append(t)
 
     return hits
 

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -105,6 +105,17 @@ def read_root() -> dict[str, str]:
     return {"message": "Taxonomy service is running"}
 
 
+@app.get("/ancestors")
+def get_ancestors(query: int, targets: list[int], db: DbConnection) -> list[int]:
+    hits = []
+
+    # for t in targets:
+    #     if q is_descendent(t):
+    #         hits.append(t)
+
+    return hits
+
+
 @app.get("/taxa")
 def query_taxa(
     scientific_name: str, db: DbConnection

--- a/taxonomy/taxonomy_service/src/taxonomy_service/config.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/config.py
@@ -9,6 +9,7 @@ class Config(BaseModel):
     tax_db_path: str
     tax_service_host: str | None
     tax_service_port: int | None
+    organism_categories: dict[int, str] = {}
 
 
 def get_config(config_file: str | Path) -> Config:

--- a/taxonomy/taxonomy_service/src/taxonomy_service/datatypes.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/datatypes.py
@@ -1,0 +1,16 @@
+# from dataclasses import dataclass
+
+import sqlite3
+from pydantic import BaseModel
+
+
+class Taxon(BaseModel):
+    tax_id: int
+    common_name: str | None
+    scientific_name: str | None
+    parent_id: int
+    depth: int
+
+    @classmethod
+    def from_row(cls, row: sqlite3.Row) -> Taxon:
+        return cls.model_validate(dict(row))

--- a/taxonomy/taxonomy_service/src/taxonomy_service/datatypes.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/datatypes.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 class Taxon(BaseModel):
     tax_id: int
     common_name: str | None
-    scientific_name: str | None
+    scientific_name: str
     parent_id: int
     depth: int
 

--- a/taxonomy/taxonomy_service/src/taxonomy_service/datatypes.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/datatypes.py
@@ -1,6 +1,8 @@
 # from dataclasses import dataclass
 
 import sqlite3
+from typing import Self
+
 from pydantic import BaseModel
 
 
@@ -12,5 +14,5 @@ class Taxon(BaseModel):
     depth: int
 
     @classmethod
-    def from_row(cls, row: sqlite3.Row) -> Taxon:
+    def from_row(cls, row: sqlite3.Row) -> Self:
         return cls.model_validate(dict(row))

--- a/taxonomy/taxonomy_service/test/test_api.py
+++ b/taxonomy/taxonomy_service/test/test_api.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 from requests import codes
-from taxonomy_service.api import app, get_db_connection
+from taxonomy_service.api import app, get_db_connection, init_app
 from taxonomy_service.config import Config, get_config
 
 client = TestClient(app)
@@ -25,8 +25,15 @@ mock_taxa = {
         "tax_id": 9605,
         "common_name": "humans",
         "scientific_name": "Homo",
-        "parent_id": 207598,
+        "parent_id": 9442,  # skipping some levels for testig purposes
         "depth": 30,
+    },
+    "Primates": {
+        "tax_id": 9442,
+        "common_name": "primates",
+        "scientific_name": "Primates",
+        "parent_id": 131567,
+        "depth": 23,
     },
     "cellular organisms": {
         "tax_id": 131567,
@@ -66,6 +73,7 @@ def get_test_db():
 class ApiTest(unittest.TestCase):
     def setUp(self) -> None:
         self.config: Config = get_config(config_file)
+        init_app(self.config)
         app.dependency_overrides[get_db_connection] = get_test_db
 
     def tearDown(self) -> None:
@@ -74,6 +82,7 @@ class ApiTest(unittest.TestCase):
     def test_get_taxon_success(self):
         taxon = mock_taxa["Homo sapiens"]
         response = client.get(f"/taxa/{taxon['tax_id']}")
+
         assert response.status_code == codes.ok
         assert response.json()["scientific_name"] == taxon["scientific_name"]
 
@@ -124,3 +133,10 @@ class ApiTest(unittest.TestCase):
             response.json()["detail"]
             == f"Unable to find common name for taxon {cellular_organisms['tax_id']}"
         )
+
+    def test_assign_host_categories(self):
+        homo_sapiens = mock_taxa["Homo sapiens"]
+        response = client.get(f"/taxa/{homo_sapiens['tax_id']}/host-categories")
+
+        assert len(response.json()) == 2
+        assert all([i in response.json() for i in ["Primates", "Cellular organisms"]])

--- a/taxonomy/taxonomy_service/test/test_config.yaml
+++ b/taxonomy/taxonomy_service/test/test_config.yaml
@@ -1,3 +1,7 @@
 tax_db_path: ":memory:" # adding for consistency, will be ignored by test framework
 tax_service_host: "127.0.0.1"
 tax_service_port: 5000
+organism_categories:
+  9442: "Primates"
+  131567: "Cellular organisms"
+  12345678: "Something else"


### PR DESCRIPTION
As a follow-up to host validation, we would like to add functionality to loculus to assign host organisms to configurable categories.

These categories could then be used for filtering sequences in the front-end; e.g., it would be nice for arboviruses if people are able to select "Mosquito" from a drop-down menu to get all sequences that were obtained from any mosquito species.

## Implementation & configuration
This PR adds a `/taxa/{tax_id}/host-categories` endpoint to the taxonomy-service. This endpoint returns a list of host category lables that apply to the provided `tax_id`. 

The labels are configured like this (obviously not labels we'd use):
```sh
organism_categories:
  7157: "BZZZZZ" # Culicidae
  131567: "I'm a cellular organism!" # Cellular organisms
  2759: "I'm a Eukaryote!" # Eukaryota
```
The keys in `organism_categories` are NCBI taxon IDs, the values are host category lables. When provided with a `tax_id`, the endpoint will return all labels associated with taxa in`organism_categories` that are an ancestor of `tax_id`.

For this to be useable in loculus/pathoplexus, we'd need to add functionality to assign host categories to each sequence during preprocessing (would be a separate PR).

## Usage
When using the example configuration shown above, the following results are returned (taxonomy-service running locally in a docker container):

Aedes aegypti (7159) and Culex pipiens (7157) are mosquitos:
```sh
➜  taxonomy_service git:(host-organism-categories) curl localhost:5000/taxa/7159/host-categories
["BZZZZZ","I'm a Eukaryote!","I'm a cellular organism!"]%                                                                                                                                                                                                                                                                                                                                                                                    

➜  taxonomy_service git:(host-organism-categories) curl localhost:5000/taxa/7175/host-categories
["BZZZZZ","I'm a Eukaryote!","I'm a cellular organism!"]%
```

Humans (9606) are not mosquitos:
```sh
➜  taxonomy_service git:(host-organism-categories) ✗ curl localhost:5000/taxa/9606/host-categories
["I'm a Eukaryote!","I'm a cellular organism!"]%
```

Yersinia pestis (632) is not a eukaryote:
```sh
➜  taxonomy_service git:(host-organism-categories) ✗ curl localhost:5000/taxa/632/host-categories
["I'm a cellular organism!"]%
```

The root is nothing:
```sh
➜  taxonomy_service git:(host-organism-categories) ✗ curl localhost:5000/taxa/1/host-categories
[]%
```

## Alternatives
An alternative way to get this functionality may be to use custom taxonomic lineage files and filter via SILO/LAPIS. This is something I'm scoping out currently.


### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable