### PR TITLE
fix(deposition): fix retry code for case where users submitted bioprojects and biosamples

### DIFF
--- a/ena-submission/config/defaults.yaml
+++ b/ena-submission/config/defaults.yaml
@@ -109,7 +109,7 @@ metadata_mapping:
 db_username: postgres
 db_password: unsecure
 db_url: "jdbc:postgresql://127.0.0.1:5432/loculus"
-retry_threshold_min: 5
+retry_threshold_min: 240
 slack_retry_threshold_min: 720
 submitting_time_threshold_min: 15
 waiting_threshold_hours: 48

--- a/ena-submission/config/defaults.yaml
+++ b/ena-submission/config/defaults.yaml
@@ -109,7 +109,7 @@ metadata_mapping:
 db_username: postgres
 db_password: unsecure
 db_url: "jdbc:postgresql://127.0.0.1:5432/loculus"
-retry_threshold_min: 240
+retry_threshold_min: 5
 slack_retry_threshold_min: 720
 submitting_time_threshold_min: 15
 waiting_threshold_hours: 48

--- a/ena-submission/scripts/test_ena_submission_integration.py
+++ b/ena-submission/scripts/test_ena_submission_integration.py
@@ -430,7 +430,7 @@ def _test_successful_sample_submission(
     check_sample_submission_started(db_engine, sequences_to_upload)
 
     sample_table_create(db_engine, config)
-    create_sample_sync_state_with_submission_table(db_engine, config)
+    create_sample_sync_state_with_submission_table(db_engine)
     check_sample_submission_submitted(db_engine, sequences_to_upload)
 
 
@@ -826,7 +826,7 @@ class TestIncorrectBioprojectPassed(TestSubmission):
 
         # check project submission fails and sends notification
         create_project_sync_state_with_submission_table(self.db_engine)
-        project_table_create(self.db_engine, self.config, test=self.config.test)
+        project_table_create(self.db_engine, self.config)
         check_project_submission_has_errors(self.db_engine, sequences_to_upload)
         project_table_handle_errors(
             self.db_engine,
@@ -852,7 +852,7 @@ class TestIncorrectBioprojectPassed(TestSubmission):
 
         # Confirm DB entry is still in error state after retrying submission
         create_project_sync_state_with_submission_table(self.db_engine)
-        project_table_create(self.db_engine, self.config, test=self.config.test)
+        project_table_create(self.db_engine, self.config)
         check_project_submission_has_errors(self.db_engine, sequences_to_upload)
 
         # Confirm retries dont change state
@@ -864,7 +864,7 @@ class TestIncorrectBioprojectPassed(TestSubmission):
         )
         check_project_submission_started(self.db_engine, sequences_to_upload)
         create_project_sync_state_with_submission_table(self.db_engine)
-        project_table_create(self.db_engine, self.config, test=self.config.test)
+        project_table_create(self.db_engine, self.config)
         check_project_submission_has_errors(self.db_engine, sequences_to_upload)
 
 
@@ -933,7 +933,7 @@ class TestKnownBioprojectAndBioSample(TestSubmission):
 
         # check project submission fails
         create_project_sync_state_with_submission_table(self.db_engine)
-        project_table_create(self.db_engine, self.config, test=self.config.test)
+        project_table_create(self.db_engine, self.config)
         check_project_submission_has_errors(self.db_engine, sequences_to_upload)
 
         # Confirm DB entry is reset to READY to retry submission
@@ -992,7 +992,7 @@ class TestKnownBioprojectAndBioSample(TestSubmission):
 
         # check sample submission fails and sends notification
         create_sample_sync_state_with_submission_table(self.db_engine)
-        sample_table_create(self.db_engine, self.config, test=self.config.test)
+        sample_table_create(self.db_engine, self.config)
         check_sample_submission_has_errors(self.db_engine, sequences_to_upload)
         sample_table_handle_errors(
             self.db_engine,
@@ -1009,7 +1009,7 @@ class TestKnownBioprojectAndBioSample(TestSubmission):
         # Confirm DB entry is reset to READY to retry submission
         check_sample_submission_started(self.db_engine, sequences_to_upload)
         create_sample_sync_state_with_submission_table(self.db_engine)
-        sample_table_create(self.db_engine, self.config, test=self.config.test)
+        sample_table_create(self.db_engine, self.config)
         create_sample_sync_state_with_submission_table(self.db_engine)
         check_sample_submission_submitted(self.db_engine, sequences_to_upload)
         _test_successful_assembly_submission(self.db_engine, self.config, sequences_to_upload)
@@ -1043,7 +1043,7 @@ class TestKnownBioprojectAndIncorrectBioSample(TestSubmission):
 
         # check sample submission fails and sends notification
         create_project_sync_state_with_submission_table(self.db_engine)
-        sample_table_create(self.db_engine, self.config, test=self.config.test)
+        sample_table_create(self.db_engine, self.config)
         check_sample_submission_has_errors(self.db_engine, sequences_to_upload)
         sample_table_handle_errors(
             self.db_engine,
@@ -1062,7 +1062,7 @@ class TestKnownBioprojectAndIncorrectBioSample(TestSubmission):
 
         # Confirm DB entry is still in error state after retrying submission
         create_project_sync_state_with_submission_table(self.db_engine)
-        sample_table_create(self.db_engine, self.config, test=self.config.test)
+        sample_table_create(self.db_engine, self.config)
         check_sample_submission_has_errors(self.db_engine, sequences_to_upload)
 
         # Confirm retries dont change state
@@ -1074,7 +1074,7 @@ class TestKnownBioprojectAndIncorrectBioSample(TestSubmission):
         )
         check_sample_submission_started(self.db_engine, sequences_to_upload)
         create_project_sync_state_with_submission_table(self.db_engine)
-        sample_table_create(self.db_engine, self.config, test=self.config.test)
+        sample_table_create(self.db_engine, self.config)
         check_sample_submission_has_errors(self.db_engine, sequences_to_upload)
 
 
@@ -1100,7 +1100,7 @@ class TestRevisionAssemblyModificationTests(TestSubmission):
 
         # submit
         create_project_sync_state_with_submission_table(self.db_engine)
-        project_table_create(self.db_engine, self.config, test=self.config.test)
+        project_table_create(self.db_engine, self.config)
         check_project_submission_submitted(self.db_engine, sequences_to_upload)
         _test_successful_sample_submission(self.db_engine, self.config, sequences_to_upload)
         _test_successful_assembly_submission(self.db_engine, self.config, sequences_to_upload)
@@ -1132,7 +1132,7 @@ class TestRevisionNoAssemblyModificationTests(TestSubmission):
 
         # submit
         create_project_sync_state_with_submission_table(self.db_engine)
-        project_table_create(self.db_engine, self.config, test=self.config.test)
+        project_table_create(self.db_engine, self.config)
         check_project_submission_submitted(self.db_engine, sequences_to_upload)
         _test_successful_sample_submission(self.db_engine, self.config, sequences_to_upload)
         _test_successful_assembly_submission_no_wait(

--- a/ena-submission/scripts/test_ena_submission_integration.py
+++ b/ena-submission/scripts/test_ena_submission_integration.py
@@ -16,6 +16,7 @@ import re
 import uuid
 from dataclasses import asdict
 from datetime import datetime, timedelta
+from itertools import chain, repeat
 from typing import Any, Final
 from unittest.mock import Mock, patch
 
@@ -425,7 +426,7 @@ def _test_assembly_submission_errored(
 def _test_successful_sample_submission(
     db_engine: Engine, config: Config, sequences_to_upload: dict[str, Any]
 ) -> None:
-    create_sample_sync_state_with_submission_table(db_engine, config=config)
+    create_sample_sync_state_with_submission_table(db_engine)
     check_sample_submission_started(db_engine, sequences_to_upload)
 
     sample_table_create(db_engine, config)
@@ -436,11 +437,11 @@ def _test_successful_sample_submission(
 def _test_successful_project_submission(
     db_engine: Engine, config: Config, sequences_to_upload: dict[str, Any]
 ) -> None:
-    create_project_sync_state_with_submission_table(db_engine, config)
+    create_project_sync_state_with_submission_table(db_engine)
     check_project_submission_started(db_engine, sequences_to_upload)
 
     project_table_create(db_engine, config)
-    create_project_sync_state_with_submission_table(db_engine, config)
+    create_project_sync_state_with_submission_table(db_engine)
     check_project_submission_submitted(db_engine, sequences_to_upload)
 
 
@@ -796,7 +797,9 @@ class TestKnownBioproject(TestSubmission):
         check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # submit
-        create_project_sync_state_with_submission_table(self.db_engine, self.config)
+        create_project_sync_state_with_submission_table(self.db_engine)
+        project_table_create(self.db_engine, self.config, test=self.config.test)
+        create_project_sync_state_with_submission_table(self.db_engine)
         check_project_submission_submitted(self.db_engine, sequences_to_upload)
         _test_successful_sample_submission(self.db_engine, self.config, sequences_to_upload)
         _test_successful_assembly_submission(self.db_engine, self.config, sequences_to_upload)
@@ -808,11 +811,13 @@ class TestKnownBioproject(TestSubmission):
 
 class TestIncorrectBioprojectPassed(TestSubmission):
     @patch("ena_deposition.notifications.notify", autospec=True)
-    def test_submit(self, mock_notify: Mock) -> None:
+    @patch("ena_deposition.call_loculus.get_group_info", autospec=True)
+    def test_submit(self, mock_get_group_info: Mock, mock_notify: Mock) -> None:
         """
         Test submitting sequences with an incorrect bioproject - this should fail
         """
         # get data
+        mock_get_group_info.return_value = TEST_GROUP
         mock_notify.return_value = None
         sequences_to_upload = get_sequences()
         for entry in sequences_to_upload.values():  # set to invalid bioproject
@@ -823,7 +828,8 @@ class TestIncorrectBioprojectPassed(TestSubmission):
         check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # check project submission fails and sends notification
-        create_project_sync_state_with_submission_table(self.db_engine, self.config)
+        create_project_sync_state_with_submission_table(self.db_engine)
+        project_table_create(self.db_engine, self.config, test=self.config.test)
         check_project_submission_has_errors(self.db_engine, sequences_to_upload)
         project_table_handle_errors(
             self.db_engine,
@@ -836,6 +842,33 @@ class TestIncorrectBioprojectPassed(TestSubmission):
             "in status HAS_ERRORS or SUBMITTING for over 0m"
         )
         mock_notify.assert_called_once_with(self.slack_config, msg)
+
+        project_table_handle_errors(
+            self.db_engine,
+            self.config,
+            self.slack_config,
+            last_retry_time=datetime.now(tz=pytz.utc) - timedelta(hours=5),
+        )
+
+        # Confirm DB entry is reset to READY to retry submission
+        check_project_submission_started(self.db_engine, sequences_to_upload)
+
+        # Confirm DB entry is still in error state after retrying submission
+        create_project_sync_state_with_submission_table(self.db_engine)
+        project_table_create(self.db_engine, self.config, test=self.config.test)
+        check_project_submission_has_errors(self.db_engine, sequences_to_upload)
+
+        # Confirm retries dont change state
+        project_table_handle_errors(
+            self.db_engine,
+            self.config,
+            self.slack_config,
+            last_retry_time=datetime.now(tz=pytz.utc) - timedelta(hours=10),
+        )
+        check_project_submission_started(self.db_engine, sequences_to_upload)
+        create_project_sync_state_with_submission_table(self.db_engine)
+        project_table_create(self.db_engine, self.config, test=self.config.test)
+        check_project_submission_has_errors(self.db_engine, sequences_to_upload)
 
 
 class TestKnownBioprojectAndBioSample(TestSubmission):
@@ -860,9 +893,136 @@ class TestKnownBioprojectAndBioSample(TestSubmission):
         check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # submit
-        create_project_sync_state_with_submission_table(self.db_engine, self.config)
+        create_project_sync_state_with_submission_table(self.db_engine)
         check_project_submission_submitted(self.db_engine, sequences_to_upload)
-        create_sample_sync_state_with_submission_table(self.db_engine, config=self.config)
+        create_sample_sync_state_with_submission_table(self.db_engine)
+        check_sample_submission_submitted(self.db_engine, sequences_to_upload)
+        _test_successful_assembly_submission(self.db_engine, self.config, sequences_to_upload)
+
+        # send to loculus
+        get_external_metadata_and_send_to_loculus(self.db_engine, self.config)
+        check_sent_to_loculus(self.db_engine, sequences_to_upload)
+
+    @patch(
+        "ena_deposition.upload_external_metadata_to_loculus.submit_external_metadata", autospec=True
+    )
+    @patch("ena_deposition.call_loculus.get_group_info", autospec=True)
+    @patch("ena_deposition.create_project.accession_exists", autospec=True)
+    @patch("ena_deposition.notifications.notify", autospec=True)
+    def test_bioproject_retry(
+        self,
+        mock_notify: Mock,
+        mock_accession_exists: Mock,
+        mock_get_group_info: Mock,
+        mock_submit_external_metadata: Mock,
+    ) -> None:
+        """
+        Test submitting sequences with accurate data and known bioproject and biosample
+        Force accession_exists test to fail on first attempt to simulate ENA
+        not processing submission in time, then retrying and succeeding
+        """
+        # get data
+        mock_get_group_info.return_value = TEST_GROUP
+        mock_submit_external_metadata.return_value = mock_requests_post()
+        mock_accession_exists.side_effect = chain([False], repeat(True))
+        mock_notify.return_value = None
+
+        sequences_to_upload = get_sequences()
+        for entry in sequences_to_upload.values():  # set to public bioproject and biosample
+            entry["metadata"]["bioprojectAccession"] = "PRJNA231221"
+            entry["metadata"]["biosampleAccession"] = "SAMN11077987"
+
+        # upload
+        upload_sequences(self.db_engine, sequences_to_upload)
+        check_sequences_uploaded(self.db_engine, sequences_to_upload)
+
+        # check project submission fails
+        create_project_sync_state_with_submission_table(self.db_engine)
+        project_table_create(self.db_engine, self.config, test=self.config.test)
+        check_project_submission_has_errors(self.db_engine, sequences_to_upload)
+
+        # Confirm DB entry is reset to READY to retry submission
+        project_table_handle_errors(
+            self.db_engine,
+            self.config,
+            self.slack_config,
+            last_retry_time=datetime.now(tz=pytz.utc) - timedelta(hours=5),
+        )
+        check_project_submission_started(self.db_engine, sequences_to_upload)
+
+        # submit
+        create_project_sync_state_with_submission_table(self.db_engine)
+        project_table_create(self.db_engine, self.config, test=self.config.test)
+        create_project_sync_state_with_submission_table(self.db_engine)
+        check_project_submission_submitted(self.db_engine, sequences_to_upload)
+        create_sample_sync_state_with_submission_table(self.db_engine)
+        sample_table_create(self.db_engine, self.config, test=self.config.test)
+        check_sample_submission_submitted(self.db_engine, sequences_to_upload)
+        _test_successful_assembly_submission(self.db_engine, self.config, sequences_to_upload)
+
+        # send to loculus
+        get_external_metadata_and_send_to_loculus(self.db_engine, self.config)
+        check_sent_to_loculus(self.db_engine, sequences_to_upload)
+
+    @patch(
+        "ena_deposition.upload_external_metadata_to_loculus.submit_external_metadata", autospec=True
+    )
+    @patch("ena_deposition.call_loculus.get_group_info", autospec=True)
+    @patch("ena_deposition.create_project.accession_exists", autospec=True)
+    @patch("ena_deposition.notifications.notify", autospec=True)
+    def test_biosample_retry(
+        self,
+        mock_notify: Mock,
+        mock_accession_exists: Mock,
+        mock_get_group_info: Mock,
+        mock_submit_external_metadata: Mock,
+    ) -> None:
+        """
+        Test submitting sequences with accurate data and known bioproject and biosample
+        Force accession_exists test to fail on first biosample query to simulate ENA
+        not processing submission in time, then retrying and succeeding
+        """
+        # get data
+        mock_get_group_info.return_value = TEST_GROUP
+        mock_submit_external_metadata.return_value = mock_requests_post()
+        mock_accession_exists.side_effect = chain([True], [False], repeat(True))
+        mock_notify.return_value = None
+
+        sequences_to_upload = get_sequences()
+        for entry in sequences_to_upload.values():  # set to public bioproject and biosample
+            entry["metadata"]["bioprojectAccession"] = "PRJNA231221"
+            entry["metadata"]["biosampleAccession"] = "SAMN11077987"
+
+        # upload
+        upload_sequences(self.db_engine, sequences_to_upload)
+        check_sequences_uploaded(self.db_engine, sequences_to_upload)
+
+        # submit
+        create_project_sync_state_with_submission_table(self.db_engine)
+        project_table_create(self.db_engine, self.config, test=self.config.test)
+        create_project_sync_state_with_submission_table(self.db_engine)
+        check_project_submission_submitted(self.db_engine, sequences_to_upload)
+
+        # check sample submission fails and sends notification
+        create_sample_sync_state_with_submission_table(self.db_engine)
+        sample_table_create(self.db_engine, self.config, test=self.config.test)
+        check_sample_submission_has_errors(self.db_engine, sequences_to_upload)
+        sample_table_handle_errors(
+            self.db_engine,
+            self.config,
+            self.slack_config,
+            last_retry_time=datetime.now(tz=pytz.utc) - timedelta(hours=5),
+        )
+        msg = (
+            f"{self.config.backend_url}: ENA Submission pipeline found 1 entries in sample_table "
+            "in status HAS_ERRORS or SUBMITTING for over 0m"
+        )
+        mock_notify.assert_called_once_with(self.slack_config, msg)
+
+        # Confirm DB entry is reset to READY to retry submission
+        check_sample_submission_started(self.db_engine, sequences_to_upload)
+        create_project_sync_state_with_submission_table(self.db_engine)
+        sample_table_create(self.db_engine, self.config, test=self.config.test)
         check_sample_submission_submitted(self.db_engine, sequences_to_upload)
         _test_successful_assembly_submission(self.db_engine, self.config, sequences_to_upload)
 
@@ -872,15 +1032,9 @@ class TestKnownBioprojectAndBioSample(TestSubmission):
 
 
 class TestKnownBioprojectAndIncorrectBioSample(TestSubmission):
-    @patch(
-        "ena_deposition.ena_submission_helper.update_with_retry",
-        autospec=True,
-    )
     @patch("ena_deposition.call_loculus.get_group_info", autospec=True)
     @patch("ena_deposition.notifications.notify", autospec=True)
-    def test_submit(
-        self, mock_notify: Mock, mock_get_group_info: Mock, mock_update_with_retry: Mock
-    ) -> None:
+    def test_submit(self, mock_notify: Mock, mock_get_group_info: Mock) -> None:
         """
         Test submitting sequences with known public bioproject and invalid biosample
         """
@@ -897,11 +1051,13 @@ class TestKnownBioprojectAndIncorrectBioSample(TestSubmission):
         check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # submit project
-        create_project_sync_state_with_submission_table(self.db_engine, self.config)
+        create_project_sync_state_with_submission_table(self.db_engine)
+        project_table_create(self.db_engine, self.config, test=self.config.test)
         check_project_submission_submitted(self.db_engine, sequences_to_upload)
 
         # check sample submission fails and sends notification
-        create_sample_sync_state_with_submission_table(self.db_engine, config=self.config)
+        create_project_sync_state_with_submission_table(self.db_engine)
+        sample_table_create(self.db_engine, self.config, test=self.config.test)
         check_sample_submission_has_errors(self.db_engine, sequences_to_upload)
         sample_table_handle_errors(
             self.db_engine,
@@ -914,7 +1070,26 @@ class TestKnownBioprojectAndIncorrectBioSample(TestSubmission):
             "in status HAS_ERRORS or SUBMITTING for over 0m"
         )
         mock_notify.assert_called_once_with(self.slack_config, msg)
-        mock_update_with_retry.assert_called_once()
+
+        # Confirm DB entry is reset to READY to retry submission
+        check_sample_submission_started(self.db_engine, sequences_to_upload)
+
+        # Confirm DB entry is still in error state after retrying submission
+        create_project_sync_state_with_submission_table(self.db_engine)
+        sample_table_create(self.db_engine, self.config, test=self.config.test)
+        check_sample_submission_has_errors(self.db_engine, sequences_to_upload)
+
+        # Confirm retries dont change state
+        sample_table_handle_errors(
+            self.db_engine,
+            self.config,
+            self.slack_config,
+            last_retry_time=datetime.now(tz=pytz.utc) - timedelta(hours=10),
+        )
+        check_sample_submission_started(self.db_engine, sequences_to_upload)
+        create_project_sync_state_with_submission_table(self.db_engine)
+        sample_table_create(self.db_engine, self.config, test=self.config.test)
+        check_sample_submission_has_errors(self.db_engine, sequences_to_upload)
 
 
 class TestRevisionAssemblyModificationTests(TestSubmission):
@@ -938,7 +1113,8 @@ class TestRevisionAssemblyModificationTests(TestSubmission):
         check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # submit
-        create_project_sync_state_with_submission_table(self.db_engine, self.config)
+        create_project_sync_state_with_submission_table(self.db_engine)
+        project_table_create(self.db_engine, self.config, test=self.config.test)
         check_project_submission_submitted(self.db_engine, sequences_to_upload)
         _test_successful_sample_submission(self.db_engine, self.config, sequences_to_upload)
         _test_successful_assembly_submission(self.db_engine, self.config, sequences_to_upload)
@@ -969,7 +1145,8 @@ class TestRevisionNoAssemblyModificationTests(TestSubmission):
         check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # submit
-        create_project_sync_state_with_submission_table(self.db_engine, self.config)
+        create_project_sync_state_with_submission_table(self.db_engine)
+        project_table_create(self.db_engine, self.config, test=self.config.test)
         check_project_submission_submitted(self.db_engine, sequences_to_upload)
         _test_successful_sample_submission(self.db_engine, self.config, sequences_to_upload)
         _test_successful_assembly_submission_no_wait(
@@ -1007,7 +1184,7 @@ class TestRevisionWithManifestChangeTests(TestSubmission):
         check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # submit
-        create_project_sync_state_with_submission_table(self.db_engine, self.config)
+        create_project_sync_state_with_submission_table(self.db_engine)
         check_project_submission_submitted(self.db_engine, sequences_to_upload)
         _test_successful_sample_submission(self.db_engine, self.config, sequences_to_upload)
 

--- a/ena-submission/scripts/test_ena_submission_integration.py
+++ b/ena-submission/scripts/test_ena_submission_integration.py
@@ -1042,7 +1042,7 @@ class TestKnownBioprojectAndIncorrectBioSample(TestSubmission):
         _test_successful_project_submission(self.db_engine, self.config, sequences_to_upload)
 
         # check sample submission fails and sends notification
-        create_project_sync_state_with_submission_table(self.db_engine)
+        create_sample_sync_state_with_submission_table(self.db_engine)
         sample_table_create(self.db_engine, self.config)
         check_sample_submission_has_errors(self.db_engine, sequences_to_upload)
         sample_table_handle_errors(

--- a/ena-submission/scripts/test_ena_submission_integration.py
+++ b/ena-submission/scripts/test_ena_submission_integration.py
@@ -797,10 +797,7 @@ class TestKnownBioproject(TestSubmission):
         check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # submit
-        create_project_sync_state_with_submission_table(self.db_engine)
-        project_table_create(self.db_engine, self.config, test=self.config.test)
-        create_project_sync_state_with_submission_table(self.db_engine)
-        check_project_submission_submitted(self.db_engine, sequences_to_upload)
+        _test_successful_project_submission(self.db_engine, self.config, sequences_to_upload)
         _test_successful_sample_submission(self.db_engine, self.config, sequences_to_upload)
         _test_successful_assembly_submission(self.db_engine, self.config, sequences_to_upload)
 
@@ -893,10 +890,8 @@ class TestKnownBioprojectAndBioSample(TestSubmission):
         check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # submit
-        create_project_sync_state_with_submission_table(self.db_engine)
-        check_project_submission_submitted(self.db_engine, sequences_to_upload)
-        create_sample_sync_state_with_submission_table(self.db_engine)
-        check_sample_submission_submitted(self.db_engine, sequences_to_upload)
+        _test_successful_project_submission(self.db_engine, self.config, sequences_to_upload)
+        _test_successful_sample_submission(self.db_engine, self.config, sequences_to_upload)
         _test_successful_assembly_submission(self.db_engine, self.config, sequences_to_upload)
 
         # send to loculus
@@ -951,13 +946,8 @@ class TestKnownBioprojectAndBioSample(TestSubmission):
         check_project_submission_started(self.db_engine, sequences_to_upload)
 
         # submit
-        create_project_sync_state_with_submission_table(self.db_engine)
-        project_table_create(self.db_engine, self.config, test=self.config.test)
-        create_project_sync_state_with_submission_table(self.db_engine)
-        check_project_submission_submitted(self.db_engine, sequences_to_upload)
-        create_sample_sync_state_with_submission_table(self.db_engine)
-        sample_table_create(self.db_engine, self.config, test=self.config.test)
-        check_sample_submission_submitted(self.db_engine, sequences_to_upload)
+        _test_successful_project_submission(self.db_engine, self.config, sequences_to_upload)
+        _test_successful_sample_submission(self.db_engine, self.config, sequences_to_upload)
         _test_successful_assembly_submission(self.db_engine, self.config, sequences_to_upload)
 
         # send to loculus
@@ -968,7 +958,7 @@ class TestKnownBioprojectAndBioSample(TestSubmission):
         "ena_deposition.upload_external_metadata_to_loculus.submit_external_metadata", autospec=True
     )
     @patch("ena_deposition.call_loculus.get_group_info", autospec=True)
-    @patch("ena_deposition.create_project.accession_exists", autospec=True)
+    @patch("ena_deposition.create_sample.accession_exists", autospec=True)
     @patch("ena_deposition.notifications.notify", autospec=True)
     def test_biosample_retry(
         self,
@@ -985,7 +975,7 @@ class TestKnownBioprojectAndBioSample(TestSubmission):
         # get data
         mock_get_group_info.return_value = TEST_GROUP
         mock_submit_external_metadata.return_value = mock_requests_post()
-        mock_accession_exists.side_effect = chain([True], [False], repeat(True))
+        mock_accession_exists.side_effect = chain([False], repeat(True))
         mock_notify.return_value = None
 
         sequences_to_upload = get_sequences()
@@ -998,10 +988,7 @@ class TestKnownBioprojectAndBioSample(TestSubmission):
         check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # submit
-        create_project_sync_state_with_submission_table(self.db_engine)
-        project_table_create(self.db_engine, self.config, test=self.config.test)
-        create_project_sync_state_with_submission_table(self.db_engine)
-        check_project_submission_submitted(self.db_engine, sequences_to_upload)
+        _test_successful_project_submission(self.db_engine, self.config, sequences_to_upload)
 
         # check sample submission fails and sends notification
         create_sample_sync_state_with_submission_table(self.db_engine)
@@ -1021,8 +1008,9 @@ class TestKnownBioprojectAndBioSample(TestSubmission):
 
         # Confirm DB entry is reset to READY to retry submission
         check_sample_submission_started(self.db_engine, sequences_to_upload)
-        create_project_sync_state_with_submission_table(self.db_engine)
+        create_sample_sync_state_with_submission_table(self.db_engine)
         sample_table_create(self.db_engine, self.config, test=self.config.test)
+        create_sample_sync_state_with_submission_table(self.db_engine)
         check_sample_submission_submitted(self.db_engine, sequences_to_upload)
         _test_successful_assembly_submission(self.db_engine, self.config, sequences_to_upload)
 
@@ -1051,9 +1039,7 @@ class TestKnownBioprojectAndIncorrectBioSample(TestSubmission):
         check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # submit project
-        create_project_sync_state_with_submission_table(self.db_engine)
-        project_table_create(self.db_engine, self.config, test=self.config.test)
-        check_project_submission_submitted(self.db_engine, sequences_to_upload)
+        _test_successful_project_submission(self.db_engine, self.config, sequences_to_upload)
 
         # check sample submission fails and sends notification
         create_project_sync_state_with_submission_table(self.db_engine)

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -157,6 +157,7 @@ def sync_state_with_submission_table(db_engine: Engine):
     for row in ready_to_submit:
         group_key = {"group_id": row.group_id, "organism": row.organism}
         seq_key = {"accession": row.accession, "version": row.version}
+        bioproject = row.seq_metadata.get("bioprojectAccession")
 
         # Check if there exists an entry in the project table for (group_id, organism)
         corresponding_project = find_conditions_in_db(
@@ -164,8 +165,7 @@ def sync_state_with_submission_table(db_engine: Engine):
         )
 
         # Use custom bioprojectAccession if it exists
-        if row.seq_metadata.get("bioprojectAccession"):
-            bioproject = row.seq_metadata["bioprojectAccession"]
+        if bioproject:
             corresponding_project = [
                 project
                 for project in corresponding_project

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -145,8 +145,8 @@ def sync_state_with_submission_table(db_engine: Engine):
     1. Find all entries in submission_table in state READY_TO_SUBMIT
     2. If (exists an entry in the project_table for (group_id, organism)):
     a.      If (exists "bioproject" in "metadata") filter to that entry
-    a.      If (in state SUBMITTED) update state in submission_table to SUBMITTED_PROJECT
-    4. Else create corresponding entry in project_table in state READY
+    b.      If (in state SUBMITTED) update state in submission_table to SUBMITTED_PROJECT
+    3. Else create corresponding entry in project_table in state READY
             (add "bioproject" to result if exists in metadata)
     """
     conditions = {"status_all": StatusAll.READY_TO_SUBMIT}
@@ -156,7 +156,7 @@ def sync_state_with_submission_table(db_engine: Engine):
     )
     for row in ready_to_submit:
         group_key = {"group_id": row.group_id, "organism": row.organism}
-        seq_key = {"accession": row.accession, "version": row.version}
+        seq_key = asdict(row.pkey)
         bioproject = row.seq_metadata.get("bioprojectAccession")
 
         # Check if there exists an entry in the project table for (group_id, organism)
@@ -231,7 +231,7 @@ def project_table_create(
     2. Create project_set: get_group_info from loculus, use entry and config for other fields
     3. Update project_table to state SUBMITTING (only proceed if update succeeds)
     4. If (create_ena_project succeeds): update state to SUBMITTED with results
-    3. Else update state to HAS_ERRORS with error messages
+    5. Else update state to HAS_ERRORS with error messages
 
     If config.random_alias=True add a timestamp to the alias suffix to allow for multiple
     submissions of the same project for testing.

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -2,7 +2,6 @@ import logging
 import threading
 import time
 from datetime import datetime
-from typing import Any
 
 import pytz
 from sqlalchemy import Engine

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -158,7 +158,6 @@ def sync_state_with_submission_table(db_engine: Engine):
     for row in ready_to_submit:
         group_key = {"group_id": row.group_id, "organism": row.organism}
         seq_key = {"accession": row.accession, "version": row.version}
-        bioproject = None
 
         # Check if there exists an entry in the project table for (group_id, organism)
         corresponding_project = find_conditions_in_db(
@@ -253,7 +252,9 @@ def project_table_create(
             continue
 
         if row.result and row.result.get("bioproject_accession"):
-            update_with_existing_bioproject(db_engine, config, row, center_name=group_info.institution)
+            update_with_existing_bioproject(
+                db_engine, config, row, center_name=group_info.institution
+            )
             continue
 
         project_set = construct_project_set_object(group_info, config, row, config.random_alias)

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -2,6 +2,7 @@ import logging
 import threading
 import time
 from datetime import datetime
+from typing import Any
 
 import pytz
 from sqlalchemy import Engine
@@ -101,79 +102,46 @@ def construct_project_set_object(
     return ProjectSet(project=[project_type])
 
 
-def set_project_table_entry(db_engine: Engine, config: Config, row: SubmissionTableEntry):
+def update_with_existing_bioproject(
+    db_engine: Engine,
+    config: Config,
+    row: ProjectTableEntry,
+    center_name: str,
+):
     """Set bioprojectAccession for entry with custom bioprojectAccession"""
-    logger.debug(f"Accession {row.accession} already has bioprojectAccession in metadata")
     group_key = {"group_id": row.group_id, "organism": row.organism}
-    seq_key = {"accession": row.accession, "version": row.version}
-    bioproject = row.seq_metadata["bioprojectAccession"]
-
-    corresponding_group = find_conditions_in_db(db_engine, ProjectTableEntry, conditions=group_key)
-    corresponding_project = [
-        project
-        for project in corresponding_group
-        if project.result and project.result.get("bioproject_accession") == bioproject
-    ]
-    if len(corresponding_project) == 1:
-        if corresponding_project[0].status != Status.SUBMITTED:
-            return
-        logger.debug(
-            "bioprojectAccession is already in project_table - adding id to submission_table"
-        )
-        update_values = {
-            "status_all": StatusAll.SUBMITTED_PROJECT,
-            "center_name": corresponding_project[0].center_name,
-            "project_id": corresponding_project[0].project_id,
-        }
-        update_db_where_conditions(
-            db_engine,
-            model_class=type(row),
-            conditions=seq_key,
-            update_values=update_values,
-        )
-        return
+    logger.debug(
+        f"Group {row.group_id} and organism {row.organism} already has "
+        f"bioprojectAccession, adding to project_table"
+    )
+    bioproject = row.result.get("bioproject_accession") if row.result else None
 
     logger.info("Checking if bioproject actually exists and is public")
-    if not accession_exists(bioproject, config):
+    if not bioproject or not accession_exists(str(bioproject), config):
         set_accession_does_not_exist_error(
             conditions=group_key,
-            accession=bioproject,
+            accession=str(bioproject),
             accession_type="BIOPROJECT",
             db_engine=db_engine,
         )
         return
 
-    logger.info("Adding bioprojectAccession to project_table")
-    try:
-        group_details = call_loculus.get_group_info(config, row.group_id)
-    except Exception as e:
-        logger.error(f"Was unable to get group info for group: {row.group_id}, {e}")
-        return
-    center_name = group_details.institution
-    project_table_entry = ProjectTableEntry(
-        group_id=row.group_id,
-        organism=row.organism,
-        result={"bioproject_accession": bioproject},
-        status=Status.SUBMITTED,
-        center_name=center_name,
-    )
-    succeeded = add_to_project_table(db_engine, project_table_entry)
-    if succeeded:
-        logger.debug("Succeeding in adding bioprojectAccession to project_table")
-        update_values = {
-            "status_all": StatusAll.SUBMITTED_PROJECT,
+    logger.info("Updating entry with bioprojectAccession to state SUBMITTED")
+    update_db_where_conditions(
+        db_engine,
+        ProjectTableEntry,
+        {"project_id": row.project_id},
+        {
+            "group_id": row.group_id,
+            "organism": row.organism,
+            "result": {"bioproject_accession": bioproject},
+            "status": Status.SUBMITTED,
             "center_name": center_name,
-            "project_id": succeeded,
-        }
-        update_db_where_conditions(
-            db_engine,
-            model_class=type(row),
-            conditions=seq_key,
-            update_values=update_values,
-        )
+        },
+    )
 
 
-def sync_state_with_submission_table(db_engine: Engine, config: Config):
+def sync_state_with_submission_table(db_engine: Engine):
     """
     1. Find all entries in submission_table in state READY_TO_SUBMIT
     2. If (exists "bioproject" in "metadata"):
@@ -190,40 +158,68 @@ def sync_state_with_submission_table(db_engine: Engine, config: Config):
     for row in ready_to_submit:
         group_key = {"group_id": row.group_id, "organism": row.organism}
         seq_key = {"accession": row.accession, "version": row.version}
+        bioproject = None
 
-        # Use custom bioprojectAccession if it exists
-        if row.seq_metadata.get("bioprojectAccession"):
-            set_project_table_entry(db_engine, config, row)
-            continue
-
-        # Create a default project entry for (group_id, organism)
         # Check if there exists an entry in the project table for (group_id, organism)
         corresponding_project = find_conditions_in_db(
             db_engine, ProjectTableEntry, conditions=group_key
         )
-        if len(corresponding_project) == 1:
-            if corresponding_project[0].status == Status.SUBMITTED:
-                update_values = {
+
+        # Use custom bioprojectAccession if it exists
+        if row.seq_metadata.get("bioprojectAccession"):
+            bioproject = row.seq_metadata["bioprojectAccession"]
+            corresponding_project = [
+                project
+                for project in corresponding_project
+                if project.result and project.result.get("bioproject_accession") == bioproject
+            ]
+
+        if len(corresponding_project) == 1 and corresponding_project[0].status == str(
+            Status.SUBMITTED
+        ):
+            update_db_where_conditions(
+                db_engine,
+                model_class=SubmissionTableEntry,
+                conditions=seq_key,
+                update_values={
                     "status_all": StatusAll.SUBMITTED_PROJECT,
                     "center_name": corresponding_project[0].center_name,
                     "project_id": corresponding_project[0].project_id,
-                }
-            else:
-                continue
-        else:
-            project_id = add_to_project_table(
-                db_engine, ProjectTableEntry(group_id=row.group_id, organism=row.organism)
+                },
             )
-            if not project_id:
-                continue
-            update_values = {
-                "project_id": project_id,
-            }
+            continue
+
+        if len(corresponding_project) == 1:
+            logger.warning(
+                f"Corresponding project not in STATE SUBMITTED for {row.group_id} and "
+                f"organism {row.organism} - not adding to project_table"
+            )
+            continue
+
+        if len(corresponding_project) > 1:
+            logger.warning(
+                f"Multiple corresponding projects found for group_id {row.group_id} and "
+                f"organism {row.organism} - not adding to project_table"
+            )
+            continue
+
+        project_id = add_to_project_table(
+            db_engine,
+            ProjectTableEntry(
+                group_id=row.group_id,
+                organism=row.organism,
+                result={"bioproject_accession": bioproject} if bioproject else None,
+            ),
+        )
+        if not project_id:
+            continue
         update_db_where_conditions(
             db_engine,
             model_class=SubmissionTableEntry,
             conditions=seq_key,
-            update_values=update_values,
+            update_values={
+                "project_id": project_id,
+            },
         )
 
 
@@ -254,6 +250,10 @@ def project_table_create(
             group_info = call_loculus.get_group_info(config, row.group_id)
         except Exception as e:
             logger.error(f"Was unable to get group info for group: {row.group_id}, {e}")
+            continue
+
+        if row.result and row.result.get("bioproject_accession"):
+            update_with_existing_bioproject(db_engine, config, row, center_name=group_info.institution)
             continue
 
         project_set = construct_project_set_object(group_info, config, row, config.random_alias)
@@ -362,12 +362,10 @@ def create_project(config: Config, stop_event: threading.Event):
             logger.warning("create_project stopped due to exception in another task")
             return
         logger.debug("Checking for projects to create")
-        sync_state_with_submission_table(db_engine, config)
+        sync_state_with_submission_table(db_engine)
 
         project_table_create(db_engine, config)
-        sync_state_with_submission_table(
-            db_engine, config
-        )  # update submission_table state after creation
+        sync_state_with_submission_table(db_engine)  # update submission_table state after creation
         last_retry_time = project_table_handle_errors(
             db_engine, config, slack_config, last_retry_time
         )

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -145,7 +145,7 @@ def sync_state_with_submission_table(db_engine: Engine):
     """
     1. Find all entries in submission_table in state READY_TO_SUBMIT
     2. If (exists "bioproject" in "metadata"):
-        attempt to use this bioproject, see set_project_table_entry function for details
+        attempt to use this bioproject, see update_with_existing_bioproject function for details
     3. If (exists an entry in the project_table for (group_id, organism)):
     a.      If (in state SUBMITTED) update state in submission_table to SUBMITTED_PROJECT
     4. Else create corresponding entry in project_table

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -1,6 +1,7 @@
 import logging
 import threading
 import time
+from dataclasses import asdict
 from datetime import datetime
 
 import pytz

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -109,7 +109,7 @@ def update_with_existing_bioproject(
     center_name: str,
 ):
     """Set bioprojectAccession for entry with custom bioprojectAccession"""
-    group_key = {"group_id": row.group_id, "organism": row.organism}
+    group_key = {"project_id": row.project_id}
     logger.debug(
         f"Group {row.group_id} and organism {row.organism} already has "
         f"bioprojectAccession, adding to project_table"
@@ -130,7 +130,7 @@ def update_with_existing_bioproject(
     update_db_where_conditions(
         db_engine,
         ProjectTableEntry,
-        {"project_id": row.project_id},
+        group_key,
         {
             "group_id": row.group_id,
             "organism": row.organism,
@@ -144,11 +144,11 @@ def update_with_existing_bioproject(
 def sync_state_with_submission_table(db_engine: Engine):
     """
     1. Find all entries in submission_table in state READY_TO_SUBMIT
-    2. If (exists "bioproject" in "metadata"):
-        attempt to use this bioproject, see update_with_existing_bioproject function for details
-    3. If (exists an entry in the project_table for (group_id, organism)):
+    2. If (exists an entry in the project_table for (group_id, organism)):
+    a.      If (exists "bioproject" in "metadata") filter to that entry
     a.      If (in state SUBMITTED) update state in submission_table to SUBMITTED_PROJECT
-    4. Else create corresponding entry in project_table
+    4. Else create corresponding entry in project_table in state READY
+            (add "bioproject" to result if exists in metadata)
     """
     conditions = {"status_all": StatusAll.READY_TO_SUBMIT}
     ready_to_submit = find_conditions_in_db(db_engine, SubmissionTableEntry, conditions=conditions)

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -282,7 +282,7 @@ def sample_table_create(db_engine: Engine, config: Config):
             db_engine, SubmissionTableEntry, conditions=asdict(seq_key)
         )
 
-        if row.result and row.result.get("bioproject_accession"):
+        if row.result and row.result.get("biosample_accession"):
             update_with_existing_biosample(db_engine, sample_data_in_submission_table[0], config)
             continue
 

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -166,12 +166,10 @@ def construct_sample_set_object(
     return SampleSetType(sample=[sample_type])
 
 
-def set_sample_table_entry(
-    db_engine: Engine, row: SubmissionTableEntry, seq_key: dict, config: Config
-):
-    """Set sample_table entry for entry with biosampleAccession"""
+def update_with_existing_biosample(db_engine: Engine, row: SubmissionTableEntry, config: Config):
+    """Update sample_table entry for entry with biosampleAccession"""
     logger.debug(
-        f"Accession: {row.accession} already has biosampleAccession, adding to sample_table"
+        f"Accession: {row.accession} already has biosampleAccession, updating sample_table"
     )
     biosample = row.seq_metadata["biosampleAccession"]
 
@@ -186,27 +184,21 @@ def set_sample_table_entry(
         )
         return
 
-    sample_table_entry = SampleTableEntry(
-        accession=row.accession,
-        version=row.version,
-        result={"ena_sample_accession": biosample, "biosample_accession": biosample},
-        status=Status.SUBMITTED,
+    logger.info("Updating entry with biosampleAccession to state SUBMITTED")
+    update_db_where_conditions(
+        db_engine,
+        model_class=SampleTableEntry,
+        conditions=seq_key,
+        update_values={
+            "accession": row.accession,
+            "version": row.version,
+            "result": {"ena_sample_accession": biosample, "biosample_accession": biosample},
+            "status": Status.SUBMITTED,
+        },
     )
-    succeeded = add_to_sample_table(db_engine, sample_table_entry)
-    if succeeded:
-        logger.debug("Succeeding in adding biosampleAccession to sample_table")
-        update_values = {
-            "status_all": StatusAll.SUBMITTED_SAMPLE,
-        }
-        update_db_where_conditions(
-            db_engine,
-            model_class=SubmissionTableEntry,
-            conditions=seq_key,
-            update_values=update_values,
-        )
 
 
-def sync_state_with_submission_table(db_engine: Engine, config: Config):
+def sync_state_with_submission_table(db_engine: Engine):
     """
     1. Find all entries in submission_table in state SUBMITTED_PROJECT
     2. If (exists an entry in the sample_table for (accession, version)):
@@ -228,20 +220,37 @@ def sync_state_with_submission_table(db_engine: Engine, config: Config):
         corresponding_sample = find_conditions_in_db(
             db_engine, SampleTableEntry, conditions=seq_key
         )
+        if len(corresponding_sample) == 1 and corresponding_sample[0].status == str(
+            Status.SUBMITTED
+        ):
+            update_db_where_conditions(
+                db_engine,
+                model_class=SubmissionTableEntry,
+                conditions=seq_key,
+                update_values={"status_all": StatusAll.SUBMITTED_SAMPLE},
+            )
+            continue
         if len(corresponding_sample) == 1:
-            if corresponding_sample[0].status == Status.SUBMITTED:
-                update_db_where_conditions(
-                    db_engine,
-                    model_class=SubmissionTableEntry,
-                    conditions=seq_key,
-                    update_values={"status_all": StatusAll.SUBMITTED_SAMPLE},
-                )
-        else:
-            if row.seq_metadata.get("biosampleAccession"):
-                set_sample_table_entry(db_engine, row, seq_key, config)
-                continue
-            if not add_to_sample_table(db_engine, SampleTableEntry(**seq_key)):
-                continue
+            logger.debug(
+                f"Entry for {seq_key} already exists in sample_table with status "
+                f"{corresponding_sample[0].status}, not updating submission_table status."
+            )
+            continue
+        if len(corresponding_sample) > 1:
+            logger.error(
+                f"Multiple entries found in sample_table for {seq_key}, not updating "
+                "submission_table status or adding to sample_table."
+            )
+            continue
+        biosample = None
+        if row and row.seq_metadata.get("biosampleAccession"):
+            biosample = row.seq_metadata["biosampleAccession"]
+        add_to_sample_table(
+            db_engine,
+            SampleTableEntry(
+                **seq_key, result={"biosample_accession": biosample} if biosample else None
+            ),
+        )
 
 
 def sample_table_create(db_engine: Engine, config: Config):
@@ -269,12 +278,18 @@ def sample_table_create(db_engine: Engine, config: Config):
             continue
 
         logger.info(f"Processing sample_table entry for {seq_key}")
-        submission_rows = find_conditions_in_db(
+        sample_data_in_submission_table = find_conditions_in_db(
             db_engine, SubmissionTableEntry, conditions=asdict(seq_key)
         )
 
+        if row.result and row.result.get("bioproject_accession"):
+            update_with_existing_biosample(db_engine, sample_data_in_submission_table[0], config)
+            continue
+
         sample_set = construct_sample_set_object(
-            config, submission_rows[0], row, config.random_alias
+            
+            config, sample_data_in_submission_table[0], row, config.random_alias
+        
         )
         update_values = {
             "status": Status.SUBMITTING,
@@ -376,12 +391,10 @@ def create_sample(config: Config, stop_event: threading.Event):
             logger.warning("create_sample stopped due to exception in another task")
             return
         logger.debug("Checking for samples to create")
-        sync_state_with_submission_table(db_engine, config=config)
+        sync_state_with_submission_table(db_engine)
 
         sample_table_create(db_engine, config)
-        sync_state_with_submission_table(
-            db_engine, config=config
-        )  # update submission_table state after creation
+        sync_state_with_submission_table(db_engine)  # update submission_table state after creation
         last_retry_time = sample_table_handle_errors(
             db_engine, config, slack_config, last_retry_time
         )

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -287,9 +287,7 @@ def sample_table_create(db_engine: Engine, config: Config):
             continue
 
         sample_set = construct_sample_set_object(
-            
             config, sample_data_in_submission_table[0], row, config.random_alias
-        
         )
         update_values = {
             "status": Status.SUBMITTING,

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -56,8 +56,7 @@ from .submission_db_helper import (
     SampleTableEntry,
     Status,
     add_to_assembly_table,
-    add_to_project_table,
-    add_to_sample_table,
+    update_db_where_conditions,
     update_with_retry,
 )
 
@@ -838,7 +837,7 @@ def accession_exists(
 
 
 def set_accession_does_not_exist_error(
-    conditions: dict[str, str | dict[str, str]],
+    conditions: dict[str, Any],
     accession: str,
     accession_type: Literal["BIOPROJECT"] | Literal["BIOSAMPLE"] | Literal["RUN_REF"],
     db_engine: Engine,
@@ -849,21 +848,27 @@ def set_accession_does_not_exist_error(
     succeeded: bool | int | None
     match accession_type:
         case "BIOSAMPLE":
-            sample_table_entry = SampleTableEntry(
-                **conditions,  # type: ignore
-                status=Status.HAS_ERRORS,
-                errors=[error_text],
-                result={"ena_sample_accession": accession, "biosample_accession": accession},
+            succeeded = update_db_where_conditions(
+                db_engine,
+                SampleTableEntry,
+                conditions,
+                {
+                    "status": Status.HAS_ERRORS,
+                    "errors": [error_text],
+                    "result": {"biosample_accession": accession, "ena_sample_accession": accession},
+                },
             )
-            succeeded = add_to_sample_table(db_engine, sample_table_entry)
         case "BIOPROJECT":
-            project_table_entry = ProjectTableEntry(
-                **conditions,  # type: ignore
-                status=Status.HAS_ERRORS,
-                errors=[error_text],
-                result={"bioproject_accession": accession},
+            succeeded = update_db_where_conditions(
+                db_engine,
+                ProjectTableEntry,
+                conditions,
+                {
+                    "status": Status.HAS_ERRORS,
+                    "errors": [error_text],
+                    "result": {"bioproject_accession": accession},
+                },
             )
-            succeeded = add_to_project_table(db_engine, project_table_entry)
         case "RUN_REF":
             assembly_table_entry = AssemblyTableEntry(
                 **conditions,  # type: ignore
@@ -907,7 +912,6 @@ def retry_failed_submissions_for_matching_errors(
             "status": Status.READY,
             "errors": None,
             "finished_at": None,
-            "result": {},
         }
         try:
             update_with_retry(

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -246,12 +246,7 @@ class AssemblyTableEntry(Base):
         return AccessionVersion(accession=self.accession, version=self.version)
 
 
-type TableEntry = (
-    SubmissionTableEntry
-    | ProjectTableEntry
-    | SampleTableEntry
-    | AssemblyTableEntry
-)
+type TableEntry = SubmissionTableEntry | ProjectTableEntry | SampleTableEntry | AssemblyTableEntry
 
 
 def highest_version_in_submission_table(engine: Engine) -> dict[Accession, Version]:
@@ -265,9 +260,7 @@ def highest_version_in_submission_table(engine: Engine) -> dict[Accession, Versi
     return {row.accession: row.version for row in rows}
 
 
-def find_conditions_in_db[
-    T: TableEntry
-](
+def find_conditions_in_db[T: TableEntry](
     engine: Engine,
     model_class: type[T],
     conditions: dict[str, Any],
@@ -289,9 +282,7 @@ def find_conditions_in_db[
         return rows
 
 
-def delete_records_in_db[
-    T: TableEntry
-](
+def delete_records_in_db[T: TableEntry](
     engine: Engine,
     model_class: type[T],
     conditions: dict[str, Any],
@@ -369,9 +360,7 @@ def find_waiting_in_db(
         return rows
 
 
-def update_db_where_conditions[
-    T: TableEntry
-](
+def update_db_where_conditions[T: TableEntry](
     engine: Engine,
     model_class: type[T],
     conditions: Mapping[str, Any],
@@ -415,9 +404,7 @@ def update_db_where_conditions[
     return updated_row_count
 
 
-def update_with_retry[
-    T: TableEntry
-](
+def update_with_retry[T: TableEntry](
     db_engine: Engine,
     conditions: Mapping[str, Any],
     model_class: type[T],


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/6269

alternative to https://github.com/loculus-project/loculus/pull/6271

## History

When users upload raw reads with bioproject and biosamples we cannot submit (as this errors) the corresponding assemblies until the bioproject and biosamples are public. We can tell if an accession is public via the ENA endpoint `"https://www.ebi.ac.uk/ena/browser/api/summary/{accession}"` called in `accession_exists`. Currently if the API tells us the bioproject or biosample is not public we set the submission state in the bioproject or biosample table to HAS_ERRORS. (We dont want to constantly try to submit as this typically takes weeks to come live and we dont want to overwhelm ENA or get our server blocked).

It makes sense to have the database perform retries for us.

I tried to extend the existing retry code to this case but encountered issues when it was run on actual data. 

### The Issue

Errors in the code annotated with A, B and C. 

- The bioproject was not public, in `set_project_table_entry` the bioproject_table was put into state HAS_ERRORS without a center name. 
- (A) The submission_table_start code called `set_project_table_entry` again which set the status in the submission_table to SUBMITTED_PROJECT without center_name. <- quite a serious error!
- The retry code reset the failed entry in the project table to state READY. 
- (B) The `project_table_create` code iterates over all entries in state READY - it did not expect to receive entries which already had bioprojects and tried to submit the bioproject, thankfully this failed due to not having the center_name.
- Seeing that the submission_table was in state SUBMITTED_PROJECT the sample_table called `set_sample_table_entry` and the biosample was put into HAS_ERRORS.
- The retry code set the state of the entry to READY in the sample_table.
- (C) The `sample_table_create` code iterates over all entries in state READY, it did not expect to receive entries which already had a bioproject and tried to submit a new biosample, thankfully this failed due to not having a center_name. 

## The solution

Clear division of work between the functions `sync_submission_table_state` and `create_project` or `create_sample`. 

The `sync_submission_table_state` is solely responsible for adding entries to the project/sample table and updating the state in the submission_table. The submission_table state is only updated after a successful submission. `sync_submission_table_state` will create new entries in the project/sample table if only they do not already exist in the table. It will also create entries for the case where a biosample/biosample exists -> this will be added to the result JSONB field.

`create_project` and `create_sample` are responsible for creating the bioprojects and biosamples, they operate on all entries in that table that are in state READY. If an entry already has a bioproject or biosample they will handle that case accordingly (i.e. check if exists in ENA and set to HAS_ERRORS or SUBMITTED). 

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
I added intergration tests for the full resubmission workflow, also ensuring entries will return to state HAS_ERRORS in case of repeated failures and that submissions can proceed if ENA returns truthy.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
Before rolling this out I would like to test this on staging. This was tested on staging: https://github.com/pathoplexus/loculus_deployments/pull/688, code is retried as desired (entries with errors stay in an error state and are retried correctly) and entries with valid bioproject and biosample are updated correctly.

🚀 Preview: Add `preview` label to enable