### PR TITLE
fix(loculus-silo): pin ruff to 0.15.13 to avoid new PLW0717 rule

### DIFF
--- a/loculus-silo/pyproject.toml
+++ b/loculus-silo/pyproject.toml
@@ -13,7 +13,7 @@ silo-import = "silo_import.__main__:main"
 
 [project.optional-dependencies]
 test = ["pytest", "mypy",
-    "ruff",]
+    "ruff==0.15.13",]
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary

Fixes #6489.

A recent ruff release added the preview `PLW0717` rule (*Try clause contains too many statements*), which started failing the `loculus-silo-tests` workflow on `main`. The lint job installed `ruff` unpinned (`uv pip install --system '.[test]'`), and `ruff.toml` enables preview rules — so the rule fired across four try blocks the moment the new ruff version landed on PyPI.

Later we should pin to more recent version and fix or whatever


🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable