### PR TITLE
chore(dependabot): ignore dtolnay/rust-toolchain updates as we want to stick to v1.92

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: weekly
     ignore:
       - dependency-name: "dtolnay/rust-toolchain"
+        # See https://github.com/loculus-project/loculus/pull/6516#issuecomment-4564199837
   - package-ecosystem: npm
     directory: website/
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      dependency-name: "dtolnay/rust-toolchain"
   - package-ecosystem: npm
     directory: website/
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: weekly
     ignore:
-      dependency-name: "dtolnay/rust-toolchain"
+      - dependency-name: "dtolnay/rust-toolchain"
   - package-ecosystem: npm
     directory: website/
     schedule:


### PR DESCRIPTION
🚀 Preview: Add `preview` label to enable