### PR TITLE
feat(backend): add organism scoping to sequence_entries table as well in new etag

### DIFF
--- a/backend/docs/db/schema.sql
+++ b/backend/docs/db/schema.sql
@@ -120,6 +120,29 @@ $$;
 ALTER FUNCTION public.update_preprocessed_data_tracker() OWNER TO postgres;
 
 --
+-- Name: update_sequence_entries_tracker(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.update_sequence_entries_tracker() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated)
+    SELECT TG_TABLE_NAME, se.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP)
+    FROM changed_rows cr
+    JOIN sequence_entries se
+      ON se.accession = cr.accession
+    GROUP BY se.organism
+    ON CONFLICT (table_name, organism, pipeline_version)
+    DO UPDATE SET last_time_updated = timezone('UTC', CURRENT_TIMESTAMP);
+    RETURN NULL;
+END;
+$$;
+
+
+ALTER FUNCTION public.update_sequence_entries_tracker() OWNER TO postgres;
+
+--
 -- Name: update_table_tracker(); Type: FUNCTION; Schema: public; Owner: postgres
 --
 
@@ -903,13 +926,6 @@ CREATE TRIGGER update_tracker_trigger AFTER INSERT OR DELETE OR UPDATE OR TRUNCA
 
 
 --
--- Name: sequence_entries update_tracker_trigger; Type: TRIGGER; Schema: public; Owner: postgres
---
-
-CREATE TRIGGER update_tracker_trigger AFTER INSERT OR DELETE OR UPDATE OR TRUNCATE ON public.sequence_entries FOR EACH STATEMENT EXECUTE FUNCTION public.update_table_tracker();
-
-
---
 -- Name: sequence_upload_aux_table update_tracker_trigger; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
@@ -938,6 +954,13 @@ CREATE TRIGGER update_tracker_trigger_del AFTER DELETE ON public.external_metada
 
 
 --
+-- Name: sequence_entries update_tracker_trigger_del; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER update_tracker_trigger_del AFTER DELETE ON public.sequence_entries REFERENCING OLD TABLE AS changed_rows FOR EACH STATEMENT EXECUTE FUNCTION public.update_sequence_entries_tracker();
+
+
+--
 -- Name: sequence_entries_preprocessed_data update_tracker_trigger_del; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
@@ -959,6 +982,13 @@ CREATE TRIGGER update_tracker_trigger_ins AFTER INSERT ON public.external_metada
 
 
 --
+-- Name: sequence_entries update_tracker_trigger_ins; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER update_tracker_trigger_ins AFTER INSERT ON public.sequence_entries REFERENCING NEW TABLE AS changed_rows FOR EACH STATEMENT EXECUTE FUNCTION public.update_sequence_entries_tracker();
+
+
+--
 -- Name: sequence_entries_preprocessed_data update_tracker_trigger_ins; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
@@ -977,6 +1007,13 @@ CREATE TRIGGER update_tracker_trigger_upd AFTER UPDATE ON public.data_use_terms_
 --
 
 CREATE TRIGGER update_tracker_trigger_upd AFTER UPDATE ON public.external_metadata REFERENCING NEW TABLE AS changed_rows FOR EACH STATEMENT EXECUTE FUNCTION public.update_external_metadata_tracker();
+
+
+--
+-- Name: sequence_entries update_tracker_trigger_upd; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER update_tracker_trigger_upd AFTER UPDATE ON public.sequence_entries REFERENCING NEW TABLE AS changed_rows FOR EACH STATEMENT EXECUTE FUNCTION public.update_sequence_entries_tracker();
 
 
 --

--- a/backend/docs/db/schema.sql
+++ b/backend/docs/db/schema.sql
@@ -128,11 +128,9 @@ CREATE FUNCTION public.update_sequence_entries_tracker() RETURNS trigger
     AS $$
 BEGIN
     INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated)
-    SELECT TG_TABLE_NAME, se.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP)
+    SELECT TG_TABLE_NAME, cr.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP)
     FROM changed_rows cr
-    JOIN sequence_entries se
-      ON se.accession = cr.accession
-    GROUP BY se.organism
+    GROUP BY cr.organism
     ON CONFLICT (table_name, organism, pipeline_version)
     DO UPDATE SET last_time_updated = timezone('UTC', CURRENT_TIMESTAMP);
     RETURN NULL;

--- a/backend/src/main/resources/db/migration/V1.28__scope_update_tracker_by_organism_and_pipeline_version.sql
+++ b/backend/src/main/resources/db/migration/V1.28__scope_update_tracker_by_organism_and_pipeline_version.sql
@@ -169,11 +169,9 @@ CREATE OR REPLACE FUNCTION update_sequence_entries_tracker()
 RETURNS TRIGGER AS $$
 BEGIN
     INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated)
-    SELECT TG_TABLE_NAME, se.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP)
+    SELECT TG_TABLE_NAME, cr.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP)
     FROM changed_rows cr
-    JOIN sequence_entries se
-      ON se.accession = cr.accession
-    GROUP BY se.organism
+    GROUP BY cr.organism
     ON CONFLICT (table_name, organism, pipeline_version)
     DO UPDATE SET last_time_updated = timezone('UTC', CURRENT_TIMESTAMP);
     RETURN NULL;

--- a/backend/src/main/resources/db/migration/V1.28__scope_update_tracker_by_organism_and_pipeline_version.sql
+++ b/backend/src/main/resources/db/migration/V1.28__scope_update_tracker_by_organism_and_pipeline_version.sql
@@ -161,8 +161,8 @@ FOR EACH STATEMENT EXECUTE FUNCTION update_data_use_terms_table_tracker();
 
 
 -- Replace the generic per-statement trigger on the sequence_entries table with
--- organism aware ones. organism is resolved via the
--- (accession, version) foreign key into sequence_entries.
+-- organism aware ones. organism is read directly from the changed rows, since
+-- it is a native column of sequence_entries.
 DROP TRIGGER IF EXISTS update_tracker_trigger ON sequence_entries;
 
 CREATE OR REPLACE FUNCTION update_sequence_entries_tracker()

--- a/backend/src/main/resources/db/migration/V1.28__scope_update_tracker_by_organism_and_pipeline_version.sql
+++ b/backend/src/main/resources/db/migration/V1.28__scope_update_tracker_by_organism_and_pipeline_version.sql
@@ -158,3 +158,39 @@ CREATE TRIGGER update_tracker_trigger_del
 AFTER DELETE ON data_use_terms_table
 REFERENCING OLD TABLE AS changed_rows
 FOR EACH STATEMENT EXECUTE FUNCTION update_data_use_terms_table_tracker();
+
+
+-- Replace the generic per-statement trigger on the sequence_entries table with
+-- organism aware ones. organism is resolved via the
+-- (accession, version) foreign key into sequence_entries.
+DROP TRIGGER IF EXISTS update_tracker_trigger ON sequence_entries;
+
+CREATE OR REPLACE FUNCTION update_sequence_entries_tracker()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated)
+    SELECT TG_TABLE_NAME, se.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP)
+    FROM changed_rows cr
+    JOIN sequence_entries se
+      ON se.accession = cr.accession
+    GROUP BY se.organism
+    ON CONFLICT (table_name, organism, pipeline_version)
+    DO UPDATE SET last_time_updated = timezone('UTC', CURRENT_TIMESTAMP);
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER update_tracker_trigger_ins
+AFTER INSERT ON sequence_entries
+REFERENCING NEW TABLE AS changed_rows
+FOR EACH STATEMENT EXECUTE FUNCTION update_sequence_entries_tracker();
+
+CREATE TRIGGER update_tracker_trigger_upd
+AFTER UPDATE ON sequence_entries
+REFERENCING NEW TABLE AS changed_rows
+FOR EACH STATEMENT EXECUTE FUNCTION update_sequence_entries_tracker();
+
+CREATE TRIGGER update_tracker_trigger_del
+AFTER DELETE ON sequence_entries
+REFERENCING OLD TABLE AS changed_rows
+FOR EACH STATEMENT EXECUTE FUNCTION update_sequence_entries_tracker();


### PR DESCRIPTION
resolves #

### Screenshot

set db to persistent and did a west nile version bump, checked logs and confirmed:
- as soon as ebola finishes processing etag is fixed, although other organisms are still being ingested
- reprocessing west-nile does not cause etag of other organisms to change
- submission (revision) and editing data use terms of ebola nolonger triggers etag of other organisms to change -> fixed in this PR!

confirmed in grafana no large changes in 
```
sum by(namespace) (
  rate(container_cpu_usage_seconds_total{container!="", pod=~".*database.*"}[5m])
)
```

```
sum by(namespace) (
  rate(container_memory_working_set_bytes{container="database"}[5m])
)
```
```
sum by(namespace) (
  rate(container_fs_writes_bytes_total{container="database"}[5m])
)
```

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://etag-anya.loculus.org