### PR TITLE
feat(website): auto-approve revocations after confirmation

### DIFF
--- a/docs/src/content/docs/for-users/revoke-sequences.md
+++ b/docs/src/content/docs/for-users/revoke-sequences.md
@@ -13,8 +13,6 @@ Revocation can only be done by members of the group that originally submitted th
 - Find the sequence you would like to revoke via searching the main database, or by viewing your submitted sequences.
   (Go to 'Submit' and 'View sequences').
 - Scroll to the bottom of the sequence page and find the 'Revoke this sequence' button in the bottom-left corner.
-- Confirm you want to revoke the sequence
-- You will be taken to the sequence review page - press 'Release' to release the revoked sequence
-- Confirm you want to release the sequence
+- Confirm you want to revoke the sequence.
 
 The sequence is now revoked.

--- a/integration-tests/tests/pages/search.page.ts
+++ b/integration-tests/tests/pages/search.page.ts
@@ -176,7 +176,7 @@ export class SearchPage {
         await this.page.getByPlaceholder('Enter reason for revocation').fill(revocationReason);
         await this.page.getByRole('button', { name: 'Confirm' }).click();
 
-        await expect(this.page.getByText('Sequence revoked successfully.')).toBeVisible();
+        await expect(this.page.getByText('Sequence revoked successfully. (This may take several minutes to become visible on the website.)')).toBeVisible();
     }
 
     async clickOnSequenceAndGetAccession(rowIndex = 0): Promise<string> {

--- a/integration-tests/tests/pages/search.page.ts
+++ b/integration-tests/tests/pages/search.page.ts
@@ -176,7 +176,7 @@ export class SearchPage {
         await this.page.getByPlaceholder('Enter reason for revocation').fill(revocationReason);
         await this.page.getByRole('button', { name: 'Confirm' }).click();
 
-        await expect(this.page.getByText('Sequence revoked successfully. (This may take several minutes to become visible on the website.)')).toBeVisible();
+        await expect(this.page.getByText('Sequence revoked successfully.')).toBeVisible();
     }
 
     async clickOnSequenceAndGetAccession(rowIndex = 0): Promise<string> {

--- a/integration-tests/tests/pages/search.page.ts
+++ b/integration-tests/tests/pages/search.page.ts
@@ -1,7 +1,6 @@
 import { type Locator, type Page, expect } from '@playwright/test';
 import { getFromLinkTargetAndAssertContent } from '../utils/link-helpers';
 import { EditPage } from './edit.page';
-import { ReviewPage } from './review.page';
 
 function makeAccessionVersion({
     accession,
@@ -172,12 +171,12 @@ export class SearchPage {
         await revokeButton.click();
 
         await expect(
-            this.page.getByText('Are you sure you want to create a revocation for this sequence?'),
+            this.page.getByText('Are you sure you want to revoke this sequence?'),
         ).toBeVisible();
         await this.page.getByPlaceholder('Enter reason for revocation').fill(revocationReason);
         await this.page.getByRole('button', { name: 'Confirm' }).click();
 
-        return new ReviewPage(this.page);
+        await expect(this.page.getByText('Sequence revoked successfully.')).toBeVisible();
     }
 
     async clickOnSequenceAndGetAccession(rowIndex = 0): Promise<string> {

--- a/integration-tests/tests/specs/features/multiseg-multiref-submission-flow.spec.ts
+++ b/integration-tests/tests/specs/features/multiseg-multiref-submission-flow.spec.ts
@@ -97,9 +97,6 @@ test.describe('Multi-segment multi-reference submission flow', () => {
         ).toBeVisible();
         await releasedPage.revokeSequence('revocation for integration test');
 
-        await reviewPage.waitForAllProcessed();
-        await reviewPage.releaseAndGoToReleasedSequences();
-
         await releasedPage.waitForAccessionVersionInSearch(firstAccessionVersion.accession, 2);
         await releasedPage.openPreviewOfAccessionVersion(`${firstAccessionVersion.accession}.2`);
         await expect(page.getByText(/This is a revocation version/)).toBeVisible();

--- a/integration-tests/tests/specs/features/search/override-hidden-fields.spec.ts
+++ b/integration-tests/tests/specs/features/search/override-hidden-fields.spec.ts
@@ -77,8 +77,11 @@ test('Override hidden fields', async ({ page, groupId }) => {
     await page.getByRole('cell', { name: 'Uganda' }).click();
     await page.getByRole('button', { name: 'Revoke this sequence' }).click();
     await page.getByRole('button', { name: 'Confirm' }).click();
+    await expect(page.getByText('Sequence revoked successfully.')).toBeVisible();
 
+    // The revocation is auto-approved; only the revision still needs to be released
     reviewPage = new ReviewPage(page);
+    await reviewPage.navigateToReviewPage();
     await reviewPage.waitForZeroProcessing();
     await reviewPage.releaseAndGoToReleasedSequences();
     while (!(await page.getByRole('cell', { name: '2012-12-13' }).isVisible())) {

--- a/integration-tests/tests/specs/features/sequence-version-banners.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-version-banners.spec.ts
@@ -97,13 +97,15 @@ test.describe('Sequence version banners', () => {
         const toRevokeId = await toRevokeLink.textContent();
         const toRevokeAccession = toRevokeId.split('.')[0];
 
-        // Click on the sequence and revoke it
+        // Click on the sequence and revoke it (auto-approves on confirmation)
         await page.getByRole('cell', { name: 'Germany' }).click();
         await page.getByRole('button', { name: 'Revoke this sequence' }).click();
         await page.getByRole('button', { name: 'Confirm' }).click();
+        await expect(page.getByText('Sequence revoked successfully.')).toBeVisible();
 
-        // Release the revision and revocation
+        // Release the revision (the revocation is already approved automatically)
         const reviewPage2 = new ReviewPage(page);
+        await reviewPage2.navigateToReviewPage();
         await reviewPage2.waitForZeroProcessing();
         await reviewPage2.releaseAndGoToReleasedSequences();
 

--- a/integration-tests/tests/specs/features/singleseg-multiref-submission-flow.spec.ts
+++ b/integration-tests/tests/specs/features/singleseg-multiref-submission-flow.spec.ts
@@ -70,9 +70,6 @@ test.describe('Single segment multi-reference submission flow', () => {
         await releasedPage.openPreviewOfAccessionVersion(firstAccessionVersion.accessionVersion);
         await releasedPage.revokeSequence('revocation for integration test');
 
-        await reviewPage.waitForAllProcessed();
-        await reviewPage.releaseAndGoToReleasedSequences();
-
         await releasedPage.waitForAccessionVersionInSearch(firstAccessionVersion.accession, 2);
         await releasedPage.openPreviewOfAccessionVersion(`${firstAccessionVersion.accession}.2`);
         await expect(page.getByText(/This is a revocation version/)).toBeVisible();

--- a/website/src/components/SearchPage/SeqPreviewModal.tsx
+++ b/website/src/components/SearchPage/SeqPreviewModal.tsx
@@ -93,6 +93,7 @@ export const SeqPreviewModal: React.FC<SeqPreviewModalProps> = ({
                         myGroups={myGroups}
                         accessToken={accessToken}
                         sequenceFlaggingConfig={data.isRevocation ? undefined : sequenceFlaggingConfig}
+                        onRevokeSuccess={onClose}
                     />
                 </div>
             ) : (

--- a/website/src/components/SequenceDetailsPage/RevokeButton.tsx
+++ b/website/src/components/SequenceDetailsPage/RevokeButton.tsx
@@ -2,8 +2,8 @@ import { type FC, useState } from 'react';
 import { confirmAlert } from 'react-confirm-alert';
 import { toast } from 'react-toastify';
 
-import { routes } from '../../routes/routes';
 import { backendClientHooks } from '../../services/serviceHooks';
+import { approveAllDataScope } from '../../types/backend';
 import type { ClientConfig } from '../../types/runtimeConfig';
 import { createAuthorizationHeader } from '../../utils/createAuthorizationHeader';
 import { stringifyMaybeAxiosError } from '../../utils/stringifyMaybeAxiosError';
@@ -18,6 +18,8 @@ type RevokeSequenceEntryProps = {
     groupId: number;
 };
 
+const REVOCATION_TOAST_ID = 'revocation-toast';
+
 const InnerRevokeButton: FC<RevokeSequenceEntryProps> = ({
     organism,
     accessToken,
@@ -26,24 +28,61 @@ const InnerRevokeButton: FC<RevokeSequenceEntryProps> = ({
     groupId,
 }) => {
     const hooks = backendClientHooks(clientConfig);
-    const useRevokeSequenceEntries = hooks.useRevokeSequences(
+
+    const useApproveProcessedData = hooks.useApproveProcessedData(
         {
             headers: createAuthorizationHeader(accessToken),
             params: { organism },
         },
         {
             onSuccess: () => {
-                document.location = routes.userSequenceReviewPage(organism, groupId);
+                toast.update(REVOCATION_TOAST_ID, {
+                    render: 'Sequence revoked successfully.',
+                    type: 'success',
+                    isLoading: false,
+                    autoClose: 4000,
+                });
             },
-            onError: (error) =>
-                toast.error(getRevokeSequenceEntryErrorMessage(error), {
-                    position: 'top-center',
+            onError: (error) => {
+                toast.update(REVOCATION_TOAST_ID, {
+                    render: getApproveRevocationErrorMessage(error),
+                    type: 'error',
+                    isLoading: false,
                     autoClose: false,
-                }),
+                });
+            },
+        },
+    );
+
+    const useRevokeSequenceEntries = hooks.useRevokeSequences(
+        {
+            headers: createAuthorizationHeader(accessToken),
+            params: { organism },
+        },
+        {
+            onSuccess: (data) => {
+                useApproveProcessedData.mutate({
+                    accessionVersionsFilter: data.map(({ accession, version }) => ({ accession, version })),
+                    groupIdsFilter: [groupId],
+                    scope: approveAllDataScope.value,
+                });
+            },
+            onError: (error) => {
+                toast.update(REVOCATION_TOAST_ID, {
+                    render: getRevokeSequenceEntryErrorMessage(error),
+                    type: 'error',
+                    isLoading: false,
+                    autoClose: false,
+                });
+            },
         },
     );
 
     const handleRevokeSequenceEntry = (inputValue: string) => {
+        toast.loading('Revoking sequence...', {
+            toastId: REVOCATION_TOAST_ID,
+            position: 'top-center',
+        });
         useRevokeSequenceEntries.mutate({ accessions: [accessionVersion], versionComment: inputValue });
     };
 
@@ -52,7 +91,7 @@ const InnerRevokeButton: FC<RevokeSequenceEntryProps> = ({
             className='btn btn-sm bg-red-400'
             onClick={() =>
                 displayRevocationDialog({
-                    dialogText: 'Are you sure you want to create a revocation for this sequence?',
+                    dialogText: 'Are you sure you want to revoke this sequence?',
                     onConfirmation: handleRevokeSequenceEntry,
                 })
             }
@@ -134,4 +173,8 @@ export const RevokeButton = withQueryProvider(InnerRevokeButton);
 
 function getRevokeSequenceEntryErrorMessage(error: unknown) {
     return 'Failed to revoke sequence entry: ' + stringifyMaybeAxiosError(error);
+}
+
+function getApproveRevocationErrorMessage(error: unknown) {
+    return 'Failed to approve revocation: ' + stringifyMaybeAxiosError(error);
 }

--- a/website/src/components/SequenceDetailsPage/RevokeButton.tsx
+++ b/website/src/components/SequenceDetailsPage/RevokeButton.tsx
@@ -39,7 +39,7 @@ const InnerRevokeButton: FC<RevokeSequenceEntryProps> = ({
         {
             onSuccess: () => {
                 toast.update(REVOCATION_TOAST_ID, {
-                    render: 'Sequence revoked successfully. (This may take several minutes to become visible on the website.)',
+                    render: 'Sequence revoked successfully. This may take several minutes to become visible on the website.',
                     type: 'success',
                     isLoading: false,
                     autoClose: 4000,

--- a/website/src/components/SequenceDetailsPage/RevokeButton.tsx
+++ b/website/src/components/SequenceDetailsPage/RevokeButton.tsx
@@ -16,6 +16,7 @@ type RevokeSequenceEntryProps = {
     clientConfig: ClientConfig;
     accessionVersion: string;
     groupId: number;
+    onRevokeSuccess?: () => void;
 };
 
 const REVOCATION_TOAST_ID = 'revocation-toast';
@@ -26,6 +27,7 @@ const InnerRevokeButton: FC<RevokeSequenceEntryProps> = ({
     clientConfig,
     accessionVersion,
     groupId,
+    onRevokeSuccess,
 }) => {
     const hooks = backendClientHooks(clientConfig);
 
@@ -42,6 +44,7 @@ const InnerRevokeButton: FC<RevokeSequenceEntryProps> = ({
                     isLoading: false,
                     autoClose: 4000,
                 });
+                onRevokeSuccess?.();
             },
             onError: (error) => {
                 toast.update(REVOCATION_TOAST_ID, {

--- a/website/src/components/SequenceDetailsPage/RevokeButton.tsx
+++ b/website/src/components/SequenceDetailsPage/RevokeButton.tsx
@@ -39,7 +39,7 @@ const InnerRevokeButton: FC<RevokeSequenceEntryProps> = ({
         {
             onSuccess: () => {
                 toast.update(REVOCATION_TOAST_ID, {
-                    render: 'Sequence revoked successfully.',
+                    render: 'Sequence revoked successfully. (This may take several minutes to become visible on the website.)',
                     type: 'success',
                     isLoading: false,
                     autoClose: 4000,

--- a/website/src/components/SequenceDetailsPage/SequenceDataUI.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceDataUI.tsx
@@ -30,6 +30,7 @@ interface Props {
     sequenceFlaggingConfig: SequenceFlaggingConfig | undefined;
     referenceGenomesInfo: ReferenceGenomesInfo;
     isRevocation?: boolean;
+    onRevokeSuccess?: () => void;
 }
 
 export const SequenceDataUI: FC<Props> = ({
@@ -45,6 +46,7 @@ export const SequenceDataUI: FC<Props> = ({
     sequenceFlaggingConfig,
     referenceGenomesInfo,
     isRevocation,
+    onRevokeSuccess,
 }: Props) => {
     const groupId = tableData.find((entry) => entry.name === 'groupId')!.value as number;
 
@@ -118,6 +120,7 @@ export const SequenceDataUI: FC<Props> = ({
                                 accessionVersion={accessionVersion.split('.')[0]}
                                 accessToken={accessToken}
                                 groupId={groupId}
+                                onRevokeSuccess={onRevokeSuccess}
                             />
                         </div>
                     </div>


### PR DESCRIPTION
## Summary

Closes #1332.

When a user clicks **Revoke this sequence**, fills in the reason and confirms, the website now automatically approves the freshly-created revocation entry instead of dropping the user on the review page to release it manually.

The previous flow had a confusing semantic: confirming "Are you sure you want to create a revocation for this sequence?" did not actually revoke the sequence — it just queued a revocation entry awaiting release. Users reasonably expected that clicking "Yes" meant the sequence would be revoked.

### Behavioural change

- Revoke button confirmation dialog text changed from "Are you sure you want to create a revocation for this sequence?" to "Are you sure you want to revoke this sequence?"
- On confirmation, the website now:
  1. Shows a "Revoking sequence..." loading toast
  2. Calls `POST /{organism}/revoke` (same as before)
  3. Immediately chains a `POST /{organism}/approve-processed-data` call for the new revocation version
  4. Updates the toast to "Sequence revoked successfully." on success, or to an error message if either call fails
- No more redirect to the review page — the user stays on the page they were on (the revocation will start showing the "revoked" banner once LAPIS has re-indexed)

The backend is not touched: the existing `/approve-processed-data` endpoint already handles revocation entries, since revocation versions are inserted with `PROCESSED` status and approval just moves them to `APPROVED_FOR_RELEASE`.

### Files

- `website/src/components/SequenceDetailsPage/RevokeButton.tsx` — chain the approve mutation in the revoke `onSuccess` handler; switch to a single updating toast.
- `docs/src/content/docs/for-users/revoke-sequences.md` — drop the manual release step from the user docs.
- `integration-tests/tests/pages/search.page.ts` — `revokeSequence` now waits for the success toast instead of returning a `ReviewPage`.
- `integration-tests/tests/specs/features/{singleseg-multiref,multiseg-multiref}-submission-flow.spec.ts` — drop the manual `waitForAllProcessed`/`releaseAndGoToReleasedSequences` step after revoke.
- `integration-tests/tests/specs/features/sequence-version-banners.spec.ts`, `.../search/override-hidden-fields.spec.ts` — for the mixed revise+revoke tests, navigate to the review page explicitly because only the revision (not the revocation) still needs to be released.

## Test plan

- [ ] Local unit tests pass (`CI=1 npm run test`) ✅ verified locally — 60 files / 652 tests pass
- [ ] Type checks pass (`npm run check-types`) ✅ verified locally
- [ ] Format passes (`npm run format`) ✅ verified locally
- [ ] CI green
- [ ] Manual: revoke a released sequence in dev — confirm success toast appears and the revocation shows up in released sequences once indexed (without going through the review page)

🚀 Preview: https://auto-approve-revocation.loculus.org