### PR TITLE
feat(deposition): only add timestamp to alias for integration tests - not when testing on staging

### DIFF
--- a/ena-submission/scripts/test_ena_submission_integration.py
+++ b/ena-submission/scripts/test_ena_submission_integration.py
@@ -428,7 +428,7 @@ def _test_successful_sample_submission(
     create_sample_sync_state_with_submission_table(db_engine, config=config)
     check_sample_submission_started(db_engine, sequences_to_upload)
 
-    sample_table_create(db_engine, config, test=config.test)
+    sample_table_create(db_engine, config)
     create_sample_sync_state_with_submission_table(db_engine, config)
     check_sample_submission_submitted(db_engine, sequences_to_upload)
 
@@ -439,7 +439,7 @@ def _test_successful_project_submission(
     create_project_sync_state_with_submission_table(db_engine, config)
     check_project_submission_started(db_engine, sequences_to_upload)
 
-    project_table_create(db_engine, config, test=config.test)
+    project_table_create(db_engine, config)
     create_project_sync_state_with_submission_table(db_engine, config)
     check_project_submission_submitted(db_engine, sequences_to_upload)
 
@@ -588,6 +588,9 @@ class TestSubmission:
             f"ENA submission URL is {self.config.ena_submission_url} instead of https://wwwdev.ebi.ac.uk/ena/submit/drop-box/submit/"
         )
         assert self.config.test, "Test mode is not enabled."
+        assert self.config.random_alias, (
+            "Random alias is not enabled, this will case conflicts in ENA dev if tests are run simultaneously."  # noqa: E501
+        )
 
 
 class TestFirstPublicUpdate(TestSubmission):

--- a/ena-submission/scripts/test_ena_submission_integration.py
+++ b/ena-submission/scripts/test_ena_submission_integration.py
@@ -589,7 +589,7 @@ class TestSubmission:
         )
         assert self.config.test, "Test mode is not enabled."
         assert self.config.random_alias, (
-            "Random alias is not enabled, this will case conflicts in ENA dev if tests are run simultaneously."  # noqa: E501
+            "Random alias is not enabled, this will cause conflicts in ENA dev if tests are run simultaneously."  # noqa: E501
         )
 
 

--- a/ena-submission/src/ena_deposition/config.py
+++ b/ena-submission/src/ena_deposition/config.py
@@ -109,6 +109,8 @@ class Config(BaseModel):
     ingest_pipeline_submission_group: int
     ena_checklist: str | None = None
     set_alias_suffix: str | None = None  # Add to test revisions in dev
+    # Add timestamp and entropy to test sample aliases in integration tests to avoid name clashes
+    random_alias: bool = False
 
     ena_http_timeout_seconds: int = 60
     ena_public_search_timeout_seconds: int = 120

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -49,7 +49,7 @@ def construct_project_set_object(
     group_info: Group,
     config: Config,
     entry: ProjectTableEntry,
-    test=False,
+    random_alias=False,
 ) -> ProjectSet:
     """
     Construct project set object, using:
@@ -57,14 +57,14 @@ def construct_project_set_object(
     - group_info of corresponding group_id
     - config information, such as enaDeposition metadata for that organism
 
-    If test=True add a timestamp to the alias suffix to allow for multiple
+    If random_alias=True add a timestamp to the alias suffix to allow for multiple
     submissions of the same project for testing.
     (ENA blocks multiple submissions with the same alias)
     """
     metadata_dict = config.enaOrganisms[entry.organism]
     alias = get_alias(
         f"{entry.group_id}:{entry.organism}:{config.unique_project_suffix}",
-        test,
+        random_alias,
         config.set_alias_suffix,
     )
 
