### PR TITLE
feat!(backend): file sharing - prevent overwrites of uploaded file

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/api/FileTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/FileTypes.kt
@@ -18,11 +18,16 @@ data class FileIdAndWriteUrl(
         example = "https://dummyendpoint.com/dummybucket/files/2ea137d0-8773-4e0a-a9aa-5591de12ff23?" +
             "X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=dummyaccesskey%2F20250330%2F" +
             "dummyregion%2Fs3%2Faws4_request&X-Amz-Date=20250330T184050Z&X-Amz-Expires=1800" +
-            "&X-Amz-SignedHeaders=host" +
+            "&X-Amz-SignedHeaders=host%3Bif-none-match" +
             "&X-Amz-Signature=9717e8d8c8242d0d266f816c665d78b1d842de5286fb59e37329f090e9bb0b9e",
     )
     @JsonProperty("url")
     val presignedWriteUrl: String,
+    @Schema(
+        description = "HTTP headers that must be included when making the PUT request to the presigned URL.",
+        example = "{\"If-None-Match\": \"*\"}",
+    )
+    val headers: Map<String, String> = mapOf("If-None-Match" to "*"),
 )
 
 data class FileIdAndMultipartWriteUrl(

--- a/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
@@ -107,8 +107,12 @@ class FilesController(
         summary = "Request S3 pre-signed URLs for file uploads",
         description =
         "Requests S3 pre-signed URLs to upload files. The endpoint returns a list of file IDs and URLs. " +
-            "The URLs should be used to upload the files. Afterwards, the file IDs can be used in the " +
-            "`fileMapping` in the /submit endpoint.",
+            "The URLs should be used to upload the files via HTTP PUT, including all headers listed in the " +
+            "`headers` field of each response entry. Afterwards, the file IDs can be used in the " +
+            "`fileMapping` in the /submit endpoint. " +
+            "Note: the presigned URL includes an `If-None-Match: *` condition to prevent accidental " +
+            "overwrites. If the file ID has already been uploaded to, S3 will return HTTP 412 " +
+            "(Precondition Failed) — this means the file already exists and cannot be overwritten.",
     )
     @ApiResponse(responseCode = "200", description = "Successfully generated pre-signed upload URLs")
     @ApiResponse(responseCode = "400", description = "Invalid request parameters")

--- a/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
@@ -112,7 +112,7 @@ class FilesController(
             "`fileMapping` in the /submit endpoint. " +
             "Note: the presigned URL includes an `If-None-Match: *` condition to prevent accidental " +
             "overwrites. If the file ID has already been uploaded to, S3 will return HTTP 412 " +
-            "(Precondition Failed) — this means the file already exists and cannot be overwritten.",
+            "(Precondition Failed) - this means the file already exists and cannot be overwritten.",
     )
     @ApiResponse(responseCode = "200", description = "Successfully generated pre-signed upload URLs")
     @ApiResponse(responseCode = "400", description = "Invalid request parameters")

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/S3Service.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/S3Service.kt
@@ -14,7 +14,6 @@ import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest
 import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload
 import software.amazon.awssdk.services.s3.model.CompletedPart
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest
 import software.amazon.awssdk.services.s3.model.PutObjectRequest

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/S3Service.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/S3Service.kt
@@ -216,17 +216,6 @@ class S3Service(private val s3Config: S3Config) {
 
     private fun getFileIdPath(fileId: FileId): String = "files/$fileId"
 
-    fun deleteObject(fileId: FileId) = s3ErrorMapping {
-        val config = getS3BucketConfig()
-        s3Client.deleteObject(
-            DeleteObjectRequest.builder()
-                .bucket(config.bucket)
-                .key(getFileIdPath(fileId))
-                .build(),
-        )
-        Unit
-    }
-
     /**
      * Returns the file size in bytes, or `null` if the file doesn't exist.
      */

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/S3Service.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/S3Service.kt
@@ -14,6 +14,7 @@ import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest
 import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload
 import software.amazon.awssdk.services.s3.model.CompletedPart
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
@@ -45,6 +46,7 @@ class S3Service(private val s3Config: S3Config) {
         val putObjectRequest = PutObjectRequest.builder()
             .bucket(config.bucket)
             .key(getFileIdPath(fileId))
+            .ifNoneMatch("*") // prevent accidental overwrites of URL contents by blocking more than one write
             .build()
         val presignRequest = PutObjectPresignRequest.builder()
             .putObjectRequest(putObjectRequest)
@@ -213,6 +215,17 @@ class S3Service(private val s3Config: S3Config) {
         .build()
 
     private fun getFileIdPath(fileId: FileId): String = "files/$fileId"
+
+    fun deleteObject(fileId: FileId) = s3ErrorMapping {
+        val config = getS3BucketConfig()
+        s3Client.deleteObject(
+            DeleteObjectRequest.builder()
+                .bucket(config.bucket)
+                .key(getFileIdPath(fileId))
+                .build(),
+        )
+        Unit
+    }
 
     /**
      * Returns the file size in bytes, or `null` if the file doesn't exist.

--- a/backend/src/test/kotlin/org/loculus/backend/controller/files/RequestUploadEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/files/RequestUploadEndpointTest.kt
@@ -82,6 +82,7 @@ class RequestUploadEndpointTest(
         val content = "test content".toByteArray()
         val request = HttpPut(url)
         request.entity = ByteArrayEntity(content, ContentType.TEXT_PLAIN)
+        request.addHeader("If-None-Match", "*")
         val httpClient = HttpClients.createDefault()
         val response = httpClient.execute(request)
         Assertions.assertEquals(200, response.statusLine.statusCode)

--- a/backend/src/test/kotlin/org/loculus/backend/controller/files/RequestUploadEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/files/RequestUploadEndpointTest.kt
@@ -74,18 +74,46 @@ class RequestUploadEndpointTest(
             .andReturn()
             .response
             .contentAsString
-        val url = objectMapper.readTree(responseContent)
-            .get(0)
-            .get("url")
-            .textValue()
+        val uploadInfo = objectMapper.readTree(responseContent).get(0)
+        val url = uploadInfo.get("url").textValue()
+        val headers = uploadInfo.get("headers").fields().asSequence()
+            .associate { it.key to it.value.textValue() }
 
         val content = "test content".toByteArray()
         val request = HttpPut(url)
         request.entity = ByteArrayEntity(content, ContentType.TEXT_PLAIN)
-        request.addHeader("If-None-Match", "*")
+        headers.forEach { (key, value) -> request.addHeader(key, value) }
         val httpClient = HttpClients.createDefault()
         val response = httpClient.execute(request)
         Assertions.assertEquals(200, response.statusLine.statusCode)
+    }
+
+    @Test
+    fun `GIVEN a presigned URL has been used to upload THEN a second upload to the same URL fails`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        val responseContent = client.requestUploads(groupId, 1)
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+        val uploadInfo = objectMapper.readTree(responseContent).get(0)
+        val url = uploadInfo.get("url").textValue()
+        val headers = uploadInfo.get("headers").fields().asSequence()
+            .associate { it.key to it.value.textValue() }
+
+        val httpClient = HttpClients.createDefault()
+
+        val firstRequest = HttpPut(url)
+        firstRequest.entity = ByteArrayEntity("first content".toByteArray(), ContentType.TEXT_PLAIN)
+        headers.forEach { (key, value) -> firstRequest.addHeader(key, value) }
+        val firstResponse = httpClient.execute(firstRequest)
+        Assertions.assertEquals(200, firstResponse.statusLine.statusCode)
+
+        val secondRequest = HttpPut(url)
+        secondRequest.entity = ByteArrayEntity("second content".toByteArray(), ContentType.TEXT_PLAIN)
+        headers.forEach { (key, value) -> secondRequest.addHeader(key, value) }
+        val secondResponse = httpClient.execute(secondRequest)
+        Assertions.assertEquals(412, secondResponse.statusLine.statusCode)
     }
 
     @Test

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataFileSharingEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataFileSharingEndpointTest.kt
@@ -50,7 +50,7 @@ class GetReleasedDataFileSharingEndpointTest(
             jwt = jwtForDefaultUser,
             numberFiles = 2,
         ).andGetFileIdsAndUrls()
-        fileIdsAndUrls.forEach { convenienceClient.uploadFile(it.presignedWriteUrl, "File") }
+        fileIdsAndUrls.forEach { convenienceClient.uploadFile(it.presignedWriteUrl, "File", it.headers) }
         val fileIds = fileIdsAndUrls.map { it.fileId }
 
         convenienceClient.extractUnprocessedData(pipelineVersion = 1)

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ReviseEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ReviseEndpointTest.kt
@@ -346,7 +346,7 @@ class ReviseEndpointTest(
             groupId = groupId,
             jwt = jwtForDefaultUser,
         ).andGetFileIdsAndUrls()[0]
-        convenienceClient.uploadFile(fileIdAndUrl.presignedWriteUrl, DEFAULT_SIMPLE_FILE_CONTENT)
+        convenienceClient.uploadFile(fileIdAndUrl.presignedWriteUrl, DEFAULT_SIMPLE_FILE_CONTENT, fileIdAndUrl.headers)
 
         client.reviseSequenceEntries(
             DefaultFiles.getRevisedMetadataFile(accessions),

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
@@ -101,12 +101,12 @@ class SubmissionConvenienceClient(
 
             DefaultFiles.submissionIds.forEachIndexed { i, submissionId ->
 
-                val request = HttpRequest.newBuilder()
+                val requestBuilder = HttpRequest.newBuilder()
                     .uri(URI.create(fileIdsAndUrls[i].presignedWriteUrl))
                     .PUT(HttpRequest.BodyPublishers.ofByteArray(fileContent))
-                    .build()
+                fileIdsAndUrls[i].headers.forEach { (k, v) -> requestBuilder.header(k, v) }
 
-                client.send(request, HttpResponse.BodyHandlers.ofString())
+                client.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
 
                 fileMapping[submissionId] =
                     mapOf("myFileCategory" to listOf(FileIdAndName(fileIdsAndUrls[i].fileId, "hello.txt")))
@@ -531,15 +531,19 @@ class SubmissionConvenienceClient(
     /**
      * Upload a file to a presigned write URL (S3).
      */
-    fun uploadFile(presignedWriteUrl: String, content: String): HttpResponse<String?> {
+    fun uploadFile(
+        presignedWriteUrl: String,
+        content: String,
+        headers: Map<String, String> = emptyMap(),
+    ): HttpResponse<String?> {
         val client = HttpClient.newBuilder().build()
         val fileContent = content.toByteArray()
 
-        val request = HttpRequest.newBuilder()
+        val requestBuilder = HttpRequest.newBuilder()
             .uri(URI.create(presignedWriteUrl))
             .PUT(HttpRequest.BodyPublishers.ofByteArray(fileContent))
-            .build()
+        headers.forEach { (k, v) -> requestBuilder.header(k, v) }
 
-        return client.send(request, HttpResponse.BodyHandlers.ofString())
+        return client.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
     }
 }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionJourneyWithFilesTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionJourneyWithFilesTest.kt
@@ -71,7 +71,7 @@ class SubmissionJourneyWithFilesTest(
             jwt = jwtForProcessingPipeline,
         ).andGetFileIdsAndUrls()[0]
         val pipelineFileContent = "Hello back!"
-        convenienceClient.uploadFile(fileIdAndUrl.presignedWriteUrl, pipelineFileContent)
+        convenienceClient.uploadFile(fileIdAndUrl.presignedWriteUrl, pipelineFileContent, fileIdAndUrl.headers)
         val processedData = unprocessedData.map {
             val processed = PreparedProcessedData.successfullyProcessed(accession = it.accession)
             val fileCategory = it.data.files!!.keys.first()

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
@@ -47,7 +47,7 @@ class SubmitEndpointFileSharingTest(
     @Test
     fun `GIVEN a valid request with a valid File ID THEN the request is valid`() {
         val fileIdAndUrl = filesClient.requestUploads(groupId).andGetFileIdsAndUrls()[0]
-        convenienceClient.uploadFile(fileIdAndUrl.presignedWriteUrl, DEFAULT_SIMPLE_FILE_CONTENT)
+        convenienceClient.uploadFile(fileIdAndUrl.presignedWriteUrl, DEFAULT_SIMPLE_FILE_CONTENT, fileIdAndUrl.headers)
 
         submissionControllerClient.submit(
             DefaultFiles.metadataFile,
@@ -69,7 +69,7 @@ class SubmitEndpointFileSharingTest(
     @Test
     fun `GIVEN a non-existing submission ID is given in submit THEN the request is not valid`() {
         val fileIdAndUrl = filesClient.requestUploads(groupId).andGetFileIdsAndUrls()[0]
-        convenienceClient.uploadFile(fileIdAndUrl.presignedWriteUrl, DEFAULT_SIMPLE_FILE_CONTENT)
+        convenienceClient.uploadFile(fileIdAndUrl.presignedWriteUrl, DEFAULT_SIMPLE_FILE_CONTENT, fileIdAndUrl.headers)
 
         submissionControllerClient.submit(
             DefaultFiles.metadataFile,
@@ -135,7 +135,7 @@ class SubmitEndpointFileSharingTest(
             groupId = otherGroupId,
             jwt = jwtForAlternativeUser,
         ).andGetFileIdsAndUrls()[0]
-        convenienceClient.uploadFile(fileIdAndUrl.presignedWriteUrl, DEFAULT_SIMPLE_FILE_CONTENT)
+        convenienceClient.uploadFile(fileIdAndUrl.presignedWriteUrl, DEFAULT_SIMPLE_FILE_CONTENT, fileIdAndUrl.headers)
 
         submissionControllerClient.submit(
             DefaultFiles.metadataFile,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
@@ -406,7 +406,7 @@ class SubmitProcessedDataEndpointTest(
             groupId = groupId,
             jwt = jwtForDefaultUser,
         ).andGetFileIdsAndUrls()[0]
-        convenienceClient.uploadFile(fileIdAndUrl.presignedWriteUrl, DEFAULT_SIMPLE_FILE_CONTENT)
+        convenienceClient.uploadFile(fileIdAndUrl.presignedWriteUrl, DEFAULT_SIMPLE_FILE_CONTENT, fileIdAndUrl.headers)
         val accession = prepareUnprocessedSequenceEntry(DEFAULT_ORGANISM, groupId = groupId)
 
         submissionControllerClient.submitProcessedData(
@@ -571,7 +571,7 @@ class SubmitProcessedDataEndpointTest(
             groupId = groupId,
             jwt = jwtForDefaultUser,
         ).andGetFileIdsAndUrls()[0]
-        convenienceClient.uploadFile(fileIdAndUrlV1.presignedWriteUrl, "FileV1")
+        convenienceClient.uploadFile(fileIdAndUrlV1.presignedWriteUrl, "FileV1", fileIdAndUrlV1.headers)
         convenienceClient.extractUnprocessedData(pipelineVersion = 1)
 
         submissionControllerClient.submitProcessedData(
@@ -590,7 +590,7 @@ class SubmitProcessedDataEndpointTest(
             groupId = groupId,
             jwt = jwtForDefaultUser,
         ).andGetFileIdsAndUrls()[0]
-        convenienceClient.uploadFile(fileIdAndUrlV2.presignedWriteUrl, "FileV2")
+        convenienceClient.uploadFile(fileIdAndUrlV2.presignedWriteUrl, "FileV2", fileIdAndUrlV2.headers)
         convenienceClient.extractUnprocessedData(pipelineVersion = 2)
 
         submissionControllerClient.submitProcessedData(
@@ -636,7 +636,7 @@ class SubmitProcessedDataEndpointTest(
             groupId = groupId,
             jwt = jwtForDefaultUser,
         ).andGetFileIdsAndUrls()[0]
-        convenienceClient.uploadFile(fileIdAndUrlV1.presignedWriteUrl, "FileV1")
+        convenienceClient.uploadFile(fileIdAndUrlV1.presignedWriteUrl, "FileV1", fileIdAndUrlV1.headers)
         convenienceClient.extractUnprocessedData(pipelineVersion = 1)
 
         submissionControllerClient.submitProcessedData(
@@ -652,7 +652,7 @@ class SubmitProcessedDataEndpointTest(
             groupId = groupId,
             jwt = jwtForDefaultUser,
         ).andGetFileIdsAndUrls()[0]
-        convenienceClient.uploadFile(fileIdAndUrlV2.presignedWriteUrl, "FileV2")
+        convenienceClient.uploadFile(fileIdAndUrlV2.presignedWriteUrl, "FileV2", fileIdAndUrlV2.headers)
         convenienceClient.extractUnprocessedData(pipelineVersion = 2)
 
         submissionControllerClient.submitProcessedData(

--- a/preprocessing/nextclade/src/loculus_preprocessing/backend.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/backend.py
@@ -223,7 +223,7 @@ def request_upload(group_id: int, number_of_files: int, config: Config) -> Seque
 
 
 def upload_embl_file_to_presigned_url(content: str, url: str) -> None:
-    headers = {"Content-Type": "chemical/x-embl-dl-nucleotide"}
+    headers = {"Content-Type": "chemical/x-embl-dl-nucleotide", "If-None-Match": "*"}
     r = requests.put(url, data=content.encode("utf-8"), headers=headers, timeout=60)
     if not r.ok:
         msg = f"Upload failed: {r.status_code}, {r.text}"

--- a/preprocessing/nextclade/src/loculus_preprocessing/backend.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/backend.py
@@ -222,8 +222,12 @@ def request_upload(group_id: int, number_of_files: int, config: Config) -> Seque
     return [FileUploadInfo(**item) for item in response.json()]
 
 
-def upload_embl_file_to_presigned_url(content: str, url: str) -> None:
-    headers = {"Content-Type": "chemical/x-embl-dl-nucleotide", "If-None-Match": "*"}
+def upload_embl_file_to_presigned_url(
+    content: str, url: str, extra_headers: dict | None = None
+) -> None:
+    headers = {"Content-Type": "chemical/x-embl-dl-nucleotide"}
+    if extra_headers:
+        headers.update(extra_headers)
     r = requests.put(url, data=content.encode("utf-8"), headers=headers, timeout=60)
     if not r.ok:
         msg = f"Upload failed: {r.status_code}, {r.text}"

--- a/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
@@ -225,6 +225,7 @@ class FileUploadInfo:
 
     fileId: str  # noqa: N815
     url: str
+    headers: dict = field(default_factory=dict)
 
 
 class MoleculeType(StrEnum):

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -658,8 +658,7 @@ def upload_flatfiles(processed: Sequence[SubmissionData], config: Config) -> Non
             file_name = f"{accession}.{version}.embl"
             upload_info = request_upload(submission_data.group_id, 1, config)[0]
             file_id = upload_info.fileId
-            url = upload_info.url
-            upload_embl_file_to_presigned_url(file_content, url)
+            upload_embl_file_to_presigned_url(file_content, upload_info.url, upload_info.headers)
             submission_data.processed_entry.data.files = {
                 "annotations": [FileIdAndName(fileId=file_id, name=file_name)]
             }


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/4056

The backend now adds `"If-None-Match": "*"` as a header when requesting presigned URLs on behalf of a user, this prevents writes to the S3 if the S3 already has data - preventing accidental overwrites.

Suggested by @tombch, see details in https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes.html https://security.stackexchange.com/a/286617

Note that this header is not required for multi-part S3 uploads as the request `complete-multipart-upload` prevents future modifications of the S3 using the presigned URL.

### Breaking change
Clients using presigned URLs (i.e. requested via the `/files/request-upload` endpoint) now need to add `"If-None-Match": "*"` to the header when submitting data using the presigned URL (this is because AWS and other S3 providers will block uploads to S3 buckets that do not use the same headers as in the created presigned URL.

## Manual Testing (by @maverbiest)

1. As the testuser, I made a submitting group via the web interface (which got groupId 2)
2. I figured out the names of the keycloak pod (https://authentication-file-sharing-nooverwrite.loculus.org/) and minio pod for the preview deployment
3. I got a token from keycloak to make requests from the command line as the testuser

```sh
# requesting a file upload as the testuser
➜  loculus git:(s3-garbage-collection) ✗ curl -X POST "https://backend-file-sharing-nooverwrite.loculus.org/files/request-upload?groupId=2&numberFiles=1" -H "Authorization: Bearer $TOKEN"
[{"fileId":"cad7567e-913f-4fbc-bd2e-a2ad44db294d","url":"https://s3-file-sharing-nooverwrite.loculus.org/loculus-preview-private/files/cad7567e-913f-4fbc-bd2e-a2ad44db294d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20260611T122529Z&X-Amz-SignedHeaders=host%3Bif-none-match&X-Amz-Credential=8LRKJBFQ3G38BIJ9KCHS%2F20260611%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Expires=1800&X-Amz-Signature=d9c32cad6f1936de9a95580fb0deed6cf73d8853df1deedbb7ea058485235859","headers":{"If-None-Match":"*"}}]%                                               
                                
# first: attempt to upload without 'If-None-Match' header; this fails
➜  loculus git:(s3-garbage-collection) ✗ curl -X PUT --upload-file ./test_file.txt "https://s3-file-sharing-nooverwrite.loculus.org/loculus-preview-private/files/cad7567e-913f-4fbc-bd2e-a2ad44db294d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20260611T122529Z&X-Amz-SignedHeaders=host%3Bif-none-match&X-Amz-Credential=8LRKJBFQ3G38BIJ9KCHS%2F20260611%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Expires=1800&X-Amz-Signature=d9c32cad6f1936de9a95580fb0deed6cf73d8853df1deedbb7ea058485235859"
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>AccessDenied</Code><Message>There were headers present in the request which were not signed</Message><Key>files/cad7567e-913f-4fbc-bd2e-a2ad44db294d</Key><BucketName>loculus-preview-private</BucketName><Resource>/loculus-preview-private/files/cad7567e-913f-4fbc-bd2e-a2ad44db294d</Resource><RequestId>18B8067B6686D9BA</RequestId><HostId>dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8</HostId></Error>%             

# second: upload with 'If-None-Match' header; succeeds
➜  loculus git:(s3-garbage-collection) ✗ curl -X PUT --upload-file ./test_file.txt "https://s3-file-sharing-nooverwrite.loculus.org/loculus-preview-private/files/cad7567e-913f-4fbc-bd2e-a2ad44db294d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20260611T122529Z&X-Amz-SignedHeaders=host%3Bif-none-match&X-Amz-Credential=8LRKJBFQ3G38BIJ9KCHS%2F20260611%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Expires=1800&X-Amz-Signature=d9c32cad6f1936de9a95580fb0deed6cf73d8853df1deedbb7ea058485235859" -H "If-None-Match: *"

# (make sure it succeeded)
➜  loculus git:(s3-garbage-collection) ✗ echo $?
0

# third: try another upload; rejected
➜  loculus git:(s3-garbage-collection) ✗ curl -X PUT --upload-file ./test_file.txt "https://s3-file-sharing-nooverwrite.loculus.org/loculus-preview-private/files/cad7567e-913f-4fbc-bd2e-a2ad44db294d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20260611T122529Z&X-Amz-SignedHeaders=host%3Bif-none-match&X-Amz-Credential=8LRKJBFQ3G38BIJ9KCHS%2F20260611%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Expires=1800&X-Amz-Signature=d9c32cad6f1936de9a95580fb0deed6cf73d8853df1deedbb7ea058485235859" -H "If-None-Match: *"
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>PreconditionFailed</Code><Message>At least one of the pre-conditions you specified did not hold</Message><Key>files/cad7567e-913f-4fbc-bd2e-a2ad44db294d</Key><BucketName>loculus-preview-private</BucketName><Resource>/loculus-preview-private/files/cad7567e-913f-4fbc-bd2e-a2ad44db294d</Resource><RequestId>18B8068BCAF0A935</RequestId><HostId>dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8</HostId></Error>%                  
   
# finally: stat the file to double check it exists on S3                                                                                                                                                                                                                                                                                                                                                                                                                 
➜  loculus git:(s3-garbage-collection) ✗ kubectl exec -n prev-file-sharing-nooverwrite minio-78d9dbd5b-cq776 -- mc stat "local/loculus-preview-private/files/cad7567e-913f-4fbc-bd2e-a2ad44db294d"
Name      : cad7567e-913f-4fbc-bd2e-a2ad44db294d
Date      : 2026-06-11 12:27:12 UTC
Size      : 20 B
ETag      : 4221d002ceb5d3c9e9137e495ceaa647
Type      : file
Metadata  :
  Content-Type: binary/octet-stream
```

### PR Checklist
- [x] Document how users should handle case where upload to S3 is disconnected: confirmed that when I break off an upload with ctrl C I can submit again to the S3 bucket, only on successful submissions does the new header apply.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://file-sharing-nooverwrite.loculus.org