### PR TITLE
fix(website): don't send false positive errors in lineage autocomplete options hooks

### DIFF
--- a/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
+++ b/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
@@ -2,8 +2,8 @@ import { useCallback } from 'react';
 
 import { lapisClientHooks } from '../../../services/serviceHooks.ts';
 import type { LineageDefinition } from '../../../types/lapis.ts';
-import { stringifyMaybeAxiosError } from '../../../utils/stringifyMaybeAxiosError.ts';
 import { NULL_QUERY_VALUE } from '../../../utils/search.ts';
+import { stringifyMaybeAxiosError } from '../../../utils/stringifyMaybeAxiosError.ts';
 import type { LapisSearchParameters } from '../DownloadDialog/SequenceFilters.tsx';
 
 export type Option = {

--- a/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
+++ b/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
@@ -173,7 +173,7 @@ const createLineageOptionsHook = (
     return function hook() {
         const {
             data,
-            isPending: aggregateIsPending,
+            isPending: aggregatedEndpointIsPending,
             error: aggregatedEndpointError,
             mutate,
         } = lapisClientHooks(lapisUrl).useAggregated();
@@ -227,7 +227,7 @@ const createLineageOptionsHook = (
 
         return {
             options,
-            isPending: aggregateIsPending || definitionIsLoading,
+            isPending: aggregatedEndpointIsPending || definitionIsLoading,
             error:
                 errors.length > 0
                     ? `Error while loading lineage autocomplete options for field "${fieldName}" from ${lapisUrl}: ${errors.join('; ')}`

--- a/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
+++ b/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 
 import { lapisClientHooks } from '../../../services/serviceHooks.ts';
 import type { LineageDefinition } from '../../../types/lapis.ts';
+import { stringifyMaybeAxiosError } from '../../../utils/stringifyMaybeAxiosError.ts';
 import { NULL_QUERY_VALUE } from '../../../utils/search.ts';
 import type { LapisSearchParameters } from '../DownloadDialog/SequenceFilters.tsx';
 
@@ -34,7 +35,7 @@ export type OptionsProvider = GenericOptionsProvider | LineageOptionsProvider;
 export type AutocompleteOptionsHook = () => {
     options: Option[];
     isPending: boolean;
-    error: Error | null;
+    error: string | null;
     load: () => void;
 };
 
@@ -80,7 +81,9 @@ const createGenericOptionsHook = (
         return {
             options,
             isPending,
-            error,
+            error: error
+                ? `Error while loading options for field "${fieldName}": ${stringifyMaybeAxiosError(error)}`
+                : null,
             load: () => mutate(lapisParams),
         };
     };
@@ -171,14 +174,14 @@ const createLineageOptionsHook = (
         const {
             data,
             isPending: aggregateIsPending,
-            error: aggregateError,
+            error: aggregatedEndpointError,
             mutate,
         } = lapisClientHooks(lapisUrl).useAggregated();
 
         const {
             data: lineageDefinition,
-            isLoading: defIsLoading,
-            error: defError,
+            isLoading: definitionIsLoading,
+            error: definitionEndpointError,
         } = lapisClientHooks(lapisUrl).useLineageDefinition(
             {
                 params: {
@@ -216,10 +219,19 @@ const createLineageOptionsHook = (
 
         options.sort((a, b) => (a.option.toLowerCase() < b.option.toLowerCase() ? -1 : 1));
 
+        const errors = [
+            aggregatedEndpointError && `aggregated endpoint: ${stringifyMaybeAxiosError(aggregatedEndpointError)}`,
+            definitionEndpointError &&
+                `lineage definition endpoint: ${stringifyMaybeAxiosError(definitionEndpointError)}`,
+        ].filter(Boolean);
+
         return {
             options,
-            isPending: aggregateIsPending || defIsLoading,
-            error: new AggregateError([aggregateError, defError].filter(Boolean)),
+            isPending: aggregateIsPending || definitionIsLoading,
+            error:
+                errors.length > 0
+                    ? `Error while loading lineage autocomplete options for field "${fieldName}" from ${lapisUrl}: ${errors.join('; ')}`
+                    : null,
             load: () => mutate(lapisParams),
         };
     };

--- a/website/src/components/SearchPage/fields/MultiChoiceAutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/MultiChoiceAutoCompleteField.tsx
@@ -50,7 +50,7 @@ export const MultiChoiceAutoCompleteField = ({
 
     useEffect(() => {
         if (error) {
-            void logger.warn(error);
+            void logger.error(error);
         }
     }, [error]);
 

--- a/website/src/components/SearchPage/fields/MultiChoiceAutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/MultiChoiceAutoCompleteField.tsx
@@ -50,7 +50,7 @@ export const MultiChoiceAutoCompleteField = ({
 
     useEffect(() => {
         if (error) {
-            void logger.error(error);
+            void logger.warn(error);
         }
     }, [error]);
 

--- a/website/src/components/SearchPage/fields/MultiChoiceAutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/MultiChoiceAutoCompleteField.tsx
@@ -50,7 +50,7 @@ export const MultiChoiceAutoCompleteField = ({
 
     useEffect(() => {
         if (error) {
-            void logger.error(`Error while loading autocomplete options: ${error.message} - ${error.stack}`);
+            void logger.error(error);
         }
     }, [error]);
 

--- a/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
@@ -58,7 +58,7 @@ export const SingleChoiceAutoCompleteField = ({
 
     useEffect(() => {
         if (error) {
-            void logger.error(error);
+            void logger.warn(error);
         }
     }, [error]);
 

--- a/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
@@ -58,7 +58,7 @@ export const SingleChoiceAutoCompleteField = ({
 
     useEffect(() => {
         if (error) {
-            void logger.error(`Error while loading autocomplete options: ${error.message} - ${error.stack}`);
+            void logger.error(error);
         }
     }, [error]);
 

--- a/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
@@ -58,7 +58,7 @@ export const SingleChoiceAutoCompleteField = ({
 
     useEffect(() => {
         if (error) {
-            void logger.warn(error);
+            void logger.error(error);
         }
     }, [error]);
 

--- a/website/src/utils/stringifyMaybeAxiosError.ts
+++ b/website/src/utils/stringifyMaybeAxiosError.ts
@@ -1,8 +1,12 @@
-import { type AxiosError } from 'axios';
+import { isAxiosError, type AxiosError } from 'axios';
 
 import type { ProblemDetail } from '../types/backend.ts';
 
 export const stringifyMaybeAxiosError = (error: unknown): string => {
+    if (isAxiosError(error) && error.response === undefined && error.request !== undefined) {
+        return `${error.message}; no response received`;
+    }
+
     const data = (error as AxiosError).response?.data;
     if (typeof data === 'object' && data !== null) {
         return (data as ProblemDetail).detail;


### PR DESCRIPTION
A bug in `createLineageOptionsHook` meant that the hook was always returning an Error - even if there was no error: `new AggregateError([aggregateError, defError].filter(Boolean))` is always an `AggregateError([])` even if it doesn't contain an interior error.

This cause lots of post requests to `/admin/logs.txt` whenever a user interacted with the lineage search field that includes sublineage functionality.

@maverbiest helped investigating this bug.

### Screenshot

Currently in production we fire off dozens of posts to `/admin/logs.txt` due to the false positive error:

<img width="1885" height="871" alt="Google Chrome 2026-05-12 15 10 06" src="https://github.com/user-attachments/assets/19ccd316-29d2-480d-aa1a-de15f1d64d6c" />

Each mpox search page load fires a dozen errors, looks like this in Grafana:

<img width="1633" height="573" alt="image" src="https://github.com/user-attachments/assets/038f7488-38d3-4534-9cdd-c9778bfe17e2" />

### Manual testing

Testing via `npm run dev`, we no longer fire off false errors.

### PR Checklist
- [ ] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable