### PR TITLE
fix(website): Make SingleChoiceAutoComplete label transparent to pointers for consistency

### DIFF
--- a/website/src/components/SearchPage/fields/TextField.tsx
+++ b/website/src/components/SearchPage/fields/TextField.tsx
@@ -121,7 +121,11 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
             label: label ?? '',
             step: props.type === 'int' ? 1 : undefined,
         };
-        return <FloatingLabel {...inputProps} variant='outlined' type={inputType} value={fieldValue} />;
+        return (
+            <div className='[&_label]:pointer-events-none'>
+                <FloatingLabel {...inputProps} variant='outlined' type={inputType} value={fieldValue} />
+            </div>
+        );
     }
     const refTextArea = ref as ForwardedRef<HTMLTextAreaElement>;
 
@@ -148,7 +152,7 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
 
             <label
                 htmlFor={id}
-                className={`absolute text-sm text-gray-500 dark:text-gray-400 ${
+                className={`absolute text-sm text-gray-500 dark:text-gray-400 pointer-events-none ${
                     isTransitionEnabled ? 'duration-300' : ''
                 } transform -translate-y-3 scale-75 top-1 z-10 origin-[0] bg-white dark:bg-gray-900 px-2 peer-focus:px-2 peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-1 peer-focus:scale-75 peer-focus:-translate-y-3 start-1 rtl:peer-focus:translate-x-1/4 rtl:peer-focus:left-auto`}
             >


### PR DESCRIPTION
This caused integration test failures when Playwright tried to click the field the label intercepted the clicks.

All other floating labels are transparent to clicks (pointer-events-none). Just this one here wasn't yet.

### Screenshot

Before:
<img width="382" height="133" alt="2026-05-12 13 16 47" src="https://github.com/user-attachments/assets/0eeacba3-15e3-4f47-b97c-46a91364b5e1" />

After:
<img width="386" height="137" alt="2026-05-12 13 17 25" src="https://github.com/user-attachments/assets/e93e21f3-e2b3-47db-8824-5976aa37a5e3" />

🚀 Preview: https://label-occlusion.loculus.org