### PR TITLE
fix(website): Also show zero counts in autocomplete options

### DIFF
--- a/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
+++ b/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
@@ -8,7 +8,7 @@ import type { LapisSearchParameters } from '../DownloadDialog/SequenceFilters.ts
 export type Option = {
     option: string;
     value: string; // Always a string, using NULL_QUERY_VALUE for nulls
-    count: number | undefined;
+    count: number;
 };
 
 /* Fetch options as all possible unique values for `fieldName` */
@@ -209,8 +209,7 @@ const createLineageOptionsHook = (
 
             // generate options
             Object.keys(lineageDefinition).forEach((lineageName) => {
-                let count: number | undefined = aggregatedCounts.get(lineageName);
-                if (count === 0) count = undefined;
+                const count: number = aggregatedCounts.get(lineageName) ?? 0;
                 options.push({ option: lineageName, value: lineageName, count });
             });
         }

--- a/website/src/components/SearchPage/fields/LineageField.spec.tsx
+++ b/website/src/components/SearchPage/fields/LineageField.spec.tsx
@@ -125,7 +125,7 @@ describe('LineageField', () => {
 
         const options = await screen.findAllByRole('option');
         expect(options.length).toBe(5);
-        expect(options[0].textContent).toBe('A');
+        expect(options[0].textContent).toBe('A(0)');
         expect(options[1].textContent).toBe('A.1(10)');
         // A.1.1.1 and B.1 are aliases -> B.1 should have aggregated count
         expect(options[4].textContent).toBe('B.1(35)');

--- a/website/src/components/SearchPage/fields/MultiChoiceAutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/MultiChoiceAutoCompleteField.tsx
@@ -227,7 +227,7 @@ export const MultiChoiceAutoCompleteField = ({
                                                         {option.option}
                                                     </span>
                                                     <span className='inline-block ml-1'>
-                                                         ({formatNumberWithDefaultLocale(option.count)})
+                                                        ({formatNumberWithDefaultLocale(option.count)})
                                                     </span>
                                                     {selected && (
                                                         <span

--- a/website/src/components/SearchPage/fields/MultiChoiceAutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/MultiChoiceAutoCompleteField.tsx
@@ -226,11 +226,9 @@ export const MultiChoiceAutoCompleteField = ({
                                                     >
                                                         {option.option}
                                                     </span>
-                                                    {option.count !== undefined && (
-                                                        <span className='inline-block ml-1'>
-                                                            ({formatNumberWithDefaultLocale(option.count)})
-                                                        </span>
-                                                    )}
+                                                    <span className='inline-block ml-1'>
+                                                         ({formatNumberWithDefaultLocale(option.count)})
+                                                    </span>
                                                     {selected && (
                                                         <span
                                                             className={`absolute inset-y-0 left-0 flex items-center pl-3 ${

--- a/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
@@ -152,11 +152,9 @@ export const SingleChoiceAutoCompleteField = ({
                                                     >
                                                         {fieldDisplayNameMap?.get(option.option) ?? option.option}
                                                     </span>
-                                                    {option.count !== undefined && (
-                                                        <span className='inline-block ml-1'>
-                                                            ({formatNumberWithDefaultLocale(option.count)})
-                                                        </span>
-                                                    )}
+                                                    <span className='inline-block ml-1'>
+                                                         ({formatNumberWithDefaultLocale(option.count)})
+                                                    </span>
                                                     {selected && (
                                                         <span
                                                             className={`absolute inset-y-0 left-0 flex items-center pl-3 ${

--- a/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
@@ -153,7 +153,7 @@ export const SingleChoiceAutoCompleteField = ({
                                                         {fieldDisplayNameMap?.get(option.option) ?? option.option}
                                                     </span>
                                                     <span className='inline-block ml-1'>
-                                                         ({formatNumberWithDefaultLocale(option.count)})
+                                                        ({formatNumberWithDefaultLocale(option.count)})
                                                     </span>
                                                     {selected && (
                                                         <span


### PR DESCRIPTION
Show '(0)' after options with zero counts in the autocomplete dropdowns.

Previous behaviour was to not show anything after the option if the count was zero. This is confusing when there are many options with zero counts (such as the host species filter). E.g., I open the dropdown and see many options, but as all of them have zero counts none of the options have a count after their name -> my assumption is that these are all valid options, but when I click them they have zero sequences associated with them.

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://autocomplete-zero-counts.loculus.org