### PR TITLE
feat(website): Support ordering multi-field searches

### DIFF
--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -320,6 +320,9 @@ organisms:
       {{- range .website.multiFieldSearches }}
         - name: {{ .name }}
           displayName: {{ .displayName }}
+          {{- if hasKey . "orderInSearchDisplay" }}
+          orderInSearchDisplay: {{ .orderInSearchDisplay }}
+          {{- end }}
           fields:
           {{- range .fields }}
           {{- if and $isSegmented (hasKey $perSegmentFields .) }}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -581,6 +581,10 @@
                         "type": "string",
                         "description": "The display name of the search field."
                       },
+                      "orderInSearchDisplay": {
+                        "type": "number",
+                        "description": "Optional display order in the search form. Lower values appear earlier."
+                      },
                       "fields": {
                         "type": "array",
                         "items": {

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1494,6 +1494,7 @@ defaultOrganismConfig: &defaultOrganismConfig
       multiFieldSearches:
         - name: identifier
           displayName: Sample Identifier
+          orderInSearchDisplay: -10000
           fields:
             - accessionVersion
             - submissionId
@@ -1504,6 +1505,7 @@ defaultOrganismConfig: &defaultOrganismConfig
             - insdcRawReadsAccession
         - name: contributor
           displayName: Contributor
+          orderInSearchDisplay: -9999
           fields:
             - authors
             - authorAffiliations

--- a/website/src/components/SearchPage/SearchForm.spec.tsx
+++ b/website/src/components/SearchPage/SearchForm.spec.tsx
@@ -97,7 +97,7 @@ const renderSearchForm = ({
         referenceSelection,
     };
 
-    render(
+    return render(
         <QueryClientProvider client={queryClient}>
             <SearchForm {...props} />
         </QueryClientProvider>,
@@ -131,6 +131,37 @@ describe('SearchForm', () => {
         const resetButton = screen.getByText('Reset');
         await userEvent.click(resetButton);
         expect(window.location.href).toMatch(/\/$/);
+    });
+
+    it('orders multi-field searches with metadata filters', () => {
+        const { container } = renderSearchForm({
+            filterSchema: new MetadataFilterSchema(
+                [
+                    {
+                        name: 'field1',
+                        type: 'string',
+                        displayName: 'Field 1',
+                        initiallyVisible: true,
+                        orderInSearchDisplay: 10,
+                    },
+                ],
+                [
+                    {
+                        name: 'identifier',
+                        displayName: 'Identifier',
+                        fields: ['field1'],
+                        orderInSearchDisplay: 0,
+                    },
+                ],
+            ),
+            searchVisibilities: new Map([['field1', new MetadataVisibility(true, undefined, undefined)]]),
+        });
+
+        const identifierField = screen.getByLabelText('Identifier');
+        const metadataField = screen.getByLabelText('Field 1');
+        const inputs = Array.from(container.querySelectorAll<HTMLElement>('input'));
+
+        expect(inputs.indexOf(identifierField)).toBeLessThan(inputs.indexOf(metadataField));
     });
 
     it('should render the reference selector in the multiReference case', async () => {

--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -18,7 +18,13 @@ import { SingleChoiceAutoCompleteField } from './fields/SingleChoiceAutoComplete
 import { searchFormHelpDocsUrl } from './searchFormHelpDocsUrl.ts';
 import { useOffCanvas } from '../../hooks/useOffCanvas.ts';
 import { ACCESSION_FIELD, IS_REVOCATION_FIELD, VERSION_STATUS_FIELD } from '../../settings.ts';
-import type { FieldValues, GroupedMetadataFilter, MetadataFilter, SetSomeFieldValues } from '../../types/config.ts';
+import type {
+    FieldValues,
+    GroupedMetadataFilter,
+    MetadataFilter,
+    MultiFieldSearch,
+    SetSomeFieldValues,
+} from '../../types/config.ts';
 import { type ReferenceGenomesInfo } from '../../types/referencesGenomes.ts';
 import type { ClientConfig } from '../../types/runtimeConfig.ts';
 import { extractArrayValue, validateSingleValue } from '../../utils/extractFieldValue.ts';
@@ -89,6 +95,18 @@ interface SearchFormProps {
     referenceSelection: ReferenceSelection;
 }
 
+const MetadataFilterItemKind = {
+    metadata: 'metadata',
+    multiFieldSearch: 'multiFieldSearch',
+} as const;
+
+type MetadataFilterItem =
+    | { kind: typeof MetadataFilterItemKind.metadata; field: GroupedMetadataFilter | MetadataFilter }
+    | { kind: typeof MetadataFilterItemKind.multiFieldSearch; field: MultiFieldSearch };
+
+const getSearchDisplayOrder = (field: GroupedMetadataFilter | MetadataFilter | MultiFieldSearch) =>
+    field.orderInSearchDisplay ?? ('order' in field ? field.order : undefined) ?? Number.POSITIVE_INFINITY;
+
 export const SearchForm = ({
     filterSchema,
     fieldValues,
@@ -122,11 +140,7 @@ export const SearchForm = ({
         )
         .filter((field) => !excluded.has(field.name));
 
-    visibleFields.sort(
-        (a, b) =>
-            (a.orderInSearchDisplay ?? a.order ?? Number.POSITIVE_INFINITY) -
-            (b.orderInSearchDisplay ?? b.order ?? Number.POSITIVE_INFINITY),
-    );
+    visibleFields.sort((a, b) => getSearchDisplayOrder(a) - getSearchDisplayOrder(b));
 
     const [isFieldSelectorOpen, setIsFieldSelectorOpen] = useState(false);
     const [isAdvancedOptionsOpen, setIsAdvancedOptionsOpen] = useState(false);
@@ -198,6 +212,18 @@ export const SearchForm = ({
 
         return { sampleFields, sequenceFieldsBySegment };
     }, [visibleFields]);
+
+    const metadataFilterItems: MetadataFilterItem[] = useMemo(
+        () =>
+            [
+                ...sampleFields.map((field) => ({ kind: MetadataFilterItemKind.metadata, field })),
+                ...filterSchema.multiFieldSearches.map((field) => ({
+                    kind: MetadataFilterItemKind.multiFieldSearch,
+                    field,
+                })),
+            ].sort((a, b) => getSearchDisplayOrder(a.field) - getSearchDisplayOrder(b.field)),
+        [filterSchema.multiFieldSearches, sampleFields],
+    );
 
     const segmentAndGeneInfo = useMemo(() => {
         return getSegmentNames(referenceGenomesInfo).reduce<Record<string, SingleSegmentAndGeneInfo | null>>(
@@ -329,24 +355,25 @@ export const SearchForm = ({
 
                         <section className='flex flex-col gap-1.5'>
                             <CollapsibleSection title='Metadata Filters' open>
-                                {sampleFields.map((filter) => (
-                                    <SearchField
-                                        key={filter.name}
-                                        field={filter}
-                                        lapisUrl={lapisUrl}
-                                        fieldValues={fieldValues}
-                                        setSomeFieldValues={setSomeFieldValues}
-                                        lapisSearchParameters={lapisSearchParameters}
-                                    />
-                                ))}
-                                {filterSchema.multiFieldSearches.map((mfs) => (
-                                    <MultiFieldSearchField
-                                        key={mfs.name}
-                                        multiFieldSearch={mfs}
-                                        fieldValue={(fieldValues[mfs.name] as string | undefined) ?? ''}
-                                        setSomeFieldValues={setSomeFieldValues}
-                                    />
-                                ))}
+                                {metadataFilterItems.map((item) =>
+                                    item.kind === MetadataFilterItemKind.metadata ? (
+                                        <SearchField
+                                            key={item.field.name}
+                                            field={item.field}
+                                            lapisUrl={lapisUrl}
+                                            fieldValues={fieldValues}
+                                            setSomeFieldValues={setSomeFieldValues}
+                                            lapisSearchParameters={lapisSearchParameters}
+                                        />
+                                    ) : (
+                                        <MultiFieldSearchField
+                                            key={item.field.name}
+                                            multiFieldSearch={item.field}
+                                            fieldValue={(fieldValues[item.field.name] as string | undefined) ?? ''}
+                                            setSomeFieldValues={setSomeFieldValues}
+                                        />
+                                    ),
+                                )}
                             </CollapsibleSection>
                         </section>
 

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -165,6 +165,7 @@ export const multiFieldSearch = z.object({
     name: z.string(),
     displayName: z.string(),
     fields: z.array(z.string()),
+    orderInSearchDisplay: z.number().optional(),
 });
 
 export type MultiFieldSearch = z.infer<typeof multiFieldSearch>;


### PR DESCRIPTION

## Summary
- add `orderInSearchDisplay` support to `multiFieldSearches` in the website config schema and Helm values schema
- preserve `orderInSearchDisplay` when Helm expands segmented multi-field search fields
- render multi-field search controls in the metadata filter order alongside regular metadata filters

## Validation
- `npm test -- --run src/components/SearchPage/SearchForm.spec.tsx`
- `npx eslint src/components/SearchPage/SearchForm.tsx src/components/SearchPage/SearchForm.spec.tsx src/types/config.ts`
- `npm run check-types` (passes with existing unrelated Astro hint for `latestVersion`)
- `helm lint kubernetes/loculus`
- `npx prettier --check src/components/SearchPage/SearchForm.tsx src/components/SearchPage/SearchForm.spec.tsx src/types/config.ts`

🚀 Preview: https://multifield-search-order.loculus.org