### PR TITLE
feat(deployment): add traefikVersion toggle for v2/v3

### DIFF
--- a/kubernetes/loculus/templates/ingressroute.yaml
+++ b/kubernetes/loculus/templates/ingressroute.yaml
@@ -1,11 +1,12 @@
-apiVersion: traefik.containo.us/v1alpha1
+{{- $traefikApiVersion := ternary "traefik.io/v1alpha1" "traefik.containo.us/v1alpha1" (eq (int $.Values.traefikVersion) 3) -}}
+apiVersion: {{ $traefikApiVersion }}
 kind: Middleware
 metadata:
   name: compression-middleware
 spec:
   compress: {}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: {{ $traefikApiVersion }}
 kind: Middleware
 metadata:
   name: redirect-middleware
@@ -15,7 +16,7 @@ spec:
     permanent: true
 {{ if $.Values.secrets.basicauth }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: {{ $traefikApiVersion }}
 kind: Middleware
 metadata:
   name: basic-auth
@@ -25,7 +26,7 @@ spec:
 {{ end  }}
 {{ if $.Values.robotsNoindexHeader }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: {{ $traefikApiVersion }}
 kind: Middleware
 metadata:
   name: noindex-robots-header
@@ -35,7 +36,7 @@ spec:
       X-Robots-Tag: "noindex, nofollow"
 {{ end }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: {{ $traefikApiVersion }}
 kind: Middleware
 metadata:
   name: redirect-www-middleware
@@ -133,7 +134,7 @@ spec:
     - host: "{{ $keycloakHost }}"
       http:
         paths:
-          - path: /{+}
+          - path: /
             pathType: Prefix
             backend:
               service:

--- a/kubernetes/loculus/templates/lapis-ingress.yaml
+++ b/kubernetes/loculus/templates/lapis-ingress.yaml
@@ -1,11 +1,12 @@
 {{- $lapisHost := printf "lapis%s%s" .Values.subdomainSeparator .Values.host }}
+{{- $traefikApiVersion := ternary "traefik.io/v1alpha1" "traefik.containo.us/v1alpha1" (eq (int $.Values.traefikVersion) 3) -}}
 {{- $enabledOrganismsResult := (include "loculus.enabledOrganisms" . | fromJson) }}
 {{- $enabledOrganismsList := $enabledOrganismsResult.organisms }}
 {{- $organismKeys := list -}}
 {{- range $_, $item := $enabledOrganismsList -}}
   {{- $organismKeys = append $organismKeys $item.key -}}
 {{- end -}}
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: {{ $traefikApiVersion }}
 kind: Middleware
 metadata:
   name: cors-all-origins
@@ -50,7 +51,7 @@ spec:
 
 {{- range $key := $organismKeys }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: {{ $traefikApiVersion }}
 kind: Middleware
 metadata:
   name: strip-{{ $key }}-prefix
@@ -60,7 +61,7 @@ spec:
       - /{{ $key }}/
 {{- end }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: {{ $traefikApiVersion }}
 kind: Middleware
 metadata:
   name: redirect-slash

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1562,6 +1562,13 @@
       "default": true,
       "description": "TODO"
     },
+    "traefikVersion": {
+      "groups": ["general"],
+      "type": "integer",
+      "enum": [2, 3],
+      "default": 2,
+      "description": "Traefik major version for CRD API group. Use 2 for traefik.containo.us/v1alpha1 (Traefik v2) or 3 for traefik.io/v1alpha1 (Traefik v3)."
+    },
     "ingestLimitSeconds": {
       "type": "integer",
       "default": 1800,

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2617,6 +2617,7 @@ runDevelopmentMainDatabase: true
 runDevelopmentS3: true
 developmentDatabasePersistence: false
 enforceHTTPS: true
+traefikVersion: 2
 registrationTermsMessage: >
   You must agree to the <a href="http://main.loculus.org/terms">terms of use</a>.
 


### PR DESCRIPTION
## Summary

Adds a `traefikVersion` Helm value (default `2`) that selects the Middleware CRD `apiVersion` group used by the chart:

- `traefikVersion: 2` → `traefik.containo.us/v1alpha1` (Traefik v2, unchanged default)
- `traefikVersion: 3` → `traefik.io/v1alpha1` (Traefik v3)

The templates compute a single `$traefikApiVersion` variable via a ternary on the value, and every `Middleware` resource in `templates/ingressroute.yaml` and `templates/lapis-ingress.yaml` (compression, redirect-to-https, basic-auth, noindex-robots-header, redirect-www, cors-all-origins, strip-*-prefix, redirect-slash) renders with that group. `values.schema.json` declares `traefikVersion` as an integer with `enum: [2, 3]`.

While in the area, this also changes the keycloak ingress path from `/{+}` to `/` with `pathType: Prefix`. The `/{+}` syntax causes 404s under Traefik v3; `/` achieves the same catch-all behavior using standard Ingress path semantics and works identically under v2.

This lets existing v2 deployments stay on their current defaults and lets operators migrate to Traefik v3 by flipping a single value — no chart fork or template patching required.

## Test plan

- [ ] `helm lint kubernetes/loculus -f kubernetes/loculus/values.yaml` passes
- [ ] `helm template kubernetes/loculus --set traefikVersion=2` emits only `traefik.containo.us/v1alpha1` for Middleware resources
- [ ] `helm template kubernetes/loculus --set traefikVersion=3` emits only `traefik.io/v1alpha1` for Middleware resources
- [ ] Deploy against a Traefik v2 cluster with defaults — website, backend, keycloak, lapis, minio ingresses all route correctly
- [ ] Deploy against a Traefik v3 cluster with `traefikVersion: 3` — same
- [ ] Verify keycloak login flow works under both versions (path `/` no longer 404s on v3)
- [ ] Schema rejects values other than `2` or `3` for `traefikVersion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable