### PR TITLE
feat(backend): get rid of warning

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -3,10 +3,11 @@ JVM_OPTS=${JVM_OPTS:-}
 # Take script arguments
 ARGS="${*}"
 
+NATIVE_ACCESS_FLAG="--enable-native-access=ALL-UNNAMED"
 if [ -n "$JVM_OPTS" ]; then
-    CMD="java $JVM_OPTS -jar app.jar --spring.profiles.active=docker $ARGS"
+    CMD="java $NATIVE_ACCESS_FLAG $JVM_OPTS -jar app.jar --spring.profiles.active=docker $ARGS"
 else
-    CMD="java -jar app.jar --spring.profiles.active=docker $ARGS"
+    CMD="java $NATIVE_ACCESS_FLAG -jar app.jar --spring.profiles.active=docker $ARGS"
 fi
 echo Running:
 echo "$CMD"


### PR DESCRIPTION
```
 WARNING: A restricted method in java.lang.System has been called
  WARNING: java.lang.System::loadLibrary has been called by com.github.luben.zstd.util.Native$1 in an unnamed module
  (jar:nested:/app/app.jar/!BOOT-INF/lib/zstd-jni-1.5.7-8.jar!/)
  WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
```

resolves #

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://backend-warning.loculus.org