### PR TITLE
fix(website): Add full stop for acknowledgement

### DIFF
--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -414,7 +414,7 @@ const Acknowledgement = ({
                             />
                             <div>
                                 <p className='text-xs pl-4 text-gray-500'>
-                                    I confirm that the data submitted is not sensitive or human-identifiable
+                                    I confirm that the data submitted is not sensitive or human-identifiable.
                                 </p>
                             </div>
                         </label>


### PR DESCRIPTION
Tiny PR just to add a full stop I noticed was missing on the submission page.

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable