### PR TITLE
fix(website): Make the download modal more responsive on smaller screen widths

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
@@ -214,7 +214,7 @@ export const DownloadForm: FC<DownloadFormProps> = ({
     }
 
     return (
-        <div className='flex flex-row flex-wrap mb-4 gap-y-2 py-4'>
+        <div className='flex flex-row flex-wrap mb-4 gap-8 py-4'>
             {dataUseTermsEnabled && (
                 <RadioOptionBlock
                     name='includeRestricted'
@@ -243,7 +243,7 @@ export const DownloadForm: FC<DownloadFormProps> = ({
                     }
                 />
             )}
-            <div className='flex-1 min-w-0'>
+            <div className='max-w-64'>
                 <RadioOptionBlock
                     name='dataType'
                     title='Data type'

--- a/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
@@ -214,7 +214,7 @@ export const DownloadForm: FC<DownloadFormProps> = ({
     }
 
     return (
-        <div className='flex flex-row flex-wrap mb-4 gap-8 py-4'>
+        <div className='flex flex-row flex-wrap mb-4 gap-4 py-4'>
             {dataUseTermsEnabled && (
                 <RadioOptionBlock
                     name='includeRestricted'

--- a/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadForm.tsx
@@ -214,7 +214,7 @@ export const DownloadForm: FC<DownloadFormProps> = ({
     }
 
     return (
-        <div className='flex flex-row flex-wrap mb-4 gap-4 py-4'>
+        <div className='flex flex-row flex-wrap mb-4 gap-4 py-4 m-2'>
             {dataUseTermsEnabled && (
                 <RadioOptionBlock
                     name='includeRestricted'


### PR DESCRIPTION
Addresses #6407 

### Screenshot

Before:

<img width="394" height="992" alt="image" src="https://github.com/user-attachments/assets/cc6818ca-8f8c-4a20-8cf5-69e0021b8a8b" />

After:

<img width="394" height="992" alt="image" src="https://github.com/user-attachments/assets/a9c5e3d2-7102-4d64-ae36-6f82bdfbc8af" />

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/23657bc5-72f3-4698-8b2c-3a89a7eff961" />





### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://download-modal-small-scre.loculus.org