### PR TITLE
feat(website): Seqset total citations

### DIFF
--- a/website/src/components/SeqSetCitations/SeqSetItem.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItem.tsx
@@ -10,6 +10,7 @@ import { SeqSetRecordsTableWithMetadata } from './SeqSetRecordsTableWithMetadata
 import type { AggregateRow } from './getSeqSetStatistics.ts';
 import { mainTailwindColor } from '../../../colors.json';
 import { getClientLogger } from '../../clientLogger';
+import { useCrossRefWork } from '../../hooks/useCrossRefOperations.ts';
 import { seqSetCitationClientHooks } from '../../services/serviceHooks';
 import type { ProblemDetail } from '../../types/backend.ts';
 import type { SeqSetGraph } from '../../types/config.ts';
@@ -21,7 +22,6 @@ import { Button } from '../common/Button.tsx';
 import { withQueryProvider } from '../common/withQueryProvider.tsx';
 import MdiDotsGrid from '~icons/mdi/dots-grid';
 import MdiViewGrid from '~icons/mdi/view-grid';
-import { useQuery } from '@tanstack/react-query';
 
 const logger = getClientLogger('SeqSetItem');
 
@@ -81,16 +81,11 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
     const [wideGraphs, setWideGraphs] = useState(false);
     const sequencesPerPage = 10;
 
