### PR TITLE
feat(backend): get rid of unused hibernate dependency

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -54,7 +54,6 @@ dependencies {
     implementation "org.jetbrains.exposed:exposed-json"
     implementation "org.jetbrains.exposed:exposed-kotlin-datetime"
     implementation "org.jetbrains.kotlinx:kotlinx-datetime:0.7.1-0.6.x-compat"
-    implementation "org.hibernate.validator:hibernate-validator"
     implementation "org.keycloak:keycloak-admin-client:26.0.8"
     implementation("io.minio:minio:8.6.0")
     implementation("software.amazon.awssdk:s3:2.42.10")


### PR DESCRIPTION
@tombch and I were looking into the exposed ORM and I realized we have a dependency for a different ORM hibernate that appears unused in the code - I now checked that the preview is healthy, so I would remove the dependency.

resolves #

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable