### PR TITLE
fix(website): improve revocation banner placement and wording

### DIFF
--- a/website/src/components/SequenceDetailsPage/SequencesBanner.tsx
+++ b/website/src/components/SequenceDetailsPage/SequencesBanner.tsx
@@ -39,7 +39,7 @@ const SequencesBanner: FC<SequencesBannerProps> = ({ sequenceEntryHistory, acces
             {ownHistoryEntry?.isRevocation && (
                 <div className='bg-red-100 border-l-4 border-red-500 text-red-700 p-3' role='alert'>
                     <p className='font-bold'>
-                        This is a revocation version. It essentially contains no data, it's just a marker that all
+                        This is a revocation version. It essentially contains no data: it is just a marker that all
                         previous versions have been revoked.
                     </p>
                 </div>

--- a/website/src/pages/seq/[accessionVersion]/index.astro
+++ b/website/src/pages/seq/[accessionVersion]/index.astro
@@ -43,17 +43,6 @@ const sequenceFlaggingConfig = getWebsiteConfig().sequenceFlagging;
     implicitOrganism={sequenceDetailsTableData.isOk() ? sequenceDetailsTableData.value.organism : undefined}
 >
     {
-        sequenceDetailsTableData.isOk() &&
-            sequenceDetailsTableData.value.result.type === SequenceDetailsTableResultType.TABLE_DATA && (
-                <div slot='banner'>
-                    <SequencesBanner
-                        sequenceEntryHistory={sequenceDetailsTableData.value.result.sequenceEntryHistory}
-                        accessionVersion={accessionVersion}
-                    />
-                </div>
-            )
-    }
-    {
         sequenceDetailsTableData.match(
             ({ organism, result }) => {
                 const showDownloadAndReport =
@@ -72,6 +61,12 @@ const sequenceFlaggingConfig = getWebsiteConfig().sequenceFlagging;
                                 showDownloadAndReport && getSegmentNames(getReferenceGenomes(organism)).length > 0
                             }
                         />
+                        {result.type === SequenceDetailsTableResultType.TABLE_DATA && (
+                            <SequencesBanner
+                                sequenceEntryHistory={result.sequenceEntryHistory}
+                                accessionVersion={accessionVersion}
+                            />
+                        )}
                         {result.type === SequenceDetailsTableResultType.TABLE_DATA &&
                             (result.isRevocation ? (
                                 <RevocationEntryDataTable


### PR DESCRIPTION
## Summary

Addresses #6425.

- Move the version/revocation banner from the page-level banner slot (which sits above the page header area) into the sequence entry's main content, just below the accession title. The banner now reads as part of the entry it describes rather than as a top-of-page notice.
- Fix the ungrammatical sentence on revocation versions:
  - Before: *"It essentially contains no data, it's just a marker that all previous versions have been revoked."*
  - After: *"It essentially contains no data: it is just a marker that all previous versions have been revoked."*

The leading sentence ("This is a revocation version.") is unchanged, so existing Playwright assertions that look for that text continue to pass.

## Test plan

- [x] `CI=1 npm run test` (website unit tests)
- [x] `npm run check-types`
- [x] `npm run format`
- [ ] Manual check: visit a revoked accession page; banner appears below the accession header within the content column
- [ ] Manual check: visit a non-latest version page; "not the latest version" banner appears below the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable