### PR TITLE
fix(website): explicitly source src/ for Tailwind class detection

### DIFF
--- a/website/src/styles/base.css
+++ b/website/src/styles/base.css
@@ -1,6 +1,17 @@
 @import 'tailwindcss';
 @import 'flowbite-react/plugin/tailwindcss';
 @source '../../.flowbite-react/class-list.json';
+/*
+ * Explicitly source the website source tree. Tailwind v4's automatic content
+ * detection skips files matched by `.gitignore`. In this repo those files are
+ * tracked, so detection works either way -- but in downstream overlays such as
+ * Pathoplexus the website source is synced in and listed in `.gitignore`, which
+ * makes automatic detection skip it and silently drops ~half the utility
+ * classes. An explicit `@source` glob bypasses the gitignore filter, so styling
+ * is correct in both setups. (A bare `@source '../'` does NOT help -- a
+ * directory source still re-applies the gitignore filter; the glob is required.)
+ */
+@source '../**/*.{astro,html,js,jsx,ts,tsx,vue,svelte,md,mdx}';
 
 @custom-variant dark (&:where(.dark, .dark *));
 


### PR DESCRIPTION
## Problem

Tailwind v4's automatic content detection **skips files matched by `.gitignore`**. In this repo all website source files are tracked, so detection works regardless and styling looks correct.

But in downstream overlays — notably **Pathoplexus** — the website source is synced in via `sync.sh` and every synced path is listed in `monorepo/.gitignore` (so the overlay repo doesn't commit upstream files). As a result, Tailwind's auto-detection skips ~all of those source files and only generates the utilities it can find in the handful of non-ignored files. Concretely, in a fresh Pathoplexus local dev setup this dropped generated utilities from ~811 to ~380 — roughly half the classes missing (`bg-gray-100`, `animate-spin`, `border-b`, margins, etc.) — leaving the site visibly unstyled.

The existing `@source '../../.flowbite-react/class-list.json'` line kept working *despite* `.flowbite-react/` being gitignored, which is the tell: an **explicit `@source`** bypasses the gitignore filter.

## Fix

Add an explicit `@source` glob for the website source tree:

```css
@source '../**/*.{astro,html,js,jsx,ts,tsx,vue,svelte,md,mdx}';
```

- **No-op for this repo** — these files are already auto-detected here, so generated CSS is unchanged.
- **Fixes downstream overlays** (Pathoplexus) where the files are gitignored — the explicit glob is scanned regardless, restoring full styling.

### Why a glob, not a directory

A bare `@source '../'` does **not** help: a directory source still runs through Tailwind's automatic detection, which re-applies the gitignore filter. Only an explicit glob pattern bypasses it.

## Verification

Reproduced against a fresh Pathoplexus local checkout: with the fix, generated utility selectors went from 380 → 862 and the previously-missing classes (`animate-spin`, `bg-gray-100`, `border-b`, `bg-primary-600`, …) are all present. Loculus's own generated CSS is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: https://tailwind-source-fix.loculus.org