### PR TITLE
feat(website): decrease white space on details page

### DIFF
--- a/website/src/components/SequenceDetailsPage/DataTable.tsx
+++ b/website/src/components/SequenceDetailsPage/DataTable.tsx
@@ -88,7 +88,10 @@ const DataTableComponent: React.FC<Props> = ({
                             <div className='flex flex-row'>
                                 <h1 className='py-2 text-lg font-semibold border-b mr-2'>{header}</h1>
                             </div>
-                            <div className='mt-4'>
+                            <div
+                                className='mt-4 grid text-sm items-start'
+                                style={{ gridTemplateColumns: 'max-content 1fr', rowGap: '0.25rem' }}
+                            >
                                 {rows.map((entry: TableDataEntry, index: number) => (
                                     <DataTableEntry
                                         key={index}
@@ -123,7 +126,10 @@ const DataTableComponent: React.FC<Props> = ({
                     {alignmentSections.map(({ header, rows }) => (
                         <div key={header} className='p-4 pl-0'>
                             <div className='flex flex-row'></div>
-                            <div className='mt-4'>
+                            <div
+                                className='mt-4 grid text-sm items-start'
+                                style={{ gridTemplateColumns: 'max-content 1fr', rowGap: '0.25rem' }}
+                            >
                                 {rows.map((entry: TableDataEntry, index: number) => (
                                     <DataTableEntry
                                         key={index}

--- a/website/src/components/SequenceDetailsPage/DataTable.tsx
+++ b/website/src/components/SequenceDetailsPage/DataTable.tsx
@@ -58,6 +58,21 @@ const DataTableComponent: React.FC<Props> = ({
     const mutationSections = dataTableData.table.filter(
         ({ header }) => header === DEFAULT_NUC_MUTATION_DETAILS_HEADER || header === DEFAULT_AA_MUTATION_DETAILS_HEADER,
     );
+
+    const calcLabelColWidth = (sections: typeof generalSections) => {
+        const maxLen = sections
+            .flatMap(({ rows }) => rows)
+            .filter((row) => row.type.kind === 'metadata')
+            .reduce((max, row) => Math.max(max, row.label.length), 0);
+        return maxLen > 0 ? `min(${maxLen}ch, 50%)` : 'max-content';
+    };
+    const generalLabelColWidth = calcLabelColWidth(generalSections);
+    const alignmentMaxLen = alignmentSections
+        .flatMap(({ rows }) => rows)
+        .filter((row) => row.type.kind === 'metadata')
+        .reduce((max, row) => Math.max(max, row.label.length), 0);
+    const alignmentLabelColWidth = alignmentMaxLen > 0 ? `min(${alignmentMaxLen}ch, 60%)` : 'max-content';
+
     return (
         <div>
             {dataTableData.topmatter.sequenceDisplayName !== undefined && (
@@ -90,7 +105,7 @@ const DataTableComponent: React.FC<Props> = ({
                             </div>
                             <div
                                 className='mt-4 grid text-sm items-start'
-                                style={{ gridTemplateColumns: 'max-content 1fr', rowGap: '0.25rem' }}
+                                style={{ gridTemplateColumns: `${generalLabelColWidth} 1fr`, rowGap: '0.25rem' }}
                             >
                                 {rows.map((entry: TableDataEntry, index: number) => (
                                     <DataTableEntry
@@ -128,7 +143,7 @@ const DataTableComponent: React.FC<Props> = ({
                             <div className='flex flex-row'></div>
                             <div
                                 className='mt-4 grid text-sm items-start'
-                                style={{ gridTemplateColumns: 'max-content 1fr', rowGap: '0.25rem' }}
+                                style={{ gridTemplateColumns: `${alignmentLabelColWidth} 1fr`, rowGap: '0.25rem' }}
                             >
                                 {rows.map((entry: TableDataEntry, index: number) => (
                                     <DataTableEntry

--- a/website/src/components/SequenceDetailsPage/DataTableEntry.tsx
+++ b/website/src/components/SequenceDetailsPage/DataTableEntry.tsx
@@ -16,14 +16,14 @@ const DataTableComponent: React.FC<Props> = ({ data, dataUseTermsHistory, refere
     return (
         <>
             {type.kind === 'metadata' && (
-                <div className='text-sm grid my-1' style={{ gridTemplateColumns: '200px 1fr' }}>
+                <>
                     <div className='font-medium text-gray-900 break-inside-avoid pr-4'>{label}</div>
                     <DataTableEntryValue
                         data={data}
                         dataUseTermsHistory={dataUseTermsHistory}
                         referenceGenomesInfo={referenceGenomesInfo}
                     />
-                </div>
+                </>
             )}
 
             {type.kind === 'mutation' && (


### PR DESCRIPTION
Flagged by @rneher 
Make the width of the metadata displayName dependent on the metadata keys and value. 

The maximum width the displayName can be is 50% for the normal metadata fields, 60% for the `alignment and QC` fields. The actual value is then calculated from the max width of all metadata displayNames (this is an approximation based on average character size - it works better than trying to calculate the true width as pre-rendering with astro is a mess).

### Screenshot
<img width="2516" height="1350" alt="image" src="https://github.com/user-attachments/assets/72d5b987-55c4-483e-bd57-609b888a1b23" />

<img width="2360" height="1128" alt="image" src="https://github.com/user-attachments/assets/a46b41ce-feb1-4556-bdae-617856e96a19" />

🚀 Preview: Add `preview` label to enable