### PR TITLE
fix(website): Remove placeholder citations plot on user seqsets page

### DIFF
--- a/website/src/pages/seqsets/index.astro
+++ b/website/src/pages/seqsets/index.astro
@@ -1,7 +1,6 @@
 ---
 import { ErrorFeedback } from '../../components/ErrorFeedback';
 import { AuthorDetails } from '../../components/SeqSetCitations/AuthorDetails';
-import { CitationPlot } from '../../components/SeqSetCitations/CitationPlot';
 import { SeqSetList } from '../../components/SeqSetCitations/SeqSetList';
 import { SeqSetListActions } from '../../components/SeqSetCitations/SeqSetListActions';
 import NeedToLogin from '../../components/common/NeedToLogin.astro';
@@ -33,8 +32,8 @@ const editAccountUrl = (await getUrlForKeycloakAccountPage()) + '/#/personal-inf
             !accessToken ? (
                 <NeedToLogin message='You need to be logged in to create new SeqSets.' />
             ) : (
-                <div class='flex flex-wrap w-full gap-y-6 lg:divide-x'>
-                    <div class='flex flex-col lg:w-3/4'>
+                <div class='flex flex-wrap w-full'>
+                    <div class='flex flex-col'>
                         {authorResponse.match(
                             (authorProfile) => (
                                 <AuthorDetails
@@ -54,7 +53,7 @@ const editAccountUrl = (await getUrlForKeycloakAccountPage()) + '/#/personal-inf
                             ),
                         )}
                         <hr />
-                        <div class='flex flex-col lg:pr-4'>
+                        <div class='flex flex-col'>
                             <div class='flex justify-between items-center py-8'>
                                 <h1 class='text-2xl font-semibold'>SeqSets</h1>
                                 <SeqSetListActions clientConfig={clientConfig} accessToken={accessToken} client:load />
@@ -85,17 +84,6 @@ const editAccountUrl = (await getUrlForKeycloakAccountPage()) + '/#/personal-inf
                                     ),
                                 )}
                             </div>
-                        </div>
-                    </div>
-                    <div class='flex flex-col lg:w-1/4 lg:pl-4'>
-                        <span class='text-xl'>Cited by</span>
-                        {/* We show an empty plot for now until we get real data. */}
-                        <div class='max-w-96'>
-                            <CitationPlot
-                                citedByData={{ years: [2020, 2021, 2022, 2023, 2024], citations: [0, 0, 0, 0, 0] }}
-                                description='Number of times your sequences have been cited in publications'
-                                client:load
-                            />
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
- Removes the placeholder citation plot on the user seqsets page, as citations will be presented elsewhere. 

### Screenshot

<img width="2994" height="1796" alt="image" src="https://github.com/user-attachments/assets/12b16b85-8e37-4d98-97ea-9e1c006d3bc7" />

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable