### PR TITLE
test(integration): don't fail on preflight request hangup from LAPIS

### DIFF
--- a/integration-tests/tests/fixtures/console-warnings.fixture.ts
+++ b/integration-tests/tests/fixtures/console-warnings.fixture.ts
@@ -10,6 +10,7 @@ export const test = base.extend({
                 const harmlessMessages = [
                     'Form submission canceled because the form is not connected',
                     'ERR_INCOMPLETE_CHUNKED_ENCODING',
+                    "Response to preflight request doesn't pass access control check", // LAPIS sometimes hangs up preflight requests for unknown reasons
                 ];
 
                 const isHarmless = harmlessMessages.some((harmless) =>


### PR DESCRIPTION
Those hangups seem to happen occasionally, not worth failing integration tests for it so adding those console errors to harmlessMessages.