### PR TITLE
fix(backend): reject whitespace-only fastaIds values

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/utils/MetadataEntry.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/MetadataEntry.kt
@@ -60,6 +60,12 @@ fun extractAndValidateFastaIds(record: CSVRecord, submissionId: String, recordNu
                 .map { it.trim() }
                 .filter { it.isNotEmpty() }
 
+            if (fastaIds.isEmpty()) {
+                throw UnprocessableEntityException(
+                    "In metadata file: record #$recordNumber: column `$FASTA_IDS_HEADER` is empty or contains only whitespace. This is invalid. Full record: $record",
+                )
+            }
+
             val duplicateFastaIds = fastaIds.groupingBy { it }.eachCount().filter { it.value > 1 }.keys
             if (duplicateFastaIds.isNotEmpty()) {
                 throw UnprocessableEntityException(

--- a/backend/src/test/kotlin/org/loculus/backend/utils/MetadataEntryTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/utils/MetadataEntryTest.kt
@@ -141,6 +141,20 @@ class MetadataEntryTest {
         assertThat(entries[0].fastaIds, equalTo(setOf("seq1", "seq2", "seq3")))
     }
 
+
+    @Test
+    fun `test whitespace-only fastaIds are rejected`() {
+        val str = """
+            submissionId${'	'}fastaIds${'	'}Country
+            foo${'	'}   ${'	'}bar
+        """.trimIndent()
+        val inputStream = ByteArrayInputStream(str.toByteArray())
+        val exception = assertThrows<UnprocessableEntityException> {
+            metadataEntryStreamAsSequence(inputStream).toList()
+        }
+        assertThat(exception.message, containsString("record #1"))
+        assertThat(exception.message, containsString("empty or contains only whitespace"))
+    }
     @Test
     fun `test multiple duplicate fasta IDs are all reported`() {
         val str = """


### PR DESCRIPTION
### Motivation

- Prevent malformed metadata rows where a `fastaIds` cell that contains only whitespace is normalized to an empty set and allowed through validation, which can produce empty `unalignedNucleotideSequences` and trigger preprocessing crashes and batch-level denial-of-service. 
- Fail fast at the parser boundary so invalid submissions are rejected before being persisted or sent to the preprocessor, avoiding stranded `IN_PROCESSING` rows and cross-tenant availability impacts.

### Description

- Add an explicit post-normalization check in `extractAndValidateFastaIds` to throw `UnprocessableEntityException` when the parsed `fastaIds` list is empty after splitting/trimming/filtering (covers whitespace-only input). 
- Add a focused regression unit test `test whitespace-only fastaIds are rejected` in `MetadataEntryTest` to assert the parser rejects whitespace-only values and includes the record number in the error message. 
- Changes are limited to `backend/src/main/kotlin/org/loculus/backend/utils/MetadataEntry.kt` and `backend/src/test/kotlin/org/loculus/backend/utils/MetadataEntryTest.kt` and are designed to be minimally invasive to existing multi-FASTA workflows.

### Testing

- A new unit test was added: `org.loculus.backend.utils.MetadataEntryTest::test whitespace-only fastaIds are rejected`, and it is included in this branch for CI to execute. 
- I attempted to run the focused test locally with `USE_NONDOCKER_INFRA=true ./gradlew test --console=plain --tests org.loculus.backend.utils.MetadataEntryTest`, but the run failed in this environment because the required Java 21 toolchain is not available, so tests could not be executed here (Gradle reported a missing Java installation matching languageVersion=21).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10f8e523fc83258bd229dd901f95a2)

🚀 Preview: Add `preview` label to enable