### PR TITLE
fix(deployment): Increase TTL for ingest trigger jobs a lot but add values hash to ens…

### DIFF
--- a/kubernetes/loculus/templates/ingest.yaml
+++ b/kubernetes/loculus/templates/ingest.yaml
@@ -124,10 +124,11 @@ metadata:
   name: loculus-ingest-trigger-{{ $key }}
   annotations:
     argocd.argoproj.io/sync-wave: "10"
+    valuesHash: {{ .Values | toJson | sha256sum | quote }}
 spec:
   activeDeadlineSeconds: 120
   backoffLimit: 0
-  ttlSecondsAfterFinished: 600
+  ttlSecondsAfterFinished: 900000
   template:
     metadata:
       labels:


### PR DESCRIPTION
Currently we are getting issues with jobs appearing out of sync, and probably constantly being recreated, because the job is deleted after 10 mins then argo tries to recreate it

🚀 Preview: Add `preview` label to enable