### PR TITLE
feat!(deployment): create PriorityClass dynamically per namespace

### DIFF
--- a/kubernetes/loculus/templates/_possiblePriorityClassName.tpl
+++ b/kubernetes/loculus/templates/_possiblePriorityClassName.tpl
@@ -1,5 +1,5 @@
 {{- define "possiblePriorityClassName" -}}
-{{- if .Values.podPriorityClassName }}
-priorityClassName: {{ .Values.podPriorityClassName }}
+{{- if hasKey .Values "podPriorityValue" }}
+priorityClassName: {{ .Release.Namespace }}
 {{- end -}}
 {{- end -}}

--- a/kubernetes/loculus/templates/_possiblePriorityClassName.tpl
+++ b/kubernetes/loculus/templates/_possiblePriorityClassName.tpl
@@ -1,5 +1,5 @@
 {{- define "possiblePriorityClassName" -}}
 {{- if hasKey .Values "podPriorityValue" }}
-priorityClassName: {{ .Release.Namespace }}
+priorityClassName: {{ .Release.Namespace }}-priority
 {{- end -}}
 {{- end -}}

--- a/kubernetes/loculus/templates/priorityclass.yaml
+++ b/kubernetes/loculus/templates/priorityclass.yaml
@@ -2,7 +2,7 @@
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: {{ .Release.Namespace }}
+  name: {{ .Release.Namespace }}-priority
   annotations:
     argocd.argoproj.io/sync-wave: "-10"
 value: {{ .Values.podPriorityValue }}

--- a/kubernetes/loculus/templates/priorityclass.yaml
+++ b/kubernetes/loculus/templates/priorityclass.yaml
@@ -1,0 +1,11 @@
+{{- if hasKey .Values "podPriorityValue" }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+value: {{ .Values.podPriorityValue }}
+globalDefault: false
+description: "Priority class for namespace {{ .Release.Namespace }}, managed by the loculus Helm chart."
+{{- end }}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1931,9 +1931,9 @@
       "type": ["string", "integer"],
       "description": "TODO - this is required/set by ArgoCD"
     },
-    "podPriorityClassName": {
-      "type": "string",
-      "description": "TODO - found in PPX production.yaml"
+    "podPriorityValue": {
+      "type": "integer",
+      "description": "If set, the chart creates a PriorityClass named after the release namespace with this value, and assigns it to all loculus pods. Higher values mean higher scheduling priority; can be negative for lower-than-default priority. If unset, no PriorityClass is created and pods run at the cluster default priority."
     },
     "testconfig": {
       "description": "TODO"

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2822,4 +2822,3 @@ defaultResources:
 ingest:
   ncbiGatewayUrl: null
   mirrorBucket: null
-podPriorityValue: 10

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2822,3 +2822,4 @@ defaultResources:
 ingest:
   ncbiGatewayUrl: null
   mirrorBucket: null
+podPriorityValue: 10


### PR DESCRIPTION
## Summary

Refs #6348.

This restructures how pod priority is configured for loculus deployments. Previously the chart referenced an externally-supplied `PriorityClass` by name through `podPriorityClassName`. That meant every cluster running loculus had to provision a `PriorityClass` out-of-band before installing the chart. [Theo edit: only if they wanted to use the priority class feature]

This PR drops `podPriorityClassName` entirely and instead lets the chart create its own `PriorityClass` resource:

- New value `podPriorityValue` (integer) in `values.yaml`/`values.schema.json`. When set, the chart renders a `PriorityClass` whose **name matches `.Release.Namespace`** and whose `value` is `podPriorityValue`. All loculus pods then reference that class via `priorityClassName: {{ .Release.Namespace }}`.
- When `podPriorityValue` is unset (the default), no `PriorityClass` is created and pods run at the cluster default priority — this is the new "no priority configured" behavior.
- The `PriorityClass` is annotated with `argocd.argoproj.io/sync-wave: "-10"` so ArgoCD creates it before the deployments that reference it.
- Tied to the namespace name so multiple loculus installs on the same cluster get distinct, non-colliding `PriorityClass` resources without any per-install naming config.
- The existing `_possiblePriorityClassName.tpl` helper now renders `priorityClassName: {{ .Release.Namespace }}` (gated on `podPriorityValue` being set), so all of the deployments that already include the helper (`backend`, `website`, `lapis`, `silo`, `keycloak`, `preprocessing`, `ingest`, `autoapprove`, `taxonomy`, `ena-submission`) are wired up automatically.

This is groundwork for #6348: now that we can manage our own `PriorityClass`, a follow-up can add a second, lower-valued class for ingest/autoapprove without requiring cluster-admin coordination.

### Migration notes for chart users

- Anyone currently passing `podPriorityClassName: foo` (e.g. in PPX `production.yaml`) will need to switch to `podPriorityValue: <integer>` to keep getting a `PriorityClass` applied. The class will then live inside the namespace's chart release rather than being externally managed.
- ArgoCD needs RBAC to create cluster-scoped `PriorityClass` objects. If that's not granted, the simplest path is to leave `podPriorityValue` unset and not use a `PriorityClass` at all.

### One subtle behavior change

The old check was `{{- if .Values.podPriorityClassName }}` (truthiness — empty string falsy). The new check is `hasKey .Values "podPriorityValue"` (presence). This means setting `podPriorityValue: 0` is now an explicit choice — it creates a `PriorityClass` with value 0 (cluster default) rather than being treated as "unset". This seemed more correct for an integer field; happy to switch to a different sentinel if preferred.

## Test plan

- [x] `helm lint kubernetes/loculus -f kubernetes/loculus/values.yaml` passes.
- [x] `helm template` with the default values: no `PriorityClass` rendered, no `priorityClassName` lines on any deployment.
- [x] `helm template ... --set podPriorityValue=100 --namespace my-test-ns`: a single `PriorityClass` named `my-test-ns` with `value: 100` is rendered, and every deployment template gets `priorityClassName: my-test-ns`.
- [x] Negative values render correctly (`value: -100`).
- [x] Verify on a real cluster that ArgoCD can create the `PriorityClass` with the `sync-wave: "-10"` annotation before the deployments that reference it.
- [x] Verify that uninstall cleans up the `PriorityClass` (it is cluster-scoped but owned by the chart release).

🚀 Preview: https://dynamic-priority-class.loculus.org