### PR TITLE
fix(silo-import): Change typing of payload in _post_silo_lineage

### DIFF
--- a/loculus-silo/src/silo_import/lineage.py
+++ b/loculus-silo/src/silo_import/lineage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 import requests
 from requests import codes
@@ -108,7 +109,8 @@ def _post_silo_lineage(url: str, values: list[str], prune: bool = False) -> requ
     request body and a ?prune=<boolean> query param
     """
     params = {"prune": "true"} if prune else None
-    return requests.post(url, json={"values": values}, params=params, timeout=60)
+    payload: dict[str, Any] = {"values": values}
+    return requests.post(url, json=payload, params=params, timeout=60)
 
 
 def _write_text(path: Path, content: str) -> None:


### PR DESCRIPTION
The function `_post_silo_lineage` (added in https://github.com/loculus-project/loculus/pull/6302) calls out to an external service to get a SILO lineage file, which is used to build hierarchical filters.

It sends the values to build a lineage over as a payload in the request body. The way this was implemented passed CI when I merged the branch (https://github.com/loculus-project/loculus/actions/runs/25690806031/job/75426395205) but started failing for later CI runs even though loculus-silo code wasn't touched (e.g., https://github.com/loculus-project/loculus/actions/runs/25721364352/job/75523091295?pr=6403).

Likely because CI resolves dependencies on each run and PyPI state had changed. The change in this PR updates typing of the request body and should prevent type checking from failing here in the future.


### PR Checklist
~- [ ] All necessary documentation has been adapted.~
- [x] The implemented feature is covered by appropriate, automated tests.
~- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)~

🚀 Preview: Add `preview` label to enable