### PR TITLE
fix(prepro): use configured timeouts for all backend calls

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/backend.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/backend.py
@@ -174,7 +174,13 @@ def submit_processed_sequences(
     }
     params = {"pipelineVersion": config.pipeline_version}
     logger.info(f"[{request_id}] Submitting {len(processed)} processed sequences to {url}")
-    response = requests.post(url, data=ndjson_string, headers=headers, params=params, timeout=10)
+    response = requests.post(
+        url,
+        data=ndjson_string,
+        headers=headers,
+        params=params,
+        timeout=config.backend_request_timeout_seconds,
+    )
     if not response.ok:
         Path("failed_submission.json").write_text(ndjson_string, encoding="utf-8")
         msg = (
@@ -204,7 +210,9 @@ def request_upload(group_id: int, number_of_files: int, config: Config) -> Seque
     logger.info(
         f"[{request_id}] Requesting upload for {number_of_files} files, group_id: {group_id}"
     )
-    response = requests.post(url, headers=headers, params=params, timeout=10)
+    response = requests.post(
+        url, headers=headers, params=params, timeout=config.backend_request_timeout_seconds
+    )
     if not response.ok:
         msg = f"[{request_id}] Upload request failed: {response.status_code}, request id: {response.headers.get('x-request-id')}, {response.text}"
         raise RuntimeError(msg)


### PR DESCRIPTION
We arent using the configured timeout in all calls to the backend leading to errors when we reprocess sequences as the requests to the backend timeout

```
  File "/opt/conda/lib/python3.14/site-packages/loculus_preprocessing/backend.py", line 177, in submit_processed_sequences
    response = requests.post(url, data=ndjson_string, headers=headers, params=params, timeout=10)
  File "/opt/conda/lib/python3.14/site-packages/requests/api.py", line 115, in post
    return request("post", url, data=data, json=json, **kwargs)
  File "/opt/conda/lib/python3.14/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable