### PR TITLE
test(integration): fix race by asserting that only one sequence is shown before getting accession

### DIFF
--- a/integration-tests/tests/specs/features/sequence-version-banners.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-version-banners.spec.ts
@@ -93,6 +93,7 @@ test.describe('Sequence version banners', () => {
         await search.select('Collection country', 'Germany');
 
         // Get the accession of the sequence to revoke
+        await search.expectSequenceCount(1);
         const toRevokeLink = page.getByRole('link', { name: /LOC_[A-Z0-9]+\.1/ });
         const toRevokeId = await toRevokeLink.textContent();
         const toRevokeAccession = toRevokeId.split('.')[0];


### PR DESCRIPTION
Playwright would sometimes try to get accessions before the filter was fully applied, while sequences were still loading. Code would fail due to ambiguous selector if more than one sequence was still showing:

```ts
// Apply some filter
await search.select('Collection country', 'Germany');

// Get accession assuming the filter is already applied
// Fails if Playwright races faster than filter application due to ambiguous selector
const toRevokeLink = page.getByRole('link', { name: /LOC_[A-Z0-9]+\.1/ });
```

We now assert that only one sequence is showing before using the selector:

```ts
await search.expectSequenceCount(1);
const toRevokeLink = page.getByRole('link', { name: /LOC_[A-Z0-9]+\.1/ });
```