### PR TITLE
feat(ingest): refactor how metadata is hashed - now in one place

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -672,12 +672,26 @@ rule compare_hashes:
             --subsample-fraction {params.subsample_fraction} \
         """
 
+rule hash_metadata:
+    input:
+        script="scripts/calculate_metadata_hashes.py",
+        prepped_metadata=prepped_metadata(),
+    output:
+        hashed_metadata="results/metadata_with_hashes.ndjson",
+    shell:
+        """
+        python {input.script} \
+            --config-file {input.config} \
+            --input {input.prepped_metadata} \
+            --output {output.hashed_metadata} \
+        """
+
 
 rule prepare_files:
     input:
         script="scripts/prepare_files.py",
         config="results/config.yaml",
-        metadata=prepped_metadata(),
+        metadata="results/metadata_with_hashes.ndjson",
         sequences=(
             "results/sequences_filtered.ndjson"
             if FILTER

--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -672,6 +672,7 @@ rule compare_hashes:
             --subsample-fraction {params.subsample_fraction} \
         """
 
+
 rule hash_metadata:
     input:
         script="scripts/calculate_metadata_hashes.py",

--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -677,6 +677,7 @@ rule hash_metadata:
     input:
         script="scripts/calculate_metadata_hashes.py",
         prepped_metadata=prepped_metadata(),
+        config="results/config.yaml",
     output:
         hashed_metadata="results/metadata_with_hashes.ndjson",
     shell:

--- a/ingest/scripts/calculate_metadata_hashes.py
+++ b/ingest/scripts/calculate_metadata_hashes.py
@@ -1,0 +1,84 @@
+"""Script to calculate hashes for metadata records and save them in a format suitable for submission to Loculus"""
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+
+import click
+import orjsonl
+import yaml
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    encoding="utf-8",
+    level=logging.DEBUG,
+    format="%(asctime)s %(levelname)8s (%(filename)20s:%(lineno)4d) - %(message)s ",
+    datefmt="%H:%M:%S",
+)
+
+
+@dataclass
+class Config:
+    segmented: bool
+    nucleotide_sequences: list[str]
+
+
+@click.command()
+@click.option("--config-file", required=True, type=click.Path(exists=True))
+@click.option("--input", required=True, type=click.Path(exists=True))
+@click.option("--output", required=True, type=click.Path())
+@click.option(
+    "--log-level",
+    default="INFO",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
+)
+def main(
+    config_file: str,
+    input: str,
+    output: str,
+    log_level: str,
+) -> None:
+    logger.setLevel(log_level)
+
+    with open(config_file, encoding="utf-8") as file:
+        full_config = yaml.safe_load(file)
+        relevant_config = {key: full_config[key] for key in Config.__annotations__}
+        config = Config(**relevant_config)
+    logger.debug(config)
+
+    count = 0
+
+    # Calculate overall hash of metadata + sequence and add to record
+    for record in orjsonl.stream(input):
+        count += 1
+        # Hash of all metadata fields should be the same if
+        # 1. field is not in keys_to_keep and
+        # 2. field is in keys_to_keep but is "" or None
+        filtered_record = {k: str(v) for k, v in record.items() if v is not None and str(v)}
+
+        # Sequence hash (of each segment)
+        sequence_hash = ""
+        if config.segmented:
+            for segment in config.nucleotide_sequences:
+                sequence_hash += record.get(f"hash_{segment}", "")
+                filtered_record.pop(f"hash_{segment}", None)
+        else:
+            sequence_hash = record.get("hash", "")
+            filtered_record.pop("hash", None)
+
+        # rename "id" to "submissionId" for back-compatibility with old hashes
+        filtered_record["submissionId"] = filtered_record.pop("id")
+        filtered_record.pop("fastaIds", None)
+
+        metadata_dump = json.dumps(filtered_record, sort_keys=True)
+        prehash = metadata_dump + sequence_hash
+
+        record["hash"] = hashlib.md5(prehash.encode(), usedforsecurity=False).hexdigest()
+
+        orjsonl.append(output, {"id": record["id"], "metadata": record})
+
+    logger.info(f"Calculated hashes for {count} sequences")
+
+
+if __name__ == "__main__":
+    main()

--- a/ingest/scripts/heuristic_group_segments.py
+++ b/ingest/scripts/heuristic_group_segments.py
@@ -14,12 +14,9 @@ Example ndjson output for a single isolate with 3 segments:
     "hash_L": "ddbfc33d45267e9c1a08f8f5e76d3e39",
     "hash_M": "f64777883ba9f5293257698255767f2c",
     "hash_S": "f716ed13dca9c8a033d46da2f3dc2ff1",
-    "hash": "ce7056d0bd7e3d6d3eca38f56b9d10f8",
     "id": "KJ682796.1.L/KJ682809.1.M/KJ682819.1.S"
 }}"""
 
-import hashlib
-import json
 import logging
 import pathlib
 from collections import defaultdict
@@ -243,19 +240,6 @@ def main(
 
         row["id"] = joint_key
         row["fastaIds"] = segments_list_str
-
-        # Hash of all metadata fields should be the same if
-        # 1. field is not in keys_to_keep and
-        # 2. field is in keys_to_keep but is "" or None
-        filtered_record = {k: str(v) for k, v in row.items() if v is not None and str(v)}
-
-        # rename "id" to "submissionId" and ignore fastaIds for back-compatibility with old hashes
-        filtered_record["submissionId"] = filtered_record.pop("id")
-        filtered_record.pop("fastaIds", None)
-
-        row["hash"] = hashlib.md5(
-            json.dumps(filtered_record, sort_keys=True).encode(), usedforsecurity=False
-        ).hexdigest()
 
         orjsonl.append(output_metadata, {"id": joint_key, "metadata": row})
         count += 1

--- a/ingest/scripts/override_group_segments.py
+++ b/ingest/scripts/override_group_segments.py
@@ -22,11 +22,9 @@ Example output for a single isolate with 3 segments:
     "hash_L": "ddbfc33d45267e9c1a08f8f5e76d3e39",
     "hash_M": "f64777883ba9f5293257698255767f2c",
     "hash_S": "f716ed13dca9c8a033d46da2f3dc2ff1",
-    "hash": "ce7056d0bd7e3d6d3eca38f56b9d10f8",
     "id": "KJ682796.1.L/KJ682809.1.M/KJ682819.1.S"
 }}"""
 
-import hashlib
 import json
 import logging
 import os
@@ -156,19 +154,6 @@ def get_metadata_of_group(
     )
     grouped_metadata["id"] = joint_key
     grouped_metadata["fastaIds"] = segments_list_str
-
-    # Hash of all metadata fields should be the same if
-    # 1. field is not in keys_to_keep and
-    # 2. field is in keys_to_keep but is "" or None
-    filtered_record = {k: str(v) for k, v in grouped_metadata.items() if v is not None and str(v)}
-
-    # rename "id" to "submissionId" and ignore fastaIds for back-compatibility with old hashes
-    filtered_record["submissionId"] = filtered_record.pop("id")
-    filtered_record.pop("fastaIds", None)
-
-    grouped_metadata["hash"] = hashlib.md5(
-        json.dumps(filtered_record, sort_keys=True).encode(), usedforsecurity=False
-    ).hexdigest()
 
     return grouped_metadata
 

--- a/ingest/scripts/prepare_metadata.py
+++ b/ingest/scripts/prepare_metadata.py
@@ -6,8 +6,6 @@
 # Like separation of country into country and division
 
 import csv
-import hashlib
-import json
 import logging
 from dataclasses import dataclass
 
@@ -128,29 +126,15 @@ def main(
             if key not in keys_to_keep:
                 record.pop(key)
 
-    # Calculate overall hash of metadata + sequence
     for record in metadata:
+        # Add sequence hash to metadata record
         fasta_id_field = config.fasta_id_field
         if config.fasta_id_field in config.rename:
             fasta_id_field = config.rename[config.fasta_id_field]
-        sequence_hash = sequence_hashes.get(record[fasta_id_field], "")
-        if not sequence_hash:
+        record["hash"] = sequence_hashes.get(record[fasta_id_field], "")
+        if not record["hash"]:
             msg = f"No hash found for {record[config.fasta_id_field]}"
             raise ValueError(msg)
-
-        # Hash of all metadata fields should be the same if
-        # 1. field is not in keys_to_keep and
-        # 2. field is in keys_to_keep but is "" or None
-        filtered_record = {k: str(v) for k, v in record.items() if v is not None and str(v)}
-
-        # rename "id" to "submissionId" for back-compatibility with old hashes
-        filtered_record["submissionId"] = filtered_record.pop("id")
-
-        metadata_dump = json.dumps(filtered_record, sort_keys=True)
-        prehash = metadata_dump + sequence_hash
-
-        record["hash"] = hashlib.md5(prehash.encode(), usedforsecurity=False).hexdigest()
-
         orjsonl.append(output, {"id": record[fasta_id_field], "metadata": record})
 
     logger.info(f"Saved metadata for {len(metadata)} sequences")


### PR DESCRIPTION
I think this is a good approach for future changes as we can make metadata changes and hash calculation backward compat changes in one file instead of across 3 files - however it means that the hash of the multi-segmented organisms will change

resolves #

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable