### PR TITLE
chore(deployment): switch workflow telemetry action

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Get runner IP
         run: curl -4 ifconfig.me
       - name: Collect Workflow Telemetry
-        uses: catchpoint/workflow-telemetry-action@v2
+        uses: ycfreeman/workflow-telemetry-action@cad169ff11f718319d5468b0a67a238db000ef3f
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Install k3d


### PR DESCRIPTION
## Summary

This PR switches the integration test workflow telemetry step from unmaintained and broken `catchpoint/workflow-telemetry-action@v2` to the maintained fork `ycfreeman/workflow-telemetry-action`, pinned to commit `cad169ff11f718319d5468b0a67a238db000ef3f`.

The upstream Catchpoint action currently only publishes `v2` / `v2.0.0`, which still uses the older Node runtime.

This action has been useful to see CPU/disk usage and timing of integration test workflow.


## Testing

New action works and produces good results

Graphs look like this:

<img width="1388" height="377" alt="image" src="https://github.com/user-attachments/assets/47989a07-548d-45a7-9d8e-9ef2c6a0f675" />

🚀 Preview: Add `preview` label to enable