@@ -231,7 +231,6 @@ def sync_state_with_submission_table(db_engine: Engine, config: Config):
 def project_table_create(
     db_engine: Engine,
     config: Config,
-    test: bool = False,
 ):
     """
     1. Find all entries in project_table in state READY
@@ -240,8 +239,8 @@ def project_table_create(
     4. If (create_ena_project succeeds): update state to SUBMITTED with results
     3. Else update state to HAS_ERRORS with error messages
 
-    If test=True add a timestamp to the alias suffix to allow for multiple submissions of the same
-    project for testing.
+    If config.random_alias=True add a timestamp to the alias suffix to allow for multiple
+    submissions of the same project for testing.
     """
     conditions = {"status": Status.READY}
     ready_to_submit_project = find_conditions_in_db(
@@ -257,7 +256,7 @@ def project_table_create(
             logger.error(f"Was unable to get group info for group: {row.group_id}, {e}")
             continue
 
-        project_set = construct_project_set_object(group_info, config, row, test)
+        project_set = construct_project_set_object(group_info, config, row, config.random_alias)
         update_values = {
             "status": Status.SUBMITTING,
             "started_at": datetime.now(tz=pytz.utc),
@@ -365,7 +364,7 @@ def create_project(config: Config, stop_event: threading.Event):
         logger.debug("Checking for projects to create")
         sync_state_with_submission_table(db_engine, config)
 
-        project_table_create(db_engine, config, test=config.test)
+        project_table_create(db_engine, config)
         sync_state_with_submission_table(
             db_engine, config
         )  # update submission_table state after creation

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -116,14 +116,14 @@ def construct_sample_set_object(
     config: Config,
     submission_row: SubmissionTableEntry,
     sample_row: SampleTableEntry,
-    test: bool = False,
+    random_alias: bool = False,
 ):
     """
     Construct sample set object, using:
     - sample_row: entry in sample_table
     - submission_row: corresponding entry in submission_table
     - config information, such as enaDeposition metadata for that organism
-    If test=True add a timestamp to the alias suffix to allow for multiple
+    If random_alias=True add a timestamp to the alias suffix to allow for multiple
     submissions of the same project for testing.
     (ENA blocks multiple submissions with the same alias)
     """
@@ -133,7 +133,7 @@ def construct_sample_set_object(
     organism_metadata = config.enaOrganisms[organism]
     alias = get_alias(
         f"{sample_row.accession}:{organism}:{config.unique_project_suffix}",
-        test,
+        random_alias,
         config.set_alias_suffix,
     )
     sample_attributes = get_sample_attributes(config.metadata_mapping, sample_metadata)
@@ -244,7 +244,7 @@ def sync_state_with_submission_table(db_engine: Engine, config: Config):
                 continue
 
 
-def sample_table_create(db_engine: Engine, config: Config, test: bool = False):
+def sample_table_create(db_engine: Engine, config: Config):
     """
     1. Find all entries in sample_table in state READY
     2. Create sample_set_object: use metadata, center_name, organism, and ingest fields
@@ -253,8 +253,8 @@ def sample_table_create(db_engine: Engine, config: Config, test: bool = False):
     4. If (create_ena_sample succeeds): update state to SUBMITTED with results
     3. Else update state to HAS_ERRORS with error messages
 
-    If test=True add a timestamp to the alias suffix to allow for multiple submissions of the same
-    sample for testing.
+    If config.random_alias=True add a timestamp to the alias suffix to allow for multiple
+    submissions of the same sample for testing.
     """
     conditions = {"status": Status.READY}
     ready_to_submit_sample = find_conditions_in_db(
@@ -273,7 +273,9 @@ def sample_table_create(db_engine: Engine, config: Config, test: bool = False):
             db_engine, SubmissionTableEntry, conditions=asdict(seq_key)
         )
 
-        sample_set = construct_sample_set_object(config, submission_rows[0], row, test)
+        sample_set = construct_sample_set_object(
+            config, submission_rows[0], row, config.random_alias
+        )
         update_values = {
             "status": Status.SUBMITTING,
             "started_at": datetime.now(tz=pytz.utc),
@@ -376,7 +378,7 @@ def create_sample(config: Config, stop_event: threading.Event):
         logger.debug("Checking for samples to create")
         sync_state_with_submission_table(db_engine, config=config)
 
-        sample_table_create(db_engine, config, test=config.test)
+        sample_table_create(db_engine, config)
         sync_state_with_submission_table(
             db_engine, config=config
         )  # update submission_table state after creation

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -149,7 +149,7 @@ def get_project_xml(project_set: ProjectSet) -> dict[str, str]:
     }
 
 
-def get_alias(prefix: str, test=False, set_alias_suffix: str | None = None) -> XmlAttribute:
+def get_alias(prefix: str, random_alias=False, set_alias_suffix: str | None = None) -> XmlAttribute:
     """
     The alias uniquely identifies project and sample submissions.
     ENA blocks duplicates, so each submission needs a unique alias.
@@ -160,7 +160,7 @@ def get_alias(prefix: str, test=False, set_alias_suffix: str | None = None) -> X
     """
     if set_alias_suffix:
         return XmlAttribute(f"{prefix}:{set_alias_suffix}")
-    if test:
+    if random_alias:
         entropy = "".join(random.choices(string.ascii_letters + string.digits, k=4))  # noqa: S311
         timestamp = datetime.now(tz=pytz.utc).strftime("%Y%m%d_%H%M%S")
         return XmlAttribute(f"{prefix}:{timestamp}_{entropy}")

--- a/ena-submission/test/test_config.yaml
+++ b/ena-submission/test/test_config.yaml
@@ -7,6 +7,7 @@ keycloak_token_url: http://localhost:8083/realms/loculus/protocol/openid-connect
 slack_hook: fake_hook
 slack_token: fake_token
 slack_channel_id: fake_channel
+random_alias: true
 
 # Deflake commonly timed-out requests
 ena_http_post_retry_attempts: 3


### PR DESCRIPTION
resolves #

### New ena deposition parameter
`random_alias` - when true add a timestamp+entropy to the biosample/bioproject submission alias (this is similar to our submissionId), this is only set for the integration tests

### Screenshot
ENA enforces that the alias (created by us from the loculus accession) of each submitted biosample is unique - this is important as it is used for revising biosamples.

However, when testing ENA submissions e.g. for the integration tests we want to be able to submit the same biosample multiple times to ENA dev. 

Previously I just added a timestamp to the alias for all submissions to ENA dev to allow multiple submissions of the same biosample on ENA dev which was directly used by the integration tests - but this means e.g. if I want to test a revision on staging (which also submits to ENA dev/test) this fails as the alias is different. 


This PR decouples adding a timestamp to the alias from if the ena deposition pod is talking to ENA test (it should have never been coupled). This keeps the current functionality for integration tests (here we add a timestamp to the alias) and additionally keeps the current functionality for production (no timestamp to alias).

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable