### PR TITLE
feat(deposition): add random_alias to defaults

### DIFF
--- a/ena-submission/config/defaults.yaml
+++ b/ena-submission/config/defaults.yaml
@@ -3,6 +3,7 @@ ena_reports_service_url: will-be-overwritten
 ena_submission_url: will-be-overwritten
 suppressed_list_url: will-be-overwritten
 test: true
+random_alias: false
 username: external_metadata_updater
 password: external_metadata_updater
 keycloak_client_id: backend-client


### PR DESCRIPTION
resolves #

### Screenshot
Since https://github.com/loculus-project/loculus/pull/6307 was merged the ENA deposition pod is failing on main because we validate the config and we didnt add `random_alias` to teh defaults. (Integration tests overwrite the config so they succeeded)

``` 
File "/opt/conda/lib/python3.12/site-packages/pydantic/main.py", line 250, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for Config
random_alias
  Input should be a valid boolean [type=bool_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.12/v/bool_type
```

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://ena-config-fix.loculus.org