### PR TITLE
test(integration): reduce CI Playwright workers from 4 to 2 to reduce flakiness with negligible runtime increase

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -118,7 +118,7 @@ jobs:
           TEST_SUITE: ${{ matrix.browser == 'cli' && 'cli' || 'browser' }}
         run: |
           set -o pipefail
-          cd integration-tests && npx playwright test --workers=4 --reporter=list,html 2>&1 | tee output.txt
+          cd integration-tests && npx playwright test --workers=1 --reporter=list,html 2>&1 | tee output.txt
           EXIT_CODE=$?
           echo '```' >> $GITHUB_STEP_SUMMARY
           sed -n '/Running [0-9]\+ tests/,$p' output.txt >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -118,7 +118,7 @@ jobs:
           TEST_SUITE: ${{ matrix.browser == 'cli' && 'cli' || 'browser' }}
         run: |
           set -o pipefail
-          cd integration-tests && npx playwright test --workers=1 --reporter=list,html 2>&1 | tee output.txt
+          cd integration-tests && npx playwright test --workers=2 --reporter=list,html 2>&1 | tee output.txt
           EXIT_CODE=$?
           echo '```' >> $GITHUB_STEP_SUMMARY
           sed -n '/Running [0-9]\+ tests/,$p' output.txt >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Reduce Playwright CI workers from 4 to 2 to reduce integration test flakiness only slightly slowing down integration tests (~5-10%, ~1min). Firefox is the slowest and goes up from 18min to 19min.

For a long time we've had strange errors like HTTP connections dropping/aborting with `ERR_EMPTY_RESPONSE` - this is not something that should happen in a healthy system.

My hunch is that the CI machine is overloaded with 4 Playwright workers and a whole cluster causing basic things like TCP to start failing due to CPU not being able to do things in reasonable time.

4 workers appears simply too many, even with 2 workers we're at near 100% CPU while running the tests. There's just ~10% headroom which seems a healthy amount.

<img width="1370" height="380" alt="Google Chrome 2026-05-08 13 31 39" src="https://github.com/user-attachments/assets/4441ae97-5d9c-478d-b101-f57deb67e797" />

Reducing workers from 2 to 1 increases overall time for tests from ~17min to ~24min - that's not too bad but 2 workers looks like the sweetspot for load/time. We want to get close to but below 100% CPU load and 2 looks best for that.