### PR TITLE
fix(website): Prevent text from going under 'X' button in autocomplete input

### DIFF
--- a/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
@@ -19,16 +19,17 @@ import MdiChevronUpDown from '~icons/mdi/chevron-up-down';
 import MdiTick from '~icons/mdi/tick';
 
 const CustomInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>((props, ref) => (
-    <TextField
-        ref={ref}
-        fieldValue={props.value}
-        onChange={props.onChange}
-        onFocus={props.onFocus}
-        disabled={props.disabled}
-        autoComplete='off'
-        label={props.placeholder ?? ''}
-        className='pr-16'
-    />
+    <div className='[&_input]:pr-16'>
+        <TextField
+            ref={ref}
+            fieldValue={props.value}
+            onChange={props.onChange}
+            onFocus={props.onFocus}
+            disabled={props.disabled}
+            autoComplete='off'
+            label={props.placeholder ?? ''}
+        />
+    </div>
 ));
 
 const logger = getClientLogger('SingleChoiceAutoCompleteField');

--- a/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
@@ -27,7 +27,7 @@ const CustomInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputEl
         disabled={props.disabled}
         autoComplete='off'
         label={props.placeholder ?? ''}
-        className='pr-14'
+        className='pr-16'
     />
 ));
 

--- a/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
@@ -27,6 +27,7 @@ const CustomInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputEl
         disabled={props.disabled}
         autoComplete='off'
         label={props.placeholder ?? ''}
+	className='pr-14'
     />
 ));
 

--- a/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
@@ -27,7 +27,7 @@ const CustomInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputEl
         disabled={props.disabled}
         autoComplete='off'
         label={props.placeholder ?? ''}
-	className='pr-14'
+        className='pr-14'
     />
 ));
 


### PR DESCRIPTION
In https://github.com/loculus-project/loculus/pull/6302 we added hierarchical filters. That PR modified the autocomplete we use to select lineages to also be usable for general hierarchical filters. The first of these filters we added is a filter on host organism. 

Since these can have long names (longer than lineage identifiers) the names now go under the 'X' button that is used to deselect the currently selected autocomplete option, which is ugly:

<img width="272" height="117" alt="grafik" src="https://github.com/user-attachments/assets/ddcacfc3-398a-48b3-a1f4-1533e82f0018" />


This PR makes it so the text is cut off before the 'X' button:

<img width="272" height="117" alt="grafik" src="https://github.com/user-attachments/assets/b177d4eb-360a-48b2-b3a7-095789157e28" />


Longer term, we should decide on whether we want to limit the length of text for autocomplete options, add line wrapping, or come up with something else to make this part of the UI cleaner.

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://fix-autocomplete-text.loculus.org