### PR TITLE
feat(website): move SeqSet creator details into a modal

### DIFF
--- a/integration-tests/tests/pages/seqset.page.ts
+++ b/integration-tests/tests/pages/seqset.page.ts
@@ -83,7 +83,7 @@ export class SeqSetPage {
 
     async expectCreatorDetailsInModal() {
         await expect(this.page.getByText('Created by', { exact: true })).toBeHidden();
-        await this.page.getByRole('button', { name: 'Show creator details' }).click();
+        await this.page.getByRole('button', { name: 'More details' }).click();
         await expect(this.page.getByRole('heading', { name: 'Creator details' })).toBeVisible();
         await expect(this.page.getByText('Created by', { exact: true })).toBeVisible();
         await expect(this.page.getByText('Created date', { exact: true })).toBeVisible();

--- a/integration-tests/tests/pages/seqset.page.ts
+++ b/integration-tests/tests/pages/seqset.page.ts
@@ -76,10 +76,19 @@ export class SeqSetPage {
         await expect(this.page.getByText('Description', { exact: true })).toBeVisible();
         await expect(this.page.getByText(description, { exact: true })).toBeVisible();
         await expect(this.page.getByText('Version', { exact: true })).toBeVisible();
-        await expect(this.page.getByText('Created by', { exact: true })).toBeVisible();
-        await expect(this.page.getByText('Created date', { exact: true })).toBeVisible();
         await expect(this.page.getByText('Size', { exact: true })).toBeVisible();
         await expect(this.page.getByText('Accession', { exact: true })).toBeVisible();
+        await this.expectCreatorDetailsInModal();
+    }
+
+    async expectCreatorDetailsInModal() {
+        await expect(this.page.getByText('Created by', { exact: true })).toBeHidden();
+        await this.page.getByRole('button', { name: 'Show creator details' }).click();
+        await expect(this.page.getByRole('heading', { name: 'Creator details' })).toBeVisible();
+        await expect(this.page.getByText('Created by', { exact: true })).toBeVisible();
+        await expect(this.page.getByText('Created date', { exact: true })).toBeVisible();
+        await this.page.keyboard.press('Escape');
+        await expect(this.page.getByRole('heading', { name: 'Creator details' })).toBeHidden();
     }
 
     async exportSeqSet(format: SeqSetExportFormat): Promise<Download> {

--- a/website/src/components/SeqSetCitations/SeqSetItem.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItem.tsx
@@ -18,10 +18,12 @@ import type { ClientConfig } from '../../types/runtimeConfig';
 import { type AuthorProfile, type CitedByResult, type SeqSet, type SeqSetRecord } from '../../types/seqSetCitation';
 import { createAuthorizationHeader } from '../../utils/createAuthorizationHeader';
 import { displayConfirmationDialog } from '../ConfirmationDialog.tsx';
+import { BaseDialog } from '../common/BaseDialog.tsx';
 import { Button } from '../common/Button.tsx';
 import { withQueryProvider } from '../common/withQueryProvider.tsx';
 import MdiDotsGrid from '~icons/mdi/dots-grid';
 import MdiViewGrid from '~icons/mdi/view-grid';
+import RiInformationLine from '~icons/ri/information-line';
 
 const logger = getClientLogger('SeqSetItem');
 
@@ -79,6 +81,7 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
 }) => {
     const [page, setPage] = useState(1);
     const [wideGraphs, setWideGraphs] = useState(false);
+    const [isCreatorInfoOpen, setIsCreatorInfoOpen] = useState(false);
     const sequencesPerPage = 10;
 
     const {
@@ -146,33 +149,49 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
     // Colour used for the plots, derived from colors.json
     const barPlotColor = mainTailwindColor[500];
 
+    const createdByValue = seqSetAuthor ? (
+        <AuthorDetails displayFullDetails={false} firstName={seqSetAuthor.firstName} lastName={seqSetAuthor.lastName} />
+    ) : (
+        'Unknown'
+    );
+
     return (
         <div className='flex flex-col'>
             <div className='grid grid-cols-1 lg:grid-cols-2'>
-                <SeqSetSection title='Details'>
+                <SeqSetSection
+                    title='Details'
+                    headerContent={
+                        <Button
+                            className='text-gray-400 hover:text-gray-600'
+                            title='Show creator details'
+                            aria-label='Show creator details'
+                            onClick={() => setIsCreatorInfoOpen(true)}
+                        >
+                            <RiInformationLine className='w-5 h-5' />
+                        </Button>
+                    }
+                >
                     <SeqSetSectionEntry label='Name' value={seqSet.name} />
                     <SeqSetSectionEntry label='Description' value={seqSet.description ?? 'N/A'} />
                     <SeqSetSectionEntry label='Version' value={seqSet.seqSetVersion} />
-                    <SeqSetSectionEntry
-                        label='Created by'
-                        value={
-                            seqSetAuthor ? (
-                                <AuthorDetails
-                                    displayFullDetails={false}
-                                    firstName={seqSetAuthor.firstName}
-                                    lastName={seqSetAuthor.lastName}
-                                />
-                            ) : (
-                                'Unknown'
-                            )
-                        }
-                    />
-                    <SeqSetSectionEntry label='Created date' value={formatDate(seqSet.createdAt)} />
                     <SeqSetSectionEntry
                         label='Size'
                         value={`${seqSetRecords.length} sequence${seqSetRecords.length === 1 ? '' : 's'}`}
                     />
                 </SeqSetSection>
+                <BaseDialog
+                    title='Creator details'
+                    isOpen={isCreatorInfoOpen}
+                    onClose={() => setIsCreatorInfoOpen(false)}
+                    fullWidth={false}
+                >
+                    <p className='mb-4 text-sm text-gray-500'>
+                        The creator is the person who assembled this SeqSet on Loculus. They are not necessarily the
+                        originator of the underlying sequence data.
+                    </p>
+                    <SeqSetSectionEntry label='Created by' value={createdByValue} />
+                    <SeqSetSectionEntry label='Created date' value={formatDate(seqSet.createdAt)} />
+                </BaseDialog>
                 <SeqSetSection title='Citations'>
                     <SeqSetSectionEntry label='DOI' value={renderDOI()} />
                     <SeqSetSectionEntry

--- a/website/src/components/SeqSetCitations/SeqSetItem.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItem.tsx
@@ -3,7 +3,6 @@ import { AxiosError } from 'axios';
 import { type FC, useState } from 'react';
 import { toast } from 'react-toastify';
 
-import { AuthorDetails } from './AuthorDetails.tsx';
 import { CitationPlot } from './CitationPlot';
 import { DatePlot, CategoryPlot } from './SeqSetPlots.tsx';
 import { SeqSetRecordsTableWithMetadata } from './SeqSetRecordsTableWithMetadata';
@@ -15,15 +14,13 @@ import { seqSetCitationClientHooks } from '../../services/serviceHooks';
 import type { ProblemDetail } from '../../types/backend.ts';
 import type { SeqSetGraph } from '../../types/config.ts';
 import type { ClientConfig } from '../../types/runtimeConfig';
-import { type AuthorProfile, type CitedByResult, type SeqSet, type SeqSetRecord } from '../../types/seqSetCitation';
+import { type CitedByResult, type SeqSet, type SeqSetRecord } from '../../types/seqSetCitation';
 import { createAuthorizationHeader } from '../../utils/createAuthorizationHeader';
 import { displayConfirmationDialog } from '../ConfirmationDialog.tsx';
-import { BaseDialog } from '../common/BaseDialog.tsx';
 import { Button } from '../common/Button.tsx';
 import { withQueryProvider } from '../common/withQueryProvider.tsx';
 import MdiDotsGrid from '~icons/mdi/dots-grid';
 import MdiViewGrid from '~icons/mdi/view-grid';
-import RiInformationLine from '~icons/ri/information-line';
 
 const logger = getClientLogger('SeqSetItem');
 
@@ -55,7 +52,6 @@ type SeqSetItemProps = {
     accessToken: string;
     seqSetAccessionVersion: string;
     seqSet: SeqSet;
-    seqSetAuthor?: AuthorProfile;
     seqSetRecords: SeqSetRecord[];
     citedByData: CitedByResult;
     seqSetGraphs: SeqSetGraph[];
@@ -70,7 +66,6 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
     accessToken,
     seqSetAccessionVersion,
     seqSet,
-    seqSetAuthor,
     seqSetRecords,
     citedByData,
     seqSetGraphs,
@@ -81,7 +76,6 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
 }) => {
     const [page, setPage] = useState(1);
     const [wideGraphs, setWideGraphs] = useState(false);
-    const [isCreatorInfoOpen, setIsCreatorInfoOpen] = useState(false);
     const sequencesPerPage = 10;
 
     const {
@@ -104,14 +98,6 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
 
     const getCrossRefUrl = () => {
         return `https://search.crossref.org/search/works?from_ui=yes&q=${seqSet.seqSetDOI}`;
-    };
-
-    const formatDate = (date?: string) => {
-        if (date === undefined) {
-            return 'N/A';
-        }
-        const dateObj = new Date(date);
-        return dateObj.toISOString().split('T')[0];
     };
 
     const renderDOI = () => {
@@ -149,28 +135,10 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
     // Colour used for the plots, derived from colors.json
     const barPlotColor = mainTailwindColor[500];
 
-    const createdByValue = seqSetAuthor ? (
-        <AuthorDetails displayFullDetails={false} firstName={seqSetAuthor.firstName} lastName={seqSetAuthor.lastName} />
-    ) : (
-        'Unknown'
-    );
-
     return (
         <div className='flex flex-col'>
             <div className='grid grid-cols-1 lg:grid-cols-2'>
-                <SeqSetSection
-                    title='Details'
-                    headerContent={
-                        <Button
-                            className='text-gray-400 hover:text-gray-600'
-                            title='Show creator details'
-                            aria-label='Show creator details'
-                            onClick={() => setIsCreatorInfoOpen(true)}
-                        >
-                            <RiInformationLine className='w-5 h-5' />
-                        </Button>
-                    }
-                >
+                <SeqSetSection title='Details'>
                     <SeqSetSectionEntry label='Name' value={seqSet.name} />
                     <SeqSetSectionEntry label='Description' value={seqSet.description ?? 'N/A'} />
                     <SeqSetSectionEntry label='Version' value={seqSet.seqSetVersion} />
@@ -179,19 +147,6 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
                         value={`${seqSetRecords.length} sequence${seqSetRecords.length === 1 ? '' : 's'}`}
                     />
                 </SeqSetSection>
-                <BaseDialog
-                    title='Creator details'
-                    isOpen={isCreatorInfoOpen}
-                    onClose={() => setIsCreatorInfoOpen(false)}
-                    fullWidth={false}
-                >
-                    <p className='mb-4 text-sm text-gray-500'>
-                        The creator is the person who assembled this SeqSet on Loculus. They are not necessarily the
-                        originator of the underlying sequence data.
-                    </p>
-                    <SeqSetSectionEntry label='Created by' value={createdByValue} />
-                    <SeqSetSectionEntry label='Created date' value={formatDate(seqSet.createdAt)} />
-                </BaseDialog>
                 <SeqSetSection title='Citations'>
                     <SeqSetSectionEntry label='DOI' value={renderDOI()} />
                     <SeqSetSectionEntry

--- a/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
@@ -1,28 +1,39 @@
 import { type FC, useState } from 'react';
 import { toast } from 'react-toastify';
 
+import { AuthorDetails } from './AuthorDetails.tsx';
 import { ExportSeqSet } from './ExportSeqSet';
 import { SeqSetForm } from './SeqSetForm';
 import { getClientLogger } from '../../clientLogger';
 import { seqSetCitationClientHooks } from '../../services/serviceHooks';
 import type { ClientConfig } from '../../types/runtimeConfig';
-import type { SeqSetRecord, SeqSet } from '../../types/seqSetCitation';
+import type { AuthorProfile, SeqSetRecord, SeqSet } from '../../types/seqSetCitation';
 import { createAuthorizationHeader } from '../../utils/createAuthorizationHeader';
 import { getAccessionVersionString } from '../../utils/extractAccessionVersion.ts';
 import { displayConfirmationDialog } from '../ConfirmationDialog.tsx';
+import { BaseDialog } from '../common/BaseDialog.tsx';
 import { Button } from '../common/Button';
 import Modal from '../common/Modal';
 import { withQueryProvider } from '../common/withQueryProvider.tsx';
 import MdiDelete from '~icons/mdi/delete';
 import MdiDownload from '~icons/mdi/download';
+import MdiInformationOutline from '~icons/mdi/information-outline';
 import MdiPencil from '~icons/mdi/pencil';
 
 const logger = getClientLogger('SeqSetItemActions');
+
+const CreatorDetailEntry: FC<{ label: string; value: React.ReactNode }> = ({ label, value }) => (
+    <div className='flex flex-row py-1.5'>
+        <div className='mr-8 w-[120px] text-gray-500'>{label}</div>
+        <div>{value}</div>
+    </div>
+);
 
 type SeqSetItemActionsProps = {
     clientConfig: ClientConfig;
     accessToken: string;
     seqSet: SeqSet;
+    seqSetAuthor?: AuthorProfile;
     seqSetRecords: SeqSetRecord[];
     isAdminView?: boolean;
     databaseName: string;
@@ -32,6 +43,7 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
     clientConfig,
     accessToken,
     seqSet,
+    seqSetAuthor,
     seqSetRecords,
     isAdminView = false,
     databaseName,
@@ -43,6 +55,7 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
 
     const [editModalVisible, setEditModalVisible] = useState(false);
     const [exportModalVisible, setExportModalVisible] = useState(false);
+    const [creatorInfoVisible, setCreatorInfoVisible] = useState(false);
 
     const { mutate: deleteSeqSet } = useDeleteSeqSetAction(
         clientConfig,
@@ -55,6 +68,19 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
     const handleDeleteSeqSet = () => {
         deleteSeqSet(undefined);
     };
+
+    const formatDate = (date?: string) => {
+        if (date === undefined) {
+            return 'N/A';
+        }
+        return new Date(date).toISOString().split('T')[0];
+    };
+
+    const createdByValue = seqSetAuthor ? (
+        <AuthorDetails displayFullDetails={false} firstName={seqSetAuthor.firstName} lastName={seqSetAuthor.lastName} />
+    ) : (
+        'Unknown'
+    );
 
     return (
         <div className='flex justify-between flex-wrap'>
@@ -69,6 +95,13 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
                     >
                         <MdiDownload className='w-4 h-4' />
                         <span className='hidden sm:block'>Export / Cite</span>
+                    </Button>
+                    <Button
+                        className='outlineButton flex items-center gap-2'
+                        onClick={() => setCreatorInfoVisible(true)}
+                    >
+                        <MdiInformationOutline className='w-4 h-4' />
+                        <span className='hidden sm:block'>More details</span>
                     </Button>
                     {isAdminView ? (
                         <Button
@@ -106,6 +139,19 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
             <Modal isModalVisible={exportModalVisible} setModalVisible={setExportModalVisible}>
                 <ExportSeqSet seqSet={seqSet} seqSetRecords={seqSetRecords} databaseName={databaseName} />
             </Modal>
+            <BaseDialog
+                title='Creator details'
+                isOpen={creatorInfoVisible}
+                onClose={() => setCreatorInfoVisible(false)}
+                fullWidth={false}
+            >
+                <p className='mb-4 text-sm text-gray-500'>
+                    The creator is the person who assembled this SeqSet on Loculus. They are not necessarily the
+                    originator of the underlying sequence data.
+                </p>
+                <CreatorDetailEntry label='Created by' value={createdByValue} />
+                <CreatorDetailEntry label='Created date' value={formatDate(seqSet.createdAt)} />
+            </BaseDialog>
         </div>
     );
 };

--- a/website/src/pages/seqsets/[seqSetId].[version].astro
+++ b/website/src/pages/seqsets/[seqSetId].[version].astro
@@ -110,6 +110,7 @@ const secondaryErrors = (
                     clientConfig={clientConfig}
                     accessToken={accessToken}
                     seqSet={seqSetResponse.value}
+                    seqSetAuthor={seqSetAuthor}
                     seqSetRecords={seqSetRecordsResponse.value}
                     isAdminView={seqSetResponse.value.createdBy === username}
                     databaseName={websiteConfig.name}
@@ -120,7 +121,6 @@ const secondaryErrors = (
                     accessToken={accessToken}
                     seqSetAccessionVersion={seqSetAccessionVersion}
                     seqSet={seqSetResponse.value}
-                    seqSetAuthor={seqSetAuthor}
                     seqSetRecords={seqSetRecordsResponse.value}
                     citedByData={citedByData}
                     seqSetGraphs={seqSetGraphs}


### PR DESCRIPTION
## Summary

Closes #6459.

It might be unclear to visitors that the *creator* of a SeqSet is simply the person who assembled a set of data on Loculus — not the person who generated the underlying sequence data. The "Created by"  fields were shown prominently in the SeqSet **Details** section, reinforcing that ambiguity.

This PR de-emphasises the creator by moving the Created by and Created date out of the Details section into a dedicated **Creator details** modal, accesses with the "More details" button.

<img width="1291" height="592" alt="image" src="https://github.com/user-attachments/assets/858dcc5e-d5de-4700-bd80-d1c5a6770fd4" />


<img width="1242" height="499" alt="image" src="https://github.com/user-attachments/assets/c09ffd6f-07dc-4edb-a70f-509a0d7516be" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: https://feat-seqset-creator-modal.loculus.org