### PR TITLE
chore(deployment): apply priority class to ingest-trigger Job

### DIFF
--- a/kubernetes/loculus/templates/ingest.yaml
+++ b/kubernetes/loculus/templates/ingest.yaml
@@ -141,6 +141,7 @@ spec:
         app: loculus
         component: loculus-ingest-trigger-{{ $key }}
     spec:
+      {{- include "possiblePriorityClassName" $ | nindent 6 }}
       restartPolicy: Never
       serviceAccountName: loculus-ingest-trigger
       containers:


### PR DESCRIPTION
## What

Adds the `possiblePriorityClassName` helper to the pod spec of the `loculus-ingest-trigger-{{ \$key }}` PostSync hook Job in `kubernetes/loculus/templates/ingest.yaml`:

```yaml
    spec:
      {{- include "possiblePriorityClassName" $ | nindent 6 }}
      restartPolicy: Never
      serviceAccountName: loculus-ingest-trigger
```

## Why

The `possiblePriorityClassName` helper injects `priorityClassName: {{ .Release.Namespace }}-priority` whenever `podPriorityValue` is set. It is currently included in essentially every Loculus workload — backend, website, keycloak, silo, lapis, taxonomy, autoapprove, ena-submission, preprocessing, and the ingest pod itself (`_ingest-pod-spec.tpl`).

The one exception was the **ingest-trigger** Job. This is the small `alpine/kubectl` PostSync hook that runs `kubectl create job --from=cronjob/...` to kick off a bootstrap ingest after a sync. Because it lacked the helper, it ran at **default** priority — so under node pressure it could be preempted/evicted before it managed to spawn the actual ingest Job, even though the ingest workload it creates *does* carry the priority class. Adding the helper makes the trigger consistent with the rest of the chart and with the workload it launches.

## Testing

- `helm lint kubernetes/loculus -f kubernetes/loculus/values.yaml` → passes.
- `helm template ... --set podPriorityValue=1000 --namespace testns` → each `loculus-ingest-trigger-*` Job now renders `priorityClassName: testns-priority`. With `podPriorityValue` unset, the helper emits nothing (no change to default behaviour).

Draft pending review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable