### PR TITLE
feat(ingest): Allow combining ingest grouping overrides

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -468,6 +468,7 @@ if GROUPING_OVERRIDE_URL and CALCULATE_GROUPS_OVERRIDE_JSON:
             script="scripts/merge_group_overrides.py",
             downloaded=DOWNLOADED_GROUPS_JSON,
             calculated=CALCULATED_GROUPS_JSON,
+            config="results/config.yaml",
         output:
             groups_json="results/groups.json",
         shell:
@@ -475,6 +476,7 @@ if GROUPING_OVERRIDE_URL and CALCULATE_GROUPS_OVERRIDE_JSON:
             python {input.script} \
             --groups {input.calculated} \
             --groups {input.downloaded} \
+            --config-file {input.config} \
             --output-file {output.groups_json}
             """
 

--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -43,7 +43,9 @@ CALCULATE_GROUPS_OVERRIDE_JSON = config.get(
 GROUPING_OVERRIDE_URL = config.get("grouping_override_url", False)
 GROUPS_OVERRIDE_JSON = CALCULATE_GROUPS_OVERRIDE_JSON or GROUPING_OVERRIDE_URL
 DOWNLOADED_GROUPS_JSON = (
-    "results/downloaded_groups.json" if CALCULATE_GROUPS_OVERRIDE_JSON else "results/groups.json"
+    "results/downloaded_groups.json"
+    if CALCULATE_GROUPS_OVERRIDE_JSON
+    else "results/groups.json"
 )
 CALCULATED_GROUPS_JSON = (
     "results/calculated_groups.json" if GROUPING_OVERRIDE_URL else "results/groups.json"

--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -40,8 +40,13 @@ FILTER = config.get("metadata_filter", None)
 CALCULATE_GROUPS_OVERRIDE_JSON = config.get(
     "calculate_groups_override_json", False
 )  # Calculate the groups override JSON based on assembly report data.
-GROUPS_OVERRIDE_JSON = CALCULATE_GROUPS_OVERRIDE_JSON or config.get(
-    "grouping_override_url", False
+GROUPING_OVERRIDE_URL = config.get("grouping_override_url", False)
+GROUPS_OVERRIDE_JSON = CALCULATE_GROUPS_OVERRIDE_JSON or GROUPING_OVERRIDE_URL
+DOWNLOADED_GROUPS_JSON = (
+    "results/downloaded_groups.json" if CALCULATE_GROUPS_OVERRIDE_JSON else "results/groups.json"
+)
+CALCULATED_GROUPS_JSON = (
+    "results/calculated_groups.json" if GROUPING_OVERRIDE_URL else "results/groups.json"
 )
 
 
@@ -366,13 +371,13 @@ rule prepare_metadata:
         """
 
 
-if GROUPS_OVERRIDE_JSON and not CALCULATE_GROUPS_OVERRIDE_JSON:
+if GROUPING_OVERRIDE_URL:
 
     rule download_groups:
         output:
-            results="results/groups.json",
+            results=DOWNLOADED_GROUPS_JSON,
         params:
-            grouping=config.get("grouping_override_url"),
+            grouping=GROUPING_OVERRIDE_URL,
         shell:
             """
             curl -L -o {output.results} {params.grouping}
@@ -439,7 +444,7 @@ if CALCULATE_GROUPS_OVERRIDE_JSON:
             ignore_list="results/grouping_ignore_list.txt",
             config_file="results/config.yaml",
         output:
-            groups_json="results/groups.json",
+            groups_json=CALCULATED_GROUPS_JSON,
         params:
             genbank_dir="results/genbank_assembly/ncbi_dataset/data",
             refseq_dir="results/refseq_assembly/ncbi_dataset/data",
@@ -451,6 +456,24 @@ if CALCULATE_GROUPS_OVERRIDE_JSON:
             --output-file {output.groups_json} \
             --ignore-list {input.ignore_list} \
             --config-file {input.config_file}
+            """
+
+
+if GROUPING_OVERRIDE_URL and CALCULATE_GROUPS_OVERRIDE_JSON:
+
+    rule merge_groups:
+        input:
+            script="scripts/merge_group_overrides.py",
+            downloaded=DOWNLOADED_GROUPS_JSON,
+            calculated=CALCULATED_GROUPS_JSON,
+        output:
+            groups_json="results/groups.json",
+        shell:
+            """
+            python {input.script} \
+            --groups {input.calculated} \
+            --groups {input.downloaded} \
+            --output-file {output.groups_json}
             """
 
 

--- a/ingest/scripts/merge_group_overrides.py
+++ b/ingest/scripts/merge_group_overrides.py
@@ -1,0 +1,63 @@
+"""Merge multiple ingest grouping override JSON files."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import click
+
+
+def merge_group_overrides(group_files: list[str]) -> dict[str, list[str]]:
+    merged_groups: dict[str, list[str]] = {}
+    accession_to_group: dict[str, str] = {}
+
+    for group_file in group_files:
+        with open(group_file, encoding="utf-8") as file:
+            groups: dict[str, list[str]] = json.load(file)
+
+        for group_name, accessions in groups.items():
+            if group_name in merged_groups:
+                if merged_groups[group_name] == accessions:
+                    continue
+                msg = f"Group name {group_name!r} is defined differently in multiple override files"
+                raise ValueError(msg)
+
+            duplicated_accessions = sorted(
+                accession for accession in accessions if accession in accession_to_group
+            )
+            if duplicated_accessions:
+                existing_groups = {
+                    accession: accession_to_group[accession] for accession in duplicated_accessions
+                }
+                msg = (
+                    f"Accessions in group {group_name!r} already appear in other override groups: "
+                    f"{existing_groups}"
+                )
+                raise ValueError(msg)
+
+            merged_groups[group_name] = accessions
+            accession_to_group.update({accession: group_name for accession in accessions})
+
+    return merged_groups
+
+
+@click.command()
+@click.option(
+    "--groups",
+    "group_files",
+    required=True,
+    multiple=True,
+    type=click.Path(exists=True),
+    help="Grouping override JSON file to merge. Can be provided multiple times.",
+)
+@click.option("--output-file", required=True, type=click.Path())
+def main(group_files: list[str], output_file: str) -> None:
+    merged_groups = merge_group_overrides(list(group_files))
+    output_path = pathlib.Path(output_file)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(merged_groups, indent=4) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/ingest/scripts/merge_group_overrides.py
+++ b/ingest/scripts/merge_group_overrides.py
@@ -18,7 +18,7 @@ def merge_group_overrides(group_files: list[str]) -> dict[str, list[str]]:
 
         for group_name, accessions in groups.items():
             if group_name in merged_groups:
-                if merged_groups[group_name] == accessions:
+                if set(merged_groups[group_name]) == set(accessions):
                     continue
                 msg = f"Group name {group_name!r} is defined differently in multiple override files"
                 raise ValueError(msg)

--- a/ingest/scripts/merge_group_overrides.py
+++ b/ingest/scripts/merge_group_overrides.py
@@ -37,7 +37,7 @@ def merge_group_overrides(group_files: list[str]) -> dict[str, list[str]]:
                 raise ValueError(msg)
 
             merged_groups[group_name] = accessions
-            accession_to_group.update({accession: group_name for accession in accessions})
+            accession_to_group.update(dict.fromkeys(accessions, group_name))
 
     return merged_groups
 

--- a/ingest/scripts/merge_group_overrides.py
+++ b/ingest/scripts/merge_group_overrides.py
@@ -3,9 +3,31 @@
 from __future__ import annotations
 
 import json
+import logging
 import pathlib
 
 import click
+import requests
+import yaml
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    encoding="utf-8",
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)8s (%(filename)20s:%(lineno)4d) - %(message)s ",
+    datefmt="%H:%M:%S",
+)
+
+
+def notify(slack_hook: str, text: str) -> None:
+    """Send slack notification with text."""
+    logger.warning(text)
+    if not slack_hook:
+        return
+    try:
+        requests.post(slack_hook, data=json.dumps({"text": text}), timeout=10)
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"Failed to send Slack notification: {exc}")
 
 
 def merge_group_overrides(group_files: list[str]) -> dict[str, list[str]]:
@@ -52,8 +74,31 @@ def merge_group_overrides(group_files: list[str]) -> dict[str, list[str]]:
     help="Grouping override JSON file to merge. Can be provided multiple times.",
 )
 @click.option("--output-file", required=True, type=click.Path())
-def main(group_files: list[str], output_file: str) -> None:
-    merged_groups = merge_group_overrides(list(group_files))
+@click.option(
+    "--config-file",
+    required=False,
+    type=click.Path(exists=True),
+    help="Path to ingest config YAML; used to read slack_hook and organism for failure alerts.",
+)
+def main(group_files: list[str], output_file: str, config_file: str | None) -> None:
+    slack_hook = ""
+    organism = ""
+    if config_file:
+        config = yaml.safe_load(pathlib.Path(config_file).read_text(encoding="utf-8")) or {}
+        slack_hook = config.get("slack_hook") or ""
+        organism = config.get("organism") or ""
+
+    try:
+        merged_groups = merge_group_overrides(list(group_files))
+    except ValueError as exc:
+        organism_prefix = f"Ingest for {organism}: " if organism else "Ingest: "
+        notify(
+            slack_hook,
+            f"{organism_prefix}merge_group_overrides failed: {exc}. "
+            "Ingest will not be able to run until the conflicting override files are fixed.",
+        )
+        raise
+
     output_path = pathlib.Path(output_file)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(merged_groups, indent=4) + "\n", encoding="utf-8")

--- a/ingest/scripts/merge_group_overrides.py
+++ b/ingest/scripts/merge_group_overrides.py
@@ -52,11 +52,17 @@ def merge_group_overrides(group_files: list[str]) -> dict[str, list[str]]:
                 existing_groups = {
                     accession: accession_to_group[accession] for accession in duplicated_accessions
                 }
-                msg = (
-                    f"Accessions in group {group_name!r} already appear in other override groups: "
-                    f"{existing_groups}"
-                )
-                raise ValueError(msg)
+                # Dont raise an error if the same accessions are in the same group in multiple files
+                # even if the group names differ.
+                if (
+                    set(duplicated_accessions) != set(accessions)
+                    or len(set(existing_groups.values())) > 1
+                ):
+                    msg = (
+                        f"Accessions in group {group_name!r} already appear in other override"
+                        f"groups: {existing_groups}"
+                    )
+                    raise ValueError(msg)
 
             merged_groups[group_name] = accessions
             accession_to_group.update(dict.fromkeys(accessions, group_name))

--- a/ingest/tests/test_merge_group_overrides.py
+++ b/ingest/tests/test_merge_group_overrides.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import importlib.util
 import json
 from pathlib import Path
+from unittest import mock
 
 import pytest
+import yaml
+from click.testing import CliRunner
 
 SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "merge_group_overrides.py"
 SPEC = importlib.util.spec_from_file_location("merge_group_overrides", SCRIPT_PATH)
@@ -60,3 +63,68 @@ def test_merge_group_overrides_rejects_accessions_in_multiple_groups(tmp_path):
 
     with pytest.raises(ValueError, match="already appear"):
         merge_group_overrides_module.merge_group_overrides([first, second])
+
+
+def test_main_sends_slack_notification_on_conflict(tmp_path):
+    first = write_groups(tmp_path / "first.json", {"assembly-1": ["A.1", "B.1"]})
+    second = write_groups(tmp_path / "second.json", {"assembly-1": ["A.1", "C.1"]})
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        yaml.safe_dump({"slack_hook": "https://hooks.slack.test/xyz", "organism": "andesvirus"}),
+        encoding="utf-8",
+    )
+    output_file = tmp_path / "groups.json"
+
+    runner = CliRunner()
+    with mock.patch.object(merge_group_overrides_module.requests, "post") as mock_post:
+        result = runner.invoke(
+            merge_group_overrides_module.main,
+            [
+                "--groups",
+                first,
+                "--groups",
+                second,
+                "--output-file",
+                str(output_file),
+                "--config-file",
+                str(config_file),
+            ],
+        )
+
+    assert result.exit_code != 0
+    assert isinstance(result.exception, ValueError)
+    assert not output_file.exists()
+    mock_post.assert_called_once()
+    args, kwargs = mock_post.call_args
+    assert args[0] == "https://hooks.slack.test/xyz"
+    payload = json.loads(kwargs["data"])
+    assert "andesvirus" in payload["text"]
+    assert "merge_group_overrides failed" in payload["text"]
+
+
+def test_main_does_not_call_slack_when_no_hook(tmp_path):
+    first = write_groups(tmp_path / "first.json", {"assembly-1": ["A.1", "B.1"]})
+    second = write_groups(tmp_path / "second.json", {"assembly-1": ["A.1", "C.1"]})
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.safe_dump({"organism": "andesvirus"}), encoding="utf-8")
+    output_file = tmp_path / "groups.json"
+
+    runner = CliRunner()
+    with mock.patch.object(merge_group_overrides_module.requests, "post") as mock_post:
+        result = runner.invoke(
+            merge_group_overrides_module.main,
+            [
+                "--groups",
+                first,
+                "--groups",
+                second,
+                "--output-file",
+                str(output_file),
+                "--config-file",
+                str(config_file),
+            ],
+        )
+
+    assert result.exit_code != 0
+    assert isinstance(result.exception, ValueError)
+    mock_post.assert_not_called()

--- a/ingest/tests/test_merge_group_overrides.py
+++ b/ingest/tests/test_merge_group_overrides.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "merge_group_overrides.py"
+SPEC = importlib.util.spec_from_file_location("merge_group_overrides", SCRIPT_PATH)
+merge_group_overrides_module = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(merge_group_overrides_module)
+
+
+def write_groups(path: Path, groups: dict[str, list[str]]) -> str:
+    path.write_text(json.dumps(groups), encoding="utf-8")
+    return str(path)
+
+
+def test_merge_group_overrides_combines_disjoint_groups(tmp_path):
+    first = write_groups(tmp_path / "first.json", {"assembly-1": ["A.1", "B.1"]})
+    second = write_groups(tmp_path / "second.json", {"curated-1": ["C.1", "D.1"]})
+
+    assert merge_group_overrides_module.merge_group_overrides([first, second]) == {
+        "assembly-1": ["A.1", "B.1"],
+        "curated-1": ["C.1", "D.1"],
+    }
+
+
+def test_merge_group_overrides_allows_identical_group_definitions(tmp_path):
+    first = write_groups(tmp_path / "first.json", {"assembly-1": ["A.1", "B.1"]})
+    second = write_groups(tmp_path / "second.json", {"assembly-1": ["A.1", "B.1"]})
+
+    assert merge_group_overrides_module.merge_group_overrides([first, second]) == {
+        "assembly-1": ["A.1", "B.1"],
+    }
+
+
+def test_merge_group_overrides_rejects_conflicting_group_names(tmp_path):
+    first = write_groups(tmp_path / "first.json", {"assembly-1": ["A.1", "B.1"]})
+    second = write_groups(tmp_path / "second.json", {"assembly-1": ["A.1", "C.1"]})
+
+    with pytest.raises(ValueError, match="defined differently"):
+        merge_group_overrides_module.merge_group_overrides([first, second])
+
+
+def test_merge_group_overrides_rejects_accessions_in_multiple_groups(tmp_path):
+    first = write_groups(tmp_path / "first.json", {"assembly-1": ["A.1", "B.1"]})
+    second = write_groups(tmp_path / "second.json", {"curated-1": ["B.1", "C.1"]})
+
+    with pytest.raises(ValueError, match="already appear"):
+        merge_group_overrides_module.merge_group_overrides([first, second])

--- a/ingest/tests/test_merge_group_overrides.py
+++ b/ingest/tests/test_merge_group_overrides.py
@@ -37,6 +37,15 @@ def test_merge_group_overrides_allows_identical_group_definitions(tmp_path):
     }
 
 
+def test_merge_group_overrides_allows_identical_group_definitions_with_different_order(tmp_path):
+    first = write_groups(tmp_path / "first.json", {"assembly-1": ["A.1", "B.1"]})
+    second = write_groups(tmp_path / "second.json", {"assembly-1": ["B.1", "A.1"]})
+
+    assert merge_group_overrides_module.merge_group_overrides([first, second]) == {
+        "assembly-1": ["A.1", "B.1"],
+    }
+
+
 def test_merge_group_overrides_rejects_conflicting_group_names(tmp_path):
     first = write_groups(tmp_path / "first.json", {"assembly-1": ["A.1", "B.1"]})
     second = write_groups(tmp_path / "second.json", {"assembly-1": ["A.1", "C.1"]})

--- a/ingest/tests/test_merge_group_overrides.py
+++ b/ingest/tests/test_merge_group_overrides.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import pytest
 
-
 SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "merge_group_overrides.py"
 SPEC = importlib.util.spec_from_file_location("merge_group_overrides", SCRIPT_PATH)
 merge_group_overrides_module = importlib.util.module_from_spec(SPEC)


### PR DESCRIPTION
## Summary
- allow ingest to use both calculated NCBI assembly grouping and a downloaded `grouping_override_url` in one run
- write calculated and downloaded grouping files to separate intermediates, then merge them into `results/groups.json`
- add a tested merge helper that rejects conflicting group names and accessions assigned to multiple groups

## Context
This is motivated by Andes virus grouping work: NCBI assembly grouping rescues 4 groups that the heuristic would miss, while a static curated file can rescue release-date-only splits such as `BA02_SMM484`. Findings gist: https://gist.github.com/theosanderson-agent/ded53e709683a52063233c174aa7c0c0

## Validation
- `python -m pytest ingest/tests/test_merge_group_overrides.py`
- `python -m py_compile ingest/scripts/merge_group_overrides.py ingest/tests/test_merge_group_overrides.py`
- `git diff --check`
- Docker Snakemake dry run with both `calculate_groups_override_json` and `grouping_override_url` configured, confirming `download_groups` + `get_assembly_groups` feed `merge_groups`, and `override_group_segments` consumes merged `results/groups.json`
- Docker Snakemake dry runs for static-only and calculated-only modes, confirming backward-compatible direct `results/groups.json` behavior

🚀 Preview: Add `preview` label to enable