### PR TITLE
fix(deployment): add Replace=true sync-option to ingest trigger jobs

### DIFF
--- a/kubernetes/loculus/templates/ingest.yaml
+++ b/kubernetes/loculus/templates/ingest.yaml
@@ -124,6 +124,7 @@ metadata:
   name: loculus-ingest-trigger-{{ $key }}
   annotations:
     argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: Replace=true
     valuesHash: {{ .Values | toJson | sha256sum | quote }}
 spec:
   activeDeadlineSeconds: 120


### PR DESCRIPTION
## Summary

Follow-up to #6567 (requested in [this comment](https://github.com/loculus-project/loculus/pull/6567#issuecomment-4591218207)). Targets the `sync` branch so it can fold into that PR.

In #6567 the ingest trigger Job got a much longer `ttlSecondsAfterFinished` (`900000`) plus a `valuesHash` annotation so it re-triggers when values change on a sync. However, with the long TTL the finished Job now lingers between syncs, and **Job specs are largely immutable** — when the `valuesHash` annotation changes on the next sync, ArgoCD cannot patch the existing Job in place.

This adds the `argocd.argoproj.io/sync-options: Replace=true` annotation, which tells ArgoCD to **delete and recreate** the Job rather than attempt an in-place update. Combined with the changing `valuesHash`, this ensures the trigger Job reliably re-runs on each sync where values change.

```yaml
metadata:
  name: loculus-ingest-trigger-{{ $key }}
  annotations:
    argocd.argoproj.io/sync-wave: "10"
    argocd.argoproj.io/sync-options: Replace=true
    valuesHash: {{ .Values | toJson | sha256sum | quote }}
```

## Testing

`helm template` renders the annotation correctly on each `loculus-ingest-trigger-*` Job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable