### PR TITLE
Address original data download review comments

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -328,6 +328,24 @@ data class AccessionVersionOriginalMetadata(
     val originalMetadata: Map<String, String?>?,
 ) : AccessionVersionInterface
 
+data class GetOriginalDataRequest(
+    @Schema(
+        description = "The group ID to download data for.",
+        required = true,
+    )
+    val groupId: Int,
+    @Schema(
+        description = "Filter by specific accessions. If not provided, all accessions for the group are returned.",
+    )
+    val accessionsFilter: List<Accession>? = null,
+)
+
+data class OriginalDataResponse(
+    override val accession: Accession,
+    override val version: Version,
+    val originalData: OriginalData<GeneticSequence>,
+) : AccessionVersionInterface
+
 enum class Status {
     @JsonProperty("RECEIVED")
     RECEIVED,

--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -331,7 +331,6 @@ data class AccessionVersionOriginalMetadata(
 data class GetOriginalDataRequest(
     @Schema(
         description = "The group ID to download data for.",
-        required = true,
     )
     val groupId: Int,
     @Schema(
@@ -343,6 +342,7 @@ data class GetOriginalDataRequest(
 data class OriginalDataResponse(
     override val accession: Accession,
     override val version: Version,
+    val submissionId: String,
     val originalData: OriginalData<GeneticSequence>,
 ) : AccessionVersionInterface
 

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -443,7 +443,6 @@ open class SubmissionController(
             organism,
             groupIdsFilter?.takeIf { it.isNotEmpty() },
             statusesFilter?.takeIf { it.isNotEmpty() },
-            null,
         )
         headers.add(X_TOTAL_RECORDS, totalRecords.toString())
         // TODO(https://github.com/loculus-project/loculus/issues/2778)
@@ -459,7 +458,6 @@ open class SubmissionController(
                 groupIdsFilter?.takeIf { it.isNotEmpty() },
                 statusesFilter?.takeIf { it.isNotEmpty() },
                 fields?.takeIf { it.isNotEmpty() },
-                null,
             )
         }
 
@@ -481,9 +479,10 @@ open class SubmissionController(
         @HiddenParam authenticatedUser: AuthenticatedUser,
         @RequestBody body: GetOriginalDataRequest,
     ): ResponseEntity<StreamingResponseBody> {
+        groupManagementPreconditionValidator.validateUserIsAllowedToModifyGroup(body.groupId, authenticatedUser)
+
         val entryCount = transaction {
             submissionDatabaseService.countOriginalData(
-                authenticatedUser,
                 organism,
                 body.groupId,
                 body.accessionsFilter,
@@ -518,7 +517,6 @@ open class SubmissionController(
                 java.util.zip.ZipOutputStream(responseBodyStream).use { zipOut ->
                     transaction {
                         val data = submissionDatabaseService.streamOriginalData(
-                            authenticatedUser,
                             organism,
                             body.groupId,
                             body.accessionsFilter,
@@ -535,17 +533,16 @@ open class SubmissionController(
                         }
                     }
                 }
+                val duration = System.currentTimeMillis() - startTime
+                log.info { "[get-original-data] Completed in ${duration}ms" }
             } catch (e: Exception) {
                 val duration = System.currentTimeMillis() - startTime
                 log.error(e) { "[get-original-data] Error after ${duration}ms: $e" }
                 throw e
+            } finally {
+                MDC.remove(REQUEST_ID_MDC_KEY)
+                MDC.remove(ORGANISM_MDC_KEY)
             }
-
-            val duration = System.currentTimeMillis() - startTime
-            log.info { "[get-original-data] Completed in ${duration}ms" }
-
-            MDC.remove(REQUEST_ID_MDC_KEY)
-            MDC.remove(ORGANISM_MDC_KEY)
         }
 
         return ResponseEntity(streamBody, headers, HttpStatus.OK)
@@ -556,7 +553,7 @@ open class SubmissionController(
         outputStream: java.io.OutputStream,
         isMultiSegmented: Boolean,
     ) {
-        val metadataKeys = data.flatMap { it.originalData.metadata.keys }.toSet().sorted()
+        val metadataKeys = data.flatMapTo(mutableSetOf()) { it.originalData.metadata.keys }.sorted()
         val headers = if (isMultiSegmented) {
             listOf("id", "accession", "fastaIds") + metadataKeys
         } else {
@@ -565,11 +562,10 @@ open class SubmissionController(
 
         TsvWriter(outputStream, headers).use { writer ->
             for (entry in data) {
-                val id = "${entry.accession}.${entry.version}"
+                val id = entry.submissionId
                 val metadataValues = metadataKeys.map { entry.originalData.metadata[it] ?: "" }
                 val row = if (isMultiSegmented) {
                     val fastaIds = entry.originalData.unalignedNucleotideSequences.keys
-                        .map { originalFastaId -> "$id|$originalFastaId" }
                         .joinToString(" ")
                     listOf(id, entry.accession, fastaIds) + metadataValues
                 } else {
@@ -587,10 +583,9 @@ open class SubmissionController(
     ) {
         FastaWriter(outputStream).use { writer ->
             for (entry in data) {
-                val id = "${entry.accession}.${entry.version}"
                 for ((originalFastaId, sequence) in entry.originalData.unalignedNucleotideSequences) {
                     if (sequence != null) {
-                        val header = if (isMultiSegmented) "$id|$originalFastaId" else id
+                        val header = if (isMultiSegmented) originalFastaId else entry.submissionId
                         writer.write(FastaEntry(header, sequence))
                     }
                 }

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -479,10 +479,9 @@ open class SubmissionController(
         @HiddenParam authenticatedUser: AuthenticatedUser,
         @RequestBody body: GetOriginalDataRequest,
     ): ResponseEntity<StreamingResponseBody> {
-        groupManagementPreconditionValidator.validateUserIsAllowedToModifyGroup(body.groupId, authenticatedUser)
-
         val entryCount = transaction {
             submissionDatabaseService.countOriginalData(
+                authenticatedUser,
                 organism,
                 body.groupId,
                 body.accessionsFilter,
@@ -517,6 +516,7 @@ open class SubmissionController(
                 java.util.zip.ZipOutputStream(responseBodyStream).use { zipOut ->
                     transaction {
                         val data = submissionDatabaseService.streamOriginalData(
+                            authenticatedUser,
                             organism,
                             body.groupId,
                             body.accessionsFilter,

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -13,6 +13,8 @@ import org.jetbrains.exposed.sql.JoinType
 import org.jetbrains.exposed.sql.LongColumnType
 import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.inList
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.less
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.plus
 import org.jetbrains.exposed.sql.Transaction
@@ -52,6 +54,7 @@ import org.loculus.backend.api.FileIdAndNameAndReadUrl
 import org.loculus.backend.api.GeneticSequence
 import org.loculus.backend.api.GetSequenceResponse
 import org.loculus.backend.api.Organism
+import org.loculus.backend.api.OriginalDataResponse
 import org.loculus.backend.api.OriginalDataWithFileUrls
 import org.loculus.backend.api.PreprocessingStatus.IN_PROCESSING
 import org.loculus.backend.api.PreprocessingStatus.PROCESSED
@@ -72,6 +75,7 @@ import org.loculus.backend.api.getFileId
 import org.loculus.backend.auth.AuthenticatedUser
 import org.loculus.backend.config.BackendSpringProperty
 import org.loculus.backend.controller.BadRequestException
+import org.loculus.backend.controller.ForbiddenException
 import org.loculus.backend.controller.ProcessingValidationException
 import org.loculus.backend.controller.UnprocessableEntityException
 import org.loculus.backend.log.AuditLogger
@@ -1182,6 +1186,7 @@ class SubmissionDatabaseService(
         organism: Organism,
         groupIdsFilter: List<Int>?,
         statusesFilter: List<Status>?,
+        accessionVersionsFilter: List<AccessionVersion>?,
     ): Op<Boolean> {
         val organismCondition = SequenceEntriesView.organismIs(organism)
         val groupCondition = getGroupCondition(groupIdsFilter, authenticatedUser)
@@ -1190,7 +1195,12 @@ class SubmissionDatabaseService(
         } else {
             Op.TRUE
         }
-        val conditions = organismCondition and groupCondition and statusCondition
+        val accessionVersionCondition = if (accessionVersionsFilter != null) {
+            SequenceEntriesView.accessionVersionIsIn(accessionVersionsFilter)
+        } else {
+            Op.TRUE
+        }
+        val conditions = organismCondition and groupCondition and statusCondition and accessionVersionCondition
 
         return conditions
     }
@@ -1200,6 +1210,7 @@ class SubmissionDatabaseService(
         organism: Organism,
         groupIdsFilter: List<Int>?,
         statusesFilter: List<Status>?,
+        accessionVersionsFilter: List<AccessionVersion>?,
     ): Long = SequenceEntriesView
         .selectAll()
         .where(
@@ -1208,6 +1219,7 @@ class SubmissionDatabaseService(
                 organism,
                 groupIdsFilter,
                 statusesFilter,
+                accessionVersionsFilter,
             ),
         )
         .count()
@@ -1218,6 +1230,7 @@ class SubmissionDatabaseService(
         groupIdsFilter: List<Int>?,
         statusesFilter: List<Status>?,
         fields: List<String>?,
+        accessionVersionsFilter: List<AccessionVersion>?,
     ): Sequence<AccessionVersionOriginalMetadata> {
         val originalMetadata = SequenceEntriesView.originalDataColumn
             // It's actually <Map<String, String>?> but exposed does not support nullable types here
@@ -1238,6 +1251,7 @@ class SubmissionDatabaseService(
                     organism,
                     groupIdsFilter,
                     statusesFilter,
+                    accessionVersionsFilter,
                 ),
             )
             .fetchSize(streamBatchSize)
@@ -1254,6 +1268,67 @@ class SubmissionDatabaseService(
                     it[SequenceEntriesView.submitterColumn],
                     it[SequenceEntriesView.isRevocationColumn],
                     selectedMetadata,
+                )
+            }
+    }
+
+    private fun originalDataConditions(
+        organism: Organism,
+        groupId: Int,
+        accessionsFilter: List<String>?,
+    ): Op<Boolean> {
+        val accessionsCondition = if (!accessionsFilter.isNullOrEmpty()) {
+            SequenceEntriesView.accessionColumn inList accessionsFilter
+        } else {
+            Op.TRUE
+        }
+
+        return SequenceEntriesView.organismIs(organism) and
+            (SequenceEntriesView.groupIdColumn eq groupId) and
+            SequenceEntriesView.statusIs(APPROVED_FOR_RELEASE) and
+            SequenceEntriesView.isMaxVersion and
+            (SequenceEntriesView.isRevocationColumn eq false) and
+            accessionsCondition
+    }
+
+    fun countOriginalData(
+        authenticatedUser: AuthenticatedUser,
+        organism: Organism,
+        groupId: Int,
+        accessionsFilter: List<String>?,
+    ): Long {
+        groupManagementPreconditionValidator.validateUserIsAllowedToModifyGroup(groupId, authenticatedUser)
+        return SequenceEntriesView
+            .select(SequenceEntriesView.accessionColumn)
+            .where(originalDataConditions(organism, groupId, accessionsFilter))
+            .count()
+    }
+
+    fun streamOriginalData(
+        authenticatedUser: AuthenticatedUser,
+        organism: Organism,
+        groupId: Int,
+        accessionsFilter: List<String>?,
+    ): Sequence<OriginalDataResponse> {
+        groupManagementPreconditionValidator.validateUserIsAllowedToModifyGroup(groupId, authenticatedUser)
+        return SequenceEntriesView
+            .select(
+                SequenceEntriesView.accessionColumn,
+                SequenceEntriesView.versionColumn,
+                SequenceEntriesView.originalDataColumn,
+            )
+            .where(originalDataConditions(organism, groupId, accessionsFilter))
+            .fetchSize(streamBatchSize)
+            .asSequence()
+            .map {
+                val compressedOriginalData = it[SequenceEntriesView.originalDataColumn]!!
+                val decompressedOriginalData = compressionService.decompressSequencesInOriginalData(
+                    compressedOriginalData,
+                )
+                OriginalDataResponse(
+                    it[SequenceEntriesView.accessionColumn],
+                    it[SequenceEntriesView.versionColumn],
+                    decompressedOriginalData,
                 )
             }
     }

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -1278,37 +1278,49 @@ class SubmissionDatabaseService(
             accessionsCondition
     }
 
-    fun countOriginalData(organism: Organism, groupId: Int, accessionsFilter: List<String>?): Long = SequenceEntriesView
-        .select(SequenceEntriesView.accessionColumn)
-        .where(originalDataConditions(organism, groupId, accessionsFilter))
-        .count()
-
-    fun streamOriginalData(
+    fun countOriginalData(
+        authenticatedUser: AuthenticatedUser,
         organism: Organism,
         groupId: Int,
         accessionsFilter: List<String>?,
-    ): Sequence<OriginalDataResponse> = SequenceEntriesView
-        .select(
-            SequenceEntriesView.accessionColumn,
-            SequenceEntriesView.versionColumn,
-            SequenceEntriesView.submissionIdColumn,
-            SequenceEntriesView.originalDataColumn,
-        )
-        .where(originalDataConditions(organism, groupId, accessionsFilter))
-        .fetchSize(streamBatchSize)
-        .asSequence()
-        .map {
-            val compressedOriginalData = it[SequenceEntriesView.originalDataColumn]!!
-            val decompressedOriginalData = compressionService.decompressSequencesInOriginalData(
-                compressedOriginalData,
+    ): Long {
+        groupManagementPreconditionValidator.validateUserIsAllowedToModifyGroup(groupId, authenticatedUser)
+        return SequenceEntriesView
+            .select(SequenceEntriesView.accessionColumn)
+            .where(originalDataConditions(organism, groupId, accessionsFilter))
+            .count()
+    }
+
+    fun streamOriginalData(
+        authenticatedUser: AuthenticatedUser,
+        organism: Organism,
+        groupId: Int,
+        accessionsFilter: List<String>?,
+    ): Sequence<OriginalDataResponse> {
+        groupManagementPreconditionValidator.validateUserIsAllowedToModifyGroup(groupId, authenticatedUser)
+        return SequenceEntriesView
+            .select(
+                SequenceEntriesView.accessionColumn,
+                SequenceEntriesView.versionColumn,
+                SequenceEntriesView.submissionIdColumn,
+                SequenceEntriesView.originalDataColumn,
             )
-            OriginalDataResponse(
-                it[SequenceEntriesView.accessionColumn],
-                it[SequenceEntriesView.versionColumn],
-                it[SequenceEntriesView.submissionIdColumn],
-                decompressedOriginalData,
-            )
-        }
+            .where(originalDataConditions(organism, groupId, accessionsFilter))
+            .fetchSize(streamBatchSize)
+            .asSequence()
+            .map {
+                val compressedOriginalData = it[SequenceEntriesView.originalDataColumn]!!
+                val decompressedOriginalData = compressionService.decompressSequencesInOriginalData(
+                    compressedOriginalData,
+                )
+                OriginalDataResponse(
+                    it[SequenceEntriesView.accessionColumn],
+                    it[SequenceEntriesView.versionColumn],
+                    it[SequenceEntriesView.submissionIdColumn],
+                    decompressedOriginalData,
+                )
+            }
+    }
 
     fun cleanUpStaleSequencesInProcessing(timeToStaleInSeconds: Long) {
         val staleDateTime = dateProvider.getCurrentInstant()

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -75,7 +75,6 @@ import org.loculus.backend.api.getFileId
 import org.loculus.backend.auth.AuthenticatedUser
 import org.loculus.backend.config.BackendSpringProperty
 import org.loculus.backend.controller.BadRequestException
-import org.loculus.backend.controller.ForbiddenException
 import org.loculus.backend.controller.ProcessingValidationException
 import org.loculus.backend.controller.UnprocessableEntityException
 import org.loculus.backend.log.AuditLogger
@@ -1186,7 +1185,6 @@ class SubmissionDatabaseService(
         organism: Organism,
         groupIdsFilter: List<Int>?,
         statusesFilter: List<Status>?,
-        accessionVersionsFilter: List<AccessionVersion>?,
     ): Op<Boolean> {
         val organismCondition = SequenceEntriesView.organismIs(organism)
         val groupCondition = getGroupCondition(groupIdsFilter, authenticatedUser)
@@ -1195,14 +1193,7 @@ class SubmissionDatabaseService(
         } else {
             Op.TRUE
         }
-        val accessionVersionCondition = if (accessionVersionsFilter != null) {
-            SequenceEntriesView.accessionVersionIsIn(accessionVersionsFilter)
-        } else {
-            Op.TRUE
-        }
-        val conditions = organismCondition and groupCondition and statusCondition and accessionVersionCondition
-
-        return conditions
+        return organismCondition and groupCondition and statusCondition
     }
 
     fun countOriginalMetadata(
@@ -1210,7 +1201,6 @@ class SubmissionDatabaseService(
         organism: Organism,
         groupIdsFilter: List<Int>?,
         statusesFilter: List<Status>?,
-        accessionVersionsFilter: List<AccessionVersion>?,
     ): Long = SequenceEntriesView
         .selectAll()
         .where(
@@ -1219,7 +1209,6 @@ class SubmissionDatabaseService(
                 organism,
                 groupIdsFilter,
                 statusesFilter,
-                accessionVersionsFilter,
             ),
         )
         .count()
@@ -1230,7 +1219,6 @@ class SubmissionDatabaseService(
         groupIdsFilter: List<Int>?,
         statusesFilter: List<Status>?,
         fields: List<String>?,
-        accessionVersionsFilter: List<AccessionVersion>?,
     ): Sequence<AccessionVersionOriginalMetadata> {
         val originalMetadata = SequenceEntriesView.originalDataColumn
             // It's actually <Map<String, String>?> but exposed does not support nullable types here
@@ -1251,7 +1239,6 @@ class SubmissionDatabaseService(
                     organism,
                     groupIdsFilter,
                     statusesFilter,
-                    accessionVersionsFilter,
                 ),
             )
             .fetchSize(streamBatchSize)
@@ -1291,47 +1278,37 @@ class SubmissionDatabaseService(
             accessionsCondition
     }
 
-    fun countOriginalData(
-        authenticatedUser: AuthenticatedUser,
-        organism: Organism,
-        groupId: Int,
-        accessionsFilter: List<String>?,
-    ): Long {
-        groupManagementPreconditionValidator.validateUserIsAllowedToModifyGroup(groupId, authenticatedUser)
-        return SequenceEntriesView
-            .select(SequenceEntriesView.accessionColumn)
-            .where(originalDataConditions(organism, groupId, accessionsFilter))
-            .count()
-    }
+    fun countOriginalData(organism: Organism, groupId: Int, accessionsFilter: List<String>?): Long = SequenceEntriesView
+        .select(SequenceEntriesView.accessionColumn)
+        .where(originalDataConditions(organism, groupId, accessionsFilter))
+        .count()
 
     fun streamOriginalData(
-        authenticatedUser: AuthenticatedUser,
         organism: Organism,
         groupId: Int,
         accessionsFilter: List<String>?,
-    ): Sequence<OriginalDataResponse> {
-        groupManagementPreconditionValidator.validateUserIsAllowedToModifyGroup(groupId, authenticatedUser)
-        return SequenceEntriesView
-            .select(
-                SequenceEntriesView.accessionColumn,
-                SequenceEntriesView.versionColumn,
-                SequenceEntriesView.originalDataColumn,
+    ): Sequence<OriginalDataResponse> = SequenceEntriesView
+        .select(
+            SequenceEntriesView.accessionColumn,
+            SequenceEntriesView.versionColumn,
+            SequenceEntriesView.submissionIdColumn,
+            SequenceEntriesView.originalDataColumn,
+        )
+        .where(originalDataConditions(organism, groupId, accessionsFilter))
+        .fetchSize(streamBatchSize)
+        .asSequence()
+        .map {
+            val compressedOriginalData = it[SequenceEntriesView.originalDataColumn]!!
+            val decompressedOriginalData = compressionService.decompressSequencesInOriginalData(
+                compressedOriginalData,
             )
-            .where(originalDataConditions(organism, groupId, accessionsFilter))
-            .fetchSize(streamBatchSize)
-            .asSequence()
-            .map {
-                val compressedOriginalData = it[SequenceEntriesView.originalDataColumn]!!
-                val decompressedOriginalData = compressionService.decompressSequencesInOriginalData(
-                    compressedOriginalData,
-                )
-                OriginalDataResponse(
-                    it[SequenceEntriesView.accessionColumn],
-                    it[SequenceEntriesView.versionColumn],
-                    decompressedOriginalData,
-                )
-            }
-    }
+            OriginalDataResponse(
+                it[SequenceEntriesView.accessionColumn],
+                it[SequenceEntriesView.versionColumn],
+                it[SequenceEntriesView.submissionIdColumn],
+                decompressedOriginalData,
+            )
+        }
 
     fun cleanUpStaleSequencesInProcessing(timeToStaleInSeconds: Long) {
         val staleDateTime = dateProvider.getCurrentInstant()

--- a/backend/src/main/kotlin/org/loculus/backend/utils/FastaWriter.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/FastaWriter.kt
@@ -1,0 +1,25 @@
+package org.loculus.backend.utils
+
+import java.io.OutputStream
+
+class FastaWriter(outputStream: OutputStream) : AutoCloseable {
+    private val writer = outputStream.bufferedWriter()
+
+    fun write(entry: FastaEntry) {
+        writer.write(">")
+        writer.write(entry.fastaId)
+        writer.newLine()
+        writer.write(entry.sequence)
+        writer.newLine()
+    }
+
+    fun writeAll(entries: Iterable<FastaEntry>) {
+        for (entry in entries) {
+            write(entry)
+        }
+    }
+
+    override fun close() {
+        writer.flush()
+    }
+}

--- a/backend/src/main/kotlin/org/loculus/backend/utils/TsvWriter.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/TsvWriter.kt
@@ -1,0 +1,21 @@
+package org.loculus.backend.utils
+
+import org.apache.commons.csv.CSVFormat
+import org.apache.commons.csv.CSVPrinter
+import java.io.OutputStream
+
+class TsvWriter(outputStream: OutputStream, headers: List<String>) : AutoCloseable {
+    private val writer = outputStream.bufferedWriter()
+    private val printer: CSVPrinter = CSVFormat.TDF.builder()
+        .setHeader(*headers.toTypedArray())
+        .get()
+        .print(writer)
+
+    fun writeRow(values: List<String?>) {
+        printer.printRecord(values)
+    }
+
+    override fun close() {
+        printer.flush()
+    }
+}

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetOriginalDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetOriginalDataEndpointTest.kt
@@ -1,0 +1,411 @@
+package org.loculus.backend.controller.submission
+
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsInAnyOrder
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.Test
+import org.loculus.backend.controller.EndpointTest
+import org.loculus.backend.controller.ORGANISM_WITHOUT_CONSENSUS_SEQUENCES
+import org.loculus.backend.controller.OTHER_ORGANISM
+import org.loculus.backend.controller.expectUnauthorizedResponse
+import org.loculus.backend.controller.generateJwtFor
+import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
+import org.loculus.backend.controller.groupmanagement.andGetGroupId
+import org.loculus.backend.controller.jwtForDefaultUser
+import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.shaded.org.awaitility.Awaitility.await
+import java.io.ByteArrayInputStream
+import java.util.zip.ZipInputStream
+
+@EndpointTest
+class GetOriginalDataEndpointTest(
+    @Autowired val convenienceClient: SubmissionConvenienceClient,
+    @Autowired val submissionControllerClient: SubmissionControllerClient,
+    @Autowired val groupManagementClient: GroupManagementControllerClient,
+) {
+    @Test
+    fun `GIVEN invalid authorization token THEN returns 401 Unauthorized`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        expectUnauthorizedResponse(isModifyingRequest = true) {
+            submissionControllerClient.getOriginalData(groupId = groupId, jwt = it)
+        }
+    }
+
+    @Test
+    fun `GIVEN user not in group THEN returns 403 Forbidden`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        val otherUserJwt = generateJwtFor("otherUser")
+        groupManagementClient.createNewGroup(jwt = otherUserJwt)
+
+        submissionControllerClient.getOriginalData(groupId = groupId, jwt = otherUserJwt)
+            .andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `GIVEN no sequence entries in database THEN returns zip with header-only metadata and empty sequences`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+
+        val response = submissionControllerClient.getOriginalData(groupId = groupId)
+            .andExpect(status().isOk)
+            .andExpect(content().contentType("application/zip"))
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val fileNames = getZipFileNames(zipContent)
+        assertThat(fileNames, containsInAnyOrder("metadata.tsv", "sequences.fasta"))
+
+        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+
+        assertThat(metadataTsv, containsString("id\taccession"))
+        val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
+        assertThat("metadata should only contain header row", metadataLines, hasSize(1))
+        assertThat(sequencesFasta, `is`(""))
+    }
+
+    @Test
+    fun `GIVEN data exists THEN returns zip with metadata TSV and sequences FASTA`() {
+        val submissionResult = convenienceClient.submitDefaultFiles()
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(groupId = submissionResult.groupId)
+
+        val response = submissionControllerClient.getOriginalData(groupId = submissionResult.groupId)
+            .andExpect(status().isOk)
+            .andExpect(content().contentType("application/zip"))
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+
+        assertThat(metadataTsv, containsString("id\taccession"))
+        val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
+        assertThat(metadataLines, hasSize(DefaultFiles.NUMBER_OF_SEQUENCES + 1))
+        assertThat(sequencesFasta, containsString(">"))
+    }
+
+    @Test
+    fun `GIVEN data exists THEN metadata TSV contains id and accession columns`() {
+        val submissionResult = convenienceClient.submitDefaultFiles()
+        val accessionVersions = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+            groupId = submissionResult.groupId,
+        )
+
+        val response = submissionControllerClient.getOriginalData(groupId = submissionResult.groupId)
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, _) = extractZipContents(zipContent)
+
+        val lines = metadataTsv.lines().filter { it.isNotBlank() }
+        val header = lines[0].split("\t")
+
+        assertThat(header[0], `is`("id"))
+        assertThat(header[1], `is`("accession"))
+
+        val firstDataRow = lines[1].split("\t")
+        assertThat(firstDataRow[0], `is`(accessionVersions[0].displayAccessionVersion()))
+        assertThat(firstDataRow[1], `is`(accessionVersions[0].accession))
+    }
+
+    @Test
+    fun `GIVEN data exists THEN FASTA headers match metadata ids`() {
+        val submissionResult = convenienceClient.submitDefaultFiles()
+        val accessionVersions = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+            groupId = submissionResult.groupId,
+        )
+
+        val response = submissionControllerClient.getOriginalData(groupId = submissionResult.groupId)
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+
+        val metadataIds = metadataTsv.lines()
+            .filter { it.isNotBlank() }
+            .drop(1)
+            .map { it.split("\t")[0] }
+            .toSet()
+
+        val fastaIds = sequencesFasta.lines()
+            .filter { it.startsWith(">") }
+            .map { it.removePrefix(">") }
+            .toSet()
+
+        assertThat(fastaIds, `is`(metadataIds))
+
+        val expectedIds = accessionVersions.map { it.displayAccessionVersion() }.toSet()
+        assertThat(metadataIds, `is`(expectedIds))
+    }
+
+    @Test
+    fun `WHEN filtering by accessions THEN returns only those accessions`() {
+        val submissionResult = convenienceClient.submitDefaultFiles()
+        val accessionVersions = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+            groupId = submissionResult.groupId,
+        )
+
+        val selectedAccessions = accessionVersions.take(2).map { it.accession }
+
+        val response = submissionControllerClient.getOriginalData(
+            groupId = submissionResult.groupId,
+            accessionsFilter = selectedAccessions,
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, _) = extractZipContents(zipContent)
+
+        val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
+        assertThat(metadataLines, hasSize(3))
+
+        val returnedAccessions = metadataLines.drop(1).map { it.split("\t")[1] }
+        assertThat(returnedAccessions, containsInAnyOrder(*selectedAccessions.toTypedArray()))
+    }
+
+    @Test
+    fun `WHEN filtering by non-existent accessions THEN returns empty data`() {
+        val submissionResult = convenienceClient.submitDefaultFiles()
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(groupId = submissionResult.groupId)
+
+        val response = submissionControllerClient.getOriginalData(
+            groupId = submissionResult.groupId,
+            accessionsFilter = listOf("NON_EXISTENT", "ALSO_NOT_THERE"),
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+
+        val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
+        assertThat(metadataLines, hasSize(1))
+        assertThat(sequencesFasta, `is`(""))
+    }
+
+    @Test
+    fun `GIVEN organism without consensus sequences THEN zip contains only metadata TSV`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+            organism = ORGANISM_WITHOUT_CONSENSUS_SEQUENCES,
+            groupId = groupId,
+        )
+
+        val response = submissionControllerClient.getOriginalData(
+            organism = ORGANISM_WITHOUT_CONSENSUS_SEQUENCES,
+            groupId = groupId,
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val fileNames = getZipFileNames(zipContent)
+
+        assertThat(fileNames, containsInAnyOrder("metadata.tsv"))
+    }
+
+    @Test
+    fun `GIVEN only non-released sequences THEN returns empty data`() {
+        val submissionResult = convenienceClient.submitDefaultFiles()
+
+        val response = submissionControllerClient.getOriginalData(groupId = submissionResult.groupId)
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, _) = extractZipContents(zipContent)
+
+        val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
+        assertThat(metadataLines, hasSize(1))
+    }
+
+    @Test
+    fun `GIVEN multi-segmented organism THEN metadata TSV has fastaIds column`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+            organism = OTHER_ORGANISM,
+            groupId = groupId,
+        )
+
+        val response = submissionControllerClient.getOriginalData(
+            organism = OTHER_ORGANISM,
+            groupId = groupId,
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, _) = extractZipContents(zipContent)
+
+        val lines = metadataTsv.lines().filter { it.isNotBlank() }
+        val header = lines[0].split("\t")
+
+        assertThat(header[0], `is`("id"))
+        assertThat(header[1], `is`("accession"))
+        assertThat(header[2], `is`("fastaIds"))
+    }
+
+    @Test
+    fun `GIVEN multi-segmented organism THEN fastaIds contain accession version and original fasta id`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        val accessionVersions = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+            organism = OTHER_ORGANISM,
+            groupId = groupId,
+        )
+
+        val response = submissionControllerClient.getOriginalData(
+            organism = OTHER_ORGANISM,
+            groupId = groupId,
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, _) = extractZipContents(zipContent)
+
+        val lines = metadataTsv.lines().filter { it.isNotBlank() }
+        val header = lines[0].split("\t")
+        val fastaIdsIndex = header.indexOf("fastaIds")
+
+        val firstDataRow = lines[1].split("\t")
+        val fastaIds = firstDataRow[fastaIdsIndex]
+        val accessionVersion = accessionVersions[0].displayAccessionVersion()
+
+        assertThat(fastaIds, containsString("$accessionVersion|"))
+    }
+
+    @Test
+    fun `GIVEN multi-segmented organism THEN FASTA headers contain accession version and original fasta id`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        val accessionVersions = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+            organism = OTHER_ORGANISM,
+            groupId = groupId,
+        )
+
+        val response = submissionControllerClient.getOriginalData(
+            organism = OTHER_ORGANISM,
+            groupId = groupId,
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (_, sequencesFasta) = extractZipContents(zipContent)
+
+        val fastaHeaders = sequencesFasta.lines().filter { it.startsWith(">") }
+        val accessionVersion = accessionVersions[0].displayAccessionVersion()
+
+        val matchingHeaders = fastaHeaders.filter { it.contains("$accessionVersion|") }
+        assertThat(matchingHeaders.size, org.hamcrest.Matchers.greaterThan(0))
+
+        for (header in matchingHeaders) {
+            assertThat(header, containsString("|"))
+        }
+    }
+
+    @Test
+    fun `GIVEN multi-segmented organism THEN fastaIds in metadata match FASTA headers`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+            organism = OTHER_ORGANISM,
+            groupId = groupId,
+        )
+
+        val response = submissionControllerClient.getOriginalData(
+            organism = OTHER_ORGANISM,
+            groupId = groupId,
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+
+        val lines = metadataTsv.lines().filter { it.isNotBlank() }
+        val header = lines[0].split("\t")
+        val fastaIdsIndex = header.indexOf("fastaIds")
+
+        val allFastaIdsFromMetadata = lines.drop(1)
+            .flatMap { it.split("\t")[fastaIdsIndex].split(" ") }
+            .toSet()
+
+        val fastaHeaderIds = sequencesFasta.lines()
+            .filter { it.startsWith(">") }
+            .map { it.removePrefix(">") }
+            .toSet()
+
+        assertThat(fastaHeaderIds, `is`(allFastaIdsFromMetadata))
+    }
+
+    private fun extractZipContents(zipContent: ByteArray): Pair<String, String> {
+        var metadataTsv = ""
+        var sequencesFasta = ""
+
+        ZipInputStream(ByteArrayInputStream(zipContent)).use { zis ->
+            var entry = zis.nextEntry
+            while (entry != null) {
+                val content = zis.readBytes().decodeToString()
+                when (entry.name) {
+                    "metadata.tsv" -> metadataTsv = content
+                    "sequences.fasta" -> sequencesFasta = content
+                }
+                entry = zis.nextEntry
+            }
+        }
+
+        return Pair(metadataTsv, sequencesFasta)
+    }
+
+    private fun getZipFileNames(zipContent: ByteArray): List<String> {
+        val fileNames = mutableListOf<String>()
+        ZipInputStream(ByteArrayInputStream(zipContent)).use { zis ->
+            var entry = zis.nextEntry
+            while (entry != null) {
+                fileNames.add(entry.name)
+                entry = zis.nextEntry
+            }
+        }
+        return fileNames
+    }
+}

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetOriginalDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetOriginalDataEndpointTest.kt
@@ -13,7 +13,6 @@ import org.loculus.backend.controller.expectUnauthorizedResponse
 import org.loculus.backend.controller.generateJwtFor
 import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
 import org.loculus.backend.controller.groupmanagement.andGetGroupId
-import org.loculus.backend.controller.jwtForDefaultUser
 import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -95,7 +94,7 @@ class GetOriginalDataEndpointTest(
     @Test
     fun `GIVEN data exists THEN metadata TSV contains id and accession columns`() {
         val submissionResult = convenienceClient.submitDefaultFiles()
-        val accessionVersions = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
             groupId = submissionResult.groupId,
         )
 
@@ -116,14 +115,14 @@ class GetOriginalDataEndpointTest(
         assertThat(header[1], `is`("accession"))
 
         val firstDataRow = lines[1].split("\t")
-        assertThat(firstDataRow[0], `is`(accessionVersions[0].displayAccessionVersion()))
-        assertThat(firstDataRow[1], `is`(accessionVersions[0].accession))
+        assertThat(firstDataRow[0], `is`(submissionResult.submissionIdMappings[0].submissionId))
+        assertThat(firstDataRow[1], `is`(submissionResult.submissionIdMappings[0].accession))
     }
 
     @Test
     fun `GIVEN data exists THEN FASTA headers match metadata ids`() {
         val submissionResult = convenienceClient.submitDefaultFiles()
-        val accessionVersions = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
             groupId = submissionResult.groupId,
         )
 
@@ -150,7 +149,7 @@ class GetOriginalDataEndpointTest(
 
         assertThat(fastaIds, `is`(metadataIds))
 
-        val expectedIds = accessionVersions.map { it.displayAccessionVersion() }.toSet()
+        val expectedIds = submissionResult.submissionIdMappings.map { it.submissionId }.toSet()
         assertThat(metadataIds, `is`(expectedIds))
     }
 
@@ -278,9 +277,9 @@ class GetOriginalDataEndpointTest(
     }
 
     @Test
-    fun `GIVEN multi-segmented organism THEN fastaIds contain accession version and original fasta id`() {
+    fun `GIVEN multi-segmented organism THEN fastaIds contain original fasta ids`() {
         val groupId = groupManagementClient.createNewGroup().andGetGroupId()
-        val accessionVersions = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
             organism = OTHER_ORGANISM,
             groupId = groupId,
         )
@@ -303,16 +302,16 @@ class GetOriginalDataEndpointTest(
         val fastaIdsIndex = header.indexOf("fastaIds")
 
         val firstDataRow = lines[1].split("\t")
+        val submissionId = firstDataRow[0]
         val fastaIds = firstDataRow[fastaIdsIndex]
-        val accessionVersion = accessionVersions[0].displayAccessionVersion()
 
-        assertThat(fastaIds, containsString("$accessionVersion|"))
+        assertThat(fastaIds, containsString("${submissionId}_"))
     }
 
     @Test
-    fun `GIVEN multi-segmented organism THEN FASTA headers contain accession version and original fasta id`() {
+    fun `GIVEN multi-segmented organism THEN FASTA headers contain original fasta ids`() {
         val groupId = groupManagementClient.createNewGroup().andGetGroupId()
-        val accessionVersions = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(
             organism = OTHER_ORGANISM,
             groupId = groupId,
         )
@@ -331,14 +330,8 @@ class GetOriginalDataEndpointTest(
         val (_, sequencesFasta) = extractZipContents(zipContent)
 
         val fastaHeaders = sequencesFasta.lines().filter { it.startsWith(">") }
-        val accessionVersion = accessionVersions[0].displayAccessionVersion()
 
-        val matchingHeaders = fastaHeaders.filter { it.contains("$accessionVersion|") }
-        assertThat(matchingHeaders.size, org.hamcrest.Matchers.greaterThan(0))
-
-        for (header in matchingHeaders) {
-            assertThat(header, containsString("|"))
-        }
+        assertThat(fastaHeaders.contains(">custom0_notOnlySegment"), `is`(true))
     }
 
     @Test

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/OriginalDataRevisionWorkflowTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/OriginalDataRevisionWorkflowTest.kt
@@ -1,0 +1,207 @@
+package org.loculus.backend.controller.submission
+
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.greaterThan
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.Test
+import org.loculus.backend.controller.EndpointTest
+import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
+import org.loculus.backend.controller.groupmanagement.andGetGroupId
+import org.loculus.backend.controller.jwtForDefaultUser
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.shaded.org.awaitility.Awaitility.await
+import java.io.ByteArrayInputStream
+import java.util.zip.ZipInputStream
+
+@EndpointTest
+class OriginalDataRevisionWorkflowTest(
+    @Autowired val convenienceClient: SubmissionConvenienceClient,
+    @Autowired val submissionControllerClient: SubmissionControllerClient,
+    @Autowired val groupManagementClient: GroupManagementControllerClient,
+) {
+
+    @Test
+    fun `GIVEN released sequences WHEN downloading and modifying original data THEN can submit revision`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        val accessionVersions = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(groupId = groupId)
+
+        assertThat(accessionVersions, hasSize(greaterThan(0)))
+        val firstAccession = accessionVersions[0].accession
+        val firstAccessionVersion = accessionVersions[0].displayAccessionVersion()
+
+        val response = submissionControllerClient.getOriginalData(groupId = groupId)
+            .andExpect(status().isOk)
+            .andExpect(content().contentType("application/zip"))
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+
+        val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
+        val headers = metadataLines[0].split("\t")
+
+        assertThat(headers.contains("id"), `is`(true))
+        assertThat(headers.contains("accession"), `is`(true))
+        assertThat(headers.contains("date"), `is`(true))
+
+        val idIndex = headers.indexOf("id")
+        val accessionIndex = headers.indexOf("accession")
+        val dateIndex = headers.indexOf("date")
+
+        val firstDataRow = metadataLines[1].split("\t")
+        assertThat(firstDataRow[idIndex], `is`(firstAccessionVersion))
+        assertThat(firstDataRow[accessionIndex], `is`(firstAccession))
+        assertThat(sequencesFasta.contains(">$firstAccessionVersion"), `is`(true))
+
+        val originalDate = firstDataRow[dateIndex]
+        val newDate = "2099-01-01"
+        assertThat(newDate, `is`(org.hamcrest.Matchers.not(originalDate)))
+
+        val revisedMetadataContent = buildRevisedMetadata(metadataLines, headers, dateIndex, newDate)
+        val revisedMetadataFile = MockMultipartFile(
+            "metadataFile",
+            "metadata.tsv",
+            MediaType.TEXT_PLAIN_VALUE,
+            revisedMetadataContent.toByteArray(),
+        )
+
+        val revisedSequencesFile = MockMultipartFile(
+            "sequenceFile",
+            "sequences.fasta",
+            MediaType.TEXT_PLAIN_VALUE,
+            sequencesFasta.toByteArray(),
+        )
+
+        submissionControllerClient.reviseSequenceEntries(
+            metadataFile = revisedMetadataFile,
+            sequencesFile = revisedSequencesFile,
+            jwt = jwtForDefaultUser,
+        )
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("\$.length()").value(accessionVersions.size))
+            .andExpect(jsonPath("\$[0].accession").value(firstAccession))
+            .andExpect(jsonPath("\$[0].version").value(2))
+
+        val revisedEntry = convenienceClient.getSequenceEntry(accession = firstAccession, version = 2)
+        assertThat(revisedEntry.accession, `is`(firstAccession))
+        assertThat(revisedEntry.version, `is`(2L))
+    }
+
+    @Test
+    fun `GIVEN filtered download WHEN modifying and submitting revision THEN only selected sequences are revised`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        val accessionVersions = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(groupId = groupId)
+
+        assertThat(accessionVersions, hasSize(greaterThan(1)))
+
+        val selectedAccession = accessionVersions[0].accession
+
+        val response = submissionControllerClient.getOriginalData(
+            groupId = groupId,
+            accessionsFilter = listOf(selectedAccession),
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        await().until { response.isCommitted }
+
+        val zipContent = response.contentAsByteArray
+        val (metadataTsv, sequencesFasta) = extractZipContents(zipContent)
+
+        val metadataLines = metadataTsv.lines().filter { it.isNotBlank() }
+        assertThat(metadataLines.size, `is`(2))
+
+        val headers = metadataLines[0].split("\t")
+        val dateIndex = headers.indexOf("date")
+
+        val revisedMetadataContent = buildRevisedMetadata(metadataLines, headers, dateIndex, "2099-12-31")
+        val revisedMetadataFile = MockMultipartFile(
+            "metadataFile",
+            "metadata.tsv",
+            MediaType.TEXT_PLAIN_VALUE,
+            revisedMetadataContent.toByteArray(),
+        )
+
+        val revisedSequencesFile = MockMultipartFile(
+            "sequenceFile",
+            "sequences.fasta",
+            MediaType.TEXT_PLAIN_VALUE,
+            sequencesFasta.toByteArray(),
+        )
+
+        submissionControllerClient.reviseSequenceEntries(
+            metadataFile = revisedMetadataFile,
+            sequencesFile = revisedSequencesFile,
+            jwt = jwtForDefaultUser,
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("\$.length()").value(1))
+            .andExpect(jsonPath("\$[0].accession").value(selectedAccession))
+            .andExpect(jsonPath("\$[0].version").value(2))
+
+        val revisedEntry = convenienceClient.getSequenceEntry(accession = selectedAccession, version = 2)
+        assertThat(revisedEntry.version, `is`(2L))
+
+        val otherAccession = accessionVersions[1].accession
+        val otherEntry = convenienceClient.getSequenceEntry(accession = otherAccession, version = 1)
+        assertThat(otherEntry.version, `is`(1L))
+    }
+
+    private fun buildRevisedMetadata(
+        metadataLines: List<String>,
+        headers: List<String>,
+        dateIndex: Int,
+        newDate: String,
+    ): String {
+        val idIndex = headers.indexOf("id")
+
+        val newHeaders = headers.toMutableList()
+        newHeaders[idIndex] = "submissionId"
+
+        val resultLines = mutableListOf<String>()
+        resultLines.add(newHeaders.joinToString("\t"))
+
+        for (i in 1 until metadataLines.size) {
+            val row = metadataLines[i].split("\t").toMutableList()
+            while (row.size < headers.size) {
+                row.add("")
+            }
+            if (dateIndex >= 0 && dateIndex < row.size) {
+                row[dateIndex] = newDate
+            }
+            resultLines.add(row.joinToString("\t"))
+        }
+
+        return resultLines.joinToString("\n")
+    }
+
+    private fun extractZipContents(zipContent: ByteArray): Pair<String, String> {
+        var metadataTsv = ""
+        var sequencesFasta = ""
+
+        ZipInputStream(ByteArrayInputStream(zipContent)).use { zis ->
+            var entry = zis.nextEntry
+            while (entry != null) {
+                val content = zis.readBytes().decodeToString()
+                when (entry.name) {
+                    "metadata.tsv" -> metadataTsv = content
+                    "sequences.fasta" -> sequencesFasta = content
+                }
+                entry = zis.nextEntry
+            }
+        }
+
+        return Pair(metadataTsv, sequencesFasta)
+    }
+}

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/OriginalDataRevisionWorkflowTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/OriginalDataRevisionWorkflowTest.kt
@@ -33,7 +33,6 @@ class OriginalDataRevisionWorkflowTest(
 
         assertThat(accessionVersions, hasSize(greaterThan(0)))
         val firstAccession = accessionVersions[0].accession
-        val firstAccessionVersion = accessionVersions[0].displayAccessionVersion()
 
         val response = submissionControllerClient.getOriginalData(groupId = groupId)
             .andExpect(status().isOk)
@@ -58,9 +57,9 @@ class OriginalDataRevisionWorkflowTest(
         val dateIndex = headers.indexOf("date")
 
         val firstDataRow = metadataLines[1].split("\t")
-        assertThat(firstDataRow[idIndex], `is`(firstAccessionVersion))
+        assertThat(firstDataRow[idIndex], `is`("custom0"))
         assertThat(firstDataRow[accessionIndex], `is`(firstAccession))
-        assertThat(sequencesFasta.contains(">$firstAccessionVersion"), `is`(true))
+        assertThat(sequencesFasta.contains(">custom0"), `is`(true))
 
         val originalDate = firstDataRow[dateIndex]
         val newDate = "2099-01-01"

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
@@ -309,6 +309,7 @@ class SubmissionControllerClient(private val mockMvc: MockMvc, private val objec
         statusesFilter: List<Status>? = null,
         fields: List<String>? = null,
         compression: String? = null,
+        accessionVersionsFilter: List<String>? = null,
     ): ResultActions = mockMvc.perform(
         get(addOrganismToPath("/get-original-metadata", organism = organism))
             .withAuth(jwt)
@@ -320,7 +321,27 @@ class SubmissionControllerClient(private val mockMvc: MockMvc, private val objec
             }
             .param("groupIdsFilter", groupIdsFilter?.joinToString(",") { it.toString() })
             .param("statusesFilter", statusesFilter?.joinToString(",") { it.name })
-            .param("fields", fields?.joinToString(",")),
+            .param("fields", fields?.joinToString(","))
+            .param("accessionVersionsFilter", accessionVersionsFilter?.joinToString(",")),
+    )
+
+    fun getOriginalData(
+        organism: String = DEFAULT_ORGANISM,
+        jwt: String? = jwtForDefaultUser,
+        groupId: Int,
+        accessionsFilter: List<String>? = null,
+    ): ResultActions = mockMvc.perform(
+        post(addOrganismToPath("/get-original-data", organism = organism))
+            .withAuth(jwt)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+                objectMapper.writeValueAsString(
+                    mapOf(
+                        "groupId" to groupId,
+                        "accessionsFilter" to accessionsFilter,
+                    ),
+                ),
+            ),
     )
 
     private fun serialize(listOfSequencesToApprove: List<AccessionVersionInterface>? = null): String =

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionConvenienceClient.kt
@@ -506,6 +506,7 @@ class SubmissionConvenienceClient(
         statusesFilter: List<Status>? = null,
         fields: List<String>? = null,
         compression: String? = null,
+        accessionVersionsFilter: List<String>? = null,
     ) = client
         .getOriginalMetadata(
             organism = organism,
@@ -514,6 +515,7 @@ class SubmissionConvenienceClient(
             statusesFilter = statusesFilter,
             fields = fields,
             compression = compression,
+            accessionVersionsFilter = accessionVersionsFilter,
         )
         .expectNdjsonAndGetContent<AccessionVersionOriginalMetadata>()
 

--- a/backend/src/test/kotlin/org/loculus/backend/utils/FastaWriterTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/utils/FastaWriterTest.kt
@@ -1,0 +1,115 @@
+package org.loculus.backend.utils
+
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+
+class FastaWriterTest {
+
+    @Test
+    fun `write multiple entries`() {
+        val outputStream = ByteArrayOutputStream()
+        FastaWriter(outputStream).use { writer ->
+            writer.write(FastaEntry("seq1", "AAATTT"))
+            writer.write(FastaEntry("seq2", "TTTCCC"))
+            writer.write(FastaEntry("seq3", "CCCGGG"))
+        }
+
+        val result = outputStream.toString()
+        val expected = """
+            >seq1
+            AAATTT
+            >seq2
+            TTTCCC
+            >seq3
+            CCCGGG
+        """.trimIndent() + "\n"
+
+        assert(result == expected)
+    }
+
+    @Test
+    fun `write single entry`() {
+        val outputStream = ByteArrayOutputStream()
+        FastaWriter(outputStream).use { writer ->
+            writer.write(FastaEntry("seq1", "AAATTT"))
+        }
+
+        val result = outputStream.toString()
+        val expected = """
+            >seq1
+            AAATTT
+        """.trimIndent() + "\n"
+
+        assert(result == expected)
+    }
+
+    @Test
+    fun `write empty entries`() {
+        val outputStream = ByteArrayOutputStream()
+        FastaWriter(outputStream).use { writer ->
+            writer.writeAll(emptyList())
+        }
+
+        val result = outputStream.toString()
+        assert(result.isEmpty())
+    }
+
+    @Test
+    fun `writeAll writes multiple entries`() {
+        val outputStream = ByteArrayOutputStream()
+        FastaWriter(outputStream).use { writer ->
+            writer.writeAll(
+                listOf(
+                    FastaEntry("seq1", "AAATTT"),
+                    FastaEntry("seq2", "TTTCCC"),
+                ),
+            )
+        }
+
+        val result = outputStream.toString()
+        val expected = """
+            >seq1
+            AAATTT
+            >seq2
+            TTTCCC
+        """.trimIndent() + "\n"
+
+        assert(result == expected)
+    }
+
+    @Test
+    fun `round-trip with FastaReader`() {
+        val entries = listOf(
+            FastaEntry("seq1", "AAATTT"),
+            FastaEntry("seq2", "TTTCCC"),
+            FastaEntry("seq3", "CCCGGG"),
+        )
+
+        val outputStream = ByteArrayOutputStream()
+        FastaWriter(outputStream).use { writer ->
+            writer.writeAll(entries)
+        }
+
+        val parsed = FastaReader(outputStream.toByteArray().inputStream()).toList()
+
+        assert(parsed.size == entries.size)
+        for (i in entries.indices) {
+            assert(parsed[i].fastaId == entries[i].fastaId)
+            assert(parsed[i].sequence == entries[i].sequence)
+        }
+    }
+
+    @Test
+    fun `handles special characters in fasta id`() {
+        val outputStream = ByteArrayOutputStream()
+        FastaWriter(outputStream).use { writer ->
+            writer.write(FastaEntry("seq1|segment_L", "AAATTT"))
+        }
+
+        val result = outputStream.toString()
+        assert(result.contains(">seq1|segment_L"))
+
+        val parsed = FastaReader(result.byteInputStream()).toList()
+        assert(parsed[0].fastaId == "seq1|segment_L")
+    }
+}

--- a/backend/src/test/kotlin/org/loculus/backend/utils/TsvWriterTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/utils/TsvWriterTest.kt
@@ -1,0 +1,121 @@
+package org.loculus.backend.utils
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+
+class TsvWriterTest {
+
+    @Test
+    fun `write multiple rows`() {
+        val outputStream = ByteArrayOutputStream()
+        TsvWriter(outputStream, listOf("id", "name", "value")).use { writer ->
+            writer.writeRow(listOf("1", "Alice", "100"))
+            writer.writeRow(listOf("2", "Bob", "200"))
+            writer.writeRow(listOf("3", "Charlie", "300"))
+        }
+
+        val result = outputStream.toString()
+        val lines = result.lines().filter { it.isNotBlank() }
+
+        assertThat(lines.size, `is`(4))
+        assertThat(lines[0], `is`("id\tname\tvalue"))
+        assertThat(lines[1], `is`("1\tAlice\t100"))
+        assertThat(lines[2], `is`("2\tBob\t200"))
+        assertThat(lines[3], `is`("3\tCharlie\t300"))
+    }
+
+    @Test
+    fun `write single row`() {
+        val outputStream = ByteArrayOutputStream()
+        TsvWriter(outputStream, listOf("id", "name")).use { writer ->
+            writer.writeRow(listOf("1", "Alice"))
+        }
+
+        val result = outputStream.toString()
+        val lines = result.lines().filter { it.isNotBlank() }
+
+        assertThat(lines.size, `is`(2))
+        assertThat(lines[0], `is`("id\tname"))
+        assertThat(lines[1], `is`("1\tAlice"))
+    }
+
+    @Test
+    fun `write headers only when no rows`() {
+        val outputStream = ByteArrayOutputStream()
+        TsvWriter(outputStream, listOf("id", "name", "value")).use { }
+
+        val result = outputStream.toString()
+        val lines = result.lines().filter { it.isNotBlank() }
+
+        assertThat(lines.size, `is`(1))
+        assertThat(lines[0], `is`("id\tname\tvalue"))
+    }
+
+    @Test
+    fun `handle null values`() {
+        val outputStream = ByteArrayOutputStream()
+        TsvWriter(outputStream, listOf("id", "name", "value")).use { writer ->
+            writer.writeRow(listOf("1", null, "100"))
+            writer.writeRow(listOf("2", "Bob", null))
+        }
+
+        val result = outputStream.toString()
+        val lines = result.lines().filter { it.isNotBlank() }
+
+        assertThat(lines.size, `is`(3))
+        assertThat(lines[0], `is`("id\tname\tvalue"))
+        assertThat(lines[1], `is`("1\t\t100"))
+        assertThat(lines[2], `is`("2\tBob\t"))
+    }
+
+    @Test
+    fun `handle empty string values`() {
+        val outputStream = ByteArrayOutputStream()
+        TsvWriter(outputStream, listOf("id", "name")).use { writer ->
+            writer.writeRow(listOf("1", ""))
+            writer.writeRow(listOf("", "Bob"))
+        }
+
+        val result = outputStream.toString()
+        val lines = result.lines().filter { it.isNotBlank() }
+
+        assertThat(lines.size, `is`(3))
+        assertThat(lines[1].startsWith("1\t"), `is`(true))
+        assertThat(lines[2].endsWith("Bob"), `is`(true))
+    }
+
+    @Test
+    fun `handle values containing special characters`() {
+        val outputStream = ByteArrayOutputStream()
+        TsvWriter(outputStream, listOf("id", "description")).use { writer ->
+            writer.writeRow(listOf("1", "value with \"quotes\""))
+            writer.writeRow(listOf("2", "value with\nnewline"))
+        }
+
+        val result = outputStream.toString()
+
+        // Values with special characters should be quoted by CSV library
+        assertThat(result.contains("1"), `is`(true))
+        assertThat(result.contains("quotes"), `is`(true))
+        assertThat(result.contains("newline"), `is`(true))
+    }
+
+    @Test
+    fun `handle single column`() {
+        val outputStream = ByteArrayOutputStream()
+        TsvWriter(outputStream, listOf("id")).use { writer ->
+            writer.writeRow(listOf("1"))
+            writer.writeRow(listOf("2"))
+        }
+
+        val result = outputStream.toString()
+        val lines = result.lines().filter { it.isNotBlank() }
+
+        assertThat(lines.size, `is`(3))
+        assertThat(lines[0], `is`("id"))
+        assertThat(lines[1], `is`("1"))
+        assertThat(lines[2], `is`("2"))
+    }
+}

--- a/docs/src/content/docs/for-users/revise-sequences.md
+++ b/docs/src/content/docs/for-users/revise-sequences.md
@@ -6,6 +6,21 @@ Sequences can be corrected or updated after they have been submitted to Loculus.
 
 The process of submitting revisions is very similar to original submission. The main difference is that you must provide an `accession` column in the metadata file, which contains the Loculus [accession number(s)](../../reference/glossary/#accession) assigned when the sequences were submitted originally.
 
+## Downloading original data for revision
+
+If you no longer have the original files you submitted, you can download them from Loculus. Note that Loculus stores your originally submitted data separately from the processed data shown on the website, so this download gives you the exact data you need for revisions.
+
+1. Navigate to your group's **Released sequences** page
+2. Filter or select specific sequences you want to revise
+3. Click the **Download original data** button on the top-right.
+
+This downloads a zip file containing:
+
+- `metadata.tsv` - your original metadata with an `accession` column already included
+- `sequences.fasta` - your original unaligned sequences (if the organism supports sequence files)
+
+You can then edit these files as needed and resubmit them as a revision. The download is limited to 500 sequences at a time.
+
 ## Preparing the metadata file
 
 The metadata file should include all the metadata fields that were originally included, **both** those that you wish to update and that should remain the same. (Not including a metadata column will set its value to 'empty'.)

--- a/integration-tests/tests/specs/features/download-original-data.spec.ts
+++ b/integration-tests/tests/specs/features/download-original-data.spec.ts
@@ -1,0 +1,170 @@
+import { expect } from '@playwright/test';
+import { test } from '../../fixtures/group.fixture';
+import { SearchPage } from '../../pages/search.page';
+import { ReviewPage } from '../../pages/review.page';
+import { SingleSequenceSubmissionPage } from '../../pages/submission.page';
+import { createTestMetadata, createTestSequenceData } from '../../test-helpers/test-data';
+import fs from 'fs';
+import { execSync } from 'child_process';
+import path from 'path';
+import os from 'os';
+
+const TEST_ORGANISM = 'ebola-sudan';
+const SEARCH_INDEXING_TIMEOUT = 60000;
+
+test.describe('Download Original Data', () => {
+    test('can download original data for all sequences on released sequences page', async ({
+        page,
+        groupId,
+    }) => {
+        test.setTimeout(200_000);
+
+        const submissionPage = new SingleSequenceSubmissionPage(page);
+        const timestamp = Date.now();
+
+        for (let i = 0; i < 2; i++) {
+            await submissionPage.completeSubmission(
+                createTestMetadata({ submissionId: `download-test-${timestamp}-${i}` }),
+                createTestSequenceData(),
+            );
+        }
+
+        const reviewPage = new ReviewPage(page);
+        await reviewPage.goto(groupId);
+        await reviewPage.waitForZeroProcessing();
+        await reviewPage.releaseValidSequences();
+
+        const searchPage = new SearchPage(page);
+        await searchPage.goToReleasedSequences(TEST_ORGANISM, groupId);
+        const accessionVersions = await searchPage.waitForSequencesInSearch(
+            2,
+            SEARCH_INDEXING_TIMEOUT,
+        );
+
+        expect(accessionVersions).toHaveLength(2);
+
+        const downloadPromise = page.waitForEvent('download');
+        await page.getByRole('button', { name: /Download original data/ }).click();
+        const download = await downloadPromise;
+
+        const downloadPath = await download.path();
+        expect(downloadPath).toBeTruthy();
+
+        // Verify ZIP magic number (PK = 0x50 0x4B)
+        const fileBuffer = fs.readFileSync(downloadPath);
+        expect(fileBuffer[0]).toBe(0x50);
+        expect(fileBuffer[1]).toBe(0x4b);
+
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'download-test-'));
+        try {
+            execSync(`unzip -o "${downloadPath}" -d "${tmpDir}"`);
+
+            const metadataPath = path.join(tmpDir, 'metadata.tsv');
+            expect(fs.existsSync(metadataPath)).toBe(true);
+
+            const sequencesPath = path.join(tmpDir, 'sequences.fasta');
+            expect(fs.existsSync(sequencesPath)).toBe(true);
+
+            const metadataContent = fs.readFileSync(metadataPath, 'utf8');
+            const metadataLines = metadataContent
+                .split('\n')
+                .filter((line) => line.trim().length > 0);
+
+            expect(metadataLines.length).toBe(3);
+
+            const header = metadataLines[0].split('\t');
+            expect(header).toContain('id');
+            expect(header).toContain('accession');
+
+            const idIndex = header.indexOf('id');
+            const accessionIndex = header.indexOf('accession');
+
+            const downloadedIds = metadataLines.slice(1).map((line) => line.split('\t')[idIndex]);
+            const downloadedAccessions = metadataLines
+                .slice(1)
+                .map((line) => line.split('\t')[accessionIndex]);
+
+            for (const av of accessionVersions) {
+                expect(downloadedIds).toContain(av.accessionVersion);
+                expect(downloadedAccessions).toContain(av.accession);
+            }
+
+            const fastaContent = fs.readFileSync(sequencesPath, 'utf8');
+            const fastaHeaders = fastaContent.split('\n').filter((line) => line.startsWith('>'));
+
+            expect(fastaHeaders.length).toBe(2);
+
+            for (const av of accessionVersions) {
+                expect(fastaHeaders.some((h) => h.includes(av.accessionVersion))).toBe(true);
+            }
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    test('can download original data for selected sequences only', async ({ page, groupId }) => {
+        test.setTimeout(200_000);
+
+        const submissionPage = new SingleSequenceSubmissionPage(page);
+        const timestamp = Date.now();
+
+        for (let i = 0; i < 3; i++) {
+            await submissionPage.completeSubmission(
+                createTestMetadata({ submissionId: `select-download-${timestamp}-${i}` }),
+                createTestSequenceData(),
+            );
+        }
+
+        const reviewPage = new ReviewPage(page);
+        await reviewPage.goto(groupId);
+        await reviewPage.waitForZeroProcessing();
+        await reviewPage.releaseValidSequences();
+
+        const searchPage = new SearchPage(page);
+        await searchPage.goToReleasedSequences(TEST_ORGANISM, groupId);
+        const accessionVersions = await searchPage.waitForSequencesInSearch(
+            3,
+            SEARCH_INDEXING_TIMEOUT,
+        );
+
+        expect(accessionVersions).toHaveLength(3);
+
+        const rows = searchPage.getSequenceRows();
+        for (let i = 0; i < 2; i++) {
+            const checkboxCell = rows.nth(i).locator('td').first();
+            await checkboxCell.click();
+        }
+
+        await expect(
+            page.getByRole('button', { name: /Download original data \(2 selected\)/ }),
+        ).toBeVisible();
+
+        const downloadPromise = page.waitForEvent('download');
+        await page.getByRole('button', { name: /Download original data/ }).click();
+        const download = await downloadPromise;
+
+        const downloadPath = await download.path();
+        expect(downloadPath).toBeTruthy();
+
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'select-download-test-'));
+        try {
+            execSync(`unzip -o "${downloadPath}" -d "${tmpDir}"`);
+
+            const metadataPath = path.join(tmpDir, 'metadata.tsv');
+            const metadataContent = fs.readFileSync(metadataPath, 'utf8');
+            const metadataLines = metadataContent
+                .split('\n')
+                .filter((line) => line.trim().length > 0);
+
+            expect(metadataLines.length).toBe(3);
+
+            const sequencesPath = path.join(tmpDir, 'sequences.fasta');
+            const fastaContent = fs.readFileSync(sequencesPath, 'utf8');
+            const fastaHeaders = fastaContent.split('\n').filter((line) => line.startsWith('>'));
+
+            expect(fastaHeaders.length).toBe(2);
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/integration-tests/tests/specs/features/download-original-data.spec.ts
+++ b/integration-tests/tests/specs/features/download-original-data.spec.ts
@@ -21,10 +21,14 @@ test.describe('Download Original Data', () => {
 
         const submissionPage = new SingleSequenceSubmissionPage(page);
         const timestamp = Date.now();
+        const submissionIds = Array.from(
+            { length: 2 },
+            (_, i) => `download-test-${timestamp}-${i}`,
+        );
 
-        for (let i = 0; i < 2; i++) {
+        for (const submissionId of submissionIds) {
             await submissionPage.completeSubmission(
-                createTestMetadata({ submissionId: `download-test-${timestamp}-${i}` }),
+                createTestMetadata({ submissionId }),
                 createTestSequenceData(),
             );
         }
@@ -84,8 +88,11 @@ test.describe('Download Original Data', () => {
                 .slice(1)
                 .map((line) => line.split('\t')[accessionIndex]);
 
+            for (const submissionId of submissionIds) {
+                expect(downloadedIds).toContain(submissionId);
+            }
+
             for (const av of accessionVersions) {
-                expect(downloadedIds).toContain(av.accessionVersion);
                 expect(downloadedAccessions).toContain(av.accession);
             }
 
@@ -94,8 +101,8 @@ test.describe('Download Original Data', () => {
 
             expect(fastaHeaders.length).toBe(2);
 
-            for (const av of accessionVersions) {
-                expect(fastaHeaders.some((h) => h.includes(av.accessionVersion))).toBe(true);
+            for (const submissionId of submissionIds) {
+                expect(fastaHeaders.some((h) => h.includes(submissionId))).toBe(true);
             }
         } finally {
             fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/website/src/components/SearchPage/DownloadDialog/DownloadOriginalDataButton.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadOriginalDataButton.tsx
@@ -104,16 +104,23 @@ export const DownloadOriginalDataButton: FC<DownloadOriginalDataButtonProps> = (
     }, [sequenceFilter, backendUrl, accessToken, organism, groupId, sequenceCount, fetchAccessions]);
 
     const isDisabled = isDownloading || exceedsLimit;
-    const tooltipText = exceedsLimit
-        ? `Download is limited to ${MAX_DOWNLOAD_ENTRIES} entries. Please select fewer sequences.`
-        : undefined;
 
     return (
         <div className='relative'>
-            <div title={tooltipText}>
-                <Button className='w-[18rem] outlineButton' onClick={() => void handleDownload()} disabled={isDisabled}>
+            <div className='group relative inline-block'>
+                <Button
+                    className={`w-[18rem] outlineButton ${exceedsLimit ? 'opacity-50 cursor-not-allowed hover:bg-white hover:text-primary-600' : ''}`}
+                    onClick={() => void handleDownload()}
+                    disabled={isDisabled}
+                >
                     {isDownloading ? 'Downloading...' : buttonText}
                 </Button>
+                {exceedsLimit && (
+                    <div className='invisible group-hover:visible absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 text-sm text-white bg-gray-800 rounded-md shadow-lg whitespace-nowrap z-20'>
+                        Limited to {formatNumberWithDefaultLocale(MAX_DOWNLOAD_ENTRIES)} entries. Please select fewer.
+                        <div className='absolute left-1/2 -translate-x-1/2 top-full w-0 h-0 border-x-8 border-x-transparent border-t-8 border-t-gray-800' />
+                    </div>
+                )}
             </div>
             {error !== null && (
                 <div className='absolute top-full left-0 mt-1 text-sm text-red-600 bg-white p-2 rounded shadow-md z-10 max-w-xs'>

--- a/website/src/components/SearchPage/DownloadDialog/DownloadOriginalDataButton.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadOriginalDataButton.tsx
@@ -1,0 +1,128 @@
+import { type FC, useState, useCallback } from 'react';
+
+import { type SequenceFilter } from './SequenceFilters';
+import { getOriginalData } from '../../../services/backendClientSideApi';
+import { downloadBlob } from '../../../utils/downloadBlob';
+import { parseAccessionVersionFromString } from '../../../utils/extractAccessionVersion';
+import { formatNumberWithDefaultLocale } from '../../../utils/formatNumber';
+import { Button } from '../../common/Button';
+
+const MAX_DOWNLOAD_ENTRIES = 500;
+
+type DownloadOriginalDataButtonProps = {
+    sequenceFilter: SequenceFilter;
+    backendUrl: string;
+    accessToken: string;
+    organism: string;
+    groupId: number;
+    totalSequences?: number;
+    fetchAccessions: () => Promise<string[]>;
+};
+
+export const DownloadOriginalDataButton: FC<DownloadOriginalDataButtonProps> = ({
+    sequenceFilter,
+    backendUrl,
+    accessToken,
+    organism,
+    groupId,
+    totalSequences,
+    fetchAccessions,
+}) => {
+    const [isDownloading, setIsDownloading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const sequenceCount = sequenceFilter.sequenceCount();
+    const effectiveCount = sequenceCount ?? totalSequences;
+    const exceedsLimit = effectiveCount !== undefined && effectiveCount > MAX_DOWNLOAD_ENTRIES;
+
+    let buttonText: string;
+    if (sequenceCount === undefined) {
+        const formattedCount = totalSequences !== undefined ? formatNumberWithDefaultLocale(totalSequences) : 'all';
+        buttonText = `Download original data (${formattedCount})`;
+    } else {
+        const formattedCount = formatNumberWithDefaultLocale(sequenceCount);
+        buttonText = `Download original data (${formattedCount} selected)`;
+    }
+
+    const extractAccessions = (accessionVersions: string[]): string[] => {
+        const accessions = accessionVersions.map((av) => parseAccessionVersionFromString(av).accession);
+        return [...new Set(accessions)];
+    };
+
+    const handleDownload = useCallback(async () => {
+        setIsDownloading(true);
+        setError(null);
+
+        try {
+            let accessionVersions: string[];
+
+            if (sequenceCount !== undefined) {
+                const apiParams = sequenceFilter.toApiParams();
+                const selectedVersions = apiParams.accessionVersion;
+                if (!Array.isArray(selectedVersions)) {
+                    throw new Error('No accessions selected');
+                }
+                accessionVersions = selectedVersions;
+            } else {
+                accessionVersions = await fetchAccessions();
+                if (accessionVersions.length > MAX_DOWNLOAD_ENTRIES) {
+                    throw new Error(
+                        `Too many sequences (${accessionVersions.length}). Please filter to ${MAX_DOWNLOAD_ENTRIES} or fewer.`,
+                    );
+                }
+            }
+
+            const accessions = extractAccessions(accessionVersions);
+            if (accessions.length === 0) {
+                throw new Error('No sequences to download');
+            }
+
+            const result = await getOriginalData(backendUrl, organism, accessToken, {
+                groupId,
+                accessionsFilter: accessions,
+            });
+
+            if (!result.ok) {
+                throw new Error(
+                    `Download failed: ${result.error.status} ${result.error.statusText}. ${result.error.detail}`,
+                );
+            }
+
+            if (result.blob.size === 0) {
+                throw new Error('No data to download');
+            }
+
+            const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+            const filename = `${organism}_original_data_${timestamp}.zip`;
+            downloadBlob(result.blob, filename);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'Download failed';
+            setError(message);
+        } finally {
+            setIsDownloading(false);
+        }
+    }, [sequenceFilter, backendUrl, accessToken, organism, groupId, sequenceCount, fetchAccessions]);
+
+    const isDisabled = isDownloading || exceedsLimit;
+    const tooltipText = exceedsLimit
+        ? `Download is limited to ${MAX_DOWNLOAD_ENTRIES} entries. Please select fewer sequences.`
+        : undefined;
+
+    return (
+        <div className='relative'>
+            <div title={tooltipText}>
+                <Button className='w-[18rem] outlineButton' onClick={() => void handleDownload()} disabled={isDisabled}>
+                    {isDownloading ? 'Downloading...' : buttonText}
+                </Button>
+            </div>
+            {error !== null && (
+                <div className='absolute top-full left-0 mt-1 text-sm text-red-600 bg-white p-2 rounded shadow-md z-10 max-w-xs'>
+                    {error}
+                    <Button className='ml-2 text-gray-500 hover:text-gray-700' onClick={() => setError(null)}>
+                        x
+                    </Button>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/website/src/components/SearchPage/DownloadDialog/DownloadOriginalDataButton.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadOriginalDataButton.tsx
@@ -65,11 +65,6 @@ export const DownloadOriginalDataButton: FC<DownloadOriginalDataButtonProps> = (
                 accessionVersions = selectedVersions;
             } else {
                 accessionVersions = await fetchAccessions();
-                if (accessionVersions.length > MAX_DOWNLOAD_ENTRIES) {
-                    throw new Error(
-                        `Too many sequences (${accessionVersions.length}). Please filter to ${MAX_DOWNLOAD_ENTRIES} or fewer.`,
-                    );
-                }
             }
 
             const accessions = extractAccessions(accessionVersions);
@@ -125,7 +120,11 @@ export const DownloadOriginalDataButton: FC<DownloadOriginalDataButtonProps> = (
             {error !== null && (
                 <div className='absolute top-full left-0 mt-1 text-sm text-red-600 bg-white p-2 rounded shadow-md z-10 max-w-xs'>
                     {error}
-                    <Button className='ml-2 text-gray-500 hover:text-gray-700' onClick={() => setError(null)}>
+                    <Button
+                        className='ml-2 text-gray-500 hover:text-gray-700'
+                        onClick={() => setError(null)}
+                        aria-label='Dismiss error'
+                    >
                         x
                     </Button>
                 </div>

--- a/website/src/components/SearchPage/SearchFullUI.spec.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.spec.tsx
@@ -117,6 +117,7 @@ function renderSearchFullUI({
         initialCount: 0,
         initialQueryDict: {},
         hiddenFieldValues,
+        isReleasedPage: true,
     } satisfies InnerSearchFullUIProps;
 
     render(

--- a/website/src/pages/[organism]/search/index.astro
+++ b/website/src/pages/[organism]/search/index.astro
@@ -68,5 +68,6 @@ const sequenceFlaggingConfig = getWebsiteConfig().sequenceFlagging;
         dataUseTermsEnabled={dataUseTermsAreEnabled()}
         sequenceFlaggingConfig={sequenceFlaggingConfig}
         linkOuts={schema.linkOuts}
+        isReleasedPage={false}
     />
 </BaseLayout>

--- a/website/src/pages/[organism]/submission/[groupId]/released.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/released.astro
@@ -71,5 +71,7 @@ const sequenceFlaggingConfig = getWebsiteConfig().sequenceFlagging;
         dataUseTermsEnabled={dataUseTermsAreEnabled()}
         sequenceFlaggingConfig={sequenceFlaggingConfig}
         showEditDataUseTermsControls
+        groupId={group.groupId}
+        isReleasedPage={true}
     />
 </SubmissionPageWrapper>

--- a/website/src/services/backendClientSideApi.ts
+++ b/website/src/services/backendClientSideApi.ts
@@ -1,0 +1,53 @@
+import { createAuthorizationHeader } from '../utils/createAuthorizationHeader.ts';
+
+/**
+ * Client-side Backend API functions.
+ * Use these for imperative backend API calls in React components that need
+ * special handling (e.g., blob responses) not supported by the Zodios hooks.
+ */
+
+export type GetOriginalDataRequest = {
+    groupId: number;
+    accessionsFilter: string[];
+};
+
+export type GetOriginalDataError = {
+    status: number;
+    statusText: string;
+    detail: string;
+};
+
+export type GetOriginalDataResult = { ok: true; blob: Blob } | { ok: false; error: GetOriginalDataError };
+
+export async function getOriginalData(
+    backendUrl: string,
+    organism: string,
+    accessToken: string,
+    request: GetOriginalDataRequest,
+): Promise<GetOriginalDataResult> {
+    const url = `${backendUrl}/${organism}/get-original-data`;
+
+    const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+            ...createAuthorizationHeader(accessToken),
+            'Content-Type': 'application/json', // eslint-disable-line @typescript-eslint/naming-convention
+        },
+        body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        return {
+            ok: false,
+            error: {
+                status: response.status,
+                statusText: response.statusText,
+                detail: errorText,
+            },
+        };
+    }
+
+    const blob = await response.blob();
+    return { ok: true, blob };
+}

--- a/website/src/services/backendClientSideApi.ts
+++ b/website/src/services/backendClientSideApi.ts
@@ -38,12 +38,23 @@ export async function getOriginalData(
 
     if (!response.ok) {
         const errorText = await response.text();
+        let detail = errorText;
+        try {
+            const errorJson = JSON.parse(errorText) as { detail?: unknown; message?: unknown };
+            detail =
+                (typeof errorJson.detail === 'string' && errorJson.detail) ||
+                (typeof errorJson.message === 'string' && errorJson.message) ||
+                errorText;
+        } catch {
+            // Keep text response when the backend did not return JSON.
+        }
+
         return {
             ok: false,
             error: {
                 status: response.status,
                 statusText: response.statusText,
-                detail: errorText,
+                detail,
             },
         };
     }

--- a/website/src/services/lapisClientSideApi.ts
+++ b/website/src/services/lapisClientSideApi.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+import type { DetailsResponse } from '../types/lapis.ts';
+
+/**
+ * Client-side LAPIS API functions.
+ * Use these for imperative LAPIS calls in React components (e.g., button click handlers).
+ * For reactive data fetching, use the hooks from serviceHooks.ts instead.
+ */
+export async function fetchDetailsFromLapis(
+    lapisUrl: string,
+    request: Record<string, unknown>,
+): Promise<DetailsResponse> {
+    const response = await axios.post<DetailsResponse>(`${lapisUrl}/sample/details`, {
+        ...request,
+        dataFormat: 'json',
+    });
+    return response.data;
+}

--- a/website/src/utils/downloadBlob.ts
+++ b/website/src/utils/downloadBlob.ts
@@ -1,0 +1,13 @@
+/**
+ * Triggers a browser download of a Blob as a file.
+ */
+export function downloadBlob(blob: Blob, filename: string): void {
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary

Follow-up for #5856 addressing several review comments on the original-data download feature.

Changes:
- preserve original submission IDs in the downloaded metadata `id` column and single-segment FASTA headers
- preserve original multi-segment FASTA IDs instead of rewriting them with accession-version prefixes
- move group authorization out of `countOriginalData` / `streamOriginalData`
- remove the unused accession-version filter plumbing from original metadata helpers
- clear MDC in a `finally` block for the zip streaming response
- parse structured backend error responses in the client helper
- remove inconsistent client-side post-fetch size validation and add an accessible dismiss label
- remove redundant `required = true` schema annotation

I left the writer close/flush comments alone: these writers are wrapping an active `ZipOutputStream` entry, so closing the wrapped writer would close the whole zip stream before later entries are written.

## Checks

- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./gradlew test --tests org.loculus.backend.controller.submission.GetOriginalDataEndpointTest`
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./gradlew ktlintCheck`
- `npm run check-types` (passes with existing `EditableSequences.spec.ts` deprecation hints)
- `npx prettier --check src/components/SearchPage/DownloadDialog/DownloadOriginalDataButton.tsx src/services/backendClientSideApi.ts`
- `git diff --check`

Note: repo-wide `npm run check-format` currently fails on existing unrelated lint issues in `EditableSequences.spec.ts`, `SearchForm.spec.tsx`, and `FileUploadComponent.tsx`.

🚀 Preview: Add `preview` label to enable