### PR TITLE
fix(website): prevent revoke modal from closing on backdrop click

### DIFF
--- a/website/src/components/SequenceDetailsPage/RevokeButton.tsx
+++ b/website/src/components/SequenceDetailsPage/RevokeButton.tsx
@@ -69,7 +69,7 @@ interface DisplayRevocationProps {
 
 export const displayRevocationDialog = ({ dialogText, onConfirmation }: DisplayRevocationProps) => {
     confirmAlert({
-        closeOnClickOutside: true,
+        closeOnClickOutside: false,
 
         customUI: ({ onClose }) => (
             <RevocationDialog


### PR DESCRIPTION
## Summary

Fixes #6401.

The sequence revoke confirmation modal (shown when clicking "Revoke this sequence" on the sequence details page) was dismissable by clicking the backdrop. This is easy to do accidentally — and discards whatever revocation reason the user has typed — so the modal felt fragile and confusing.

This PR flips `closeOnClickOutside` from `true` to `false` in `displayRevocationDialog` (`website/src/components/SequenceDetailsPage/RevokeButton.tsx`). The modal now only closes via the explicit Cancel button, the ✕ button in the corner, or Confirm.

This matches the behavior users typically expect from a destructive-action confirmation modal: an outside click is much more likely to be accidental than intentional, especially when there is form state inside.

## Test

Theo checked working as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: https://fix-revoke-modal-backdrop.loculus.org