### PR TITLE
test(integration): assert released page is reached before starting reload

### DIFF
--- a/integration-tests/tests/fixtures/sequence.fixture.ts
+++ b/integration-tests/tests/fixtures/sequence.fixture.ts
@@ -55,9 +55,7 @@ export const test = groupTest.extend<SequenceFixtures>({
             await editPage.addSequenceFile(`>edited_S\n${CCHF_S_SEGMENT_FULL_SEQUENCE}`);
             await editPage.fillField('Authors', 'Integration, Test');
             await editPage.submitChanges();
-            await reviewPage.releaseValidSequences();
-
-            await page.getByRole('link', { name: 'Released Sequences' }).click();
+            await reviewPage.releaseAndGoToReleasedSequences();
             await expect
                 .poll(
                     async () => {

--- a/integration-tests/tests/pages/review.page.ts
+++ b/integration-tests/tests/pages/review.page.ts
@@ -148,12 +148,18 @@ export class ReviewPage {
     async releaseValidSequences() {
         await this.page.getByRole('button', { name: /Release \d+ valid sequence/ }).click();
         await this.page.getByRole('button', { name: 'Release', exact: true }).click();
+        await expect(this.page.getByText('released successfully')).toBeVisible();
+    }
+
+    async goToReleasedSequences(): Promise<SearchPage> {
+        await this.page.getByRole('link', { name: 'released sequences' }).click();
+        await expect(this.page).toHaveURL((url) => url.pathname.endsWith('/released'));
+        return new SearchPage(this.page);
     }
 
     async releaseAndGoToReleasedSequences(): Promise<SearchPage> {
         await this.releaseValidSequences();
-        await this.page.getByRole('link', { name: 'released sequences' }).click();
-        return new SearchPage(this.page);
+        return this.goToReleasedSequences();
     }
 
     async checkFilesInReviewDialog(

--- a/integration-tests/tests/readonly.setup.ts
+++ b/integration-tests/tests/readonly.setup.ts
@@ -78,10 +78,9 @@ setup('Initialize some ebola sequences as base data', async ({ page }) => {
         );
 
         await reviewPage.waitForZeroProcessing();
-        await reviewPage.releaseValidSequences();
+        await reviewPage.releaseAndGoToReleasedSequences();
     }
 
-    await page.getByRole('link', { name: 'released sequences' }).click();
     // Reloading is required as the page does not automatically update with new data
     await expect
         .poll(

--- a/integration-tests/tests/specs/features/search/lineage-field.spec.ts
+++ b/integration-tests/tests/specs/features/search/lineage-field.spec.ts
@@ -37,8 +37,7 @@ test('Lineage field lineage counts', async ({ page, groupId }) => {
     const reviewPage = await submissionPage.submitSequence();
 
     await reviewPage.waitForZeroProcessing();
-    await reviewPage.releaseValidSequences();
-    await page.getByRole('link', { name: 'released sequences' }).click();
+    await reviewPage.releaseAndGoToReleasedSequences();
 
     while (!(await page.getByText('Search returned 6 sequences').isVisible())) {
         await page.reload();

--- a/integration-tests/tests/specs/features/search/override-hidden-fields.spec.ts
+++ b/integration-tests/tests/specs/features/search/override-hidden-fields.spec.ts
@@ -40,8 +40,7 @@ test('Override hidden fields', async ({ page, groupId }) => {
     );
 
     await reviewPage.waitForZeroProcessing();
-    await reviewPage.releaseValidSequences();
-    await page.getByRole('link', { name: 'released sequences' }).click();
+    await reviewPage.releaseAndGoToReleasedSequences();
 
     while (!(await page.getByText('Search returned 2 sequences').isVisible())) {
         await page.reload();
@@ -81,8 +80,7 @@ test('Override hidden fields', async ({ page, groupId }) => {
 
     reviewPage = new ReviewPage(page);
     await reviewPage.waitForZeroProcessing();
-    await reviewPage.releaseValidSequences();
-    await page.getByRole('link', { name: 'released sequences' }).click();
+    await reviewPage.releaseAndGoToReleasedSequences();
     while (!(await page.getByRole('cell', { name: '2012-12-13' }).isVisible())) {
         await page.reload();
         await page.waitForTimeout(2000);

--- a/integration-tests/tests/specs/features/sequence-version-banners.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-version-banners.spec.ts
@@ -58,8 +58,7 @@ test.describe('Sequence version banners', () => {
 
         // Release both sequences
         await reviewPage.waitForZeroProcessing();
-        await reviewPage.releaseValidSequences();
-        await page.getByRole('link', { name: 'released sequences' }).click();
+        await reviewPage.releaseAndGoToReleasedSequences();
 
         // Wait for sequences to appear in search
         while (!(await page.getByText('Search returned 2 sequences').isVisible())) {
@@ -105,8 +104,7 @@ test.describe('Sequence version banners', () => {
         // Release the revision and revocation
         const reviewPage2 = new ReviewPage(page);
         await reviewPage2.waitForZeroProcessing();
-        await reviewPage2.releaseValidSequences();
-        await page.getByRole('link', { name: 'released sequences' }).click();
+        await reviewPage2.releaseAndGoToReleasedSequences();
 
         // Wait for the revised sequence to appear (with new date)
         while (!(await page.getByRole('cell', { name: '2023-06-15' }).isVisible())) {
@@ -163,8 +161,7 @@ test.describe('Sequence version banners', () => {
 
         // Release the sequence
         await reviewPage.waitForZeroProcessing();
-        await reviewPage.releaseValidSequences();
-        await page.getByRole('link', { name: 'released sequences' }).click();
+        await reviewPage.releaseAndGoToReleasedSequences();
 
         // Wait for sequence to appear
         while (!(await page.getByRole('link', { name: /LOC_/ }).isVisible())) {
@@ -192,8 +189,7 @@ test.describe('Sequence version banners', () => {
         // Release the revision
         const reviewPage2 = new ReviewPage(page);
         await reviewPage2.waitForZeroProcessing();
-        await reviewPage2.releaseValidSequences();
-        await page.getByRole('link', { name: 'released sequences' }).click();
+        await reviewPage2.releaseAndGoToReleasedSequences();
 
         // Wait for revised sequence
         while (!(await page.getByRole('cell', { name: '2023-09-20' }).isVisible())) {

--- a/integration-tests/tests/specs/features/submission-flow.spec.ts
+++ b/integration-tests/tests/specs/features/submission-flow.spec.ts
@@ -3,6 +3,7 @@ import { test } from '../../fixtures/group.fixture';
 import { join } from 'path';
 import { BulkSubmissionPage, SingleSequenceSubmissionPage } from '../../pages/submission.page';
 import { NavigationPage } from '../../pages/navigation.page';
+import { ReviewPage } from '../../pages/review.page';
 
 test.describe('Submission flow', () => {
     test('submission page shows group creation button when not in a group', async ({
@@ -41,9 +42,8 @@ test.describe('Submission flow', () => {
             page.getByRole('heading', { name: 'Review current submissions' }),
         ).toBeVisible();
 
-        await page.getByRole('button', { name: 'Release 1 valid sequence' }).click();
-        await page.getByRole('button', { name: 'Release', exact: true }).click();
-        await page.getByRole('link', { name: 'Released Sequences' }).click();
+        const reviewPage = new ReviewPage(page);
+        await reviewPage.releaseAndGoToReleasedSequences();
 
         await expect
             .poll(
@@ -84,15 +84,13 @@ test.describe('Submission flow', () => {
                 'GTGTTCTCTTGAGTGTTGGCAAAATGGAAAACAAAATCGAGGTGAACAACAAAGATGAGATGAACAAATGGTTTGAGGAGTTCAAGAAAGGAAATGGACTTGTGGACACTTTCACAAACTCNTATTCCTTTTGTGAAAGCGTNCCAAATCTGGACAGNTTTGTNTTCCAGATGGCNAGTGCCACTGATGATGCACAAAANGANTCCATCTACGCATCTGCNCTGGTGGANGCAACCAAATTTTGTGCACCTATATACGAGTGTGCTTGGGCTAGCTCCACTGGCATTGTTAAAAAGGGACTGGAGTGGTTCGAGAAAAATGCAGGAACCATTAAATCCTGGGATGAGAGTTATACTGAGCTTAAAGTTGAAGTTCCCAAAATAGAACAACTCTCCAACTACCAGCAGGCTGCTCTCAAATGGAGAAAAGACATAGGCTTCCGTGTCAATGCAAATACGGCAGCTTTGAGTAACAAAGTCCTAGCAGAGTACAAAGTTCCTGGCGAGATTGTAATGTCTGTCAAAGAGATGTTGTCAGATATGATTAGAAGNAGGAACCTGATTCTCAACAGAGGTGGTGATGAGAACCCACGCGGCCCAGTTAGCCGTGAACATGTGGAGTGGTGC',
         });
         await submissionPage.acceptTerms();
-        await submissionPage.submitSequence();
+        const reviewPage = await submissionPage.submitSequence();
 
         await expect(
             page.getByRole('heading', { name: 'Review current submissions' }),
         ).toBeVisible();
 
-        await page.getByRole('button', { name: 'Release 1 valid sequence' }).click();
-        await page.getByRole('button', { name: 'Release', exact: true }).click();
-        await page.getByRole('link', { name: 'Released Sequences' }).click();
+        await reviewPage.releaseAndGoToReleasedSequences();
 
         while (!(await page.getByRole('cell', { name: 'Colombia' }).isVisible())) {
             await page.reload();


### PR DESCRIPTION
Some integration test flakes were due to us starting reload code before navigation had happened after clicking a link. This caused thet navigation to abort and the reloads to happen on the wrong page:

Example of flaky test code that fails when page reload happens before url has changed:

```ts
await page.getByRole('link', { name: 'Released Sequences' }).click();
while (!(await page.getByRole('cell', { name: '2012-12-13' }).isVisible())) {
        await page.reload();
        await page.waitForTimeout(2000);
}
```

Whenever we navigate to the released sequences page after releasing valid sequences we now wait for the navigation to have succeeded.