### PR TITLE
fix(website): use consistent checkbox css in search filters

### DIFF
--- a/website/src/components/SearchPage/fields/DateRangeField.tsx
+++ b/website/src/components/SearchPage/fields/DateRangeField.tsx
@@ -121,7 +121,7 @@ export const DateRangeField = ({ field, fieldValues, setSomeFieldValues }: DateR
                     <span className='text-gray-400 text-sm mr-2'>strict</span>
                     <input
                         type='checkbox'
-                        className='checkbox checkbox-sm text-3xl [--chkbg:white] [--chkfg:theme(colors.gray.700)] checked:border-gray-300'
+                        className='h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-600 cursor-pointer'
                         checked={strictMode}
                         onChange={(event) => setStrictMode(event.target.checked)}
                     />


### PR DESCRIPTION
We used different css for segment filters and strictness checkbox.

The checkbox was the only one to use DaisyUI CSS classes. Replacing with the standard pattern we use for checkboxes across search UI.

Tested locally: no more jumping, consistent look.

Resolves #6483

### Screenshots

Before:

<img width="348" height="198" alt="Google Chrome 2026-05-22 15 57 21" src="https://github.com/user-attachments/assets/309d080b-554b-446a-8df7-b927258e8bfe" />

After:

<img width="293" height="165" alt="Google Chrome 2026-05-22 15 57 12" src="https://github.com/user-attachments/assets/890881a9-2e96-4efd-8f1b-57b15f52280f" />

🚀 Preview: Add `preview` label to enable