### PR TITLE
fix(website): avoid empty `?` being appended to search URL

### DIFF
--- a/website/src/components/SearchPage/useStateSyncedWithUrlQueryParams.spec.ts
+++ b/website/src/components/SearchPage/useStateSyncedWithUrlQueryParams.spec.ts
@@ -163,11 +163,11 @@ describe('useStateSyncedWithUrlQueryParams', () => {
                 result.current[1]({ country: [] });
             });
 
-            // Empty arrays should not appear in the URL
+            // Empty arrays should not appear in the URL, and no trailing '?' should be added
             expect(replaceStateMock).toHaveBeenCalledWith(
-                { path: 'http://localhost:3000/test?' },
+                { path: 'http://localhost:3000/test' },
                 '',
-                'http://localhost:3000/test?',
+                'http://localhost:3000/test',
             );
         });
     });

--- a/website/src/components/SearchPage/useStateSyncedWithUrlQueryParams.ts
+++ b/website/src/components/SearchPage/useStateSyncedWithUrlQueryParams.ts
@@ -43,8 +43,14 @@ function dictToSearchParams(dict: QueryState) {
 function buildUrlFromParams(params: URLSearchParams) {
     const base = window.location.protocol + '//' + window.location.host + window.location.pathname;
 
-    // Keep the original behavior of always appending '?'
-    let url = base + '?' + params.toString();
+    const paramsString = params.toString();
+
+    // Avoid appending an empty '?' when there are no query parameters
+    if (paramsString === '') {
+        return base;
+    }
+
+    let url = base + '?' + paramsString;
 
     // Avoid '*' at the end because some systems do not recognize it as part of the link
     if (url.endsWith('*')) {


### PR DESCRIPTION
## Summary

Fixes #6451.

Visiting a search page without any filters — e.g. `https://pathoplexus.org/ebola-bdbv/search` — would immediately rewrite the URL to `https://pathoplexus.org/ebola-bdbv/search?` with a trailing empty `?`.

The cause is in `useStateSyncedWithUrlQueryParams`, which keeps the browser URL in sync with the search page state. Its `buildUrlFromParams` helper always appended `?` followed by `params.toString()`. When the state has no query parameters, `params.toString()` is an empty string, leaving a bare trailing `?`.

## Change

`buildUrlFromParams` now returns the base path unchanged when there are no query parameters, so no empty `?` is appended. When parameters are present, behaviour is unchanged (including the existing `*`-suffix workaround).

## Testing

- Updated the existing "correctly serializes empty arrays" unit test to expect `/test` instead of `/test?`.
- `useStateSyncedWithUrlQueryParams.spec.ts` (11 tests) and `SearchFullUI.spec.tsx` (21 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable