### PR TITLE
do not merge: branch for testing hostTaxonId as string with sped-up prepro

### DIFF
--- a/integration-tests/tests/specs/features/sequence-version-banners.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-version-banners.spec.ts
@@ -92,6 +92,7 @@ test.describe('Sequence version banners', () => {
         await search.select('Collection country', 'Germany');
 
         // Get the accession of the sequence to revoke
+        await search.expectSequenceCount(1);
         const toRevokeLink = page.getByRole('link', { name: /LOC_[A-Z0-9]+\.1/ });
         const toRevokeId = await toRevokeLink.textContent();
         const toRevokeAccession = toRevokeId.split('.')[0];

--- a/loculus-silo/src/silo_import/lineage.py
+++ b/loculus-silo/src/silo_import/lineage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 import requests
 from requests import codes
@@ -108,7 +109,8 @@ def _post_silo_lineage(url: str, values: list[str], prune: bool = False) -> requ
     request body and a ?prune=<boolean> query param
     """
     params = {"prune": "true"} if prune else None
-    return requests.post(url, json={"values": values}, params=params, timeout=60)
+    payload: dict[str, Any] = {"values": values}
+    return requests.post(url, json=payload, params=params, timeout=60)
 
 
 def _write_text(path: Path, content: str) -> None:

--- a/preprocessing/nextclade/environment.yml
+++ b/preprocessing/nextclade/environment.yml
@@ -6,7 +6,6 @@ channels:
 dependencies:
   - python=3.14.4
   - biopython=1.87
-  - dpath=2.2.0
   - nextclade=3.21.2
   - pip=25.2
   - uv=0.11.8

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -5,8 +5,6 @@ from collections.abc import Sequence
 from tempfile import TemporaryDirectory
 from typing import Any
 
-import dpath
-
 from .backend import (
     download_diamond_db,
     download_minimizer,
@@ -134,6 +132,17 @@ def truncate_after_wildcard(path: str, separator: str = ".") -> str:
     return path
 
 
+def get_nested_metadata(metadata: dict[str, Any], path: str, separator: str = ".") -> Any | None:
+    value: Any = metadata
+    for part in path.split(separator):
+        if not isinstance(value, dict):
+            return None
+        value = value.get(part)
+        if value is None:
+            return None
+    return value
+
+
 def add_nextclade_metadata(
     spec: ProcessingSpec,
     unprocessed: UnprocessedAfterNextclade,
@@ -169,12 +178,10 @@ def add_nextclade_metadata(
     ):
         return InputData(datum=None)
 
-    raw: str | None = dpath.get(
+    raw: Any | None = get_nested_metadata(
         unprocessed.nextcladeMetadata[sequence_name],
         truncate_after_wildcard(nextclade_path),
-        separator=".",
-        default=None,
-    )  # type: ignore[assignment]
+    )
 
     match nextclade_path:
         case "frameShifts":

--- a/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
+++ b/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
@@ -32,7 +32,7 @@ from loculus_preprocessing.datatypes import (
     UnprocessedEntry,
 )
 from loculus_preprocessing.embl import create_flatfile, reformat_authors_from_loculus_to_embl_style
-from loculus_preprocessing.prepro import process_all
+from loculus_preprocessing.prepro import get_nested_metadata, process_all
 from loculus_preprocessing.processing_functions import (
     format_frameshift,
     format_stop_codon,
@@ -57,6 +57,28 @@ CCHF_DATASET = "tests/cchfv"
 SINGLE_SEGMENT_EMBL = "tests/flatfiles/single_segment.embl"
 MUTATIONS_FROM_FOUNDER_CLADE = "tests/mutationsFromFounderClade.json"
 LABELED_PRIVATE_MUTATIONS = "tests/labeledPrivateMutations.json"
+
+
+def test_get_nested_metadata_uses_simple_dot_paths():
+    metadata = {
+        "coverage": 0.98,
+        "qc": {"stopCodons": {"totalStopCodons": 0, "stopCodons": []}},
+        "cladeFounderInfo": {
+            "aaMutations": [{"privateSubstitutions": ["NS1:Y35H"]}],
+        },
+    }
+
+    assert get_nested_metadata(metadata, "coverage") == 0.98
+    assert get_nested_metadata(metadata, "qc.stopCodons.totalStopCodons") == 0
+    assert get_nested_metadata(metadata, "qc.stopCodons.stopCodons") == []
+    assert get_nested_metadata(metadata, "cladeFounderInfo.aaMutations") == [
+        {"privateSubstitutions": ["NS1:Y35H"]},
+    ]
+    assert get_nested_metadata(metadata, "qc.missing.total") is None
+    assert get_nested_metadata(metadata, "coverage.value") is None
+
+    metadata_with_zero = {"qc": {"score": 0}}
+    assert get_nested_metadata(metadata_with_zero, "qc.score") == 0
 
 
 def consensus_sequence(


### PR DESCRIPTION
This branch is just for testing the breaking change of making hostTaxonId a string. 

The branch starts at old Loculus commit https://github.com/loculus-project/loculus/pull/6404 (state where hierarchical filtering implementation was merged) and then cherry-picks https://github.com/loculus-project/loculus/pull/6453 to have faster preprocessing.

🚀 Preview: Add `preview` label to enable