### PR TITLE
test(backend): cover overwrite-prevention and read upload headers from response

### DIFF
--- a/backend/src/test/kotlin/org/loculus/backend/controller/files/RequestUploadEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/files/RequestUploadEndpointTest.kt
@@ -74,18 +74,46 @@ class RequestUploadEndpointTest(
             .andReturn()
             .response
             .contentAsString
-        val url = objectMapper.readTree(responseContent)
-            .get(0)
-            .get("url")
-            .textValue()
+        val uploadInfo = objectMapper.readTree(responseContent).get(0)
+        val url = uploadInfo.get("url").textValue()
+        val headers = uploadInfo.get("headers").fields().asSequence()
+            .associate { it.key to it.value.textValue() }
 
         val content = "test content".toByteArray()
         val request = HttpPut(url)
         request.entity = ByteArrayEntity(content, ContentType.TEXT_PLAIN)
-        request.addHeader("If-None-Match", "*")
+        headers.forEach { (key, value) -> request.addHeader(key, value) }
         val httpClient = HttpClients.createDefault()
         val response = httpClient.execute(request)
         Assertions.assertEquals(200, response.statusLine.statusCode)
+    }
+
+    @Test
+    fun `GIVEN a presigned URL has been used to upload THEN a second upload to the same URL fails`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        val responseContent = client.requestUploads(groupId, 1)
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+        val uploadInfo = objectMapper.readTree(responseContent).get(0)
+        val url = uploadInfo.get("url").textValue()
+        val headers = uploadInfo.get("headers").fields().asSequence()
+            .associate { it.key to it.value.textValue() }
+
+        val httpClient = HttpClients.createDefault()
+
+        val firstRequest = HttpPut(url)
+        firstRequest.entity = ByteArrayEntity("first content".toByteArray(), ContentType.TEXT_PLAIN)
+        headers.forEach { (key, value) -> firstRequest.addHeader(key, value) }
+        val firstResponse = httpClient.execute(firstRequest)
+        Assertions.assertEquals(200, firstResponse.statusLine.statusCode)
+
+        val secondRequest = HttpPut(url)
+        secondRequest.entity = ByteArrayEntity("second content".toByteArray(), ContentType.TEXT_PLAIN)
+        headers.forEach { (key, value) -> secondRequest.addHeader(key, value) }
+        val secondResponse = httpClient.execute(secondRequest)
+        Assertions.assertEquals(412, secondResponse.statusLine.statusCode)
     }
 
     @Test


### PR DESCRIPTION
Addresses [@anna-parker's review on #6381](https://github.com/loculus-project/loculus/pull/6381#discussion_r3212902266).

## Summary
- Refactors `GIVEN a request for a URL THEN returns a valid presigned URL` to read the required upload headers from the `headers` field on the response JSON instead of hardcoding `If-None-Match: *`. This exercises the same client-side flow that real callers (e.g. the preprocessing pipeline) are expected to follow.
- Adds a new test, `GIVEN a presigned URL has been used to upload THEN a second upload to the same URL fails`, that uses the same presigned URL twice and asserts the second PUT is rejected with HTTP 412 — the overwrite-prevention guarantee that motivated #6381.

## Test plan
- [x] `./gradlew test --tests 'org.loculus.backend.controller.files.RequestUploadEndpointTest'` — all 16 tests pass, including the new one (412 returned by MinIO on the second PUT).
- [x] `./gradlew ktlintFormat` — no changes.

This PR is targeted at the `file_sharing_nooverwrite` branch so it can land alongside #6381.

🚀 Preview: Add `preview` label to enable