### PR TITLE
feat(config): cchf - use same config as ppx

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2113,7 +2113,7 @@ defaultOrganisms:
       <<: *ingest
       configFile:
         taxon_id: 3052518
-        calculate_groups_override_json: true
+        grouping_override_url: "https://pathoplexus.github.io/curation_data/grouping_override/cchf/curated_group_02-03-2026.json"
         segment_identification:
           method: "align"
           nextclade_dataset_name: community/pathoplexus/cchfv


### PR DESCRIPTION
The grouping override json used on loculus and ppx is different, I think its good to make them the same to avoid confusion in future.

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable