### PR TITLE
feat(various): Add read-only mode support for maintenance and archival

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/Config.kt
@@ -13,6 +13,7 @@ data class BackendConfig(
     val fileSharing: FileSharing = FileSharing(),
     val zstdCompressionLevel: Int = 10,
     val pipelineVersionUpgradeCheckIntervalSeconds: Long = 10,
+    val readOnlyMode: Boolean = false,
 ) {
     fun getInstanceConfig(organism: Organism) = organisms[organism.name] ?: throw IllegalArgumentException(
         "Organism: ${organism.name} not found in backend config. Available organisms: ${organisms.keys}",

--- a/backend/src/main/kotlin/org/loculus/backend/config/ReadOnlyModeInterceptor.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/ReadOnlyModeInterceptor.kt
@@ -1,0 +1,23 @@
+package org.loculus.backend.config
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.loculus.backend.controller.ServiceUnavailableException
+import org.springframework.web.servlet.HandlerInterceptor
+
+class ReadOnlyModeInterceptor(private val backendConfig: BackendConfig) : HandlerInterceptor {
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        if (backendConfig.readOnlyMode && isWriteMethod(request.method)) {
+            throw ServiceUnavailableException(
+                "This Loculus instance is in read-only mode; write requests are disabled.",
+            )
+        }
+        return true
+    }
+
+    private fun isWriteMethod(method: String): Boolean = method in WRITE_METHODS
+
+    companion object {
+        private val WRITE_METHODS = setOf("POST", "PUT", "DELETE", "PATCH")
+    }
+}

--- a/backend/src/main/kotlin/org/loculus/backend/config/WebConfig.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/WebConfig.kt
@@ -9,7 +9,7 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
-class WebConfig : WebMvcConfigurer {
+class WebConfig(private val backendConfig: BackendConfig) : WebMvcConfigurer {
     override fun addCorsMappings(registry: CorsRegistry) {
         registry.addMapping("/**")
             .allowedOrigins("*") // Allow requests from any origin
@@ -19,6 +19,7 @@ class WebConfig : WebMvcConfigurer {
     }
 
     override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(ReadOnlyModeInterceptor(backendConfig))
         registry.addInterceptor(OrganismMdcInterceptor())
     }
 

--- a/backend/src/main/kotlin/org/loculus/backend/controller/ExceptionHandler.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/ExceptionHandler.kt
@@ -111,6 +111,17 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
             )
     }
 
+    @ExceptionHandler(ServiceUnavailableException::class)
+    @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+    fun handleServiceUnavailableException(e: ServiceUnavailableException): ResponseEntity<ProblemDetail> {
+        log.info { "Caught service unavailable exception: ${e.message}" }
+
+        return responseEntity(
+            HttpStatus.SERVICE_UNAVAILABLE,
+            e.message,
+        )
+    }
+
     private fun responseEntity(httpStatus: HttpStatus, detail: String?): ResponseEntity<ProblemDetail> =
         responseEntity(httpStatus, httpStatus.reasonPhrase, detail)
 
@@ -160,3 +171,4 @@ class NotFoundException(message: String) : RuntimeException(message)
 class ProcessingValidationException(message: String) : RuntimeException(message)
 class DuplicateKeyException(message: String) : RuntimeException(message)
 class ConflictException(message: String) : RuntimeException(message)
+class ServiceUnavailableException(message: String) : RuntimeException(message)

--- a/backend/src/test/kotlin/org/loculus/backend/config/ReadOnlyModeInterceptorTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/config/ReadOnlyModeInterceptorTest.kt
@@ -1,0 +1,66 @@
+package org.loculus.backend.config
+
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.loculus.backend.controller.ServiceUnavailableException
+
+class ReadOnlyModeInterceptorTest {
+    private val response: HttpServletResponse = mockk(relaxed = true)
+    private val handler: Any = Any()
+
+    @Test
+    fun `GIVEN readOnlyMode disabled THEN all methods pass`() {
+        val config = backendConfig(readOnly = false)
+        val interceptor = ReadOnlyModeInterceptor(config)
+
+        for (method in listOf("GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH", "DELETE")) {
+            assertDoesNotThrow("$method should pass when readOnlyMode is off") {
+                assertThat(interceptor.preHandle(request(method), response, handler), `is`(true))
+            }
+        }
+    }
+
+    @Test
+    fun `GIVEN readOnlyMode enabled THEN read methods pass`() {
+        val config = backendConfig(readOnly = true)
+        val interceptor = ReadOnlyModeInterceptor(config)
+
+        for (method in listOf("GET", "HEAD", "OPTIONS")) {
+            assertDoesNotThrow("$method should pass when readOnlyMode is on") {
+                assertThat(interceptor.preHandle(request(method), response, handler), `is`(true))
+            }
+        }
+    }
+
+    @Test
+    fun `GIVEN readOnlyMode enabled THEN write methods throw ServiceUnavailableException`() {
+        val config = backendConfig(readOnly = true)
+        val interceptor = ReadOnlyModeInterceptor(config)
+
+        for (method in listOf("POST", "PUT", "PATCH", "DELETE")) {
+            val thrown = assertThrows<ServiceUnavailableException>("$method should be rejected") {
+                interceptor.preHandle(request(method), response, handler)
+            }
+            assertThat(thrown.message, `is`("This Loculus instance is in read-only mode; write requests are disabled."))
+        }
+    }
+
+    private fun request(method: String): HttpServletRequest {
+        val request: HttpServletRequest = mockk()
+        every { request.method } returns method
+        return request
+    }
+
+    private fun backendConfig(readOnly: Boolean): BackendConfig {
+        val config: BackendConfig = mockk()
+        every { config.readOnlyMode } returns readOnly
+        return config
+    }
+}

--- a/docs/src/content/docs/reference/helm-chart-config.mdx
+++ b/docs/src/content/docs/reference/helm-chart-config.mdx
@@ -40,6 +40,22 @@ Instead, external managed databases should be used.
 
 <SchemaDocs group='services' fieldColumnClass='w-48' />
 
+### Read-only mode
+
+Setting `readOnlyMode: true` at the top level of `values.yaml` puts the instance
+into a read-only state. When enabled:
+
+- The backend rejects every mutating request (`POST`, `PUT`, `PATCH`, `DELETE`)
+  with `503 Service Unavailable` and a problem-detail body explaining that the
+  instance is in read-only mode. `GET` requests continue to work.
+- The website hides the Login and Submit navigation items, disables the
+  submission pages (they return 404), skips the Keycloak redirect on pages that
+  would otherwise enforce login (they render a read-only notice instead), and
+  shows a banner informing users the instance is read-only.
+
+This flag is intended for migrations, archival instances, and maintenance
+windows. It defaults to `false`.
+
 ## SILO Configuration
 
 <SchemaDocs group='silo' fieldColumnClass='w-48' />

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -208,6 +208,7 @@ additionalHeadHTML: {{ quote $.Values.additionalHeadHTML }}
 enableLoginNavigationItem: {{ $.Values.website.websiteConfig.enableLoginNavigationItem }}
 enableSubmissionNavigationItem: {{ $.Values.website.websiteConfig.enableSubmissionNavigationItem }}
 enableSubmissionPages: {{ $.Values.website.websiteConfig.enableSubmissionPages }}
+readOnlyMode: {{ $.Values.readOnlyMode | default false }}
 enableSeqSets: {{ $.Values.seqSets.enabled }}
 {{- if $.Values.seqSets.fieldsToDisplay }}
 seqSetsFieldsToDisplay: {{ $.Values.seqSets.fieldsToDisplay | toJson }}
@@ -430,6 +431,7 @@ fields:
 accessionPrefix: {{ quote $.Values.accessionPrefix }}
 zstdCompressionLevel: {{ $.Values.zstdCompressionLevel }}
 pipelineVersionUpgradeCheckIntervalSeconds: {{ $.Values.pipelineVersionUpgradeCheckIntervalSeconds }}
+readOnlyMode: {{ $.Values.readOnlyMode | default false }}
 name: {{ quote $.Values.name }}
 dataUseTerms:
   {{$.Values.dataUseTerms | toYaml | nindent 2}}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1516,6 +1516,12 @@
       "default": false,
       "description": "If true, disables the taxonomy service deployment."
     },
+    "readOnlyMode": {
+      "groups": ["services"],
+      "type": "boolean",
+      "default": false,
+      "description": "If true, the instance runs in read-only mode: the backend rejects write requests (POST/PUT/DELETE/PATCH) with 503 Service Unavailable, and the website hides login/submission entry points and shows a read-only banner."
+    },
     "organisms": {
       "groups": ["organism-conf"],
       "type": "object",

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -33,6 +33,7 @@ disablePreprocessing: false
 disableIngest: false
 disableEnaSubmission: true
 disableTaxonomyService: false
+readOnlyMode: false
 website:
   websiteConfig:
     enableLoginNavigationItem: true

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -33,7 +33,7 @@ disablePreprocessing: false
 disableIngest: false
 disableEnaSubmission: true
 disableTaxonomyService: false
-readOnlyMode: false
+readOnlyMode: true # TODO: disable once migration/maintenance is complete
 website:
   websiteConfig:
     enableLoginNavigationItem: true

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -33,7 +33,7 @@ disablePreprocessing: false
 disableIngest: false
 disableEnaSubmission: true
 disableTaxonomyService: false
-readOnlyMode: true # TODO: disable once migration/maintenance is complete
+readOnlyMode: false
 website:
   websiteConfig:
     enableLoginNavigationItem: true

--- a/website/src/config.spec.ts
+++ b/website/src/config.spec.ts
@@ -14,6 +14,7 @@ const defaultConfig: WebsiteConfig = {
     logo: { url: '', width: 0, height: 0 },
     name: '',
     organisms: {},
+    readOnlyMode: false,
 };
 
 describe('validateWebsiteConfig', () => {

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -255,11 +255,11 @@ export function getDataUseTermsAgreementHTML() {
     return getWebsiteConfig().dataUseTermsAgreementHTML;
 }
 
-function readTypedConfigFile<T>(fileName: string, schema: z.ZodType<T>) {
+function readTypedConfigFile<Schema extends z.ZodTypeAny>(fileName: string, schema: Schema): z.infer<Schema> {
     const configFilePath = path.join(getConfigDir(), fileName);
     const json = JSON.parse(fs.readFileSync(configFilePath, 'utf8'));
     try {
-        return schema.parse(json);
+        return schema.parse(json) as z.infer<Schema>;
     } catch (e) {
         const zodError = e as ZodError;
         throw new Error(`Type error reading ${configFilePath}: ${zodError.message}`);

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -19,9 +19,12 @@ const {
     bannerMessage: configBannerMessage,
     additionalHeadHTML,
     gitHubMainUrl,
+    readOnlyMode,
 } = websiteConfig;
 const remoteBannerMessage = await getRemoteBannerMessage();
-const bannerMessage = remoteBannerMessage ?? configBannerMessage;
+const bannerMessage = readOnlyMode
+    ? 'This instance is in read-only mode. Submissions and login are disabled.'
+    : (remoteBannerMessage ?? configBannerMessage);
 
 interface Props {
     title: string;

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -22,9 +22,10 @@ const {
     readOnlyMode,
 } = websiteConfig;
 const remoteBannerMessage = await getRemoteBannerMessage();
-const bannerMessage = readOnlyMode
+const readOnlyBannerMessage = readOnlyMode
     ? 'This instance is in read-only mode. Submissions and login are disabled.'
-    : (remoteBannerMessage ?? configBannerMessage);
+    : undefined;
+const bannerMessage = remoteBannerMessage ?? configBannerMessage ?? readOnlyBannerMessage;
 
 interface Props {
     title: string;

--- a/website/src/middleware.ts
+++ b/website/src/middleware.ts
@@ -6,8 +6,9 @@ import { catchErrorMiddleware } from './middleware/catchErrorMiddleware.ts';
 import { organismValidatorMiddleware } from './middleware/organismValidatorMiddleware.ts';
 import { submissionPagesDisablingMiddleware } from './middleware/submissionPagesDisablingMiddleware.ts';
 
+const websiteConfig = safeGetWebsiteConfig();
 const middlewares = [catchErrorMiddleware, organismValidatorMiddleware, authMiddleware];
-if (!(safeGetWebsiteConfig()?.enableSubmissionPages ?? false)) {
+if (!(websiteConfig?.enableSubmissionPages ?? false) || (websiteConfig?.readOnlyMode ?? false)) {
     middlewares.push(submissionPagesDisablingMiddleware);
 }
 

--- a/website/src/middleware/authMiddleware.ts
+++ b/website/src/middleware/authMiddleware.ts
@@ -5,7 +5,7 @@ import JwksRsa from 'jwks-rsa';
 import { err, ok, ResultAsync } from 'neverthrow';
 import { type BaseClient, type TokenSet } from 'openid-client';
 
-import { getConfiguredOrganisms, getRuntimeConfig } from '../config.ts';
+import { getConfiguredOrganisms, getRuntimeConfig, getWebsiteConfig } from '../config.ts';
 import { getInstanceLogger } from '../logger.ts';
 import { KeycloakClientManager } from '../utils/KeycloakClientManager.ts';
 import { getAuthUrl } from '../utils/getAuthUrl.ts';
@@ -64,6 +64,19 @@ async function getValidTokenAndUserInfoFromParams(context: APIContext, client: B
 export const authMiddleware = defineMiddleware(async (context, next) => {
     let token: TokenCookie | undefined;
     let userInfo;
+
+    if (getWebsiteConfig().readOnlyMode) {
+        const enforceLogin = shouldMiddlewareEnforceLogin(
+            context.url.pathname,
+            getConfiguredOrganisms().map((it) => it.key),
+        );
+        if (enforceLogin) {
+            return context.redirect('/503?service=readonly');
+        }
+        deleteCookie(context);
+        context.locals.session = { isLoggedIn: false };
+        return next();
+    }
 
     const client = await KeycloakClientManager.getClient();
     if (client !== undefined) {

--- a/website/src/middleware/submissionPagesDisablingMiddleware.ts
+++ b/website/src/middleware/submissionPagesDisablingMiddleware.ts
@@ -1,9 +1,14 @@
 import { defineMiddleware } from 'astro/middleware';
 
+import { getWebsiteConfig } from '../config.ts';
+
 export const submissionPagesDisablingMiddleware = defineMiddleware(async (context, next) => {
     const organism = context.params.organism;
 
     if (organism !== undefined && context.url.pathname.includes(`${organism}/submission`)) {
+        if (getWebsiteConfig().readOnlyMode) {
+            return context.rewrite('/503?service=readonly');
+        }
         return context.rewrite('/404');
     }
 

--- a/website/src/pages/503.astro
+++ b/website/src/pages/503.astro
@@ -6,6 +6,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 const allowedServiceNames = ['authentication'];
 
 const serviceParam = Astro.url.searchParams.get('service');
+const isReadOnly = serviceParam?.toLowerCase() === 'readonly';
 
 let service = 'Internal';
 let bodyService = 'internal service you are trying to access';
@@ -15,11 +16,23 @@ if (serviceParam !== null && serviceParam !== '' && allowedServiceNames.includes
 }
 ---
 
-<BaseLayout title={`${service} service unavailable`}>
-    <div class='bc'>
-        <h1 class='title'>{`${service} service unavailable`}</h1>
-        <p>
-            The {bodyService} is currently unavailable. Please check back later.
-        </p>
-    </div>
-</BaseLayout>
+{
+    isReadOnly ? (
+        <BaseLayout title='Read-only mode'>
+            <div class='bc'>
+                <h1 class='title'>Read-only mode</h1>
+                <p>
+                    This Loculus instance is currently in read-only mode. Login, submissions, and other write operations
+                    are disabled. You can still browse and search existing data.
+                </p>
+            </div>
+        </BaseLayout>
+    ) : (
+        <BaseLayout title={`${service} service unavailable`}>
+            <div class='bc'>
+                <h1 class='title'>{`${service} service unavailable`}</h1>
+                <p>The {bodyService} is currently unavailable. Please check back later.</p>
+            </div>
+        </BaseLayout>
+    )
+}

--- a/website/src/routes/navigationItems.ts
+++ b/website/src/routes/navigationItems.ts
@@ -34,7 +34,7 @@ export function getSequenceRelatedItems(organism: string | undefined) {
         icon: SearchIcon,
     };
 
-    if (!getWebsiteConfig().enableSubmissionNavigationItem) {
+    if (!getWebsiteConfig().enableSubmissionNavigationItem || getWebsiteConfig().readOnlyMode) {
         return [browseItem];
     }
 
@@ -61,7 +61,7 @@ function getSeqSetsItems() {
 }
 
 function getAccountItems(isLoggedIn: boolean, loginUrl: string) {
-    if (!getWebsiteConfig().enableLoginNavigationItem) {
+    if (!getWebsiteConfig().enableLoginNavigationItem || getWebsiteConfig().readOnlyMode) {
         return [];
     }
 

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -258,6 +258,7 @@ export const websiteConfig = z.object({
     enableSubmissionNavigationItem: z.boolean(),
     enableSubmissionPages: z.boolean(),
     enableDataUseTerms: z.boolean(),
+    readOnlyMode: z.boolean(),
     dataUseTermsAgreementHTML: z.string().optional(),
     sequenceFlagging: sequenceFlaggingConfig.optional(),
 });

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -258,7 +258,7 @@ export const websiteConfig = z.object({
     enableSubmissionNavigationItem: z.boolean(),
     enableSubmissionPages: z.boolean(),
     enableDataUseTerms: z.boolean(),
-    readOnlyMode: z.boolean(),
+    readOnlyMode: z.boolean().default(false),
     dataUseTermsAgreementHTML: z.string().optional(),
     sequenceFlagging: sequenceFlaggingConfig.optional(),
 });


### PR DESCRIPTION
## Description

Implements a read-only mode feature that allows Loculus instances to be put into a maintenance or archival state where write operations are disabled while read access remains available.

### Changes

**Backend:**
- Added `ReadOnlyModeInterceptor` that rejects mutating HTTP requests (POST, PUT, PATCH, DELETE) with a 503 Service Unavailable response when read-only mode is enabled
- Added `ServiceUnavailableException` and corresponding exception handler to return proper error responses
- Integrated the interceptor into the Spring Web configuration
- Added `readOnlyMode` configuration property to `BackendConfig`

**Website:**
- Added `readOnlyMode` configuration property to website config
- Modified `authMiddleware` to redirect users attempting to access login-enforced pages to a read-only notice page instead of Keycloak
- Updated navigation to hide Login and Submit items when read-only mode is active
- Added submission pages disabling middleware trigger for read-only mode
- Created dedicated 503 page with read-only specific messaging
- Added read-only banner message to `BaseLayout`

**Configuration:**
- Added `readOnlyMode` to Helm values schema and default values
- Updated Kubernetes template to pass read-only mode configuration to website
- Added configuration validation in website config spec

### Testing

- Added comprehensive unit tests in `ReadOnlyModeInterceptorTest` covering:
  - All HTTP methods pass when read-only mode is disabled
  - Read methods (GET, HEAD, OPTIONS) pass when read-only mode is enabled
  - Write methods (POST, PUT, PATCH, DELETE) throw `ServiceUnavailableException` with appropriate error message

### Documentation

- Added read-only mode section to Helm chart configuration documentation explaining the feature behavior and use cases

## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Manual testing: Read-only mode can be enabled via configuration; write requests are rejected with 503; read requests work normally; UI hides login/submission entry points and shows read-only banner.

https://claude.ai/code/session_01ED1KDPF4ZQ5ghobteqs1BN

🚀 Preview: https://claude-add-readonly-mode.loculus.org