### PR TITLE
feat(taxonomy): endpoint to get taxonomic SILO lineage

### DIFF
--- a/taxonomy/taxonomy_service/README.md
+++ b/taxonomy/taxonomy_service/README.md
@@ -16,7 +16,7 @@ The DB version is configured in `values.yaml` (`taxonomyService.dbVersion`).
 | `GET /` | Health check |
 | `GET /taxa?scientific_name=<string>` | Endpoint used to validate user input. If the input is valid, the details of all associated taxa are returned. Currently only supports validation of scientific names (case-insensitive) through the `scientific_name` query parameter. |
 | `GET /taxa/{tax_id}?find_common_name=<boolean>` |  Endpoint to use once a valid taxon ID is found. Looks up a taxon by NCBI taxon ID and returns it. If find_common_name=true, returns the nearest ancestor (including self) that has a common name. |
-| `POST /silo-lineage?prune=<boolean>&allow_large=<boolean>` |  Return a taxonomy based on the taxa provided in the request body. The taxonomy is returned as a SILO lineage yaml file. |
+| `POST /silo-lineage?prune=<boolean>&allow_large=<boolean>` |  Return a taxonomy based on the taxa provided in the request body (should be provided as {values: [<ids>]}). The taxonomy is returned as a SILO lineage yaml file. |
 
 ## Updating the NCBI database
 

--- a/taxonomy/taxonomy_service/README.md
+++ b/taxonomy/taxonomy_service/README.md
@@ -16,6 +16,7 @@ The DB version is configured in `values.yaml` (`taxonomyService.dbVersion`).
 | `GET /` | Health check |
 | `GET /taxa?scientific_name=<string>` | Endpoint used to validate user input. If the input is valid, the details of all associated taxa are returned. Currently only supports validation of scientific names (case-insensitive) through the `scientific_name` query parameter. |
 | `GET /taxa/{tax_id}?find_common_name=<boolean>` |  Endpoint to use once a valid taxon ID is found. Looks up a taxon by NCBI taxon ID and returns it. If find_common_name=true, returns the nearest ancestor (including self) that has a common name. |
+| `POST /silo-lineage?prune=<boolean>&allow_large=<boolean>` |  Return a taxonomy based on the taxa provided in the request body. The taxonomy is returned as a SILO lineage yaml file. |
 
 ## Updating the NCBI database
 

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -271,7 +271,10 @@ def get_silo_lineage(
     if missing:
         logger.warning(f"one or more requested taxa don't exist: {sorted(missing)}")
         for m in missing:
-            lineage[str(m)] = {"aliases": [], "parents": []}
+            lineage[str(m)] = {
+                "aliases": [f"Taxon {m}"],
+                "parents": ["1"],  # attach these directly to root node
+            }
 
     return Response(
         content=yaml.dump(lineage, sort_keys=False), media_type="application/yaml"

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -206,10 +206,13 @@ def get_silo_lineage(
     for child_list in children.values():
         child_list.sort()
 
-    missing = (keep_ids - {1}) - observed
-    logger.warning(f"WARNING: one or more requested taxa don't exist: {missing}")
-
     lineage = build_pruned_lineage(1, keep_ids, children, None)
+    missing = (keep_ids - {1}) - observed
+    if missing:
+        logger.warning(f"WARNING: one or more requested taxa don't exist: {missing}")
+        for m in missing:
+            lineage[m] = {"aliases": [], "parents": []}
+
     return Response(
         content=yaml.dump(lineage, sort_keys=False), media_type="application/yaml"
     )

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -111,16 +111,16 @@ def fetch_common_name(db_conn: sqlite3.Connection, taxon: Taxon) -> Taxon | None
     return None
 
 
-def get_spanning_tree(db_conn: sqlite3.Connection, tax_ids: set[int]) -> list[Taxon]:
+def get_spanning_tree(
+    db_conn: sqlite3.Connection, tax_ids: set[int]
+) -> list[tuple[int, int]]:
     """Run a recursive CTE against the database to collect the path
     from each taxon in tax_ids to the root node.
 
     Uses UNION to prevent having to evaluate parts of paths shared by
     several input taxa multiple times.
     """
-    keep_ids = tax_ids | {1}  # always include root node
-    placeholders = ",".join("?" * len(keep_ids))
-
+    placeholders = ",".join("?" * len(tax_ids))
     rows = db_conn.execute(
         f"""
       WITH RECURSIVE ancestors AS (
@@ -133,23 +133,19 @@ def get_spanning_tree(db_conn: sqlite3.Connection, tax_ids: set[int]) -> list[Ta
       )
       SELECT * FROM ancestors
     """,
-        list(keep_ids),
+        list(tax_ids),
     ).fetchall()
 
-    return [Taxon.from_row(row) for row in rows]
+    return [(row["tax_id"], row["parent_id"]) for row in rows]
 
 
-def map_child_nodes(tree: list[Taxon]) -> dict[int, list[int]]:
-    """Create a dict where keys are taxon ids and values are lists off
-    all children associated with a taxon
-    """
+def map_child_nodes(tree: list[tuple[int, int]]) -> dict[int, list[int]]:
     children: dict[int, list[int]] = defaultdict(list)
-    for taxon in tree:
-        if taxon.tax_id != taxon.parent_id:
-            children[taxon.parent_id].append(taxon.tax_id)
+    for tax_id, parent_id in tree:
+        if tax_id != parent_id:
+            children[parent_id].append(tax_id)
     for child_list in children.values():
         child_list.sort()
-
     return children
 
 
@@ -226,7 +222,7 @@ def get_silo_lineage(
     payload: SubtreeRequestBody,
     db: DbConnection,
 ) -> Response:
-    taxon_ids = set()
+    taxon_ids = {1}  # always include the root node
     for i in payload.tax_ids:
         try:
             taxon_ids.add(int(i))

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -165,7 +165,7 @@ def build_silo_lineage(
 
     if node_id in keep_ids:
         taxon = tree[node_id]
-        alias = f"{node_id}; {taxon.scientific_name}"
+        alias = f"Taxon {node_id}: {taxon.scientific_name}"
         if taxon.common_name is not None:
             alias += f"; {taxon.common_name}"
         result[str(node_id)] = {

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -207,9 +207,12 @@ def get_silo_lineage(
         child_list.sort()
 
     lineage = build_pruned_lineage(1, keep_ids, children, None)
+
     missing = (keep_ids - {1}) - observed
     if missing:
-        logger.warning(f"WARNING: one or more requested taxa don't exist: {missing}")
+        logger.warning(
+            f"WARNING: one or more requested taxa don't exist: {sorted(missing)}"
+        )
         for m in missing:
             lineage[m] = {"aliases": [], "parents": []}
 

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -111,18 +111,51 @@ def fetch_common_name(db_conn: sqlite3.Connection, taxon: Taxon) -> Taxon | None
     return None
 
 
-def build_pruned_lineage(
+def get_spanning_tree(db_conn: sqlite3.Connection, tax_ids: set[int]):
+    keep_ids = set(tax_ids) | {1}
+    placeholders = ",".join("?" * len(keep_ids))
+
+    rows = db_conn.execute(
+        f"""
+      WITH RECURSIVE ancestors AS (
+          SELECT tax_id, parent_id
+          FROM taxonomy WHERE tax_id IN ({placeholders})
+          UNION
+          SELECT t.tax_id, t.parent_id
+          FROM taxonomy t JOIN ancestors a ON t.tax_id = a.parent_id
+          WHERE t.tax_id != t.parent_id
+      )
+      SELECT * FROM ancestors
+    """,
+        list(keep_ids),
+    ).fetchall()
+
+    return rows
+
+
+def map_child_nodes(tree):
+    children: dict[int, list[int]] = defaultdict(list)
+    for node in tree:
+        if node["tax_id"] != node["parent_id"]:
+            children[node["parent_id"]].append(node["tax_id"])
+    for child_list in children.values():
+        child_list.sort()
+
+    return children
+
+
+def build_silo_lineage(
     node_id: int,
     keep_ids: set[int],
     children: dict[int, list[int]],
     parent_in_output: int | None,
-) -> dict[int, dict]:
-    result: dict[int, dict] = {}
+) -> dict[str, dict]:
+    result: dict[str, dict] = {}
 
     if node_id in keep_ids:
-        result[node_id] = {
+        result[str(node_id)] = {
             "aliases": [],
-            "parents": [parent_in_output] if parent_in_output is not None else [],
+            "parents": [str(parent_in_output)] if parent_in_output is not None else [],
         }
         next_parent = (
             node_id  # this node becomes the nearest-kept-parent for descendants
@@ -131,7 +164,7 @@ def build_pruned_lineage(
         next_parent = parent_in_output  # skip this node , pass through current parent
 
     for child_id in children.get(node_id, []):
-        result.update(build_pruned_lineage(child_id, keep_ids, children, next_parent))
+        result.update(build_silo_lineage(child_id, keep_ids, children, next_parent))
 
     return result
 
@@ -174,47 +207,29 @@ def get_taxon(
     return taxon
 
 
-@app.post("/subtree")
+@app.post("/silo-lineage")
 def get_silo_lineage(
     payload: SubtreeRequestBody,
     db: DbConnection,
 ) -> Response:
-    keep_ids = set(payload.tax_ids) | {1}
-    placeholders = ",".join("?" * len(keep_ids))
+    taxon_ids = {1}
+    for i in payload.tax_ids:
+        try:
+            taxon_ids.add(int(i))
+        except ValueError:
+            raise HTTPException(
+                status_code=400, detail=f"tax_ids must be numeric, got '{i}'"
+            )
 
-    rows = db.execute(
-        f"""
-      WITH RECURSIVE ancestors AS (
-          SELECT tax_id, parent_id
-          FROM taxonomy WHERE tax_id IN ({placeholders})
-          UNION
-          SELECT t.tax_id, t.parent_id
-          FROM taxonomy t JOIN ancestors a ON t.tax_id = a.parent_id
-          WHERE t.tax_id != t.parent_id
-      )
-      SELECT * FROM ancestors
-    """,
-        list(keep_ids),
-    ).fetchall()
+    spanning_tree = get_spanning_tree(db, taxon_ids)
+    children = map_child_nodes(spanning_tree)
+    lineage = build_silo_lineage(1, taxon_ids, children, None)
 
-    observed = set()
-    children: dict[int, list[int]] = defaultdict(list)
-    for row in rows:
-        observed.add(row["tax_id"])
-        if row["tax_id"] != row["parent_id"]:
-            children[row["parent_id"]].append(row["tax_id"])
-    for child_list in children.values():
-        child_list.sort()
-
-    lineage = build_pruned_lineage(1, keep_ids, children, None)
-
-    missing = (keep_ids - {1}) - observed
+    missing = (taxon_ids - {1}) - {int(k) for k in lineage}
     if missing:
-        logger.warning(
-            f"WARNING: one or more requested taxa don't exist: {sorted(missing)}"
-        )
+        logger.warning(f"one or more requested taxa don't exist: {sorted(missing)}")
         for m in missing:
-            lineage[m] = {"aliases": [], "parents": []}
+            lineage[str(m)] = {"aliases": [], "parents": []}
 
     return Response(
         content=yaml.dump(lineage, sort_keys=False), media_type="application/yaml"

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -113,7 +113,7 @@ def fetch_common_name(db_conn: sqlite3.Connection, taxon: Taxon) -> Taxon | None
 
 def get_spanning_tree(
     db_conn: sqlite3.Connection, tax_ids: set[int]
-) -> list[tuple[int, int]]:
+) -> dict[int, Taxon]:
     """Run a recursive CTE against the database to collect the path
     from each taxon in tax_ids to the root node.
 
@@ -124,10 +124,10 @@ def get_spanning_tree(
     rows = db_conn.execute(
         f"""
       WITH RECURSIVE ancestors AS (
-          SELECT tax_id, parent_id
+          SELECT *
           FROM taxonomy WHERE tax_id IN ({placeholders})
           UNION
-          SELECT t.tax_id, t.parent_id
+          SELECT t.*
           FROM taxonomy t JOIN ancestors a ON t.tax_id = a.parent_id
           WHERE t.tax_id != t.parent_id
       )
@@ -136,14 +136,14 @@ def get_spanning_tree(
         list(tax_ids),
     ).fetchall()
 
-    return [(row["tax_id"], row["parent_id"]) for row in rows]
+    return {row["tax_id"]: Taxon.from_row(row) for row in rows}
 
 
-def map_child_nodes(tree: list[tuple[int, int]]) -> dict[int, list[int]]:
+def map_child_nodes(tree: dict[int, Taxon]) -> dict[int, list[int]]:
     children: dict[int, list[int]] = defaultdict(list)
-    for tax_id, parent_id in tree:
-        if tax_id != parent_id:
-            children[parent_id].append(tax_id)
+    for taxon in tree.values():
+        if taxon.tax_id != taxon.parent_id:
+            children[taxon.parent_id].append(taxon.tax_id)
     for child_list in children.values():
         child_list.sort()
     return children
@@ -152,6 +152,7 @@ def map_child_nodes(tree: list[tuple[int, int]]) -> dict[int, list[int]]:
 def build_silo_lineage(
     node_id: int,
     keep_ids: set[int],
+    tree: dict[int, Taxon],
     children: dict[int, list[int]],
     parent_in_output: int | None,
 ) -> dict[str, dict]:
@@ -163,8 +164,12 @@ def build_silo_lineage(
     result: dict[str, dict] = {}
 
     if node_id in keep_ids:
+        taxon = tree[node_id]
+        alias = f"{node_id}; {taxon.scientific_name}"
+        if taxon.common_name is not None:
+            alias += f"; {taxon.common_name}"
         result[str(node_id)] = {
-            "aliases": [],
+            "aliases": [alias],
             "parents": [str(parent_in_output)] if parent_in_output is not None else [],
         }
         next_parent = (
@@ -174,7 +179,9 @@ def build_silo_lineage(
         next_parent = parent_in_output  # skip this node, pass through current parent
 
     for child_id in children.get(node_id, []):
-        result.update(build_silo_lineage(child_id, keep_ids, children, next_parent))
+        result.update(
+            build_silo_lineage(child_id, keep_ids, tree, children, next_parent)
+        )
 
     return result
 
@@ -233,7 +240,7 @@ def get_silo_lineage(
 
     spanning_tree = get_spanning_tree(db, taxon_ids)
     children = map_child_nodes(spanning_tree)
-    lineage = build_silo_lineage(1, taxon_ids, children, None)
+    lineage = build_silo_lineage(1, taxon_ids, spanning_tree, children, None)
 
     missing = (taxon_ids - {1}) - {int(k) for k in lineage}
     if missing:

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -1,10 +1,14 @@
+from collections import defaultdict
 import logging
 import sqlite3
 from collections.abc import Generator
 from typing import Annotated
 
 import uvicorn
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, Response
+import yaml
+
+from taxonomy_service.datatypes import SubtreeRequestBody
 
 from taxonomy_service.datatypes import Taxon
 
@@ -107,6 +111,31 @@ def fetch_common_name(db_conn: sqlite3.Connection, taxon: Taxon) -> Taxon | None
     return None
 
 
+def build_pruned_lineage(
+    node_id: int,
+    keep_ids: set[int],
+    children: dict[int, list[int]],
+    parent_in_output: int | None,
+) -> dict[int, dict]:
+    result: dict[int, dict] = {}
+
+    if node_id in keep_ids:
+        result[node_id] = {
+            "aliases": [],
+            "parents": [parent_in_output] if parent_in_output is not None else [],
+        }
+        next_parent = (
+            node_id  # this node becomes the nearest-kept-parent for descendants
+        )
+    else:
+        next_parent = parent_in_output  # skip this node , pass through current parent
+
+    for child_id in children.get(node_id, []):
+        result.update(build_pruned_lineage(child_id, keep_ids, children, next_parent))
+
+    return result
+
+
 @app.get("/")
 def read_root() -> dict[str, str]:
     return {"message": "Taxonomy service is running"}
@@ -143,6 +172,47 @@ def get_taxon(
         return taxon_with_common_name
 
     return taxon
+
+
+@app.post("/subtree")
+def get_silo_lineage(
+    payload: SubtreeRequestBody,
+    db: DbConnection,
+) -> Response:
+    keep_ids = set(payload.tax_ids) | {1}
+    placeholders = ",".join("?" * len(keep_ids))
+
+    rows = db.execute(
+        f"""
+      WITH RECURSIVE ancestors AS (
+          SELECT tax_id, parent_id
+          FROM taxonomy WHERE tax_id IN ({placeholders})
+          UNION
+          SELECT t.tax_id, t.parent_id
+          FROM taxonomy t JOIN ancestors a ON t.tax_id = a.parent_id
+          WHERE t.tax_id != t.parent_id
+      )
+      SELECT * FROM ancestors
+    """,
+        list(keep_ids),
+    ).fetchall()
+
+    observed = set()
+    children: dict[int, list[int]] = defaultdict(list)
+    for row in rows:
+        observed.add(row["tax_id"])
+        if row["tax_id"] != row["parent_id"]:
+            children[row["parent_id"]].append(row["tax_id"])
+    for child_list in children.values():
+        child_list.sort()
+
+    missing = (keep_ids - {1}) - observed
+    logger.warning(f"WARNING: one or more requested taxa don't exist: {missing}")
+
+    lineage = build_pruned_lineage(1, keep_ids, children, None)
+    return Response(
+        content=yaml.dump(lineage, sort_keys=False), media_type="application/yaml"
+    )
 
 
 def init_app(config: Config):

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -111,8 +111,14 @@ def fetch_common_name(db_conn: sqlite3.Connection, taxon: Taxon) -> Taxon | None
     return None
 
 
-def get_spanning_tree(db_conn: sqlite3.Connection, tax_ids: set[int]):
-    keep_ids = set(tax_ids) | {1}
+def get_spanning_tree(db_conn: sqlite3.Connection, tax_ids: set[int]) -> list[Taxon]:
+    """Run a recursive CTE against the database to collect the path
+    from each taxon in tax_ids to the root node.
+
+    Uses UNION to prevent having to evaluate parts of paths shared by
+    several input taxa multiple times.
+    """
+    keep_ids = tax_ids | {1}  # always include root node
     placeholders = ",".join("?" * len(keep_ids))
 
     rows = db_conn.execute(
@@ -130,14 +136,17 @@ def get_spanning_tree(db_conn: sqlite3.Connection, tax_ids: set[int]):
         list(keep_ids),
     ).fetchall()
 
-    return rows
+    return [Taxon.from_row(row) for row in rows]
 
 
-def map_child_nodes(tree):
+def map_child_nodes(tree: list[Taxon]) -> dict[int, list[int]]:
+    """Create a dict where keys are taxon ids and values are lists off
+    all children associated with a taxon
+    """
     children: dict[int, list[int]] = defaultdict(list)
-    for node in tree:
-        if node["tax_id"] != node["parent_id"]:
-            children[node["parent_id"]].append(node["tax_id"])
+    for taxon in tree:
+        if taxon.tax_id != taxon.parent_id:
+            children[taxon.parent_id].append(taxon.tax_id)
     for child_list in children.values():
         child_list.sort()
 
@@ -150,6 +159,11 @@ def build_silo_lineage(
     children: dict[int, list[int]],
     parent_in_output: int | None,
 ) -> dict[str, dict]:
+    """Build a dict representing a SILO-formatted lineage.
+
+    Prune nodes that aren't in `keep_ids`. If a node is pruned, connect
+    its child nodes to the node's parent so the overall hierarchy is preserved.
+    """
     result: dict[str, dict] = {}
 
     if node_id in keep_ids:
@@ -161,7 +175,7 @@ def build_silo_lineage(
             node_id  # this node becomes the nearest-kept-parent for descendants
         )
     else:
-        next_parent = parent_in_output  # skip this node , pass through current parent
+        next_parent = parent_in_output  # skip this node, pass through current parent
 
     for child_id in children.get(node_id, []):
         result.update(build_silo_lineage(child_id, keep_ids, children, next_parent))
@@ -212,7 +226,7 @@ def get_silo_lineage(
     payload: SubtreeRequestBody,
     db: DbConnection,
 ) -> Response:
-    taxon_ids = {1}
+    taxon_ids = set()
     for i in payload.tax_ids:
         try:
             taxon_ids.add(int(i))

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 import logging
 import sqlite3
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from typing import Annotated
 
 import uvicorn
@@ -111,9 +111,7 @@ def fetch_common_name(db_conn: sqlite3.Connection, taxon: Taxon) -> Taxon | None
     return None
 
 
-def get_spanning_tree(
-    db_conn: sqlite3.Connection, tax_ids: set[int]
-) -> dict[int, Taxon]:
+def get_spanning_tree(db_conn: sqlite3.Connection, tax_ids: set[int]) -> list[Taxon]:
     """Run a recursive CTE against the database to collect the path
     from each taxon in tax_ids to the root node.
 
@@ -132,56 +130,83 @@ def get_spanning_tree(
           WHERE t.tax_id != t.parent_id
       )
       SELECT * FROM ancestors
+      ORDER BY depth, tax_id
     """,
         list(tax_ids),
     ).fetchall()
 
-    return {row["tax_id"]: Taxon.from_row(row) for row in rows}
+    return [Taxon.from_row(row) for row in rows]
 
 
-def map_child_nodes(tree: dict[int, Taxon]) -> dict[int, list[int]]:
+def map_child_nodes(tree: list[Taxon]) -> dict[int, list[int]]:
+    """Take a list of Taxons (each of which declares its parent) and
+    return a dict that maps each Taxon's id to its children
+    """
     children: dict[int, list[int]] = defaultdict(list)
-    for taxon in tree.values():
+
+    for taxon in tree:
         if taxon.tax_id != taxon.parent_id:
             children[taxon.parent_id].append(taxon.tax_id)
     for child_list in children.values():
         child_list.sort()
+
     return children
 
 
-def build_silo_lineage(
-    node_id: int,
+def prune_tree(
+    tree: list[Taxon],
     keep_ids: set[int],
-    tree: dict[int, Taxon],
-    children: dict[int, list[int]],
-    parent_in_output: int | None,
-) -> dict[str, dict]:
-    """Build a dict representing a SILO-formatted lineage.
+    root_id: int,
+) -> list[Taxon]:
+    """Return a list of Taxa pruned to `keep_ids`, rooted at `root_id`.
+    Pruned taxa are skipped; their children reattach to the nearest kept ancestor
+    to preserve the overall hierarchy.
+    """
+    indexed_by_id: dict[int, Taxon] = {t.tax_id: t for t in tree}
+    children = map_child_nodes(tree)
+    return list(_prune(indexed_by_id, keep_ids, children, root_id, root_id).values())
 
-    Prune nodes that aren't in `keep_ids`. If a node is pruned, connect
-    its child nodes to the node's parent so the overall hierarchy is preserved.
+
+def _prune(
+    tree_by_id: dict[int, Taxon],
+    keep_ids: set[int],
+    children: dict[int, list[int]],
+    node_id: int,
+    parent_in_output: int,
+) -> dict[int, Taxon]:
+    result: dict[int, Taxon] = {}
+
+    current_taxon = tree_by_id[node_id]
+    if current_taxon.tax_id in keep_ids:
+        result[node_id] = current_taxon.model_copy(
+            update={"parent_id": parent_in_output}
+        )
+        next_parent = current_taxon.tax_id
+    else:
+        next_parent = parent_in_output
+
+    for child_id in children.get(node_id, []):
+        result.update(_prune(tree_by_id, keep_ids, children, child_id, next_parent))
+
+    return result
+
+
+def convert_to_silo_yaml(taxa: Iterable[Taxon]) -> dict[str, dict]:
+    """Generate a dict that can be dumped to a SILO-compatible yaml
+    file representing the taxonomic hierarchy.
     """
     result: dict[str, dict] = {}
 
-    if node_id in keep_ids:
-        taxon = tree[node_id]
-        alias = f"Taxon {node_id}: {taxon.scientific_name}"
+    for taxon in taxa:
+        alias = f"Taxon {taxon.tax_id}: {taxon.scientific_name}"
         if taxon.common_name is not None:
             alias += f"; {taxon.common_name}"
-        result[str(node_id)] = {
+        result[str(taxon.tax_id)] = {
             "aliases": [alias],
-            "parents": [str(parent_in_output)] if parent_in_output is not None else [],
+            "parents": [str(taxon.parent_id)]
+            if taxon.tax_id != taxon.parent_id
+            else [],
         }
-        next_parent = (
-            node_id  # this node becomes the nearest-kept-parent for descendants
-        )
-    else:
-        next_parent = parent_in_output  # skip this node, pass through current parent
-
-    for child_id in children.get(node_id, []):
-        result.update(
-            build_silo_lineage(child_id, keep_ids, tree, children, next_parent)
-        )
 
     return result
 
@@ -226,8 +251,7 @@ def get_taxon(
 
 @app.post("/silo-lineage")
 def get_silo_lineage(
-    payload: SubtreeRequestBody,
-    db: DbConnection,
+    payload: SubtreeRequestBody, db: DbConnection, prune: bool = False
 ) -> Response:
     taxon_ids = {1}  # always include the root node
     for i in payload.tax_ids:
@@ -239,8 +263,9 @@ def get_silo_lineage(
             )
 
     spanning_tree = get_spanning_tree(db, taxon_ids)
-    children = map_child_nodes(spanning_tree)
-    lineage = build_silo_lineage(1, taxon_ids, spanning_tree, children, None)
+    if prune:
+        spanning_tree = prune_tree(spanning_tree, taxon_ids, root_id=1)
+    lineage = convert_to_silo_yaml(spanning_tree)
 
     missing = (taxon_ids - {1}) - {int(k) for k in lineage}
     if missing:

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -14,6 +14,11 @@ from taxonomy_service.datatypes import Taxon
 
 from .config import Config
 
+# LAPIS/SILO uses Jackson to parse YAML files, which by default sets a limit of 3MB
+# If we send a lineage file over the limit to SILO it will crash and take down the
+# instance, so for large files we send back status 413 instead.
+LARGE_FILE_THRESHOLD = 2.5 * 1024 * 1024
+
 logger = logging.getLogger()
 
 app = FastAPI(
@@ -250,8 +255,11 @@ def get_taxon(
 
 
 @app.post("/silo-lineage")
-def get_silo_lineage(
-    payload: SubtreeRequestBody, db: DbConnection, prune: bool = False
+def post_silo_lineage(
+    payload: SubtreeRequestBody,
+    db: DbConnection,
+    prune: bool = False,
+    allow_large: bool = False,
 ) -> Response:
     taxon_ids = {1}  # always include the root node
     for i in payload.tax_ids:
@@ -276,9 +284,19 @@ def get_silo_lineage(
                 "parents": ["1"],  # attach these directly to root node
             }
 
-    return Response(
-        content=yaml.dump(lineage, sort_keys=False), media_type="application/yaml"
-    )
+    lineage_yaml = yaml.dump(lineage, sort_keys=False)
+    yaml_size = len(lineage_yaml.encode("utf-8"))
+    if yaml_size > LARGE_FILE_THRESHOLD and not allow_large:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"Generated lineage file is {yaml_size / 1024 / 1024:.2f}MB, "
+                f"larger than the default limit of {LARGE_FILE_THRESHOLD / 1024 / 1024:.2f}MB. "
+                f"Retry request with `allow_large=true` to get the full file"
+            ),
+        )
+
+    return Response(content=lineage_yaml, media_type="application/yaml")
 
 
 def init_app(config: Config):

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -102,8 +102,8 @@ def post_silo_lineage(
                         If False, return status 413 if the generated yaml file is
                         larger than `LARGE_FILE_THRESHOLD`
     """
-    tax_ids = set(payload.tax_ids)
-    if not tax_ids:
+    tax_ids = {ROOT_TAX_ID} | set(payload.tax_ids)
+    if tax_ids == {ROOT_TAX_ID}:
         return Response(content="{}\n", media_type="application/yaml")
 
     spanning_tree, missing_ids = get_spanning_tree(db, tax_ids)
@@ -114,15 +114,13 @@ def post_silo_lineage(
         )
 
     if prune:
-        spanning_tree = prune_tree(
-            spanning_tree, tax_ids | {ROOT_TAX_ID}, root_id=ROOT_TAX_ID
-        )
+        spanning_tree = prune_tree(spanning_tree, tax_ids, root_id=ROOT_TAX_ID)
 
     lineage = convert_to_lineage_dict(spanning_tree)
     for m in missing_ids:
         lineage[str(m)] = {
             "aliases": [f"Taxon {m}"],
-            "parents": ["1"],  # attach these to the root
+            "parents": [f"{ROOT_TAX_ID}"],  # attach these to the root
         }
 
     lineage_yaml = lineage_dict_to_string(lineage, allow_large)

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -102,15 +102,15 @@ def post_silo_lineage(
                         If False, return status 413 if the generated yaml file is
                         larger than `LARGE_FILE_THRESHOLD`
     """
-    tax_ids = {ROOT_TAX_ID} | set(payload.tax_ids)
-    if tax_ids == {ROOT_TAX_ID}:
+    tax_ids = set(payload.tax_ids)
+    if not tax_ids:
         return Response(content="{}\n", media_type="application/yaml")
 
     spanning_tree, missing_ids = get_spanning_tree(db, tax_ids)
     if missing_ids:
         logger.warning(
             f"one or more provided taxa don't exist "
-            f"and will be attached to the root taxon: {sorted(missing_ids)}"
+            f"and will be added as orphan nodes: {sorted(missing_ids)}"
         )
 
     if prune:
@@ -120,7 +120,7 @@ def post_silo_lineage(
     for m in missing_ids:
         lineage[str(m)] = {
             "aliases": [f"Taxon {m}"],
-            "parents": [f"{ROOT_TAX_ID}"],  # attach these to the root
+            "parents": [],  # add these as orphan nodes
         }
 
     lineage_yaml = lineage_dict_to_string(lineage, allow_large)

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -4,25 +4,21 @@ from collections.abc import Generator
 from typing import Annotated
 
 import uvicorn
-import yaml
 from fastapi import Depends, FastAPI, HTTPException, Response
 
 from taxonomy_service.datatypes import SubtreeRequestBody, Taxon
 from taxonomy_service.helpers import (
-    convert_to_silo_yaml,
+    convert_to_lineage_dict,
     fetch_by_id,
     fetch_by_sci_name,
     fetch_common_name,
+    find_existing_ids,
     get_spanning_tree,
+    lineage_dict_to_string,
     prune_tree,
 )
 
 from .config import Config
-
-# LAPIS/SILO uses Jackson to parse YAML files, which by default sets a limit of 3MB
-# If we send a lineage file over the limit to SILO it will crash and take down the
-# instance, so for large files we send back status 413 instead.
-LARGE_FILE_THRESHOLD = 2.5 * 1024 * 1024
 
 logger = logging.getLogger()
 
@@ -106,34 +102,32 @@ def post_silo_lineage(
                         If False, return status 413 if the generated yaml file is
                         larger than `LARGE_FILE_THRESHOLD`
     """
-    taxon_ids = {1} | set(payload.tax_ids)  # always include the root node
+    tax_ids = set(payload.tax_ids)
+    existing_ids = find_existing_ids(db, tax_ids)
+    if not existing_ids:
+        lineage = {str(t): {"aliases": [f"Taxon {t}"], "parents": []} for t in tax_ids}
+        lineage_yaml = lineage_dict_to_string(lineage, allow_large)
+        return Response(content=lineage_yaml, media_type="application/yaml")
 
-    spanning_tree = get_spanning_tree(db, taxon_ids)
-    if prune:
-        spanning_tree = prune_tree(spanning_tree, taxon_ids, root_id=1)
-    lineage = convert_to_silo_yaml(spanning_tree)
-
-    missing = (taxon_ids - {1}) - {int(k) for k in lineage}
+    missing = tax_ids - existing_ids
     if missing:
-        logger.warning(f"one or more requested taxa don't exist: {sorted(missing)}")
-        for m in missing:
-            lineage[str(m)] = {
-                "aliases": [f"Taxon {m}"],
-                "parents": ["1"],  # attach these directly to root node
-            }
-
-    lineage_yaml = yaml.dump(lineage, sort_keys=False)
-    yaml_size = len(lineage_yaml.encode("utf-8"))
-    if yaml_size > LARGE_FILE_THRESHOLD and not allow_large:
-        raise HTTPException(
-            status_code=413,
-            detail=(
-                f"Generated lineage file is {yaml_size / 1024 / 1024:.2f}MB, "
-                f"larger than the default limit of {LARGE_FILE_THRESHOLD / 1024 / 1024:.2f}MB. "
-                f"Retry request with `allow_large=true` to get the full file"
-            ),
+        logger.warning(
+            f"one or more provided taxa don't exist "
+            f"and will be added as orphan nodes: {sorted(missing)}"
         )
 
+    spanning_tree, root_id = get_spanning_tree(db, existing_ids)
+    if prune:
+        spanning_tree = prune_tree(spanning_tree, existing_ids, root_id=root_id)
+
+    lineage = convert_to_lineage_dict(spanning_tree)
+    for m in missing:
+        lineage[str(m)] = {
+            "aliases": [f"Taxon {m}"],
+            "parents": [],  # add these as orphan nodes
+        }
+
+    lineage_yaml = lineage_dict_to_string(lineage, allow_large)
     return Response(content=lineage_yaml, media_type="application/yaml")
 
 

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -175,18 +175,33 @@ def _prune(
     keep_ids: set[int],
     children: dict[int, list[int]],
     node_id: int,
-    parent_in_output: int,
+    parent_id_after_prune: int,
 ) -> dict[int, Taxon]:
+    """Recursively walk the subtree rooted at `node_id`, keeping only taxa in `keep_ids`.
+
+    Kept taxa are emitted with their `parent_id` rewritten to `parent_id_after_prune` (the
+    nearest kept ancestor in the output), so the children of skipped taxa reattach to
+    that ancestor and the overall hierarchy is preserved.
+
+    args:
+      tree_by_id (dict[int, Taxon]):  all taxa in the spanning tree, indexed by tax_id
+      keep_ids (set[int]):            tax_ids that should appear in the output
+      children (dict[int, list[int]]):
+                                      map of tax_id -> list of child tax_ids
+      node_id (int):                  tax_id of the node currently being visited
+      parent_id_after_prune (int):    tax_id of the nearest kept ancestor; used as the
+                                      rewritten parent_id when `node_id` is kept
+    """
     result: dict[int, Taxon] = {}
 
     current_taxon = tree_by_id[node_id]
     if current_taxon.tax_id in keep_ids:
         result[node_id] = current_taxon.model_copy(
-            update={"parent_id": parent_in_output}
+            update={"parent_id": parent_id_after_prune}
         )
         next_parent = current_taxon.tax_id
     else:
-        next_parent = parent_in_output
+        next_parent = parent_id_after_prune
 
     for child_id in children.get(node_id, []):
         result.update(_prune(tree_by_id, keep_ids, children, child_id, next_parent))

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -8,11 +8,11 @@ from fastapi import Depends, FastAPI, HTTPException, Response
 
 from taxonomy_service.datatypes import SubtreeRequestBody, Taxon
 from taxonomy_service.helpers import (
+    ROOT_TAX_ID,
     convert_to_lineage_dict,
     fetch_by_id,
     fetch_by_sci_name,
     fetch_common_name,
-    find_existing_ids,
     get_spanning_tree,
     lineage_dict_to_string,
     prune_tree,
@@ -103,28 +103,26 @@ def post_silo_lineage(
                         larger than `LARGE_FILE_THRESHOLD`
     """
     tax_ids = set(payload.tax_ids)
-    existing_ids = find_existing_ids(db, tax_ids)
-    if not existing_ids:
-        lineage = {str(t): {"aliases": [f"Taxon {t}"], "parents": []} for t in tax_ids}
-        lineage_yaml = lineage_dict_to_string(lineage, allow_large)
-        return Response(content=lineage_yaml, media_type="application/yaml")
+    if not tax_ids:
+        return Response(content="{}\n", media_type="application/yaml")
 
-    missing = tax_ids - existing_ids
-    if missing:
+    spanning_tree, missing_ids = get_spanning_tree(db, tax_ids)
+    if missing_ids:
         logger.warning(
             f"one or more provided taxa don't exist "
-            f"and will be added as orphan nodes: {sorted(missing)}"
+            f"and will be attached to the root taxon: {sorted(missing_ids)}"
         )
 
-    spanning_tree, root_id = get_spanning_tree(db, existing_ids)
     if prune:
-        spanning_tree = prune_tree(spanning_tree, existing_ids, root_id=root_id)
+        spanning_tree = prune_tree(
+            spanning_tree, tax_ids | {ROOT_TAX_ID}, root_id=ROOT_TAX_ID
+        )
 
     lineage = convert_to_lineage_dict(spanning_tree)
-    for m in missing:
+    for m in missing_ids:
         lineage[str(m)] = {
             "aliases": [f"Taxon {m}"],
-            "parents": [],  # add these as orphan nodes
+            "parents": ["1"],  # attach these to the root
         }
 
     lineage_yaml = lineage_dict_to_string(lineage, allow_large)

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -261,6 +261,19 @@ def post_silo_lineage(
     prune: bool = False,
     allow_large: bool = False,
 ) -> Response:
+    """Return a taxonomy based on the taxa provided in the request body
+    The taxonomy is returned as a SILO-compatible yaml file.
+
+    Args:
+        prune: bool     If False, return a lineage that contains all provided tax_ids,
+                        as well as all taxa on the path from the provided tax_ids to the root.
+                        If True, return a lineage that only contains the provided tax_ids
+                        (and root), but with the overall hierarchy preserved by connecting
+                        the children of pruned taxa to the parent taxon.
+        allow_large: bool
+                        If False, return status 413 if the generated yaml file is
+                        larger than `LARGE_FILE_THRESHOLD`
+    """
     taxon_ids = {1}  # always include the root node
     for i in payload.tax_ids:
         try:

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -102,7 +102,7 @@ def post_silo_lineage(
                         If False, return status 413 if the generated yaml file is
                         larger than `LARGE_FILE_THRESHOLD`
     """
-    tax_ids = set(payload.tax_ids)
+    tax_ids = set(payload.values)
     if not tax_ids:
         return Response(content="{}\n", media_type="application/yaml")
 

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -1,14 +1,21 @@
-from collections import defaultdict
 import logging
 import sqlite3
-from collections.abc import Generator, Iterable
+from collections.abc import Generator
 from typing import Annotated
 
 import uvicorn
-from fastapi import Depends, FastAPI, HTTPException, Response
 import yaml
+from fastapi import Depends, FastAPI, HTTPException, Response
 
 from taxonomy_service.datatypes import SubtreeRequestBody, Taxon
+from taxonomy_service.helpers import (
+    convert_to_silo_yaml,
+    fetch_by_id,
+    fetch_by_sci_name,
+    fetch_common_name,
+    get_spanning_tree,
+    prune_tree,
+)
 
 from .config import Config
 
@@ -39,194 +46,6 @@ def get_db_connection() -> Generator[sqlite3.Connection]:
 
 
 DbConnection = Annotated[sqlite3.Connection, Depends(get_db_connection)]
-
-
-def fetch_by_sci_name(db_conn: sqlite3.Connection, name: str) -> list[Taxon] | None:
-    """Check if a scientific name exists in the taxonomy and, if so, return all taxa associated
-    with that name
-
-    args:
-        db_conn (sqlite3.Connection):   connection to a database. The caller is responsible
-                                        for closing it
-        name (str):                     scientific name to query the database with
-    """
-    taxa = db_conn.execute(
-        "SELECT * FROM taxonomy WHERE scientific_name = ? COLLATE NOCASE", (name,)
-    ).fetchall()
-
-    if not taxa:
-        return None
-
-    return [Taxon.from_row(row) for row in taxa]
-
-
-def fetch_by_id(db_conn: sqlite3.Connection, tax_id: int) -> Taxon | None:
-    """Return the taxon associated with `tax_id`. Return None if `tax_id` does not exist in the DB
-
-    args:
-        db_conn (sqlite3.Connection):   connection to a database. The caller is responsible for closing it
-        tax_id (int):                   NCBI taxon ID to query the database with
-    """
-    taxon = db_conn.execute(
-        "SELECT * FROM taxonomy WHERE tax_id = ?", (tax_id,)
-    ).fetchone()
-    if not taxon:
-        return None
-
-    return Taxon.from_row(taxon)
-
-
-def fetch_common_name(db_conn: sqlite3.Connection, taxon: Taxon) -> Taxon | None:
-    """Return a taxon with a common name
-
-    If the supplied `taxon` is associated with a common name, return the taxon.
-
-    If there is no common name associated with the taxon, keep stepping up the taxonomy until
-    a taxon is found with a common name, and return that
-
-    args:
-        db_conn (sqlite3.Connection):   connection to a database. The caller is responsible for closing it
-        taxon (Taxon):                  Taxon for which to find a common name
-    """
-    if taxon.common_name is not None:
-        return taxon
-
-    # creating a reusable cursor here instead of calling `fetch_by_id` in the while loop
-    cursor = db_conn.cursor()
-    tax_id = taxon.parent_id
-    while tax_id > 1:  # tax_id 1 is the root
-        row = cursor.execute(
-            "SELECT * FROM taxonomy WHERE tax_id = ?", (tax_id,)
-        ).fetchone()
-        if row is None:
-            break
-
-        taxon = Taxon.from_row(row)
-        if taxon.depth == 0:
-            # for safety, break when depth is 0 (in case NCBI decide at some
-            # point that the root should no longer be 1)
-            break
-        if taxon.common_name is not None:
-            return taxon
-
-        tax_id = taxon.parent_id
-
-    return None
-
-
-def get_spanning_tree(db_conn: sqlite3.Connection, tax_ids: set[int]) -> list[Taxon]:
-    """Run a recursive CTE against the database to collect the path
-    from each taxon in tax_ids to the root node.
-
-    Uses UNION to prevent having to evaluate parts of paths shared by
-    several input taxa multiple times.
-    """
-    placeholders = ",".join("?" * len(tax_ids))
-    rows = db_conn.execute(
-        f"""
-      WITH RECURSIVE ancestors AS (
-          SELECT *
-          FROM taxonomy WHERE tax_id IN ({placeholders})
-          UNION
-          SELECT t.*
-          FROM taxonomy t JOIN ancestors a ON t.tax_id = a.parent_id
-          WHERE t.tax_id != t.parent_id
-      )
-      SELECT * FROM ancestors
-      ORDER BY depth, tax_id
-    """,
-        list(tax_ids),
-    ).fetchall()
-
-    return [Taxon.from_row(row) for row in rows]
-
-
-def map_child_nodes(tree: list[Taxon]) -> dict[int, list[int]]:
-    """Take a list of Taxons (each of which declares its parent) and
-    return a dict that maps each Taxon's id to its children
-    """
-    children: dict[int, list[int]] = defaultdict(list)
-
-    for taxon in tree:
-        if taxon.tax_id != taxon.parent_id:
-            children[taxon.parent_id].append(taxon.tax_id)
-    for child_list in children.values():
-        child_list.sort()
-
-    return children
-
-
-def prune_tree(
-    tree: list[Taxon],
-    keep_ids: set[int],
-    root_id: int,
-) -> list[Taxon]:
-    """Return a list of Taxa pruned to `keep_ids`, rooted at `root_id`.
-    Pruned taxa are skipped; their children reattach to the nearest kept ancestor
-    to preserve the overall hierarchy.
-    """
-    indexed_by_id: dict[int, Taxon] = {t.tax_id: t for t in tree}
-    children = map_child_nodes(tree)
-    return list(_prune(indexed_by_id, keep_ids, children, root_id, root_id).values())
-
-
-def _prune(
-    tree_by_id: dict[int, Taxon],
-    keep_ids: set[int],
-    children: dict[int, list[int]],
-    node_id: int,
-    parent_id_after_prune: int,
-) -> dict[int, Taxon]:
-    """Recursively walk the subtree rooted at `node_id`, keeping only taxa in `keep_ids`.
-
-    Kept taxa are emitted with their `parent_id` rewritten to `parent_id_after_prune` (the
-    nearest kept ancestor in the output), so the children of skipped taxa reattach to
-    that ancestor and the overall hierarchy is preserved.
-
-    args:
-      tree_by_id (dict[int, Taxon]):  all taxa in the spanning tree, indexed by tax_id
-      keep_ids (set[int]):            tax_ids that should appear in the output
-      children (dict[int, list[int]]):
-                                      map of tax_id -> list of child tax_ids
-      node_id (int):                  tax_id of the node currently being visited
-      parent_id_after_prune (int):    tax_id of the nearest kept ancestor; used as the
-                                      rewritten parent_id when `node_id` is kept
-    """
-    result: dict[int, Taxon] = {}
-
-    current_taxon = tree_by_id[node_id]
-    if current_taxon.tax_id in keep_ids:
-        result[node_id] = current_taxon.model_copy(
-            update={"parent_id": parent_id_after_prune}
-        )
-        next_parent = current_taxon.tax_id
-    else:
-        next_parent = parent_id_after_prune
-
-    for child_id in children.get(node_id, []):
-        result.update(_prune(tree_by_id, keep_ids, children, child_id, next_parent))
-
-    return result
-
-
-def convert_to_silo_yaml(taxa: Iterable[Taxon]) -> dict[str, dict]:
-    """Generate a dict that can be dumped to a SILO-compatible yaml
-    file representing the taxonomic hierarchy.
-    """
-    result: dict[str, dict] = {}
-
-    for taxon in taxa:
-        alias = f"Taxon {taxon.tax_id}: {taxon.scientific_name}"
-        if taxon.common_name is not None:
-            alias += f"; {taxon.common_name}"
-        result[str(taxon.tax_id)] = {
-            "aliases": [alias],
-            "parents": [str(taxon.parent_id)]
-            if taxon.tax_id != taxon.parent_id
-            else [],
-        }
-
-    return result
 
 
 @app.get("/")

--- a/taxonomy/taxonomy_service/src/taxonomy_service/api.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/api.py
@@ -8,9 +8,7 @@ import uvicorn
 from fastapi import Depends, FastAPI, HTTPException, Response
 import yaml
 
-from taxonomy_service.datatypes import SubtreeRequestBody
-
-from taxonomy_service.datatypes import Taxon
+from taxonomy_service.datatypes import SubtreeRequestBody, Taxon
 
 from .config import Config
 
@@ -274,14 +272,7 @@ def post_silo_lineage(
                         If False, return status 413 if the generated yaml file is
                         larger than `LARGE_FILE_THRESHOLD`
     """
-    taxon_ids = {1}  # always include the root node
-    for i in payload.tax_ids:
-        try:
-            taxon_ids.add(int(i))
-        except ValueError:
-            raise HTTPException(
-                status_code=400, detail=f"tax_ids must be numeric, got '{i}'"
-            )
+    taxon_ids = {1} | set(payload.tax_ids)  # always include the root node
 
     spanning_tree = get_spanning_tree(db, taxon_ids)
     if prune:

--- a/taxonomy/taxonomy_service/src/taxonomy_service/datatypes.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/datatypes.py
@@ -16,4 +16,4 @@ class Taxon(BaseModel):
 
 
 class SubtreeRequestBody(BaseModel):
-    tax_ids: list[int]
+    tax_ids: list[str]

--- a/taxonomy/taxonomy_service/src/taxonomy_service/datatypes.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/datatypes.py
@@ -13,3 +13,7 @@ class Taxon(BaseModel):
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> Self:
         return cls.model_validate(dict(row))
+
+
+class SubtreeRequestBody(BaseModel):
+    tax_ids: list[int]

--- a/taxonomy/taxonomy_service/src/taxonomy_service/datatypes.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/datatypes.py
@@ -16,4 +16,4 @@ class Taxon(BaseModel):
 
 
 class SubtreeRequestBody(BaseModel):
-    tax_ids: list[int]
+    values: list[int]

--- a/taxonomy/taxonomy_service/src/taxonomy_service/datatypes.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/datatypes.py
@@ -16,4 +16,4 @@ class Taxon(BaseModel):
 
 
 class SubtreeRequestBody(BaseModel):
-    tax_ids: list[str]
+    tax_ids: list[int]

--- a/taxonomy/taxonomy_service/src/taxonomy_service/helpers.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/helpers.py
@@ -111,7 +111,9 @@ def get_spanning_tree(
 ) -> tuple[list[Taxon], set[int]]:
     """Run a recursive CTE against the database to collect the path
     from each taxon in tax_ids to the taxonomic root
-    NOTE: root itself is only included in output if it is part of `tax_ids`
+
+    The root taxon has itself as a parent, but the use of UNION in the recursive
+    CTE avoids an infinite loop: it stops recursing if no new rows are added
 
     args:
         db_conn: sqlite3.Connection:
@@ -138,7 +140,6 @@ def get_spanning_tree(
           UNION
           SELECT t.*
           FROM taxonomy t JOIN ancestors a ON t.tax_id = a.parent_id
-          WHERE t.tax_id != t.parent_id
       )
       SELECT * FROM ancestors
       ORDER BY depth, tax_id
@@ -177,7 +178,9 @@ def prune_tree(
     if root_id not in indexed_by_id:
         raise ValueError(f"root_id {root_id} does not exist in the provided tree")
     children = map_child_nodes(tree)
-    return list(_prune(indexed_by_id, keep_ids, children, root_id, root_id).values())
+    return list(
+        _prune(indexed_by_id, keep_ids | {root_id}, children, root_id, root_id).values()
+    )
 
 
 def _prune(

--- a/taxonomy/taxonomy_service/src/taxonomy_service/helpers.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/helpers.py
@@ -2,8 +2,15 @@ import sqlite3
 from collections import defaultdict
 from collections.abc import Iterable
 
+import yaml
+from fastapi import HTTPException
 
 from taxonomy_service.datatypes import Taxon
+
+# LAPIS/SILO uses Jackson to parse YAML files, which by default sets a limit of 3MB
+# If we send a lineage file over the limit to SILO it will crash and take down the
+# instance, so for large files we send back status 413 instead.
+LARGE_FILE_THRESHOLD = 2.5 * 1024 * 1024
 
 
 def fetch_by_sci_name(db_conn: sqlite3.Connection, name: str) -> list[Taxon] | None:
@@ -79,31 +86,79 @@ def fetch_common_name(db_conn: sqlite3.Connection, taxon: Taxon) -> Taxon | None
     return None
 
 
-def get_spanning_tree(db_conn: sqlite3.Connection, tax_ids: set[int]) -> list[Taxon]:
-    """Run a recursive CTE against the database to collect the path
-    from each taxon in tax_ids to the root node.
+def find_existing_ids(db_conn: sqlite3.Connection, tax_ids: set[int]) -> set[int]:
+    """Take in a set of unvalidated tax_ids and return the ones
+    that exist in the database
+    """
+    if not tax_ids:
+        return set()
 
-    Uses UNION to prevent having to evaluate parts of paths shared by
-    several input taxa multiple times.
+    placeholders = ",".join("?" * len(tax_ids))
+    existing = {
+        row["tax_id"]
+        for row in db_conn.execute(
+            f"SELECT tax_id FROM taxonomy WHERE tax_id IN ({placeholders})",
+            list(tax_ids),
+        ).fetchall()
+    }
+
+    return existing
+
+
+def get_spanning_tree(
+    db_conn: sqlite3.Connection, tax_ids: set[int]
+) -> tuple[list[Taxon], int]:
+    """Run a recursive CTE against the database to collect the path
+    from each taxon in tax_ids to their most recent common ancestor.
+
+    NOTE: `tax_ids` is assumed to have at least one ID, and all IDs are assumed to exist!
+    See `find_existing_ids()`
     """
     placeholders = ",".join("?" * len(tax_ids))
     rows = db_conn.execute(
         f"""
-      WITH RECURSIVE ancestors AS (
-          SELECT *
-          FROM taxonomy WHERE tax_id IN ({placeholders})
+    WITH RECURSIVE ancestors AS (
+          SELECT
+              tax_id AS original_tax_id,
+              taxonomy.*
+          FROM taxonomy
+          WHERE tax_id IN ({placeholders})
+
           UNION
-          SELECT t.*
-          FROM taxonomy t JOIN ancestors a ON t.tax_id = a.parent_id
+
+          SELECT
+              a.original_tax_id,
+              t.*
+          FROM taxonomy t
+          JOIN ancestors a ON t.tax_id = a.parent_id
           WHERE t.tax_id != t.parent_id
+      ),
+      mrca AS (
+          SELECT tax_id, depth
+          FROM ancestors
+          GROUP BY tax_id, depth
+          HAVING COUNT(DISTINCT original_tax_id) = {len(tax_ids)}
+          ORDER BY depth DESC
+          LIMIT 1
       )
-      SELECT * FROM ancestors
-      ORDER BY depth, tax_id
+      SELECT t.*
+      FROM taxonomy t
+      CROSS JOIN mrca m
+      WHERE t.tax_id IN (SELECT tax_id FROM ancestors)
+        AND t.depth >= m.depth
+      ORDER BY t.depth, t.tax_id;
     """,
         list(tax_ids),
     ).fetchall()
 
-    return [Taxon.from_row(row) for row in rows]
+    taxa = [Taxon.from_row(row) for row in rows]
+    if any(t.depth == taxa[0].depth for t in taxa[1:]):
+        raise RuntimeError(
+            "spanning tree contained multiple taxa at MRCA depth, which should be impossible"
+        )
+    taxa[0] = taxa[0].model_copy(update={"parent_id": taxa[0].tax_id})
+
+    return taxa, taxa[0].tax_id
 
 
 def map_child_nodes(tree: list[Taxon]) -> dict[int, list[int]]:
@@ -174,7 +229,7 @@ def _prune(
     return result
 
 
-def convert_to_silo_yaml(taxa: Iterable[Taxon]) -> dict[str, dict]:
+def convert_to_lineage_dict(taxa: Iterable[Taxon]) -> dict[str, dict]:
     """Generate a dict that can be dumped to a SILO-compatible yaml
     file representing the taxonomic hierarchy.
     """
@@ -192,3 +247,25 @@ def convert_to_silo_yaml(taxa: Iterable[Taxon]) -> dict[str, dict]:
         }
 
     return result
+
+
+def lineage_dict_to_string(lineage: dict[str, dict], allow_large: bool) -> str:
+    """Generates a yaml string representation of a lineage dictionary and
+    checks its size.
+
+    If the size is > LARGE_FILE_THRESHOLD and allow_large is false, raise
+    a 413 HTTPException
+    """
+    lineage_yaml = yaml.dump(lineage, sort_keys=False)
+    yaml_size = len(lineage_yaml.encode("utf-8"))
+    if yaml_size > LARGE_FILE_THRESHOLD and not allow_large:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"Generated lineage file is {yaml_size / 1024 / 1024:.2f}MB, "
+                f"larger than the default limit of {LARGE_FILE_THRESHOLD / 1024 / 1024:.2f}MB. "
+                f"Retry request with `allow_large=true` to get the full file"
+            ),
+        )
+
+    return lineage_yaml

--- a/taxonomy/taxonomy_service/src/taxonomy_service/helpers.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/helpers.py
@@ -11,6 +11,7 @@ from taxonomy_service.datatypes import Taxon
 # If we send a lineage file over the limit to SILO it will crash and take down the
 # instance, so for large files we send back status 413 instead.
 LARGE_FILE_THRESHOLD = 2.5 * 1024 * 1024
+ROOT_TAX_ID = 1
 
 
 def fetch_by_sci_name(db_conn: sqlite3.Connection, name: str) -> list[Taxon] | None:
@@ -66,7 +67,7 @@ def fetch_common_name(db_conn: sqlite3.Connection, taxon: Taxon) -> Taxon | None
     # creating a reusable cursor here instead of calling `fetch_by_id` in the while loop
     cursor = db_conn.cursor()
     tax_id = taxon.parent_id
-    while tax_id > 1:  # tax_id 1 is the root
+    while tax_id > ROOT_TAX_ID:
         row = cursor.execute(
             "SELECT * FROM taxonomy WHERE tax_id = ?", (tax_id,)
         ).fetchone()
@@ -107,58 +108,45 @@ def find_existing_ids(db_conn: sqlite3.Connection, tax_ids: set[int]) -> set[int
 
 def get_spanning_tree(
     db_conn: sqlite3.Connection, tax_ids: set[int]
-) -> tuple[list[Taxon], int]:
+) -> tuple[list[Taxon], set[int]]:
     """Run a recursive CTE against the database to collect the path
-    from each taxon in tax_ids to their most recent common ancestor.
+    from each taxon in tax_ids to the taxonomic root
 
-    NOTE: `tax_ids` is assumed to have at least one ID, and all IDs are assumed to exist!
-    See `find_existing_ids()`
+    args:
+        db_conn: sqlite3.Connection:
+                        Connection to the database
+        tax_ids: set[int]
+                        A set of taxon identifiers to build a spanning tree for
+
+    returns:
+        list[Taxon]:    The taxonomic tree spanning all input tax_ids, represented
+                        as a list of taxa
+        set[int]:       Taxon ids in `tax_ids` that do not exist in the database
     """
-    placeholders = ",".join("?" * len(tax_ids))
+    existing_ids = find_existing_ids(db_conn, tax_ids)
+    if not existing_ids:
+        return [], tax_ids
+    existing_ids = {ROOT_TAX_ID} | existing_ids  # always include the root node
+    missing_ids = tax_ids - existing_ids
+
+    placeholders = ",".join("?" * len(existing_ids))
     rows = db_conn.execute(
         f"""
-    WITH RECURSIVE ancestors AS (
-          SELECT
-              tax_id AS original_tax_id,
-              taxonomy.*
-          FROM taxonomy
-          WHERE tax_id IN ({placeholders})
-
+      WITH RECURSIVE ancestors AS (
+          SELECT *
+          FROM taxonomy WHERE tax_id IN ({placeholders})
           UNION
-
-          SELECT
-              a.original_tax_id,
-              t.*
-          FROM taxonomy t
-          JOIN ancestors a ON t.tax_id = a.parent_id
+          SELECT t.*
+          FROM taxonomy t JOIN ancestors a ON t.tax_id = a.parent_id
           WHERE t.tax_id != t.parent_id
-      ),
-      mrca AS (
-          SELECT tax_id, depth
-          FROM ancestors
-          GROUP BY tax_id, depth
-          HAVING COUNT(DISTINCT original_tax_id) = {len(tax_ids)}
-          ORDER BY depth DESC
-          LIMIT 1
       )
-      SELECT t.*
-      FROM taxonomy t
-      CROSS JOIN mrca m
-      WHERE t.tax_id IN (SELECT tax_id FROM ancestors)
-        AND t.depth >= m.depth
-      ORDER BY t.depth, t.tax_id;
+      SELECT * FROM ancestors
+      ORDER BY depth, tax_id
     """,
-        list(tax_ids),
+        list(existing_ids),
     ).fetchall()
 
-    taxa = [Taxon.from_row(row) for row in rows]
-    if any(t.depth == taxa[0].depth for t in taxa[1:]):
-        raise RuntimeError(
-            "spanning tree contained multiple taxa at MRCA depth, which should be impossible"
-        )
-    taxa[0] = taxa[0].model_copy(update={"parent_id": taxa[0].tax_id})
-
-    return taxa, taxa[0].tax_id
+    return [Taxon.from_row(row) for row in rows], missing_ids
 
 
 def map_child_nodes(tree: list[Taxon]) -> dict[int, list[int]]:

--- a/taxonomy/taxonomy_service/src/taxonomy_service/helpers.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/helpers.py
@@ -111,6 +111,7 @@ def get_spanning_tree(
 ) -> tuple[list[Taxon], set[int]]:
     """Run a recursive CTE against the database to collect the path
     from each taxon in tax_ids to the taxonomic root
+    NOTE: root itself is only included in output if it is part of `tax_ids`
 
     args:
         db_conn: sqlite3.Connection:
@@ -121,13 +122,12 @@ def get_spanning_tree(
     returns:
         list[Taxon]:    The taxonomic tree spanning all input tax_ids, represented
                         as a list of taxa
-        set[int]:       Taxon ids in `tax_ids` that do not exist in the database
+        set[int]:       Taxon IDs in `tax_ids` that do not exist in the database
     """
     existing_ids = find_existing_ids(db_conn, tax_ids)
+    missing_ids = tax_ids - existing_ids
     if not existing_ids:
         return [], tax_ids
-    existing_ids = {ROOT_TAX_ID} | existing_ids  # always include the root node
-    missing_ids = tax_ids - existing_ids
 
     placeholders = ",".join("?" * len(existing_ids))
     rows = db_conn.execute(
@@ -174,6 +174,8 @@ def prune_tree(
     to preserve the overall hierarchy.
     """
     indexed_by_id: dict[int, Taxon] = {t.tax_id: t for t in tree}
+    if root_id not in indexed_by_id:
+        raise ValueError(f"root_id {root_id} does not exist in the provided tree")
     children = map_child_nodes(tree)
     return list(_prune(indexed_by_id, keep_ids, children, root_id, root_id).values())
 

--- a/taxonomy/taxonomy_service/src/taxonomy_service/helpers.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/helpers.py
@@ -1,0 +1,194 @@
+import sqlite3
+from collections import defaultdict
+from collections.abc import Iterable
+
+
+from taxonomy_service.datatypes import Taxon
+
+
+def fetch_by_sci_name(db_conn: sqlite3.Connection, name: str) -> list[Taxon] | None:
+    """Check if a scientific name exists in the taxonomy and, if so, return all taxa associated
+    with that name
+
+    args:
+        db_conn (sqlite3.Connection):   connection to a database. The caller is responsible
+                                        for closing it
+        name (str):                     scientific name to query the database with
+    """
+    taxa = db_conn.execute(
+        "SELECT * FROM taxonomy WHERE scientific_name = ? COLLATE NOCASE", (name,)
+    ).fetchall()
+
+    if not taxa:
+        return None
+
+    return [Taxon.from_row(row) for row in taxa]
+
+
+def fetch_by_id(db_conn: sqlite3.Connection, tax_id: int) -> Taxon | None:
+    """Return the taxon associated with `tax_id`. Return None if `tax_id` does not exist in the DB
+
+    args:
+        db_conn (sqlite3.Connection):   connection to a database. The caller is responsible for closing it
+        tax_id (int):                   NCBI taxon ID to query the database with
+    """
+    taxon = db_conn.execute(
+        "SELECT * FROM taxonomy WHERE tax_id = ?", (tax_id,)
+    ).fetchone()
+    if not taxon:
+        return None
+
+    return Taxon.from_row(taxon)
+
+
+def fetch_common_name(db_conn: sqlite3.Connection, taxon: Taxon) -> Taxon | None:
+    """Return a taxon with a common name
+
+    If the supplied `taxon` is associated with a common name, return the taxon.
+
+    If there is no common name associated with the taxon, keep stepping up the taxonomy until
+    a taxon is found with a common name, and return that
+
+    args:
+        db_conn (sqlite3.Connection):   connection to a database. The caller is responsible for closing it
+        taxon (Taxon):                  Taxon for which to find a common name
+    """
+    if taxon.common_name is not None:
+        return taxon
+
+    # creating a reusable cursor here instead of calling `fetch_by_id` in the while loop
+    cursor = db_conn.cursor()
+    tax_id = taxon.parent_id
+    while tax_id > 1:  # tax_id 1 is the root
+        row = cursor.execute(
+            "SELECT * FROM taxonomy WHERE tax_id = ?", (tax_id,)
+        ).fetchone()
+        if row is None:
+            break
+
+        taxon = Taxon.from_row(row)
+        if taxon.depth == 0:
+            # for safety, break when depth is 0 (in case NCBI decide at some
+            # point that the root should no longer be 1)
+            break
+        if taxon.common_name is not None:
+            return taxon
+
+        tax_id = taxon.parent_id
+
+    return None
+
+
+def get_spanning_tree(db_conn: sqlite3.Connection, tax_ids: set[int]) -> list[Taxon]:
+    """Run a recursive CTE against the database to collect the path
+    from each taxon in tax_ids to the root node.
+
+    Uses UNION to prevent having to evaluate parts of paths shared by
+    several input taxa multiple times.
+    """
+    placeholders = ",".join("?" * len(tax_ids))
+    rows = db_conn.execute(
+        f"""
+      WITH RECURSIVE ancestors AS (
+          SELECT *
+          FROM taxonomy WHERE tax_id IN ({placeholders})
+          UNION
+          SELECT t.*
+          FROM taxonomy t JOIN ancestors a ON t.tax_id = a.parent_id
+          WHERE t.tax_id != t.parent_id
+      )
+      SELECT * FROM ancestors
+      ORDER BY depth, tax_id
+    """,
+        list(tax_ids),
+    ).fetchall()
+
+    return [Taxon.from_row(row) for row in rows]
+
+
+def map_child_nodes(tree: list[Taxon]) -> dict[int, list[int]]:
+    """Take a list of Taxons (each of which declares its parent) and
+    return a dict that maps each Taxon's id to its children
+    """
+    children: dict[int, list[int]] = defaultdict(list)
+
+    for taxon in tree:
+        if taxon.tax_id != taxon.parent_id:
+            children[taxon.parent_id].append(taxon.tax_id)
+    for child_list in children.values():
+        child_list.sort()
+
+    return children
+
+
+def prune_tree(
+    tree: list[Taxon],
+    keep_ids: set[int],
+    root_id: int,
+) -> list[Taxon]:
+    """Return a list of Taxa pruned to `keep_ids`, rooted at `root_id`.
+    Pruned taxa are skipped; their children reattach to the nearest kept ancestor
+    to preserve the overall hierarchy.
+    """
+    indexed_by_id: dict[int, Taxon] = {t.tax_id: t for t in tree}
+    children = map_child_nodes(tree)
+    return list(_prune(indexed_by_id, keep_ids, children, root_id, root_id).values())
+
+
+def _prune(
+    tree_by_id: dict[int, Taxon],
+    keep_ids: set[int],
+    children: dict[int, list[int]],
+    node_id: int,
+    parent_id_after_prune: int,
+) -> dict[int, Taxon]:
+    """Recursively walk the subtree rooted at `node_id`, keeping only taxa in `keep_ids`.
+
+    Kept taxa are emitted with their `parent_id` rewritten to `parent_id_after_prune` (the
+    nearest kept ancestor in the output), so the children of skipped taxa reattach to
+    that ancestor and the overall hierarchy is preserved.
+
+    args:
+      tree_by_id (dict[int, Taxon]):  all taxa in the spanning tree, indexed by tax_id
+      keep_ids (set[int]):            tax_ids that should appear in the output
+      children (dict[int, list[int]]):
+                                      map of tax_id -> list of child tax_ids
+      node_id (int):                  tax_id of the node currently being visited
+      parent_id_after_prune (int):    tax_id of the nearest kept ancestor; used as the
+                                      rewritten parent_id when `node_id` is kept
+    """
+    result: dict[int, Taxon] = {}
+
+    current_taxon = tree_by_id[node_id]
+    if current_taxon.tax_id in keep_ids:
+        result[node_id] = current_taxon.model_copy(
+            update={"parent_id": parent_id_after_prune}
+        )
+        next_parent = current_taxon.tax_id
+    else:
+        next_parent = parent_id_after_prune
+
+    for child_id in children.get(node_id, []):
+        result.update(_prune(tree_by_id, keep_ids, children, child_id, next_parent))
+
+    return result
+
+
+def convert_to_silo_yaml(taxa: Iterable[Taxon]) -> dict[str, dict]:
+    """Generate a dict that can be dumped to a SILO-compatible yaml
+    file representing the taxonomic hierarchy.
+    """
+    result: dict[str, dict] = {}
+
+    for taxon in taxa:
+        alias = f"Taxon {taxon.tax_id}: {taxon.scientific_name}"
+        if taxon.common_name is not None:
+            alias += f"; {taxon.common_name}"
+        result[str(taxon.tax_id)] = {
+            "aliases": [alias],
+            "parents": [str(taxon.parent_id)]
+            if taxon.tax_id != taxon.parent_id
+            else [],
+        }
+
+    return result

--- a/taxonomy/taxonomy_service/test/test_api.py
+++ b/taxonomy/taxonomy_service/test/test_api.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import yaml
 from fastapi.testclient import TestClient
 from requests import codes
+
 from taxonomy_service.api import app, get_db_connection, init_app
 from taxonomy_service.config import Config, get_config
 
@@ -28,6 +29,15 @@ mock_taxa = {
         "common_name": "humans",
         "scientific_name": "Homo",
         "parent_id": 131567,  # skipping some levels for testing purposes
+        "depth": 30,
+    },
+    "Pan": {
+        # sibling of Homo under "cellular organisms" so we can test
+        # an MRCA that is not part of the input
+        "tax_id": 9596,
+        "common_name": "chimpanzees",
+        "scientific_name": "Pan",
+        "parent_id": 131567,
         "depth": 30,
     },
     "cellular organisms": {
@@ -146,52 +156,41 @@ class PostSiloLineageTest(unittest.TestCase):
             params=params,
         )
 
-    def test_returns_full_ancestry_for_single_taxon(self):
+    def test_single_taxon_returns_only_itself_as_root(self):
         homo_sapiens = mock_taxa["Homo sapiens"]
         response = self._post([homo_sapiens["tax_id"]])
 
         assert response.status_code == codes.ok
         lineage = yaml.safe_load(response.text)
-        assert set(lineage.keys()) == {"1", "131567", "9605", "9606"}
+        assert set(lineage.keys()) == {"9606"}
+        assert lineage["9606"]["parents"] == []
 
-    def test_root_always_included_with_no_parents(self):
-        homo = mock_taxa["Homo"]
-        response = self._post([homo["tax_id"]])
+    def test_returns_subtree_rooted_at_mrca_for_branching_inputs(self):
+        # Homo sapiens (9606) and Pan (9596) branch at "cellular organisms" (131567),
+        # which is their MRCA and therefore the root of the output subtree.
+        response = self._post([9606, 9596])
 
         assert response.status_code == codes.ok
         lineage = yaml.safe_load(response.text)
-        assert "1" in lineage
-        assert lineage["1"]["parents"] == []
-
-    def test_parent_relationships_preserved(self):
-        homo_sapiens = mock_taxa["Homo sapiens"]
-        response = self._post([homo_sapiens["tax_id"]])
-
-        lineage = yaml.safe_load(response.text)
-        assert lineage["9606"]["parents"] == ["9605"]
+        assert set(lineage.keys()) == {"131567", "9605", "9596", "9606"}
+        assert lineage["131567"]["parents"] == []
         assert lineage["9605"]["parents"] == ["131567"]
-        assert lineage["131567"]["parents"] == ["1"]
+        assert lineage["9596"]["parents"] == ["131567"]
+        assert lineage["9606"]["parents"] == ["9605"]
 
-    def test_alias_includes_common_name_when_present(self):
-        homo = mock_taxa["Homo"]
-        response = self._post([homo["tax_id"]])
+    def test_alias_includes_host_names(self):
+        response = self._post([9605, 9606])
 
         lineage = yaml.safe_load(response.text)
         assert lineage["9605"]["aliases"] == ["Taxon 9605: Homo; humans"]
-
-    def test_alias_omits_common_name_when_absent(self):
-        homo_sapiens = mock_taxa["Homo sapiens"]
-        response = self._post([homo_sapiens["tax_id"]])
-
-        lineage = yaml.safe_load(response.text)
         assert lineage["9606"]["aliases"] == ["Taxon 9606: Homo sapiens"]
 
-    def test_empty_tax_ids_returns_root_only(self):
+    def test_empty_tax_ids_returns_empty_lineage(self):
         response = self._post([])
 
         assert response.status_code == codes.ok
         lineage = yaml.safe_load(response.text)
-        assert set(lineage.keys()) == {"1"}
+        assert lineage == {}
 
     def test_non_numeric_tax_id_returns_422(self):
         response = client.post("/silo-lineage", json={"tax_ids": ["not-a-number"]})
@@ -199,36 +198,43 @@ class PostSiloLineageTest(unittest.TestCase):
         assert response.status_code == codes.unprocessable_entity
         assert "Input should be a valid integer" in response.json()["detail"][0]["msg"]
 
-    def test_missing_taxon_attached_to_root_with_placeholder_alias(self):
+    def test_missing_taxa_returned_as_unrooted_entries(self):
+        # Missing taxa should be included as orphan nodes
         response = self._post([mock_missing_taxon])
 
         assert response.status_code == codes.ok
         lineage = yaml.safe_load(response.text)
-        assert lineage[str(mock_missing_taxon)]["parents"] == ["1"]
+        assert lineage[str(mock_missing_taxon)]["parents"] == []
         assert lineage[str(mock_missing_taxon)]["aliases"] == [
             f"Taxon {mock_missing_taxon}"
         ]
 
-    def test_prune_reattaches_descendant_to_nearest_kept_ancestor(self):
-        # Spanning tree for Homo sapiens is {1, 131567, 9605, 9606}.
-        # With prune=true, only the requested taxa + root are kept (1 and 9606),
-        # so 9606 should reattach directly to 1.
-        homo_sapiens = mock_taxa["Homo sapiens"]
-        response = self._post([homo_sapiens["tax_id"]], params={"prune": "true"})
+        response = self._post([9606, 9596, mock_missing_taxon])
 
         assert response.status_code == codes.ok
         lineage = yaml.safe_load(response.text)
-        assert set(lineage.keys()) == {"1", "9606"}
-        assert lineage["9606"]["parents"] == ["1"]
+        assert lineage[str(mock_missing_taxon)]["parents"] == []
+
+    def test_prune_reattaches_descendant_to_nearest_kept_ancestor(self):
+        # MRCA of [131567, 9606] is 131567; the full tree is
+        # {131567, 9605, 9606}. With prune=true only the requested taxa are
+        # kept, so 9606 should reattach directly to 131567 (skipping 9605).
+        response = self._post([131567, 9606], params={"prune": "true"})
+
+        assert response.status_code == codes.ok
+        lineage = yaml.safe_load(response.text)
+        assert set(lineage.keys()) == {"131567", "9606"}
+        assert lineage["131567"]["parents"] == []
+        assert lineage["9606"]["parents"] == ["131567"]
 
     def test_returns_413_when_response_exceeds_threshold(self):
-        with patch("taxonomy_service.api.LARGE_FILE_THRESHOLD", 10):
+        with patch("taxonomy_service.helpers.LARGE_FILE_THRESHOLD", 10):
             response = self._post([mock_taxa["Homo sapiens"]["tax_id"]])
 
         assert response.status_code == codes.request_entity_too_large
 
     def test_allow_large_bypasses_size_guard(self):
-        with patch("taxonomy_service.api.LARGE_FILE_THRESHOLD", 10):
+        with patch("taxonomy_service.helpers.LARGE_FILE_THRESHOLD", 10):
             response = self._post(
                 [mock_taxa["Homo sapiens"]["tax_id"]],
                 params={"allow_large": "true"},

--- a/taxonomy/taxonomy_service/test/test_api.py
+++ b/taxonomy/taxonomy_service/test/test_api.py
@@ -193,13 +193,11 @@ class PostSiloLineageTest(unittest.TestCase):
         lineage = yaml.safe_load(response.text)
         assert set(lineage.keys()) == {"1"}
 
-    def test_non_numeric_tax_id_returns_400(self):
-        response = client.post(
-            "/silo-lineage", json={"tax_ids": ["not-a-number"]}
-        )
+    def test_non_numeric_tax_id_returns_422(self):
+        response = client.post("/silo-lineage", json={"tax_ids": ["not-a-number"]})
 
-        assert response.status_code == codes.bad_request
-        assert "must be numeric" in response.json()["detail"]
+        assert response.status_code == codes.unprocessable_entity
+        assert "Input should be a valid integer" in response.json()["detail"][0]["msg"]
 
     def test_missing_taxon_attached_to_root_with_placeholder_alias(self):
         response = self._post([mock_missing_taxon])
@@ -216,9 +214,7 @@ class PostSiloLineageTest(unittest.TestCase):
         # With prune=true, only the requested taxa + root are kept (1 and 9606),
         # so 9606 should reattach directly to 1.
         homo_sapiens = mock_taxa["Homo sapiens"]
-        response = self._post(
-            [homo_sapiens["tax_id"]], params={"prune": "true"}
-        )
+        response = self._post([homo_sapiens["tax_id"]], params={"prune": "true"})
 
         assert response.status_code == codes.ok
         lineage = yaml.safe_load(response.text)

--- a/taxonomy/taxonomy_service/test/test_api.py
+++ b/taxonomy/taxonomy_service/test/test_api.py
@@ -156,29 +156,19 @@ class PostSiloLineageTest(unittest.TestCase):
             params=params,
         )
 
-    def test_single_taxon_returns_only_itself_as_root(self):
-        homo_sapiens = mock_taxa["Homo sapiens"]
-        response = self._post([homo_sapiens["tax_id"]])
-
-        assert response.status_code == codes.ok
-        lineage = yaml.safe_load(response.text)
-        assert set(lineage.keys()) == {"9606"}
-        assert lineage["9606"]["parents"] == []
-
-    def test_returns_subtree_rooted_at_mrca_for_branching_inputs(self):
+    def test_returns_expected_tree(self):
         # Homo sapiens (9606) and Pan (9596) branch at "cellular organisms" (131567),
-        # which is their MRCA and therefore the root of the output subtree.
         response = self._post([9606, 9596])
 
         assert response.status_code == codes.ok
         lineage = yaml.safe_load(response.text)
-        assert set(lineage.keys()) == {"131567", "9605", "9596", "9606"}
-        assert lineage["131567"]["parents"] == []
+        assert set(lineage.keys()) == {"1", "131567", "9605", "9596", "9606"}
+        assert lineage["131567"]["parents"] == ["1"]
         assert lineage["9605"]["parents"] == ["131567"]
         assert lineage["9596"]["parents"] == ["131567"]
         assert lineage["9606"]["parents"] == ["9605"]
 
-    def test_alias_includes_host_names(self):
+    def test_alias_includes_names(self):
         response = self._post([9605, 9606])
 
         lineage = yaml.safe_load(response.text)
@@ -198,33 +188,33 @@ class PostSiloLineageTest(unittest.TestCase):
         assert response.status_code == codes.unprocessable_entity
         assert "Input should be a valid integer" in response.json()["detail"][0]["msg"]
 
-    def test_missing_taxa_returned_as_unrooted_entries(self):
-        # Missing taxa should be included as orphan nodes
+    def test_missing_taxa_attached_to_root(self):
         response = self._post([mock_missing_taxon])
 
         assert response.status_code == codes.ok
         lineage = yaml.safe_load(response.text)
-        assert lineage[str(mock_missing_taxon)]["parents"] == []
+        assert lineage[str(mock_missing_taxon)]["parents"] == ["1"]
         assert lineage[str(mock_missing_taxon)]["aliases"] == [
             f"Taxon {mock_missing_taxon}"
         ]
 
+        # Also if other valid taxa are provided
         response = self._post([9606, 9596, mock_missing_taxon])
 
         assert response.status_code == codes.ok
         lineage = yaml.safe_load(response.text)
-        assert lineage[str(mock_missing_taxon)]["parents"] == []
+        assert lineage[str(mock_missing_taxon)]["parents"] == ["1"]
 
     def test_prune_reattaches_descendant_to_nearest_kept_ancestor(self):
-        # MRCA of [131567, 9606] is 131567; the full tree is
-        # {131567, 9605, 9606}. With prune=true only the requested taxa are
-        # kept, so 9606 should reattach directly to 131567 (skipping 9605).
+        # The relevant tree is {1, 131567, 9605, 9606}.
+        # With prune=true only the requested taxa (and root) are kept,
+        # so 9606 should reattach directly to 131567 (skipping 9605).
         response = self._post([131567, 9606], params={"prune": "true"})
 
         assert response.status_code == codes.ok
         lineage = yaml.safe_load(response.text)
-        assert set(lineage.keys()) == {"131567", "9606"}
-        assert lineage["131567"]["parents"] == []
+        assert set(lineage.keys()) == {"1", "131567", "9606"}
+        assert lineage["131567"]["parents"] == ["1"]
         assert lineage["9606"]["parents"] == ["131567"]
 
     def test_returns_413_when_response_exceeds_threshold(self):

--- a/taxonomy/taxonomy_service/test/test_api.py
+++ b/taxonomy/taxonomy_service/test/test_api.py
@@ -2,7 +2,9 @@ import sqlite3
 import unittest
 import urllib.parse
 from pathlib import Path
+from unittest.mock import patch
 
+import yaml
 from fastapi.testclient import TestClient
 from requests import codes
 from taxonomy_service.api import app, get_db_connection, init_app
@@ -126,3 +128,116 @@ class ApiTest(unittest.TestCase):
             response.json()["detail"]
             == f"Unable to find common name for taxon {cellular_organisms['tax_id']}"
         )
+
+
+class PostSiloLineageTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.config: Config = get_config(config_file)
+        init_app(self.config)
+        app.dependency_overrides[get_db_connection] = get_test_db
+
+    def tearDown(self) -> None:
+        return app.dependency_overrides.clear()
+
+    def _post(self, tax_ids, params=None):
+        return client.post(
+            "/silo-lineage",
+            json={"tax_ids": [str(t) for t in tax_ids]},
+            params=params,
+        )
+
+    def test_returns_full_ancestry_for_single_taxon(self):
+        homo_sapiens = mock_taxa["Homo sapiens"]
+        response = self._post([homo_sapiens["tax_id"]])
+
+        assert response.status_code == codes.ok
+        lineage = yaml.safe_load(response.text)
+        assert set(lineage.keys()) == {"1", "131567", "9605", "9606"}
+
+    def test_root_always_included_with_no_parents(self):
+        homo = mock_taxa["Homo"]
+        response = self._post([homo["tax_id"]])
+
+        assert response.status_code == codes.ok
+        lineage = yaml.safe_load(response.text)
+        assert "1" in lineage
+        assert lineage["1"]["parents"] == []
+
+    def test_parent_relationships_preserved(self):
+        homo_sapiens = mock_taxa["Homo sapiens"]
+        response = self._post([homo_sapiens["tax_id"]])
+
+        lineage = yaml.safe_load(response.text)
+        assert lineage["9606"]["parents"] == ["9605"]
+        assert lineage["9605"]["parents"] == ["131567"]
+        assert lineage["131567"]["parents"] == ["1"]
+
+    def test_alias_includes_common_name_when_present(self):
+        homo = mock_taxa["Homo"]
+        response = self._post([homo["tax_id"]])
+
+        lineage = yaml.safe_load(response.text)
+        assert lineage["9605"]["aliases"] == ["Taxon 9605: Homo; humans"]
+
+    def test_alias_omits_common_name_when_absent(self):
+        homo_sapiens = mock_taxa["Homo sapiens"]
+        response = self._post([homo_sapiens["tax_id"]])
+
+        lineage = yaml.safe_load(response.text)
+        assert lineage["9606"]["aliases"] == ["Taxon 9606: Homo sapiens"]
+
+    def test_empty_tax_ids_returns_root_only(self):
+        response = self._post([])
+
+        assert response.status_code == codes.ok
+        lineage = yaml.safe_load(response.text)
+        assert set(lineage.keys()) == {"1"}
+
+    def test_non_numeric_tax_id_returns_400(self):
+        response = client.post(
+            "/silo-lineage", json={"tax_ids": ["not-a-number"]}
+        )
+
+        assert response.status_code == codes.bad_request
+        assert "must be numeric" in response.json()["detail"]
+
+    def test_missing_taxon_attached_to_root_with_placeholder_alias(self):
+        response = self._post([mock_missing_taxon])
+
+        assert response.status_code == codes.ok
+        lineage = yaml.safe_load(response.text)
+        assert lineage[str(mock_missing_taxon)]["parents"] == ["1"]
+        assert lineage[str(mock_missing_taxon)]["aliases"] == [
+            f"Taxon {mock_missing_taxon}"
+        ]
+
+    def test_prune_reattaches_descendant_to_nearest_kept_ancestor(self):
+        # Spanning tree for Homo sapiens is {1, 131567, 9605, 9606}.
+        # With prune=true, only the requested taxa + root are kept (1 and 9606),
+        # so 9606 should reattach directly to 1.
+        homo_sapiens = mock_taxa["Homo sapiens"]
+        response = self._post(
+            [homo_sapiens["tax_id"]], params={"prune": "true"}
+        )
+
+        assert response.status_code == codes.ok
+        lineage = yaml.safe_load(response.text)
+        assert set(lineage.keys()) == {"1", "9606"}
+        assert lineage["9606"]["parents"] == ["1"]
+
+    def test_returns_413_when_response_exceeds_threshold(self):
+        with patch("taxonomy_service.api.LARGE_FILE_THRESHOLD", 10):
+            response = self._post([mock_taxa["Homo sapiens"]["tax_id"]])
+
+        assert response.status_code == codes.request_entity_too_large
+
+    def test_allow_large_bypasses_size_guard(self):
+        with patch("taxonomy_service.api.LARGE_FILE_THRESHOLD", 10):
+            response = self._post(
+                [mock_taxa["Homo sapiens"]["tax_id"]],
+                params={"allow_large": "true"},
+            )
+
+        assert response.status_code == codes.ok
+        lineage = yaml.safe_load(response.text)
+        assert "9606" in lineage

--- a/taxonomy/taxonomy_service/test/test_api.py
+++ b/taxonomy/taxonomy_service/test/test_api.py
@@ -188,12 +188,12 @@ class PostSiloLineageTest(unittest.TestCase):
         assert response.status_code == codes.unprocessable_entity
         assert "Input should be a valid integer" in response.json()["detail"][0]["msg"]
 
-    def test_missing_taxa_attached_to_root(self):
+    def test_missing_taxa_added_as_orphans(self):
         response = self._post([mock_missing_taxon])
 
         assert response.status_code == codes.ok
         lineage = yaml.safe_load(response.text)
-        assert lineage[str(mock_missing_taxon)]["parents"] == ["1"]
+        assert lineage[str(mock_missing_taxon)]["parents"] == []
         assert lineage[str(mock_missing_taxon)]["aliases"] == [
             f"Taxon {mock_missing_taxon}"
         ]
@@ -203,7 +203,7 @@ class PostSiloLineageTest(unittest.TestCase):
 
         assert response.status_code == codes.ok
         lineage = yaml.safe_load(response.text)
-        assert lineage[str(mock_missing_taxon)]["parents"] == ["1"]
+        assert lineage[str(mock_missing_taxon)]["parents"] == []
 
     def test_prune_reattaches_descendant_to_nearest_kept_ancestor(self):
         # The relevant tree is {1, 131567, 9605, 9606}.

--- a/taxonomy/taxonomy_service/test/test_api.py
+++ b/taxonomy/taxonomy_service/test/test_api.py
@@ -149,10 +149,10 @@ class PostSiloLineageTest(unittest.TestCase):
     def tearDown(self) -> None:
         return app.dependency_overrides.clear()
 
-    def _post(self, tax_ids, params=None):
+    def _post(self, values, params=None):
         return client.post(
             "/silo-lineage",
-            json={"tax_ids": [str(t) for t in tax_ids]},
+            json={"values": [str(t) for t in values]},
             params=params,
         )
 
@@ -183,7 +183,7 @@ class PostSiloLineageTest(unittest.TestCase):
         assert lineage == {}
 
     def test_non_numeric_tax_id_returns_422(self):
-        response = client.post("/silo-lineage", json={"tax_ids": ["not-a-number"]})
+        response = client.post("/silo-lineage", json={"values": ["not-a-number"]})
 
         assert response.status_code == codes.unprocessable_entity
         assert "Input should be a valid integer" in response.json()["detail"][0]["msg"]


### PR DESCRIPTION
This PR adds a new endpoint to the taxonomy service: `POST /silo-lineage`
The endpoint takes a list of taxon ids to keep (in the request body), and returns the NCBI taxonomy with as SILO-compatible YAML:
```sh
'1':
  aliases:
  - 'Taxon 1: root'
  parents: []
'131567':
  aliases:
  - 'Taxon 131567: cellular organisms'
  parents:
  - '1'
'2759':
  aliases:
  - 'Taxon 2759: Eukaryota; eukaryotes'
  parents:
  - '131567'
...
  ```

The enpoint has two query parameters:

```python
        prune: bool = False
                                If False, return a lineage that contains all provided tax_ids,
                                as well as all taxa on the path from the provided tax_ids to the root.
                                If True, return a lineage that only contains the provided tax_ids
                                (and root), but with the overall hierarchy preserved by connecting
                                the children of pruned taxa to the parent taxon.
        allow_large: bool = False
                                If False, return status 413 if the generated yaml file is
                                larger than `LARGE_FILE_THRESHOLD`
```

`LARGE_FILE_THRESHOLD` is set to 2.5MB. The reason we refuse to send back lineages larger than this size by default is that LAPIS/SILO uses Jackson to parse YAML files, which has a limit of 3MB. If we send a lineage file over the limit to SILO it will crash and take down the instance.

## Manual testing
I made POST requests agains this endpoint with curl on the command line using all 449 host organisms we currently have in PPX (across all organisms). With `prune=true`, the resulting yaml is 41KB in size, with `prune=false`, the resulting yaml contains 960 taxa and is 76KB in size.

I also have this branch https://github.com/loculus-project/loculus/pull/6302 where I'm implementing the `silo-importer` side of things. I made a preview off this branch, and SILO pods are healthy and I can use the taxonomic lineage to filter host organisms.

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable