### PR TITLE
Ingest grouping dates

### DIFF
--- a/ingest/scripts/heuristic_group_segments.py
+++ b/ingest/scripts/heuristic_group_segments.py
@@ -38,10 +38,15 @@ def sort_authors(authors: str) -> str:
     return "; ".join(sorted([author.strip() for author in authors.split(";")]))
 
 
-def values_with_sorted_authors(values: dict[str, str]) -> dict[str, str]:
+def values_with_sorted_authors_fallback_date(
+    values: dict[str, str], rename: dict[str, str]
+) -> dict[str, str]:
     """Sort authors values and return modified values"""
     values_copy = values.copy()
     values_copy["authors"] = sort_authors(values_copy["authors"])
+    values_copy[rename["ncbiCollectionDate"]] = (
+        values_copy[rename["ncbiCollectionDate"]] or values_copy["ncbiReleaseDate"]
+    )
     return values_copy
 
 
@@ -61,6 +66,7 @@ class Config:
     insdc_segment_specific_fields: list[str]  # Fields that can vary between segments in a group
     nucleotide_sequences: list[str]
     segmented: bool
+    rename: dict[str, str]
 
 
 # id is actually NCBI accession
@@ -140,7 +146,7 @@ def main(
     for accession, values in segment_metadata.items():
         # Author order sometimes varies among segments from same isolate
         # Example: JX999734.1 (L) and JX999735.1 (M)
-        modified_values = values_with_sorted_authors(values)
+        modified_values = values_with_sorted_authors_fallback_date(values, config.rename)
         group_key = str(
             tuple((field, value) for field in shared_fields if (value := modified_values[field]))
         )

--- a/kubernetes/loculus/templates/_preprocessingFromValues.tpl
+++ b/kubernetes/loculus/templates/_preprocessingFromValues.tpl
@@ -8,8 +8,17 @@
   {{- end }}
   {{- if hasKey .preprocessing "inputs" }}
   inputs:
-    {{- with index .preprocessing "inputs" }}
-    {{- . | toYaml | nindent 4 }}
+    {{- $segment := .segment }}
+    {{- $perSegmentFields := .perSegmentFields | default dict }}
+    {{- range $argName, $inputField := (index .preprocessing "inputs") }}
+    {{- /* When generating a per-segment spec, inputs that reference a per-segment
+           metadata field must be suffixed with the segment, because the submitted
+           metadata for those fields is itself segment-specific (e.g. ncbiReleaseDate_L). */}}
+    {{- if and $segment (hasKey $perSegmentFields $inputField) }}
+    {{ $argName }}: {{ printf "%s_%s" $inputField $segment }}
+    {{- else }}
+    {{ $argName }}: {{ $inputField }}
+    {{- end }}
     {{- end }}
   {{- end }}
   args:
@@ -67,12 +76,21 @@
 {{- $rawUniqueSegments := (include "loculus.getNucleotideSegmentNames" $referenceGenomes | fromYaml).segments }}
 {{- $isSegmented := gt (len $rawUniqueSegments) 1 }}
 
+{{- /* Names of fields that are split per segment. Inputs referencing these must be
+       segment-suffixed when generating per-segment specs. */}}
+{{- $perSegmentFields := dict }}
+{{- if $isSegmented }}
+{{- range $metadata }}
+{{- if .perSegment }}{{- $_ := set $perSegmentFields .name true }}{{- end }}
+{{- end }}
+{{- end }}
+
 {{- range $metadata }}
     {{- $currentItem := . }}
     {{- if and $isSegmented .perSegment }}
         {{- range $segment := $rawUniqueSegments }}
             {{- with $currentItem }}
-            {{- $args := deepCopy . | merge (dict "segment" $segment "key" (printf "%s_%s" .name $segment)) }}
+            {{- $args := deepCopy . | merge (dict "segment" $segment "key" (printf "%s_%s" .name $segment) "perSegmentFields" $perSegmentFields) }}
             {{- include "loculus.sharedPreproSpecs" $args }}
             {{- end }}
         {{- end }}
@@ -81,7 +99,7 @@
         {{- if .relatesToSegment }}
         {{- $segment = .relatesToSegment }}
         {{- end }}
-        {{- $args := deepCopy . | merge (dict "segment" $segment "key" .name) }}
+        {{- $args := deepCopy . | merge (dict "segment" $segment "key" .name "perSegmentFields" $perSegmentFields) }}
         {{- include "loculus.sharedPreproSpecs" $args }}
     {{- end }}
 {{- end }}

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -135,7 +135,7 @@ defaultOrganismConfig: &defaultOrganismConfig
           function: parse_date_into_range
           inputs:
             date: sampleCollectionDate
-            releaseDate: earliestReleaseDate
+            releaseDate: processed.earliestReleaseDate
           args:
             fieldType: dateRangeString
         required: true
@@ -152,7 +152,7 @@ defaultOrganismConfig: &defaultOrganismConfig
           function: parse_date_into_range
           inputs:
             date: sampleCollectionDate
-            releaseDate: earliestReleaseDate
+            releaseDate: processed.earliestReleaseDate
           args:
             fieldType: dateRangeLower
         rangeOverlapSearch:
@@ -171,7 +171,7 @@ defaultOrganismConfig: &defaultOrganismConfig
           function: parse_date_into_range
           inputs:
             date: sampleCollectionDate
-            releaseDate: earliestReleaseDate
+            releaseDate: processed.earliestReleaseDate
           args:
             fieldType: dateRangeUpper
         rangeOverlapSearch:
@@ -196,6 +196,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         definition: Date the viral nucleotide accession was first released on the INSDC.
         type: date
         header: "INSDC"
+        oneHeader: true
         orderOnDetailsPage: 1000
         preprocessing:
           function: parse_timestamp

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -135,7 +135,7 @@ defaultOrganismConfig: &defaultOrganismConfig
           function: parse_date_into_range
           inputs:
             date: sampleCollectionDate
-            releaseDate: ncbiReleaseDate
+            releaseDate: earliestReleaseDate
           args:
             fieldType: dateRangeString
         required: true
@@ -152,7 +152,7 @@ defaultOrganismConfig: &defaultOrganismConfig
           function: parse_date_into_range
           inputs:
             date: sampleCollectionDate
-            releaseDate: ncbiReleaseDate
+            releaseDate: earliestReleaseDate
           args:
             fieldType: dateRangeLower
         rangeOverlapSearch:
@@ -171,7 +171,7 @@ defaultOrganismConfig: &defaultOrganismConfig
           function: parse_date_into_range
           inputs:
             date: sampleCollectionDate
-            releaseDate: ncbiReleaseDate
+            releaseDate: earliestReleaseDate
           args:
             fieldType: dateRangeUpper
         rangeOverlapSearch:
@@ -203,6 +203,7 @@ defaultOrganismConfig: &defaultOrganismConfig
             timestamp: ncbiReleaseDate
         noInput: true
         columnWidth: 100
+        perSegment: true
       - name: earliestReleaseDate
         displayName: Earliest release date
         definition: The earliest release date for the accession, across all versions in both Loculus and the INSDC.
@@ -2014,6 +2015,12 @@ defaultOrganisms:
       submissionDataTypes:
         <<: *defaultSubmissionDataTypes
         maxSequencesPerEntry: 3
+      earliestReleaseDate:
+        enabled: true
+        externalFields:
+          - ncbiReleaseDate_L
+          - ncbiReleaseDate_M
+          - ncbiReleaseDate_S
       organismName: "Crimean-Congo Hemorrhagic Fever Virus"
       image: "/images/organisms/cchf_small.jpg"
       linkOuts:
@@ -2059,7 +2066,7 @@ defaultOrganisms:
           - lineage
           - authors
           - authorAffiliations
-          - ncbiReleaseDate
+          - earliestReleaseDate
           - hostNameScientific
           - length_M
           - length_S
@@ -2094,6 +2101,7 @@ defaultOrganisms:
       <<: *ingest
       configFile:
         taxon_id: 3052518
+        calculate_groups_override_json: true
         grouping_override_url: "https://pathoplexus.github.io/curation_data/grouping_override/cchf/curated_group_02-03-2026.json"
         segment_identification:
           method: "align"
@@ -2136,6 +2144,12 @@ defaultOrganisms:
       submissionDataTypes:
         <<: *defaultSubmissionDataTypes
         maxSequencesPerEntry: 3
+      earliestReleaseDate:
+        enabled: true
+        externalFields:
+          - ncbiReleaseDate_L
+          - ncbiReleaseDate_M
+          - ncbiReleaseDate_S
       organismName: "CCHF (Multi-Ref)"
       image: "/images/organisms/cchf_small.jpg"
       linkOuts:
@@ -2267,7 +2281,7 @@ defaultOrganisms:
           - lineage
           - authors
           - authorAffiliations
-          - ncbiReleaseDate
+          - earliestReleaseDate
           - hostNameScientific
           - length_M
           - length_S


### PR DESCRIPTION
see [@theosanderson](https://github.com/theosanderson)'s report https://gist.github.com/theosanderson-agent/ded53e709683a52063233c174aa7c0c0

### Screenshot
New groupings
- AY389361.2.L/AF467768.2.M/U88410.1.S (three sequences merged)
- NC_005301.3.L/NC_005300.2.M/NC_005302.1.S (three sequences merged)
- KT384388.1.L and KT384397.1.S split
- PQ463982.1.L, PQ463983.1.M and PQ463984.1.S split

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://ingest-grouping-dates.loculus.org