### PR TITLE
feat(config): put silo and lapis into the same sync wave as ingest - …

### DIFF
--- a/kubernetes/loculus/templates/lapis-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-deployment.yaml
@@ -9,6 +9,7 @@ kind: Deployment
 metadata:
   name: loculus-lapis-{{ $key }}
   annotations:
+    argocd.argoproj.io/sync-wave: "10"
 spec:
   replicas: {{ $.Values.replicas.lapis | default 1 }}
   selector:

--- a/kubernetes/loculus/templates/silo-deployment.yaml
+++ b/kubernetes/loculus/templates/silo-deployment.yaml
@@ -13,6 +13,7 @@ metadata:
   annotations:
     # Force replace when run a) with dev db and b) without persistence to ensure silo prepro fails loudly
     argocd.argoproj.io/sync-options: Replace=true{{ if (and (not $.Values.developmentDatabasePersistence) $.Values.runDevelopmentMainDatabase) }},Force=true{{ end }}
+    argocd.argoproj.io/sync-wave: "10"
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
…so that we dont have to wait for them to complete (ingest only needs the backend, keycloak and ena)

resolves #

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://silo-syncwave.loculus.org