### PR TITLE
Mirror mpox parent taxon (3431483) in priority-1

### DIFF
--- a/.github/workflows/datasets-mirror-priority-1.yml
+++ b/.github/workflows/datasets-mirror-priority-1.yml
@@ -18,6 +18,7 @@ jobs:
           - 3052462  # Orthoebolavirus zairense
           - 3052505  # Orthomarburgvirus marburgense
           - 3052518  # CCHFV
+          - 3431483  # Mpox (parent taxon)
       fail-fast: false
     uses: ./.github/workflows/datasets-mirror.yml
     secrets: inherit

--- a/.github/workflows/datasets-mirror-priority-1.yml
+++ b/.github/workflows/datasets-mirror-priority-1.yml
@@ -18,7 +18,7 @@ jobs:
           - 3052462  # Orthoebolavirus zairense
           - 3052505  # Orthomarburgvirus marburgense
           - 3052518  # CCHFV
-          - 3431483  # Mpox (parent taxon)
+          - 3431483  # Mpox (parental taxon)
       fail-fast: false
     uses: ./.github/workflows/datasets-mirror.yml
     secrets: inherit


### PR DESCRIPTION
## Summary
- Adds mpox parent taxon `3431483` to the priority-1 NCBI datasets mirror.

## Context
Pathoplexus is switching its mpox ingest from taxon `10244` to the parent taxon `3431483` (see pathoplexus/pathoplexus#947). Anna flagged that the new taxon needs to be present in the loculus mirror before pathoplexus can use it. This PR adds the new taxon to the priority-1 schedule alongside the existing entry.

## Test plan
- [ ] Manually trigger `Mirror NCBI Datasets (Priority 1 - Every 2 Hours)` and confirm the `3431483` matrix job succeeds and uploads to S3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable