### PR TITLE
fix(website): Update user seqsets page to have better display on small screen widths

### DIFF
--- a/website/src/components/SeqSetCitations/AuthorDetails.tsx
+++ b/website/src/components/SeqSetCitations/AuthorDetails.tsx
@@ -40,10 +40,10 @@ export const AuthorDetails: FC<Props> = ({
 
     const renderFullDetails = () => (
         <div className='flex self-start my-4 flex-row'>
-            <div className='flex'>
-                <AccountCircleIcon fontSize={120} />
+            <div className='pr-4'>
+                <AccountCircleIcon className='text-7xl sm:text-[120px]' />
             </div>
-            <div className='flex flex-col pl-4'>
+            <div className='flex flex-col'>
                 <div className='flex flex-row justify-start items-center pt-2 pb-4'>
                     <h1 className='flex text-xl font-semibold pr-2'>{renderName()}</h1>
                     {editAccountUrl !== null ? (

--- a/website/src/components/SeqSetCitations/SeqSetList.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetList.tsx
@@ -22,6 +22,7 @@ const SeqSetListHead = (props: SeqSetListHeadProps) => {
     interface HeadCell {
         id: keyof SeqSet;
         label: string;
+        hideOnSmall?: boolean;
     }
 
     const headCells: readonly HeadCell[] = [
@@ -40,6 +41,7 @@ const SeqSetListHead = (props: SeqSetListHeadProps) => {
         {
             id: 'seqSetDOI',
             label: 'DOI',
+            hideOnSmall: true,
         },
     ];
 
@@ -53,7 +55,7 @@ const SeqSetListHead = (props: SeqSetListHeadProps) => {
                 {headCells.map((headCell, index) => (
                     <th
                         key={headCell.id}
-                        className={`px-2 py-5 text-xs w-1/12 font-medium tracking-wider uppercase ${index === 0 ? 'pl-6' : 'last:pr-6 text-left'}`}
+                        className={`px-2 py-5 text-xs w-1/12 font-medium tracking-wider uppercase ${index === 0 ? 'pl-6' : 'last:pr-6 text-left'} ${headCell.hideOnSmall ? 'hidden sm:table-cell' : ''}`}
                     >
                         <span
                             className={`cursor-pointer ${orderBy === headCell.id ? 'active' : ''}`}
@@ -176,7 +178,7 @@ export const SeqSetList: FC<SeqSetListProps> = ({ seqSets }) => {
                                 </td>
                                 <td className='px-2 py-2 text-primary-900 last:pr-6'>{truncateCell(row.name)}</td>
                                 <td className='px-2 py-2 text-primary-900 last:pr-6'>{row.seqSetVersion}</td>
-                                <td className='px-2 py-2 text-primary-900 last:pr-6'>
+                                <td className='px-2 py-2 text-primary-900 last:pr-6 hidden sm:table-cell'>
                                     {row.seqSetDOI !== undefined ? truncateCell(row.seqSetDOI) : 'N/A'}
                                 </td>
                             </tr>

--- a/website/src/components/SeqSetCitations/SeqSetListActions.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetListActions.tsx
@@ -23,7 +23,7 @@ const SeqSetListActionsInner: FC<SeqSetListActionsProps> = ({ clientConfig, acce
                     className='btn btn-sm loculusColor text-white flex items-center gap-1'
                     onClick={() => setCreateModalVisible(true)}
                 >
-                    <AddBoxIcon fontSize='large' />
+                    <AddBoxIcon className='w-4 h-4' />
                     Create SeqSet
                 </Button>
             </div>

--- a/website/src/pages/seqsets/index.astro
+++ b/website/src/pages/seqsets/index.astro
@@ -57,17 +57,13 @@ const editAccountUrl = (await getUrlForKeycloakAccountPage()) + '/#/personal-inf
                         <div class='flex flex-col md:pr-4'>
                             <div class='flex justify-between items-center py-8'>
                                 <h1 class='text-2xl font-semibold'>SeqSets</h1>
-                                <SeqSetListActions
-                                    clientConfig={clientConfig}
-                                    accessToken={accessToken}
-                                    client:load
-                                />
+                                <SeqSetListActions clientConfig={clientConfig} accessToken={accessToken} client:load />
                             </div>
                             <div>
                                 <p>
-                                    SeqSets are collections of sequences with a unique identifier that can be used
-                                    to reference that set of sequences. SeqSets can also be used to generate DOIs,
-                                    which can in turn be used in publications, public communications etc.
+                                    SeqSets are collections of sequences with a unique identifier that can be used to
+                                    reference that set of sequences. SeqSets can also be used to generate DOIs, which
+                                    can in turn be used in publications, public communications etc.
                                 </p>
                                 <p class='py-4'>
                                     You can learn how to generate SeqSets

--- a/website/src/pages/seqsets/index.astro
+++ b/website/src/pages/seqsets/index.astro
@@ -28,13 +28,13 @@ const editAccountUrl = (await getUrlForKeycloakAccountPage()) + '/#/personal-inf
 ---
 
 <BaseLayout title='SeqSets' data-testid='seqSets-list-container' activeTopNavigationItem='seqsets'>
-    <div class='flex flex-col justify-center items-center'>
+    <div class='flex flex-col items-center'>
         {
             !accessToken ? (
                 <NeedToLogin message='You need to be logged in to create new SeqSets.' />
             ) : (
-                <div class='flex flex-row justify-center w-5/6 divide-x max-w-7xl'>
-                    <div class='w-3/4 flex flex-col justify-start'>
+                <div class='flex flex-col md:flex-row w-full md:w-5/6 md:divide-x gap-y-6'>
+                    <div class='md:w-3/4 flex flex-col'>
                         {authorResponse.match(
                             (authorProfile) => (
                                 <AuthorDetails
@@ -54,46 +54,44 @@ const editAccountUrl = (await getUrlForKeycloakAccountPage()) + '/#/personal-inf
                             ),
                         )}
                         <hr />
-                        <div class='flex justify-start'>
-                            <div class='w-11/12'>
-                                <div class='flex justify-between items-center py-8'>
-                                    <h1 class='text-2xl font-semibold'>SeqSets</h1>
-                                    <SeqSetListActions
-                                        clientConfig={clientConfig}
-                                        accessToken={accessToken}
-                                        client:load
-                                    />
-                                </div>
-                                <div>
-                                    <p>
-                                        SeqSets are collections of sequences with a unique identifier that can be used
-                                        to reference that set of sequences. SeqSets can also be used to generate DOIs,
-                                        which can in turn be used in publications, public communications etc.
-                                    </p>
-                                    <p class='py-4'>
-                                        You can learn how to generate SeqSets
-                                        <a href='/docs/how-to/generate-seqset' class='text-primary-700  opacity-90'>
-                                            here.
-                                        </a>
-                                    </p>
-                                </div>
-                                <div>
-                                    {seqSetsResponse.match(
-                                        (seqSets) => (
-                                            <SeqSetList seqSets={seqSets} client:load />
-                                        ),
-                                        (error) => (
-                                            <ErrorFeedback
-                                                message={'Error while fetching seqSets: ' + JSON.stringify(error)}
-                                                client:load
-                                            />
-                                        ),
-                                    )}
-                                </div>
+                        <div class='flex flex-col md:pr-4'>
+                            <div class='flex justify-between items-center py-8'>
+                                <h1 class='text-2xl font-semibold'>SeqSets</h1>
+                                <SeqSetListActions
+                                    clientConfig={clientConfig}
+                                    accessToken={accessToken}
+                                    client:load
+                                />
+                            </div>
+                            <div>
+                                <p>
+                                    SeqSets are collections of sequences with a unique identifier that can be used
+                                    to reference that set of sequences. SeqSets can also be used to generate DOIs,
+                                    which can in turn be used in publications, public communications etc.
+                                </p>
+                                <p class='py-4'>
+                                    You can learn how to generate SeqSets
+                                    <a href='/docs/how-to/generate-seqset' class='text-primary-700 opacity-90'>
+                                        here.
+                                    </a>
+                                </p>
+                            </div>
+                            <div>
+                                {seqSetsResponse.match(
+                                    (seqSets) => (
+                                        <SeqSetList seqSets={seqSets} client:load />
+                                    ),
+                                    (error) => (
+                                        <ErrorFeedback
+                                            message={'Error while fetching seqSets: ' + JSON.stringify(error)}
+                                            client:load
+                                        />
+                                    ),
+                                )}
                             </div>
                         </div>
                     </div>
-                    <div class='w-1/4 flex flex-col justify-start items-start pl-4'>
+                    <div class='w-1/4 flex flex-col items-start pl-4'>
                         <span class='text-xl'>Cited by</span>
                         {/* We show an empty plot for now until we get real data. */}
                         <CitationPlot

--- a/website/src/pages/seqsets/index.astro
+++ b/website/src/pages/seqsets/index.astro
@@ -33,8 +33,8 @@ const editAccountUrl = (await getUrlForKeycloakAccountPage()) + '/#/personal-inf
             !accessToken ? (
                 <NeedToLogin message='You need to be logged in to create new SeqSets.' />
             ) : (
-                <div class='flex flex-col md:flex-row w-full md:w-5/6 md:divide-x gap-y-6'>
-                    <div class='md:w-3/4 flex flex-col'>
+                <div class='flex flex-wrap w-full gap-y-6 lg:divide-x'>
+                    <div class='flex flex-col lg:w-3/4'>
                         {authorResponse.match(
                             (authorProfile) => (
                                 <AuthorDetails
@@ -54,7 +54,7 @@ const editAccountUrl = (await getUrlForKeycloakAccountPage()) + '/#/personal-inf
                             ),
                         )}
                         <hr />
-                        <div class='flex flex-col md:pr-4'>
+                        <div class='flex flex-col lg:pr-4'>
                             <div class='flex justify-between items-center py-8'>
                                 <h1 class='text-2xl font-semibold'>SeqSets</h1>
                                 <SeqSetListActions clientConfig={clientConfig} accessToken={accessToken} client:load />
@@ -87,10 +87,10 @@ const editAccountUrl = (await getUrlForKeycloakAccountPage()) + '/#/personal-inf
                             </div>
                         </div>
                     </div>
-                    <div class='md:w-1/4 flex flex-col pl-4'>
+                    <div class='flex flex-col lg:w-1/4 lg:pl-4'>
                         <span class='text-xl'>Cited by</span>
                         {/* We show an empty plot for now until we get real data. */}
-                        <div class='w-80'>
+                        <div class='max-w-96'>
                             <CitationPlot
                                 citedByData={{ years: [2020, 2021, 2022, 2023, 2024], citations: [0, 0, 0, 0, 0] }}
                                 description='Number of times your sequences have been cited in publications'

--- a/website/src/pages/seqsets/index.astro
+++ b/website/src/pages/seqsets/index.astro
@@ -87,14 +87,16 @@ const editAccountUrl = (await getUrlForKeycloakAccountPage()) + '/#/personal-inf
                             </div>
                         </div>
                     </div>
-                    <div class='w-1/4 flex flex-col items-start pl-4'>
+                    <div class='md:w-1/4 flex flex-col pl-4'>
                         <span class='text-xl'>Cited by</span>
                         {/* We show an empty plot for now until we get real data. */}
-                        <CitationPlot
-                            citedByData={{ years: [2020, 2021, 2022, 2023, 2024], citations: [0, 0, 0, 0, 0] }}
-                            description='Number of times your sequences have been cited in publications'
-                            client:load
-                        />
+                        <div class='w-80'>
+                            <CitationPlot
+                                citedByData={{ years: [2020, 2021, 2022, 2023, 2024], citations: [0, 0, 0, 0, 0] }}
+                                description='Number of times your sequences have been cited in publications'
+                                client:load
+                            />
+                        </div>
                     </div>
                 </div>
             )


### PR DESCRIPTION
Updates the user SeqSets page to display better on varying screen widths. The DOI column is now set to hidden on small screen widths.

### Screenshot

Before:

<img width="485" height="1176" alt="image" src="https://github.com/user-attachments/assets/cadad489-20c7-4bc9-8be5-3a77455e9424" />

After:

<img width="485" height="1001" alt="image" src="https://github.com/user-attachments/assets/e5e36d6d-d3ae-4422-80b0-a903a7d52a05" />




### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://user-seqsets-layout-fix.loculus.org