### PR TITLE
feat!(ingest): do not use ncbi release data for assigning segment groups

### DIFF
--- a/ingest/scripts/heuristic_group_segments.py
+++ b/ingest/scripts/heuristic_group_segments.py
@@ -38,10 +38,15 @@ def sort_authors(authors: str) -> str:
     return "; ".join(sorted([author.strip() for author in authors.split(";")]))
 
 
-def values_with_sorted_authors(values: dict[str, str]) -> dict[str, str]:
+def values_with_sorted_authors_fallback_date(
+    values: dict[str, str], rename: dict[str, str]
+) -> dict[str, str]:
     """Sort authors values and return modified values"""
     values_copy = values.copy()
     values_copy["authors"] = sort_authors(values_copy["authors"])
+    values_copy[rename["ncbiCollectionDate"]] = (
+        values_copy[rename["ncbiCollectionDate"]] or values_copy["ncbiReleaseDate"]
+    )
     return values_copy
 
 
@@ -61,10 +66,13 @@ class Config:
     insdc_segment_specific_fields: list[str]  # Fields that can vary between segments in a group
     nucleotide_sequences: list[str]
     segmented: bool
+    rename: dict[str, str]  # Mapping from old field names to new field names
 
 
 # id is actually NCBI accession
-INTRINSICALLY_SEGMENT_SPECIFIC_FIELDS: Final = {"segment", "id"}
+# ncbiReleaseDate is segment-specific but as it is used as bound for earliestReleaseDate
+# we need ingest to return only one ncbiReleaseDate per group
+INTRINSICALLY_SEGMENT_SPECIFIC_FIELDS: Final = {"segment", "id", "ncbiReleaseDate"}
 
 
 @click.command()
@@ -140,7 +148,7 @@ def main(
     for accession, values in segment_metadata.items():
         # Author order sometimes varies among segments from same isolate
         # Example: JX999734.1 (L) and JX999735.1 (M)
-        modified_values = values_with_sorted_authors(values)
+        modified_values = values_with_sorted_authors_fallback_date(values, config.rename)
         group_key = str(
             tuple((field, value) for field in shared_fields if (value := modified_values[field]))
         )
@@ -243,6 +251,9 @@ def main(
 
         row["id"] = joint_key
         row["fastaIds"] = segments_list_str
+        row["ncbiReleaseDate"] = max(
+            segment_metadata[group[segment]]["ncbiReleaseDate"] for segment in group
+        )
 
         # Hash of all metadata fields should be the same if
         # 1. field is not in keys_to_keep and

--- a/ingest/scripts/heuristic_group_segments.py
+++ b/ingest/scripts/heuristic_group_segments.py
@@ -251,9 +251,8 @@ def main(
 
         row["id"] = joint_key
         row["fastaIds"] = segments_list_str
-        row["ncbiReleaseDate"] = min(
-            segment_metadata[group[segment]]["ncbiReleaseDate"] for segment in group
-        )
+        dates = [segment_metadata[group[s]].get("ncbiReleaseDate") for s in group]
+        row["ncbiReleaseDate"] = min((d for d in dates if d), default=None)
 
         # Hash of all metadata fields should be the same if
         # 1. field is not in keys_to_keep and

--- a/ingest/scripts/heuristic_group_segments.py
+++ b/ingest/scripts/heuristic_group_segments.py
@@ -251,7 +251,7 @@ def main(
 
         row["id"] = joint_key
         row["fastaIds"] = segments_list_str
-        row["ncbiReleaseDate"] = max(
+        row["ncbiReleaseDate"] = min(
             segment_metadata[group[segment]]["ncbiReleaseDate"] for segment in group
         )
 


### PR DESCRIPTION
see [@theosanderson](https://github.com/theosanderson)'s report https://gist.github.com/theosanderson-agent/ded53e709683a52063233c174aa7c0c0 for why this would be good to have to andes virus

Use NCBI release date as a segment-specific field in ingest when grouping but still have only one release date per segment-group (as this is used for calculating the earliestReleaseDate making it segment specific would be a massive overhaul - see https://github.com/loculus-project/loculus/pull/6390 for a starting attempt in this direction)

### BREAKING CHANGE
This change is not breaking but will lead to users receiving a notification that they need to revoke and regroup some sequences - so I wanted to highlight this here.

### Changes in CCHF

Based on claude's summary of me running the diff script.
 

  1. individual → grouped

  Previously separate single-segment records are combined into groups:

```
  ┌─────────────────────────────┬───────────────────────────┐
  │    Removed (individual)     │      Added (grouped)      │
  ├─────────────────────────────┼───────────────────────────┤
  │ ON623080.1.M + ON142178.1.S │ ON623080.1.M/ON142178.1.S │
  ├─────────────────────────────┼───────────────────────────┤
  │ ON623086.1.L + ON142179.1.S │ ON623086.1.L/ON142179.1.S │
  ├─────────────────────────────┼───────────────────────────┤
  │ OQ935542.1.M + ON254096.1.S │ OQ935542.1.M/ON254096.1.S │
  ├─────────────────────────────┼───────────────────────────┤
  │ OQ935543.1.M + ON254100.1.S │ OQ935543.1.M/ON254100.1.S │
  ├─────────────────────────────┼───────────────────────────┤
  │ OQ935544.1.M + ON254097.1.S │ OQ935544.1.M/ON254097.1.S │
  ├─────────────────────────────┼───────────────────────────┤
  │ PV210235.1.L + PV168397.1.M │ PV210235.1.L/PV168397.1.M │
  ├─────────────────────────────┼───────────────────────────┤
  │ PV210236.1.L + PV168394.1.M │ PV210236.1.L/PV168394.1.M │
  └─────────────────────────────┴───────────────────────────┘
```

  2. grouped → split
  
  Previously grouped records (only L and M interestingly) are split into individual segment entries. These seem to be all from the same submitting group: `Stavropol State Research Anti-Plague Institute, Laboratory for diagnostics of viral infections`

For example first two examples: https://pathoplexus.org/cchf/search?visibility_specimenCollectorSampleId=true&specimenCollectorSampleId=229-ARM-TI-2023 have the same specimenCollectorSampleId and metadata (only release date was used to split) so it actually does make sense to split them up:

```
  ┌───────────────────────────┬─────────────────────────────┐
  │     Removed (grouped)     │     Added (individual)      │  specimenCollectorSampleId
  ├───────────────────────────┼─────────────────────────────┤
  │ PQ878918.1.L/PQ878909.1.M │ PQ878918.1.L + PQ878909.1.M │  229-ARM-TI-2023
  ├───────────────────────────┼─────────────────────────────┤
  │ PV105948.1.L/PV091003.1.M │ PV105948.1.L + PV091003.1.M │  229-ARM-TI-2023
  ├───────────────────────────┼─────────────────────────────┤
  │ PQ878919.1.L/PQ878910.1.M │ PQ878919.1.L + PQ878910.1.M │  279-ARM-TI-2023
  ├───────────────────────────┼─────────────────────────────┤
  │ PV105949.1.L/PV091004.1.M │ PV105949.1.L + PV091004.1.M │  279-ARM-TI-2023
  ├───────────────────────────┼─────────────────────────────┤
  │ PQ878920.1.L/PQ878911.1.M │ PQ878920.1.L + PQ878911.1.M │  345-ARM-TI-2023
  ├───────────────────────────┼─────────────────────────────┤
  │ PQ878922.1.L/PQ878913.1.M │ PQ878922.1.L + PQ878913.1.M │  372-ARM-TI-2022
  ├───────────────────────────┼─────────────────────────────┤
  │ PQ878925.1.L/PQ878916.1.M │ PQ878925.1.L + PQ878916.1.M │  423-ARM-TI-2023
  ├───────────────────────────┼─────────────────────────────┤
  │ PQ878926.1.L/PQ878917.1.M │ PQ878926.1.L + PQ878917.1.M │  521-ARM-TI-2023
  ├───────────────────────────┼─────────────────────────────┤
  │ PV105950.1.L/PV091005.1.M │ PV105950.1.L + PV091005.1.M │  345-ARM-TI-2023
  ├───────────────────────────┼─────────────────────────────┤
  │ PV105951.1.L/PV091006.1.M │ PV105951.1.L + PV091006.1.M │  423-ARM-TI-2023
  ├───────────────────────────┼─────────────────────────────┤
  │ PV105952.1.L/PV091007.1.M │ PV105952.1.L + PV091007.1.M │ 521-ARM-TI-2023
  ├───────────────────────────┼─────────────────────────────┤
  │ PV105953.1.L/PV091008.1.M │ PV105953.1.L + PV091008.1.M │  372-ARM-TI-2022
  └───────────────────────────┴─────────────────────────────┘
```
### PR Checklist
- [x] Test on andes virus to see if this improves grouping there as well: testing results on andes are good: https://github.com/pathoplexus/pathoplexus/pull/983
- [x] test on staging that does not trigger a revision of all grouped sequences (should not happen as the hash value will be the same unless the release date was different and in these cases the grouping will change anyways: tested here: https://github.com/pathoplexus/loculus_deployments/pull/743#issuecomment-4612516881

🚀 Preview: https://ingest-grouping-2.loculus.org