### PR TITLE
chore(preprocessing): don't restrict Nextclade to a single job

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/nextclade.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/nextclade.py
@@ -470,7 +470,6 @@ def assign_segment_with_nextclade_align(
                 "--retry-reverse-complement=true",
                 f"--output-tsv={result_file_seg}",
                 f"--input-dataset={dataset_dir}/{name}",
-                "--jobs=1",
                 "--",
                 input_file,
             ]
@@ -857,7 +856,6 @@ def enrich_with_nextclade(  # noqa: PLR0914
                 f"--output-all={result_dir_seg}",
                 f"--input-dataset={dataset_dir}/{name}",
                 f"--output-translations={result_dir_seg}/nextclade.cds_translation.{{cds}}.fasta",
-                "--jobs=1",
                 *sequence_and_dataset.nextclade_additional_args,
                 "--",
                 input_file,


### PR DESCRIPTION
## What

Removes the hardcoded `--jobs=1` flag from both `nextclade3 run` invocations in the Nextclade preprocessing pipeline (`preprocessing/nextclade/src/loculus_preprocessing/nextclade.py`):

- `assign_segment_with_nextclade_align` — the alignment-only run (`--output-tsv=...`)
- `enrich_with_nextclade` — the full run (`--output-all=...`, with CDS translations)

## Why

Both `nextclade3 run` calls currently pass `--jobs=1`, which caps Nextclade to a single thread regardless of how many CPUs the preprocessing pod is given. Dropping the flag lets Nextclade fall back to its default behaviour of using all available cores, so a Nextclade run over a batch of sequences can parallelise across the cores allocated to the pod.

## Notes / things to confirm before un-drafting

- **Resource limits.** Nextclade's default is to use *all* detected cores. In Kubernetes, the core count it detects is the node's, not necessarily the pod's CPU limit — so we should sanity-check the preprocessing pod's CPU `requests`/`limits` and decide whether to pin `--jobs` to a sensible value (e.g. derived from the pod's CPU allocation) rather than leave it fully unbounded.
- **Throughput vs. parallelism model.** The pipeline may already process multiple sequences/segments concurrently at a higher level; worth confirming that letting each Nextclade invocation grab all cores is actually a net win and doesn't cause oversubscription.
- Marked as **draft** pending the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable