### PR TITLE
test(integration): fix racy URL construction by preventing double `?`

### DIFF
--- a/integration-tests/tests/specs/features/file-sharing.spec.ts
+++ b/integration-tests/tests/specs/features/file-sharing.spec.ts
@@ -161,8 +161,9 @@ test('bulk revise 2 seqs with files', async ({ page, groupId, tmpDir }) => {
     await reviewPage2.releaseValidSequences();
 
     const searchPage2 = new SearchPage(page);
-    await searchPage2.goToReleasedSequences(ORGANISM_URL_NAME, groupId);
-    await page.goto(page.url() + '?column_submissionId=true');
+    await page.goto(
+        `/${ORGANISM_URL_NAME}/submission/${groupId}/released?column_submissionId=true`,
+    );
 
     // Check that revised sequences have the files
     await searchPage2.checkFileContentInModal('cell', revId1, REVISION_FILES);

--- a/integration-tests/tests/specs/features/search/download.dependent.spec.ts
+++ b/integration-tests/tests/specs/features/search/download.dependent.spec.ts
@@ -2,6 +2,7 @@ import { expect } from '@playwright/test';
 import { test } from '../../../fixtures/console-warnings.fixture';
 import { SearchPage } from '../../../pages/search.page';
 import fs from 'fs';
+import { setUrlParamsAndGoTo } from '../../../utils/setUrlParamsAndGoTo';
 
 const NULL_QUERY_VALUE = '_null_';
 
@@ -45,7 +46,7 @@ test('Download with null filter sends isNull param to LAPIS', async ({ page, bro
     await searchPage.ebolaSudan();
 
     // Navigate with a null filter applied via URL to avoid needing the option in autocomplete
-    await page.goto(`${page.url()}?geoLocCountry=${NULL_QUERY_VALUE}`);
+    await setUrlParamsAndGoTo(page, { geoLocCountry: NULL_QUERY_VALUE });
 
     await page.getByRole('button', { name: 'Download all entries' }).click();
     await page.getByLabel('I agree to the data use terms.').check();

--- a/integration-tests/tests/utils/setUrlParamsAndGoTo.ts
+++ b/integration-tests/tests/utils/setUrlParamsAndGoTo.ts
@@ -3,18 +3,14 @@ import { Page } from '@playwright/test';
 type UrlParamValue = string | number | boolean;
 
 /**
- * Safe way to add/update/remove URL search params and navigate to the new URL. Handles relative URLs correctly.
+ * Safe way to add/update URL search params and navigate to the new URL.
  * Should be used in place of `page.goto(page.url() + '?column_submissionId=true');`
  */
 export async function setUrlParamsAndGoTo(page: Page, params: Record<string, UrlParamValue>) {
     const url = new URL(page.url());
 
     for (const [key, value] of Object.entries(params)) {
-        if (value === undefined || value === null) {
-            url.searchParams.delete(key);
-        } else {
-            url.searchParams.set(key, String(value));
-        }
+        url.searchParams.set(key, String(value));
     }
 
     await page.goto(url.toString());

--- a/integration-tests/tests/utils/setUrlParamsAndGoTo.ts
+++ b/integration-tests/tests/utils/setUrlParamsAndGoTo.ts
@@ -1,0 +1,21 @@
+import { Page } from '@playwright/test';
+
+type UrlParamValue = string | number | boolean;
+
+/**
+ * Safe way to add/update/remove URL search params and navigate to the new URL. Handles relative URLs correctly.
+ * Should be used in place of `page.goto(page.url() + '?column_submissionId=true');`
+ */
+export async function setUrlParamsAndGoTo(page: Page, params: Record<string, UrlParamValue>) {
+    const url = new URL(page.url());
+
+    for (const [key, value] of Object.entries(params)) {
+        if (value === undefined || value === null) {
+            url.searchParams.delete(key);
+        } else {
+            url.searchParams.set(key, String(value));
+        }
+    }
+
+    await page.goto(url.toString());
+}


### PR DESCRIPTION
It's buggy to add a URL param by appending `?param` as this requires the URL to not end in ? or have other params set:

```
    await page.goto(`${page.url()}?geoLocCountry=${NULL_QUERY_VALUE}`);
```

This caused flakes in tests as we automatically add trailing `?` in various places in react code. Tests would pass when playwright was faster than the addition of the `?` - but sometimes playwright was fast enough causing failures.

I spotted this by looking at playwright trace and seeing the URL being `http://localhost:3000/dummy-organism-with-files/submission/6/released??column_submissionId=true`

Now, we construct the full URL with params upfront or safely add extra params using a helper `setUrlParamsAndGoTo`

This fixes this test failure (or at least one way this would show up sporadically):

```
1) [firefox-without-dep] › tests/specs/features/file-sharing.spec.ts:102:5 › bulk revise 2 seqs with files

    Test timeout of 300000ms exceeded.

    Error: page.reload: Test timeout of 300000ms exceeded.
    Call log:
      - waiting for navigation until "load"

       at pages/search.page.ts:221

      219 |     async waitForSequences(role: 'link' | 'cell', name: string | RegExp) {
      220 |         while (!(await this.page.getByRole(role, { name: name }).isVisible())) {
    > 221 |             await this.page.reload();
          |                             ^
      222 |             await this.page.waitForTimeout(2000);
      223 |         }
      224 |     }
```

I tried to find all instances of this bug across the codebase and identified (and fixed) one more instance.