### PR TITLE
fix(website): stop date range strictness checkbox stuck on strict when no date entered

### DIFF
--- a/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
+++ b/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
@@ -158,6 +158,38 @@ describe('DateRangeField', () => {
         );
     });
 
+    it('does not snap back to strict when user toggles without having entered dates', async () => {
+        function Wrapper() {
+            const [values, _setValues] = useState<FieldValues>({});
+
+            const setValues: SetSomeFieldValues = useCallback((...fieldValuesToSet) => {
+                _setValues((state) => {
+                    const newState = { ...state };
+                    fieldValuesToSet.forEach(([k, v]) => {
+                        // mirror the production behaviour of useSearchPageState: null/'' deletes
+                        if (v === null || v === '') {
+                            delete newState[k];
+                        } else {
+                            newState[k] = v;
+                        }
+                    });
+                    return newState;
+                });
+            }, []);
+
+            return <DateRangeField field={field} fieldValues={values} setSomeFieldValues={setValues} />;
+        }
+
+        const user = userEvent.setup();
+        render(<Wrapper />);
+
+        const strictCheckbox = screen.getByRole('checkbox');
+        expect(strictCheckbox).toBeChecked();
+
+        await user.click(strictCheckbox);
+        expect(strictCheckbox).not.toBeChecked();
+    });
+
     it('setting fieldValue to empty string clears date field', async () => {
         function Wrapper() {
             const [values, _setValues] = useState<FieldValues>({

--- a/website/src/components/SearchPage/fields/DateRangeField.tsx
+++ b/website/src/components/SearchPage/fields/DateRangeField.tsx
@@ -60,14 +60,17 @@ export const DateRangeField = ({ field, fieldValues, setSomeFieldValues }: DateR
     const [upperValue, setUpperValue] = useState(getFieldValue(upperField.name));
 
     useEffect(() => {
-        setStrictMode(
-            isStrictMode(
-                lowerFromField.name in fieldValues,
-                lowerToField.name in fieldValues,
-                upperFromField.name in fieldValues,
-                upperToField.name in fieldValues,
-            ),
-        );
+        const lowerFromDefined = lowerFromField.name in fieldValues;
+        const lowerToDefined = lowerToField.name in fieldValues;
+        const upperFromDefined = upperFromField.name in fieldValues;
+        const upperToDefined = upperToField.name in fieldValues;
+        // Only re-derive strictMode from fieldValues when at least one bound is actually defined.
+        // When the user toggles strictness without having entered any dates the other effect
+        // below clears all four fields, which would otherwise feed back into isStrictMode and
+        // collapse strictMode back to its default `true` — making the checkbox appear stuck on.
+        if (lowerFromDefined || lowerToDefined || upperFromDefined || upperToDefined) {
+            setStrictMode(isStrictMode(lowerFromDefined, lowerToDefined, upperFromDefined, upperToDefined));
+        }
         setLowerValue(validateSingleValue(fieldValues[lowerField.name], lowerField.name));
         setUpperValue(validateSingleValue(fieldValues[upperField.name], upperField.name));
     }, [field, fieldValues]);


### PR DESCRIPTION
Fixes #6483

## What was happening

When you toggled the strictness checkbox in a `DateRangeField` (e.g. the Collection date filter) without having entered any dates, was stuck on. This matches the user reports in #6483:

- The checkbox "actually seems stuck enabled"

## Fix

In the read-in effect, skip the `setStrictMode` call when none of the four bound fields are defined — there is no signal to derive from in that case, so we preserve the user's manual selection. When at least one field is defined the existing `isStrictMode` logic still runs and stays in charge.

The write-out effect is unchanged. External (URL-driven) changes still flow in correctly because they always come with at least one bound defined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: https://fix-date-range-strictness.loculus.org