### PR TITLE
fix(deployment): use negative sync-wave for development databases

### DIFF
--- a/kubernetes/loculus/templates/keycloak-database-service.yaml
+++ b/kubernetes/loculus/templates/keycloak-database-service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: loculus-keycloak-database-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "-5"
 spec:
   type: ClusterIP
   selector:

--- a/kubernetes/loculus/templates/keycloak-database-standin.yaml
+++ b/kubernetes/loculus/templates/keycloak-database-standin.yaml
@@ -6,6 +6,7 @@ metadata:
   name: loculus-keycloak-database
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
+    argocd.argoproj.io/sync-wave: "-5"
 spec:
   replicas: 1
   selector:

--- a/kubernetes/loculus/templates/loculus-database-service.yaml
+++ b/kubernetes/loculus/templates/loculus-database-service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: loculus-database-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "-5"
 spec:
   
   {{- template "loculus.serviceType" .}}

--- a/kubernetes/loculus/templates/loculus-database-standin.yaml
+++ b/kubernetes/loculus/templates/loculus-database-standin.yaml
@@ -62,6 +62,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: loculus-database-init
+  annotations:
+    argocd.argoproj.io/sync-wave: "-5"
 data:
   init-pg-stat.sql: |
     CREATE EXTENSION IF NOT EXISTS pg_stat_statements;

--- a/kubernetes/loculus/templates/loculus-database-standin.yaml
+++ b/kubernetes/loculus/templates/loculus-database-standin.yaml
@@ -6,6 +6,7 @@ metadata:
   name: loculus-database
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
+    argocd.argoproj.io/sync-wave: "-5"
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
## Summary

Fixes #6414.

Adds `argocd.argoproj.io/sync-wave: "-5"` to the development standin database deployments (main + keycloak) and their services so they sync ahead of consumers like keycloak and the backend.

### Why

The standin deployments use `Replace=true` and re-create on every docker tag change (via the `LOCULUS_VERSION` env var). Without an explicit sync wave, ArgoCD may process the standin database and its consumers (keycloak/backend) in the same wave. That means:

1. Consumers can start a connection to the soon-to-be-replaced DB pod.
2. The standin DB is then deleted and recreated empty.
3. The consumer holds connections to the dying DB and/or reads the new (empty) one mid-handshake, leading to flaky data loss in dev environments.

By placing the standin DBs and their services in sync wave `-5` (between `-10` used by `PriorityClass` and the default `0`), ArgoCD ensures the new DB pod is up and the service routes to it before any consumer is touched in the same sync.

This is the simpler alternative mentioned in the issue compared to the approach taken in #6216.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable