### PR TITLE
fix(website): increase vertical spacing between search filter fields

### DIFF
--- a/website/src/components/SearchPage/fields/FloatingLabelContainer.tsx
+++ b/website/src/components/SearchPage/fields/FloatingLabelContainer.tsx
@@ -40,7 +40,7 @@ export const FloatingLabelContainer: React.FC<FloatingLabelContainerProps> = ({
     const borderClasses = borderClassName ?? (isFocused ? 'border-blue-600' : 'border-gray-300 hover:border-gray-400');
 
     return (
-        <div className='relative my-2'>
+        <div className='relative my-1.5'>
             <div
                 className={`relative flex flex-wrap items-center rounded-md cursor-text transition-colors bg-white min-h-[52px] border ${borderClasses} ${className}`}
                 onClick={onClick}

--- a/website/src/components/SearchPage/fields/FloatingLabelContainer.tsx
+++ b/website/src/components/SearchPage/fields/FloatingLabelContainer.tsx
@@ -40,7 +40,7 @@ export const FloatingLabelContainer: React.FC<FloatingLabelContainerProps> = ({
     const borderClasses = borderClassName ?? (isFocused ? 'border-blue-600' : 'border-gray-300 hover:border-gray-400');
 
     return (
-        <div className='relative my-1'>
+        <div className='relative my-2'>
             <div
                 className={`relative flex flex-wrap items-center rounded-md cursor-text transition-colors bg-white min-h-[52px] border ${borderClasses} ${className}`}
                 onClick={onClick}

--- a/website/src/components/SearchPage/fields/TextField.tsx
+++ b/website/src/components/SearchPage/fields/TextField.tsx
@@ -127,7 +127,7 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
         };
 
         return (
-            <div className='[&_label]:pointer-events-none my-2'>
+            <div className='[&_label]:pointer-events-none my-1.5'>
                 <FloatingLabel
                     theme={{
                         helperText: {

--- a/website/src/components/SearchPage/fields/TextField.tsx
+++ b/website/src/components/SearchPage/fields/TextField.tsx
@@ -127,7 +127,7 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
         };
 
         return (
-            <div className='[&_label]:pointer-events-none'>
+            <div className='[&_label]:pointer-events-none my-2'>
                 <FloatingLabel
                     theme={{
                         helperText: {
@@ -164,7 +164,7 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
     };
 
     return (
-        <div className='relative my-1'>
+        <div className='relative my-2'>
             <textarea
                 {...textareaProps}
                 rows={hasFocus || (fieldValue !== undefined && fieldValue.toString().split('\n').length > 1) ? 4 : 1}


### PR DESCRIPTION
## Summary

Fixes #6439. The floating labels on stacked search filter fields were rendered too close to the field above, so when a field below was filled in, its floating label visually overlapped the bottom border of the field above.
<img width="266" height="124" alt="image" src="https://github.com/user-attachments/assets/64e2f19a-1d0d-40d5-bf8d-df473b4bf605" />

🚀 Preview: https://fix-website-search-field.loculus.org