### PR TITLE
fix(preprocessing): suffix per-segment inputs with segment name

### DIFF
--- a/kubernetes/loculus/templates/_preprocessingFromValues.tpl
+++ b/kubernetes/loculus/templates/_preprocessingFromValues.tpl
@@ -8,8 +8,17 @@
   {{- end }}
   {{- if hasKey .preprocessing "inputs" }}
   inputs:
-    {{- with index .preprocessing "inputs" }}
-    {{- . | toYaml | nindent 4 }}
+    {{- $segment := .segment }}
+    {{- $perSegmentFields := .perSegmentFields | default dict }}
+    {{- range $argName, $inputField := (index .preprocessing "inputs") }}
+    {{- /* When generating a per-segment spec, inputs that reference a per-segment
+           metadata field must be suffixed with the segment, because the submitted
+           metadata for those fields is itself segment-specific (e.g. ncbiReleaseDate_L). */}}
+    {{- if and $segment (hasKey $perSegmentFields $inputField) }}
+    {{ $argName }}: {{ printf "%s_%s" $inputField $segment }}
+    {{- else }}
+    {{ $argName }}: {{ $inputField }}
+    {{- end }}
     {{- end }}
   {{- end }}
   args:
@@ -67,12 +76,21 @@
 {{- $rawUniqueSegments := (include "loculus.getNucleotideSegmentNames" $referenceGenomes | fromYaml).segments }}
 {{- $isSegmented := gt (len $rawUniqueSegments) 1 }}
 
+{{- /* Names of fields that are split per segment. Inputs referencing these must be
+       segment-suffixed when generating per-segment specs. */}}
+{{- $perSegmentFields := dict }}
+{{- if $isSegmented }}
+{{- range $metadata }}
+{{- if .perSegment }}{{- $_ := set $perSegmentFields .name true }}{{- end }}
+{{- end }}
+{{- end }}
+
 {{- range $metadata }}
     {{- $currentItem := . }}
     {{- if and $isSegmented .perSegment }}
         {{- range $segment := $rawUniqueSegments }}
             {{- with $currentItem }}
-            {{- $args := deepCopy . | merge (dict "segment" $segment "key" (printf "%s_%s" .name $segment)) }}
+            {{- $args := deepCopy . | merge (dict "segment" $segment "key" (printf "%s_%s" .name $segment) "perSegmentFields" $perSegmentFields) }}
             {{- include "loculus.sharedPreproSpecs" $args }}
             {{- end }}
         {{- end }}
@@ -81,7 +99,7 @@
         {{- if .relatesToSegment }}
         {{- $segment = .relatesToSegment }}
         {{- end }}
-        {{- $args := deepCopy . | merge (dict "segment" $segment "key" .name) }}
+        {{- $args := deepCopy . | merge (dict "segment" $segment "key" .name "perSegmentFields" $perSegmentFields) }}
         {{- include "loculus.sharedPreproSpecs" $args }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
## Why

Targets the `ingest_grouping_dates` branch (#6390). On that branch `@anna-parker` observed that `earliestReleaseDate` for CCHF shows the Loculus internal release date instead of the earliest NCBI release date.

## Root cause

#6390 makes `ncbiReleaseDate` `perSegment: true` (so it is no longer used for grouping and can vary per segment), and points CCHF's `earliestReleaseDate.externalFields` at `ncbiReleaseDate_L/_M/_S`.

For a `perSegment` field, the website/backend schemas and the ingest grouping correctly produce segment-suffixed fields (`ncbiReleaseDate_L`, `ncbiReleaseDate_M`, `ncbiReleaseDate_S`). The submitted metadata therefore contains only those suffixed keys — there is no bare `ncbiReleaseDate`.

However, `loculus.preprocessingSpecs` (`kubernetes/loculus/templates/_preprocessingFromValues.tpl`) generated the per-segment preprocessing specs with the **unsuffixed** input name. The rendered config looked like:

```yaml
ncbiReleaseDate_L:
  function: parse_timestamp
  inputs:
    timestamp: ncbiReleaseDate   # <-- not ncbiReleaseDate_L
  args:
    segment: L
```

`add_input_metadata` in the preprocessing pipeline looks the input path up verbatim in the submitted metadata. `ncbiReleaseDate` is absent, so it returns `None`, and the processed `ncbiReleaseDate_L/_M/_S` fields are all null.

`EarliestReleaseDateFinder` then sees only null external date fields and falls back to `releasedAtTimestamp` (the Loculus internal release date) — exactly the reported symptom.

This only affected fields that are both `perSegment` **and** have an explicit `preprocessing.inputs` block referencing a plain submitted field. `ncbiUpdateDate` had the same latcreated bug since 2024, but it is only a display column so it went unnoticed. Fields with `nextclade.*` inputs were unaffected because those are resolved per-segment via the `segment` arg.

## Fix

`loculus.preprocessingSpecs` now builds the set of `perSegment` field names and, when generating a per-segment spec, suffixes any input that references one of those fields with the segment name. `nextclade.*` / `processed.*` inputs are left untouched.

Rendered result after the fix:

```yaml
ncbiReleaseDate_L:
  function: parse_timestamp
  inputs:
    timestamp: ncbiReleaseDate_L
  args:
    segment: L
```

## Testing

- `helm template kubernetes/loculus -f kubernetes/loculus/values.yaml --show-only templates/loculus-preprocessing-config.yaml` — `ncbiReleaseDate_{L,M,S}` and `ncbiUpdateDate_{L,M,S}` now read the matching segment-suffixed input; `nextclade.*` inputs (e.g. `totalSnps`, `completeness`) remain unchanged.
- `helm lint kubernetes/loculus -f kubernetes/loculus/values.yaml` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable