### PR TITLE
demo, maybe: Subset lineage YAML files to observed values

### DIFF
--- a/loculus-silo/pyproject.toml
+++ b/loculus-silo/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
     "zstandard>=0.22,<0.26",
     "requests>=2.31,<3.0",
     "orjsonl>=0.3,<2.0",
+    "PyYAML>=6.0,<7.0",
 ]
 
 [project.scripts]

--- a/loculus-silo/src/silo_import/constants.py
+++ b/loculus-silo/src/silo_import/constants.py
@@ -8,3 +8,6 @@ SPECIAL_ETAG_NONE = "0"
 # File names for downloaded data
 DATA_FILENAME = "untransformed_data.ndjson.zst"
 TRANSFORMED_DATA_FILENAME = "data.ndjson.zst"  # name is set by SILO
+
+# SILO database configuration file (mounted into the silo-importer container)
+DATABASE_CONFIG_FILENAME = "database_config.yaml"

--- a/loculus-silo/src/silo_import/decompressor.py
+++ b/loculus-silo/src/silo_import/decompressor.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import orjsonl
@@ -17,17 +18,27 @@ class NdjsonAnalysis:
 
     record_count: int
     pipeline_version: int | None
+    lineage_values: dict[str, set[str]] = field(default_factory=dict)
 
 
-def analyze_ndjson(path: Path) -> NdjsonAnalysis:
+def analyze_ndjson(
+    path: Path,
+    lineage_field_mapping: Mapping[str, list[str]] | None = None,
+) -> NdjsonAnalysis:
     """
     Decompress and analyze a zstd-compressed NDJSON file.
 
     Args:
         path: Path to the compressed NDJSON file
+        lineage_field_mapping: Optional mapping of ``lineage system name ->
+            list of metadata field names`` whose values should be collected.
+            For each lineage system, the unique non-empty values found across
+            all of its metadata fields are returned in
+            ``NdjsonAnalysis.lineage_values``.
 
     Returns:
-        NdjsonAnalysis with record count and pipeline versions found
+        NdjsonAnalysis with record count, pipeline version and (optionally)
+        the unique lineage values observed per lineage system.
 
     Raises:
         RuntimeError: If decompression or JSON parsing fails
@@ -36,15 +47,38 @@ def analyze_ndjson(path: Path) -> NdjsonAnalysis:
     record_count = 0
     pipeline_version: int | None = None
 
+    mapping = dict(lineage_field_mapping or {})
+    # Invert the mapping: field name -> list of systems that consume it.
+    field_to_systems: dict[str, list[str]] = {}
+    for system, fields in mapping.items():
+        for field_name in fields:
+            field_to_systems.setdefault(field_name, []).append(system)
+
+    lineage_values: dict[str, set[str]] = {system: set() for system in mapping}
+
     try:
         for record in orjsonl.stream(path):
             record_count += 1
+            metadata = record.get("metadata", {}) or {}  # type: ignore[union-attr]
             if pipeline_version is None:
-                pipeline_version = record.get("metadata", {}).get("pipelineVersion")  # type: ignore
+                pipeline_version = metadata.get("pipelineVersion")
+            if not field_to_systems:
+                continue
+            for field_name, systems in field_to_systems.items():
+                value = metadata.get(field_name)
+                if value is None or value == "":
+                    continue
+                value_str = str(value)
+                for system in systems:
+                    lineage_values[system].add(value_str)
 
     except Exception as exc:
         msg = f"Failed to decompress {path}: {exc}"
         logger.error(msg)
         raise RuntimeError(msg) from exc
 
-    return NdjsonAnalysis(record_count=record_count, pipeline_version=pipeline_version)
+    return NdjsonAnalysis(
+        record_count=record_count,
+        pipeline_version=pipeline_version,
+        lineage_values=lineage_values,
+    )

--- a/loculus-silo/src/silo_import/download_manager.py
+++ b/loculus-silo/src/silo_import/download_manager.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import hashlib
 import logging
 import time
-from collections.abc import Callable
-from dataclasses import dataclass
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
 from http.client import BAD_REQUEST
 from pathlib import Path
 
@@ -79,6 +79,7 @@ class DownloadResult:
     transformed_path: Path
     etag: str
     pipeline_version: int | None
+    lineage_values: dict[str, set[str]] = field(default_factory=dict)
 
 
 def _download_file(
@@ -142,6 +143,7 @@ class DownloadManager:
         config: ImporterConfig,
         paths: ImporterPaths,
         last_etag: str,
+        lineage_field_mapping: Mapping[str, list[str]] | None = None,
     ) -> DownloadResult:
         """
         Download and validate a data release from the backend.
@@ -150,6 +152,12 @@ class DownloadManager:
             config: Importer configuration
             paths: Importer paths
             last_etag: ETag from previous download for conditional request
+            lineage_field_mapping: Optional mapping from lineage system name
+                to the metadata field names that hold values from that system.
+                When provided, the unique lineage values found in the data are
+                collected and returned in ``DownloadResult.lineage_values``,
+                so the lineage YAML files can later be subset to exactly the
+                entries needed by the data.
 
         Returns:
             DownloadResult with paths and metadata
@@ -205,7 +213,7 @@ class DownloadManager:
 
             # Decompress and analyze the data
             try:
-                analysis = analyze_ndjson(data_path)
+                analysis = analyze_ndjson(data_path, lineage_field_mapping)
             except RuntimeError as exc:
                 logger.warning(
                     "Failed to decompress %s (size=%s bytes): %s",
@@ -245,6 +253,7 @@ class DownloadManager:
                 transformed_path=transformed_path,
                 etag=etag_value,
                 pipeline_version=analysis.pipeline_version,
+                lineage_values=analysis.lineage_values,
             )
 
         except (

--- a/loculus-silo/src/silo_import/lineage.py
+++ b/loculus-silo/src/silo_import/lineage.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable, Mapping
 from pathlib import Path
+from typing import Any
 
 import requests
+import yaml
 
 from .config import ImporterConfig
 from .paths import ImporterPaths
@@ -11,11 +14,70 @@ from .paths import ImporterPaths
 logger = logging.getLogger(__name__)
 
 
+def read_lineage_field_mapping(database_config_path: Path) -> dict[str, list[str]]:
+    """Return a mapping of ``lineage system name -> metadata field names``.
+
+    Parses the SILO database config (``database_config.yaml``) and inspects
+    each metadata entry for the ``generateLineageIndex`` attribute. Multiple
+    metadata fields may reference the same lineage system (for example one
+    per segment in segmented organisms), so the value is a list of field
+    names.
+
+    Returns an empty mapping if the file does not exist or is malformed.
+    """
+    if not database_config_path.exists():
+        logger.info(
+            "Database config not found at %s; lineage subsetting disabled",
+            database_config_path,
+        )
+        return {}
+
+    try:
+        with database_config_path.open("r", encoding="utf-8") as handle:
+            config = yaml.safe_load(handle) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning("Could not read database config %s: %s", database_config_path, exc)
+        return {}
+
+    mapping: dict[str, list[str]] = {}
+    metadata_entries = (config.get("schema") or {}).get("metadata") or []
+    if not isinstance(metadata_entries, list):
+        return {}
+
+    for entry in metadata_entries:
+        if not isinstance(entry, Mapping):
+            continue
+        lineage_system = entry.get("generateLineageIndex")
+        field_name = entry.get("name")
+        if not lineage_system or not field_name:
+            continue
+        mapping.setdefault(str(lineage_system), []).append(str(field_name))
+
+    return mapping
+
+
 def update_lineage_definitions(
     pipeline_version: int | None,
     config: ImporterConfig,
     paths: ImporterPaths,
+    lineage_values_per_system: Mapping[str, set[str]] | None = None,
 ) -> None:
+    """Download lineage definition files and subset them to the values used in the data.
+
+    For each configured lineage system, the upstream YAML file is downloaded
+    and then reduced to the entries actually needed: only lineages whose
+    canonical name (or one of their aliases) appears in the data are kept,
+    along with the transitive closure of their parents. This keeps the file
+    SILO has to load small while preserving the hierarchy required for
+    sublineage queries.
+
+    ``lineage_values_per_system`` is the mapping returned by the data-scan
+    step: for every lineage system whose metadata field was tracked, it
+    contains the (possibly empty) set of values observed in the records.
+    Lineage systems that are absent from the mapping fall back to writing
+    the upstream file unchanged - this happens when no metadata field
+    references them, e.g. when the database config could not be read.
+    """
     if not config.lineage_definitions:
         logger.info("LINEAGE_DEFINITIONS not provided; skipping lineage configuration")
         return
@@ -27,6 +89,8 @@ def update_lineage_definitions(
             _write_text(paths.input_dir / f"{lineage}.yaml", "{}\n")
         return
 
+    values_by_system = lineage_values_per_system or {}
+
     for lineage, item in config.lineage_definitions.items():
         lineage_url: str | None = item.get(int(pipeline_version))
         if not lineage_url:
@@ -36,18 +100,118 @@ def update_lineage_definitions(
             )
             raise RuntimeError(msg)
 
-        logger.info("Downloading lineage definitions for pipeline version %s", pipeline_version)
+        logger.info(
+            "Downloading lineage definitions for system '%s' (pipeline version %s)",
+            lineage,
+            pipeline_version,
+        )
         try:
-            _download_lineage_file(lineage_url, paths.input_dir / f"{lineage}.yaml")
+            content = _download_lineage_text(lineage_url)
         except requests.RequestException as exc:
             msg = f"Failed to download lineage definitions: {exc}"
             raise RuntimeError(msg) from exc
 
+        destination = paths.input_dir / f"{lineage}.yaml"
 
-def _download_lineage_file(url: str, destination: Path) -> None:
+        if lineage in values_by_system:
+            used_values = values_by_system[lineage]
+            try:
+                content, kept, total = subset_lineage_yaml(content, used_values)
+            except yaml.YAMLError as exc:
+                logger.warning(
+                    "Could not parse lineage YAML for '%s'; writing it unchanged: %s",
+                    lineage,
+                    exc,
+                )
+            else:
+                logger.info(
+                    "Subsetted lineage system '%s' from %s to %s entries (%s observed values)",
+                    lineage,
+                    total,
+                    kept,
+                    len(used_values),
+                )
+        else:
+            logger.info(
+                "No metadata field uses lineage system '%s'; writing full file",
+                lineage,
+            )
+
+        _write_text(destination, content)
+
+
+def subset_lineage_yaml(content: str, used_values: Iterable[str]) -> tuple[str, int, int]:
+    """Return YAML containing only the lineages actually needed for ``used_values``.
+
+    The lineage YAML maps a canonical lineage name to a mapping with
+    ``aliases`` (alternative names) and ``parents`` (canonical parent names).
+    Data records may contain either canonical names or aliases. The result
+    keeps every entry whose canonical name is required, plus the transitive
+    closure of its parents, so that SILO can still resolve sublineage
+    relationships correctly.
+
+    Returns ``(yaml_text, kept_count, total_count)``. If the parsed YAML is
+    not a mapping or is empty, the original content is returned unchanged.
+    """
+    parsed: Any = yaml.safe_load(content)
+    if not isinstance(parsed, Mapping) or not parsed:
+        return content, 0, 0
+
+    full: dict[str, Mapping[str, Any]] = {
+        str(name): (entry if isinstance(entry, Mapping) else {})
+        for name, entry in parsed.items()
+    }
+    total = len(full)
+
+    alias_to_canonical: dict[str, str] = {}
+    for canonical, entry in full.items():
+        alias_to_canonical.setdefault(canonical, canonical)
+        for alias in _string_list(entry.get("aliases")):
+            # Don't let an alias override an existing canonical name.
+            alias_to_canonical.setdefault(alias, canonical)
+
+    needed: set[str] = set()
+    queue: list[str] = []
+    for value in used_values:
+        if value is None:
+            continue
+        canonical = alias_to_canonical.get(str(value))
+        if canonical is None:
+            logger.debug("Lineage value %r not found in definition file; skipping", value)
+            continue
+        if canonical not in needed:
+            needed.add(canonical)
+            queue.append(canonical)
+
+    while queue:
+        current = queue.pop()
+        entry = full.get(current, {})
+        for parent in _string_list(entry.get("parents")):
+            parent_canonical = alias_to_canonical.get(parent, parent)
+            if parent_canonical in full and parent_canonical not in needed:
+                needed.add(parent_canonical)
+                queue.append(parent_canonical)
+
+    subset = {name: entry for name, entry in parsed.items() if str(name) in needed}
+    if not subset:
+        return "{}\n", 0, total
+
+    # ``sort_keys=False`` preserves the order of the upstream file.
+    return yaml.safe_dump(subset, sort_keys=False), len(subset), total
+
+
+def _string_list(value: Any) -> list[str]:
+    if not value:
+        return []
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if item is not None]
+
+
+def _download_lineage_text(url: str) -> str:
     response = requests.get(url, timeout=60)
     response.raise_for_status()
-    _write_text(destination, response.text)
+    return response.text
 
 
 def _write_text(path: Path, content: str) -> None:

--- a/loculus-silo/src/silo_import/paths.py
+++ b/loculus-silo/src/silo_import/paths.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from .constants import (
+    DATABASE_CONFIG_FILENAME,
     TRANSFORMED_DATA_FILENAME,
 )
 
@@ -14,6 +15,7 @@ class ImporterPaths:
     input_dir: Path
     output_dir: Path
     silo_input_data_path: Path
+    database_config_path: Path
     silo_binary: Path
     preprocessing_config: Path
 
@@ -27,6 +29,7 @@ class ImporterPaths:
             input_dir=input_dir,
             output_dir=output_dir,
             silo_input_data_path=input_dir / TRANSFORMED_DATA_FILENAME,
+            database_config_path=input_dir / DATABASE_CONFIG_FILENAME,
             silo_binary=silo_binary,
             preprocessing_config=preprocessing_config,
         )

