### PR TITLE
Mirror Bundibugyo taxon in priority 1

### DIFF
--- a/.github/workflows/datasets-mirror-priority-1.yml
+++ b/.github/workflows/datasets-mirror-priority-1.yml
@@ -14,6 +14,7 @@ jobs:
           - 3048148  # Metapneumovirus hominis
           - 3048448  # West nile virus
           - 3052345  # Morbillivirus hominis
+          - 3052458  # Orthoebolavirus bundibugyoense
           - 3052460  # Orthoebolavirus sudanense
           - 3052462  # Orthoebolavirus zairense
           - 3052505  # Orthomarburgvirus marburgense


### PR DESCRIPTION
## Summary
- Adds Bundibugyo species taxon `3052458` to the priority-1 NCBI datasets mirror.

## Context
Pathoplexus is adding an `ebola-bdbv` organism that ingests `Orthoebolavirus bundibugyoense` (`3052458`). This makes the corresponding NCBI datasets package available in the priority-1 mirror bucket before Pathoplexus uses it.

## Test plan
- Parsed `.github/workflows/datasets-mirror-priority-1.yml` with Python/YAML.
- Confirmed `3052458` appears once in the priority-1 taxon matrix.

🚀 Preview: Add `preview` label to enable