### PR TITLE
TESTING:  benchmark ingest

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -127,6 +127,8 @@ rule fetch_inflate_ncbi_dataset_package:
         dataset_package=directory("results/ncbi_dataset"),
         compressed_package_tzst="results/dataset.tar.zst",
         compressed_package_zip="results/dataset.zip",
+    benchmark:
+        "benchmarks/fetch_inflate_ncbi_dataset_package.tsv"
     shell:
         """
         if [[ "{params.use_mirror}" == "True" ]]; then
@@ -152,6 +154,8 @@ rule format_ncbi_dataset_report:
         config="results/config.yaml",
     output:
         ncbi_dataset_tsv="results/metadata_post_rename.tsv",
+    benchmark:
+        "benchmarks/format_ncbi_dataset_report.tsv"
     shell:
         """
         python {input.script} \
@@ -169,6 +173,8 @@ rule format_ncbi_dataset_sequences:
         dataset_sequences="results/ncbi_dataset/data/genomic.fna",
     output:
         ncbi_dataset_sequences="results/sequences.fasta",
+    benchmark:
+        "benchmarks/format_ncbi_dataset_sequences.tsv"
     shell:
         """
         seqkit seq -w0 -i \
@@ -188,6 +194,8 @@ if CHECK_ENA_DEPOSITION:
             config="results/config.yaml",
         output:
             exclude_insdc_accessions="results/accessions_to_exclude.json",
+        benchmark:
+            "benchmarks/get_loculus_depositions.tsv"
         params:
             log_level=LOG_LEVEL,
         shell:
@@ -208,6 +216,8 @@ if CHECK_ENA_DEPOSITION:
             metadata_tsv="results/filtered_metadata.tsv",
         params:
             log_level=LOG_LEVEL,
+        benchmark:
+            "benchmarks/filter_out_loculus_depositions.tsv"
         shell:
             """
             python {input.script} \
@@ -227,6 +237,8 @@ rule calculate_sequence_hashes:
     output:
         sequence_hashes="results/sequence_hashes.ndjson",
         sequence_json="results/sequences.ndjson",
+    benchmark:
+        "benchmarks/calculate_sequence_hashes.tsv"
     params:
         log_level=LOG_LEVEL,
     shell:
@@ -249,6 +261,8 @@ if SEGMENTED and segment_detection_method == SegmentDetectionMethod.ALIGN:
         params:
             dataset_server=lambda w: dataset_server_map[w.segment],
             dataset_name=lambda w: dataset_name_map[w.segment],
+        benchmark:
+            "benchmarks/nextclade_align_{segment}.tsv"
         shell:
             """
             nextclade run \
@@ -267,6 +281,8 @@ if SEGMENTED and segment_detection_method == SegmentDetectionMethod.ALIGN:
             script="scripts/parse_alignment_output.py",
         output:
             merged="results/nextclade_merged.tsv",
+        benchmark:
+            "benchmarks/parse_alignment_output.tsv"
         params:
             segment_paths=" ".join(
                 [
@@ -293,6 +309,8 @@ if APPLY_MINIMIZER:
                 if config.get("segment_identification")
                 else config.get("minimizer_url")
             ),
+        benchmark:
+            "benchmarks/download_minimizer.tsv"
         shell:
             """
             curl -L -o {output.results} {params.minimizer}
@@ -304,6 +322,8 @@ if APPLY_MINIMIZER:
             minimizer="results/minimizer.json",
         output:
             results="results/sort_results.tsv",
+        benchmark:
+            "benchmarks/nextclade_sort.tsv"
         shell:
             """
             nextclade sort -m {input.minimizer} \
@@ -318,6 +338,8 @@ if APPLY_MINIMIZER:
             script="scripts/parse_nextclade_sort_output.py",
         output:
             merged="results/nextclade_merged.tsv",
+        benchmark:
+            "benchmarks/parse_nextclade_sort_output.tsv"
         params:
             log_level=LOG_LEVEL,
         shell:
@@ -347,6 +369,8 @@ rule prepare_metadata:
             if (SEGMENTED or APPLY_MINIMIZER)
             else "results/config.yaml"
         ),
+    benchmark:
+        "benchmarks/prepare_metadata.tsv"
     output:
         metadata="results/metadata_post_prepare.ndjson",
     params:
@@ -375,6 +399,8 @@ if GROUPS_OVERRIDE_JSON and not CALCULATE_GROUPS_OVERRIDE_JSON:
             results="results/groups.json",
         params:
             grouping=config.get("grouping_override_url"),
+        benchmark:
+            "benchmarks/download_groups.tsv"
         shell:
             """
             curl -L -o {output.results} {params.grouping}
@@ -388,6 +414,8 @@ if CALCULATE_GROUPS_OVERRIDE_JSON:
             ignore_list="results/grouping_ignore_list.txt",
         params:
             grouping_ignore_list_url=config.get("grouping_ignore_list_url", ""),
+        benchmark:
+            "benchmarks/download_ignore_list.tsv"
         shell:
             """
             if [[ -n "{params.grouping_ignore_list_url}" ]]; then
@@ -410,6 +438,8 @@ if CALCULATE_GROUPS_OVERRIDE_JSON:
             compressed_package_tzst="results/{source}_assembly.tar.zst",
             compressed_package_zip="results/{source}_assembly.zip",
             package=directory("results/{source}_assembly"),
+        benchmark:
+            "benchmarks/fetch_inflate_{source}_assemblies.tsv"
         shell:
             """
             if [[ "{params.use_mirror}" == "True" ]]; then
@@ -445,6 +475,8 @@ if CALCULATE_GROUPS_OVERRIDE_JSON:
         params:
             genbank_dir="results/genbank_assembly/ncbi_dataset/data",
             refseq_dir="results/refseq_assembly/ncbi_dataset/data",
+        benchmark:
+            "benchmarks/calculate_assembly_groups.tsv"
         shell:
             """
             python {input.script} \
@@ -471,6 +503,8 @@ if GROUPS_OVERRIDE_JSON:
             sequences="results/sequences_grouped.ndjson",
             ungrouped_metadata="results/metadata_ungrouped.ndjson",
             ungrouped_sequences="results/sequences_ungrouped.ndjson",
+        benchmark:
+            "benchmarks/override_group_segments.tsv"
         params:
             log_level=LOG_LEVEL,
             match_prev_flag=lambda w: (
@@ -522,6 +556,8 @@ rule heuristic_group_segments:
     output:
         metadata="results/metadata_post_group.ndjson",
         sequences="results/sequences_post_group.ndjson",
+    benchmark:
+        "benchmarks/heuristic_group_segments.tsv"
     params:
         log_level=LOG_LEVEL,
         GROUPS_OVERRIDE_JSON="true" if GROUPS_OVERRIDE_JSON else "false",
@@ -561,6 +597,8 @@ if FILTER:
             ),
             script="scripts/metadata_filter.py",
             config="results/config.yaml",
+        benchmark:
+            "benchmarks/metadata_filter.tsv"
         output:
             sequences="results/sequences_filtered.ndjson",
             metadata="results/metadata_filtered.ndjson",
@@ -604,6 +642,8 @@ rule get_previous_submissions:
     params:
         log_level=LOG_LEVEL,
         sleep=config["post_start_sleep"],
+    benchmark:
+        "benchmarks/get_previous_submissions.tsv"
     shell:
         """
         sleep {params.sleep}
@@ -631,6 +671,8 @@ rule compare_hashes:
     params:
         log_level=LOG_LEVEL,
         subsample_fraction=config.get("subsample_fraction", 1.0),
+    benchmark:
+        "benchmarks/compare_hashes.tsv"
     shell:
         """
         python {input.script} \
@@ -672,6 +714,8 @@ rule prepare_files:
         metadata_submit="results/submit_metadata.tsv",
         metadata_revise="results/revise_metadata.tsv",
         metadata_revoke="results/metadata_to_submit_prior_to_revoke.tsv",
+    benchmark:
+        "benchmarks/prepare_files.tsv"
     shell:
         """
         python {input.script} \
@@ -696,6 +740,8 @@ rule sort_fasta:
         sequences="results/{basename}.fasta",
     output:
         sorted="results/{basename}_sorted.fasta",
+    benchmark:
+        "benchmarks/sort_{basename}_fasta.tsv"
     shell:
         """
         seqkit sort -N --two-pass {input.sequences} | seqkit seq -w 0 > {output.sorted}
@@ -708,6 +754,8 @@ rule sort_metadata:
         metadata="results/{basename}.tsv",
     output:
         sorted="results/{basename}_sorted.tsv",
+    benchmark:
+        "benchmarks/sort_{basename}_metadata.tsv"
     shell:
         """
         columnNumber=$(awk -F'\\t' '{{for(i=1;i<=NF;i++) if($i=="id") print i}}' {input.metadata});
@@ -729,6 +777,8 @@ rule submit:
         submitted=touch("results/submitted"),
     params:
         log_level=LOG_LEVEL,
+    benchmark:
+        "benchmarks/submit.tsv"
     shell:
         """
         if [ -s {input.metadata} ]; then
@@ -752,6 +802,8 @@ rule revise:
         revised=touch("results/revised"),
     params:
         log_level=LOG_LEVEL,
+    benchmark:
+        "benchmarks/revise.tsv"
     shell:
         """
         if [ -s {input.metadata} ]; then
@@ -776,6 +828,8 @@ rule regroup_and_revoke:
         revoked=touch("results/revoked"),
     params:
         log_level=LOG_LEVEL,
+    benchmark:
+        "benchmarks/regroup_and_revoke.tsv"
     shell:
         """
         if [ -s {input.metadata} ]; then
@@ -799,6 +853,8 @@ rule approve:
     params:
         log_level=LOG_LEVEL,
         approve_timeout_min=APPROVE_TIMEOUT_MIN,
+    benchmark:
+        "benchmarks/approve.tsv"
     shell:
         """
         python {input.script} \

--- a/ingest/scripts/loculus_client.py
+++ b/ingest/scripts/loculus_client.py
@@ -61,7 +61,12 @@ def get_jwt(config: Config) -> str:
 
     keycloak_token_url = config.keycloak_token_url
 
-    response = requests.post(keycloak_token_url, data=data, headers=headers, timeout=config.backend_request_timeout_seconds)
+    response = requests.post(
+        keycloak_token_url,
+        data=data,
+        headers=headers,
+        timeout=config.backend_request_timeout_seconds,
+    )
     response.raise_for_status()
 
     jwt_keycloak = response.json()
@@ -327,9 +332,13 @@ def submit_or_revise(
 
     url = f"{organism_url(config)}/{endpoint}"
 
-    # with open(metadata, encoding="utf-8") as f:
-    #     metadata_lines = sum(1 for _ in f) - 1
-    # logger.info(f"{logging_strings['gerund']} {metadata_lines} sequence(s) to Loculus")
+    count = 0
+    with open(metadata, encoding="utf-8") as f:
+        for _ in f:
+            count += 1
+    logger.info(
+        f"{logging_strings['gerund']} {count - 1} sequence(s) to Loculus"
+    )  # subtract 1 for header
 
     params = {
         "groupId": group_id,

--- a/ingest/scripts/loculus_client.py
+++ b/ingest/scripts/loculus_client.py
@@ -302,7 +302,7 @@ def post_fasta_batches(
 
 def submit_or_revise(
     metadata, sequences, config: Config, group_id, mode=Literal["submit", "revise"]
-):
+) -> list[dict[str, Any]]:
     """
     Submit/revise data to Loculus -requires metadata and sequences sorted by id.
     """
@@ -327,9 +327,9 @@ def submit_or_revise(
 
     url = f"{organism_url(config)}/{endpoint}"
 
-    with open(metadata, encoding="utf-8") as f:
-        metadata_lines = sum(1 for _ in f) - 1
-    logger.info(f"{logging_strings['gerund']} {metadata_lines} sequence(s) to Loculus")
+    # with open(metadata, encoding="utf-8") as f:
+    #     metadata_lines = sum(1 for _ in f) - 1
+    # logger.info(f"{logging_strings['gerund']} {metadata_lines} sequence(s) to Loculus")
 
     params = {
         "groupId": group_id,

--- a/ingest/scripts/loculus_client.py
+++ b/ingest/scripts/loculus_client.py
@@ -332,13 +332,18 @@ def submit_or_revise(
 
     url = f"{organism_url(config)}/{endpoint}"
 
-    count = 0
-    with open(metadata, encoding="utf-8") as f:
-        for _ in f:
-            count += 1
+    def count_lines(path, chunk_size=1024 * 1024):
+        count = 0
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(chunk_size), b""):
+                count += chunk.count(b"\n")
+        return count
+
+    metadata_lines = max(count_lines(metadata) - 1, 0)
+
     logger.info(
-        f"{logging_strings['gerund']} {count - 1} sequence(s) to Loculus"
-    )  # subtract 1 for header
+        f"{logging_strings['gerund']} {metadata_lines} sequence(s) to Loculus"
+    )
 
     params = {
         "groupId": group_id,

--- a/ingest/scripts/loculus_client.py
+++ b/ingest/scripts/loculus_client.py
@@ -327,7 +327,8 @@ def submit_or_revise(
 
     url = f"{organism_url(config)}/{endpoint}"
 
-    metadata_lines = len(Path(metadata).read_text(encoding="utf-8").splitlines()) - 1
+    with open(metadata, encoding="utf-8") as f:
+        metadata_lines = sum(1 for _ in f) - 1
     logger.info(f"{logging_strings['gerund']} {metadata_lines} sequence(s) to Loculus")
 
     params = {

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2052,7 +2052,6 @@ defaultOrganisms:
     ingest:
       <<: *ingest
       configFile:
-        <<: *defaultIngestConfigFile
         taxon_id: 10244
     enaDeposition:
       singleReference:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1762,247 +1762,661 @@ defaultOrganisms:
                 sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/env.fasta]]"
               - name: prM
                 sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/prM.fasta]]"
-  dummy-organism:
+  mpox:
+    <<: *defaultOrganismConfig
     schema:
-      submissionDataTypes: *defaultSubmissionDataTypes
-      image: "https://www.un.org/sites/un2.un.org/files/field/image/1583952355.1997.jpg"
-      organismName: "Test Dummy Organism"
-      metadataTemplate:
-        - country
-        - date
-      metadata: &dummyMetadata
-        - name: date
-          displayName: Date
-          type: date
-          initiallyVisible: true
-          header: "Collection Details"
-        - name: region
-          displayName: Region
-          type: string
-          initiallyVisible: true
+      <<: *schema
+      organismName: "Mpox Virus"
+      image: "/images/organisms/mpox_small.jpg"
+      linkOuts:
+        - name: "Nextclade"
+          maxNumberOfRecommendedEntries: 200 # Nextclade handles ~80MB of sequences, mpox is ~197kB
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences+rich|fasta]}}&dataset-name=nextstrain/mpox/all-clades"
+        - name: "Sealion"
+          maxNumberOfRecommendedEntries: 200
+          url: "https://artic-network.github.io/sealion/?fastaUrl={{[alignedNucleotideSequences+rich|fasta]}}"
+        - name: "Country map"
+          maxNumberOfRecommendedEntries: 45000
+          url: "https://mapoplexus.genomium.org/?url={{[metadata]}}"
+      metadataAdd:
+        - name: clade
+          displayName: Clade
+          isSequenceFilter: true
+          header: "Clade & Lineage"
+          includeInDownloadsByDefault: true
+          noInput: true
           generateIndex: true
           autocomplete: true
-          header: "Collection Details"
-        - name: country
-          displayName: Country
           initiallyVisible: true
-          type: string
+          preprocessing:
+            inputs: {input: nextclade.clade}
+          columnWidth: 60
+          order: 5
+          orderOnDetailsPage: 700
+        - name: outbreak
+          displayName: Outbreak
+          isSequenceFilter: true
+          header: "Clade & Lineage"
+          includeInDownloadsByDefault: true
+          noInput: true
           generateIndex: true
           autocomplete: true
-          options:
-            - name: Germany
-            - name: Canada
-            - name: New Zealand
-            - name: Colombia
-          header: "Collection Details"
-        - name: division
-          displayName: Division
-          initiallyVisible: true
-          type: string
-          generateIndex: true
-          autocomplete: true
-          header: "Collection Details"
-        - name: host
-          displayName: Host
-          initiallyVisible: true
-          type: string
-          autocomplete: true
-          header: "Collection Details"
+          preprocessing:
+            inputs: {input: nextclade.customNodeAttributes.outbreak}
+          columnWidth: 74
+          order: 6
+          orderOnDetailsPage: 720
         - name: lineage
           displayName: Lineage
           isSequenceFilter: true
-          initiallyVisible: false
-          notSearchable: true
-        - name: pangoLineage
-          isSequenceFilter: true
-          initiallyVisible: true
-          displayName: "Pango lineage"
-          autocomplete: true
-          required: true
-          type: string
-          lineageSystem: pangoLineage
-          options:
-            - name: A
-            - name: A.1
-            - name: A.1.1
-            - name: A.2
-            - name: B
-          preprocessing:
-            function: process_options
-            inputs:
-              input: lineage
-        - name: hiddenField
-          displayName: "Hidden Field"
-          initiallyVisible: false
-          type: string
-          hideInSearchResultsTable: true
-      website:
-        tableColumns:
-          - country
-          - division
-          - date
-          - pangoLineage
-        defaultOrder: descending
-        defaultOrderBy: date
-    preprocessing:
-      - version: 2
-        image: ghcr.io/loculus-project/preprocessing-dummy
-        args:
-          - "--watch"
-          - "--withWarnings"
-          - "--withErrors"
-          - "--randomWarnError"
-    referenceGenomes:
-      - name: main
-        references:
-          - name: singleReference
-            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/reference.fasta]]"
-            genes:
-              - name: E
-                sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/E.fasta]]"
-              - name: M
-                sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/M.fasta]]"
-              - name: "N"
-                sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/N.fasta]]"
-              - name: ORF1a
-                sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF1a.fasta]]"
-              - name: ORF1b
-                sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF1b.fasta]]"
-              - name: ORF3a
-                sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF3a.fasta]]"
-              - name: ORF6
-                sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF6.fasta]]"
-              - name: ORF7a
-                sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF7a.fasta]]"
-              - name: ORF7b
-                sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF7b.fasta]]"
-              - name: ORF8
-                sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF8.fasta]]"
-              - name: ORF9b
-                sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/ORF9b.fasta]]"
-              - name: S
-                sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/S.fasta]]"
-  dummy-organism-with-files:
-    schema:
-      image: "https://cdn.who.int/media/images/default-source/mca/mca-covid-19/coronavirus-2.tmb-1920v.jpg?sfvrsn=4dba955c_19"
-      organismName: "Test organism (with files)"
-      submissionDataTypes:
-        consensusSequences: false
-        files:
-          enabled: true
-          categories:
-            - name: raw_reads
-              displayName: Raw reads
-      files:
-        - name: raw_reads
-          displayName: Raw reads
-      metadata: *dummyMetadata
-      website:
-        tableColumns:
-          - country
-          - division
-          - date
-        defaultOrder: descending
-        defaultOrderBy: date
-    preprocessing:
-      - version: 1
-        image: ghcr.io/loculus-project/preprocessing-dummy
-        args:
-          - "--watch"
-          - "--disableConsensusSequences"
-    referenceGenomes: []
-  not-aligned-organism:
-    enabled: true
-    schema:
-      submissionDataTypes: *defaultSubmissionDataTypes
-      image: "https://cdn.who.int/media/images/default-source/mca/mca-covid-19/coronavirus-2.tmb-1920v.jpg?sfvrsn=4dba955c_19"
-      organismName: "Test organism (without alignment)"
-      metadata:
-        - name: date
-          displayName: Date
-          type: date
-          initiallyVisible: true
-          header: "Collection Details"
-          required: true
-          preprocessing:
-            function: parse_and_assert_past_date
-            inputs:
-              date: date
-        - name: lineage
-          isSequenceFilter: true
-          initiallyVisible: true
-          displayName: "Lineage"
-          autocomplete: true
-          required: true
-          type: string
-          lineageSystem: alternativeLineage
-          options:
-            - name: A
-            - name: A.1
-            - name: A.1.1
-            - name: A.2
-            - name: B
-            - name: B.1
-            - name: B.1.1
-            - name: B.1.1.1
-            - name: C
-            - name: C.1
-          preprocessing:
-            function: process_options
-            inputs:
-              input: lineage
-        - name: region
-          displayName: Region
-          type: string
-          initiallyVisible: true
+          header: "Clade & Lineage"
+          includeInDownloadsByDefault: true
+          noInput: true
           generateIndex: true
           autocomplete: true
-          header: "Collection Details"
-        - name: country
-          displayName: Country
           initiallyVisible: true
-          type: string
-          generateIndex: true
-          autocomplete: true
-          header: "Collection Details"
-        - name: division
-          displayName: Division
-          initiallyVisible: true
-          type: string
-          generateIndex: true
-          autocomplete: true
-          header: "Collection Details"
-        - name: host
-          displayName: Host
-          initiallyVisible: true
-          type: string
-          autocomplete: true
-          header: "Collection Details"
+          preprocessing:
+            inputs: {input: nextclade.customNodeAttributes.lineage}
+          columnWidth: 64
+          order: 7
+          orderOnDetailsPage: 740
+        - &gisaidIsolateIdMetadataField
+          name: gisaidIsolateId
+          displayName: GISAID Isolate ID
+          header: "Sample details"
+          orderOnDetailsPage: 640
+          definition: "GISAID EPI isolate ID (also known as EPI_ISL ID)"
+          guidance: "Add the GISAID isolate ID if sequence has also been uploaded to GISAID"
+          example: "EPI_ISL_123456"
+          preprocessing:
+            function: check_regex
+            inputs:
+              regex_field: gisaidIsolateId
+            args:
+              pattern: "^EPI_ISL_[0-9]+$"
       website:
+        <<: *website
         tableColumns:
-          - country
-          - division
-          - date
+          - sampleCollectionDate
+          - geoLocCountry
+          - geoLocAdmin1
+          - authors
+          - authorAffiliations
+          - earliestReleaseDate
+          - clade
+          - lineage
+          - length
+        defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
-        defaultOrderBy: date
     preprocessing:
-      - version: 4
-        image: ghcr.io/loculus-project/preprocessing-nextclade
-        args:
-          - "prepro"
+      - &mpoxPreprocessing
+        <<: *preprocessing
+        replicas: 1
+        version:
+          - 18
         configFile:
-          log_level: DEBUG
-          batch_size: 100
+          <<: *preprocessingConfigFile
+          batch_size: 5
           segments:
-            - name: main
+            - &mpoxDataset
+              name: main
               references:
-                - name: singleReference
-                  genes: []
+              - name: singleReference
+                nextclade_dataset_name: nextstrain/mpox/all-clades
+                nextclade_dataset_tag: 2025-12-16--20-07-31Z
+                genes:
+                  - OPG001
+                  - OPG002
+                  - OPG003
+                  - OPG005
+                  - OPG015
+                  - OPG016
+                  - OPG019
+                  - OPG021
+                  - OPG022
+                  - OPG023
+                  - OPG024
+                  - OPG025
+                  - OPG027
+                  - OPG029
+                  - OPG030
+                  - OPG031
+                  - OPG034
+                  - OPG035
+                  - OPG036
+                  - OPG037
+                  - OPG038
+                  - OPG039
+                  - OPG040
+                  - OPG042
+                  - OPG043
+                  - OPG044
+                  - OPG045
+                  - OPG046
+                  - OPG047
+                  - OPG048
+                  - OPG049
+                  - OPG050
+                  - OPG051
+                  - OPG052
+                  - OPG053
+                  - OPG054
+                  - OPG055
+                  - OPG056
+                  - OPG057
+                  - OPG058
+                  - OPG059
+                  - OPG060
+                  - OPG061
+                  - OPG062
+                  - OPG063
+                  - OPG064
+                  - OPG065
+                  - OPG066
+                  - OPG068
+                  - OPG069
+                  - OPG070
+                  - OPG071
+                  - OPG072
+                  - OPG073
+                  - OPG074
+                  - OPG075
+                  - OPG076
+                  - OPG077
+                  - OPG078
+                  - OPG079
+                  - OPG080
+                  - OPG081
+                  - OPG082
+                  - OPG083
+                  - OPG084
+                  - OPG085
+                  - OPG086
+                  - OPG087
+                  - OPG088
+                  - OPG089
+                  - OPG090
+                  - OPG091
+                  - OPG092
+                  - OPG093
+                  - OPG094
+                  - OPG095
+                  - OPG096
+                  - OPG097
+                  - OPG098
+                  - OPG099
+                  - OPG100
+                  - OPG101
+                  - OPG102
+                  - OPG103
+                  - OPG104
+                  - OPG105
+                  - OPG106
+                  - OPG107
+                  - OPG108
+                  - OPG109
+                  - OPG110
+                  - OPG111
+                  - OPG112
+                  - OPG113
+                  - OPG114
+                  - OPG115
+                  - OPG116
+                  - OPG117
+                  - OPG118
+                  - OPG119
+                  - OPG120
+                  - OPG121
+                  - OPG122
+                  - OPG123
+                  - OPG124
+                  - OPG125
+                  - OPG126
+                  - OPG127
+                  - OPG128
+                  - OPG129
+                  - OPG130
+                  - OPG131
+                  - OPG132
+                  - OPG133
+                  - OPG134
+                  - OPG135
+                  - OPG136
+                  - OPG137
+                  - OPG138
+                  - OPG139
+                  - OPG140
+                  - OPG141
+                  - OPG142
+                  - OPG143
+                  - OPG144
+                  - OPG145
+                  - OPG146
+                  - OPG147
+                  - OPG148
+                  - OPG149
+                  - OPG150
+                  - OPG151
+                  - OPG153
+                  - OPG154
+                  - OPG155
+                  - OPG156
+                  - OPG157
+                  - OPG158
+                  - OPG159
+                  - OPG160
+                  - OPG161
+                  - OPG162
+                  - OPG163
+                  - OPG164
+                  - OPG165
+                  - OPG166
+                  - OPG167
+                  - OPG170
+                  - OPG171
+                  - OPG172
+                  - OPG173
+                  - OPG174
+                  - OPG175
+                  - OPG176
+                  - OPG178
+                  - OPG180
+                  - OPG181
+                  - OPG185
+                  - OPG187
+                  - OPG188
+                  - OPG189
+                  - OPG190
+                  - OPG191
+                  - OPG192
+                  - OPG193
+                  - OPG195
+                  - OPG197
+                  - OPG198
+                  - OPG199
+                  - OPG200
+                  - OPG204
+                  - OPG205
+                  - OPG208
+                  - OPG209
+                  - OPG210
+      # - <<: *mpoxPreprocessing
+      #   replicas: 3
+      #   version:
+      #     - 18
+      #   configFile:
+      #     <<: *preprocessingConfigFile
+      #     batch_size: 10
+      #     segments:
+      #       - <<: *mpoxDataset
+    ingest:
+      <<: *ingest
+      configFile:
+        <<: *defaultIngestConfigFile
+        taxon_id: 10244
+    enaDeposition:
+      singleReference:
+        configFile:
+          taxon_id: 10244
+          scientific_name: "Monkeypox virus"
+          molecule_type: "genomic DNA"
     referenceGenomes:
-      - name: main
+      - name: "main"
         references:
-          - name: singleReference
-            sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/sars-cov-2/reference.fasta]]"
+        - name: singleReference
+          sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/mpox/reference.fasta]]"
+          insdcAccessionFull: NC_063383.1
+          genes:
+            - name: OPG001
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG001.fa]]"
+            - name: OPG002
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG002.fa]]"
+            - name: OPG003
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG003.fa]]"
+            - name: OPG005
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG005.fa]]"
+            - name: OPG015
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG015.fa]]"
+            - name: OPG016
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG016.fa]]"
+            - name: OPG019
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG019.fa]]"
+            - name: OPG021
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG021.fa]]"
+            - name: OPG022
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG022.fa]]"
+            - name: OPG023
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG023.fa]]"
+            - name: OPG024
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG024.fa]]"
+            - name: OPG025
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG025.fa]]"
+            - name: OPG027
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG027.fa]]"
+            - name: OPG029
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG029.fa]]"
+            - name: OPG030
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG030.fa]]"
+            - name: OPG031
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG031.fa]]"
+            - name: OPG034
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG034.fa]]"
+            - name: OPG035
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG035.fa]]"
+            - name: OPG036
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG036.fa]]"
+            - name: OPG037
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG037.fa]]"
+            - name: OPG038
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG038.fa]]"
+            - name: OPG039
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG039.fa]]"
+            - name: OPG040
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG040.fa]]"
+            - name: OPG042
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG042.fa]]"
+            - name: OPG043
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG043.fa]]"
+            - name: OPG044
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG044.fa]]"
+            - name: OPG045
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG045.fa]]"
+            - name: OPG046
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG046.fa]]"
+            - name: OPG047
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG047.fa]]"
+            - name: OPG048
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG048.fa]]"
+            - name: OPG049
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG049.fa]]"
+            - name: OPG050
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG050.fa]]"
+            - name: OPG051
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG051.fa]]"
+            - name: OPG052
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG052.fa]]"
+            - name: OPG053
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG053.fa]]"
+            - name: OPG054
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG054.fa]]"
+            - name: OPG055
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG055.fa]]"
+            - name: OPG056
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG056.fa]]"
+            - name: OPG057
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG057.fa]]"
+            - name: OPG058
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG058.fa]]"
+            - name: OPG059
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG059.fa]]"
+            - name: OPG060
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG060.fa]]"
+            - name: OPG061
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG061.fa]]"
+            - name: OPG062
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG062.fa]]"
+            - name: OPG063
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG063.fa]]"
+            - name: OPG064
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG064.fa]]"
+            - name: OPG065
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG065.fa]]"
+            - name: OPG066
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG066.fa]]"
+            - name: OPG068
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG068.fa]]"
+            - name: OPG069
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG069.fa]]"
+            - name: OPG070
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG070.fa]]"
+            - name: OPG071
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG071.fa]]"
+            - name: OPG072
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG072.fa]]"
+            - name: OPG073
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG073.fa]]"
+            - name: OPG074
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG074.fa]]"
+            - name: OPG075
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG075.fa]]"
+            - name: OPG076
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG076.fa]]"
+            - name: OPG077
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG077.fa]]"
+            - name: OPG078
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG078.fa]]"
+            - name: OPG079
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG079.fa]]"
+            - name: OPG080
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG080.fa]]"
+            - name: OPG081
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG081.fa]]"
+            - name: OPG082
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG082.fa]]"
+            - name: OPG083
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG083.fa]]"
+            - name: OPG084
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG084.fa]]"
+            - name: OPG085
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG085.fa]]"
+            - name: OPG086
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG086.fa]]"
+            - name: OPG087
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG087.fa]]"
+            - name: OPG088
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG088.fa]]"
+            - name: OPG089
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG089.fa]]"
+            - name: OPG090
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG090.fa]]"
+            - name: OPG091
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG091.fa]]"
+            - name: OPG092
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG092.fa]]"
+            - name: OPG093
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG093.fa]]"
+            - name: OPG094
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG094.fa]]"
+            - name: OPG095
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG095.fa]]"
+            - name: OPG096
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG096.fa]]"
+            - name: OPG097
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG097.fa]]"
+            - name: OPG098
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG098.fa]]"
+            - name: OPG099
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG099.fa]]"
+            - name: OPG100
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG100.fa]]"
+            - name: OPG101
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG101.fa]]"
+            - name: OPG102
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG102.fa]]"
+            - name: OPG103
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG103.fa]]"
+            - name: OPG104
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG104.fa]]"
+            - name: OPG105
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG105.fa]]"
+            - name: OPG106
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG106.fa]]"
+            - name: OPG107
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG107.fa]]"
+            - name: OPG108
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG108.fa]]"
+            - name: OPG109
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG109.fa]]"
+            - name: OPG110
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG110.fa]]"
+            - name: OPG111
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG111.fa]]"
+            - name: OPG112
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG112.fa]]"
+            - name: OPG113
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG113.fa]]"
+            - name: OPG114
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG114.fa]]"
+            - name: OPG115
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG115.fa]]"
+            - name: OPG116
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG116.fa]]"
+            - name: OPG117
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG117.fa]]"
+            - name: OPG118
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG118.fa]]"
+            - name: OPG119
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG119.fa]]"
+            - name: OPG120
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG120.fa]]"
+            - name: OPG121
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG121.fa]]"
+            - name: OPG122
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG122.fa]]"
+            - name: OPG123
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG123.fa]]"
+            - name: OPG124
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG124.fa]]"
+            - name: OPG125
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG125.fa]]"
+            - name: OPG126
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG126.fa]]"
+            - name: OPG127
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG127.fa]]"
+            - name: OPG128
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG128.fa]]"
+            - name: OPG129
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG129.fa]]"
+            - name: OPG130
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG130.fa]]"
+            - name: OPG131
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG131.fa]]"
+            - name: OPG132
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG132.fa]]"
+            - name: OPG133
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG133.fa]]"
+            - name: OPG134
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG134.fa]]"
+            - name: OPG135
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG135.fa]]"
+            - name: OPG136
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG136.fa]]"
+            - name: OPG137
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG137.fa]]"
+            - name: OPG138
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG138.fa]]"
+            - name: OPG139
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG139.fa]]"
+            - name: OPG140
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG140.fa]]"
+            - name: OPG141
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG141.fa]]"
+            - name: OPG142
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG142.fa]]"
+            - name: OPG143
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG143.fa]]"
+            - name: OPG144
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG144.fa]]"
+            - name: OPG145
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG145.fa]]"
+            - name: OPG146
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG146.fa]]"
+            - name: OPG147
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG147.fa]]"
+            - name: OPG148
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG148.fa]]"
+            - name: OPG149
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG149.fa]]"
+            - name: OPG150
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG150.fa]]"
+            - name: OPG151
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG151.fa]]"
+            - name: OPG153
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG153.fa]]"
+            - name: OPG154
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG154.fa]]"
+            - name: OPG155
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG155.fa]]"
+            - name: OPG156
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG156.fa]]"
+            - name: OPG157
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG157.fa]]"
+            - name: OPG158
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG158.fa]]"
+            - name: OPG159
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG159.fa]]"
+            - name: OPG160
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG160.fa]]"
+            - name: OPG161
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG161.fa]]"
+            - name: OPG162
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG162.fa]]"
+            - name: OPG163
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG163.fa]]"
+            - name: OPG164
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG164.fa]]"
+            - name: OPG165
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG165.fa]]"
+            - name: OPG166
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG166.fa]]"
+            - name: OPG167
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG167.fa]]"
+            - name: OPG170
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG170.fa]]"
+            - name: OPG171
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG171.fa]]"
+            - name: OPG172
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG172.fa]]"
+            - name: OPG173
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG173.fa]]"
+            - name: OPG174
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG174.fa]]"
+            - name: OPG175
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG175.fa]]"
+            - name: OPG176
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG176.fa]]"
+            - name: OPG178
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG178.fa]]"
+            - name: OPG180
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG180.fa]]"
+            - name: OPG181
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG181.fa]]"
+            - name: OPG185
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG185.fa]]"
+            - name: OPG187
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG187.fa]]"
+            - name: OPG188
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG188.fa]]"
+            - name: OPG189
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG189.fa]]"
+            - name: OPG190
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG190.fa]]"
+            - name: OPG191
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG191.fa]]"
+            - name: OPG192
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG192.fa]]"
+            - name: OPG193
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG193.fa]]"
+            - name: OPG195
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG195.fa]]"
+            - name: OPG197
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG197.fa]]"
+            - name: OPG198
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG198.fa]]"
+            - name: OPG199
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG199.fa]]"
+            - name: OPG200
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG200.fa]]"
+            - name: OPG204
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG204.fa]]"
+            - name: OPG205
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG205.fa]]"
+            - name: OPG208
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG208.fa]]"
+            - name: OPG209
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG209.fa]]"
+            - name: OPG210
+              sequence: "[[URL:https://theosanderson.github.io/mpox/OPG210.fa]]"
   cchf:
     <<: *defaultOrganismConfig
     schema:


### PR DESCRIPTION
sadly snakemake benchmarking doesnt work on MacOS but requires a linux... ugghhh.

So this adds benchmarking and then I plan on going inside the ingest pod to look at the benchmark results for a larger organism (lets see if I can identify the mem spike on west nile otherwise I can add mpox)

```
 kubectl exec -it loculus-ingest-deployment-west-nile-64f8f6d684-dphzm  -n prev-benchmark-ingest  -- /bin/sh
for f in *.tsv; do
  echo "===== $f ====="
  cat "$f"
done
```

## Current benchmark results

```
===== calculate_sequence_hashes.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
6.61	0:00:06	47.10	267.12	28.62	30.35	0.00	60.78	16.17	1.20
===== compare_hashes.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
0.75	0:00:00	37.44	48.10	23.91	24.96	0.00	0.00	0.00	0.19
===== fetch_inflate_ncbi_dataset_package.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
1.85	0:00:01	19.00	168.29	11.69	12.78	0.00	85.94	8.66	0.20
===== filter_out_loculus_depositions.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
3.17	0:00:03	95.07	288.29	66.18	69.48	0.00	5.65	16.41	0.61
===== format_ncbi_dataset_report.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
5.06	0:00:05	19.38	25.58	10.00	10.74	0.00	5.30	13.59	0.77
===== format_ncbi_dataset_sequences.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
2.10	0:00:02	74.96	1320.48	59.99	64.43	0.00	63.28	5.70	0.30
===== get_loculus_depositions.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
1.60	0:00:01	31.46	41.45	19.60	20.41	0.00	0.00	4.14	0.14
===== get_previous_submissions.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
0.56	0:00:00	38.88	47.98	24.32	25.64	0.00	0.00	0.00	0.16
===== prepare_files.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
11.02	0:00:11	38.77	49.74	26.37	27.44	0.00	23.56	36.48	4.20
===== prepare_metadata.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
3.75	0:00:03	133.07	326.77	103.41	107.55	0.00	18.80	31.74	1.37
===== revise.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
0.06	0:00:00	2.88	4.65	0.29	0.67	0.00	0.00	0.00	0.00
===== sort_revise_metadata_metadata.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
0.16	0:00:00	NA	NA	NA	NA	NA	NA	NA	NA
===== sort_revise_sequences_fasta.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
0.90	0:00:00	73.85	1319.98	61.16	65.06	0.00	0.00	0.00	0.05
===== sort_submit_metadata_metadata.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
1.10	0:00:01	5.36	9.56	0.37	0.95	0.00	0.00	0.00	0.00
===== sort_submit_sequences_fasta.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
4.46	0:00:04	111.77	2572.79	85.66	98.58	0.00	0.76	23.82	1.17
===== submit.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
47.81	0:00:47	203.86	215.80	185.89	187.67	0.00	0.00	0.73	0.51
```

Look at the `max_rss` column, the peak is at `submit.tsv` - I now changed the code for calculating the number of metadata entries (the issue was loading everything into mem, but the stream also seems to have quite large lines so this code now reduces how much is loaded at once):
```
===== submit.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
0.09	0:00:00	1.40	4.30	0.19	0.49	0.00	0.00	0.00	0.00
```

I also checked results for mpox and this looks good now:
```
===== calculate_sequence_hashes.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
19.02	0:00:19	49.28	270.64	30.69	33.93	0.01	1685.34	30.55	5.98
===== compare_hashes.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
0.50	0:00:00	2.75	4.65	0.76	0.78	0.00	0.00	0.00	0.00
===== fetch_inflate_ncbi_dataset_package.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
12.81	0:00:12	18.88	168.27	13.82	13.98	0.00	2151.02	31.61	4.12
===== filter_out_loculus_depositions.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
2.70	0:00:02	88.05	279.72	58.98	63.04	0.00	5.85	14.43	0.47
===== format_ncbi_dataset_report.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
3.31	0:00:03	19.62	25.57	9.96	11.05	0.00	5.81	14.50	0.56
===== format_ncbi_dataset_sequences.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
25.11	0:00:25	75.18	1320.22	73.94	73.96	0.00	2145.31	17.17	4.57
===== get_loculus_depositions.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
1.29	0:00:01	31.59	41.44	19.60	20.67	0.00	0.00	4.65	0.15
===== get_previous_submissions.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
0.59	0:00:00	38.59	48.10	24.33	25.69	0.02	0.00	0.00	0.17
===== prepare_files.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
13.21	0:00:13	38.04	52.94	25.68	26.75	0.00	2145.27	37.79	5.18
===== prepare_metadata.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
2.32	0:00:02	104.74	298.02	75.04	79.32	0.07	10.80	25.91	0.78
===== revise.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
0.09	0:00:00	NA	NA	NA	NA	NA	NA	NA	NA
===== sort_revise_metadata_metadata.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
0.01	0:00:00	NA	NA	NA	NA	NA	NA	NA	NA
===== sort_revise_sequences_fasta.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
0.89	0:00:00	57.40	2503.46	42.19	46.89	0.00	0.00	0.00	0.04
===== sort_submit_metadata_metadata.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
0.89	0:00:00	16.59	26.97	7.97	8.83	0.00	5.62	0.00	0.01
===== sort_submit_sequences_fasta.tsv =====
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
84.80	0:01:24	103.84	2635.91	79.58	91.09	0.00	1880.43	35.02	29.78
```

🚀 Preview: https://benchmark-ingest.loculus.org