### PR TITLE
feat(silo-import, helm, website): Revive hierarchical filter functionality

### DIFF
--- a/docs/src/content/docs/reference/helm-chart-config.mdx
+++ b/docs/src/content/docs/reference/helm-chart-config.mdx
@@ -81,6 +81,15 @@ lineageSystemDefinitions:
 
 Note: Lineages should be determined by the preprocessing pipeline and not the user, set the lineage field to `noInput: true` to reflect this or alternatively only allow users to submit valid lineage values by adding an `options` list.
 
+### Hierarchical filter sources
+
+For metadata fields whose values form a hierarchy that's resolved at SILO import
+time (rather than fetched as a static file per pipeline version), set
+`hierarchicalFilter: <URL>`, where URL is the URL of the service that will create the
+hierarchical file for SILO. The importer collects observed
+values for the field, sends them to that service, and writes the returned YAML
+into SILO's input directory as `<MetadataName>.yaml`.
+
 ### Organism (type)
 
 Each organism object has the following fields:

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -372,6 +372,12 @@ organisms:
   {{- if .lineageSystem }}
   lineageSearch: true
   {{- end }}
+  {{- if .hierarchicalFilter }}
+  hierarchicalSearch: true
+  {{- end }}
+  {{- if and .hierarchicalFilter .hierarchicalSearchLabel }}
+  hierarchicalSearchLabel: {{ .hierarchicalSearchLabel }}
+  {{- end }}
   {{- if .hideOnSequenceDetailsPage }}
   hideOnSequenceDetailsPage: {{ .hideOnSequenceDetailsPage }}
   {{- end }}

--- a/kubernetes/loculus/templates/_hierarchical-filters-for-organism.tpl
+++ b/kubernetes/loculus/templates/_hierarchical-filters-for-organism.tpl
@@ -1,0 +1,11 @@
+{{- define "loculus.hierarchicalFiltersForOrganism" -}}
+{{- $organism := . -}}
+{{- $schema := $organism.schema | include "loculus.patchMetadataSchema" | fromYaml }}
+{{- $filters := dict }}
+{{- range $entry := $schema.metadata }}
+  {{- if hasKey $entry "hierarchicalFilter" }}
+    {{- $_ := set $filters $entry.name $entry.hierarchicalFilter }}
+  {{- end }}
+{{- end }}
+{{- $filters | toYaml -}}
+{{- end }}

--- a/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
+++ b/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
@@ -1,12 +1,13 @@
 {{- define "loculus.siloDatabaseShared" -}}
 {{- $type := default "string" .type -}}
+{{- $lineageName := ternary .name (default "" .lineageSystem) (not (empty .hierarchicalFilter)) -}}
 - type: {{ ($type | eq "timestamp") | ternary "int" (($type | eq "authors") | ternary "string" $type) }}
   {{- if .generateIndex }}
   generateIndex: {{ .generateIndex }}
   {{- end }}
-  {{- if .lineageSystem }}
+  {{- if $lineageName }}
   generateIndex: true
-  generateLineageIndex: {{ .lineageSystem }} {{- /* must match the file name in the lineageDefinitionFilenames */}}
+  generateLineageIndex: {{ $lineageName }} {{- /* must match the file name in the lineageDefinitionFilenames */}}
   {{- end }}
 {{- end }}
 

--- a/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
+++ b/kubernetes/loculus/templates/_siloDatabaseConfig.tpl
@@ -2,7 +2,7 @@
 {{- $type := default "string" .type -}}
 {{- $lineageName := ternary .name (default "" .lineageSystem) (not (empty .hierarchicalFilter)) -}}
 - type: {{ ($type | eq "timestamp") | ternary "int" (($type | eq "authors") | ternary "string" $type) }}
-  {{- if .generateIndex }}
+  {{- if and .generateIndex (not $lineageName) }}
   generateIndex: {{ .generateIndex }}
   {{- end }}
   {{- if $lineageName }}

--- a/kubernetes/loculus/templates/lapis-silo-database-config.yaml
+++ b/kubernetes/loculus/templates/lapis-silo-database-config.yaml
@@ -5,6 +5,11 @@
 {{- $organismContent := $item.contents }}
 
 {{- $lineageSystem := $organismContent | include "loculus.lineageSystemForOrganism" | fromYamlArray }}
+{{- $hierarchicalFilters := $organismContent | include "loculus.hierarchicalFiltersForOrganism" | fromYaml }}
+{{- $allLineageNames := $lineageSystem }}
+{{- range $name, $_ := $hierarchicalFilters }}
+  {{- $allLineageNames = append $allLineageNames $name }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -24,10 +29,10 @@ data:
     outputDirectory: /preprocessing/output
     ndjsonInputFilename: data.ndjson.zst
     referenceGenomeFilename: reference_genomes.json
-    {{- if $lineageSystem }}
+    {{- if $allLineageNames }}
     lineageDefinitionFilenames:
-    {{- range $ls := $lineageSystem }}
-      - {{ printf "%s.yaml" $ls }}
+    {{- range $name := $allLineageNames }}
+      - {{ printf "%s.yaml" $name }}
     {{- end }}
     {{- end }}
 

--- a/kubernetes/loculus/templates/silo-deployment.yaml
+++ b/kubernetes/loculus/templates/silo-deployment.yaml
@@ -5,6 +5,7 @@
 {{- $key := $item.key }}
 {{- $organismContent := $item.contents }}
 {{- $lineageSystem := $organismContent | include "loculus.lineageSystemForOrganism" | fromYamlArray }}
+{{- $hierarchicalFilters := $organismContent | include "loculus.hierarchicalFiltersForOrganism" | fromYaml }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -93,6 +94,10 @@ spec:
               {{- end }}
             - name: LINEAGE_DEFINITIONS
               value: {{ $defsBySystem | toJson | quote }}
+            {{- end }}
+            {{- if $hierarchicalFilters }}
+            - name: HIERARCHICAL_FILTERS
+              value: {{ $hierarchicalFilters | toJson | quote }}
             {{- end }}
             - name: SILO_RUN_TIMEOUT_SECONDS
               value: {{ $.Values.siloImport.siloTimeoutSeconds | quote }}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -232,6 +232,16 @@
           "groups": ["metadata"],
           "type": "string",
           "description": "Use this on string fields that contain lineages, if you want to enable searches that can include sublineages. The value needs to be a lineage system that is defined under the `lineageSystemDefinitions` key."
+        },
+        "hierarchicalFilter": {
+          "groups": ["metadata"],
+          "type": "string",
+          "description": "Use this on string fields whose values form a hierarchy resolved at SILO import time. The value should be an URL to the lineage file."
+        },
+        "hierarchicalSearchLabel": {
+          "groups": ["metadata"],
+          "type": "string",
+          "description": "CheckBox label for hierarchical search - only applies when using hierarchicalFilter."
         }
       },
       "required": ["name"],
@@ -288,6 +298,24 @@
               "type": { "enum": ["string", "authors"] }
             },
             "errorMessage": "When lineageSystem is set, type must be 'string' or 'authors'"
+          }
+        },
+        {
+          "if": {
+            "properties": { "hierarchicalFilter": { "type": "string" } },
+            "required": ["hierarchicalFilter"]
+          },
+          "then": {
+            "properties": {
+              "type": { "enum": ["string", "authors"] }
+            },
+            "errorMessage": "When hierarchicalFilter is set, type must be 'string' or 'authors'"
+          }
+        },
+        {
+          "not": {
+            "description": "lineageSystem and hierarchicalFilter cannot both be set",
+            "required": ["lineageSystem", "hierarchicalFilter"]
           }
         },
         {

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1256,7 +1256,7 @@ defaultOrganismConfig: &defaultOrganismConfig
             hostNameScientific: hostNameScientific
             hostTaxonId: hostTaxonId
           args:
-            taxonomy_service_url: "http://loculus-taxonomy-service:5000"
+            taxonomy_service_url: &taxonomy_service_url http://loculus-taxonomy-service:5000
       - name: hostNameScientific
         displayName: Host name - scientific
         definition: "The scientific name of the host from which the sample was collected."
@@ -1276,7 +1276,7 @@ defaultOrganismConfig: &defaultOrganismConfig
             hostTaxonId: processed.hostTaxonId
             hostNameScientific: hostNameScientific
           args:
-            taxonomy_service_url: "http://loculus-taxonomy-service:5000"
+            taxonomy_service_url: *taxonomy_service_url
       - name: hostNameCommon
         displayName: Host name - common
         definition: "The common name of the host from which the sample was collected."
@@ -1295,7 +1295,7 @@ defaultOrganismConfig: &defaultOrganismConfig
           inputs:
             hostTaxonId: processed.hostTaxonId
           args:
-            taxonomy_service_url: "http://loculus-taxonomy-service:5000"
+            taxonomy_service_url: *taxonomy_service_url
       - name: isLabHost
         displayName: Is lab host
         definition: "If a laboratory host (e.g. cultured cell line) was used to propagate the sample."
@@ -1535,7 +1535,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         - "prepro"
       replicas: 1
       taxonomyServiceArgs: &preprocessingTaxonomyServiceArgs
-        taxonomy_service_url: "http://loculus-taxonomy-service:5000"
+        taxonomy_service_url: *taxonomy_service_url
       configFile: &preprocessingConfigFile
         log_level: DEBUG
         batch_size: 100

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1657,6 +1657,9 @@ defaultOrganisms:
               regex_pattern: '^(?:[^/]+/)?[^/]+/(?P<identifier>[^/]+)/\d{4}(?:-\d{2}){0,2}$'
         - <<: *hostTaxonIdConfig
           required: true
+          hierarchicalFilter: *taxonomy_service_url
+          hierarchicalSearchLabel: "include subtaxa"
+          initiallyVisible: true
         - name: lineage
           displayName: Lineage
           definition: "Assigned clade label from the nearest reference tree node."

--- a/loculus-silo/README.md
+++ b/loculus-silo/README.md
@@ -4,9 +4,10 @@ Python service that retrieves released datasets from the Loculus backend, transf
 for SILO, and runs SILO preprocessing directly.
 
 The importer downloads data from the Loculus backend, [transforms it into the format required by SILO](https://github.com/GenSpectrum/LAPIS-SILO/tree/main/tools/legacyNdjsonTransformer), and runs SILO preprocessing only if the following conditions hold:
+
 1. The data is in a valid format (e.g. ndjson format where each line is a valid json, has number of expected records, and the pipeline version exists and is a valid integer if a lineage definition is required).
 2. The lineage definitions file can be produced if it is required.
-3. The data has changed since the last download or it has been over more than `HARD_REFRESH_INTERVAL` since the last hard refresh. We determine if the data has changed from the header (e.g. 304 not modified) and by comparing a hash of the data. 
+3. The data has changed since the last download or it has been over more than `HARD_REFRESH_INTERVAL` since the last hard refresh. We determine if the data has changed from the header (e.g. 304 not modified) and by comparing a hash of the data.
 
 ## Local development
 

--- a/loculus-silo/src/silo_import/config.py
+++ b/loculus-silo/src/silo_import/config.py
@@ -5,6 +5,9 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+MetadataField = str
+HierarchicalServiceUrl = str
+
 
 @dataclass(frozen=True)
 class ImporterConfig:
@@ -16,6 +19,7 @@ class ImporterConfig:
     root_dir: Path
     silo_binary: Path
     preprocessing_config: Path
+    hierarchical_filters: dict[MetadataField, HierarchicalServiceUrl] | None = None
 
     @classmethod
     def from_env(cls) -> ImporterConfig:
@@ -47,6 +51,8 @@ class ImporterConfig:
             except TypeError as exc:
                 raise RuntimeError(str(exc)) from exc
 
+        hierarchical_filters = _parse_hierarchical_filters(env.get("HIERARCHICAL_FILTERS"))
+
         hard_refresh_interval = int(env.get("HARD_REFRESH_INTERVAL", "3600"))
         poll_interval = int(env.get("SILO_IMPORT_POLL_INTERVAL_SECONDS", "30"))
         silo_run_timeout = int(env.get("SILO_RUN_TIMEOUT_SECONDS", "3600"))
@@ -66,8 +72,28 @@ class ImporterConfig:
             root_dir=root_dir,
             silo_binary=silo_binary,
             preprocessing_config=preprocessing_config,
+            hierarchical_filters=hierarchical_filters,
         )
 
     @property
     def released_data_endpoint(self) -> str:
         return f"{self.backend_base_url}/get-released-data?compression=zstd"
+
+
+def _parse_hierarchical_filters(
+    raw: str | None,
+) -> dict[MetadataField, HierarchicalServiceUrl] | None:
+    if not raw:
+        return None
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        msg = "HIERARCHICAL_FILTERS must be valid JSON"
+        raise RuntimeError(msg) from exc
+
+    if not isinstance(data, dict):
+        msg = f"HIERARCHICAL_FILTERS must be a JSON object, got: {raw}"
+        raise TypeError(msg)
+
+    return data or None

--- a/loculus-silo/src/silo_import/decompressor.py
+++ b/loculus-silo/src/silo_import/decompressor.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import orjsonl
+
+from .config import HierarchicalServiceUrl, MetadataField
 
 logger = logging.getLogger(__name__)
 
@@ -17,17 +19,23 @@ class NdjsonAnalysis:
 
     record_count: int
     pipeline_version: int | None
+    hierarchical_filter_values: dict[MetadataField, set[str]] = field(default_factory=dict)
 
 
-def analyze_ndjson(path: Path) -> NdjsonAnalysis:
+def analyze_ndjson(
+    path: Path,
+    hierarchical_filters: dict[MetadataField, HierarchicalServiceUrl] | None = None,
+) -> NdjsonAnalysis:
     """
     Decompress and analyze a zstd-compressed NDJSON file.
 
     Args:
         path: Path to the compressed NDJSON file
+        hierarchical_filters: Map of hierarchical metadata field names to service URLs
 
     Returns:
-        NdjsonAnalysis with record count and pipeline versions found
+        NdjsonAnalysis with record count, pipeline version, and
+        observed values for the configured hierarchical filters.
 
     Raises:
         RuntimeError: If decompression or JSON parsing fails
@@ -35,16 +43,29 @@ def analyze_ndjson(path: Path) -> NdjsonAnalysis:
     logger.info("Starting analyze_and_transform_ndjson")
     record_count = 0
     pipeline_version: int | None = None
+    filter_values: dict[MetadataField, set[str]] = (
+        {name: set() for name in hierarchical_filters} if hierarchical_filters else {}
+    )
 
     try:
         for record in orjsonl.stream(path):
             record_count += 1
+            metadata = record.get("metadata", {})  # type: ignore
             if pipeline_version is None:
-                pipeline_version = record.get("metadata", {}).get("pipelineVersion")  # type: ignore
+                pipeline_version = metadata.get("pipelineVersion")
+            if hierarchical_filters:
+                for name in hierarchical_filters:
+                    raw_value = metadata.get(name)
+                    if raw_value is not None:
+                        filter_values[name].add(str(raw_value))
 
     except Exception as exc:
         msg = f"Failed to decompress {path}: {exc}"
         logger.error(msg)
         raise RuntimeError(msg) from exc
 
-    return NdjsonAnalysis(record_count=record_count, pipeline_version=pipeline_version)
+    return NdjsonAnalysis(
+        record_count=record_count,
+        pipeline_version=pipeline_version,
+        hierarchical_filter_values=filter_values,
+    )

--- a/loculus-silo/src/silo_import/download_manager.py
+++ b/loculus-silo/src/silo_import/download_manager.py
@@ -17,7 +17,7 @@ from .constants import (
     DATA_FILENAME,
     TRANSFORMED_DATA_FILENAME,
 )
-from .decompressor import analyze_ndjson
+from .decompressor import NdjsonAnalysis, analyze_ndjson
 from .errors import (
     DecompressionFailedError,
     HashUnchangedError,
@@ -78,7 +78,7 @@ class DownloadResult:
     directory: Path
     transformed_path: Path
     etag: str
-    pipeline_version: int | None
+    analysis: NdjsonAnalysis
 
 
 def _download_file(
@@ -205,7 +205,7 @@ class DownloadManager:
 
             # Decompress and analyze the data
             try:
-                analysis = analyze_ndjson(data_path)
+                analysis = analyze_ndjson(data_path, config.hierarchical_filters)
             except RuntimeError as exc:
                 logger.warning(
                     "Failed to decompress %s (size=%s bytes): %s",
@@ -244,7 +244,7 @@ class DownloadManager:
                 directory=download_dir,
                 transformed_path=transformed_path,
                 etag=etag_value,
-                pipeline_version=analysis.pipeline_version,
+                analysis=analysis,
             )
 
         except (

--- a/loculus-silo/src/silo_import/lineage.py
+++ b/loculus-silo/src/silo_import/lineage.py
@@ -4,8 +4,9 @@ import logging
 from pathlib import Path
 
 import requests
+from requests import codes
 
-from .config import ImporterConfig
+from .config import ImporterConfig, MetadataField
 from .paths import ImporterPaths
 
 logger = logging.getLogger(__name__)
@@ -44,10 +45,70 @@ def update_lineage_definitions(
             raise RuntimeError(msg) from exc
 
 
+def update_hierarchical_filters(
+    metadata_values: dict[MetadataField, set[str]],
+    old_metadata_values: dict[MetadataField, set[str]],
+    config: ImporterConfig,
+    paths: ImporterPaths,
+) -> None:
+    """Dispatch each configured filter to the hierarchical filter handler.
+
+    Skips filters whose observed values have not changed since the last run.
+    """
+    if not config.hierarchical_filters:
+        return
+    for field, url in config.hierarchical_filters.items():
+        new_values = metadata_values.get(field, set())
+        if old_metadata_values.get(field) == new_values:
+            logger.info("No change in values for hierarchical filter '%s'; skipping update", field)
+            continue
+        if not url:
+            continue
+        fetch_updated_hierarchy(field, new_values, url, paths)
+
+
+def fetch_updated_hierarchy(
+    file_base: str,
+    values: set[str],
+    service_url: str,
+    paths: ImporterPaths,
+) -> None:
+    destination = paths.input_dir / f"{file_base}.yaml"
+    if not values:
+        logger.info("No values for filter '%s'; writing empty file", file_base)
+        _write_text(destination, "{}\n")
+        return
+
+    url = f"{service_url.rstrip('/')}/silo-lineage"
+    logger.info("Fetching %s hierarchy over %d values", file_base, len(values))
+    sorted_values = sorted(values)
+    try:
+        response = _post_silo_lineage(url, sorted_values)
+        if response.status_code == codes.request_entity_too_large:
+            logger.warning(
+                "Unpruned %s lineage exceeds size threshold; retrying with prune=true", file_base
+            )
+            response = _post_silo_lineage(url, sorted_values, prune=True)
+        response.raise_for_status()
+        _write_text(destination, response.text)
+    except requests.RequestException as exc:
+        msg = f"Failed to fetch lineage from {url}: {exc}"
+        raise RuntimeError(msg) from exc
+
+
 def _download_lineage_file(url: str, destination: Path) -> None:
     response = requests.get(url, timeout=60)
     response.raise_for_status()
     _write_text(destination, response.text)
+
+
+def _post_silo_lineage(url: str, values: list[str], prune: bool = False) -> requests.Response:
+    """The service providing hierarchical filter lineage files is expected to
+    expose a POST /silo-lineage endpoint that takes a {values: [<values>]}
+    request body and a ?prune=<boolean> query param
+    """
+    params = {"prune": "true"} if prune else None
+    return requests.post(url, json={"values": values}, params=params, timeout=60)
 
 
 def _write_text(path: Path, content: str) -> None:

--- a/loculus-silo/src/silo_import/lineage.py
+++ b/loculus-silo/src/silo_import/lineage.py
@@ -7,7 +7,7 @@ from typing import Any
 import requests
 from requests import codes
 
-from .config import ImporterConfig, MetadataField
+from .config import HierarchicalServiceUrl, ImporterConfig, MetadataField
 from .paths import ImporterPaths
 
 logger = logging.getLogger(__name__)
@@ -63,15 +63,13 @@ def update_hierarchical_filters(
         if old_metadata_values.get(field) == new_values:
             logger.info("No change in values for hierarchical filter '%s'; skipping update", field)
             continue
-        if not url:
-            continue
         fetch_updated_hierarchy(field, new_values, url, paths)
 
 
 def fetch_updated_hierarchy(
-    file_base: str,
+    file_base: MetadataField,
     values: set[str],
-    service_url: str,
+    service_url: HierarchicalServiceUrl,
     paths: ImporterPaths,
 ) -> None:
     destination = paths.input_dir / f"{file_base}.yaml"

--- a/loculus-silo/src/silo_import/lineage.py
+++ b/loculus-silo/src/silo_import/lineage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 import requests
 from requests import codes
@@ -108,7 +109,8 @@ def _post_silo_lineage(url: str, values: list[str], prune: bool = False) -> requ
     request body and a ?prune=<boolean> query param
     """
     params = {"prune": "true"} if prune else None
-    return requests.post(url, json={"values": values}, params=params, timeout=60)
+    payload: dict[str, Any] = {"values": values}
+    return requests.post(url, json=payload, params=params, timeout=60)
 
 
 def _write_text(path: Path, content: str) -> None:

--- a/loculus-silo/src/silo_import/runner.py
+++ b/loculus-silo/src/silo_import/runner.py
@@ -4,7 +4,7 @@ import logging
 import shutil
 import time
 
-from .config import ImporterConfig
+from .config import ImporterConfig, MetadataField
 from .constants import SPECIAL_ETAG_NONE
 from .download_manager import DownloadManager
 from .errors import (
@@ -15,7 +15,7 @@ from .errors import (
 )
 from .filesystem import prune_timestamped_directories, safe_remove
 from .instruct_silo import SiloRunner
-from .lineage import update_lineage_definitions
+from .lineage import update_hierarchical_filters, update_lineage_definitions
 from .paths import ImporterPaths
 
 logger = logging.getLogger(__name__)
@@ -31,6 +31,7 @@ class ImporterRunner:
         self.download_manager = DownloadManager()
         self.current_etag = SPECIAL_ETAG_NONE
         self.last_hard_refresh: float = 0
+        self.hierarchical_filter_values: dict[MetadataField, set[str]] = {}
 
     def _clear_download_directories(self) -> None:
         """Clear all timestamped download directories on startup."""
@@ -79,7 +80,14 @@ class ImporterRunner:
             return
 
         try:
-            update_lineage_definitions(download.pipeline_version, self.config, self.paths)
+            update_lineage_definitions(download.analysis.pipeline_version, self.config, self.paths)
+            update_hierarchical_filters(
+                download.analysis.hierarchical_filter_values,
+                self.hierarchical_filter_values,
+                self.config,
+                self.paths,
+            )
+            self.hierarchical_filter_values = download.analysis.hierarchical_filter_values
         except Exception:
             logger.exception("Failed to download lineage definitions; cleaning up input")
             safe_remove(self.paths.silo_input_data_path)

--- a/loculus-silo/tests/helpers.py
+++ b/loculus-silo/tests/helpers.py
@@ -38,6 +38,17 @@ def mock_records():
     ]
 
 
+def mock_records_with_hierarchical_filters(taxa: list[str], filter_name: str) -> list[dict]:
+    """Like mock_records() but stamps each record's metadata with a hierarchical filter value.
+
+    Useful for exercising the hierarchical-filter value-extraction path.
+    """
+    records = mock_records()
+    for record, taxon in zip(records, taxa, strict=False):
+        record["metadata"][filter_name] = taxon
+    return records
+
+
 def mock_transformed_records():
     return [
         {

--- a/loculus-silo/tests/test_config.py
+++ b/loculus-silo/tests/test_config.py
@@ -1,11 +1,14 @@
 # ruff: noqa: S101
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 
 import pytest
-from silo_import.config import ImporterConfig
+from silo_import.config import (
+    ImporterConfig,
+)
 
 HARD_REFRESH_INTERVAL = 10
 SILO_IMPORT_POLL_INTERVAL_SECONDS = 5
@@ -31,6 +34,7 @@ def test_config_from_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
     assert config.poll_interval == SILO_IMPORT_POLL_INTERVAL_SECONDS
     assert config.silo_run_timeout == SILO_RUN_TIMEOUT_SECONDS
     assert config.root_dir == tmp_path
+    assert config.hierarchical_filters is None
 
 
 def test_config_missing_backend_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -38,4 +42,26 @@ def test_config_missing_backend_env(monkeypatch: pytest.MonkeyPatch) -> None:
         if key.startswith("BACKEND_BASE_URL"):
             monkeypatch.delenv(key, raising=False)
     with pytest.raises(RuntimeError):
+        ImporterConfig.from_env()
+
+
+def test_hierarchical_filters_parsed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BACKEND_BASE_URL", "http://example.com")
+    monkeypatch.setenv(
+        "HIERARCHICAL_FILTERS",
+        json.dumps({"hostTaxon": "http://taxonomy:5000"}),
+    )
+
+    config = ImporterConfig.from_env()
+
+    assert config.hierarchical_filters == {
+        "hostTaxon": "http://taxonomy:5000",
+    }
+
+
+def test_hierarchical_filters_invalid_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BACKEND_BASE_URL", "http://example.com")
+    monkeypatch.setenv("HIERARCHICAL_FILTERS", "not-json")
+
+    with pytest.raises(RuntimeError, match="HIERARCHICAL_FILTERS must be valid JSON"):
         ImporterConfig.from_env()

--- a/loculus-silo/tests/test_runner.py
+++ b/loculus-silo/tests/test_runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from typing import Final
 from unittest.mock import patch
 
 import pytest
@@ -11,11 +12,12 @@ from helpers import (
     compress_ndjson,
     make_mock_download_func,
     mock_records,
+    mock_records_with_hierarchical_filters,
     mock_transformed_records,
     read_ndjson_file,
 )
 from silo_import import lineage
-from silo_import.config import ImporterConfig
+from silo_import.config import HierarchicalServiceUrl, ImporterConfig, MetadataField
 from silo_import.download_manager import DownloadManager
 from silo_import.paths import ImporterPaths
 from silo_import.runner import ImporterRunner
@@ -25,6 +27,7 @@ def make_config(
     tmp_path: Path,
     lineage_definitions: dict[str, dict[int, str]] | None = None,
     hard_refresh_interval: int = 1,
+    hierarchical_filters: dict[MetadataField, HierarchicalServiceUrl] | None = None,
 ) -> ImporterConfig:
     return ImporterConfig(
         backend_base_url="http://backend",
@@ -35,6 +38,7 @@ def make_config(
         root_dir=tmp_path,
         silo_binary=tmp_path / "silo",
         preprocessing_config=tmp_path / "config.yaml",
+        hierarchical_filters=hierarchical_filters,
     )
 
 
@@ -191,3 +195,101 @@ def test_runner_cleans_up_on_decompress_failure(
     assert not [p for p in paths.input_dir.iterdir() if p.is_dir() and p.name.isdigit()]
     assert runner.current_etag == 'W/"old"'
     assert not responses_list
+
+
+HOST_TAXON_NAME: Final = "hostTaxonId"
+
+
+@pytest.fixture
+def host_taxon_setup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[ImporterConfig, ImporterPaths, list[tuple[str, list[str]]]]:
+    config = make_config(
+        tmp_path,
+        hierarchical_filters={HOST_TAXON_NAME: "http://taxonomy:5000"},
+        hard_refresh_interval=1000,
+    )
+    paths = make_paths(tmp_path)
+    paths.ensure_directories()
+
+    fake_response = type(
+        "Resp",
+        (),
+        {
+            "status_code": 200,
+            "text": "lineage: host\n",
+            "raise_for_status": lambda _: None,
+        },
+    )()
+
+    post_calls: list[tuple[str, list[str]]] = []
+
+    def fake_post(url: str, taxa: list[str], prune: bool = False):  # noqa: ARG001
+        post_calls.append((url, list(taxa)))
+        return fake_response
+
+    monkeypatch.setattr(lineage, "_post_silo_lineage", fake_post)
+
+    return config, paths, post_calls
+
+
+def test_runner_writes_hierarchical_filter_yaml(
+    host_taxon_setup: tuple[ImporterConfig, ImporterPaths, list[tuple[str, list[str]]]],
+) -> None:
+    config, paths, post_calls = host_taxon_setup
+
+    records = mock_records_with_hierarchical_filters(["9606", "10090", "9606"], HOST_TAXON_NAME)
+    body = compress_ndjson(records)
+    responses = [
+        MockHttpResponse(
+            status=200,
+            headers={"ETag": 'W/"hf"', "x-total-records": str(len(records))},
+            body=body,
+        )
+    ]
+    mock_download, _ = make_mock_download_func(responses)
+
+    runner = ImporterRunner(config, paths)
+    runner.download_manager = DownloadManager(download_func=mock_download)
+
+    with patch.object(runner.silo, "run_preprocessing"):
+        runner.run_once()
+
+    host_taxon_yaml = paths.input_dir / f"{HOST_TAXON_NAME}.yaml"
+    assert host_taxon_yaml.read_text(encoding="utf-8") == "lineage: host\n"
+    assert len(post_calls) == 1
+    assert post_calls[0][0] == "http://taxonomy:5000/silo-lineage"
+    assert post_calls[0][1] == ["10090", "9606"]
+    assert runner.hierarchical_filter_values == {HOST_TAXON_NAME: {"9606", "10090"}}
+
+
+def test_runner_skips_filter_refetch_when_taxa_unchanged(
+    host_taxon_setup: tuple[ImporterConfig, ImporterPaths, list[tuple[str, list[str]]]],
+) -> None:
+    config, paths, post_calls = host_taxon_setup
+
+    records = mock_records_with_hierarchical_filters(["9606", "10090", "9606"], HOST_TAXON_NAME)
+    body = compress_ndjson(records)
+    responses = [
+        MockHttpResponse(
+            status=200,
+            headers={"ETag": 'W/"first"', "x-total-records": str(len(records))},
+            body=body,
+        ),
+        MockHttpResponse(
+            status=200,
+            headers={"ETag": 'W/"second"', "x-total-records": str(len(records))},
+            body=body,
+        ),
+    ]
+    mock_download, _ = make_mock_download_func(responses)
+
+    runner = ImporterRunner(config, paths)
+    runner.download_manager = DownloadManager(download_func=mock_download)
+
+    with patch.object(runner.silo, "run_preprocessing"):
+        runner.run_once()
+        runner.run_once()
+
+    # Second run sees identical taxa → no second POST
+    assert len(post_calls) == 1

--- a/taxonomy/taxonomy_service/src/taxonomy_service/helpers.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/helpers.py
@@ -124,12 +124,13 @@ def get_spanning_tree(
     returns:
         list[Taxon]:    The taxonomic tree spanning all input tax_ids, represented
                         as a list of taxa
-        set[int]:       Taxon IDs in `tax_ids` that do not exist in the database
+        set[int]:       Taxon ids in `tax_ids` that do not exist in the database
     """
     existing_ids = find_existing_ids(db_conn, tax_ids)
-    missing_ids = tax_ids - existing_ids
     if not existing_ids:
         return [], tax_ids
+    existing_ids = {ROOT_TAX_ID} | existing_ids  # always include the root node
+    missing_ids = tax_ids - existing_ids
 
     placeholders = ",".join("?" * len(existing_ids))
     rows = db_conn.execute(
@@ -175,8 +176,6 @@ def prune_tree(
     to preserve the overall hierarchy.
     """
     indexed_by_id: dict[int, Taxon] = {t.tax_id: t for t in tree}
-    if root_id not in indexed_by_id:
-        raise ValueError(f"root_id {root_id} does not exist in the provided tree")
     children = map_child_nodes(tree)
     return list(
         _prune(indexed_by_id, keep_ids | {root_id}, children, root_id, root_id).values()

--- a/taxonomy/taxonomy_service/src/taxonomy_service/helpers.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/helpers.py
@@ -228,9 +228,10 @@ def convert_to_lineage_dict(taxa: Iterable[Taxon]) -> dict[str, dict]:
     result: dict[str, dict] = {}
 
     for taxon in taxa:
-        alias = f"Taxon {taxon.tax_id}: {taxon.scientific_name}"
+        alias = str(taxon.scientific_name)
         if taxon.common_name is not None:
             alias += f"; {taxon.common_name}"
+        alias += f" [Taxon {taxon.tax_id}]"
         result[str(taxon.tax_id)] = {
             "aliases": [alias],
             "parents": [str(taxon.parent_id)]

--- a/taxonomy/taxonomy_service/test/test_api.py
+++ b/taxonomy/taxonomy_service/test/test_api.py
@@ -172,8 +172,8 @@ class PostSiloLineageTest(unittest.TestCase):
         response = self._post([9605, 9606])
 
         lineage = yaml.safe_load(response.text)
-        assert lineage["9605"]["aliases"] == ["Taxon 9605: Homo; humans"]
-        assert lineage["9606"]["aliases"] == ["Taxon 9606: Homo sapiens"]
+        assert lineage["9605"]["aliases"] == ["Homo; humans [Taxon 9605]"]
+        assert lineage["9606"]["aliases"] == ["Homo sapiens [Taxon 9606]"]
 
     def test_empty_tax_ids_returns_empty_lineage(self):
         response = self._post([])

--- a/website/src/components/SearchPage/SearchForm.tsx
+++ b/website/src/components/SearchPage/SearchForm.tsx
@@ -9,7 +9,7 @@ import { SegmentFilter } from './SegmentFilter.tsx';
 import { AccessionField } from './fields/AccessionField.tsx';
 import { DateField, TimestampField } from './fields/DateField.tsx';
 import { DateRangeField } from './fields/DateRangeField.tsx';
-import { LineageField } from './fields/LineageField.tsx';
+import { HierarchicalField } from './fields/HierarchicalField.tsx';
 import { MultiChoiceAutoCompleteField } from './fields/MultiChoiceAutoCompleteField';
 import { MultiFieldSearchField } from './fields/MultiFieldSearchField.tsx';
 import { MutationField } from './fields/MutationField.tsx';
@@ -469,14 +469,15 @@ const SearchField = ({ field, lapisUrl, fieldValues, setSomeFieldValues, lapisSe
                 />
             );
         default:
-            if (field.lineageSearch) {
+            if (field.lineageSearch || field.hierarchicalSearch) {
                 return (
-                    <LineageField
+                    <HierarchicalField
                         field={field}
                         fieldValue={(fieldValues[field.name] ?? '') as string}
                         setSomeFieldValues={setSomeFieldValues}
                         lapisUrl={lapisUrl}
                         lapisSearchParameters={lapisSearchParameters}
+                        mode={field.lineageSearch ? 'lineage' : 'default'}
                     />
                 );
             }

--- a/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
+++ b/website/src/components/SearchPage/fields/AutoCompleteOptions.ts
@@ -27,6 +27,15 @@ type LineageOptionsProvider = {
     lapisSearchParameters: LapisSearchParameters;
     fieldName: string;
     includeSublineages: boolean;
+    /**
+     * When true, show only the alias for a lineage (when one exists) instead of the canonical
+     * name. Used by hierarchical filters where the alias is the user-facing label.
+     */
+    showAlias?: boolean;
+    /**
+     * When false, only show options with a count higher than zero
+     */
+    includeZeroCounts?: boolean;
 };
 
 /* Defines where how the options in the dropdown of the AutocompleteField are fetched. */
@@ -158,6 +167,8 @@ const createLineageOptionsHook = (
     fieldName: string,
     lapisSearchParameters: LapisSearchParameters,
     includeSublineages: boolean,
+    showAlias: boolean,
+    includeZeroCounts: boolean,
 ): AutocompleteOptionsHook => {
     const otherFields = { ...lapisSearchParameters };
     delete otherFields[fieldName];
@@ -213,7 +224,13 @@ const createLineageOptionsHook = (
             // generate options
             Object.keys(lineageDefinition).forEach((lineageName) => {
                 const count: number = aggregatedCounts.get(lineageName) ?? 0;
-                options.push({ option: lineageName, value: lineageName, count });
+                if (count === 0) {
+                    if (!includeZeroCounts) return;
+                }
+
+                const aliases = lineageDefinition[lineageName].aliases ?? [];
+                const label = showAlias && aliases.length > 0 ? aliases[0] : lineageName;
+                options.push({ option: label, value: lineageName, count });
             });
         }
 
@@ -256,6 +273,8 @@ export const createOptionsProviderHook = (optionsProvider: OptionsProvider): Aut
                     optionsProvider.fieldName,
                     optionsProvider.lapisSearchParameters,
                     optionsProvider.includeSublineages,
+                    optionsProvider.showAlias ?? false,
+                    optionsProvider.includeZeroCounts ?? true,
                 ),
                 [optionsProvider],
             );

--- a/website/src/components/SearchPage/fields/HierarchicalField.spec.tsx
+++ b/website/src/components/SearchPage/fields/HierarchicalField.spec.tsx
@@ -3,10 +3,10 @@ import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-import { LineageField } from './LineageField';
+import { HierarchicalField } from './HierarchicalField.tsx';
 import { lapisClientHooks } from '../../../services/serviceHooks.ts';
-import type { MetadataFilter } from '../../../types/config';
-import { Button } from '../../common/Button';
+import type { MetadataFilter } from '../../../types/config.ts';
+import { Button } from '../../common/Button.tsx';
 
 vi.mock('../../../services/serviceHooks.ts');
 vi.mock('../../../clientLogger.ts', () => ({
@@ -24,7 +24,7 @@ lapisClientHooks.mockReturnValue({
     useLineageDefinition: mockUseLineageDefinition,
 });
 
-describe('LineageField', () => {
+describe('HierarchicalField - lineage mode', () => {
     const field: MetadataFilter = { name: 'lineage', displayName: 'My Lineage', type: 'string' };
     const setSomeFieldValues = vi.fn();
     const lapisUrl = 'https://example.com/api';
@@ -76,12 +76,13 @@ describe('LineageField', () => {
 
     it('renders correctly with initial state', () => {
         render(
-            <LineageField
+            <HierarchicalField
                 field={field}
                 fieldValue='initialValue'
                 setSomeFieldValues={setSomeFieldValues}
                 lapisUrl={lapisUrl}
                 lapisSearchParameters={lapisSearchParameters}
+                mode='lineage'
             />,
         );
 
@@ -94,12 +95,13 @@ describe('LineageField', () => {
 
     it('updates query when sublineages checkbox is toggled', () => {
         render(
-            <LineageField
+            <HierarchicalField
                 field={field}
                 fieldValue='A.1'
                 setSomeFieldValues={setSomeFieldValues}
                 lapisUrl={lapisUrl}
                 lapisSearchParameters={lapisSearchParameters}
+                mode='lineage'
             />,
         );
 
@@ -112,12 +114,13 @@ describe('LineageField', () => {
 
     it('aggregates counts for aliases correctly', async () => {
         render(
-            <LineageField
+            <HierarchicalField
                 field={field}
                 fieldValue='A.1'
                 setSomeFieldValues={setSomeFieldValues}
                 lapisUrl={lapisUrl}
                 lapisSearchParameters={lapisSearchParameters}
+                mode='lineage'
             />,
         );
 
@@ -133,12 +136,13 @@ describe('LineageField', () => {
 
     it('aggregates counts for sublineages correctly', async () => {
         render(
-            <LineageField
+            <HierarchicalField
                 field={field}
                 fieldValue='A.1'
                 setSomeFieldValues={setSomeFieldValues}
                 lapisUrl={lapisUrl}
                 lapisSearchParameters={lapisSearchParameters}
+                mode='lineage'
             />,
         );
 
@@ -157,19 +161,20 @@ describe('LineageField', () => {
 
     it('handles input changes and calls setSomeFieldValues', async () => {
         render(
-            <LineageField
+            <HierarchicalField
                 field={field}
                 fieldValue='A.1'
                 setSomeFieldValues={setSomeFieldValues}
                 lapisUrl={lapisUrl}
                 lapisSearchParameters={lapisSearchParameters}
+                mode='lineage'
             />,
         );
 
         await userEvent.click(screen.getByLabelText('My Lineage'));
 
-        const options = await screen.findAllByRole('option');
-        await userEvent.click(options[2]);
+        await screen.findAllByRole('option');
+        await userEvent.click(screen.getByRole('option', { name: /A\.1\.1/ }));
 
         expect(setSomeFieldValues).toHaveBeenCalledWith(['lineage', 'A.1.1']);
 
@@ -182,12 +187,13 @@ describe('LineageField', () => {
 
     it('clears wildcard when sublineages is unchecked', () => {
         render(
-            <LineageField
+            <HierarchicalField
                 field={field}
                 fieldValue='value*'
                 setSomeFieldValues={setSomeFieldValues}
                 lapisUrl={lapisUrl}
                 lapisSearchParameters={lapisSearchParameters}
+                mode='lineage'
             />,
         );
 
@@ -205,12 +211,13 @@ describe('LineageField', () => {
 
             return (
                 <>
-                    <LineageField
+                    <HierarchicalField
                         field={field}
                         fieldValue={value}
                         setSomeFieldValues={setSomeFieldValues}
                         lapisUrl={lapisUrl}
                         lapisSearchParameters={lapisSearchParameters}
+                        mode='lineage'
                     />
                     <Button onClick={() => setValue('')}>reset</Button>
                 </>
@@ -228,5 +235,178 @@ describe('LineageField', () => {
 
         expect(checkbox).not.toBeChecked();
         expect(textbox).toHaveValue('');
+    });
+});
+describe('HierarchicalField - default mode', () => {
+    const field: MetadataFilter = {
+        name: 'hostTaxon',
+        displayName: 'Host Taxon',
+        type: 'string',
+        hierarchicalSearchLabel: 'include subtaxa',
+    };
+    const setSomeFieldValues = vi.fn();
+    const lapisUrl = 'https://example.com/api';
+    const lapisSearchParameters = {};
+
+    beforeEach(() => {
+        setSomeFieldValues.mockClear();
+
+        mockUseLineageDefinition.mockReturnValue({
+            /* eslint-disable @typescript-eslint/naming-convention */
+            data: {
+                'Mammalia': {},
+                'Rodentia': {
+                    parents: ['Mammalia'],
+                },
+                'Muridae': {
+                    parents: ['Rodentia'],
+                    aliases: ['True mice'],
+                },
+                'Mus musculus': {
+                    parents: ['Muridae'],
+                    aliases: ['House mouse'],
+                },
+                'Rattus rattus': {
+                    parents: ['Rodentia'],
+                    aliases: ['Black rat'],
+                },
+            },
+            /* eslint-enable @typescript-eslint/naming-convention */
+            isLoading: false,
+            error: null,
+            mutate: vi.fn(),
+        });
+
+        mockUseAggregated.mockReturnValue({
+            data: {
+                data: [
+                    { hostTaxon: 'Mammalia', count: 2 },
+                    { hostTaxon: 'Rodentia', count: 10 },
+                    { hostTaxon: 'Muridae', count: 5 },
+                    { hostTaxon: 'Mus musculus', count: 20 },
+                    { hostTaxon: 'Rattus rattus', count: 8 },
+                ],
+            },
+            isPending: false,
+            error: null,
+            mutate: vi.fn(),
+        });
+    });
+
+    it('defaults the subtaxa checkbox to checked when fieldValue is empty', () => {
+        render(
+            <HierarchicalField
+                field={field}
+                fieldValue=''
+                setSomeFieldValues={setSomeFieldValues}
+                lapisUrl={lapisUrl}
+                lapisSearchParameters={lapisSearchParameters}
+            />,
+        );
+
+        expect(screen.getByRole('checkbox')).toBeChecked();
+    });
+
+    it('appends wildcard when selecting from an empty field', async () => {
+        render(
+            <HierarchicalField
+                field={field}
+                fieldValue=''
+                setSomeFieldValues={setSomeFieldValues}
+                lapisUrl={lapisUrl}
+                lapisSearchParameters={lapisSearchParameters}
+            />,
+        );
+
+        await userEvent.click(screen.getByLabelText('Host Taxon'));
+        await screen.findAllByRole('option');
+        await userEvent.click(screen.getByRole('option', { name: /Rodentia/ }));
+
+        expect(setSomeFieldValues).toHaveBeenCalledWith(['hostTaxon', 'Rodentia*']);
+    });
+
+    it('respects an explicit non-wildcard fieldValue', () => {
+        render(
+            <HierarchicalField
+                field={field}
+                fieldValue='Rodentia'
+                setSomeFieldValues={setSomeFieldValues}
+                lapisUrl={lapisUrl}
+                lapisSearchParameters={lapisSearchParameters}
+            />,
+        );
+
+        expect(screen.getByRole('checkbox')).not.toBeChecked();
+    });
+
+    it('shows common names instead of scientific names when an alias exists', async () => {
+        render(
+            <HierarchicalField
+                field={field}
+                fieldValue=''
+                setSomeFieldValues={setSomeFieldValues}
+                lapisUrl={lapisUrl}
+                lapisSearchParameters={lapisSearchParameters}
+            />,
+        );
+
+        await userEvent.click(screen.getByLabelText('Host Taxon'));
+        const optionTexts = (await screen.findAllByRole('option')).map((o) => o.textContent);
+
+        // Muridae → 'True mice', Mus musculus → 'House mouse', Rattus rattus → 'Black rat'
+        expect(optionTexts).toEqual([
+            'Black rat(8)',
+            'House mouse(20)',
+            'Mammalia(45)',
+            'Rodentia(43)',
+            'True mice(25)',
+        ]);
+    });
+
+    it('uses the scientific name as the value when a common name is selected', async () => {
+        render(
+            <HierarchicalField
+                field={field}
+                fieldValue=''
+                setSomeFieldValues={setSomeFieldValues}
+                lapisUrl={lapisUrl}
+                lapisSearchParameters={lapisSearchParameters}
+            />,
+        );
+
+        await userEvent.click(screen.getByLabelText('Host Taxon'));
+        await screen.findAllByRole('option');
+        // 'True mice' is the alias for canonical 'Muridae'
+        await userEvent.click(screen.getByRole('option', { name: /True mice/ }));
+
+        expect(setSomeFieldValues).toHaveBeenCalledWith(['hostTaxon', 'Muridae*']);
+    });
+
+    it('displays the common name in the input when fieldValue is a scientific name with an alias', async () => {
+        render(
+            <HierarchicalField
+                field={field}
+                fieldValue='Mus musculus*'
+                setSomeFieldValues={setSomeFieldValues}
+                lapisUrl={lapisUrl}
+                lapisSearchParameters={lapisSearchParameters}
+            />,
+        );
+
+        expect(await screen.findByDisplayValue('House mouse')).toBeInTheDocument();
+    });
+
+    it('uses the hierarchicalSearchLabel as the checkbox label', () => {
+        render(
+            <HierarchicalField
+                field={field}
+                fieldValue=''
+                setSomeFieldValues={setSomeFieldValues}
+                lapisUrl={lapisUrl}
+                lapisSearchParameters={lapisSearchParameters}
+            />,
+        );
+
+        expect(screen.getByText('include subtaxa')).toBeInTheDocument();
     });
 });

--- a/website/src/components/SearchPage/fields/HierarchicalField.tsx
+++ b/website/src/components/SearchPage/fields/HierarchicalField.tsx
@@ -5,27 +5,63 @@ import type { MetadataFilter, SetSomeFieldValues } from '../../../types/config';
 import { Checkbox } from '../../common/Checkbox';
 import type { LapisSearchParameters } from '../DownloadDialog/SequenceFilters';
 
-interface LineageFieldProps {
+export type HierarchicalFieldMode = 'lineage' | 'default';
+
+interface ModeConfig {
+    defaultIncludeSublineages: boolean;
+    includeZeroCounts: boolean;
+    showAlias: boolean;
+    checkBoxLabel: string;
+}
+
+const MODE_CONFIGS: Record<HierarchicalFieldMode, ModeConfig> = {
+    lineage: {
+        defaultIncludeSublineages: false,
+        includeZeroCounts: true,
+        showAlias: false,
+        checkBoxLabel: 'include sublineages',
+    },
+    default: {
+        defaultIncludeSublineages: true,
+        includeZeroCounts: true,
+        showAlias: true,
+        checkBoxLabel: 'include subcategories',
+    },
+};
+
+interface HierarchicalFieldProps {
     lapisUrl: string;
     lapisSearchParameters: LapisSearchParameters;
     field: MetadataFilter;
     fieldValue: string;
     setSomeFieldValues: SetSomeFieldValues;
+    mode?: HierarchicalFieldMode;
 }
 
-export const LineageField: FC<LineageFieldProps> = ({
+export const HierarchicalField: FC<HierarchicalFieldProps> = ({
     field,
     fieldValue,
     setSomeFieldValues,
     lapisUrl,
     lapisSearchParameters,
+    mode = 'default',
 }) => {
-    const [includeSublineages, _setIncludeSubLineages] = useState(fieldValue.endsWith('*'));
+    const {
+        defaultIncludeSublineages,
+        includeZeroCounts,
+        showAlias,
+        checkBoxLabel: defaultCheckBoxLabel,
+    } = MODE_CONFIGS[mode];
+    const checkBoxLabel = field.hierarchicalSearchLabel ?? defaultCheckBoxLabel;
+
+    const [includeSublineages, _setIncludeSubLineages] = useState(
+        fieldValue.endsWith('*') || (fieldValue === '' && defaultIncludeSublineages),
+    );
     const [inputText, _setInputText] = useState(fieldValue.endsWith('*') ? fieldValue.slice(0, -1) : fieldValue);
 
     useEffect(() => {
         _setInputText(fieldValue.endsWith('*') ? fieldValue.slice(0, -1) : fieldValue);
-        _setIncludeSubLineages(fieldValue.endsWith('*'));
+        _setIncludeSubLineages(fieldValue.endsWith('*') || (fieldValue === '' && defaultIncludeSublineages));
     }, [fieldValue]);
 
     function queryText(includeSublineages: boolean, inputText: string) {
@@ -54,6 +90,8 @@ export const LineageField: FC<LineageFieldProps> = ({
                     lapisSearchParameters,
                     fieldName: field.name,
                     includeSublineages,
+                    showAlias,
+                    includeZeroCounts,
                 }}
                 setSomeFieldValues={([_, value]) => {
                     setInputText(value as string);

--- a/website/src/components/SearchPage/fields/HierarchicalField.tsx
+++ b/website/src/components/SearchPage/fields/HierarchicalField.tsx
@@ -100,7 +100,7 @@ export const HierarchicalField: FC<HierarchicalFieldProps> = ({
             />
             <div className='flex flex-row justify-end'>
                 <label>
-                    <span className='text-gray-400 text-sm mr-2'>include sublineages</span>
+                    <span className='text-gray-400 text-sm mr-2'>{checkBoxLabel}</span>
                     <Checkbox
                         size='sm'
                         outline

--- a/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
+++ b/website/src/components/SearchPage/fields/SingleChoiceAutoCompleteField.tsx
@@ -62,6 +62,8 @@ export const SingleChoiceAutoCompleteField = ({
         }
     }, [error]);
 
+    const valueToLabel = useMemo(() => new Map(options.map((o) => [o.value, o.option])), [options]);
+
     const filteredOptions = useMemo(() => {
         const allMatchedOptions =
             query === ''
@@ -101,7 +103,8 @@ export const SingleChoiceAutoCompleteField = ({
                                 if (value === null || value === NULL_QUERY_VALUE) {
                                     return '(blank)';
                                 }
-                                return String(value);
+                                const stringValue = String(value);
+                                return valueToLabel.get(stringValue) ?? stringValue;
                             }}
                             onChange={(event) => setQuery(event.target.value)}
                             onFocus={load}

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -80,6 +80,8 @@ export const metadata = z.object({
     rangeOverlapSearch: rangeOverlapSearch.optional(),
     substringSearch: z.boolean().optional(),
     lineageSearch: z.boolean().optional(),
+    hierarchicalSearch: z.boolean().optional(),
+    hierarchicalSearchLabel: z.string().optional(),
     columnWidth: z.number().optional(),
     order: z.number().optional(),
     orderOnDetailsPage: z.number().optional(),


### PR DESCRIPTION
resolves #

This PR reintroduces hierarchical filtering functionality that was added in https://github.com/loculus-project/loculus/pull/6302 and https://github.com/loculus-project/loculus/pull/6404 but reverted so that we could roll out the required breaking change from `hostTaxonId: int` to `hostTaxonId: string` on its own first.

Below is an updated description taken from the original PR:

## Summary

Introduces a new "hierarchical filter" concept for metadata fields whose values form a hierarchy resolved dynamically at SILO import time (rather than statically pinned per pipeline version, the way lineageSystem works). The first use case is hostTaxonId: at import time the SILO importer collects the set of host taxon IDs observed in the released data, asks the taxonomy service to render a SILO-format lineage YAML for those taxa, and writes it into SILO's input directory. SILO then indexes the column as a lineage, which gives the website a hierarchical search UI ("Culicidae" matches records of all mosquito species, etc.).

This PR introduces changes to the helm chart, the SILO importer, and the website.

## Helm / config

- New metadata-field property hierarchicalFilter: <URL>. Mutually exclusive with lineageSystem (enforced in values.schema.json). When set, the field is treated like a lineage system for  SILO indexing (generateLineageIndex) and surfaces a new hierarchicalSearch: true flag in the website config.
- _hierarchical-filters-for-organism.tpl mirrors the existing lineageSystemForOrganism helper. The SILO database config combines both lists into lineageDefinitionFilenames.
- silo-deployment.yaml builds and injects the HIERARCHICAL_FILTERS env var (JSON map) consumed by the importer.
- West-nile given hierarchicalFilter: *taxonomy_service_url to observe the new feature on previews.
- New section in helm-chart-config.mdx documenting the feature.

## SILO import

- HIERARCHICAL_FILTERS env var parsed at startup. 
- update_hierarchical_filters checks whether the most recent import cycle returned new values for the hierarchical filter field, and fetches an updated lineage if so. The response is written to <input_dir>/<field>.yaml. If the service responds 413 (file exceeds SILO's Jackson YAML size limit), the importer retries with prune=true.
- New tests in tests/test_runner.py cover both the happy path and the skip-when-unchanged path; new tests in tests/test_config.py cover env-var parsing.

## Frontend

- New config options (types/config.ts). Two optional fields added to the metadata schema: hierarchicalSearch: boolean — opt a field into the hierarchical filter UI. hierarchicalSearchLabel: string — custom label for the "include sublineages/subcategories" checkbox

- LineageField.tsx is renamed and extended to HierarchicalField.tsx. The component was now has a mode prop ('lineage' | 'default') with a MODE_CONFIGS table:

| | `lineage` mode | `default` (hierarchical) mode |
|---|---|---|
| default "include sublineages" | off | **on** |
| `showAlias` | false | **true** |
| checkbox label | "include sublineages" | "include subcategories" |
| `includeZeroCounts` | true | true |

- SearchForm.tsx renders the HierarchicalField when either field.lineageSearch or field.hierarchicalSearch is set, passing mode='lineage' for the former and 'default' for the latter.

- The lineage options hook in AutoCompleteOptions.ts gains two parameters: 1) showAlias — when a lineage/node has aliases, display the first alias as the user-facing label (the value stays the canonical name). This is the hierarchical filter's user-facing label. 2) includeZeroCounts — when false, options with a count of 0 are filtered out.

- Added a valueToLabel map to SingleChoiceAutoCompleteField.tsx so the input's displayValue shows the human-readable label (e.g., the alias) instead of the raw stored value.

## Screenshots & manual testing
I configured a hierarchical filter for hostTaxonId and set up a preview. On the preview, I tested filtering west-nile sequences using the new hierarchical filter autocomplete. It seems to work as intended, and also the interplay with the existing host name - common / scientific looks reasonable: if I set a filter for the species 'Culex' using host name-scientific, all the options with zero count (birds etc.) no longes show up in the hierarchical filter autocomplete.

This is how the autocomplete looks:

<img width="274" height="122" alt="grafik" src="https://github.com/user-attachments/assets/8224989c-a64e-4154-b45a-72f4551faa0b" />


<img width="274" height="343" alt="grafik" src="https://github.com/user-attachments/assets/89b0eb28-4f9e-4dd8-9273-a01dd0702d65" />



### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://revive-hierarchical-filte.loculus.org