### PR TITLE
fix(website): Remove hardcoded Pathoplexus/Loculus on submission/revision pages

### DIFF
--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -31,6 +31,7 @@ export type UploadAction = 'submit' | 'revise';
 
 type DataUploadFormProps = {
     accessToken: string;
+    instanceName: string;
     organism: string;
     clientConfig: ClientConfig;
     action: UploadAction;
@@ -47,6 +48,7 @@ const logger = getClientLogger('DataUploadForm');
 
 const InnerDataUploadForm = ({
     accessToken,
+    instanceName,
     organism,
     clientConfig,
     action,
@@ -189,6 +191,7 @@ const InnerDataUploadForm = ({
                 {action === 'submit' && dataUseTermsEnabled && (
                     <>
                         <DataUseTerms
+                            instanceName={instanceName}
                             dataUseTermsType={dataUseTermsType}
                             setDataUseTermsType={setDataUseTermsType}
                             restrictedUntil={restrictedUntil}
@@ -200,6 +203,7 @@ const InnerDataUploadForm = ({
                 {dataUseTermsEnabled && (
                     <>
                         <Acknowledgement
+                            instanceName={instanceName}
                             confirmedNoPII={confirmedNoPII}
                             setConfirmedNoPII={setConfirmedNoPII}
                             agreedToINSDCUploadTerms={agreedToINSDCUploadTerms}
@@ -318,11 +322,13 @@ export const ExtraFilesUpload = ({
 };
 
 const DataUseTerms = ({
+    instanceName,
     dataUseTermsType,
     setDataUseTermsType,
     restrictedUntil,
     setRestrictedUntil,
 }: {
+    instanceName: string;
     dataUseTermsType: DataUseTermsOption;
     setDataUseTermsType: (dataUseTermsType: DataUseTermsOption) => void;
     restrictedUntil: DateTime;
@@ -353,10 +359,12 @@ const DataUseTerms = ({
                         />
                     </div>
                     {dataUseTermsType === openDataUseTermsOption ? (
-                        <p className='text-sm'>Your data will be available on Pathoplexus under the open use terms.</p>
+                        <p className='text-sm'>
+                            Your data will be available on {instanceName} under the open use terms.
+                        </p>
                     ) : (
                         <p className='text-sm'>
-                            Your data will be available on Pathoplexus, under the restricted use terms until{' '}
+                            Your data will be available on {instanceName}, under the restricted use terms until{' '}
                             {restrictedUntil.toFormat('yyyy-MM-dd')} and under the open use terms after that date.
                         </p>
                     )}
@@ -367,11 +375,13 @@ const DataUseTerms = ({
 };
 
 const Acknowledgement = ({
+    instanceName,
     confirmedNoPII,
     setConfirmedNoPII,
     agreedToINSDCUploadTerms,
     setAgreedToINSDCUploadTerms,
 }: {
+    instanceName: string;
     confirmedNoPII: boolean;
     setConfirmedNoPII: Dispatch<SetStateAction<boolean>>;
     agreedToINSDCUploadTerms: boolean;
@@ -386,7 +396,7 @@ const Acknowledgement = ({
             <div className='gap-x-6 gap-y-8 col-span-2'>
                 <div>
                     <p className='block text-sm'>
-                        Your data will be available on Pathoplexus, under the selected data use terms. Data with open
+                        Your data will be available on {instanceName}, under the selected data use terms. Data with open
                         data use terms will additionally be made publicly available through the{' '}
                         <a href='https://www.insdc.org/' className='text-primary-600 hover:underline'>
                             INSDC
@@ -421,7 +431,8 @@ const Acknowledgement = ({
                             <div>
                                 <p className='text-xs pl-4 text-gray-500'>
                                     I confirm I have not and will not submit this data independently to INSDC, to avoid
-                                    data duplication. I agree to Loculus handling the submission of this data to INSDC.{' '}
+                                    data duplication. I agree to {instanceName} handling the submission of this data to
+                                    INSDC.{' '}
                                     <a
                                         href='/docs/concepts/insdc-submission'
                                         className='text-primary-600 hover:underline'

--- a/website/src/components/Submission/RevisionForm.tsx
+++ b/website/src/components/Submission/RevisionForm.tsx
@@ -10,6 +10,7 @@ import type { ClientConfig } from '../../types/runtimeConfig.ts';
 
 type RevisionFormProps = {
     accessToken: string;
+    instanceName: string;
     organism: string;
     clientConfig: ClientConfig;
     group: Group;
@@ -20,6 +21,7 @@ type RevisionFormProps = {
 
 export const RevisionForm: FC<RevisionFormProps> = ({
     accessToken,
+    instanceName,
     organism,
     clientConfig,
     group,
@@ -31,6 +33,7 @@ export const RevisionForm: FC<RevisionFormProps> = ({
         <div className='flex flex-col items-center'>
             <DataUploadForm
                 accessToken={accessToken}
+                instanceName={instanceName}
                 organism={organism}
                 metadataTemplateFields={metadataTemplateFields}
                 clientConfig={clientConfig}

--- a/website/src/components/Submission/SubmissionForm.spec.tsx
+++ b/website/src/components/Submission/SubmissionForm.spec.tsx
@@ -23,6 +23,8 @@ vi.mock('react-toastify', () => ({
     },
 }));
 
+const INSTANCE_NAME = 'test-instance';
+
 const group: Group = {
     groupId: 1,
     groupName: testGroups[0].groupName,
@@ -49,6 +51,7 @@ function renderSubmissionForm({
 } = {}) {
     return render(
         <SubmissionForm
+            instanceName={INSTANCE_NAME}
             inputMode={inputMode}
             accessToken={testAccessToken}
             organism={testOrganism}

--- a/website/src/components/Submission/SubmissionForm.spec.tsx
+++ b/website/src/components/Submission/SubmissionForm.spec.tsx
@@ -264,6 +264,11 @@ describe('SubmitForm', () => {
         );
     });
 
+    test('instance name should be present in the submission form', () => {
+        const { container } = renderSubmissionForm();
+        expect(container.textContent).toContain(INSTANCE_NAME);
+    });
+
     async function submitAndExpectErrorMessageContains(receivedUnexpectedMessageFromBackend: string) {
         const { getByLabelText, getByRole, findByRole } = renderSubmissionForm();
 

--- a/website/src/components/Submission/SubmissionForm.tsx
+++ b/website/src/components/Submission/SubmissionForm.tsx
@@ -11,6 +11,7 @@ import type { ClientConfig } from '../../types/runtimeConfig.ts';
 
 type SubmissionFormProps = {
     accessToken: string;
+    instanceName: string;
     organism: string;
     clientConfig: ClientConfig;
     group: Group;
@@ -22,6 +23,7 @@ type SubmissionFormProps = {
 
 export const SubmissionForm: FC<SubmissionFormProps> = ({
     accessToken,
+    instanceName,
     organism,
     clientConfig,
     group,
@@ -34,6 +36,7 @@ export const SubmissionForm: FC<SubmissionFormProps> = ({
         <div className='flex flex-col items-center'>
             <DataUploadForm
                 accessToken={accessToken}
+                instanceName={instanceName}
                 organism={organism}
                 metadataTemplateFields={metadataTemplateFields}
                 clientConfig={clientConfig}

--- a/website/src/pages/[organism]/submission/[groupId]/revise.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/revise.astro
@@ -2,7 +2,13 @@
 import { cleanOrganism } from '../../../../components/Navigation/cleanOrganism';
 import { RevisionForm } from '../../../../components/Submission/RevisionForm';
 import SubmissionPageWrapper from '../../../../components/Submission/SubmissionPageWrapper.astro';
-import { dataUseTermsAreEnabled, getGroupedInputFields, getRuntimeConfig, getSchema, getWebsiteConfig } from '../../../../config';
+import {
+    dataUseTermsAreEnabled,
+    getGroupedInputFields,
+    getRuntimeConfig,
+    getSchema,
+    getWebsiteConfig,
+} from '../../../../config';
 import { getAccessToken } from '../../../../utils/getAccessToken';
 import { getGroupsAndCurrentGroup } from '../../../../utils/submissionPages';
 

--- a/website/src/pages/[organism]/submission/[groupId]/revise.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/revise.astro
@@ -2,10 +2,11 @@
 import { cleanOrganism } from '../../../../components/Navigation/cleanOrganism';
 import { RevisionForm } from '../../../../components/Submission/RevisionForm';
 import SubmissionPageWrapper from '../../../../components/Submission/SubmissionPageWrapper.astro';
-import { dataUseTermsAreEnabled, getGroupedInputFields, getRuntimeConfig, getSchema } from '../../../../config';
+import { dataUseTermsAreEnabled, getGroupedInputFields, getRuntimeConfig, getSchema, getWebsiteConfig } from '../../../../config';
 import { getAccessToken } from '../../../../utils/getAccessToken';
 import { getGroupsAndCurrentGroup } from '../../../../utils/submissionPages';
 
+const instanceName = getWebsiteConfig().name;
 const organism = Astro.params.organism!;
 const { organism: cleanedOrganism } = cleanOrganism(Astro.params.organism);
 
@@ -29,6 +30,7 @@ const clientConfig = getRuntimeConfig().public;
             ({ currentGroup: group }) => (
                 <RevisionForm
                     accessToken={getAccessToken(Astro.locals.session)!}
+                    instanceName={instanceName}
                     organism={organism}
                     metadataTemplateFields={groupedInputFields}
                     clientConfig={clientConfig}

--- a/website/src/pages/[organism]/submission/[groupId]/submit.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/submit.astro
@@ -3,11 +3,17 @@ import { cleanOrganism } from '../../../../components/Navigation/cleanOrganism';
 import type { InputMode } from '../../../../components/Submission/FormOrUploadWrapper';
 import { SubmissionForm } from '../../../../components/Submission/SubmissionForm';
 import SubmissionPageWrapper from '../../../../components/Submission/SubmissionPageWrapper.astro';
-import { dataUseTermsAreEnabled, getGroupedInputFields, getRuntimeConfig, getSchema, getWebsiteConfig } from '../../../../config';
+import {
+    dataUseTermsAreEnabled,
+    getGroupedInputFields,
+    getRuntimeConfig,
+    getSchema,
+    getWebsiteConfig,
+} from '../../../../config';
 import { getAccessToken } from '../../../../utils/getAccessToken';
 import { getGroupsAndCurrentGroup } from '../../../../utils/submissionPages';
 
-const instanceName = getWebsiteConfig().name
+const instanceName = getWebsiteConfig().name;
 const organism = Astro.params.organism!;
 
 const { organism: cleanedOrganism } = cleanOrganism(Astro.params.organism);

--- a/website/src/pages/[organism]/submission/[groupId]/submit.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/submit.astro
@@ -3,10 +3,11 @@ import { cleanOrganism } from '../../../../components/Navigation/cleanOrganism';
 import type { InputMode } from '../../../../components/Submission/FormOrUploadWrapper';
 import { SubmissionForm } from '../../../../components/Submission/SubmissionForm';
 import SubmissionPageWrapper from '../../../../components/Submission/SubmissionPageWrapper.astro';
-import { dataUseTermsAreEnabled, getGroupedInputFields, getRuntimeConfig, getSchema } from '../../../../config';
+import { dataUseTermsAreEnabled, getGroupedInputFields, getRuntimeConfig, getSchema, getWebsiteConfig } from '../../../../config';
 import { getAccessToken } from '../../../../utils/getAccessToken';
 import { getGroupsAndCurrentGroup } from '../../../../utils/submissionPages';
 
+const instanceName = getWebsiteConfig().name
 const organism = Astro.params.organism!;
 
 const { organism: cleanedOrganism } = cleanOrganism(Astro.params.organism);
@@ -39,6 +40,7 @@ Astro.response.headers.append('Expires', '0');
             ({ currentGroup: group }) => (
                 <SubmissionForm
                     accessToken={getAccessToken(Astro.locals.session)!}
+                    instanceName={instanceName}
                     metadataTemplateFields={groupedInputFields}
                     organism={organism}
                     clientConfig={clientConfig}


### PR DESCRIPTION
Switches from hardcoded Loculus/Pathoplexus to use the instance name on the sequence submission/revision pages.

### Screenshot

<img width="967" height="666" alt="image" src="https://github.com/user-attachments/assets/e7e96d73-77ba-4ed5-9a96-eef1a2202546" />


### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable