### PR TITLE
fix(website): Reduce margin of banner for restricted use sequences

### DIFF
--- a/website/src/components/common/ErrorBox.tsx
+++ b/website/src/components/common/ErrorBox.tsx
@@ -6,11 +6,12 @@ import WarningTwoToneIcon from '~icons/material-symbols/warning-outline';
 interface Props {
     title?: string;
     level?: 'error' | 'warning';
+    className?: string;
     children: React.ReactNode;
 }
 
-const ErrorBox: React.FC<Props> = ({ title, children, level = 'error' }) => {
-    const alertClass = `my-8 alert ${level === 'error' ? 'alert-error' : 'alert-warning'}`;
+const ErrorBox: React.FC<Props> = ({ title, children, level = 'error', className = 'my-8' }) => {
+    const alertClass = `${className} alert ${level === 'error' ? 'alert-error' : 'alert-warning'}`;
 
     return (
         <div className={alertClass}>

--- a/website/src/components/common/RestrictedUseWarning.tsx
+++ b/website/src/components/common/RestrictedUseWarning.tsx
@@ -5,7 +5,7 @@ import { routes } from '../../routes/routes';
 
 const RestrictedUseWarning: React.FC = () => {
     return (
-        <ErrorBox title='Restricted-Use sequence' level='warning'>
+        <ErrorBox title='Restricted-Use sequence' level='warning' className='mb-6'>
             This sequence is only available under the Restricted Use Terms. If you make use of this data, you must
             follow the{' '}
             <a href={routes.datauseTermsPage()} className='underline'>


### PR DESCRIPTION
Removes a too-big-gap above the restricted sequence banner.

State after:

<img width="947" height="197" alt="image" src="https://github.com/user-attachments/assets/4a234e43-5d66-49cf-88d8-93f69a77f1ab" />
