### PR TITLE
Add dengue and yellow fever to priority-1 NCBI mirror

### DIFF
--- a/.github/workflows/datasets-mirror-priority-1.yml
+++ b/.github/workflows/datasets-mirror-priority-1.yml
@@ -11,11 +11,13 @@ jobs:
           - 10244    # Mpox
           - 1868215  # Orthopneumovirus
           - 1980456  # Andes virus
+          - 3046277  # Yellow fever virus
           - 3048148  # Metapneumovirus hominis
           - 3048448  # West nile virus
           - 3052345  # Morbillivirus hominis
           - 3052460  # Orthoebolavirus sudanense
           - 3052462  # Orthoebolavirus zairense
+          - 3052464  # Dengue virus
           - 3052505  # Orthomarburgvirus marburgense
           - 3052518  # CCHFV
           - 3431483  # Mpox (parental taxon)

--- a/.github/workflows/datasets-mirror-priority-1.yml
+++ b/.github/workflows/datasets-mirror-priority-1.yml
@@ -11,13 +11,13 @@ jobs:
           - 10244    # Mpox
           - 1868215  # Orthopneumovirus
           - 1980456  # Andes virus
-          - 3046277  # Yellow fever virus
+          - 3046277  # Orthoflavivirus flavi
           - 3048148  # Metapneumovirus hominis
           - 3048448  # West nile virus
           - 3052345  # Morbillivirus hominis
           - 3052460  # Orthoebolavirus sudanense
           - 3052462  # Orthoebolavirus zairense
-          - 3052464  # Dengue virus
+          - 3052464  # Orthoflavivirus denguei
           - 3052505  # Orthomarburgvirus marburgense
           - 3052518  # CCHFV
           - 3431483  # Mpox (parental taxon)


### PR DESCRIPTION
## Summary

- Adds dengue (`3052464`) and yellow fever (`3046277`) to the priority-1 NCBI Datasets mirror schedule (every 2 hours).

## Context

Requested via pathoplexus/pathoplexus#950, which updates the Pathoplexus INSDC ingest taxon IDs to these current NCBI species-level parent nodes:

- dengue: `12637` -> `3052464`
- yellow-fever: `11089` -> `3046277`

Mirroring them at priority 1 keeps the ingest fed by the mirror bucket on the higher-frequency schedule.

Note: the legacy dengue id `12637` is still present in `datasets-mirror-priority-2.yml`; it can be dropped separately once nothing depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable