### PR TITLE
feat(website): use display names in multi-field search tooltip

### DIFF
--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -371,6 +371,7 @@ export const SearchForm = ({
                                             multiFieldSearch={item.field}
                                             fieldValue={(fieldValues[item.field.name] as string | undefined) ?? ''}
                                             setSomeFieldValues={setSomeFieldValues}
+                                            filterSchema={filterSchema}
                                         />
                                     ),
                                 )}

--- a/website/src/components/SearchPage/fields/MultiFieldSearchField.tsx
+++ b/website/src/components/SearchPage/fields/MultiFieldSearchField.tsx
@@ -3,6 +3,7 @@ import { useId } from 'react';
 import { TextField } from './TextField';
 import type { MultiFieldSearch, SetSomeFieldValues } from '../../../types/config.ts';
 import { CustomTooltip } from '../../../utils/CustomTooltip';
+import type { MetadataFilterSchema } from '../../../utils/search.ts';
 import DisabledUntilHydrated from '../../DisabledUntilHydrated';
 import MaterialSymbolsHelpOutline from '~icons/material-symbols/help-outline';
 
@@ -10,12 +11,14 @@ export interface MultiFieldSearchFieldProps {
     multiFieldSearch: MultiFieldSearch;
     setSomeFieldValues: SetSomeFieldValues;
     fieldValue: string;
+    filterSchema: MetadataFilterSchema;
 }
 
 export const MultiFieldSearchField = ({
     multiFieldSearch,
     setSomeFieldValues,
     fieldValue,
+    filterSchema,
 }: MultiFieldSearchFieldProps) => {
     const tooltipId = useId();
 
@@ -31,10 +34,7 @@ export const MultiFieldSearchField = ({
                 />
             </DisabledUntilHydrated>
             <div className='absolute top-1/2 -translate-y-1/3 right-1'>
-                <span
-                    data-tooltip-id={tooltipId}
-                    className='text-gray-400 hover:text-primary-600 cursor-help inline-flex'
-                >
+                <span data-tooltip-id={tooltipId} className='text-gray-400 hover:text-primary-600 inline-flex'>
                     <MaterialSymbolsHelpOutline className='inline-block h-6 w-5' />
                 </span>
             </div>
@@ -42,8 +42,8 @@ export const MultiFieldSearchField = ({
                 <p className='mb-1'>Search across the following fields:</p>
                 <ul className='list-disc list-inside'>
                     {multiFieldSearch.fields.map((field) => (
-                        <li key={field} className='font-mono text-xs'>
-                            {field}
+                        <li key={field} className='text-xs'>
+                            {filterSchema.getLabel(field)}
                         </li>
                     ))}
                 </ul>


### PR DESCRIPTION

<img width="408" height="270" alt="image" src="https://github.com/user-attachments/assets/eac0e897-52f1-4db9-bbf2-8d8bb9fe3093" />


Closes #6384.

Two small tweaks for the multi-field search help tooltip:

- **Use display names, not technical field names.** Previously the tooltip listed the underlying schema field names (e.g. `pangoLineage`) in a monospace font. It now resolves each entry to its user-facing display name via `MetadataFilterSchema.getLabel(...)`, so the list matches the wording used everywhere else in the search UI. `getLabel` already handles multi-field searches, grouped fields, and falls back to the technical name when no display name is configured, so this is a drop-in.
- **Drop the `cursor-help` styling.** [Theo: my instinct was that this is so rare in UI terms that it felt unexpected but I don't feel strongly]

🚀 Preview: https://fix-multi-field-search-to.loculus.org