### PR TITLE
feat(website): Sort organism cards by display name

### DIFF
--- a/website/src/config.spec.ts
+++ b/website/src/config.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { validateWebsiteConfig } from './config.ts';
+import { configuredOrganismsFromConfig, validateWebsiteConfig } from './config.ts';
 import type { WebsiteConfig } from './types/config.ts';
 import { SINGLE_SEG_MULTI_REF_REFERENCEGENOMES_SCHEMA } from './types/referenceGenomes.spec.ts';
 
@@ -42,5 +42,41 @@ describe('validateWebsiteConfig', () => {
         expect(errors[0].message).contains(
             `Organism 'dummyOrganism' has multiple references but referenceIdentifierField is not defined in the schema.`,
         );
+    });
+});
+
+describe('configuredOrganismsFromConfig', () => {
+    it('sorts organisms by display name instead of key', () => {
+        const organisms = configuredOrganismsFromConfig({
+            ...defaultConfig,
+            organisms: {
+                zika: {
+                    schema: {
+                        organismName: 'Zika Virus',
+                        inputFields: [],
+                        tableColumns: [],
+                        primaryKey: '',
+                        metadata: [],
+                        defaultOrderBy: '',
+                        defaultOrder: 'ascending',
+                        submissionDataTypes: { consensusSequences: false },
+                    },
+                },
+                andes: {
+                    schema: {
+                        organismName: 'Andes Virus [Hantavirus]',
+                        inputFields: [],
+                        tableColumns: [],
+                        primaryKey: '',
+                        metadata: [],
+                        defaultOrderBy: '',
+                        defaultOrder: 'ascending',
+                        submissionDataTypes: { consensusSequences: false },
+                    },
+                },
+            },
+        });
+
+        expect(organisms.map((organism) => organism.key)).toEqual(['andes', 'zika']);
     });
 });

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -121,12 +121,18 @@ export type Organism = {
     image?: string;
 };
 
+export function configuredOrganismsFromConfig(config: WebsiteConfig): Organism[] {
+    return Object.entries(config.organisms)
+        .map(([key, instance]) => ({
+            key,
+            displayName: instance.schema.organismName,
+            image: instance.schema.image,
+        }))
+        .sort((a, b) => a.displayName.localeCompare(b.displayName));
+}
+
 export function getConfiguredOrganisms() {
-    return Object.entries(getWebsiteConfig().organisms).map(([key, instance]) => ({
-        key,
-        displayName: instance.schema.organismName,
-        image: instance.schema.image,
-    }));
+    return configuredOrganismsFromConfig(getWebsiteConfig());
 }
 
 function getConfig(organism: string): InstanceConfig {

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -128,7 +128,7 @@ export function configuredOrganismsFromConfig(config: WebsiteConfig): Organism[]
             displayName: instance.schema.organismName,
             image: instance.schema.image,
         }))
-        .sort((a, b) => a.displayName.localeCompare(b.displayName));
+        .sort((a, b) => a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' }));
 }
 
 export function getConfiguredOrganisms() {


### PR DESCRIPTION
## Summary

Sort configured organisms by their display name when building the website organism list, so front-page organism cards are ordered by the visible organism name rather than the technical slug.

This PR was written by AI.

## Validation

- `npm test -- --run src/config.spec.ts`
- `npx prettier --check src/config.ts src/config.spec.ts`
- `npx eslint src/config.ts src/config.spec.ts`
- `npm run check-types` (passes with one pre-existing Astro hint about `latestVersion` in `src/pages/seqsets/[seqSetId].astro`)

🚀 Preview: https://sort-organism-cards-by-di.loculus.org