### PR TITLE
fix(ingest): correct sudden dependency clash between snakemake and pandas

### DIFF
--- a/ingest/environment.yml
+++ b/ingest/environment.yml
@@ -15,13 +15,13 @@ dependencies:
   - ncbi-datasets-cli=18.22.1
   - nextclade=3.21.0
   - orjsonl=1.0.0
-  - pandas=3.0.0
+  - pandas=2.3.3
   - psycopg2=2.9.11
-  - pytz=2025.2
+  - pytz=2026.1.post1
   - PyYAML=6.0.3
   - requests=2.33.1
   - seqkit=2.13.0
-  - snakefmt=1.0.0
-  - snakemake=9.13.4
+  - snakefmt=1.1.0
+  - snakemake=9.19.0
   - unzip=6.0
   - pytest=9.0.2


### PR DESCRIPTION
resolves #

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable