### PR TITLE
feat(deposition): add constants for mapping between database keys and Loculus field names for external metadata fields

### DIFF
--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -13,10 +13,10 @@ from unittest import mock
 import xmltodict
 import yaml
 from ena_deposition.config import (
-    BIOPROJECT_ACCESSION_DB_KEY,
-    BIOSAMPLE_ACCESSION_DB_KEY,
-    NUCCORE_ACCESSION_PREFIX_DB_KEY,
-    VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY,
+    DBKeys.BIOPROJECT_ACCESSION,
+    DBKeys.BIOSAMPLE_ACCESSION,
+    DBKeys.NUCCORE_ACCESSION_PREFIX,
+    DBKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX,
     EnaOrganismDetails,
     ManifestFieldDetails,
     MetadataMapping,
@@ -175,7 +175,7 @@ class ProjectCreationTests(unittest.TestCase):
         project_set = default_project_set()
         response = create_ena_project(MOCK_CONFIG, project_set)
         desired_response = {
-            BIOPROJECT_ACCESSION_DB_KEY: "PRJEB20767",
+            DBKeys.BIOPROJECT_ACCESSION: "PRJEB20767",
             "ena_submission_accession": "ERA912529",
         }
         assert response.result == desired_response
@@ -220,7 +220,7 @@ class TestCreateSample:
         response = create_ena_sample(MOCK_CONFIG, sample_set)
         desired_response = {
             "ena_sample_accession": "ERS1833148",
-            BIOSAMPLE_ACCESSION_DB_KEY: "SAMEA104174130",
+            DBKeys.BIOSAMPLE_ACCESSION: "SAMEA104174130",
             "ena_submission_accession": "ERA979927",
         }
         assert response.result == desired_response
@@ -417,10 +417,10 @@ class AssemblyCreationTests(unittest.TestCase):
         self.assertEqual(
             result_multi,
             {
-                f"{NUCCORE_ACCESSION_PREFIX_DB_KEY}_seg2": "OZ189935",
-                f"{NUCCORE_ACCESSION_PREFIX_DB_KEY}_seg3": "OZ189936",
-                f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}_seg2": "OZ189935.1",
-                f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}_seg3": "OZ189936.1",
+                f"{DBKeys.NUCCORE_ACCESSION_PREFIX}_seg2": "OZ189935",
+                f"{DBKeys.NUCCORE_ACCESSION_PREFIX}_seg3": "OZ189936",
+                f"{DBKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX}_seg2": "OZ189935.1",
+                f"{DBKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX}_seg3": "OZ189936.1",
             },
         )
 
@@ -430,8 +430,8 @@ class AssemblyCreationTests(unittest.TestCase):
         self.assertEqual(
             result_single,
             {
-                f"{NUCCORE_ACCESSION_PREFIX_DB_KEY}": "OZ189935",
-                f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}": "OZ189935.1",
+                f"{DBKeys.NUCCORE_ACCESSION_PREFIX}": "OZ189935",
+                f"{DBKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX}": "OZ189935.1",
             },
         )
 
@@ -441,8 +441,8 @@ class AssemblyCreationTests(unittest.TestCase):
         self.assertEqual(
             result_single,
             {
-                f"{NUCCORE_ACCESSION_PREFIX_DB_KEY}_seg3": "OZ189935",
-                f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}_seg3": "OZ189935.1",
+                f"{DBKeys.NUCCORE_ACCESSION_PREFIX}_seg3": "OZ189935",
+                f"{DBKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX}_seg3": "OZ189935.1",
             },
         )
 
@@ -470,8 +470,8 @@ class AssemblyCreationTests(unittest.TestCase):
         )
         desired_response = {
             "erz_accession": "ERZ000001",
-            NUCCORE_ACCESSION_PREFIX_DB_KEY: "OZ189999",
-            VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY: "OZ189999.1",
+            DBKeys.NUCCORE_ACCESSION_PREFIX: "OZ189999",
+            DBKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX: "OZ189999.1",
             "segment_order": ["main"],
         }
         self.assertEqual(response.result, desired_response)

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -12,7 +12,15 @@ from unittest import mock
 
 import xmltodict
 import yaml
-from ena_deposition.config import EnaOrganismDetails, ManifestFieldDetails, MetadataMapping
+from ena_deposition.config import (
+    BIOPROJECT_ACCESSION_DB_KEY,
+    BIOSAMPLE_ACCESSION_DB_KEY,
+    NUCCORE_ACCESSION_PREFIX_DB_KEY,
+    VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY,
+    EnaOrganismDetails,
+    ManifestFieldDetails,
+    MetadataMapping,
+)
 from ena_deposition.create_assembly import (
     create_chromosome_list_object,
     create_manifest_object,
@@ -167,7 +175,7 @@ class ProjectCreationTests(unittest.TestCase):
         project_set = default_project_set()
         response = create_ena_project(MOCK_CONFIG, project_set)
         desired_response = {
-            "bioproject_accession": "PRJEB20767",
+            BIOPROJECT_ACCESSION_DB_KEY: "PRJEB20767",
             "ena_submission_accession": "ERA912529",
         }
         assert response.result == desired_response
@@ -212,7 +220,7 @@ class TestCreateSample:
         response = create_ena_sample(MOCK_CONFIG, sample_set)
         desired_response = {
             "ena_sample_accession": "ERS1833148",
-            "biosample_accession": "SAMEA104174130",
+            BIOSAMPLE_ACCESSION_DB_KEY: "SAMEA104174130",
             "ena_submission_accession": "ERA979927",
         }
         assert response.result == desired_response
@@ -409,10 +417,10 @@ class AssemblyCreationTests(unittest.TestCase):
         self.assertEqual(
             result_multi,
             {
-                "insdc_accession_seg2": "OZ189935",
-                "insdc_accession_seg3": "OZ189936",
-                "insdc_accession_full_seg2": "OZ189935.1",
-                "insdc_accession_full_seg3": "OZ189936.1",
+                f"{NUCCORE_ACCESSION_PREFIX_DB_KEY}_seg2": "OZ189935",
+                f"{NUCCORE_ACCESSION_PREFIX_DB_KEY}_seg3": "OZ189936",
+                f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}_seg2": "OZ189935.1",
+                f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}_seg3": "OZ189936.1",
             },
         )
 
@@ -422,8 +430,8 @@ class AssemblyCreationTests(unittest.TestCase):
         self.assertEqual(
             result_single,
             {
-                "insdc_accession": "OZ189935",
-                "insdc_accession_full": "OZ189935.1",
+                f"{NUCCORE_ACCESSION_PREFIX_DB_KEY}": "OZ189935",
+                f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}": "OZ189935.1",
             },
         )
 
@@ -433,8 +441,8 @@ class AssemblyCreationTests(unittest.TestCase):
         self.assertEqual(
             result_single,
             {
-                "insdc_accession_seg3": "OZ189935",
-                "insdc_accession_full_seg3": "OZ189935.1",
+                f"{NUCCORE_ACCESSION_PREFIX_DB_KEY}_seg3": "OZ189935",
+                f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}_seg3": "OZ189935.1",
             },
         )
 
@@ -462,8 +470,8 @@ class AssemblyCreationTests(unittest.TestCase):
         )
         desired_response = {
             "erz_accession": "ERZ000001",
-            "insdc_accession": "OZ189999",
-            "insdc_accession_full": "OZ189999.1",
+            NUCCORE_ACCESSION_PREFIX_DB_KEY: "OZ189999",
+            VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY: "OZ189999.1",
             "segment_order": ["main"],
         }
         self.assertEqual(response.result, desired_response)

--- a/ena-submission/scripts/test_ena_submission.py
+++ b/ena-submission/scripts/test_ena_submission.py
@@ -13,10 +13,7 @@ from unittest import mock
 import xmltodict
 import yaml
 from ena_deposition.config import (
-    DBKeys.BIOPROJECT_ACCESSION,
-    DBKeys.BIOSAMPLE_ACCESSION,
-    DBKeys.NUCCORE_ACCESSION_PREFIX,
-    DBKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX,
+    DBKeys,
     EnaOrganismDetails,
     ManifestFieldDetails,
     MetadataMapping,

--- a/ena-submission/scripts/test_ena_submission_integration.py
+++ b/ena-submission/scripts/test_ena_submission_integration.py
@@ -27,16 +27,9 @@ from ena_deposition.check_external_visibility import (
     check_and_update_visibility_for_column,
 )
 from ena_deposition.config import (
-    ASSEMBLY_ACCESSION_DB_KEY,
-    ASSEMBLY_ACCESSION_LOCULUS_KEY,
-    BIOPROJECT_ACCESSION_DB_KEY,
-    BIOPROJECT_ACCESSION_LOCULUS_KEY,
-    BIOSAMPLE_ACCESSION_DB_KEY,
-    BIOSAMPLE_ACCESSION_LOCULUS_KEY,
-    NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY,
-    VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY,
-    VERSIONED_NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY,
     Config,
+    DBKeys,
+    LoculusKeys,
     get_config,
 )
 from ena_deposition.create_assembly import (
@@ -103,7 +96,7 @@ def assert_biosample_accession(
     assert len(rows) == 1, f"Sample for {full_accession} not found in sample table."
     if biosample_accession:
         assert rows[0].result, f"No result for sample {full_accession} in sample table."
-        assert rows[0].result.get(BIOSAMPLE_ACCESSION_DB_KEY) == biosample_accession, (
+        assert rows[0].result.get(DBKeys.BIOSAMPLE_ACCESSION) == biosample_accession, (
             "Incorrect biosample accession in sample table."
         )
 
@@ -114,7 +107,7 @@ def assert_bioproject_accession(
     assert len(rows) == 1, f"Project {group_id} for {full_accession} not found in project table."
     if bioproject_accession:
         assert rows[0].result, f"No result for project {group_id} in project table."
-        assert rows[0].result.get(BIOPROJECT_ACCESSION_DB_KEY) == bioproject_accession, (
+        assert rows[0].result.get(DBKeys.BIOPROJECT_ACCESSION) == bioproject_accession, (
             "Incorrect bioproject accession in project table."
         )
 
@@ -182,7 +175,7 @@ def check_sample_submission_submitted(
             conditions={"accession": accession, "version": version, "status": "SUBMITTED"},
         )
         assert_biosample_accession(
-            rows, data["metadata"][BIOSAMPLE_ACCESSION_LOCULUS_KEY], full_accession
+            rows, data["metadata"][LoculusKeys.BIOSAMPLE_ACCESSION], full_accession
         )
         assert in_submission_table(
             db_engine,
@@ -201,7 +194,7 @@ def check_sample_submission_has_errors(
             conditions={"accession": accession, "version": version, "status": "HAS_ERRORS"},
         )
         assert_biosample_accession(
-            rows, data["metadata"][BIOSAMPLE_ACCESSION_LOCULUS_KEY], full_accession
+            rows, data["metadata"][LoculusKeys.BIOSAMPLE_ACCESSION], full_accession
         )
 
 
@@ -288,9 +281,9 @@ def check_assembly_submission_with_nuc_without_gca(
             f"Assembly for {full_accession} not in state 'WAITING' in assembly table."
         )
         assert rows[0].result, f"No result for assembly {full_accession} in assembly table."
-        assert rows[0].result.get(f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}_L") is not None
-        assert rows[0].result.get(f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}_M") is None
-        assert rows[0].result.get(ASSEMBLY_ACCESSION_DB_KEY) is None
+        assert rows[0].result.get(f"{DBKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX}_L") is not None
+        assert rows[0].result.get(f"{DBKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX}_M") is None
+        assert rows[0].result.get(DBKeys.ASSEMBLY_ACCESSION) is None
 
 
 def check_sent_to_loculus(db_engine: Engine, sequences_to_upload: dict[str, Any]) -> None:
@@ -319,7 +312,7 @@ def check_project_submission_submitted(
             conditions={"group_id": group_id, "organism": organism, "status": "SUBMITTED"},
         )
         assert_bioproject_accession(
-            rows, data["metadata"][BIOPROJECT_ACCESSION_LOCULUS_KEY], group_id, full_accession
+            rows, data["metadata"][LoculusKeys.BIOPROJECT_ACCESSION], group_id, full_accession
         )
         assert in_submission_table(
             db_engine,
@@ -339,7 +332,7 @@ def check_project_submission_has_errors(
             conditions={"group_id": group_id, "organism": organism, "status": "HAS_ERRORS"},
         )
         assert_bioproject_accession(
-            rows, data["metadata"][BIOPROJECT_ACCESSION_LOCULUS_KEY], group_id, full_accession
+            rows, data["metadata"][LoculusKeys.BIOPROJECT_ACCESSION], group_id, full_accession
         )
 
 
@@ -527,8 +520,8 @@ def multi_segment_submission(
     payload = args[0][0][0]  # first positional argument of first call
     assert payload["accession"] == "LOC_0001TLY"
     assert payload["version"] == 1
-    assert set(payload["externalMetadata"]) == {BIOPROJECT_ACCESSION_LOCULUS_KEY}
-    assert payload["externalMetadata"][BIOPROJECT_ACCESSION_LOCULUS_KEY].startswith("PRJEB")
+    assert set(payload["externalMetadata"]) == {LoculusKeys.BIOPROJECT_ACCESSION}
+    assert payload["externalMetadata"][LoculusKeys.BIOPROJECT_ACCESSION].startswith("PRJEB")
 
     _test_successful_sample_submission(db_engine, config, sequences_to_upload)
     get_external_metadata_and_send_to_loculus(db_engine, config)
@@ -538,11 +531,11 @@ def multi_segment_submission(
     assert payload["accession"] == "LOC_0001TLY"
     assert payload["version"] == 1
     assert set(payload["externalMetadata"]) == {
-        BIOPROJECT_ACCESSION_LOCULUS_KEY,
-        BIOSAMPLE_ACCESSION_LOCULUS_KEY,
+        LoculusKeys.BIOPROJECT_ACCESSION,
+        LoculusKeys.BIOSAMPLE_ACCESSION,
     }
-    assert payload["externalMetadata"][BIOPROJECT_ACCESSION_LOCULUS_KEY].startswith("PRJEB")
-    assert payload["externalMetadata"][BIOSAMPLE_ACCESSION_LOCULUS_KEY].startswith("SAMEA")
+    assert payload["externalMetadata"][LoculusKeys.BIOPROJECT_ACCESSION].startswith("PRJEB")
+    assert payload["externalMetadata"][LoculusKeys.BIOSAMPLE_ACCESSION].startswith("SAMEA")
 
     _test_successful_assembly_submission(db_engine, config, sequences_to_upload, single_segment)
     get_external_metadata_and_send_to_loculus(db_engine, config)
@@ -557,19 +550,19 @@ def multi_segment_submission(
     extra_items = set()
     if not single_segment:
         extra_items = {
-            ASSEMBLY_ACCESSION_LOCULUS_KEY,
-            f"{NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY}_M",
-            f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY}_M",
+            LoculusKeys.ASSEMBLY_ACCESSION,
+            f"{LoculusKeys.NUCCORE_ACCESSION_PREFIX}_M",
+            f"{LoculusKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX}_M",
         }
     assert set(payload["externalMetadata"]) == {
-        BIOPROJECT_ACCESSION_LOCULUS_KEY,
-        BIOSAMPLE_ACCESSION_LOCULUS_KEY,
-        f"{NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY}_L",
-        f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY}_L",
+        LoculusKeys.BIOPROJECT_ACCESSION,
+        LoculusKeys.BIOSAMPLE_ACCESSION,
+        f"{LoculusKeys.NUCCORE_ACCESSION_PREFIX}_L",
+        f"{LoculusKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX}_L",
         *extra_items,
     }
-    assert payload["externalMetadata"][BIOPROJECT_ACCESSION_LOCULUS_KEY].startswith("PRJEB")
-    assert payload["externalMetadata"][BIOSAMPLE_ACCESSION_LOCULUS_KEY].startswith("SAMEA")
+    assert payload["externalMetadata"][LoculusKeys.BIOPROJECT_ACCESSION].startswith("PRJEB")
+    assert payload["externalMetadata"][LoculusKeys.BIOSAMPLE_ACCESSION].startswith("SAMEA")
 
     insdc_full_pattern = r"^[A-Z]{2}[0-9]{6}\.[0-9]+$"
     insdc_base_pattern = r"^[A-Z]{2}[0-9]{6}$"
@@ -577,22 +570,22 @@ def multi_segment_submission(
 
     assert re.match(
         insdc_full_pattern,
-        payload["externalMetadata"][f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY}_L"],
+        payload["externalMetadata"][f"{LoculusKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX}_L"],
     ), (
         "insdcAccessionFull_L "
-        f"'{payload['externalMetadata'][f'{VERSIONED_NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY}_L']}' "
+        f"'{payload['externalMetadata'][f'{LoculusKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX}_L']}' "
         f"does not match INSDC full pattern {insdc_full_pattern}"
     )
     assert re.match(
-        insdc_base_pattern, payload["externalMetadata"][f"{NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY}_L"]
+        insdc_base_pattern, payload["externalMetadata"][f"{LoculusKeys.NUCCORE_ACCESSION_PREFIX}_L"]
     ), (
         f"insdcAccessionBase_L "
-        f"'{payload['externalMetadata'][f'{NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY}_L']}' "
+        f"'{payload['externalMetadata'][f'{LoculusKeys.NUCCORE_ACCESSION_PREFIX}_L']}' "
         f"does not match INSDC base pattern {insdc_base_pattern}"
     )
     if not single_segment:
-        assert re.match(gca_pattern, payload["externalMetadata"][ASSEMBLY_ACCESSION_LOCULUS_KEY]), (
-            f"gcaAccession '{payload['externalMetadata'][ASSEMBLY_ACCESSION_LOCULUS_KEY]}' "
+        assert re.match(gca_pattern, payload["externalMetadata"][LoculusKeys.ASSEMBLY_ACCESSION]), (
+            f"gcaAccession '{payload['externalMetadata'][LoculusKeys.ASSEMBLY_ACCESSION]}' "
             f"does not match GCA pattern {gca_pattern}"
         )
 
@@ -622,8 +615,8 @@ class TestSubmission:
 
 class TestFirstPublicUpdate(TestSubmission):
     PROJECT_CONFIG: Final = {
-        "invalid_result": {BIOPROJECT_ACCESSION_DB_KEY: "PRJEB2"},
-        "valid_result": {BIOPROJECT_ACCESSION_DB_KEY: "PRJEB53055"},
+        "invalid_result": {DBKeys.BIOPROJECT_ACCESSION: "PRJEB2"},
+        "valid_result": {DBKeys.BIOPROJECT_ACCESSION: "PRJEB53055"},
         "base_entry": {
             "group_id": 1,
             "organism": "test_organism",
@@ -633,8 +626,8 @@ class TestFirstPublicUpdate(TestSubmission):
     }
 
     SAMPLE_CONFIG: Final = {
-        "invalid_result": {BIOSAMPLE_ACCESSION_DB_KEY: "SAMEA999999999"},
-        "valid_result": {BIOSAMPLE_ACCESSION_DB_KEY: "SAMEA7997453"},
+        "invalid_result": {DBKeys.BIOSAMPLE_ACCESSION: "SAMEA999999999"},
+        "valid_result": {DBKeys.BIOSAMPLE_ACCESSION: "SAMEA7997453"},
         "base_entry": {
             "accession": "test_accession",
             "version": 1,
@@ -645,12 +638,12 @@ class TestFirstPublicUpdate(TestSubmission):
 
     NUCLEOTIDE_CONFIG: Final = {
         "invalid_result": {
-            f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}_seg1": "XY999999",
-            f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}_seg2": "XY999998",
+            f"{DBKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX}_seg1": "XY999999",
+            f"{DBKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX}_seg2": "XY999998",
         },
         "valid_result": {
-            f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}_seg1": "OZ271453",
-            f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}_seg2": "OZ271454",
+            f"{DBKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX}_seg1": "OZ271453",
+            f"{DBKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX}_seg2": "OZ271454",
         },
         "base_entry": {
             "accession": "test_accession",
@@ -661,8 +654,8 @@ class TestFirstPublicUpdate(TestSubmission):
     }
 
     GCA_CONFIG: Final = {
-        "invalid_result": {ASSEMBLY_ACCESSION_DB_KEY: "GCA_999999999.1"},
-        "valid_result": {ASSEMBLY_ACCESSION_DB_KEY: "GCA_965196905.1"},
+        "invalid_result": {DBKeys.ASSEMBLY_ACCESSION: "GCA_999999999.1"},
+        "valid_result": {DBKeys.ASSEMBLY_ACCESSION: "GCA_965196905.1"},
         "base_entry": {
             "accession": "test_accession",
             "version": 1,
@@ -816,7 +809,7 @@ class TestKnownBioproject(TestSubmission):
         mock_submit_external_metadata.return_value = mock_requests_post()
         sequences_to_upload = get_sequences()
         for entry in sequences_to_upload.values():  # set to known public bioproject
-            entry["metadata"][BIOPROJECT_ACCESSION_LOCULUS_KEY] = "PRJNA231221"
+            entry["metadata"][LoculusKeys.BIOPROJECT_ACCESSION] = "PRJNA231221"
 
         # upload sequences
         upload_sequences(self.db_engine, sequences_to_upload)
@@ -843,7 +836,7 @@ class TestIncorrectBioprojectPassed(TestSubmission):
         mock_notify.return_value = None
         sequences_to_upload = get_sequences()
         for entry in sequences_to_upload.values():  # set to invalid bioproject
-            entry["metadata"][BIOPROJECT_ACCESSION_LOCULUS_KEY] = "INVALID_ACCESSION"
+            entry["metadata"][LoculusKeys.BIOPROJECT_ACCESSION] = "INVALID_ACCESSION"
 
         # upload sequences
         upload_sequences(self.db_engine, sequences_to_upload)
@@ -879,8 +872,8 @@ class TestKnownBioprojectAndBioSample(TestSubmission):
         mock_submit_external_metadata.return_value = mock_requests_post()
         sequences_to_upload = get_sequences()
         for entry in sequences_to_upload.values():  # set to public bioproject and biosample
-            entry["metadata"][BIOPROJECT_ACCESSION_LOCULUS_KEY] = "PRJNA231221"
-            entry["metadata"][BIOSAMPLE_ACCESSION_LOCULUS_KEY] = "SAMN11077987"
+            entry["metadata"][LoculusKeys.BIOPROJECT_ACCESSION] = "PRJNA231221"
+            entry["metadata"][LoculusKeys.BIOSAMPLE_ACCESSION] = "SAMN11077987"
 
         # upload
         upload_sequences(self.db_engine, sequences_to_upload)
@@ -916,8 +909,8 @@ class TestKnownBioprojectAndIncorrectBioSample(TestSubmission):
         mock_notify.return_value = None
         sequences_to_upload = get_sequences()
         for entry in sequences_to_upload.values():  # set to invalid biosample
-            entry["metadata"][BIOPROJECT_ACCESSION_LOCULUS_KEY] = "PRJNA231221"
-            entry["metadata"][BIOSAMPLE_ACCESSION_LOCULUS_KEY] = "INVALID_ACCESSION"
+            entry["metadata"][LoculusKeys.BIOPROJECT_ACCESSION] = "PRJNA231221"
+            entry["metadata"][LoculusKeys.BIOSAMPLE_ACCESSION] = "INVALID_ACCESSION"
 
         # upload
         upload_sequences(self.db_engine, sequences_to_upload)

--- a/ena-submission/scripts/test_ena_submission_integration.py
+++ b/ena-submission/scripts/test_ena_submission_integration.py
@@ -26,7 +26,19 @@ from ena_deposition.check_external_visibility import (
     EntityType,
     check_and_update_visibility_for_column,
 )
-from ena_deposition.config import Config, get_config
+from ena_deposition.config import (
+    ASSEMBLY_ACCESSION_DB_KEY,
+    ASSEMBLY_ACCESSION_LOCULUS_KEY,
+    BIOPROJECT_ACCESSION_DB_KEY,
+    BIOPROJECT_ACCESSION_LOCULUS_KEY,
+    BIOSAMPLE_ACCESSION_DB_KEY,
+    BIOSAMPLE_ACCESSION_LOCULUS_KEY,
+    NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY,
+    VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY,
+    VERSIONED_NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY,
+    Config,
+    get_config,
+)
 from ena_deposition.create_assembly import (
     assembly_table_create,
     assembly_table_handle_errors,
@@ -91,7 +103,7 @@ def assert_biosample_accession(
     assert len(rows) == 1, f"Sample for {full_accession} not found in sample table."
     if biosample_accession:
         assert rows[0].result, f"No result for sample {full_accession} in sample table."
-        assert rows[0].result.get("biosample_accession") == biosample_accession, (
+        assert rows[0].result.get(BIOSAMPLE_ACCESSION_DB_KEY) == biosample_accession, (
             "Incorrect biosample accession in sample table."
         )
 
@@ -102,7 +114,7 @@ def assert_bioproject_accession(
     assert len(rows) == 1, f"Project {group_id} for {full_accession} not found in project table."
     if bioproject_accession:
         assert rows[0].result, f"No result for project {group_id} in project table."
-        assert rows[0].result.get("bioproject_accession") == bioproject_accession, (
+        assert rows[0].result.get(BIOPROJECT_ACCESSION_DB_KEY) == bioproject_accession, (
             "Incorrect bioproject accession in project table."
         )
 
@@ -169,7 +181,9 @@ def check_sample_submission_submitted(
             SampleTableEntry,
             conditions={"accession": accession, "version": version, "status": "SUBMITTED"},
         )
-        assert_biosample_accession(rows, data["metadata"]["biosampleAccession"], full_accession)
+        assert_biosample_accession(
+            rows, data["metadata"][BIOSAMPLE_ACCESSION_LOCULUS_KEY], full_accession
+        )
         assert in_submission_table(
             db_engine,
             {"accession": accession, "version": version, "status_all": StatusAll.SUBMITTED_SAMPLE},
@@ -186,7 +200,9 @@ def check_sample_submission_has_errors(
             SampleTableEntry,
             conditions={"accession": accession, "version": version, "status": "HAS_ERRORS"},
         )
-        assert_biosample_accession(rows, data["metadata"]["biosampleAccession"], full_accession)
+        assert_biosample_accession(
+            rows, data["metadata"][BIOSAMPLE_ACCESSION_LOCULUS_KEY], full_accession
+        )
 
 
 def check_assembly_submission_waiting(
@@ -272,9 +288,9 @@ def check_assembly_submission_with_nuc_without_gca(
             f"Assembly for {full_accession} not in state 'WAITING' in assembly table."
         )
         assert rows[0].result, f"No result for assembly {full_accession} in assembly table."
-        assert rows[0].result.get("insdc_accession_full_L") is not None
-        assert rows[0].result.get("insdc_accession_full_M") is None
-        assert rows[0].result.get("gca_accession") is None
+        assert rows[0].result.get(f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}_L") is not None
+        assert rows[0].result.get(f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}_M") is None
+        assert rows[0].result.get(ASSEMBLY_ACCESSION_DB_KEY) is None
 
 
 def check_sent_to_loculus(db_engine: Engine, sequences_to_upload: dict[str, Any]) -> None:
@@ -303,7 +319,7 @@ def check_project_submission_submitted(
             conditions={"group_id": group_id, "organism": organism, "status": "SUBMITTED"},
         )
         assert_bioproject_accession(
-            rows, data["metadata"]["bioprojectAccession"], group_id, full_accession
+            rows, data["metadata"][BIOPROJECT_ACCESSION_LOCULUS_KEY], group_id, full_accession
         )
         assert in_submission_table(
             db_engine,
@@ -323,7 +339,7 @@ def check_project_submission_has_errors(
             conditions={"group_id": group_id, "organism": organism, "status": "HAS_ERRORS"},
         )
         assert_bioproject_accession(
-            rows, data["metadata"]["bioprojectAccession"], group_id, full_accession
+            rows, data["metadata"][BIOPROJECT_ACCESSION_LOCULUS_KEY], group_id, full_accession
         )
 
 
@@ -511,8 +527,8 @@ def multi_segment_submission(
     payload = args[0][0][0]  # first positional argument of first call
     assert payload["accession"] == "LOC_0001TLY"
     assert payload["version"] == 1
-    assert set(payload["externalMetadata"]) == {"bioprojectAccession"}
-    assert payload["externalMetadata"]["bioprojectAccession"].startswith("PRJEB")
+    assert set(payload["externalMetadata"]) == {BIOPROJECT_ACCESSION_LOCULUS_KEY}
+    assert payload["externalMetadata"][BIOPROJECT_ACCESSION_LOCULUS_KEY].startswith("PRJEB")
 
     _test_successful_sample_submission(db_engine, config, sequences_to_upload)
     get_external_metadata_and_send_to_loculus(db_engine, config)
@@ -521,9 +537,12 @@ def multi_segment_submission(
     payload = args[1][0][0]  # first positional argument of second call
     assert payload["accession"] == "LOC_0001TLY"
     assert payload["version"] == 1
-    assert set(payload["externalMetadata"]) == {"bioprojectAccession", "biosampleAccession"}
-    assert payload["externalMetadata"]["bioprojectAccession"].startswith("PRJEB")
-    assert payload["externalMetadata"]["biosampleAccession"].startswith("SAMEA")
+    assert set(payload["externalMetadata"]) == {
+        BIOPROJECT_ACCESSION_LOCULUS_KEY,
+        BIOSAMPLE_ACCESSION_LOCULUS_KEY,
+    }
+    assert payload["externalMetadata"][BIOPROJECT_ACCESSION_LOCULUS_KEY].startswith("PRJEB")
+    assert payload["externalMetadata"][BIOSAMPLE_ACCESSION_LOCULUS_KEY].startswith("SAMEA")
 
     _test_successful_assembly_submission(db_engine, config, sequences_to_upload, single_segment)
     get_external_metadata_and_send_to_loculus(db_engine, config)
@@ -537,32 +556,43 @@ def multi_segment_submission(
     assert payload["version"] == 1
     extra_items = set()
     if not single_segment:
-        extra_items = {"gcaAccession", "insdcAccessionBase_M", "insdcAccessionFull_M"}
+        extra_items = {
+            ASSEMBLY_ACCESSION_LOCULUS_KEY,
+            f"{NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY}_M",
+            f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY}_M",
+        }
     assert set(payload["externalMetadata"]) == {
-        "bioprojectAccession",
-        "biosampleAccession",
-        "insdcAccessionBase_L",
-        "insdcAccessionFull_L",
+        BIOPROJECT_ACCESSION_LOCULUS_KEY,
+        BIOSAMPLE_ACCESSION_LOCULUS_KEY,
+        f"{NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY}_L",
+        f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY}_L",
         *extra_items,
     }
-    assert payload["externalMetadata"]["bioprojectAccession"].startswith("PRJEB")
-    assert payload["externalMetadata"]["biosampleAccession"].startswith("SAMEA")
+    assert payload["externalMetadata"][BIOPROJECT_ACCESSION_LOCULUS_KEY].startswith("PRJEB")
+    assert payload["externalMetadata"][BIOSAMPLE_ACCESSION_LOCULUS_KEY].startswith("SAMEA")
 
     insdc_full_pattern = r"^[A-Z]{2}[0-9]{6}\.[0-9]+$"
     insdc_base_pattern = r"^[A-Z]{2}[0-9]{6}$"
     gca_pattern = r"^GCA_[0-9]{9}\.[0-9]+$"
 
-    assert re.match(insdc_full_pattern, payload["externalMetadata"]["insdcAccessionFull_L"]), (
-        f"insdcAccessionFull_L '{payload['externalMetadata']['insdcAccessionFull_L']}' "
+    assert re.match(
+        insdc_full_pattern,
+        payload["externalMetadata"][f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY}_L"],
+    ), (
+        "insdcAccessionFull_L "
+        f"'{payload['externalMetadata'][f'{VERSIONED_NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY}_L']}' "
         f"does not match INSDC full pattern {insdc_full_pattern}"
     )
-    assert re.match(insdc_base_pattern, payload["externalMetadata"]["insdcAccessionBase_L"]), (
-        f"insdcAccessionBase_L '{payload['externalMetadata']['insdcAccessionBase_L']}' "
+    assert re.match(
+        insdc_base_pattern, payload["externalMetadata"][f"{NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY}_L"]
+    ), (
+        f"insdcAccessionBase_L "
+        f"'{payload['externalMetadata'][f'{NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY}_L']}' "
         f"does not match INSDC base pattern {insdc_base_pattern}"
     )
     if not single_segment:
-        assert re.match(gca_pattern, payload["externalMetadata"]["gcaAccession"]), (
-            f"gcaAccession '{payload['externalMetadata']['gcaAccession']}' "
+        assert re.match(gca_pattern, payload["externalMetadata"][ASSEMBLY_ACCESSION_LOCULUS_KEY]), (
+            f"gcaAccession '{payload['externalMetadata'][ASSEMBLY_ACCESSION_LOCULUS_KEY]}' "
             f"does not match GCA pattern {gca_pattern}"
         )
 
@@ -592,8 +622,8 @@ class TestSubmission:
 
 class TestFirstPublicUpdate(TestSubmission):
     PROJECT_CONFIG: Final = {
-        "invalid_result": {"bioproject_accession": "PRJEB2"},
-        "valid_result": {"bioproject_accession": "PRJEB53055"},
+        "invalid_result": {BIOPROJECT_ACCESSION_DB_KEY: "PRJEB2"},
+        "valid_result": {BIOPROJECT_ACCESSION_DB_KEY: "PRJEB53055"},
         "base_entry": {
             "group_id": 1,
             "organism": "test_organism",
@@ -603,8 +633,8 @@ class TestFirstPublicUpdate(TestSubmission):
     }
 
     SAMPLE_CONFIG: Final = {
-        "invalid_result": {"biosample_accession": "SAMEA999999999"},
-        "valid_result": {"biosample_accession": "SAMEA7997453"},
+        "invalid_result": {BIOSAMPLE_ACCESSION_DB_KEY: "SAMEA999999999"},
+        "valid_result": {BIOSAMPLE_ACCESSION_DB_KEY: "SAMEA7997453"},
         "base_entry": {
             "accession": "test_accession",
             "version": 1,
@@ -615,12 +645,12 @@ class TestFirstPublicUpdate(TestSubmission):
 
     NUCLEOTIDE_CONFIG: Final = {
         "invalid_result": {
-            "insdc_accession_full_seg1": "XY999999",
-            "insdc_accession_full_seg2": "XY999998",
+            f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}_seg1": "XY999999",
+            f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}_seg2": "XY999998",
         },
         "valid_result": {
-            "insdc_accession_full_seg1": "OZ271453",
-            "insdc_accession_full_seg2": "OZ271454",
+            f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}_seg1": "OZ271453",
+            f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}_seg2": "OZ271454",
         },
         "base_entry": {
             "accession": "test_accession",
@@ -631,8 +661,8 @@ class TestFirstPublicUpdate(TestSubmission):
     }
 
     GCA_CONFIG: Final = {
-        "invalid_result": {"gca_accession": "GCA_999999999.1"},
-        "valid_result": {"gca_accession": "GCA_965196905.1"},
+        "invalid_result": {ASSEMBLY_ACCESSION_DB_KEY: "GCA_999999999.1"},
+        "valid_result": {ASSEMBLY_ACCESSION_DB_KEY: "GCA_965196905.1"},
         "base_entry": {
             "accession": "test_accession",
             "version": 1,
@@ -786,7 +816,7 @@ class TestKnownBioproject(TestSubmission):
         mock_submit_external_metadata.return_value = mock_requests_post()
         sequences_to_upload = get_sequences()
         for entry in sequences_to_upload.values():  # set to known public bioproject
-            entry["metadata"]["bioprojectAccession"] = "PRJNA231221"
+            entry["metadata"][BIOPROJECT_ACCESSION_LOCULUS_KEY] = "PRJNA231221"
 
         # upload sequences
         upload_sequences(self.db_engine, sequences_to_upload)
@@ -813,7 +843,7 @@ class TestIncorrectBioprojectPassed(TestSubmission):
         mock_notify.return_value = None
         sequences_to_upload = get_sequences()
         for entry in sequences_to_upload.values():  # set to invalid bioproject
-            entry["metadata"]["bioprojectAccession"] = "INVALID_ACCESSION"
+            entry["metadata"][BIOPROJECT_ACCESSION_LOCULUS_KEY] = "INVALID_ACCESSION"
 
         # upload sequences
         upload_sequences(self.db_engine, sequences_to_upload)
@@ -849,8 +879,8 @@ class TestKnownBioprojectAndBioSample(TestSubmission):
         mock_submit_external_metadata.return_value = mock_requests_post()
         sequences_to_upload = get_sequences()
         for entry in sequences_to_upload.values():  # set to public bioproject and biosample
-            entry["metadata"]["bioprojectAccession"] = "PRJNA231221"
-            entry["metadata"]["biosampleAccession"] = "SAMN11077987"
+            entry["metadata"][BIOPROJECT_ACCESSION_LOCULUS_KEY] = "PRJNA231221"
+            entry["metadata"][BIOSAMPLE_ACCESSION_LOCULUS_KEY] = "SAMN11077987"
 
         # upload
         upload_sequences(self.db_engine, sequences_to_upload)
@@ -886,8 +916,8 @@ class TestKnownBioprojectAndIncorrectBioSample(TestSubmission):
         mock_notify.return_value = None
         sequences_to_upload = get_sequences()
         for entry in sequences_to_upload.values():  # set to invalid biosample
-            entry["metadata"]["bioprojectAccession"] = "PRJNA231221"
-            entry["metadata"]["biosampleAccession"] = "INVALID_ACCESSION"
+            entry["metadata"][BIOPROJECT_ACCESSION_LOCULUS_KEY] = "PRJNA231221"
+            entry["metadata"][BIOSAMPLE_ACCESSION_LOCULUS_KEY] = "INVALID_ACCESSION"
 
         # upload
         upload_sequences(self.db_engine, sequences_to_upload)

--- a/ena-submission/src/ena_deposition/api.py
+++ b/ena-submission/src/ena_deposition/api.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from sqlalchemy import Engine, select
 from sqlalchemy.orm import Session
 
-from .config import BIOSAMPLE_ACCESSION_DB_KEY, VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY, Config
+from .config import Config, DBKeys
 from .submission_db_helper import AssemblyTableEntry, SampleTableEntry, Status, db_init
 
 logger = logging.getLogger(__name__)
@@ -27,7 +27,7 @@ def get_bio_sample_accessions(engine: Engine) -> dict[str, str]:
         stmt = select(SampleTableEntry).where(SampleTableEntry.status == Status.SUBMITTED)
         results = list(session.scalars(stmt).all())
     return {
-        row.accession: cast(str, row.result[BIOSAMPLE_ACCESSION_DB_KEY])
+        row.accession: cast(str, row.result[DBKeys.BIOSAMPLE_ACCESSION])
         for row in results
         if row.result
     }
@@ -43,7 +43,7 @@ def get_insdc_accessions(engine: Engine) -> dict[str, list[str]]:
         row.accession: [
             cast(str, row.result[key])
             for key in row.result
-            if key.startswith(VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY)
+            if key.startswith(DBKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX)
         ]
         for row in results
         if row.result

--- a/ena-submission/src/ena_deposition/api.py
+++ b/ena-submission/src/ena_deposition/api.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from sqlalchemy import Engine, select
 from sqlalchemy.orm import Session
 
-from .config import Config
+from .config import BIOSAMPLE_ACCESSION_DB_KEY, VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY, Config
 from .submission_db_helper import AssemblyTableEntry, SampleTableEntry, Status, db_init
 
 logger = logging.getLogger(__name__)
@@ -27,7 +27,7 @@ def get_bio_sample_accessions(engine: Engine) -> dict[str, str]:
         stmt = select(SampleTableEntry).where(SampleTableEntry.status == Status.SUBMITTED)
         results = list(session.scalars(stmt).all())
     return {
-        row.accession: cast(str, row.result["biosample_accession"]) for row in results if row.result
+        row.accession: cast(str, row.result[BIOSAMPLE_ACCESSION_DB_KEY]) for row in results if row.result
     }
 
 
@@ -41,7 +41,7 @@ def get_insdc_accessions(engine: Engine) -> dict[str, list[str]]:
         row.accession: [
             cast(str, row.result[key])
             for key in row.result
-            if key.startswith("insdc_accession_full")
+            if key.startswith(VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY)
         ]
         for row in results
         if row.result

--- a/ena-submission/src/ena_deposition/api.py
+++ b/ena-submission/src/ena_deposition/api.py
@@ -27,7 +27,9 @@ def get_bio_sample_accessions(engine: Engine) -> dict[str, str]:
         stmt = select(SampleTableEntry).where(SampleTableEntry.status == Status.SUBMITTED)
         results = list(session.scalars(stmt).all())
     return {
-        row.accession: cast(str, row.result[BIOSAMPLE_ACCESSION_DB_KEY]) for row in results if row.result
+        row.accession: cast(str, row.result[BIOSAMPLE_ACCESSION_DB_KEY])
+        for row in results
+        if row.result
     }
 
 

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -21,11 +21,8 @@ import requests
 from sqlalchemy import Engine
 
 from ena_deposition.config import (
-    ASSEMBLY_ACCESSION_DB_KEY,
-    BIOPROJECT_ACCESSION_DB_KEY,
-    BIOSAMPLE_ACCESSION_DB_KEY,
-    VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY,
     Config,
+    DBKeys,
 )
 from ena_deposition.submission_db_helper import (
     AssemblyTableEntry,
@@ -158,25 +155,25 @@ COLUMN_CONFIGS = {
     (EntityType.PROJECT, "ena_first_publicly_visible"): ColumnCheckConfig(
         entry_class=ProjectTableEntry,
         visibility_column="ena_first_publicly_visible",
-        accession_field_name_prefix=BIOPROJECT_ACCESSION_DB_KEY,
+        accession_field_name_prefix=DBKeys.BIOPROJECT_ACCESSION,
         checker_class=ENAVisibilityChecker,
     ),
     (EntityType.PROJECT, "ncbi_first_publicly_visible"): ColumnCheckConfig(
         entry_class=ProjectTableEntry,
         visibility_column="ncbi_first_publicly_visible",
-        accession_field_name_prefix=BIOPROJECT_ACCESSION_DB_KEY,
+        accession_field_name_prefix=DBKeys.BIOPROJECT_ACCESSION,
         checker_class=NCBIVisibilityChecker,
     ),
     (EntityType.SAMPLE, "ena_first_publicly_visible"): ColumnCheckConfig(
         entry_class=SampleTableEntry,
         visibility_column="ena_first_publicly_visible",
-        accession_field_name_prefix=BIOSAMPLE_ACCESSION_DB_KEY,
+        accession_field_name_prefix=DBKeys.BIOSAMPLE_ACCESSION,
         checker_class=ENAVisibilityChecker,
     ),
     (EntityType.SAMPLE, "ncbi_first_publicly_visible"): ColumnCheckConfig(
         entry_class=SampleTableEntry,
         visibility_column="ncbi_first_publicly_visible",
-        accession_field_name_prefix=BIOSAMPLE_ACCESSION_DB_KEY,
+        accession_field_name_prefix=DBKeys.BIOSAMPLE_ACCESSION,
         checker_class=NCBIVisibilityChecker,
     ),
     # Assemblies - ENA nucleotide accessions
@@ -184,27 +181,27 @@ COLUMN_CONFIGS = {
         entry_class=AssemblyTableEntry,
         visibility_column="ena_nucleotide_first_publicly_visible",
         # Prefix for multi-segment accessions
-        accession_field_name_prefix=VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY,
+        accession_field_name_prefix=DBKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX,
         checker_class=ENAVisibilityChecker,
     ),
     (EntityType.ASSEMBLY, "ncbi_nucleotide_first_publicly_visible"): ColumnCheckConfig(
         entry_class=AssemblyTableEntry,
         visibility_column="ncbi_nucleotide_first_publicly_visible",
         # Prefix for multi-segment accessions
-        accession_field_name_prefix=VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY,
+        accession_field_name_prefix=DBKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX,
         checker_class=NCBIVisibilityChecker,
     ),
     # Assemblies - ENA GCA accessions
     (EntityType.ASSEMBLY, "ena_gca_first_publicly_visible"): ColumnCheckConfig(
         entry_class=AssemblyTableEntry,
         visibility_column="ena_gca_first_publicly_visible",
-        accession_field_name_prefix=ASSEMBLY_ACCESSION_DB_KEY,
+        accession_field_name_prefix=DBKeys.ASSEMBLY_ACCESSION,
         checker_class=ENAVisibilityChecker,
     ),
     (EntityType.ASSEMBLY, "ncbi_gca_first_publicly_visible"): ColumnCheckConfig(
         entry_class=AssemblyTableEntry,
         visibility_column="ncbi_gca_first_publicly_visible",
-        accession_field_name_prefix=ASSEMBLY_ACCESSION_DB_KEY,
+        accession_field_name_prefix=DBKeys.ASSEMBLY_ACCESSION,
         checker_class=NCBIVisibilityChecker,
     ),
 }

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -20,7 +20,13 @@ import pytz
 import requests
 from sqlalchemy import Engine
 
-from ena_deposition.config import Config
+from ena_deposition.config import (
+    ASSEMBLY_ACCESSION_DB_KEY,
+    BIOPROJECT_ACCESSION_DB_KEY,
+    BIOSAMPLE_ACCESSION_DB_KEY,
+    VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY,
+    Config,
+)
 from ena_deposition.submission_db_helper import (
     AssemblyTableEntry,
     ProjectTableEntry,
@@ -152,51 +158,53 @@ COLUMN_CONFIGS = {
     (EntityType.PROJECT, "ena_first_publicly_visible"): ColumnCheckConfig(
         entry_class=ProjectTableEntry,
         visibility_column="ena_first_publicly_visible",
-        accession_field_name_prefix="bioproject_accession",
+        accession_field_name_prefix=BIOPROJECT_ACCESSION_DB_KEY,
         checker_class=ENAVisibilityChecker,
     ),
     (EntityType.PROJECT, "ncbi_first_publicly_visible"): ColumnCheckConfig(
         entry_class=ProjectTableEntry,
         visibility_column="ncbi_first_publicly_visible",
-        accession_field_name_prefix="bioproject_accession",
+        accession_field_name_prefix=BIOPROJECT_ACCESSION_DB_KEY,
         checker_class=NCBIVisibilityChecker,
     ),
     (EntityType.SAMPLE, "ena_first_publicly_visible"): ColumnCheckConfig(
         entry_class=SampleTableEntry,
         visibility_column="ena_first_publicly_visible",
-        accession_field_name_prefix="biosample_accession",
+        accession_field_name_prefix=BIOSAMPLE_ACCESSION_DB_KEY,
         checker_class=ENAVisibilityChecker,
     ),
     (EntityType.SAMPLE, "ncbi_first_publicly_visible"): ColumnCheckConfig(
         entry_class=SampleTableEntry,
         visibility_column="ncbi_first_publicly_visible",
-        accession_field_name_prefix="biosample_accession",
+        accession_field_name_prefix=BIOSAMPLE_ACCESSION_DB_KEY,
         checker_class=NCBIVisibilityChecker,
     ),
     # Assemblies - ENA nucleotide accessions
     (EntityType.ASSEMBLY, "ena_nucleotide_first_publicly_visible"): ColumnCheckConfig(
         entry_class=AssemblyTableEntry,
         visibility_column="ena_nucleotide_first_publicly_visible",
-        accession_field_name_prefix="insdc_accession_full",  # Prefix for multi-segment accessions
+        # Prefix for multi-segment accessions
+        accession_field_name_prefix=VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY,
         checker_class=ENAVisibilityChecker,
     ),
     (EntityType.ASSEMBLY, "ncbi_nucleotide_first_publicly_visible"): ColumnCheckConfig(
         entry_class=AssemblyTableEntry,
         visibility_column="ncbi_nucleotide_first_publicly_visible",
-        accession_field_name_prefix="insdc_accession_full",  # Prefix for multi-segment accessions
+        # Prefix for multi-segment accessions
+        accession_field_name_prefix=VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY,
         checker_class=NCBIVisibilityChecker,
     ),
     # Assemblies - ENA GCA accessions
     (EntityType.ASSEMBLY, "ena_gca_first_publicly_visible"): ColumnCheckConfig(
         entry_class=AssemblyTableEntry,
         visibility_column="ena_gca_first_publicly_visible",
-        accession_field_name_prefix="gca_accession",
+        accession_field_name_prefix=ASSEMBLY_ACCESSION_DB_KEY,
         checker_class=ENAVisibilityChecker,
     ),
     (EntityType.ASSEMBLY, "ncbi_gca_first_publicly_visible"): ColumnCheckConfig(
         entry_class=AssemblyTableEntry,
         visibility_column="ncbi_gca_first_publicly_visible",
-        accession_field_name_prefix="gca_accession",
+        accession_field_name_prefix=ASSEMBLY_ACCESSION_DB_KEY,
         checker_class=NCBIVisibilityChecker,
     ),
 }

--- a/ena-submission/src/ena_deposition/config.py
+++ b/ena-submission/src/ena_deposition/config.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from dataclasses import field
+from typing import Final
 
 import dotenv
 import yaml
@@ -9,6 +10,18 @@ from pydantic import BaseModel
 from ena_deposition.ena_types import MoleculeType, Topology
 
 logger = logging.getLogger(__name__)
+
+# Constants for mapping between database keys and Loculus field names for external metadata fields
+BIOPROJECT_ACCESSION_DB_KEY: Final = "bioproject_accession"
+BIOPROJECT_ACCESSION_LOCULUS_KEY: Final = "bioprojectAccession"
+BIOSAMPLE_ACCESSION_DB_KEY: Final = "biosample_accession"
+BIOSAMPLE_ACCESSION_LOCULUS_KEY: Final = "biosampleAccession"
+ASSEMBLY_ACCESSION_DB_KEY: Final = "gca_accession"
+ASSEMBLY_ACCESSION_LOCULUS_KEY: Final = "gcaAccession"
+NUCCORE_ACCESSION_PREFIX_DB_KEY: Final = "insdc_accession"
+NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY: Final = "insdcAccessionBase"
+VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY: Final = "insdc_accession_full"
+VERSIONED_NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY: Final = "insdcAccessionFull"
 
 
 class MetadataMapping(BaseModel):

--- a/ena-submission/src/ena_deposition/config.py
+++ b/ena-submission/src/ena_deposition/config.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from dataclasses import field
-from typing import Final
+from enum import StrEnum
 
 import dotenv
 import yaml
@@ -11,17 +11,22 @@ from ena_deposition.ena_types import MoleculeType, Topology
 
 logger = logging.getLogger(__name__)
 
+
 # Constants for mapping between database keys and Loculus field names for external metadata fields
-BIOPROJECT_ACCESSION_DB_KEY: Final = "bioproject_accession"
-BIOPROJECT_ACCESSION_LOCULUS_KEY: Final = "bioprojectAccession"
-BIOSAMPLE_ACCESSION_DB_KEY: Final = "biosample_accession"
-BIOSAMPLE_ACCESSION_LOCULUS_KEY: Final = "biosampleAccession"
-ASSEMBLY_ACCESSION_DB_KEY: Final = "gca_accession"
-ASSEMBLY_ACCESSION_LOCULUS_KEY: Final = "gcaAccession"
-NUCCORE_ACCESSION_PREFIX_DB_KEY: Final = "insdc_accession"
-NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY: Final = "insdcAccessionBase"
-VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY: Final = "insdc_accession_full"
-VERSIONED_NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY: Final = "insdcAccessionFull"
+class DBKeys(StrEnum):
+    BIOPROJECT_ACCESSION = "bioproject_accession"
+    BIOSAMPLE_ACCESSION = "biosample_accession"
+    ASSEMBLY_ACCESSION = "gca_accession"
+    NUCCORE_ACCESSION_PREFIX = "insdc_accession"
+    VERSIONED_NUCCORE_ACCESSION_PREFIX = "insdc_accession_full"
+
+
+class LoculusKeys(StrEnum):
+    BIOPROJECT_ACCESSION = "bioprojectAccession"
+    BIOSAMPLE_ACCESSION = "biosampleAccession"
+    ASSEMBLY_ACCESSION = "gcaAccession"
+    NUCCORE_ACCESSION_PREFIX = "insdcAccessionBase"
+    VERSIONED_NUCCORE_ACCESSION_PREFIX = "insdcAccessionFull"
 
 
 class MetadataMapping(BaseModel):

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -15,13 +15,10 @@ from sqlalchemy import Engine
 from ena_deposition import call_loculus
 
 from .config import (
-    ASSEMBLY_ACCESSION_DB_KEY,
-    BIOPROJECT_ACCESSION_DB_KEY,
-    BIOPROJECT_ACCESSION_LOCULUS_KEY,
-    BIOSAMPLE_ACCESSION_LOCULUS_KEY,
-    VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY,
     Config,
+    DBKeys,
     EnaOrganismDetails,
+    LoculusKeys,
 )
 from .ena_submission_helper import (
     CreationResult,
@@ -385,8 +382,8 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
         f"Previous sample accession: {previous_sample_accession}, "
         f"previous study accession: {previous_study_accession}"
     )
-    if submission_row.seq_metadata.get(BIOSAMPLE_ACCESSION_LOCULUS_KEY):
-        new_sample_accession = submission_row.seq_metadata[BIOSAMPLE_ACCESSION_LOCULUS_KEY]
+    if submission_row.seq_metadata.get(LoculusKeys.BIOSAMPLE_ACCESSION):
+        new_sample_accession = submission_row.seq_metadata[LoculusKeys.BIOSAMPLE_ACCESSION]
         if previous_sample_accession != new_sample_accession:
             error = (
                 "Assembly cannot be revised because biosampleAccession in new version: "
@@ -400,8 +397,8 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
                 update_type="revision",
             )
             return False
-    if submission_row.seq_metadata.get(BIOPROJECT_ACCESSION_LOCULUS_KEY):
-        new_project_accession = submission_row.seq_metadata[BIOPROJECT_ACCESSION_LOCULUS_KEY]
+    if submission_row.seq_metadata.get(LoculusKeys.BIOPROJECT_ACCESSION):
+        new_project_accession = submission_row.seq_metadata[LoculusKeys.BIOPROJECT_ACCESSION]
         if new_project_accession != previous_study_accession:
             error = (
                 "Assembly cannot be revised because bioprojectAccession in new version: "
@@ -552,7 +549,7 @@ def get_project_and_sample_results(
         sample_rows[0].result.get("ena_sample_accession") if sample_rows[0].result else None
     )
     study_accession = (
-        project_rows[0].result.get(BIOPROJECT_ACCESSION_DB_KEY) if project_rows[0].result else None
+        project_rows[0].result.get(DBKeys.BIOPROJECT_ACCESSION) if project_rows[0].result else None
     )
     if not sample_accession or not study_accession:
         error_msg = (
@@ -708,9 +705,9 @@ def assembly_table_update(db_engine: Engine, config: Config, time_threshold: int
             if not new_result.result:
                 continue
 
-            result_contains_gca_accession = ASSEMBLY_ACCESSION_DB_KEY in new_result.result
+            result_contains_gca_accession = DBKeys.ASSEMBLY_ACCESSION in new_result.result
             result_contains_insdc_accession = any(
-                key.startswith(VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY)
+                key.startswith(DBKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX)
                 for key in new_result.result
             )
 

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -14,7 +14,15 @@ from sqlalchemy import Engine
 
 from ena_deposition import call_loculus
 
-from .config import Config, EnaOrganismDetails
+from .config import (
+    ASSEMBLY_ACCESSION_DB_KEY,
+    BIOPROJECT_ACCESSION_DB_KEY,
+    BIOPROJECT_ACCESSION_LOCULUS_KEY,
+    BIOSAMPLE_ACCESSION_LOCULUS_KEY,
+    VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY,
+    Config,
+    EnaOrganismDetails,
+)
 from .ena_submission_helper import (
     CreationResult,
     accession_exists,
@@ -377,8 +385,8 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
         f"Previous sample accession: {previous_sample_accession}, "
         f"previous study accession: {previous_study_accession}"
     )
-    if submission_row.seq_metadata.get("biosampleAccession"):
-        new_sample_accession = submission_row.seq_metadata["biosampleAccession"]
+    if submission_row.seq_metadata.get(BIOSAMPLE_ACCESSION_LOCULUS_KEY):
+        new_sample_accession = submission_row.seq_metadata[BIOSAMPLE_ACCESSION_LOCULUS_KEY]
         if previous_sample_accession != new_sample_accession:
             error = (
                 "Assembly cannot be revised because biosampleAccession in new version: "
@@ -392,8 +400,8 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
                 update_type="revision",
             )
             return False
-    if submission_row.seq_metadata.get("bioprojectAccession"):
-        new_project_accession = submission_row.seq_metadata["bioprojectAccession"]
+    if submission_row.seq_metadata.get(BIOPROJECT_ACCESSION_LOCULUS_KEY):
+        new_project_accession = submission_row.seq_metadata[BIOPROJECT_ACCESSION_LOCULUS_KEY]
         if new_project_accession != previous_study_accession:
             error = (
                 "Assembly cannot be revised because bioprojectAccession in new version: "
@@ -544,7 +552,7 @@ def get_project_and_sample_results(
         sample_rows[0].result.get("ena_sample_accession") if sample_rows[0].result else None
     )
     study_accession = (
-        project_rows[0].result.get("bioproject_accession") if project_rows[0].result else None
+        project_rows[0].result.get(BIOPROJECT_ACCESSION_DB_KEY) if project_rows[0].result else None
     )
     if not sample_accession or not study_accession:
         error_msg = (
@@ -700,9 +708,10 @@ def assembly_table_update(db_engine: Engine, config: Config, time_threshold: int
             if not new_result.result:
                 continue
 
-            result_contains_gca_accession = "gca_accession" in new_result.result
+            result_contains_gca_accession = ASSEMBLY_ACCESSION_DB_KEY in new_result.result
             result_contains_insdc_accession = any(
-                key.startswith("insdc_accession_full") for key in new_result.result
+                key.startswith(VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY)
+                for key in new_result.result
             )
 
             if not (result_contains_gca_accession and result_contains_insdc_accession):

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -9,7 +9,7 @@ from sqlalchemy import Engine
 from ena_deposition import call_loculus
 from ena_deposition.loculus_models import Group
 
-from .config import Config
+from .config import BIOPROJECT_ACCESSION_DB_KEY, BIOPROJECT_ACCESSION_LOCULUS_KEY, Config
 from .ena_submission_helper import (
     CreationResult,
     accession_exists,
@@ -106,13 +106,13 @@ def set_project_table_entry(db_engine: Engine, config: Config, row: SubmissionTa
     logger.debug(f"Accession {row.accession} already has bioprojectAccession in metadata")
     group_key = {"group_id": row.group_id, "organism": row.organism}
     seq_key = {"accession": row.accession, "version": row.version}
-    bioproject = row.seq_metadata["bioprojectAccession"]
+    bioproject = row.seq_metadata[BIOPROJECT_ACCESSION_DB_KEY]
 
     corresponding_group = find_conditions_in_db(db_engine, ProjectTableEntry, conditions=group_key)
     corresponding_project = [
         project
         for project in corresponding_group
-        if project.result and project.result.get("bioproject_accession") == bioproject
+        if project.result and project.result.get(BIOPROJECT_ACCESSION_DB_KEY) == bioproject
     ]
     if len(corresponding_project) == 1:
         if corresponding_project[0].status != Status.SUBMITTED:
@@ -153,7 +153,7 @@ def set_project_table_entry(db_engine: Engine, config: Config, row: SubmissionTa
     project_table_entry = ProjectTableEntry(
         group_id=row.group_id,
         organism=row.organism,
-        result={"bioproject_accession": bioproject},
+        result={BIOPROJECT_ACCESSION_DB_KEY: bioproject},
         status=Status.SUBMITTED,
         center_name=center_name,
     )
@@ -192,7 +192,7 @@ def sync_state_with_submission_table(db_engine: Engine, config: Config):
         seq_key = {"accession": row.accession, "version": row.version}
 
         # Use custom bioprojectAccession if it exists
-        if row.seq_metadata.get("bioprojectAccession"):
+        if row.seq_metadata.get(BIOPROJECT_ACCESSION_LOCULUS_KEY):
             set_project_table_entry(db_engine, config, row)
             continue
 

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -9,7 +9,7 @@ from sqlalchemy import Engine
 from ena_deposition import call_loculus
 from ena_deposition.loculus_models import Group
 
-from .config import BIOPROJECT_ACCESSION_DB_KEY, BIOPROJECT_ACCESSION_LOCULUS_KEY, Config
+from .config import Config, DBKeys, LoculusKeys
 from .ena_submission_helper import (
     CreationResult,
     accession_exists,
@@ -106,13 +106,13 @@ def set_project_table_entry(db_engine: Engine, config: Config, row: SubmissionTa
     logger.debug(f"Accession {row.accession} already has bioprojectAccession in metadata")
     group_key = {"group_id": row.group_id, "organism": row.organism}
     seq_key = {"accession": row.accession, "version": row.version}
-    bioproject = row.seq_metadata[BIOPROJECT_ACCESSION_DB_KEY]
+    bioproject = row.seq_metadata[LoculusKeys.BIOPROJECT_ACCESSION]
 
     corresponding_group = find_conditions_in_db(db_engine, ProjectTableEntry, conditions=group_key)
     corresponding_project = [
         project
         for project in corresponding_group
-        if project.result and project.result.get(BIOPROJECT_ACCESSION_DB_KEY) == bioproject
+        if project.result and project.result.get(DBKeys.BIOPROJECT_ACCESSION) == bioproject
     ]
     if len(corresponding_project) == 1:
         if corresponding_project[0].status != Status.SUBMITTED:
@@ -153,7 +153,7 @@ def set_project_table_entry(db_engine: Engine, config: Config, row: SubmissionTa
     project_table_entry = ProjectTableEntry(
         group_id=row.group_id,
         organism=row.organism,
-        result={BIOPROJECT_ACCESSION_DB_KEY: bioproject},
+        result={DBKeys.BIOPROJECT_ACCESSION: bioproject},
         status=Status.SUBMITTED,
         center_name=center_name,
     )
@@ -192,7 +192,7 @@ def sync_state_with_submission_table(db_engine: Engine, config: Config):
         seq_key = {"accession": row.accession, "version": row.version}
 
         # Use custom bioprojectAccession if it exists
-        if row.seq_metadata.get(BIOPROJECT_ACCESSION_LOCULUS_KEY):
+        if row.seq_metadata.get(LoculusKeys.BIOPROJECT_ACCESSION):
             set_project_table_entry(db_engine, config, row)
             continue
 

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -8,7 +8,12 @@ from datetime import datetime
 import pytz
 from sqlalchemy import Engine
 
-from .config import Config, MetadataMapping
+from .config import (
+    BIOSAMPLE_ACCESSION_DB_KEY,
+    BIOSAMPLE_ACCESSION_LOCULUS_KEY,
+    Config,
+    MetadataMapping,
+)
 from .ena_submission_helper import (
     CreationResult,
     accession_exists,
@@ -173,7 +178,7 @@ def set_sample_table_entry(
     logger.debug(
         f"Accession: {row.accession} already has biosampleAccession, adding to sample_table"
     )
-    biosample = row.seq_metadata["biosampleAccession"]
+    biosample = row.seq_metadata[BIOSAMPLE_ACCESSION_DB_KEY]
 
     logger.info("Checking if biosample actually exists and is public")
     seq_key = asdict(row.pkey)
@@ -189,7 +194,7 @@ def set_sample_table_entry(
     sample_table_entry = SampleTableEntry(
         accession=row.accession,
         version=row.version,
-        result={"ena_sample_accession": biosample, "biosample_accession": biosample},
+        result={"ena_sample_accession": biosample, BIOSAMPLE_ACCESSION_DB_KEY: biosample},
         status=Status.SUBMITTED,
     )
     succeeded = add_to_sample_table(db_engine, sample_table_entry)
@@ -211,7 +216,7 @@ def sync_state_with_submission_table(db_engine: Engine, config: Config):
     1. Find all entries in submission_table in state SUBMITTED_PROJECT
     2. If (exists an entry in the sample_table for (accession, version)):
     a.      If (in state SUBMITTED) update state in submission_table to SUBMITTED_SAMPLE
-    3. If (exists "biosampleAccession" in "metadata"):
+    3. If (exists BIOSAMPLE_ACCESSION_LOCULUS_KEY in "metadata"):
         create entry in sample_table, update state to SUBMITTED_SAMPLE
     4. Else create corresponding entry in sample_table
     """
@@ -237,7 +242,7 @@ def sync_state_with_submission_table(db_engine: Engine, config: Config):
                     update_values={"status_all": StatusAll.SUBMITTED_SAMPLE},
                 )
         else:
-            if row.seq_metadata.get("biosampleAccession"):
+            if row.seq_metadata.get(BIOSAMPLE_ACCESSION_LOCULUS_KEY):  # type: ignore
                 set_sample_table_entry(db_engine, row, seq_key, config)
                 continue
             if not add_to_sample_table(db_engine, SampleTableEntry(**seq_key)):

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -178,7 +178,7 @@ def set_sample_table_entry(
     logger.debug(
         f"Accession: {row.accession} already has biosampleAccession, adding to sample_table"
     )
-    biosample = row.seq_metadata[DBKeys.BIOSAMPLE_ACCESSION]
+    biosample = row.seq_metadata[LoculusKeys.BIOSAMPLE_ACCESSION]
 
     logger.info("Checking if biosample actually exists and is public")
     seq_key = asdict(row.pkey)

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -9,9 +9,9 @@ import pytz
 from sqlalchemy import Engine
 
 from .config import (
-    BIOSAMPLE_ACCESSION_DB_KEY,
-    BIOSAMPLE_ACCESSION_LOCULUS_KEY,
     Config,
+    DBKeys,
+    LoculusKeys,
     MetadataMapping,
 )
 from .ena_submission_helper import (
@@ -178,7 +178,7 @@ def set_sample_table_entry(
     logger.debug(
         f"Accession: {row.accession} already has biosampleAccession, adding to sample_table"
     )
-    biosample = row.seq_metadata[BIOSAMPLE_ACCESSION_DB_KEY]
+    biosample = row.seq_metadata[DBKeys.BIOSAMPLE_ACCESSION]
 
     logger.info("Checking if biosample actually exists and is public")
     seq_key = asdict(row.pkey)
@@ -194,7 +194,7 @@ def set_sample_table_entry(
     sample_table_entry = SampleTableEntry(
         accession=row.accession,
         version=row.version,
-        result={"ena_sample_accession": biosample, BIOSAMPLE_ACCESSION_DB_KEY: biosample},
+        result={"ena_sample_accession": biosample, DBKeys.BIOSAMPLE_ACCESSION: biosample},
         status=Status.SUBMITTED,
     )
     succeeded = add_to_sample_table(db_engine, sample_table_entry)
@@ -216,7 +216,7 @@ def sync_state_with_submission_table(db_engine: Engine, config: Config):
     1. Find all entries in submission_table in state SUBMITTED_PROJECT
     2. If (exists an entry in the sample_table for (accession, version)):
     a.      If (in state SUBMITTED) update state in submission_table to SUBMITTED_SAMPLE
-    3. If (exists BIOSAMPLE_ACCESSION_LOCULUS_KEY in "metadata"):
+    3. If (exists LoculusKeys.BIOSAMPLE_ACCESSION in "metadata"):
         create entry in sample_table, update state to SUBMITTED_SAMPLE
     4. Else create corresponding entry in sample_table
     """
@@ -242,7 +242,7 @@ def sync_state_with_submission_table(db_engine: Engine, config: Config):
                     update_values={"status_all": StatusAll.SUBMITTED_SAMPLE},
                 )
         else:
-            if row.seq_metadata.get(BIOSAMPLE_ACCESSION_LOCULUS_KEY):  # type: ignore
+            if row.seq_metadata.get(LoculusKeys.BIOSAMPLE_ACCESSION):  # type: ignore
                 set_sample_table_entry(db_engine, row, seq_key, config)
                 continue
             if not add_to_sample_table(db_engine, SampleTableEntry(**seq_key)):

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -34,7 +34,15 @@ from tenacity import (
 )
 from unidecode import unidecode
 
-from ena_deposition.config import Config, EnaOrganismDetails
+from ena_deposition.config import (
+    ASSEMBLY_ACCESSION_DB_KEY,
+    BIOPROJECT_ACCESSION_DB_KEY,
+    BIOSAMPLE_ACCESSION_DB_KEY,
+    NUCCORE_ACCESSION_PREFIX_DB_KEY,
+    VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY,
+    Config,
+    EnaOrganismDetails,
+)
 
 from .ena_types import (
     DEFAULT_EMBL_PROPERTY_FIELDS,
@@ -261,7 +269,7 @@ def create_ena_project(config: Config, project_set: ProjectSet) -> CreationResul
         errors.append(error_message)
         return CreationResult(errors=errors, warnings=warnings)
     project_results = {
-        "bioproject_accession": parsed_response["RECEIPT"]["PROJECT"]["@accession"],
+        BIOPROJECT_ACCESSION_DB_KEY: parsed_response["RECEIPT"]["PROJECT"]["@accession"],
         "ena_submission_accession": parsed_response["RECEIPT"]["SUBMISSION"]["@accession"],
     }
     return CreationResult(result=project_results, errors=errors, warnings=warnings)
@@ -334,7 +342,7 @@ def create_ena_sample(
         return CreationResult(errors=errors, warnings=warnings)
     sample_results = {
         "ena_sample_accession": parsed_response["RECEIPT"]["SAMPLE"]["@accession"],
-        "biosample_accession": parsed_response["RECEIPT"]["SAMPLE"]["EXT_ID"]["@accession"],
+        BIOSAMPLE_ACCESSION_DB_KEY: parsed_response["RECEIPT"]["SAMPLE"]["EXT_ID"]["@accession"],
         "ena_submission_accession": parsed_response["RECEIPT"]["SUBMISSION"]["@accession"],
     }
     return CreationResult(result=sample_results, errors=errors, warnings=warnings)
@@ -734,7 +742,7 @@ def get_ena_analysis_process(
             if gca_accession:
                 assembly_results.update(
                     {
-                        "gca_accession": gca_accession,
+                        ASSEMBLY_ACCESSION_DB_KEY: gca_accession,
                     }
                 )
             insdc_accession_range = acc_dict.get("chromosomes")
@@ -799,14 +807,14 @@ def get_chromsome_accessions(
         if not is_multi_segment:
             accession = f"{start_letters}{start_num:0{num_digits}d}"
             return {
-                "insdc_accession": accession,
-                "insdc_accession_full": f"{accession}.1",
+                NUCCORE_ACCESSION_PREFIX_DB_KEY: accession,
+                VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY: f"{accession}.1",
             }
         results = {}
         for i, segment in enumerate(segment_order):
             accession = f"{start_letters}{(start_num + i):0{num_digits}d}"
-            results[f"insdc_accession_{segment}"] = accession
-            results[f"insdc_accession_full_{segment}"] = f"{accession}.1"
+            results[f"{NUCCORE_ACCESSION_PREFIX_DB_KEY}_{segment}"] = accession
+            results[f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}_{segment}"] = f"{accession}.1"
         return results
 
     # Don't handle the Value error here, let it propagate
@@ -853,7 +861,7 @@ def set_accession_does_not_exist_error(
                 **conditions,  # type: ignore
                 status=Status.HAS_ERRORS,
                 errors=[error_text],
-                result={"ena_sample_accession": accession, "biosample_accession": accession},
+                result={"ena_sample_accession": accession, BIOSAMPLE_ACCESSION_DB_KEY: accession},
             )
             succeeded = add_to_sample_table(db_engine, sample_table_entry)
         case "BIOPROJECT":
@@ -861,7 +869,7 @@ def set_accession_does_not_exist_error(
                 **conditions,  # type: ignore
                 status=Status.HAS_ERRORS,
                 errors=[error_text],
-                result={"bioproject_accession": accession},
+                result={BIOPROJECT_ACCESSION_DB_KEY: accession},
             )
             succeeded = add_to_project_table(db_engine, project_table_entry)
         case "RUN_REF":

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -35,12 +35,8 @@ from tenacity import (
 from unidecode import unidecode
 
 from ena_deposition.config import (
-    ASSEMBLY_ACCESSION_DB_KEY,
-    BIOPROJECT_ACCESSION_DB_KEY,
-    BIOSAMPLE_ACCESSION_DB_KEY,
-    NUCCORE_ACCESSION_PREFIX_DB_KEY,
-    VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY,
     Config,
+    DBKeys,
     EnaOrganismDetails,
 )
 
@@ -269,7 +265,7 @@ def create_ena_project(config: Config, project_set: ProjectSet) -> CreationResul
         errors.append(error_message)
         return CreationResult(errors=errors, warnings=warnings)
     project_results = {
-        BIOPROJECT_ACCESSION_DB_KEY: parsed_response["RECEIPT"]["PROJECT"]["@accession"],
+        DBKeys.BIOPROJECT_ACCESSION: parsed_response["RECEIPT"]["PROJECT"]["@accession"],
         "ena_submission_accession": parsed_response["RECEIPT"]["SUBMISSION"]["@accession"],
     }
     return CreationResult(result=project_results, errors=errors, warnings=warnings)
@@ -342,7 +338,7 @@ def create_ena_sample(
         return CreationResult(errors=errors, warnings=warnings)
     sample_results = {
         "ena_sample_accession": parsed_response["RECEIPT"]["SAMPLE"]["@accession"],
-        BIOSAMPLE_ACCESSION_DB_KEY: parsed_response["RECEIPT"]["SAMPLE"]["EXT_ID"]["@accession"],
+        DBKeys.BIOSAMPLE_ACCESSION: parsed_response["RECEIPT"]["SAMPLE"]["EXT_ID"]["@accession"],
         "ena_submission_accession": parsed_response["RECEIPT"]["SUBMISSION"]["@accession"],
     }
     return CreationResult(result=sample_results, errors=errors, warnings=warnings)
@@ -742,7 +738,7 @@ def get_ena_analysis_process(
             if gca_accession:
                 assembly_results.update(
                     {
-                        ASSEMBLY_ACCESSION_DB_KEY: gca_accession,
+                        DBKeys.ASSEMBLY_ACCESSION: gca_accession,
                     }
                 )
             insdc_accession_range = acc_dict.get("chromosomes")
@@ -807,14 +803,14 @@ def get_chromsome_accessions(
         if not is_multi_segment:
             accession = f"{start_letters}{start_num:0{num_digits}d}"
             return {
-                NUCCORE_ACCESSION_PREFIX_DB_KEY: accession,
-                VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY: f"{accession}.1",
+                DBKeys.NUCCORE_ACCESSION_PREFIX: accession,
+                DBKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX: f"{accession}.1",
             }
         results = {}
         for i, segment in enumerate(segment_order):
             accession = f"{start_letters}{(start_num + i):0{num_digits}d}"
-            results[f"{NUCCORE_ACCESSION_PREFIX_DB_KEY}_{segment}"] = accession
-            results[f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}_{segment}"] = f"{accession}.1"
+            results[f"{DBKeys.NUCCORE_ACCESSION_PREFIX}_{segment}"] = accession
+            results[f"{DBKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX}_{segment}"] = f"{accession}.1"
         return results
 
     # Don't handle the Value error here, let it propagate
@@ -861,7 +857,7 @@ def set_accession_does_not_exist_error(
                 **conditions,  # type: ignore
                 status=Status.HAS_ERRORS,
                 errors=[error_text],
-                result={"ena_sample_accession": accession, BIOSAMPLE_ACCESSION_DB_KEY: accession},
+                result={"ena_sample_accession": accession, DBKeys.BIOSAMPLE_ACCESSION: accession},
             )
             succeeded = add_to_sample_table(db_engine, sample_table_entry)
         case "BIOPROJECT":
@@ -869,7 +865,7 @@ def set_accession_does_not_exist_error(
                 **conditions,  # type: ignore
                 status=Status.HAS_ERRORS,
                 errors=[error_text],
-                result={BIOPROJECT_ACCESSION_DB_KEY: accession},
+                result={DBKeys.BIOPROJECT_ACCESSION: accession},
             )
             succeeded = add_to_project_table(db_engine, project_table_entry)
         case "RUN_REF":

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -246,12 +246,7 @@ class AssemblyTableEntry(Base):
         return AccessionVersion(accession=self.accession, version=self.version)
 
 
-type TableEntry = (
-    SubmissionTableEntry
-    | ProjectTableEntry
-    | SampleTableEntry
-    | AssemblyTableEntry
-)
+type TableEntry = SubmissionTableEntry | ProjectTableEntry | SampleTableEntry | AssemblyTableEntry
 
 
 def highest_version_in_submission_table(engine: Engine) -> dict[Accession, Version]:
@@ -265,9 +260,7 @@ def highest_version_in_submission_table(engine: Engine) -> dict[Accession, Versi
     return {row.accession: row.version for row in rows}
 
 
-def find_conditions_in_db[
-    T: TableEntry
-](
+def find_conditions_in_db[T: TableEntry](
     engine: Engine,
     model_class: type[T],
     conditions: dict[str, Any],
@@ -289,9 +282,7 @@ def find_conditions_in_db[
         return rows
 
 
-def delete_records_in_db[
-    T: TableEntry
-](
+def delete_records_in_db[T: TableEntry](
     engine: Engine,
     model_class: type[T],
     conditions: dict[str, Any],
@@ -369,9 +360,7 @@ def find_waiting_in_db(
         return rows
 
 
-def update_db_where_conditions[
-    T: TableEntry
-](
+def update_db_where_conditions[T: TableEntry](
     engine: Engine,
     model_class: type[T],
     conditions: Mapping[str, Any],
@@ -415,9 +404,7 @@ def update_db_where_conditions[
     return updated_row_count
 
 
-def update_with_retry[
-    T: TableEntry
-](
+def update_with_retry[T: TableEntry](
     db_engine: Engine,
     conditions: Mapping[str, Any],
     model_class: type[T],

--- a/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
+++ b/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
@@ -12,7 +12,20 @@ from sqlalchemy import Engine
 
 from ena_deposition.call_loculus import submit_external_metadata
 
-from .config import Config, EnaOrganismDetails
+from .config import (
+    ASSEMBLY_ACCESSION_DB_KEY,
+    ASSEMBLY_ACCESSION_LOCULUS_KEY,
+    BIOPROJECT_ACCESSION_DB_KEY,
+    BIOPROJECT_ACCESSION_LOCULUS_KEY,
+    BIOSAMPLE_ACCESSION_DB_KEY,
+    BIOSAMPLE_ACCESSION_LOCULUS_KEY,
+    NUCCORE_ACCESSION_PREFIX_DB_KEY,
+    NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY,
+    VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY,
+    VERSIONED_NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY,
+    Config,
+    EnaOrganismDetails,
+)
 from .notifications import SlackConfig, send_slack_notification, slack_conn_init
 from .submission_db_helper import (
     AssemblyTableEntry,
@@ -61,10 +74,10 @@ def get_bioproject_accession_from_db(db_engine: Engine, project_id: int | None) 
         db_engine, ProjectTableEntry, conditions={"project_id": project_id}
     )
 
-    if not result or "bioproject_accession" not in result:
+    if not result or BIOPROJECT_ACCESSION_DB_KEY not in result:
         return {}
 
-    return {"bioprojectAccession": result["bioproject_accession"]}
+    return {BIOPROJECT_ACCESSION_LOCULUS_KEY: result[BIOPROJECT_ACCESSION_DB_KEY]}
 
 
 def get_biosample_accession_from_db(
@@ -76,10 +89,10 @@ def get_biosample_accession_from_db(
         conditions={"accession": accession, "version": version},
     )
 
-    if not result or "biosample_accession" not in result:
+    if not result or BIOSAMPLE_ACCESSION_DB_KEY not in result:
         return {}
 
-    return {"biosampleAccession": result["biosample_accession"]}
+    return {BIOSAMPLE_ACCESSION_LOCULUS_KEY: result[BIOSAMPLE_ACCESSION_DB_KEY]}
 
 
 def get_assembly_accessions_from_db(
@@ -100,8 +113,8 @@ def get_assembly_accessions_from_db(
     data = {}
     all_present = True
 
-    if gca := result.get("gca_accession"):
-        data["gcaAccession"] = gca
+    if gca := result.get(ASSEMBLY_ACCESSION_DB_KEY):
+        data[ASSEMBLY_ACCESSION_LOCULUS_KEY] = gca
     else:
         all_present = False
 
@@ -109,15 +122,17 @@ def get_assembly_accessions_from_db(
     for segment in segment_names:
         segment_suffix = f"_{segment}" if organism.is_multi_segment() else ""
 
-        base_key = f"insdc_accession{segment_suffix}"
+        base_key = f"{NUCCORE_ACCESSION_PREFIX_DB_KEY}{segment_suffix}"
         if base_key in result:
-            data[f"insdcAccessionBase{segment_suffix}"] = result[base_key]
+            data[f"{NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY}{segment_suffix}"] = result[base_key]
         else:
             all_present = False
 
-        full_key = f"insdc_accession_full{segment_suffix}"
+        full_key = f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}{segment_suffix}"
         if full_key in result:
-            data[f"insdcAccessionFull{segment_suffix}"] = result[full_key]
+            data[f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY}{segment_suffix}"] = result[
+                full_key
+            ]
         else:
             all_present = False
 

--- a/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
+++ b/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
@@ -13,18 +13,10 @@ from sqlalchemy import Engine
 from ena_deposition.call_loculus import submit_external_metadata
 
 from .config import (
-    ASSEMBLY_ACCESSION_DB_KEY,
-    ASSEMBLY_ACCESSION_LOCULUS_KEY,
-    BIOPROJECT_ACCESSION_DB_KEY,
-    BIOPROJECT_ACCESSION_LOCULUS_KEY,
-    BIOSAMPLE_ACCESSION_DB_KEY,
-    BIOSAMPLE_ACCESSION_LOCULUS_KEY,
-    NUCCORE_ACCESSION_PREFIX_DB_KEY,
-    NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY,
-    VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY,
-    VERSIONED_NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY,
     Config,
+    DBKeys,
     EnaOrganismDetails,
+    LoculusKeys,
 )
 from .notifications import SlackConfig, send_slack_notification, slack_conn_init
 from .submission_db_helper import (
@@ -74,10 +66,10 @@ def get_bioproject_accession_from_db(db_engine: Engine, project_id: int | None) 
         db_engine, ProjectTableEntry, conditions={"project_id": project_id}
     )
 
-    if not result or BIOPROJECT_ACCESSION_DB_KEY not in result:
+    if not result or DBKeys.BIOPROJECT_ACCESSION not in result:
         return {}
 
-    return {BIOPROJECT_ACCESSION_LOCULUS_KEY: result[BIOPROJECT_ACCESSION_DB_KEY]}
+    return {LoculusKeys.BIOPROJECT_ACCESSION: result[DBKeys.BIOPROJECT_ACCESSION]}
 
 
 def get_biosample_accession_from_db(
@@ -89,10 +81,10 @@ def get_biosample_accession_from_db(
         conditions={"accession": accession, "version": version},
     )
 
-    if not result or BIOSAMPLE_ACCESSION_DB_KEY not in result:
+    if not result or DBKeys.BIOSAMPLE_ACCESSION not in result:
         return {}
 
-    return {BIOSAMPLE_ACCESSION_LOCULUS_KEY: result[BIOSAMPLE_ACCESSION_DB_KEY]}
+    return {LoculusKeys.BIOSAMPLE_ACCESSION: result[DBKeys.BIOSAMPLE_ACCESSION]}
 
 
 def get_assembly_accessions_from_db(
@@ -113,8 +105,8 @@ def get_assembly_accessions_from_db(
     data = {}
     all_present = True
 
-    if gca := result.get(ASSEMBLY_ACCESSION_DB_KEY):
-        data[ASSEMBLY_ACCESSION_LOCULUS_KEY] = gca
+    if gca := result.get(DBKeys.ASSEMBLY_ACCESSION):
+        data[LoculusKeys.ASSEMBLY_ACCESSION] = gca
     else:
         all_present = False
 
@@ -122,15 +114,15 @@ def get_assembly_accessions_from_db(
     for segment in segment_names:
         segment_suffix = f"_{segment}" if organism.is_multi_segment() else ""
 
-        base_key = f"{NUCCORE_ACCESSION_PREFIX_DB_KEY}{segment_suffix}"
+        base_key = f"{DBKeys.NUCCORE_ACCESSION_PREFIX}{segment_suffix}"
         if base_key in result:
-            data[f"{NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY}{segment_suffix}"] = result[base_key]
+            data[f"{LoculusKeys.NUCCORE_ACCESSION_PREFIX}{segment_suffix}"] = result[base_key]
         else:
             all_present = False
 
-        full_key = f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_DB_KEY}{segment_suffix}"
+        full_key = f"{DBKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX}{segment_suffix}"
         if full_key in result:
-            data[f"{VERSIONED_NUCCORE_ACCESSION_PREFIX_LOCULUS_KEY}{segment_suffix}"] = result[
+            data[f"{LoculusKeys.VERSIONED_NUCCORE_ACCESSION_PREFIX}{segment_suffix}"] = result[
                 full_key
             ]
         else:


### PR DESCRIPTION
partially resolves https://github.com/loculus-project/loculus/issues/5646

The ENA deposition pod uses JSONB fields (like the backend). This PR makes the field names CONSTANTS hopefully reducing the number of ways they could be misspelled leading to errors.

### Screenshot

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented - I ran the integration tests locally to see the state of the entries in the DB

🚀 Preview: Add `preview` label to enable