--- a/loculus-silo/src/silo_import/runner.py
+++ b/loculus-silo/src/silo_import/runner.py
@@ -15,7 +15,7 @@ from .errors import (
 )
 from .filesystem import prune_timestamped_directories, safe_remove
 from .instruct_silo import SiloRunner
-from .lineage import update_lineage_definitions
+from .lineage import read_lineage_field_mapping, update_lineage_definitions
 from .paths import ImporterPaths
 
 logger = logging.getLogger(__name__)
@@ -63,8 +63,21 @@ class ImporterRunner:
         # Use special ETag for hard refresh to force re-download
         last_etag = SPECIAL_ETAG_NONE if hard_refresh else self.current_etag
 
+        # Build {lineage system -> [metadata field names]} so the data scan can
+        # collect the lineage values that are actually used.
+        lineage_field_mapping = (
+            read_lineage_field_mapping(self.paths.database_config_path)
+            if self.config.lineage_definitions
+            else {}
+        )
+
         try:
-            download = self.download_manager.download_release(self.config, self.paths, last_etag)
+            download = self.download_manager.download_release(
+                self.config,
+                self.paths,
+                last_etag,
+                lineage_field_mapping=lineage_field_mapping,
+            )
         except (NotModifiedError, HashUnchangedError) as skip:
             logger.info("Skipping run: %s", skip)
             if skip.new_etag is not None:
@@ -79,7 +92,12 @@ class ImporterRunner:
             return
 
         try:
-            update_lineage_definitions(download.pipeline_version, self.config, self.paths)
+            update_lineage_definitions(
+                download.pipeline_version,
+                self.config,
+                self.paths,
+                lineage_values_per_system=download.lineage_values,
+            )
         except Exception:
             logger.exception("Failed to download lineage definitions; cleaning up input")
             safe_remove(self.paths.silo_input_data_path)

--- a/loculus-silo/tests/test_integration.py
+++ b/loculus-silo/tests/test_integration.py
@@ -72,8 +72,8 @@ def test_full_import_cycle_with_real_zstd_data(
 
     monkeypatch.setattr(
         lineage,
-        "_download_lineage_file",
-        lambda url, path: path.write_text("lineage: test-data\n"),  # noqa: ARG005
+        "_download_lineage_text",
+        lambda url: "lineage: test-data\n",  # noqa: ARG005
     )
 
     runner = ImporterRunner(config, paths)
@@ -119,8 +119,8 @@ def test_multiple_runs_with_state_persistence(
 
     monkeypatch.setattr(
         lineage,
-        "_download_lineage_file",
-        lambda url, path: path.write_text("lineage: v1\n"),  # noqa: ARG005
+        "_download_lineage_text",
+        lambda url: "lineage: v1\n",  # noqa: ARG005
     )
 
     # Run 1: Initial import
@@ -199,8 +199,8 @@ def test_hard_refresh_forces_redownload(tmp_path: Path, monkeypatch: pytest.Monk
 
     monkeypatch.setattr(
         lineage,
-        "_download_lineage_file",
-        lambda url, path: path.write_text("lineage: data\n"),  # noqa: ARG005
+        "_download_lineage_text",
+        lambda url: "lineage: data\n",  # noqa: ARG005
     )
 
     records = mock_records()
@@ -263,8 +263,8 @@ def test_error_recovery_cleans_up_properly(tmp_path: Path, monkeypatch: pytest.M
 
     monkeypatch.setattr(
         lineage,
-        "_download_lineage_file",
-        lambda url, path: path.write_text("lineage: data\n"),  # noqa: ARG005
+        "_download_lineage_text",
+        lambda url: "lineage: data\n",  # noqa: ARG005
     )
 
     runner = ImporterRunner(config, paths)
@@ -303,11 +303,11 @@ def test_lineage_download_failure_cleanup(tmp_path: Path, monkeypatch: pytest.Mo
     mock_download, _ = make_mock_download_func(responses)
 
     # Make lineage download fail
-    def failing_lineage_download(url: str, path: Path) -> None:  # noqa: ARG001
+    def failing_lineage_download(url: str) -> str:  # noqa: ARG001
         msg = "Simulated lineage download failure"
         raise RuntimeError(msg)
 
-    monkeypatch.setattr(lineage, "_download_lineage_file", failing_lineage_download)
+    monkeypatch.setattr(lineage, "_download_lineage_text", failing_lineage_download)
 
     runner = ImporterRunner(config, paths)
     runner.download_manager = DownloadManager(download_func=mock_download)
@@ -344,8 +344,8 @@ def test_interrupted_run_cleanup_and_hash_skip(
 
     monkeypatch.setattr(
         lineage,
-        "_download_lineage_file",
-        lambda url, path: path.write_text("lineage: data\n"),  # noqa: ARG005
+        "_download_lineage_text",
+        lambda url: "lineage: data\n",  # noqa: ARG005
     )
 
     runner = ImporterRunner(config, paths)

--- a/loculus-silo/tests/test_lineage.py
+++ b/loculus-silo/tests/test_lineage.py
@@ -1,0 +1,308 @@
+"""Tests for lineage definition subsetting and field-mapping discovery."""
+
+# ruff: noqa: S101
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+from unittest.mock import patch
+
+import pytest
+import yaml
+from helpers import compress_ndjson
+from silo_import import lineage
+from silo_import.config import ImporterConfig
+from silo_import.lineage import (
+    read_lineage_field_mapping,
+    subset_lineage_yaml,
+    update_lineage_definitions,
+)
+from silo_import.paths import ImporterPaths
+
+
+SAMPLE_LINEAGE_YAML = dedent(
+    """\
+    A:
+      aliases: []
+      parents: []
+    A.1:
+      aliases: []
+      parents:
+        - A
+    A.1.1:
+      aliases:
+        - B
+      parents:
+        - A.1
+    A.2:
+      aliases: []
+      parents:
+        - A
+    """
+)
+
+
+def _make_paths(tmp_path: Path) -> ImporterPaths:
+    silo_binary = tmp_path / "silo"
+    preprocessing_config = tmp_path / "config.yaml"
+    paths = ImporterPaths.from_root(tmp_path, silo_binary, preprocessing_config)
+    paths.ensure_directories()
+    return paths
+
+
+def _make_config(
+    tmp_path: Path,
+    lineage_definitions: dict[str, dict[int, str]] | None,
+) -> ImporterConfig:
+    return ImporterConfig(
+        backend_base_url="http://backend",
+        lineage_definitions=lineage_definitions,
+        hard_refresh_interval=1,
+        poll_interval=1,
+        silo_run_timeout=5,
+        root_dir=tmp_path,
+        silo_binary=tmp_path / "silo",
+        preprocessing_config=tmp_path / "config.yaml",
+    )
+
+
+def test_subset_keeps_only_observed_lineage_and_its_ancestors() -> None:
+    text, kept, total = subset_lineage_yaml(SAMPLE_LINEAGE_YAML, ["A.1.1"])
+
+    parsed = yaml.safe_load(text)
+    assert set(parsed.keys()) == {"A", "A.1", "A.1.1"}
+    # Sibling branches are dropped.
+    assert "A.2" not in parsed
+    assert kept == 3
+    assert total == 4
+
+
+def test_subset_resolves_aliases_to_canonical_names() -> None:
+    # "B" is an alias for canonical "A.1.1".
+    text, kept, _ = subset_lineage_yaml(SAMPLE_LINEAGE_YAML, ["B"])
+
+    parsed = yaml.safe_load(text)
+    assert set(parsed.keys()) == {"A", "A.1", "A.1.1"}
+    assert parsed["A.1.1"]["aliases"] == ["B"]
+    assert kept == 3
+
+
+def test_subset_handles_unknown_values_gracefully() -> None:
+    # Unknown values are dropped silently; A.2 is real and brings in A.
+    text, kept, _ = subset_lineage_yaml(SAMPLE_LINEAGE_YAML, ["A.2", "totally-bogus", ""])
+
+    parsed = yaml.safe_load(text)
+    assert set(parsed.keys()) == {"A", "A.2"}
+    assert kept == 2
+
+
+def test_subset_with_no_used_values_yields_empty_yaml() -> None:
+    text, kept, total = subset_lineage_yaml(SAMPLE_LINEAGE_YAML, [])
+
+    assert yaml.safe_load(text) is None or yaml.safe_load(text) == {}
+    assert kept == 0
+    assert total == 4
+
+
+def test_subset_returns_input_unchanged_when_yaml_is_not_a_mapping() -> None:
+    # Garbage in -> garbage out, but no exception.
+    junk = "lineage: data\n"
+    text, kept, total = subset_lineage_yaml(junk, ["A"])
+
+    # ``lineage: data`` *is* a mapping, so it parses to {"lineage": "data"} and
+    # is reduced to {} because "A" isn't in it. Use a non-mapping instead.
+    text, kept, total = subset_lineage_yaml("- only\n- a\n- list\n", ["A"])
+    assert text == "- only\n- a\n- list\n"
+    assert kept == 0
+    assert total == 0
+
+
+def test_read_lineage_field_mapping_extracts_generate_lineage_index(tmp_path: Path) -> None:
+    db_config = tmp_path / "database_config.yaml"
+    db_config.write_text(
+        dedent(
+            """\
+            schema:
+              instanceName: SARS-CoV-2
+              metadata:
+                - name: accession
+                  type: string
+                - name: pangoLineage
+                  type: string
+                  generateIndex: true
+                  generateLineageIndex: pangoLineage
+                - name: alternativeLineage
+                  type: string
+                  generateIndex: true
+                  generateLineageIndex: alternativeLineage
+                - name: cladeS_S
+                  type: string
+                  generateIndex: true
+                  generateLineageIndex: cchfS
+                - name: cladeS_L
+                  type: string
+                  generateIndex: true
+                  generateLineageIndex: cchfS
+              primaryKey: accession
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    mapping = read_lineage_field_mapping(db_config)
+
+    assert mapping == {
+        "pangoLineage": ["pangoLineage"],
+        "alternativeLineage": ["alternativeLineage"],
+        "cchfS": ["cladeS_S", "cladeS_L"],
+    }
+
+
+def test_read_lineage_field_mapping_returns_empty_when_file_missing(tmp_path: Path) -> None:
+    assert read_lineage_field_mapping(tmp_path / "missing.yaml") == {}
+
+
+def test_update_lineage_definitions_writes_subsetted_yaml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = _make_paths(tmp_path)
+    config = _make_config(
+        tmp_path, lineage_definitions={"pangoLineage": {1: "http://lineage"}}
+    )
+
+    monkeypatch.setattr(lineage, "_download_lineage_text", lambda url: SAMPLE_LINEAGE_YAML)  # noqa: ARG005
+
+    update_lineage_definitions(
+        pipeline_version=1,
+        config=config,
+        paths=paths,
+        lineage_values_per_system={"pangoLineage": {"A.1.1"}},
+    )
+
+    written = (paths.input_dir / "pangoLineage.yaml").read_text(encoding="utf-8")
+    parsed = yaml.safe_load(written)
+    assert set(parsed.keys()) == {"A", "A.1", "A.1.1"}
+
+
+def test_update_lineage_definitions_falls_back_to_full_when_no_field_mapping(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = _make_paths(tmp_path)
+    config = _make_config(
+        tmp_path, lineage_definitions={"pangoLineage": {1: "http://lineage"}}
+    )
+
+    monkeypatch.setattr(lineage, "_download_lineage_text", lambda url: SAMPLE_LINEAGE_YAML)  # noqa: ARG005
+
+    # No values_per_system entry for ``pangoLineage`` -> write full file
+    # unchanged. This preserves behaviour for setups whose database config
+    # cannot be parsed.
+    update_lineage_definitions(
+        pipeline_version=1,
+        config=config,
+        paths=paths,
+        lineage_values_per_system={},
+    )
+
+    written = (paths.input_dir / "pangoLineage.yaml").read_text(encoding="utf-8")
+    assert written == SAMPLE_LINEAGE_YAML
+
+
+def test_update_lineage_definitions_writes_empty_when_pipeline_version_missing(
+    tmp_path: Path,
+) -> None:
+    paths = _make_paths(tmp_path)
+    config = _make_config(
+        tmp_path, lineage_definitions={"pangoLineage": {1: "http://lineage"}}
+    )
+
+    update_lineage_definitions(
+        pipeline_version=None,
+        config=config,
+        paths=paths,
+        lineage_values_per_system=None,
+    )
+
+    written = (paths.input_dir / "pangoLineage.yaml").read_text(encoding="utf-8")
+    assert written == "{}\n"
+
+
+def test_runner_subsets_lineage_yaml_to_observed_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end: data + database config -> subsetted lineage file."""
+    from helpers import MockHttpResponse, make_mock_download_func
+    from silo_import.download_manager import DownloadManager
+    from silo_import.runner import ImporterRunner
+
+    paths = _make_paths(tmp_path)
+    config = _make_config(
+        tmp_path, lineage_definitions={"pangoLineage": {1: "http://lineage"}}
+    )
+
+    # Database config tells the importer that ``pangoLineageField`` is the
+    # metadata field that holds values from system ``pangoLineage``.
+    paths.database_config_path.write_text(
+        dedent(
+            """\
+            schema:
+              metadata:
+                - name: pangoLineageField
+                  type: string
+                  generateIndex: true
+                  generateLineageIndex: pangoLineage
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    records = [
+        {
+            "metadata": {
+                "pipelineVersion": "1",
+                "accession": "seq1",
+                "pangoLineageField": "A.1.1",
+            },
+            "unalignedNucleotideSequences": {"main": "ATCG"},
+            "alignedNucleotideSequences": {"main": "ATCG"},
+            "alignedAminoAcidSequences": {"gene1": "MYKW"},
+            "nucleotideInsertions": {"main": []},
+            "aminoAcidInsertions": {"gene1": []},
+        },
+        {
+            "metadata": {
+                "pipelineVersion": "1",
+                "accession": "seq2",
+                "pangoLineageField": "A.2",
+            },
+            "unalignedNucleotideSequences": {"main": "GCTA"},
+            "alignedNucleotideSequences": {"main": "GCTA"},
+            "alignedAminoAcidSequences": {"gene1": "MYKW"},
+            "nucleotideInsertions": {"main": []},
+            "aminoAcidInsertions": {"gene1": []},
+        },
+    ]
+    body = compress_ndjson(records)
+
+    responses = [
+        MockHttpResponse(
+            status=200,
+            headers={"ETag": 'W/"abc"', "x-total-records": str(len(records))},
+            body=body,
+        )
+    ]
+    mock_download, _ = make_mock_download_func(responses)
+
+    monkeypatch.setattr(lineage, "_download_lineage_text", lambda url: SAMPLE_LINEAGE_YAML)  # noqa: ARG005
+
+    runner = ImporterRunner(config, paths)
+    runner.download_manager = DownloadManager(download_func=mock_download)
+
+    with patch.object(runner.silo, "run_preprocessing"):
+        runner.run_once()
+
+    written = (paths.input_dir / "pangoLineage.yaml").read_text(encoding="utf-8")
+    parsed = yaml.safe_load(written)
+    # A.1.1 -> needs A.1 and A. A.2 -> needs A. So the subset is {A, A.1,
+    # A.1.1, A.2}, and unrelated branches (none here) are dropped.
+    assert set(parsed.keys()) == {"A", "A.1", "A.1.1", "A.2"}

--- a/loculus-silo/tests/test_runner.py
+++ b/loculus-silo/tests/test_runner.py
@@ -62,8 +62,8 @@ def test_runner_successful_cycle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 
     monkeypatch.setattr(
         lineage,
-        "_download_lineage_file",
-        lambda url, path: path.write_text("lineage: data"),  # noqa: ARG005
+        "_download_lineage_text",
+        lambda url: "lineage: data\n",  # noqa: ARG005
     )
 
     runner = ImporterRunner(config, paths)
@@ -76,8 +76,11 @@ def test_runner_successful_cycle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert records_out == mock_transformed_records()
     assert runner.current_etag == 'W/"123"'
     assert runner.last_hard_refresh > 0
+    # No database config is mounted in this test, so the importer can't tell
+    # which metadata field uses lineage system "test"; the upstream YAML is
+    # written through unchanged.
     lineage_definition_file = paths.input_dir / "test.yaml"
-    assert lineage_definition_file.read_text(encoding="utf-8") == "lineage: data"
+    assert lineage_definition_file.read_text(encoding="utf-8") == "lineage: data\n"
 
     input_dirs = [p for p in paths.input_dir.iterdir() if p.is_dir() and p.name.isdigit()]
     assert len(input_dirs) == 1
@@ -127,8 +130,8 @@ def test_runner_skips_on_hash_match_updates_etag(
 
     monkeypatch.setattr(
         lineage,
-        "_download_lineage_file",
-        lambda url, path: path.write_text("lineage: data"),  # noqa: ARG005
+        "_download_lineage_text",
+        lambda url: "lineage: data\n",  # noqa: ARG005
     )
 
     runner = ImporterRunner(config, paths)


### PR DESCRIPTION
The below all written by claude, not intended for real use

## Description

This PR implements intelligent subsetting of lineage definition YAML files to reduce their size and improve performance. Instead of loading complete lineage hierarchies, SILO now only loads the lineages actually present in the data, along with their parent lineages needed for hierarchy resolution.

### Key Changes

1. **Lineage YAML Subsetting** (`lineage.py`)
   - Added `subset_lineage_yaml()` function that filters lineage definitions to only include:
     - Lineages whose canonical names or aliases appear in the data
     - All transitive parent lineages (to preserve hierarchy queries)
   - Handles alias resolution to map aliases back to canonical names
   - Returns statistics on how many entries were kept vs. total

2. **Database Config Parsing** (`lineage.py`)
   - Added `read_lineage_field_mapping()` to extract metadata field-to-lineage-system mappings from SILO's database config
   - Parses `generateLineageIndex` attributes to identify which metadata fields hold lineage values
   - Gracefully handles missing or malformed configs

3. **Data Scanning** (`decompressor.py`)
   - Enhanced `analyze_ndjson()` to collect unique lineage values observed in records
   - Takes optional `lineage_field_mapping` parameter to know which fields to scan
   - Returns collected values per lineage system in `NdjsonAnalysis.lineage_values`

4. **Integration** (`runner.py`, `download_manager.py`)
   - Updated download pipeline to pass lineage field mapping through to data analysis
   - Modified `update_lineage_definitions()` to accept observed lineage values and subset accordingly
   - Falls back to writing full upstream file if no field mapping is available (preserves backward compatibility)

5. **Dependencies**
   - Added PyYAML dependency for YAML parsing and generation

### Testing

Comprehensive test coverage added in `test_lineage.py`:
- Unit tests for `subset_lineage_yaml()` covering alias resolution, parent traversal, and edge cases
- Unit tests for `read_lineage_field_mapping()` with various config structures
- Integration tests verifying the full pipeline from data import to subsetted lineage files
- End-to-end test demonstrating the complete workflow

All existing tests updated to work with the refactored `_download_lineage_text()` function signature.

### Backward Compatibility

The changes are fully backward compatible:
- If no database config is available, lineage files are written unchanged
- If a lineage system has no metadata field referencing it, the full upstream file is used
- Existing configurations without lineage definitions continue to work as before

https://claude.ai/code/session_01NqAoS8sLdfSzTSz9ooo5zj

🚀 Preview: https://claude-filter-silo-lineag.loculus.org