-    const { data: totalCitations, isLoading: isTotalCitationsLoading } = useQuery({
-        queryKey: ['seqset-total-citations', seqSet.seqSetDOI],
-        queryFn: async () => {
-            return fetch(`https://api.crossref.org/works/${seqSet.seqSetDOI}/`)
-                .then((r) => r.json())
-                .then((data) => {
-                    return data.message['is-referenced-by-count'] as number;
-                });
-        },
-    });
+    const {
+        data: seqSetCrossRefWork,
+        isLoading: isCrossRefWorkLoading,
+        isError: isCrossRefWorkError,
+    } = useCrossRefWork(seqSet.seqSetDOI);
 
     const { mutate: createSeqSetDOI } = useCreateSeqSetDOIAction(
         clientConfig,
@@ -183,20 +178,22 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
                     <SeqSetSectionEntry
                         label='Total citations'
                         value={
-                            seqSet.seqSetDOI === undefined || seqSet.seqSetDOI === null ? (
-                                <p className='text'>Cited by 0</p>
-                            ) : (
+                            seqSet.seqSetDOI ? (
                                 <a
                                     className='mr-4 cursor-pointer font-medium text-blue-600 hover:text-blue-800'
                                     href={getCrossRefUrl()}
                                     target='_blank'
                                 >
-                                    {isTotalCitationsLoading ? (
+                                    {isCrossRefWorkLoading ? (
                                         <span className='loading loading-spinner loading-xs'></span>
+                                    ) : isCrossRefWorkError ? (
+                                        <span>Failed to load total citations</span>
                                     ) : (
-                                        <span>Cited by {totalCitations}</span>
+                                        <span>Cited by {seqSetCrossRefWork.message.isReferencedByCount}</span>
                                     )}
                                 </a>
+                            ) : (
+                                <p className='text'>Cited by 0</p>
                             )
                         }
                     />

--- a/website/src/components/SeqSetCitations/SeqSetItem.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItem.tsx
@@ -179,21 +179,21 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
                         label='Total citations'
                         value={
                             seqSet.seqSetDOI ? (
-                                <a
-                                    className='mr-4 cursor-pointer font-medium text-blue-600 hover:text-blue-800'
-                                    href={getCrossRefUrl()}
-                                    target='_blank'
-                                >
-                                    {isCrossRefWorkLoading ? (
-                                        <span className='loading loading-spinner loading-xs'></span>
-                                    ) : isCrossRefWorkError ? (
-                                        <span>Failed to load total citations</span>
-                                    ) : (
-                                        <span>Cited by {seqSetCrossRefWork.message.isReferencedByCount}</span>
-                                    )}
-                                </a>
+                                isCrossRefWorkLoading ? (
+                                    <span className='loading loading-spinner loading-xs'></span>
+                                ) : isCrossRefWorkError ? (
+                                    <span>Failed to load citations.</span>
+                                ) : (
+                                    <a
+                                        className='mr-4 cursor-pointer font-medium text-blue-600 hover:text-blue-800'
+                                        href={getCrossRefUrl()}
+                                        target='_blank'
+                                    >
+                                        Cited by {seqSetCrossRefWork.message.isReferencedByCount}
+                                    </a>
+                                )
                             ) : (
-                                <p className='text'>Cited by 0</p>
+                                <span>Cited by 0</span>
                             )
                         }
                     />

--- a/website/src/components/SeqSetCitations/SeqSetItem.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItem.tsx
@@ -188,6 +188,7 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
                                         className='mr-4 cursor-pointer font-medium text-blue-600 hover:text-blue-800'
                                         href={getCrossRefUrl()}
                                         target='_blank'
+                                        rel='noopener noreferrer'
                                     >
                                         Cited by {seqSetCrossRefWork.message.isReferencedByCount}
                                     </a>

--- a/website/src/components/SeqSetCitations/SeqSetItem.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItem.tsx
@@ -21,6 +21,7 @@ import { Button } from '../common/Button.tsx';
 import { withQueryProvider } from '../common/withQueryProvider.tsx';
 import MdiDotsGrid from '~icons/mdi/dots-grid';
 import MdiViewGrid from '~icons/mdi/view-grid';
+import { useQuery } from '@tanstack/react-query';
 
 const logger = getClientLogger('SeqSetItem');
 
@@ -80,6 +81,17 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
     const [wideGraphs, setWideGraphs] = useState(false);
     const sequencesPerPage = 10;
 
+    const { data: totalCitations, isLoading: isTotalCitationsLoading } = useQuery({
+        queryKey: ['seqset-total-citations', seqSet.seqSetDOI],
+        queryFn: async () => {
+            return fetch(`https://api.crossref.org/works/${seqSet.seqSetDOI}/`)
+                .then((r) => r.json())
+                .then((data) => {
+                    return data.message['is-referenced-by-count'] as number;
+                });
+        },
+    });
+
     const { mutate: createSeqSetDOI } = useCreateSeqSetDOIAction(
         clientConfig,
         accessToken,
@@ -127,8 +139,6 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
             </a>
         );
     };
-
-    const totalCitations = citedByData.citations.reduce((sum, citation) => sum + citation, 0);
 
     const getMaxPages = () => {
         return Math.ceil(seqSetRecords.length / sequencesPerPage);
@@ -181,7 +191,11 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
                                     href={getCrossRefUrl()}
                                     target='_blank'
                                 >
-                                    Cited by {totalCitations}
+                                    {isTotalCitationsLoading ? (
+                                        <span className='loading loading-spinner loading-xs'></span>
+                                    ) : (
+                                        <span>Cited by {totalCitations}</span>
+                                    )}
                                 </a>
                             )
                         }

--- a/website/src/hooks/useCrossRefOperations.ts
+++ b/website/src/hooks/useCrossRefOperations.ts
@@ -1,0 +1,16 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import axios from 'axios';
+
+import { crossRefWork, type CrossRefWork } from '../types/seqSetCitation';
+
+export const useCrossRefWork = (doi?: string | null): UseQueryResult<CrossRefWork> => {
+    return useQuery({
+        queryKey: ['getCrossRefWork', doi],
+        queryFn: async () => {
+            return axios
+                .get(`https://api.crossref.org/works/${doi}/`)
+                .then((response) => crossRefWork.parse(response.data));
+        },
+        enabled: !!doi,
+    });
+};

--- a/website/src/types/seqSetCitation.ts
+++ b/website/src/types/seqSetCitation.ts
@@ -38,3 +38,15 @@ export const authorProfile = z.object({
     university: z.string().nullish(),
 });
 export type AuthorProfile = z.infer<typeof authorProfile>;
+
+export const crossRefWork = z.object({
+    message: z
+        .object({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            'is-referenced-by-count': z.number(),
+        })
+        .transform((data) => ({
+            isReferencedByCount: data['is-referenced-by-count'],
+        })),
+});
+export type CrossRefWork = z.infer<typeof crossRefWork>;


### PR DESCRIPTION
Adds the total citation count (CrossRef `is-referenced-by-count`) for a seqSet using CrossRef's [REST API](https://www.crossref.org/documentation/retrieve-metadata/rest-api/).

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable