### PR TITLE
refactor(website): get rid of excessive white space in linkout data use terms modal - switch from material to headless ui

### DIFF
--- a/integration-tests/tests/specs/features/search/linkout-modal.dependent.spec.ts
+++ b/integration-tests/tests/specs/features/search/linkout-modal.dependent.spec.ts
@@ -1,0 +1,57 @@
+import { expect } from '@playwright/test';
+import { test } from '../../../fixtures/console-warnings.fixture';
+import { SearchPage } from '../../../pages/search.page';
+
+async function mockWindowOpen(page: import('@playwright/test').Page) {
+    await page.evaluate(() => {
+        window.open = (url?: string | URL) => {
+            const openedUrls = ((window as typeof window & { openedUrls?: string[] }).openedUrls ??=
+                []);
+            openedUrls.push(String(url));
+            return null;
+        };
+    });
+}
+
+async function getOpenedUrls(page: import('@playwright/test').Page) {
+    return page.evaluate(
+        () => (window as typeof window & { openedUrls?: string[] }).openedUrls ?? [],
+    );
+}
+
+test.describe('Search linkout data use terms modal', () => {
+    test('can be opened, closed, and launched with both data-use options', async ({ page }) => {
+        const searchPage = new SearchPage(page);
+        await searchPage.ebolaSudan();
+        await mockWindowOpen(page);
+        page.on('dialog', async (dialog) => {
+            expect(dialog.message()).toContain('This tool is recommended for at most');
+            await dialog.accept();
+        });
+
+        await page.getByRole('button', { name: 'Tools' }).click();
+        await page.getByRole('menuitem', { name: 'Nextclade' }).click();
+
+        await expect(page.getByRole('heading', { name: 'Options for launching' })).toBeVisible();
+
+        await page.getByRole('button', { name: 'Close' }).click();
+        await expect(page.getByRole('heading', { name: 'Options for launching' })).toBeHidden();
+        expect(await getOpenedUrls(page)).toEqual([]);
+
+        await page.getByRole('button', { name: 'Tools' }).click();
+        await page.getByRole('menuitem', { name: 'Nextclade' }).click();
+        await page.getByRole('button', { name: 'Open sequences only' }).click();
+
+        let openedUrls = await getOpenedUrls(page);
+        expect(openedUrls).toHaveLength(1);
+        expect(openedUrls[0]).toContain('dataUseTerms%3DOPEN');
+
+        await page.getByRole('button', { name: 'Tools' }).click();
+        await page.getByRole('menuitem', { name: 'Nextclade' }).click();
+        await page.getByRole('button', { name: 'Include Restricted-Use' }).click();
+
+        openedUrls = await getOpenedUrls(page);
+        expect(openedUrls).toHaveLength(2);
+        expect(openedUrls[1]).not.toContain('dataUseTerms%3DOPEN');
+    });
+});

--- a/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.spec.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.spec.tsx
@@ -69,6 +69,26 @@ describe('LinkOutMenu with enabled data use terms', () => {
         expect(screen.getByText('Data use terms')).toBeInTheDocument();
     });
 
+    test('closes modal without opening tool when close button is clicked', () => {
+        render(
+            <LinkOutMenu
+                downloadUrlGenerator={realDownloadUrlGenerator}
+                sequenceFilter={mockSequenceFilter}
+                sequenceCount={1}
+                linkOuts={linkOuts}
+                dataUseTermsEnabled={true}
+                referenceGenomesInfo={SINGLE_SEG_SINGLE_REF_REFERENCEGENOMES}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /Tools/ }));
+        fireEvent.click(screen.getByText('Basic'));
+        fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+        expect(screen.queryByText('Options for launching Basic')).not.toBeInTheDocument();
+        expect(window.open).not.toHaveBeenCalled();
+    });
+
     test('generates URLs with open-access only when selected', () => {
         const generateDownloadUrlSpy = vi.spyOn(realDownloadUrlGenerator, 'generateDownloadUrl');
 

--- a/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
@@ -10,8 +10,8 @@ import { formatNumberWithDefaultLocale } from '../../../utils/formatNumber';
 import type { ReferenceSelection } from '../../../utils/referenceSelection';
 import { getSegmentLapisNames } from '../../../utils/sequenceTypeHelpers';
 import { processTemplate, matchPlaceholders } from '../../../utils/templateProcessor';
+import { BaseDialog } from '../../common/BaseDialog';
 import { Button } from '../../common/Button';
-import BasicModal from '../../common/Modal';
 import DashiconsExternal from '~icons/dashicons/external';
 import IwwaArrowDown from '~icons/iwwa/arrow-down';
 
@@ -256,17 +256,19 @@ function LinkOutMenuDataUseTermModal(props: {
     onClick1: () => void;
 }) {
     return (
-        <BasicModal isModalVisible={props.modalVisible} setModalVisible={props.setModalVisible}>
-            <div className='p-6'>
-                <h2 className='text-xl font-bold mb-2'>
-                    Options for launching {props.currentLinkOut.current?.name ?? 'Tool'}
-                </h2>
-                <h3 className='text-lg font-medium text-gray-700 mb-4 mt-6'>Data use terms</h3>
-                <p className='mb-6 text-gray-600'>
+        <BaseDialog
+            title={`Options for launching ${props.currentLinkOut.current?.name ?? 'Tool'}`}
+            isOpen={props.modalVisible}
+            onClose={() => props.setModalVisible(false)}
+            fullWidth={false}
+        >
+            <div className='max-w-lg'>
+                <h3 className='text-lg font-medium text-gray-700 mb-3'>Data use terms</h3>
+                <p className='mb-6 text-gray-600 leading-relaxed'>
                     Would you like to include Restricted-Use sequences in this analysis? (If you do, you must comply
                     with the Restricted-Use terms.)
                 </p>
-                <div className='flex justify-end space-x-4'>
+                <div className='flex flex-col-reverse sm:flex-row sm:justify-end gap-3'>
                     <Button
                         className='px-4 py-2 border border-gray-300 rounded-md text-gray-700 font-medium hover:bg-gray-50 transition-colors'
                         onClick={props.onClick}
@@ -281,6 +283,6 @@ function LinkOutMenuDataUseTermModal(props: {
                     </Button>
                 </div>
             </div>
-        </BasicModal>
+        </BaseDialog>
     );
 }


### PR DESCRIPTION
The huge amount of white space in the tools data use terms modal has bothered me for a while.

This PR switches away from the material ui modal to headless ui and styles it to be more in line with our other modals, less white space.

I remember we wanted to get rid of material ui at some point anyways.

Also adds integration test for the modal - checking it opens, closes and calls a URL with open/restricted appropriately set.

### Manual testing

I clicked through the modal and checked it still works.

### Screenshot

Before:

<img width="1615" height="938" alt="Google Chrome 2026-05-20 17 20 12" src="https://github.com/user-attachments/assets/fcb70822-6feb-4091-b5db-6d7443f9d7a2" />

After:

<img width="1440" height="534" alt="Google Chrome 2026-05-20 17 20 04" src="https://github.com/user-attachments/assets/59d92e4a-6c58-473f-9cf1-b9088cc6f3ff" />

🚀 Preview: https://linkout-model-shrink.loculus.org