### PR TITLE
fix(website): Make custom tooltips clickable on mobile

### DIFF
--- a/website/src/components/SearchPage/fields/MultiFieldSearchField.tsx
+++ b/website/src/components/SearchPage/fields/MultiFieldSearchField.tsx
@@ -22,7 +22,6 @@ export const MultiFieldSearchField = ({
     filterSchema,
 }: MultiFieldSearchFieldProps) => {
     const tooltipId = useId();
-    const isTouchOnly = typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
 
     return (
         <div className='relative'>
@@ -40,13 +39,7 @@ export const MultiFieldSearchField = ({
                     <MaterialSymbolsHelpOutline className='inline-block h-6 w-5' />
                 </Button>
             </div>
-            <CustomTooltip
-                id={tooltipId}
-                place='top'
-                openEvents={{ mouseenter: !isTouchOnly, focus: false, click: true }}
-                closeEvents={{ mouseleave: !isTouchOnly, blur: true, click: true }}
-                globalCloseEvents={{ clickOutsideAnchor: true, scroll: true }}
-            >
+            <CustomTooltip id={tooltipId} place='top'>
                 <p className='mb-1'>Search across the following fields:</p>
                 <ul className='list-disc list-inside'>
                     {multiFieldSearch.fields.map((field) => (

--- a/website/src/components/SearchPage/fields/MultiFieldSearchField.tsx
+++ b/website/src/components/SearchPage/fields/MultiFieldSearchField.tsx
@@ -42,7 +42,7 @@ export const MultiFieldSearchField = ({
             <CustomTooltip
                 id={tooltipId}
                 place='top'
-                openEvents={{ mouseenter: true, focus: true, click: true }}
+                openEvents={{ mouseenter: true, focus: false, click: true }}
                 closeEvents={{ mouseleave: true, blur: true, click: true }}
                 globalCloseEvents={{ clickOutsideAnchor: true }}
             >

--- a/website/src/components/SearchPage/fields/MultiFieldSearchField.tsx
+++ b/website/src/components/SearchPage/fields/MultiFieldSearchField.tsx
@@ -5,7 +5,6 @@ import type { MultiFieldSearch, SetSomeFieldValues } from '../../../types/config
 import { CustomTooltip } from '../../../utils/CustomTooltip';
 import type { MetadataFilterSchema } from '../../../utils/search.ts';
 import DisabledUntilHydrated from '../../DisabledUntilHydrated';
-import { Button } from '../../common/Button.tsx';
 import MaterialSymbolsHelpOutline from '~icons/material-symbols/help-outline';
 
 export interface MultiFieldSearchFieldProps {
@@ -35,9 +34,9 @@ export const MultiFieldSearchField = ({
                 />
             </DisabledUntilHydrated>
             <div className='absolute top-1/2 -translate-y-1/3 right-1.5'>
-                <Button data-tooltip-id={tooltipId} className='text-gray-400 hover:text-primary-600 inline-flex'>
+                <span data-tooltip-id={tooltipId} className='text-gray-400 hover:text-primary-600 inline-flex'>
                     <MaterialSymbolsHelpOutline className='inline-block h-6 w-5' />
-                </Button>
+                </span>
             </div>
             <CustomTooltip id={tooltipId} place='top'>
                 <p className='mb-1'>Search across the following fields:</p>

--- a/website/src/components/SearchPage/fields/MultiFieldSearchField.tsx
+++ b/website/src/components/SearchPage/fields/MultiFieldSearchField.tsx
@@ -5,6 +5,7 @@ import type { MultiFieldSearch, SetSomeFieldValues } from '../../../types/config
 import { CustomTooltip } from '../../../utils/CustomTooltip';
 import type { MetadataFilterSchema } from '../../../utils/search.ts';
 import DisabledUntilHydrated from '../../DisabledUntilHydrated';
+import { Button } from '../../common/Button.tsx';
 import MaterialSymbolsHelpOutline from '~icons/material-symbols/help-outline';
 
 export interface MultiFieldSearchFieldProps {
@@ -33,10 +34,13 @@ export const MultiFieldSearchField = ({
                     autoComplete='off'
                 />
             </DisabledUntilHydrated>
-            <div className='absolute top-1/2 -translate-y-1/3 right-1.5'>
-                <span data-tooltip-id={tooltipId} className='text-gray-400 hover:text-primary-600 inline-flex'>
+            <div className='absolute top-1/2 -translate-y-1/3 right-0'>
+                <Button
+                    data-tooltip-id={tooltipId}
+                    className='text-gray-400 hover:text-primary-600 inline-flex cursor-default px-2'
+                >
                     <MaterialSymbolsHelpOutline className='inline-block h-6 w-5' />
-                </span>
+                </Button>
             </div>
             <CustomTooltip id={tooltipId} place='top'>
                 <p className='mb-1'>Search across the following fields:</p>

--- a/website/src/components/SearchPage/fields/MultiFieldSearchField.tsx
+++ b/website/src/components/SearchPage/fields/MultiFieldSearchField.tsx
@@ -42,6 +42,7 @@ export const MultiFieldSearchField = ({
             <CustomTooltip
                 id={tooltipId}
                 place='top'
+                delayShow={200}
                 openEvents={{ mouseenter: true, focus: false, click: true }}
                 closeEvents={{ mouseleave: true, blur: true, click: true }}
                 globalCloseEvents={{ clickOutsideAnchor: true, scroll: true }}

--- a/website/src/components/SearchPage/fields/MultiFieldSearchField.tsx
+++ b/website/src/components/SearchPage/fields/MultiFieldSearchField.tsx
@@ -22,6 +22,7 @@ export const MultiFieldSearchField = ({
     filterSchema,
 }: MultiFieldSearchFieldProps) => {
     const tooltipId = useId();
+    const isTouchOnly = typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
 
     return (
         <div className='relative'>
@@ -42,9 +43,8 @@ export const MultiFieldSearchField = ({
             <CustomTooltip
                 id={tooltipId}
                 place='top'
-                delayShow={200}
-                openEvents={{ mouseenter: true, focus: false, click: true }}
-                closeEvents={{ mouseleave: true, blur: true, click: true }}
+                openEvents={{ mouseenter: !isTouchOnly, focus: false, click: true }}
+                closeEvents={{ mouseleave: !isTouchOnly, blur: true, click: true }}
                 globalCloseEvents={{ clickOutsideAnchor: true, scroll: true }}
             >
                 <p className='mb-1'>Search across the following fields:</p>

--- a/website/src/components/SearchPage/fields/MultiFieldSearchField.tsx
+++ b/website/src/components/SearchPage/fields/MultiFieldSearchField.tsx
@@ -5,6 +5,7 @@ import type { MultiFieldSearch, SetSomeFieldValues } from '../../../types/config
 import { CustomTooltip } from '../../../utils/CustomTooltip';
 import type { MetadataFilterSchema } from '../../../utils/search.ts';
 import DisabledUntilHydrated from '../../DisabledUntilHydrated';
+import { Button } from '../../common/Button.tsx';
 import MaterialSymbolsHelpOutline from '~icons/material-symbols/help-outline';
 
 export interface MultiFieldSearchFieldProps {
@@ -34,11 +35,17 @@ export const MultiFieldSearchField = ({
                 />
             </DisabledUntilHydrated>
             <div className='absolute top-1/2 -translate-y-1/3 right-1.5'>
-                <span data-tooltip-id={tooltipId} className='text-gray-400 hover:text-primary-600 inline-flex'>
+                <Button data-tooltip-id={tooltipId} className='text-gray-400 hover:text-primary-600 inline-flex'>
                     <MaterialSymbolsHelpOutline className='inline-block h-6 w-5' />
-                </span>
+                </Button>
             </div>
-            <CustomTooltip id={tooltipId} place='top'>
+            <CustomTooltip
+                id={tooltipId}
+                place='top'
+                openEvents={{ mouseenter: true, focus: true, click: true }}
+                closeEvents={{ mouseleave: true, blur: true, click: true }}
+                globalCloseEvents={{ clickOutsideAnchor: true }}
+            >
                 <p className='mb-1'>Search across the following fields:</p>
                 <ul className='list-disc list-inside'>
                     {multiFieldSearch.fields.map((field) => (

--- a/website/src/components/SearchPage/fields/MultiFieldSearchField.tsx
+++ b/website/src/components/SearchPage/fields/MultiFieldSearchField.tsx
@@ -44,7 +44,7 @@ export const MultiFieldSearchField = ({
                 place='top'
                 openEvents={{ mouseenter: true, focus: false, click: true }}
                 closeEvents={{ mouseleave: true, blur: true, click: true }}
-                globalCloseEvents={{ clickOutsideAnchor: true }}
+                globalCloseEvents={{ clickOutsideAnchor: true, scroll: true }}
             >
                 <p className='mb-1'>Search across the following fields:</p>
                 <ul className='list-disc list-inside'>

--- a/website/src/utils/CustomTooltip.tsx
+++ b/website/src/utils/CustomTooltip.tsx
@@ -1,12 +1,19 @@
 import type { ComponentProps, FC } from 'react';
 import { Tooltip } from 'react-tooltip';
 
-export const CustomTooltip: FC<ComponentProps<typeof Tooltip>> = ({ className, ...props }) => (
+export const CustomTooltip: FC<ComponentProps<typeof Tooltip>> = ({ className, ...props }) => {
+    const isTouchOnly = typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
+
     // Set positionStrategy and z-index to make the Tooltip float above the ReviewPage toolbar
-    <Tooltip
-        positionStrategy='fixed'
-        place='right'
-        className={`z-20 max-w-sm whitespace-pre-wrap break-words ${className ?? ''}`}
-        {...props}
-    />
-);
+    return (
+        <Tooltip
+            positionStrategy='fixed'
+            place='right'
+            className={`z-20 max-w-sm whitespace-pre-wrap break-words ${className ?? ''}`}
+            openEvents={{ mouseenter: !isTouchOnly, click: isTouchOnly, focus: false }}
+            closeEvents={{ mouseleave: !isTouchOnly, click: isTouchOnly, blur: true }}
+            globalCloseEvents={{ clickOutsideAnchor: true, scroll: true }}
+            {...props}
+        />
+    );
+};


### PR DESCRIPTION
- Updates the `CustomTooltip` component to be clickable on touchscreen only, and hover-able otherwise.
- This PR was opened because I noticed the tooltip for multi field search and the date range field was not clickable on mobile, and sometimes flickered into view, due to being triggered by the hovering event.

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable