### PR TITLE
chore(prepro): Extracting shared code from taxonomy-service preprocessing functions

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -264,8 +264,7 @@ def taxonomy_service_request(
     try:
         if cache:
             return cache.get_or_fetch(url), None
-        else:
-            return requests.get(url, timeout=15), None
+        return requests.get(url, timeout=15), None
     except requests.exceptions.RequestException as e:
         return None, ProcessingResult(
             datum=None,

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -251,33 +251,25 @@ def missing_taxonomy_service_error(input_fields: list[str], output_field: str) -
     )
 
 
-def taxonomy_service_request(
-    url: str,
+def taxonomy_network_error(
     subject: str,
     action: str,
+    e: Exception,
     input_fields: list[str],
     output_field: str,
-    cache: RequestCache | None = None,
-) -> tuple[requests.Response | None, ProcessingResult | None]:
-    """Fetch `url` from the taxonomy service, using a cache if provided.
-    Returns (response, None) on success, (None, error_result) on network failure."""
-    try:
-        if cache:
-            return cache.get_or_fetch(url), None
-        return requests.get(url, timeout=15), None
-    except requests.exceptions.RequestException as e:
-        return None, ProcessingResult(
-            datum=None,
-            warnings=[],
-            errors=[
-                ProcessingAnnotation.from_fields(
-                    input_fields,
-                    [output_field],
-                    AnnotationSourceType.METADATA,
-                    message=f"Internal error: network error while {action} '{subject}': {e}. Please contact the administrator.",
-                )
-            ],
-        )
+) -> ProcessingResult:
+    return ProcessingResult(
+        datum=None,
+        warnings=[],
+        errors=[
+            ProcessingAnnotation.from_fields(
+                input_fields,
+                [output_field],
+                AnnotationSourceType.METADATA,
+                message=f"Internal error: network error while {action} '{subject}': {e}. Please contact the administrator.",
+            )
+        ],
+    )
 
 
 class ProcessingFunctions:
@@ -1656,11 +1648,10 @@ class ProcessingFunctions:
             query = urllib.parse.urlencode({"scientific_name": unvalidated})
             url = f"{tax_service}/taxa?{query}"
 
-        response, error = taxonomy_service_request(
-            url, unvalidated, "validating", input_fields, output_field, taxonomy_cache
-        )
-        if error:
-            return error
+        try:
+            response = taxonomy_cache.get_or_fetch(url)
+        except requests.exceptions.RequestException as e:
+            return taxonomy_network_error(unvalidated, "validating", e, input_fields, output_field)
 
         body = response.json()
         if response.status_code != requests.codes.ok:
@@ -1734,11 +1725,10 @@ class ProcessingFunctions:
             )
 
         url = f"{tax_service}/taxa/{tax_id}"
-        response, error = taxonomy_service_request(
-            url, tax_id, "validating", input_fields, output_field, taxonomy_cache
-        )
-        if error:
-            return error
+        try:
+            response = taxonomy_cache.get_or_fetch(url)
+        except requests.exceptions.RequestException as e:
+            return taxonomy_network_error(tax_id, "validating", e, input_fields, output_field)
 
         body = response.json()
         if response.status_code != requests.codes.ok:
@@ -1796,11 +1786,12 @@ class ProcessingFunctions:
             )
 
         url = f"{tax_service}/taxa/{tax_id}?find_common_name=true"
-        response, error = taxonomy_service_request(
-            url, tax_id, "getting common name for", input_fields, output_field, taxonomy_cache
-        )
-        if error:
-            return error
+        try:
+            response = taxonomy_cache.get_or_fetch(url)
+        except requests.exceptions.RequestException as e:
+            return taxonomy_network_error(
+                tax_id, "getting common name for", e, input_fields, output_field
+            )
 
         body = response.json()
         if response.status_code != requests.codes.ok:

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -236,6 +236,51 @@ def regex_error(
     )
 
 
+def missing_taxonomy_service_error(input_fields: list[str], output_field: str) -> ProcessingResult:
+    return ProcessingResult(
+        datum=None,
+        warnings=[],
+        errors=[
+            ProcessingAnnotation.from_fields(
+                input_fields,
+                [output_field],
+                AnnotationSourceType.METADATA,
+                message="Configuration error: taxonomy_service_url was None. Please contact the administrator.",
+            )
+        ],
+    )
+
+
+def taxonomy_service_request(
+    url: str,
+    subject: str,
+    action: str,
+    input_fields: list[str],
+    output_field: str,
+    cache: RequestCache | None = None,
+) -> tuple[requests.Response | None, ProcessingResult | None]:
+    """Fetch `url` from the taxonomy service, using a cache if provided.
+    Returns (response, None) on success, (None, error_result) on network failure."""
+    try:
+        if cache:
+            return cache.get_or_fetch(url), None
+        else:
+            return requests.get(url, timeout=15), None
+    except requests.exceptions.RequestException as e:
+        return None, ProcessingResult(
+            datum=None,
+            warnings=[],
+            errors=[
+                ProcessingAnnotation.from_fields(
+                    input_fields,
+                    [output_field],
+                    AnnotationSourceType.METADATA,
+                    message=f"Internal error: network error while {action} '{subject}': {e}. Please contact the administrator.",
+                )
+            ],
+        )
+
+
 class ProcessingFunctions:
     @classmethod
     def call_function(
@@ -1588,18 +1633,7 @@ class ProcessingFunctions:
 
         tax_service = args.get("taxonomy_service_url")
         if not tax_service:
-            return ProcessingResult(
-                datum=None,
-                warnings=[],
-                errors=[
-                    ProcessingAnnotation.from_fields(
-                        input_fields,
-                        [output_field],
-                        AnnotationSourceType.METADATA,
-                        message="Configuration error: taxonomy_service_url was None. Please contact the administrator.",
-                    )
-                ],
-            )
+            return missing_taxonomy_service_error(input_fields, output_field)
 
         # host will exist only for direct submissions
         # hostTaxonId and hostNameScientific are noInput, so the only case where they exist is
@@ -1623,21 +1657,11 @@ class ProcessingFunctions:
             query = urllib.parse.urlencode({"scientific_name": unvalidated})
             url = f"{tax_service}/taxa?{query}"
 
-        try:
-            response = taxonomy_cache.get_or_fetch(url)
-        except requests.exceptions.RequestException as e:
-            return ProcessingResult(
-                datum=None,
-                warnings=[],
-                errors=[
-                    ProcessingAnnotation.from_fields(
-                        input_fields,
-                        [output_field],
-                        AnnotationSourceType.METADATA,
-                        message=f"Internal error: network error while validating '{unvalidated}': {e}. Please contact the administrator",
-                    )
-                ],
-            )
+        response, error = taxonomy_service_request(
+            url, unvalidated, "validating", input_fields, output_field, taxonomy_cache
+        )
+        if error:
+            return error
 
         body = response.json()
         if response.status_code != requests.codes.ok:
@@ -1700,18 +1724,7 @@ class ProcessingFunctions:
 
         tax_service = args.get("taxonomy_service_url")
         if not tax_service:
-            return ProcessingResult(
-                datum=None,
-                warnings=[],
-                errors=[
-                    ProcessingAnnotation.from_fields(
-                        input_fields,
-                        [output_field],
-                        AnnotationSourceType.METADATA,
-                        message="Configuration error: taxonomy_service_url was None. Please contact the administrator.",
-                    )
-                ],
-            )
+            return missing_taxonomy_service_error(input_fields, output_field)
 
         tax_id: str | None = input_data.get("hostTaxonId")
         if not tax_id:
@@ -1722,21 +1735,11 @@ class ProcessingFunctions:
             )
 
         url = f"{tax_service}/taxa/{tax_id}"
-        try:
-            response = taxonomy_cache.get_or_fetch(url)
-        except requests.exceptions.RequestException as e:
-            return ProcessingResult(
-                datum=None,
-                warnings=[],
-                errors=[
-                    ProcessingAnnotation.from_fields(
-                        input_fields,
-                        [output_field],
-                        AnnotationSourceType.METADATA,
-                        message=f"Internal error: network error while validating '{tax_id}': {e}. Please contact the administrator",
-                    )
-                ],
-            )
+        response, error = taxonomy_service_request(
+            url, tax_id, "validating", input_fields, output_field, taxonomy_cache
+        )
+        if error:
+            return error
 
         body = response.json()
         if response.status_code != requests.codes.ok:
@@ -1783,18 +1786,7 @@ class ProcessingFunctions:
     ) -> ProcessingResult:
         tax_service = args.get("taxonomy_service_url")
         if not tax_service:
-            return ProcessingResult(
-                datum=None,
-                warnings=[],
-                errors=[
-                    ProcessingAnnotation.from_fields(
-                        input_fields,
-                        [output_field],
-                        AnnotationSourceType.METADATA,
-                        message="Configuration error: taxonomy_service_url was None. Please contact the administrator.",
-                    )
-                ],
-            )
+            return missing_taxonomy_service_error(input_fields, output_field)
 
         tax_id: str | None = input_data.get("hostTaxonId")
         if not tax_id:
@@ -1805,21 +1797,11 @@ class ProcessingFunctions:
             )
 
         url = f"{tax_service}/taxa/{tax_id}?find_common_name=true"
-        try:
-            response = taxonomy_cache.get_or_fetch(url)
-        except requests.exceptions.RequestException as e:
-            return ProcessingResult(
-                datum=None,
-                warnings=[],
-                errors=[
-                    ProcessingAnnotation.from_fields(
-                        input_fields,
-                        [output_field],
-                        AnnotationSourceType.METADATA,
-                        message=f"Internal error: network error while getting common name for '{tax_id}': {e}. Please contact the administrator.",
-                    )
-                ],
-            )
+        response, error = taxonomy_service_request(
+            url, tax_id, "getting common name for", input_fields, output_field, taxonomy_cache
+        )
+        if error:
+            return error
 
         body = response.json()
         if response.status_code != requests.codes.ok:


### PR DESCRIPTION
There was quite a bit of shared code between `validate_host()`, `scientific_name_from_id()` and `common_name_from_id()`

This PR extracts the shared functionality into functions that are now called by each of the three functions. This was mainly done by Claude, and tweaked by me.


### PR Checklist
~- [ ] All necessary documentation has been adapted.~
- [x] The implemented feature is covered by appropriate, automated tests.
~- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~

🚀 Preview: Add `preview` label to enable