### PR TITLE
feat(website): add docs search

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -35,6 +35,7 @@
                 "just-kebab-case": "^4.2.0",
                 "jwks-rsa": "^4.0.1",
                 "luxon": "^3.7.2",
+                "minisearch": "^6.3.0",
                 "neverthrow": "^8.2.0",
                 "openid-client": "^5.7.1",
                 "papaparse": "^5.5.3",
@@ -48,6 +49,7 @@
                 "sanitize-html": "^2.17.4",
                 "unplugin-icons": "^22.5.0",
                 "winston": "^3.19.0",
+                "yaml": "^2.4.5",
                 "zod": "^3.25.67"
             },
             "devDependencies": {
@@ -11848,6 +11850,12 @@
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
+        },
+        "node_modules/minisearch": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.3.0.tgz",
+            "integrity": "sha512-ihFnidEeU8iXzcVHy74dhkxh/dn8Dc08ERl0xwoMMGqp4+LvRSCgicb+zGqWthVokQKvCSxITlh3P08OzdTYCQ==",
+            "license": "MIT"
         },
         "node_modules/mlly": {
             "version": "1.8.0",

--- a/website/package.json
+++ b/website/package.json
@@ -20,6 +20,8 @@
     "dependencies": {
         "@astrojs/mdx": "^4.3.13",
         "@astrojs/node": "^9.5.2",
+        "minisearch": "^6.3.0",
+        "yaml": "^2.4.5",
         "@emotion/react": "^11.14.0",
         "@headlessui/react": "^2.2.0",
         "@lokalise/xlsx": "^0.20.3",

--- a/website/src/components/Navigation/DocsSearch.tsx
+++ b/website/src/components/Navigation/DocsSearch.tsx
@@ -1,0 +1,183 @@
+import MiniSearch from 'minisearch';
+import { useState, useEffect, useRef, type FC } from 'react';
+
+import { Button } from '../common/Button';
+import CloseIcon from '~icons/material-symbols/close';
+import SearchIcon from '~icons/material-symbols/search';
+
+interface SearchResult {
+    id: string;
+    title: string;
+    url: string;
+    section: 'docs' | 'about';
+    score?: number;
+}
+
+interface SearchIndexResponse {
+    options: ConstructorParameters<typeof MiniSearch>[0];
+    documents: Record<string, unknown>[];
+}
+
+const DocsSearch: FC = () => {
+    const [query, setQuery] = useState('');
+    const [results, setResults] = useState<SearchResult[]>([]);
+    const [isOpen, setIsOpen] = useState(false);
+    const [miniSearch, setMiniSearch] = useState<MiniSearch | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const searchRef = useRef<HTMLDivElement>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    // Load and initialize the search index
+    useEffect(() => {
+        const loadIndex = async () => {
+            try {
+                const response = await fetch('/search-index.json');
+                const data = (await response.json()) as SearchIndexResponse;
+                const ms = new MiniSearch(data.options);
+                ms.addAll(data.documents);
+                setMiniSearch(ms);
+            } catch {
+                // Search remains unavailable until reload.
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        void loadIndex();
+    }, []);
+
+    // Handle search
+    useEffect(() => {
+        if (!miniSearch || !query.trim()) {
+            setResults([]);
+            return;
+        }
+
+        try {
+            const searchResults = miniSearch.search(query, {
+                prefix: true,
+                fuzzy: 0.2,
+            }) as unknown as SearchResult[];
+            setResults(searchResults.slice(0, 8));
+        } catch {
+            setResults([]);
+        }
+    }, [query, miniSearch]);
+
+    // Close dropdown when clicking outside
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (searchRef.current && !searchRef.current.contains(event.target as Node)) {
+                setIsOpen(false);
+            }
+        };
+
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, []);
+
+    // Group results by section
+    const docsResults = results.filter((r) => r.section === 'docs');
+    const aboutResults = results.filter((r) => r.section === 'about');
+
+    return (
+        <div ref={searchRef} className='mb-4 relative'>
+            <div className='relative'>
+                <div className='flex items-center bg-primary-50 border border-primary-200 rounded-md px-3 py-2'>
+                    <SearchIcon className='w-4 h-4 text-primary-600 flex-shrink-0' aria-hidden='true' />
+                    <input
+                        ref={inputRef}
+                        type='text'
+                        placeholder='Search documentation...'
+                        value={query}
+                        onChange={(e) => {
+                            setQuery(e.target.value);
+                            setIsOpen(true);
+                        }}
+                        onFocus={() => setIsOpen(true)}
+                        disabled={isLoading}
+                        className='flex-1 ml-2 bg-transparent border-none outline-none text-sm text-gray-700 placeholder-primary-500 disabled:opacity-50'
+                        aria-label='Search documentation'
+                    />
+                    {query && (
+                        <Button
+                            type='button'
+                            onClick={() => {
+                                setQuery('');
+                                setResults([]);
+                                inputRef.current?.focus();
+                            }}
+                            className='text-primary-600 hover:text-primary-700 p-1'
+                            aria-label='Clear search'
+                        >
+                            <CloseIcon className='w-4 h-4' />
+                        </Button>
+                    )}
+                </div>
+
+                {/* Results dropdown */}
+                {isOpen && query && (
+                    <div className='absolute top-full left-0 right-0 mt-1 bg-white border border-primary-200 rounded-md shadow-lg z-50 max-h-96 overflow-y-auto'>
+                        {results.length === 0 ? (
+                            <div className='px-4 py-3 text-sm text-gray-500'>No results found</div>
+                        ) : (
+                            <>
+                                {docsResults.length > 0 && (
+                                    <div>
+                                        <div className='px-4 py-2 bg-gray-50 border-b border-primary-200 text-xs font-semibold text-primary-700 uppercase'>
+                                            Documentation
+                                        </div>
+                                        <ul className='py-1'>
+                                            {docsResults.map((result) => (
+                                                <li key={result.id}>
+                                                    <a
+                                                        href={result.url}
+                                                        className='block px-4 py-2 text-sm text-gray-700 hover:bg-primary-50 transition-colors'
+                                                        onClick={() => {
+                                                            setQuery('');
+                                                            setIsOpen(false);
+                                                        }}
+                                                    >
+                                                        {result.title}
+                                                    </a>
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    </div>
+                                )}
+
+                                {aboutResults.length > 0 && (
+                                    <div>
+                                        <div className='px-4 py-2 bg-gray-50 border-b border-primary-200 text-xs font-semibold text-primary-700 uppercase'>
+                                            About
+                                        </div>
+                                        <ul className='py-1'>
+                                            {aboutResults.map((result) => (
+                                                <li key={result.id}>
+                                                    <a
+                                                        href={result.url}
+                                                        className='block px-4 py-2 text-sm text-gray-700 hover:bg-primary-50 transition-colors'
+                                                        onClick={() => {
+                                                            setQuery('');
+                                                            setIsOpen(false);
+                                                        }}
+                                                    >
+                                                        {result.title}
+                                                    </a>
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    </div>
+                                )}
+                            </>
+                        )}
+                    </div>
+                )}
+            </div>
+
+            {isLoading && <div className='text-xs text-gray-500 mt-1'>Loading search...</div>}
+        </div>
+    );
+};
+
+export default DocsSearch;

--- a/website/src/components/Navigation/DocsSearch.tsx
+++ b/website/src/components/Navigation/DocsSearch.tsx
@@ -95,8 +95,7 @@ const DocsSearch: FC = () => {
                             setIsOpen(true);
                         }}
                         onFocus={() => setIsOpen(true)}
-                        disabled={isLoading}
-                        className='flex-1 ml-2 bg-transparent border-none outline-none text-sm text-gray-700 placeholder-primary-500 disabled:opacity-50'
+                        className='flex-1 ml-2 bg-transparent border-none outline-none text-sm text-gray-700 placeholder-primary-500'
                         aria-label='Search documentation'
                     />
                     {query && (
@@ -115,10 +114,11 @@ const DocsSearch: FC = () => {
                     )}
                 </div>
 
-                {/* Results dropdown */}
                 {isOpen && query && (
                     <div className='absolute top-full left-0 right-0 mt-1 bg-white border border-primary-200 rounded-md shadow-lg z-50 max-h-96 overflow-y-auto'>
-                        {results.length === 0 ? (
+                        {isLoading ? (
+                            <div className='px-4 py-3 text-sm text-gray-500'>Loading search…</div>
+                        ) : results.length === 0 ? (
                             <div className='px-4 py-3 text-sm text-gray-500'>No results found</div>
                         ) : (
                             <>
@@ -175,7 +175,6 @@ const DocsSearch: FC = () => {
                 )}
             </div>
 
-            {isLoading && <div className='text-xs text-gray-500 mt-1'>Loading search...</div>}
         </div>
     );
 };

--- a/website/src/components/Navigation/DocsSearch.tsx
+++ b/website/src/components/Navigation/DocsSearch.tsx
@@ -1,6 +1,7 @@
 import MiniSearch from 'minisearch';
 import { useState, useEffect, useRef, type FC } from 'react';
 
+import DisabledUntilHydrated from '../DisabledUntilHydrated';
 import { Button } from '../common/Button';
 import CloseIcon from '~icons/material-symbols/close';
 import SearchIcon from '~icons/material-symbols/search';
@@ -85,19 +86,21 @@ const DocsSearch: FC = () => {
             <div className='relative'>
                 <div className='flex items-center bg-primary-50 border border-primary-200 rounded-md px-3 py-2 focus-within:border-primary-400'>
                     <SearchIcon className='w-4 h-4 text-primary-600 flex-shrink-0' aria-hidden='true' />
-                    <input
-                        ref={inputRef}
-                        type='text'
-                        placeholder='Search documentation...'
-                        value={query}
-                        onChange={(e) => {
-                            setQuery(e.target.value);
-                            setIsOpen(true);
-                        }}
-                        onFocus={() => setIsOpen(true)}
-                        className='flex-1 ml-2 bg-transparent border-none text-sm text-gray-700 placeholder-primary-500 focus:outline-none focus:ring-0'
-                        aria-label='Search documentation'
-                    />
+                    <DisabledUntilHydrated>
+                        <input
+                            ref={inputRef}
+                            type='text'
+                            placeholder='Search documentation...'
+                            value={query}
+                            onChange={(e) => {
+                                setQuery(e.target.value);
+                                setIsOpen(true);
+                            }}
+                            onFocus={() => setIsOpen(true)}
+                            className='flex-1 ml-2 bg-transparent border-none text-sm text-gray-700 placeholder-primary-500 focus:outline-none focus:ring-0 disabled:cursor-not-allowed'
+                            aria-label='Search documentation'
+                        />
+                    </DisabledUntilHydrated>
                     {query && (
                         <Button
                             type='button'

--- a/website/src/components/Navigation/DocsSearch.tsx
+++ b/website/src/components/Navigation/DocsSearch.tsx
@@ -83,7 +83,7 @@ const DocsSearch: FC = () => {
     return (
         <div ref={searchRef} className='mb-4 relative'>
             <div className='relative'>
-                <div className='flex items-center bg-primary-50 border border-primary-200 rounded-md px-3 py-2'>
+                <div className='flex items-center bg-primary-50 border border-primary-200 rounded-md px-3 py-2 focus-within:border-primary-400'>
                     <SearchIcon className='w-4 h-4 text-primary-600 flex-shrink-0' aria-hidden='true' />
                     <input
                         ref={inputRef}
@@ -95,7 +95,7 @@ const DocsSearch: FC = () => {
                             setIsOpen(true);
                         }}
                         onFocus={() => setIsOpen(true)}
-                        className='flex-1 ml-2 bg-transparent border-none outline-none text-sm text-gray-700 placeholder-primary-500'
+                        className='flex-1 ml-2 bg-transparent border-none text-sm text-gray-700 placeholder-primary-500 focus:outline-none focus:ring-0'
                         aria-label='Search documentation'
                     />
                     {query && (
@@ -174,7 +174,6 @@ const DocsSearch: FC = () => {
                     </div>
                 )}
             </div>
-
         </div>
     );
 };

--- a/website/src/layouts/AboutLayout.astro
+++ b/website/src/layouts/AboutLayout.astro
@@ -2,6 +2,7 @@
 import '../styles/mdcontainer.scss';
 import BaseLayout from './BaseLayout.astro';
 import DocsMenu from '../components/Navigation/DocsMenu';
+import DocsSearch from '../components/Navigation/DocsSearch';
 import type { MdxPage } from '../types/mdxTypes';
 
 const { frontmatter } = Astro.props;
@@ -12,7 +13,10 @@ const currentPageUrl = Astro.url.pathname;
 
 <BaseLayout title={frontmatter.title} activeTopNavigationItem={activeTopNavigationItem}>
     <div class='md:flex md:justify-between max-w-5xl mx-auto items-start gap-10'>
-        <DocsMenu docsPages={aboutPages} currentPageUrl={currentPageUrl} title='About' client:load />
+        <div class='md:w-64 md:flex-none'>
+            <DocsSearch client:load />
+            <DocsMenu docsPages={aboutPages} currentPageUrl={currentPageUrl} title='About' client:load />
+        </div>
         <div class='mdContainer mdContainerItself text-gray-700 leading-relaxed'>
             <h1>{frontmatter.title}</h1>
 

--- a/website/src/layouts/DocLayout.astro
+++ b/website/src/layouts/DocLayout.astro
@@ -2,6 +2,7 @@
 import '../styles/mdcontainer.scss';
 import BaseLayout from './BaseLayout.astro';
 import DocsMenu from '../components/Navigation/DocsMenu';
+import DocsSearch from '../components/Navigation/DocsSearch';
 import { getWebsiteConfig } from '../config';
 import type { MdxPage } from '../types/mdxTypes';
 import MdiGithub from '~icons/mdi/github';
@@ -19,7 +20,10 @@ const editUrl = `${gitHubEditLink}${fileLocation}`;
 
 <BaseLayout title={frontmatter.title} activeTopNavigationItem={activeTopNavigationItem}>
     <div class='md:flex md:justify-between max-w-5xl mx-auto items-start gap-10'>
-        <DocsMenu docsPages={docsPages} currentPageUrl={currentPageUrl} title='Documentation' client:load />
+        <div class='md:w-64 md:flex-none'>
+            <DocsSearch client:load />
+            <DocsMenu docsPages={docsPages} currentPageUrl={currentPageUrl} title='Documentation' client:load />
+        </div>
         <div class='mdContainer mdContainerItself text-gray-700 leading-relaxed'>
             <h1>{frontmatter.title}</h1>
             <slot />

--- a/website/src/pages/search-index.json.ts
+++ b/website/src/pages/search-index.json.ts
@@ -1,0 +1,8 @@
+import { searchIndexJson } from '../utils/buildSearchIndex';
+
+export function GET() {
+    return new Response(searchIndexJson, {
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- HTTP header name
+        headers: { 'Content-Type': 'application/json' },
+    });
+}

--- a/website/src/pages/search-index.json.ts
+++ b/website/src/pages/search-index.json.ts
@@ -1,8 +1,23 @@
-import { searchIndexJson } from '../utils/buildSearchIndex';
+import { searchIndexETag, searchIndexJson } from '../utils/buildSearchIndex';
 
-export function GET() {
+/* eslint-disable @typescript-eslint/naming-convention -- HTTP header names */
+export function GET({ request }: { request: Request }) {
+    if (request.headers.get('if-none-match') === searchIndexETag) {
+        return new Response(null, {
+            status: 304,
+            headers: {
+                'ETag': searchIndexETag,
+                'Cache-Control': 'public, max-age=3600',
+            },
+        });
+    }
+
     return new Response(searchIndexJson, {
-        // eslint-disable-next-line @typescript-eslint/naming-convention -- HTTP header name
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+            'Content-Type': 'application/json',
+            'Cache-Control': 'public, max-age=3600',
+            'ETag': searchIndexETag,
+        },
     });
 }
+/* eslint-enable @typescript-eslint/naming-convention */

--- a/website/src/utils/buildSearchIndex.ts
+++ b/website/src/utils/buildSearchIndex.ts
@@ -40,23 +40,14 @@ const splitFrontmatter = (content: string): { frontmatter: Record<string, unknow
     return { frontmatter, body: content.slice(match[0].length) };
 };
 
-const stripMarkdown = (body: string): string => {
-    let current = body;
-    let previous: string;
-    do {
-        previous = current;
-        current = current
-            .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-            .replace(/^#{1,6}\s+/gm, '')
-            .replace(/```[\s\S]*?```/g, '')
-            .replace(/`([^`]+)`/g, '$1')
-            .replace(/<!--[\s\S]*?-->/g, '')
-            .replace(/\s+/g, ' ')
-            .trim();
-    } while (current !== previous);
-
-    return current;
-};
+const stripMarkdown = (body: string): string =>
+    body
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+        .replace(/^#{1,6}\s+/gm, '')
+        .replace(/```[\s\S]*?```/g, '')
+        .replace(/`([^`]+)`/g, '$1')
+        .replace(/\s+/g, ' ')
+        .trim();
 
 const pathToUrl = (modulePath: string): string => {
     // ../pages/docs/how-to/revise-submissions.mdx -> /docs/how-to/revise-submissions

--- a/website/src/utils/buildSearchIndex.ts
+++ b/website/src/utils/buildSearchIndex.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import type MiniSearch from 'minisearch';
 import { parse as parseYaml } from 'yaml';
 
@@ -80,3 +82,4 @@ const payload: SearchIndexPayload = {
 };
 
 export const searchIndexJson: string = JSON.stringify(payload);
+export const searchIndexETag: string = `"${createHash('sha1').update(searchIndexJson).digest('hex')}"`;

--- a/website/src/utils/buildSearchIndex.ts
+++ b/website/src/utils/buildSearchIndex.ts
@@ -40,15 +40,23 @@ const splitFrontmatter = (content: string): { frontmatter: Record<string, unknow
     return { frontmatter, body: content.slice(match[0].length) };
 };
 
-const stripMarkdown = (body: string): string =>
-    body
-        .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-        .replace(/^#{1,6}\s+/gm, '')
-        .replace(/```[\s\S]*?```/g, '')
-        .replace(/`([^`]+)`/g, '$1')
-        .replace(/<!--[\s\S]*?-->/g, '')
-        .replace(/\s+/g, ' ')
-        .trim();
+const stripMarkdown = (body: string): string => {
+    let current = body;
+    let previous: string;
+    do {
+        previous = current;
+        current = current
+            .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+            .replace(/^#{1,6}\s+/gm, '')
+            .replace(/```[\s\S]*?```/g, '')
+            .replace(/`([^`]+)`/g, '$1')
+            .replace(/<!--[\s\S]*?-->/g, '')
+            .replace(/\s+/g, ' ')
+            .trim();
+    } while (current !== previous);
+
+    return current;
+};
 
 const pathToUrl = (modulePath: string): string => {
     // ../pages/docs/how-to/revise-submissions.mdx -> /docs/how-to/revise-submissions

--- a/website/src/utils/buildSearchIndex.ts
+++ b/website/src/utils/buildSearchIndex.ts
@@ -25,7 +25,7 @@ const aboutRaw = import.meta.glob<string>('../pages/about/**/*.mdx', {
     import: 'default',
 });
 
-const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n?/;
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
 
 const splitFrontmatter = (content: string): { frontmatter: Record<string, unknown>; body: string } => {
     const match = FRONTMATTER_RE.exec(content);

--- a/website/src/utils/buildSearchIndex.ts
+++ b/website/src/utils/buildSearchIndex.ts
@@ -1,0 +1,83 @@
+import type MiniSearch from 'minisearch';
+import { parse as parseYaml } from 'yaml';
+
+interface SearchDocument {
+    id: string;
+    title: string;
+    section: 'docs' | 'about';
+    url: string;
+    content: string;
+}
+
+interface SearchIndexPayload {
+    options: ConstructorParameters<typeof MiniSearch>[0];
+    documents: SearchDocument[];
+}
+
+const docsRaw = import.meta.glob<string>('../pages/docs/**/*.mdx', {
+    eager: true,
+    query: '?raw',
+    import: 'default',
+});
+const aboutRaw = import.meta.glob<string>('../pages/about/**/*.mdx', {
+    eager: true,
+    query: '?raw',
+    import: 'default',
+});
+
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n?/;
+
+const splitFrontmatter = (content: string): { frontmatter: Record<string, unknown>; body: string } => {
+    const match = FRONTMATTER_RE.exec(content);
+    if (!match) return { frontmatter: {}, body: content };
+    let parsed: unknown = {};
+    try {
+        parsed = parseYaml(match[1]) ?? {};
+    } catch {
+        parsed = {};
+    }
+    const frontmatter = (typeof parsed === 'object' && parsed !== null ? parsed : {}) as Record<string, unknown>;
+    return { frontmatter, body: content.slice(match[0].length) };
+};
+
+const stripMarkdown = (body: string): string =>
+    body
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+        .replace(/^#{1,6}\s+/gm, '')
+        .replace(/```[\s\S]*?```/g, '')
+        .replace(/`([^`]+)`/g, '$1')
+        .replace(/<!--[\s\S]*?-->/g, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+const pathToUrl = (modulePath: string): string => {
+    // ../pages/docs/how-to/revise-submissions.mdx -> /docs/how-to/revise-submissions
+    // ../pages/docs/how-to/index.mdx              -> /docs/how-to
+    const fromPages = modulePath.split('/pages/')[1];
+    return '/' + fromPages.replace(/\.mdx$/, '').replace(/\/index$/, '');
+};
+
+const buildDocuments = (modules: Record<string, string>, section: 'docs' | 'about'): SearchDocument[] => {
+    return Object.entries(modules).map(([modulePath, raw], i) => {
+        const { frontmatter, body } = splitFrontmatter(raw);
+        const title =
+            typeof frontmatter.title === 'string' && frontmatter.title.length > 0 ? frontmatter.title : 'Untitled';
+        return {
+            id: `${section}-${i}`,
+            title,
+            section,
+            url: pathToUrl(modulePath),
+            content: stripMarkdown(body),
+        };
+    });
+};
+
+const payload: SearchIndexPayload = {
+    options: {
+        fields: ['title', 'content'],
+        storeFields: ['title', 'url', 'section'],
+    },
+    documents: [...buildDocuments(docsRaw, 'docs'), ...buildDocuments(aboutRaw, 'about')],
+};
+
+export const searchIndexJson: string = JSON.stringify(payload);


### PR DESCRIPTION
## Why

> It's quite hard to find things in our docs — the menu on the left is quite overwhelming to read through. If you know exactly what you want, it's ok, but for a newcomer I imagine it's quite intimidating.
>
> — @emmahodcroft, [pathoplexus/pathoplexus#974](https://github.com/pathoplexus/pathoplexus/pull/974)

So let's fix it. This adds a client-side search bar at the top of the `/docs` and `/about` menus.

## What's here

A MiniSearch-powered search across all MDX content in `src/pages/docs/**` and `src/pages/about/**`:

- **Fuzzy + prefix matching** — finds "revison" → "revision", "subm" → "submission".
- **Results grouped** by section (Documentation / About).
- **Built at build time, not per request.** `buildSearchIndex.ts` uses `import.meta.glob('?raw')` so Vite bundles the MDX content into the server output; the `{options, documents}` JSON payload is `JSON.stringify`-ed once at module load. The `/search-index.json` route is a one-liner that hands the precomputed string back — no per-request work, no Cache-Control / ETag plumbing needed.
- **Works for downstream consumers (e.g. Pathoplexus)** automatically. The glob resolves at *their* build time against the merged filesystem (sync overlay + loculus tree), so any extra MDX pages they add get indexed without further changes.

Frontmatter is parsed with the `yaml` library (tolerant of CRLF), so titles render correctly regardless of which OS authored the file.

UI niceties picked up along the way:
- Input is wrapped in `DisabledUntilHydrated` so Playwright / early keystrokes can't race hydration (per `website/AGENTS.md`).
- "Loading…" indicator lives inside the absolutely-positioned dropdown rather than below the input → no layout shift on mount.
- Custom focus state on the wrapper (`focus-within:border-primary-400`) so the input doesn't show the browser's default blue ring.

## Files

| File | What it does |
|---|---|
| `website/src/utils/buildSearchIndex.ts` | Reads MDX via `import.meta.glob('?raw')`, parses frontmatter with `yaml`, produces the JSON payload. |
| `website/src/pages/search-index.json.ts` | One-line GET route returning the precomputed string. |
| `website/src/components/Navigation/DocsSearch.tsx` | Search bar + dropdown + result grouping. |
| `website/src/layouts/{Doc,About}Layout.astro` | Render `<DocsSearch client:load />` above the menu. |
| `website/package.json` / `package-lock.json` | Adds `minisearch` + `yaml`. |

🚀 Preview: Add `preview` label to enable