### PR TITLE
fix(website): remove duplicate placeholder on lineage search fields

### DIFF
--- a/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.spec.tsx
+++ b/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.spec.tsx
@@ -63,6 +63,7 @@ describe('SingleChoiceAutoCompleteField', () => {
 
         const input = screen.getByLabelText('Test Field');
         expect(input).toBeInTheDocument();
+        expect(input).toHaveAttribute('placeholder', ' ');
 
         await userEvent.click(input);
 

--- a/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
@@ -26,7 +26,6 @@ const CustomInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputEl
         onFocus={props.onFocus}
         disabled={props.disabled}
         autoComplete='off'
-        placeholder={props.placeholder ?? ''}
         label={props.placeholder ?? ''}
     />
 ));

--- a/website/src/components/SearchPage/fields/TextField.tsx
+++ b/website/src/components/SearchPage/fields/TextField.tsx
@@ -20,7 +20,6 @@ interface TextFieldProps {
     fieldValue?: string | number | readonly string[];
     className?: string;
     onFocus?: FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
-    placeholder?: string;
     multiline?: boolean;
     onBlur?: FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
     type?: string;
@@ -30,8 +29,7 @@ const helperTextClasses = getTheme().floatingLabel.helperText.default;
 const inputClasses = getTheme().floatingLabel.input.default.outlined.md;
 
 export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, TextFieldProps>(function (props, ref) {
-    const { label, disabled, onChange, autoComplete, fieldValue, className, onFocus, placeholder, multiline, onBlur } =
-        props;
+    const { label, disabled, onChange, autoComplete, fieldValue, className, onFocus, multiline, onBlur } = props;
     const id = useId();
     const [isTransitionEnabled, setIsTransitionEnabled] = useState(false);
     const [hasFocus, setHasFocus] = useState(false);
@@ -123,7 +121,7 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
             ref: ref as LegacyRef<HTMLInputElement>,
             label: label ?? '',
             step: props.type === 'int' ? 1 : undefined,
-            placeholder: placeholder ?? ' ',
+            placeholder: ' ', // Label already serves as placeholder
         };
 
         return (
@@ -160,7 +158,7 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
         onFocus: onFocusHTMLArea,
         onBlur: onBlurHTMLArea,
         value: fieldValue,
-        placeholder: placeholder ?? ' ',
+        placeholder: ' ', // Label already serves as placeholder
     };
 
     return (


### PR DESCRIPTION
Resolves #6470

CustomInput in SingleChoiceAutoCompleteField.tsx passes both placeholder and label with the same value to TextField, causing duplicate visible text in the input field

Fix: remove placeholder prop from CustomInput's TextField call

### Screenshot

No more double placeholder:

<img width="340" height="126" alt="image" src="https://github.com/user-attachments/assets/79efa97f-528e-4c1d-b6e5-a51eeb51982a" />

🚀 Preview: Add `preview` label to enable