### PR TITLE
fix(taxonomy-service): Update order of information in lineage alias values

### DIFF
--- a/taxonomy/taxonomy_service/src/taxonomy_service/helpers.py
+++ b/taxonomy/taxonomy_service/src/taxonomy_service/helpers.py
@@ -228,9 +228,10 @@ def convert_to_lineage_dict(taxa: Iterable[Taxon]) -> dict[str, dict]:
     result: dict[str, dict] = {}
 
     for taxon in taxa:
-        alias = f"Taxon {taxon.tax_id}: {taxon.scientific_name}"
+        alias = str(taxon.scientific_name)
         if taxon.common_name is not None:
             alias += f"; {taxon.common_name}"
+        alias += f" [Taxon {taxon.tax_id}]"
         result[str(taxon.tax_id)] = {
             "aliases": [alias],
             "parents": [str(taxon.parent_id)]

--- a/taxonomy/taxonomy_service/test/test_api.py
+++ b/taxonomy/taxonomy_service/test/test_api.py
@@ -172,8 +172,8 @@ class PostSiloLineageTest(unittest.TestCase):
         response = self._post([9605, 9606])
 
         lineage = yaml.safe_load(response.text)
-        assert lineage["9605"]["aliases"] == ["Taxon 9605: Homo; humans"]
-        assert lineage["9606"]["aliases"] == ["Taxon 9606: Homo sapiens"]
+        assert lineage["9605"]["aliases"] == ["Homo; humans [Taxon 9605]"]
+        assert lineage["9606"]["aliases"] == ["Homo sapiens [Taxon 9606]"]
 
     def test_empty_tax_ids_returns_empty_lineage(self):
         response = self._post([])


### PR DESCRIPTION
`convert_to_lineage_dict` in the taxonomy service used to generate aliases in the format "Taxon \<id\>: \<scientific name\>; \<common name\>". This put the least interesting information up front and made downstream UI components using this information less nice, most notably the autocomplete for the hierarchical filter.

This PR updates the format to "\<scientific name\>; \<common name\> [Taxon \<id\>]".

### Screenshot

<img width="274" height="327" alt="grafik" src="https://github.com/user-attachments/assets/edbfa30f-ddae-4025-acb9-75c438fa0e8e" />

IMO this is an improvement over the previous state, it also comes with the advantage that the alphabetical sorting now puts more interesting taxa at the top of the list (before, 'Taxon 1: root' would always get sorted to the top of the list).

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://update-taxon-lineage-alia.loculus.org