### PR TITLE
fix(website): Fix floating label display in Textfield for Safari, and implement placeholder prop

### DIFF
--- a/website/src/components/SearchPage/fields/TextField.tsx
+++ b/website/src/components/SearchPage/fields/TextField.tsx
@@ -30,7 +30,7 @@ const helperTextClasses = getTheme().floatingLabel.helperText.default;
 const inputClasses = getTheme().floatingLabel.input.default.outlined.md;
 
 export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, TextFieldProps>(function (props, ref) {
-    const { label, disabled, onChange, autoComplete, fieldValue, className, onFocus, multiline, onBlur, placeholder } =
+    const { label, disabled, onChange, autoComplete, fieldValue, className, onFocus, placeholder, multiline, onBlur } =
         props;
     const id = useId();
     const [isTransitionEnabled, setIsTransitionEnabled] = useState(false);

--- a/website/src/components/SearchPage/fields/TextField.tsx
+++ b/website/src/components/SearchPage/fields/TextField.tsx
@@ -160,6 +160,7 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
         onFocus: onFocusHTMLArea,
         onBlur: onBlurHTMLArea,
         value: fieldValue,
+        placeholder: placeholder ?? ' ',
     };
 
     return (
@@ -168,7 +169,6 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
                 {...textareaProps}
                 rows={hasFocus || (fieldValue !== undefined && fieldValue.toString().split('\n').length > 1) ? 4 : 1}
                 className={`rounded-md block px-2.5 pb-2 pt-4 w-full text-sm text-gray-900 bg-transparent border-1 border-gray-300 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-blue-500 focus:outline-none focus:ring-0 focus:border-blue-600 peer hover:border-gray-400 transition-colors ${className}`}
-                placeholder={placeholder ?? ' '}
             ></textarea>
 
             <label

--- a/website/src/components/SearchPage/fields/TextField.tsx
+++ b/website/src/components/SearchPage/fields/TextField.tsx
@@ -20,7 +20,6 @@ interface TextFieldProps {
     fieldValue?: string | number | readonly string[];
     className?: string;
     onFocus?: FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
-    placeholder?: string;
     multiline?: boolean;
     onBlur?: FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
     type?: string;

--- a/website/src/components/SearchPage/fields/TextField.tsx
+++ b/website/src/components/SearchPage/fields/TextField.tsx
@@ -20,6 +20,7 @@ interface TextFieldProps {
     fieldValue?: string | number | readonly string[];
     className?: string;
     onFocus?: FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+    placeholder?: string;
     multiline?: boolean;
     onBlur?: FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
     type?: string;
@@ -29,7 +30,8 @@ const helperTextClasses = getTheme().floatingLabel.helperText.default;
 const inputClasses = getTheme().floatingLabel.input.default.outlined.md;
 
 export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, TextFieldProps>(function (props, ref) {
-    const { label, disabled, onChange, autoComplete, fieldValue, className, onFocus, multiline, onBlur } = props;
+    const { label, disabled, onChange, autoComplete, fieldValue, className, onFocus, multiline, onBlur, placeholder } =
+        props;
     const id = useId();
     const [isTransitionEnabled, setIsTransitionEnabled] = useState(false);
     const [hasFocus, setHasFocus] = useState(false);
@@ -121,6 +123,7 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
             ref: ref as LegacyRef<HTMLInputElement>,
             label: label ?? '',
             step: props.type === 'int' ? 1 : undefined,
+            placeholder: placeholder ?? ' ',
         };
 
         return (
@@ -165,7 +168,7 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
                 {...textareaProps}
                 rows={hasFocus || (fieldValue !== undefined && fieldValue.toString().split('\n').length > 1) ? 4 : 1}
                 className={`rounded-md block px-2.5 pb-2 pt-4 w-full text-sm text-gray-900 bg-transparent border-1 border-gray-300 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-blue-500 focus:outline-none focus:ring-0 focus:border-blue-600 peer hover:border-gray-400 transition-colors ${className}`}
-                placeholder=' '
+                placeholder={placeholder ?? ' '}
             ></textarea>
 
             <label

--- a/website/src/components/SearchPage/fields/TextField.tsx
+++ b/website/src/components/SearchPage/fields/TextField.tsx
@@ -120,7 +120,6 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
             onBlur: inputOnBlur,
             onPaste: handlePaste,
             ref: ref as LegacyRef<HTMLInputElement>,
-            placeholder: '',
             label: label ?? '',
             step: props.type === 'int' ? 1 : undefined,
         };
@@ -156,7 +155,6 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
     const textareaProps = {
         ...standardProps,
         ref: refTextArea,
-        placeholder: '',
         onFocus: onFocusHTMLArea,
         onBlur: onBlurHTMLArea,
         value: fieldValue,
@@ -168,7 +166,7 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
                 {...textareaProps}
                 rows={hasFocus || (fieldValue !== undefined && fieldValue.toString().split('\n').length > 1) ? 4 : 1}
                 className={`rounded-md block px-2.5 pb-2 pt-4 w-full text-sm text-gray-900 bg-transparent border-1 border-gray-300 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-blue-500 focus:outline-none focus:ring-0 focus:border-blue-600 peer hover:border-gray-400 transition-colors ${className}`}
-                placeholder=''
+                placeholder=' '
             ></textarea>
 
             <label


### PR DESCRIPTION
I noticed when viewing the website on Safari that the labels for accession and the multi field search fields were displayed differently to the others. I asked Claude and this is because we had `placeholder` set to `''` rather than the default for the floating label which is  `' '`. Apparently, with `placeholder: ''`, chrome/firefox handle this differently to safari, but `placeholder: ' '` they all determine as 'placeholder text' and display the input correctly...

The placeholder  is just there for display and has no effect on queries. There are other components which still set `placeholder=''` (e.g. the `ComboboxInput` for the `MutationField`), but these dont' causing an issue.

The `placeholder` also existed as a prop but wasn't implemented, so I have added this.

### Screenshot

Before (on Safari):

<img width="311" height="413" alt="Screenshot 2026-05-13 at 11 24 19" src="https://github.com/user-attachments/assets/59f8b6d4-90cb-47ac-8531-5ddd1d13a0f4" />

After (on Safari):

<img width="311" height="413" alt="Screenshot 2026-05-13 at 11 24 00" src="https://github.com/user-attachments/assets/a2d89fbc-d35c-422d-af74-9572f89f746f" />



### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable