### PR TITLE
[codex] Show restricted download exclusion count

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx
@@ -61,6 +61,7 @@ async function renderDialog({
     selectedReferenceNames = { main: null },
     referenceIdentifierField,
     referenceGenomesInfo = SINGLE_SEG_SINGLE_REF_REFERENCEGENOMES,
+    restrictedSequenceCount,
 }: {
     downloadParams?: SequenceFilter;
     allowSubmissionOfConsensusSequences?: boolean;
@@ -71,6 +72,7 @@ async function renderDialog({
     selectedReferenceNames?: SegmentReferenceSelections;
     referenceIdentifierField?: string;
     referenceGenomesInfo?: ReferenceGenomesInfo;
+    restrictedSequenceCount?: number;
 } = {}) {
     const schema: Schema = {
         defaultOrder: 'ascending',
@@ -99,6 +101,7 @@ async function renderDialog({
             richFastaHeaderFields={richFastaHeaderFields}
             selectedReferenceNames={selectedReferenceNames}
             referenceIdentifierField={referenceIdentifierField}
+            restrictedSequenceCount={restrictedSequenceCount}
         />,
     );
 
@@ -317,6 +320,24 @@ describe('DownloadDialog', () => {
         expectRouteInPathMatches(path, `/sample/details`);
         expect(query).toMatch(/field2=/);
         expect(query).not.toMatch(/field1=/);
+    });
+
+    test('shows how many restricted sequences will be excluded when only downloading open data', async () => {
+        await renderDialog({ restrictedSequenceCount: 1234 });
+
+        expect(
+            screen.getByText('1,234 restricted sequences will not be included in this download.'),
+        ).toBeInTheDocument();
+    });
+
+    test('hides the restricted exclusion notice when restricted sequences are included', async () => {
+        await renderDialog({ restrictedSequenceCount: 1234 });
+
+        await userEvent.click(screen.getByLabelText(/include restricted data/));
+
+        expect(
+            screen.queryByText('1,234 restricted sequences will not be included in this download.'),
+        ).not.toBeInTheDocument();
     });
 
     test('should not show the fasta header options when rich fasta headers are disabled', async () => {

--- a/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadDialog.tsx
@@ -10,6 +10,7 @@ import type { SequenceFilter } from './SequenceFilters.tsx';
 import { ACCESSION_VERSION_FIELD } from '../../../settings.ts';
 import type { Metadata, Schema } from '../../../types/config.ts';
 import type { ReferenceGenomesInfo } from '../../../types/referencesGenomes.ts';
+import { formatNumberWithDefaultLocale } from '../../../utils/formatNumber.tsx';
 import { MetadataVisibility } from '../../../utils/search.ts';
 import {
     getSegmentAndGeneInfo,
@@ -34,6 +35,7 @@ type DownloadDialogProps = {
     richFastaHeaderFields: Schema['richFastaHeaderFields'];
     selectedReferenceNames?: SegmentReferenceSelections;
     referenceIdentifierField: string | undefined;
+    restrictedSequenceCount?: number;
 };
 
 export const DownloadDialog: FC<DownloadDialogProps> = ({
@@ -47,6 +49,7 @@ export const DownloadDialog: FC<DownloadDialogProps> = ({
     richFastaHeaderFields,
     selectedReferenceNames,
     referenceIdentifierField,
+    restrictedSequenceCount,
 }) => {
     const [isOpen, setIsOpen] = useState(false);
 
@@ -152,6 +155,16 @@ export const DownloadDialog: FC<DownloadDialogProps> = ({
                             </label>
                         </div>
                     )}
+                    {dataUseTermsEnabled &&
+                        !downloadFormState.includeRestricted &&
+                        restrictedSequenceCount !== undefined &&
+                        restrictedSequenceCount > 0 && (
+                            <div className='mb-4 text-sm text-gray-600'>
+                                {formatNumberWithDefaultLocale(restrictedSequenceCount)} restricted{' '}
+                                {restrictedSequenceCount === 1 ? 'sequence' : 'sequences'} will not be included in this
+                                download.
+                            </div>
+                        )}
                     <DownloadButton
                         downloadUrlGenerator={downloadUrlGenerator}
                         downloadOption={downloadOption}

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -63,6 +63,16 @@ const buildSequenceCountText = (totalSequences: number | undefined, oldCount: nu
     return `Search returned ${formattedCount} sequence${pluralSuffix}`;
 };
 
+type AggregatedData = ({ count: number } & Record<string, unknown>)[];
+
+const getRestrictedSequenceCount = (aggregatedData: AggregatedData | undefined): number | undefined => {
+    if (aggregatedData === undefined) {
+        return undefined;
+    }
+
+    return aggregatedData.find((row) => row[DATA_USE_TERMS_FIELD] === 'RESTRICTED')?.count ?? 0;
+};
+
 /* eslint-disable @typescript-eslint/no-unsafe-member-access -- TODO(#3451) this component is a mess a needs to be refactored */
 export const InnerSearchFullUI = ({
     accessToken,
@@ -156,6 +166,7 @@ export const InnerSearchFullUI = ({
 
     const hooks = lapisClientHooks(lapisUrl);
     const aggregatedHook = hooks.useAggregated();
+    const restrictedSequenceCountHook = hooks.useAggregated();
     const detailsHook = hooks.useDetails();
 
     const [selectedSeqs, setSelectedSeqs] = useState(new Set<string>());
@@ -179,7 +190,11 @@ export const InnerSearchFullUI = ({
      */
     const lapisSearchParameters = useMemo(() => tableFilter.toApiParams(), [tableFilter]);
 
-    const downloadFilter: SequenceFilter = sequencesSelected ? new SequenceEntrySelection(selectedSeqs) : tableFilter;
+    const downloadFilter = useMemo<SequenceFilter>(
+        () => (sequencesSelected ? new SequenceEntrySelection(selectedSeqs) : tableFilter),
+        [sequencesSelected, selectedSeqs, tableFilter],
+    );
+    const downloadLapisSearchParameters = useMemo(() => downloadFilter.toApiParams(), [downloadFilter]);
 
     useEffect(() => {
         aggregatedHook.mutate({
@@ -202,7 +217,22 @@ export const InnerSearchFullUI = ({
         });
     }, [lapisSearchParameters, schema.tableColumns, schema.primaryKey, pageSize, page, orderByField, orderDirection]);
 
+    useEffect(() => {
+        if (!dataUseTermsEnabled) {
+            return;
+        }
+
+        restrictedSequenceCountHook.mutate({
+            ...downloadLapisSearchParameters,
+            fields: [DATA_USE_TERMS_FIELD],
+        });
+    }, [dataUseTermsEnabled, downloadLapisSearchParameters]);
+
     const totalSequences = aggregatedHook.data?.data[0].count ?? undefined;
+    const restrictedSequenceCount =
+        dataUseTermsEnabled && !restrictedSequenceCountHook.isPending && !restrictedSequenceCountHook.isError
+            ? getRestrictedSequenceCount(restrictedSequenceCountHook.data?.data)
+            : undefined;
     const linkOutSequenceCount = downloadFilter.sequenceCount() ?? totalSequences;
 
     const [oldData, setOldData] = useState<TableSequenceData[] | null>(null);
@@ -365,6 +395,7 @@ export const InnerSearchFullUI = ({
                                 richFastaHeaderFields={schema.richFastaHeaderFields}
                                 selectedReferenceNames={referenceSelection?.selectedReferences}
                                 referenceIdentifierField={schema.referenceIdentifierField}
+                                restrictedSequenceCount={restrictedSequenceCount}
                             />
                             {linkOuts !== undefined && linkOuts.length > 0 && (
                                 <LinkOutMenu


### PR DESCRIPTION
## Summary

Show a notice in the download modal when restricted-use data is excluded. If the user leaves "No, only download open data" selected, the modal now states how many restricted sequences will not be included in the download.

## Implementation

- Adds an aggregated LAPIS query grouped by `dataUseTerms` for the active download filter.
- Passes the restricted sequence count into the download dialog.
- Hides the notice when restricted data is included.

## Validation

- `npm test -- --run src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx src/components/SearchPage/SearchFullUI.spec.tsx`
- `npx eslint src/components/SearchPage/DownloadDialog/DownloadDialog.tsx src/components/SearchPage/SearchFullUI.tsx src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx`
- `npx prettier --check src/components/SearchPage/DownloadDialog/DownloadDialog.tsx src/components/SearchPage/SearchFullUI.tsx src/components/SearchPage/DownloadDialog/DownloadDialog.spec.tsx`
- `npm run check-types`

🚀 Preview: Add `preview` label to enable