### PR TITLE
feat(deployment): experimentally add Andes virus organism

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1812,6 +1812,7 @@ defaultOrganisms:
       <<: *ingest
       configFile:
         taxon_id: 1980442
+        calculate_groups_override_json: true
         segment_identification:
           method: "minimizer"
           minimizer_url: "https://raw.githubusercontent.com/loculus-project/agent_store/d65a90b79f460203aad04dd346ca943aed55de56/hantavirus/segment-minimizer.json"

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1762,7 +1762,7 @@ defaultOrganisms:
                 sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/env.fasta]]"
               - name: prM
                 sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/prM.fasta]]"
-  hantavirus:
+  andes-virus:
     <<: *defaultOrganismConfig
     enabled: true
     schema:
@@ -1770,7 +1770,7 @@ defaultOrganisms:
       submissionDataTypes:
         <<: *defaultSubmissionDataTypes
         maxSequencesPerEntry: 3
-      organismName: "Hantavirus"
+      organismName: "Andes virus"
       website:
         <<: *website
         tableColumns:
@@ -1792,62 +1792,62 @@ defaultOrganisms:
         configFile:
           <<: *preprocessingConfigFile
           create_embl_file: false
-          taxon_id: 1980442
-          scientific_name: "Orthohantavirus"
+          taxon_id: 1980456
+          scientific_name: "Andes virus"
           molecule_type: "genomic RNA"
-          nextclade_dataset_server: "https://raw.githubusercontent.com/loculus-project/agent_store/4cc6d9dd4240c28945eba44a1a3199cd51b95fd1/hantavirus/nextclade_data"
+          nextclade_dataset_server: "https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/nextclade_data"
           segments:
             - name: L
               references:
                 - name: singleReference
-                  nextclade_dataset_name: orthohantavirus/L
+                  nextclade_dataset_name: andes-virus/L
                   genes: [RdRp]
             - name: M
               references:
                 - name: singleReference
-                  nextclade_dataset_name: orthohantavirus/M
+                  nextclade_dataset_name: andes-virus/M
                   genes: [GPC]
             - name: S
               references:
                 - name: singleReference
-                  nextclade_dataset_name: orthohantavirus/S
+                  nextclade_dataset_name: andes-virus/S
                   genes: ["N", NSs]
     ingest:
       <<: *ingest
       configFile:
-        taxon_id: 1980442
+        taxon_id: 1980456
         calculate_groups_override_json: true
         segment_identification:
           method: "minimizer"
-          minimizer_url: "https://raw.githubusercontent.com/loculus-project/agent_store/4cc6d9dd4240c28945eba44a1a3199cd51b95fd1/hantavirus/segment-minimizer.json"
+          minimizer_url: "https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/segment-minimizer.json"
           minimizer_parser: ["segment"]
     referenceGenomes:
       - name: L
         references:
           - name: singleReference
-            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/4cc6d9dd4240c28945eba44a1a3199cd51b95fd1/hantavirus/NC_003468.2.fasta]]"
+            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/NC_003468.2.fasta]]"
             insdcAccessionFull: NC_003468.2
             genes:
               - name: RdRp
-                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/4cc6d9dd4240c28945eba44a1a3199cd51b95fd1/hantavirus/genes/RdRp.fasta]]"
+                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/genes/RdRp.fasta]]"
       - name: M
         references:
           - name: singleReference
-            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/4cc6d9dd4240c28945eba44a1a3199cd51b95fd1/hantavirus/NC_003467.2.fasta]]"
+            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/NC_003467.2.fasta]]"
             insdcAccessionFull: NC_003467.2
             genes:
               - name: GPC
-                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/4cc6d9dd4240c28945eba44a1a3199cd51b95fd1/hantavirus/genes/GPC.fasta]]"
+                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/genes/GPC.fasta]]"
       - name: S
         references:
           - name: singleReference
-            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/4cc6d9dd4240c28945eba44a1a3199cd51b95fd1/hantavirus/NC_003466.1.fasta]]"
+            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/NC_003466.1.fasta]]"
             insdcAccessionFull: NC_003466.1
             genes:
               - name: "N"
-                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/4cc6d9dd4240c28945eba44a1a3199cd51b95fd1/hantavirus/genes/N.fasta]]"
+                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/genes/N.fasta]]"
               - name: NSs
-                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/4cc6d9dd4240c28945eba44a1a3199cd51b95fd1/hantavirus/genes/NSs.fasta]]"
+                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/genes/NSs.fasta]]"
   dummy-organism:
     schema:
       submissionDataTypes: *defaultSubmissionDataTypes

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1812,7 +1812,6 @@ defaultOrganisms:
       <<: *ingest
       configFile:
         taxon_id: 1980442
-        calculate_groups_override_json: true
         segment_identification:
           method: "minimizer"
           minimizer_url: "https://raw.githubusercontent.com/loculus-project/agent_store/d65a90b79f460203aad04dd346ca943aed55de56/hantavirus/segment-minimizer.json"

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1767,7 +1767,25 @@ defaultOrganisms:
     enabled: true
     schema:
       <<: *schema
+      submissionDataTypes:
+        <<: *defaultSubmissionDataTypes
+        maxSequencesPerEntry: 3
       organismName: "Hantavirus"
+      website:
+        <<: *website
+        tableColumns:
+          - sampleCollectionDate
+          - geoLocCountry
+          - geoLocAdmin1
+          - authors
+          - authorAffiliations
+          - ncbiReleaseDate
+          - hostNameScientific
+          - length_M
+          - length_S
+          - length_L
+        defaultOrderBy: sampleCollectionDate
+        defaultOrder: descending
     preprocessing:
       - <<: *preprocessing
         version: 1
@@ -1778,7 +1796,15 @@ defaultOrganisms:
           scientific_name: "Orthohantavirus"
           molecule_type: "genomic RNA"
           segments:
-            - name: main
+            - name: L
+              references:
+                - name: singleReference
+                  genes: []
+            - name: M
+              references:
+                - name: singleReference
+                  genes: []
+            - name: S
               references:
                 - name: singleReference
                   genes: []
@@ -1786,8 +1812,23 @@ defaultOrganisms:
       <<: *ingest
       configFile:
         taxon_id: 1980442
+        calculate_groups_override_json: true
+        segment_identification:
+          method: "minimizer"
+          minimizer_url: "https://raw.githubusercontent.com/loculus-project/agent_store/ce409e4a9ed0ecbbae131d0059db4a381a143abd/hantavirus/segment-minimizer.json"
+          minimizer_parser: ["segment"]
     referenceGenomes:
-      - name: main
+      - name: L
+        references:
+          - name: singleReference
+            sequence: "[[URL:https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?id=NC_005222.1&db=nuccore&report=fasta&retmode=text]]"
+            insdcAccessionFull: NC_005222.1
+      - name: M
+        references:
+          - name: singleReference
+            sequence: "[[URL:https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?id=NC_005219.1&db=nuccore&report=fasta&retmode=text]]"
+            insdcAccessionFull: NC_005219.1
+      - name: S
         references:
           - name: singleReference
             sequence: "[[URL:https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?id=NC_005218.1&db=nuccore&report=fasta&retmode=text]]"

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1795,19 +1795,23 @@ defaultOrganisms:
           taxon_id: 1980442
           scientific_name: "Orthohantavirus"
           molecule_type: "genomic RNA"
+          nextclade_dataset_server: "https://raw.githubusercontent.com/loculus-project/agent_store/4cc6d9dd4240c28945eba44a1a3199cd51b95fd1/hantavirus/nextclade_data"
           segments:
             - name: L
               references:
                 - name: singleReference
-                  genes: []
+                  nextclade_dataset_name: orthohantavirus/L
+                  genes: [RdRp]
             - name: M
               references:
                 - name: singleReference
-                  genes: []
+                  nextclade_dataset_name: orthohantavirus/M
+                  genes: [GPC]
             - name: S
               references:
                 - name: singleReference
-                  genes: []
+                  nextclade_dataset_name: orthohantavirus/S
+                  genes: ["N", NSs]
     ingest:
       <<: *ingest
       configFile:
@@ -1815,24 +1819,35 @@ defaultOrganisms:
         calculate_groups_override_json: true
         segment_identification:
           method: "minimizer"
-          minimizer_url: "https://raw.githubusercontent.com/loculus-project/agent_store/d65a90b79f460203aad04dd346ca943aed55de56/hantavirus/segment-minimizer.json"
+          minimizer_url: "https://raw.githubusercontent.com/loculus-project/agent_store/4cc6d9dd4240c28945eba44a1a3199cd51b95fd1/hantavirus/segment-minimizer.json"
           minimizer_parser: ["segment"]
     referenceGenomes:
       - name: L
         references:
           - name: singleReference
-            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/d65a90b79f460203aad04dd346ca943aed55de56/hantavirus/NC_005222.1.fasta]]"
-            insdcAccessionFull: NC_005222.1
+            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/4cc6d9dd4240c28945eba44a1a3199cd51b95fd1/hantavirus/NC_003468.2.fasta]]"
+            insdcAccessionFull: NC_003468.2
+            genes:
+              - name: RdRp
+                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/4cc6d9dd4240c28945eba44a1a3199cd51b95fd1/hantavirus/genes/RdRp.fasta]]"
       - name: M
         references:
           - name: singleReference
-            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/d65a90b79f460203aad04dd346ca943aed55de56/hantavirus/NC_005219.1.fasta]]"
-            insdcAccessionFull: NC_005219.1
+            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/4cc6d9dd4240c28945eba44a1a3199cd51b95fd1/hantavirus/NC_003467.2.fasta]]"
+            insdcAccessionFull: NC_003467.2
+            genes:
+              - name: GPC
+                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/4cc6d9dd4240c28945eba44a1a3199cd51b95fd1/hantavirus/genes/GPC.fasta]]"
       - name: S
         references:
           - name: singleReference
-            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/d65a90b79f460203aad04dd346ca943aed55de56/hantavirus/NC_005218.1.fasta]]"
-            insdcAccessionFull: NC_005218.1
+            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/4cc6d9dd4240c28945eba44a1a3199cd51b95fd1/hantavirus/NC_003466.1.fasta]]"
+            insdcAccessionFull: NC_003466.1
+            genes:
+              - name: "N"
+                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/4cc6d9dd4240c28945eba44a1a3199cd51b95fd1/hantavirus/genes/N.fasta]]"
+              - name: NSs
+                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/4cc6d9dd4240c28945eba44a1a3199cd51b95fd1/hantavirus/genes/NSs.fasta]]"
   dummy-organism:
     schema:
       submissionDataTypes: *defaultSubmissionDataTypes

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1773,6 +1773,7 @@ defaultOrganisms:
       organismName: "Andes virus"
       website:
         <<: *website
+        image: "https://raw.githubusercontent.com/loculus-project/agent_store/9607d5fb7772685222e1769ed32169db3351e2a4/andes-virus/images/copper_r.png"
         tableColumns:
           - sampleCollectionDate
           - geoLocCountry

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1762,6 +1762,36 @@ defaultOrganisms:
                 sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/env.fasta]]"
               - name: prM
                 sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/prM.fasta]]"
+  hantavirus:
+    <<: *defaultOrganismConfig
+    enabled: true
+    schema:
+      <<: *schema
+      organismName: "Hantavirus"
+    preprocessing:
+      - <<: *preprocessing
+        version: 1
+        configFile:
+          <<: *preprocessingConfigFile
+          create_embl_file: false
+          taxon_id: 1980442
+          scientific_name: "Orthohantavirus"
+          molecule_type: "genomic RNA"
+          segments:
+            - name: main
+              references:
+                - name: singleReference
+                  genes: []
+    ingest:
+      <<: *ingest
+      configFile:
+        taxon_id: 1980442
+    referenceGenomes:
+      - name: main
+        references:
+          - name: singleReference
+            sequence: "[[URL:https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?id=NC_005218.1&db=nuccore&report=fasta&retmode=text]]"
+            insdcAccessionFull: NC_005218.1
   dummy-organism:
     schema:
       submissionDataTypes: *defaultSubmissionDataTypes

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1773,7 +1773,7 @@ defaultOrganisms:
       organismName: "Andes virus"
       website:
         <<: *website
-        image: "https://raw.githubusercontent.com/loculus-project/agent_store/9607d5fb7772685222e1769ed32169db3351e2a4/andes-virus/images/copper_r.png"
+        image: "https://raw.githubusercontent.com/loculus-project/agent_store/eb5ead95768351c5ee1576065a731bb32e6502f2/andes-virus/images/viridis_invert.png"
         tableColumns:
           - sampleCollectionDate
           - geoLocCountry

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1771,9 +1771,9 @@ defaultOrganisms:
         <<: *defaultSubmissionDataTypes
         maxSequencesPerEntry: 3
       organismName: "Andes virus"
+      image: "https://raw.githubusercontent.com/loculus-project/agent_store/eb5ead95768351c5ee1576065a731bb32e6502f2/andes-virus/images/viridis_invert.png"
       website:
         <<: *website
-        image: "https://raw.githubusercontent.com/loculus-project/agent_store/eb5ead95768351c5ee1576065a731bb32e6502f2/andes-virus/images/viridis_invert.png"
         tableColumns:
           - sampleCollectionDate
           - geoLocCountry

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1815,23 +1815,23 @@ defaultOrganisms:
         calculate_groups_override_json: true
         segment_identification:
           method: "minimizer"
-          minimizer_url: "https://raw.githubusercontent.com/loculus-project/agent_store/ce409e4a9ed0ecbbae131d0059db4a381a143abd/hantavirus/segment-minimizer.json"
+          minimizer_url: "https://raw.githubusercontent.com/loculus-project/agent_store/d65a90b79f460203aad04dd346ca943aed55de56/hantavirus/segment-minimizer.json"
           minimizer_parser: ["segment"]
     referenceGenomes:
       - name: L
         references:
           - name: singleReference
-            sequence: "[[URL:https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?id=NC_005222.1&db=nuccore&report=fasta&retmode=text]]"
+            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/d65a90b79f460203aad04dd346ca943aed55de56/hantavirus/NC_005222.1.fasta]]"
             insdcAccessionFull: NC_005222.1
       - name: M
         references:
           - name: singleReference
-            sequence: "[[URL:https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?id=NC_005219.1&db=nuccore&report=fasta&retmode=text]]"
+            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/d65a90b79f460203aad04dd346ca943aed55de56/hantavirus/NC_005219.1.fasta]]"
             insdcAccessionFull: NC_005219.1
       - name: S
         references:
           - name: singleReference
-            sequence: "[[URL:https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?id=NC_005218.1&db=nuccore&report=fasta&retmode=text]]"
+            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/d65a90b79f460203aad04dd346ca943aed55de56/hantavirus/NC_005218.1.fasta]]"
             insdcAccessionFull: NC_005218.1
   dummy-organism:
     schema:


### PR DESCRIPTION
## Summary

Adds `andes-virus` as a default organism with NCBI ingest enabled for Andes virus (`1980456`). The organism is configured as segmented with expected `L`, `M`, and `S` sequences per entry.

Preprocessing uses minimal Nextclade datasets for each segment, staged outside this repo in `loculus-project/agent_store` under the new `andes-virus/` folder and referenced through an immutable raw dataset server URL. The datasets use these Andes virus references:

- `L`: `NC_003468.2`, gene `RdRp`
- `M`: `NC_003467.2`, gene `GPC`
- `S`: `NC_003466.1`, genes `N` and `NSs`

For NCBI ingest, segment assignment uses a rebuilt Andes-specific `nextclade sort` minimizer with dataset names `L`, `M`, and `S`. Grouping follows the CCHF-style segmented ingest path with `calculate_groups_override_json: true`, using mirrored NCBI assembly packages to provide assembly-derived grouping overrides.

## Validation

- `git diff --check`
- Parsed `kubernetes/loculus/values.yaml` as YAML with aliases enabled.
- Confirmed the new `agent_store` dataset index and minimizer URLs load from GitHub.
- Confirmed the rebuilt minimizer classifies the three Andes reference segments as `L`, `M`, and `S` with score `1.0`.
- Confirmed `nextclade dataset get` and `nextclade run` work from the raw `agent_store` dataset server for all three segment datasets.
- Confirmed the external reference nucleotide and amino acid sequence files in the new `andes-virus/` store folder are headerless raw sequence strings with no newline characters.

## Authorship

Written by AI with human guidance.

🚀 Preview: https://hanta.loculus.org