### PR TITLE
feat(website): display version comment on review cards for revocations

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -276,6 +276,12 @@ data class SequenceEntryStatus(
     val isRevocation: Boolean = false,
     val submissionId: String,
     val dataUseTerms: DataUseTerms,
+    @Schema(
+        description = "Comment supplied by the submitter for this version. " +
+            "For revocations this is the revocation reason; otherwise it is the value of the user-supplied " +
+            "`versionComment` metadata field. Null if no comment was provided.",
+    )
+    val versionComment: String? = null,
 ) : AccessionVersionInterface
 
 data class EditedSequenceEntryData(

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -827,6 +827,10 @@ class SubmissionDatabaseService(
                 not(SequenceEntriesView.statusIs(Status.PROCESSED))
         }
 
+        val versionCommentExpression = SequenceEntriesView.unprocessedDataColumn
+            .extract<String>("metadata", "versionComment", toScalar = true)
+            .alias("version_comment")
+
         val entries = SequenceEntriesView
             .join(
                 DataUseTermsTable,
@@ -847,6 +851,7 @@ class SubmissionDatabaseService(
                 SequenceEntriesView.processingResultColumn,
                 DataUseTermsTable.dataUseTermsTypeColumn,
                 DataUseTermsTable.restrictedUntilColumn,
+                versionCommentExpression,
             )
             .where { groupCondition and organismCondition and statusCondition and processingResultCondition }
             .orderBy(SequenceEntriesView.accessionColumn)
@@ -873,6 +878,7 @@ class SubmissionDatabaseService(
                         DataUseTermsType.fromString(row[DataUseTermsTable.dataUseTermsTypeColumn]),
                         row[DataUseTermsTable.restrictedUntilColumn],
                     ),
+                    versionComment = row[versionCommentExpression],
                 )
             }
 

--- a/website/src/components/ReviewPage/ReviewCard.tsx
+++ b/website/src/components/ReviewPage/ReviewCard.tsx
@@ -95,6 +95,14 @@ export const ReviewCard: FC<ReviewCardProps> = ({
                             disableTruncate
                         />
                     )}
+                    {sequenceEntryStatus.isRevocation && sequenceEntryStatus.versionComment && (
+                        <KeyValueComponent
+                            accessionVersion={getAccessionVersionString(sequenceEntryStatus)}
+                            keyName='Version comment'
+                            value={sequenceEntryStatus.versionComment}
+                            disableTruncate
+                        />
+                    )}
                 </div>
                 <ButtonBar
                     sequenceEntryStatus={sequenceEntryStatus}

--- a/website/src/components/ReviewPage/ReviewPage.spec.tsx
+++ b/website/src/components/ReviewPage/ReviewPage.spec.tsx
@@ -86,6 +86,19 @@ const awaitingApprovalTestData: SequenceEntryStatus = {
     submitter: 'submitter',
 };
 
+const revocationTestData: SequenceEntryStatus = {
+    submissionId: 'custom5',
+    status: processedStatus,
+    processingResult: noIssuesProcessingResult,
+    accession: 'accession5',
+    version: 2,
+    isRevocation: true,
+    dataUseTerms: openDataUseTerms,
+    groupId: 42,
+    submitter: 'submitter',
+    versionComment: 'Withdrawn due to contamination',
+};
+
 const emptyStatusCounts = {
     [receivedStatus]: 0,
     [inProcessingStatus]: 0,
@@ -198,6 +211,17 @@ describe('ReviewPage', () => {
 
         await waitFor(() => {
             expect(getByText(unreleasedSequencesRegex)).toBeDefined();
+        });
+    });
+
+    test('should show the version comment for revocation entries', async () => {
+        mockRequest.backend.getSequences(200, generateGetSequencesResponse([revocationTestData]));
+
+        const { getByText } = renderReviewPage();
+
+        await waitFor(() => {
+            expect(getByText('Version comment')).toBeDefined();
+            expect(getByText(revocationTestData.versionComment!)).toBeDefined();
         });
     });
 

--- a/website/src/types/backend.ts
+++ b/website/src/types/backend.ts
@@ -139,6 +139,7 @@ export const sequenceEntryStatus = accessionVersion.merge(
         dataUseTerms,
         groupId: z.number(),
         submitter: z.string(),
+        versionComment: z.string().nullish(),
     }),
 );
 


### PR DESCRIPTION
## Summary

<img width="1411" height="114" alt="image" src="https://github.com/user-attachments/assets/d16d6cac-67c8-46a9-a6ff-ec9f9d9f2f9d" />


Fixes #6394 (and addresses #4522).

Previously, when reviewing a revocation entry on the review page, there was no way to see the version comment the submitter entered when creating the revocation. The card only showed a generic message: *"This is a revocation entry, which will create a new version that revokes this accession"*. This made it impossible to double-check the revocation reason before approving the entry.

This PR surfaces the version comment alongside the existing revocation marker on the review card.

## Changes

### Backend
- Add `versionComment: String?` to `SequenceEntryStatus` ([SubmissionTypes.kt](https://github.com/loculus-project/loculus/blob/main/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt)).
- In `getSequences` ([SubmissionDatabaseService.kt](https://github.com/loculus-project/loculus/blob/main/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt)), extract the value from `unprocessed_data.metadata.versionComment` using a JSONB scalar path. After the [V1.27 migration](https://github.com/loculus-project/loculus/blob/main/backend/src/main/resources/db/migration/V1.27__move_version_comment_to_metadata.sql) the comment lives there for revocations.

### Website
- Add `versionComment` to the `sequenceEntryStatus` zod schema.
- Render a `Version comment` `KeyValueComponent` on the review card whenever the entry is a revocation and a comment was provided.
- Add a Vitest case asserting the comment is rendered for revocation entries.

## Design notes

- The existing `/get-data-to-edit` endpoint (used by `useGetMetadataAndAnnotations` to populate the review card's metadata) explicitly errors for revocations, so it was not appropriate to repurpose. Returning the comment on the list response means no extra HTTP round-trip per card.
- For non-revocation revisions, `versionComment` is already part of the processed metadata and rendered via the existing `MetadataList`. The new card field is gated on `isRevocation` to avoid showing it twice.

## Test plan

- [ ] Manual check: submit a revocation with a version comment, open the review page, confirm the comment is shown on the card.
- [ ] Manual check: submit a revocation without a comment — no "Version comment" row appears (only the existing revocation marker).
- [ ] Manual check: revisions still show their `versionComment` via the normal metadata list (unchanged behavior).
- [x] `CI=1 npm run test` (website) — 646 tests passing including new `should show the version comment for revocation entries` case.
- [x] `CI=1 npm run check-types` (website) — clean.
- [x] `npm run format` (website) — clean.
- [x] `./gradlew compileKotlin && ./gradlew ktlintFormat` (backend) — clean.
- [ ] Backend integration tests — could not run locally (test infra needs Docker/postgres setup); rely on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable