### PR TITLE
fix(deployment): restart keycloak on every deploy when dev DB is wiped

### DIFF
--- a/kubernetes/loculus/templates/keycloak-deployment.yaml
+++ b/kubernetes/loculus/templates/keycloak-deployment.yaml
@@ -14,6 +14,10 @@ spec:
       component: keycloak
   template:
     metadata:
+      {{- if and .Values.runDevelopmentKeycloakDatabase (not .Values.developmentDatabasePersistence) }}
+      annotations:
+        timestamp: {{ now | quote }}
+      {{- end }}
       labels:
         app: loculus
         component: keycloak


### PR DESCRIPTION
## Summary

Closes #6431.

Preview/dev deployments reset the Keycloak DB on every Helm sync — the `loculus-keycloak-database` pod has a `timestamp: {{ now }}` annotation, and (when `developmentDatabasePersistence: false`) no PVC, so its data is lost whenever the pod is recreated.

The Keycloak pod itself was only restarted when the docker tag changed (via the `LOCULUS_VERSION` env var added in #4720). So a redeploy with the same image tag (e.g. a config-only sync, or two argo syncs of the same commit) would wipe the DB without restarting Keycloak. Keycloak then ran on with internal/in-memory state pointing at rows that no longer existed, producing the `Unexpected error when handling authentication request to identity provider` errors.

### Fix

Add a `timestamp: {{ now }}` annotation to the Keycloak pod template, **gated on `runDevelopmentKeycloakDatabase && !developmentDatabasePersistence`** — so the Keycloak Deployment rolls every sync, exactly when its DB is going to be wiped.

We deliberately do **not** restart Keycloak unconditionally — #4326 removed an unconditional timestamp here because it was rolling Keycloak every 24h in production and logging everyone out. The new condition only fires for ephemeral dev/preview DBs, never for prod or for persistent dev DBs.

| `runDevelopmentKeycloakDatabase` | `developmentDatabasePersistence` | Keycloak restart on each sync? |
|---|---|---|
| `false` (prod) | n/a | No (unchanged) |
| `true` | `true` (persistent PVC) | No (data survives) |
| `true` | `false` (ephemeral, default for previews) | **Yes (new)** |


🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable