### PR TITLE
feat(ingest): reduce memory spikes in ingest

### DIFF
--- a/ingest/scripts/loculus_client.py
+++ b/ingest/scripts/loculus_client.py
@@ -61,7 +61,12 @@ def get_jwt(config: Config) -> str:
 
     keycloak_token_url = config.keycloak_token_url
 
-    response = requests.post(keycloak_token_url, data=data, headers=headers, timeout=config.backend_request_timeout_seconds)
+    response = requests.post(
+        keycloak_token_url,
+        data=data,
+        headers=headers,
+        timeout=config.backend_request_timeout_seconds,
+    )
     response.raise_for_status()
 
     jwt_keycloak = response.json()
@@ -302,7 +307,7 @@ def post_fasta_batches(
 
 def submit_or_revise(
     metadata, sequences, config: Config, group_id, mode=Literal["submit", "revise"]
-):
+) -> list[dict[str, Any]]:
     """
     Submit/revise data to Loculus -requires metadata and sequences sorted by id.
     """
@@ -327,8 +332,19 @@ def submit_or_revise(
 
     url = f"{organism_url(config)}/{endpoint}"
 
-    metadata_lines = len(Path(metadata).read_text(encoding="utf-8").splitlines()) - 1
-    logger.info(f"{logging_strings['gerund']} {metadata_lines} sequence(s) to Loculus")
+    def count_lines(path, chunk_size=1024 * 1024):
+        """Memory efficient way to count the number of lines in a file by reading in chunks."""
+        count = 0
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(chunk_size), b""):
+                count += chunk.count(b"\n")
+        return count
+
+    metadata_lines = max(count_lines(metadata) - 1, 0)
+
+    logger.info(
+        f"{logging_strings['gerund']} {metadata_lines} sequence(s) to Loculus"
+    )
 
     params = {
         "groupId": group_id,

--- a/ingest/scripts/loculus_client.py
+++ b/ingest/scripts/loculus_client.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from dataclasses import dataclass
 from http import HTTPMethod
 from io import BytesIO
-from pathlib import Path
 from time import sleep
 from typing import Any, Literal
 

--- a/ingest/scripts/loculus_client.py
+++ b/ingest/scripts/loculus_client.py
@@ -304,6 +304,19 @@ def post_fasta_batches(
     return response
 
 
+def count_lines(path, chunk_size=1024 * 1024):
+    """Memory efficient way to count the number of lines in a file by reading in chunks."""
+    count = 0
+    last_char = b""
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(chunk_size), b""):
+            count += chunk.count(b"\n")
+            last_char = chunk[-1:]  # keep last byte
+    if count != 0 and last_char != b"\n":
+        count += 1
+    return count
+
+
 def submit_or_revise(
     metadata, sequences, config: Config, group_id, mode=Literal["submit", "revise"]
 ) -> list[dict[str, Any]]:
@@ -331,19 +344,9 @@ def submit_or_revise(
 
     url = f"{organism_url(config)}/{endpoint}"
 
-    def count_lines(path, chunk_size=1024 * 1024):
-        """Memory efficient way to count the number of lines in a file by reading in chunks."""
-        count = 0
-        with open(path, "rb") as f:
-            for chunk in iter(lambda: f.read(chunk_size), b""):
-                count += chunk.count(b"\n")
-        return count
-
     metadata_lines = max(count_lines(metadata) - 1, 0)
 
-    logger.info(
-        f"{logging_strings['gerund']} {metadata_lines} sequence(s) to Loculus"
-    )
+    logger.info(f"{logging_strings['gerund']} {metadata_lines} sequence(s) to Loculus")
 
     params = {
         "groupId": group_id,


### PR DESCRIPTION
- dont read full metadata file into memory when calculating number of entries

resolves #

### Screenshot
I tested on https://github.com/loculus-project/loculus/pull/6344 that this actually reduces the memory spikes by adding benchmarking

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable