### PR TITLE
fix(deployment): forward Release into ingestPodSpec so PriorityClass renders

### DIFF
--- a/kubernetes/loculus/templates/_ingest-pod-spec.tpl
+++ b/kubernetes/loculus/templates/_ingest-pod-spec.tpl
@@ -8,6 +8,7 @@ Expects a dict:
   dockerTag       - resolved docker tag
   organismContent - the organism's contents (must contain .ingest)
   Values          - root .Values (for resources, image pull policy, priority class)
+  Release         - root .Release (for namespace-derived priority class name)
   args            - list of args for the ingest container
 */}}
 {{- define "loculus.ingestPodSpec" -}}

--- a/kubernetes/loculus/templates/ingest.yaml
+++ b/kubernetes/loculus/templates/ingest.yaml
@@ -111,6 +111,7 @@ spec:
             "dockerTag" $dockerTag
             "organismContent" $organismContent
             "Values" $.Values
+            "Release" $.Release
             "args" (list "snakemake" "results/submitted" "results/revised" "--all-temp")
           ) | nindent 8 }}
 {{/*
@@ -174,6 +175,7 @@ spec:
             "dockerTag" $dockerTag
             "organismContent" $organismContent
             "Values" $.Values
+            "Release" $.Release
             "args" (list "snakemake" "results/submitted" "results/revised" "results/revoked" "--all-temp")
           ) | nindent 8 }}
 {{- end }}


### PR DESCRIPTION
## Summary

Companion fix to #6349. The new `possiblePriorityClassName` helper reads `.Release.Namespace`, but `ingest.yaml` calls `loculus.ingestPodSpec` with a dict that only carries `Values`, not `Release`. Inside the define, `include "possiblePriorityClassName" .` then evaluates `.Release.Namespace` against the passed-in dict and explodes with:

```
template: loculus/templates/_possiblePriorityClassName.tpl:3:30:
executing "possiblePriorityClassName" at <.Release.Namespace>:
nil pointer evaluating interface {}.Namespace
```

This breaks `helm template` for any environment with `podPriorityValue` set — currently caught by [pathoplexus#924](https://github.com/pathoplexus/pathoplexus/pull/924) (the companion values migration).

This PR forwards `Release` through the dict at both call sites (the scheduled ingest CronJob and the revoke-and-regroup CronJob) and documents the new requirement on the `loculus.ingestPodSpec` define.

I audited the other 10 callers of `possiblePriorityClassName` — all of them call it from a top-level deployment template where `.` is the chart root (so both `.Values` and `.Release` are present). Only the ingest define hit the bug, since it's the only caller invoked through a custom-built dict.

## Test plan

- [x] `helm template` against pathoplexus `demo`/`staging`/`production` value files (with `podPriorityValue` set) now succeeds for all three.
- [x] Rendered output: `priorityClassName: <namespace>-priority` appears on every `loculus-ingest-cronjob-*` and `loculus-revoke-and-regroup-cronjob-*`, alongside the other deployments that already had it.
- [x] The `PriorityClass` resource itself still renders correctly with the namespace-derived name and the configured integer value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable