### PR TITLE
feat(website): Increase max acceptable URL length to 7400

### DIFF
--- a/website/src/routes/routes.ts
+++ b/website/src/routes/routes.ts
@@ -10,7 +10,7 @@ export type ContinueSubmissionIntent = {
     organism: string;
 };
 
-export const approxMaxAcceptableUrlLength = 7900;
+export const approxMaxAcceptableUrlLength = 7400;
 
 export const routes = {
     apiDocumentationPage: () => '/api-documentation',

--- a/website/src/routes/routes.ts
+++ b/website/src/routes/routes.ts
@@ -10,7 +10,7 @@ export type ContinueSubmissionIntent = {
     organism: string;
 };
 
-export const approxMaxAcceptableUrlLength = 1900;
+export const approxMaxAcceptableUrlLength = 7900;
 
 export const routes = {
     apiDocumentationPage: () => '/api-documentation',


### PR DESCRIPTION
This makes it possible to get a URL to copy for downloading when all columns are enabled for download, which seems quite important.

<img width="894" height="718" alt="image" src="https://github.com/user-attachments/assets/ab5ecce7-70d0-4d50-8d27-709efa4a312d" />


It is recommended that all servers be able to support up to 8k URLs. Below from Claude

___

# Maximum URL Lengths by System

A reference guide to URL length limits across browsers, servers, and other systems.

## Browsers

| Browser | Max URL Length |
|---------|---------------|
| Internet Explorer | 2,083 characters |
| Microsoft Edge | 2,083 characters (legacy), ~80,000+ (Chromium-based) |
| Google Chrome | ~32,779 characters (address bar), 2 MB (internally) |
| Mozilla Firefox | ~65,536 characters (address bar may truncate display ~64k) |
| Safari | ~80,000 characters |
| Opera | ~190,000 characters |

## Web Servers

| Server | Default Max URL Length |
|--------|----------------------|
| Apache HTTP Server | 8,177 characters (`LimitRequestLine` directive, default 8190 bytes for full request line) |
| Nginx | 4,096 or 8,192 characters (depends on `large_client_header_buffers`) |
| Microsoft IIS | 16,384 characters (configurable via `maxUrl`) |
| Tomcat | 8,192 characters (configurable via `maxHttpHeaderSize`) |
| Node.js (HTTP) | 8,192 characters (default `--max-http-header-size`) |

🚀 Preview: https://increasemax.loculus.org