### PR TITLE
feat(ingest, backend): improve ingest curation warning - add diff

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.loculus.backend.controller.UnprocessableEntityException
 import org.loculus.backend.model.FastaId
 import org.loculus.backend.model.SubmissionId
 import org.loculus.backend.service.files.FileId
@@ -26,7 +27,27 @@ interface AccessionVersionInterface {
 }
 
 data class AccessionVersion(override val accession: Accession, override val version: Version) :
-    AccessionVersionInterface
+    AccessionVersionInterface {
+    companion object {
+        fun fromString(value: String): AccessionVersion {
+            val accession = value.substringBeforeLast('.', missingDelimiterValue = "")
+            val versionString = value.substringAfterLast('.', missingDelimiterValue = "")
+
+            if (accession.isEmpty() || versionString.isEmpty() || '.' in accession) {
+                throw UnprocessableEntityException(
+                    "Invalid accession version format '$value', expected 'accession.version'",
+                )
+            }
+
+            val version = versionString.toLongOrNull()
+                ?: throw UnprocessableEntityException(
+                    "Invalid version in accession version '$value', expected a number",
+                )
+
+            return AccessionVersion(accession, version)
+        }
+    }
+}
 
 data class SubmissionIdMapping(
     override val accession: Accession,

--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -43,6 +43,11 @@ data class AccessionVersion(override val accession: Accession, override val vers
                 ?: throw UnprocessableEntityException(
                     "Invalid version in accession version '$value', expected a number",
                 )
+            if (version < 1) {
+                throw UnprocessableEntityException(
+                    "Invalid version in accession version '$value', version must be at least 1",
+                )
+            }
 
             return AccessionVersion(accession, version)
         }

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -418,6 +418,10 @@ open class SubmissionController(
             description = "The metadata fields that should be returned. If not provided, all fields are returned.",
         ) @RequestParam(required = false) fields: List<String>?,
         @Parameter(
+            description = "Filter by accession versions in 'accession.version' format. " +
+                "If not provided, all accession versions are considered.",
+        ) @RequestParam(required = false) accessionVersionsFilter: List<String>?,
+        @Parameter(
             description = "Filter by group ids. If not provided, all groups are considered.",
         ) @RequestParam(required = false) groupIdsFilter: List<Int>?,
         @Parameter(
@@ -432,11 +436,22 @@ open class SubmissionController(
             headers.add(HttpHeaders.CONTENT_ENCODING, compression.compressionName)
         }
 
+        val parsedAccessionVersions = accessionVersionsFilter?.takeIf { it.isNotEmpty() }?.map {
+            val lastDot = it.lastIndexOf('.')
+            if (lastDot <= 0 || lastDot == it.length - 1) {
+                throw BadRequestException("Invalid accession version format '$it', expected 'accession.version'")
+            }
+            val version = it.substring(lastDot + 1).toLongOrNull()
+                ?: throw BadRequestException("Invalid version in accession version '$it', expected a number")
+            AccessionVersion(it.substring(0, lastDot), version)
+        }
+
         val totalRecords = submissionDatabaseService.countUnprocessedMetadata(
             authenticatedUser,
             organism,
             groupIdsFilter?.takeIf { it.isNotEmpty() },
             statusesFilter?.takeIf { it.isNotEmpty() },
+            parsedAccessionVersions,
         )
         headers.add(X_TOTAL_RECORDS, totalRecords.toString())
         // TODO(https://github.com/loculus-project/loculus/issues/2778)
@@ -452,6 +467,7 @@ open class SubmissionController(
                 groupIdsFilter?.takeIf { it.isNotEmpty() },
                 statusesFilter?.takeIf { it.isNotEmpty() },
                 fields?.takeIf { it.isNotEmpty() },
+                parsedAccessionVersions,
             )
         }
 

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -437,13 +437,7 @@ open class SubmissionController(
         }
 
         val parsedAccessionVersions = accessionVersionsFilter?.takeIf { it.isNotEmpty() }?.map {
-            val lastDot = it.lastIndexOf('.')
-            if (lastDot <= 0 || lastDot == it.length - 1) {
-                throw BadRequestException("Invalid accession version format '$it', expected 'accession.version'")
-            }
-            val version = it.substring(lastDot + 1).toLongOrNull()
-                ?: throw BadRequestException("Invalid version in accession version '$it', expected a number")
-            AccessionVersion(it.substring(0, lastDot), version)
+            AccessionVersion.fromString(it)
         }
 
         val totalRecords = submissionDatabaseService.countUnprocessedMetadata(

--- a/backend/src/main/kotlin/org/loculus/backend/service/seqsetcitations/SeqSetCitationsDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/seqsetcitations/SeqSetCitationsDatabaseService.kt
@@ -482,20 +482,7 @@ class SeqSetCitationsDatabaseService(
         }
         val accessionsWithVersions = mutableListOf<AccessionVersion>()
         for (record in seqSetRecords.filter { it.accession.contains('.') }) {
-            val parts = record.accession.split('.')
-            if (parts.size != 2) {
-                throw UnprocessableEntityException(
-                    "Invalid accession format '${record.accession}': expected format 'ACCESSION.VERSION'",
-                )
-            }
-            val versionString = parts[1]
-            val version = versionString.toLongOrNull()
-            if (version == null) {
-                throw UnprocessableEntityException(
-                    "Invalid version in accession '${record.accession}': '$versionString' is not a valid integer",
-                )
-            }
-            accessionsWithVersions.add(AccessionVersion(parts[0], version))
+            accessionsWithVersions.add(AccessionVersion.fromString(record.accession))
         }
 
         for (chunk in accessionsWithVersions.chunked(1000)) {

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -1228,6 +1228,7 @@ class SubmissionDatabaseService(
         organism: Organism,
         groupIdsFilter: List<Int>?,
         statusesFilter: List<Status>?,
+        accessionVersionsFilter: List<AccessionVersion>?,
     ): Op<Boolean> {
         val organismCondition = SequenceEntriesView.organismIs(organism)
         val groupCondition = getGroupCondition(groupIdsFilter, authenticatedUser)
@@ -1236,7 +1237,12 @@ class SubmissionDatabaseService(
         } else {
             Op.TRUE
         }
-        val conditions = organismCondition and groupCondition and statusCondition
+        val accessionVersionCondition = if (accessionVersionsFilter != null) {
+            SequenceEntriesView.accessionVersionIsIn(accessionVersionsFilter)
+        } else {
+            Op.TRUE
+        }
+        val conditions = organismCondition and groupCondition and statusCondition and accessionVersionCondition
 
         return conditions
     }
@@ -1246,6 +1252,7 @@ class SubmissionDatabaseService(
         organism: Organism,
         groupIdsFilter: List<Int>?,
         statusesFilter: List<Status>?,
+        accessionVersionsFilter: List<AccessionVersion>?,
     ): Long = SequenceEntriesView
         .selectAll()
         .where(
@@ -1254,6 +1261,7 @@ class SubmissionDatabaseService(
                 organism,
                 groupIdsFilter,
                 statusesFilter,
+                accessionVersionsFilter,
             ),
         )
         .count()
@@ -1264,6 +1272,7 @@ class SubmissionDatabaseService(
         groupIdsFilter: List<Int>?,
         statusesFilter: List<Status>?,
         fields: List<String>?,
+        accessionVersionsFilter: List<AccessionVersion>?,
     ): Sequence<AccessionVersionUnprocessedMetadata> {
         val unprocessedMetadata = SequenceEntriesView.unprocessedDataColumn
             // It's actually <Map<String, String>?> but exposed does not support nullable types here
@@ -1284,6 +1293,7 @@ class SubmissionDatabaseService(
                     organism,
                     groupIdsFilter,
                     statusesFilter,
+                    accessionVersionsFilter,
                 ),
             )
             .fetchSize(streamBatchSize)

--- a/backend/src/test/kotlin/org/loculus/backend/api/SubmissionTypesTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/api/SubmissionTypesTest.kt
@@ -1,0 +1,35 @@
+package org.loculus.backend.api
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.loculus.backend.controller.UnprocessableEntityException
+
+class SubmissionTypesTest {
+    @Test
+    fun `GIVEN valid accession version string THEN parses accession and version`() {
+        assertThat(AccessionVersion.fromString("LOC_123.42"), `is`(AccessionVersion("LOC_123", 42)))
+    }
+
+    @Test
+    fun `GIVEN accession version with invalid format THEN throws format exception`() {
+        listOf("LOC_123", ".1", "LOC_123.", "LOC.123.1").forEach {
+            assertThrows<UnprocessableEntityException> {
+                AccessionVersion.fromString(it)
+            }
+        }
+    }
+
+    @Test
+    fun `GIVEN non-numeric version THEN throws version exception`() {
+        val exception = assertThrows<UnprocessableEntityException> {
+            AccessionVersion.fromString("LOC_123.invalid")
+        }
+
+        assertThat(
+            exception.message,
+            `is`("Invalid version in accession version 'LOC_123.invalid', expected a number"),
+        )
+    }
+}

--- a/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/SeqSetValidationEndpointsTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/SeqSetValidationEndpointsTest.kt
@@ -67,7 +67,7 @@ class SeqSetValidationEndpointsTest(
                 jsonPath(
                     "\$.detail",
                     containsString(
-                        "Invalid version in accession 'ABCD.EF'",
+                        "Invalid version in accession version 'ABCD.EF', expected a number",
                     ),
                 ),
             )

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetUnprocessedMetadataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetUnprocessedMetadataEndpointTest.kt
@@ -190,6 +190,29 @@ class GetUnprocessedMetadataEndpointTest(
             .andExpect(status().isOk)
     }
 
+    @Test
+    fun `WHEN I filter by accessionVersions THEN should return only those entries`() {
+        val entries = convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease()
+        val target = entries.first()
+        val accessionVersion = target.displayAccessionVersion()
+
+        val response = submissionControllerClient.getSubmittedMetadata(
+            accessionVersionsFilter = listOf(accessionVersion),
+        )
+        response.andExpect(status().isOk)
+            .andExpect(header().string("x-total-records", `is`("1")))
+        val responseBody = response.expectNdjsonAndGetContent<AccessionVersionSubmittedMetadata>()
+        assertThat(responseBody, hasSize(1))
+        assertThat(responseBody[0].displayAccessionVersion(), `is`(accessionVersion))
+    }
+
+    @Test
+    fun `WHEN I filter by accessionVersions with invalid format THEN returns 400`() {
+        submissionControllerClient.getSubmittedMetadata(
+            accessionVersionsFilter = listOf("not-a-valid-accession-version"),
+        ).andExpect(status().isBadRequest)
+    }
+
     // Regression test for https://github.com/loculus-project/loculus/issues/4036
     @Test
     fun `GIVEN revoked sequences exist THEN endpoint does not throw exception`() {

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetUnprocessedMetadataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetUnprocessedMetadataEndpointTest.kt
@@ -207,10 +207,10 @@ class GetUnprocessedMetadataEndpointTest(
     }
 
     @Test
-    fun `WHEN I filter by accessionVersions with invalid format THEN returns 400`() {
+    fun `WHEN I filter by accessionVersions with invalid format THEN returns 422`() {
         submissionControllerClient.getUnprocessedMetadata(
             accessionVersionsFilter = listOf("not-a-valid-accession-version"),
-        ).andExpect(status().isBadRequest)
+        ).andExpect(status().isUnprocessableEntity)
     }
 
     // Regression test for https://github.com/loculus-project/loculus/issues/4036

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetUnprocessedMetadataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetUnprocessedMetadataEndpointTest.kt
@@ -196,19 +196,19 @@ class GetUnprocessedMetadataEndpointTest(
         val target = entries.first()
         val accessionVersion = target.displayAccessionVersion()
 
-        val response = submissionControllerClient.getSubmittedMetadata(
+        val response = submissionControllerClient.getUnprocessedMetadata(
             accessionVersionsFilter = listOf(accessionVersion),
         )
         response.andExpect(status().isOk)
             .andExpect(header().string("x-total-records", `is`("1")))
-        val responseBody = response.expectNdjsonAndGetContent<AccessionVersionSubmittedMetadata>()
+        val responseBody = response.expectNdjsonAndGetContent<AccessionVersionUnprocessedMetadata>()
         assertThat(responseBody, hasSize(1))
         assertThat(responseBody[0].displayAccessionVersion(), `is`(accessionVersion))
     }
 
     @Test
     fun `WHEN I filter by accessionVersions with invalid format THEN returns 400`() {
-        submissionControllerClient.getSubmittedMetadata(
+        submissionControllerClient.getUnprocessedMetadata(
             accessionVersionsFilter = listOf("not-a-valid-accession-version"),
         ).andExpect(status().isBadRequest)
     }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
@@ -307,6 +307,7 @@ class SubmissionControllerClient(private val mockMvc: MockMvc, private val objec
         jwt: String? = jwtForDefaultUser,
         groupIdsFilter: List<Int>? = null,
         statusesFilter: List<Status>? = null,
+        accessionVersionsFilter: List<String>? = null,
         fields: List<String>? = null,
         compression: String? = null,
     ): ResultActions = mockMvc.perform(
@@ -320,6 +321,7 @@ class SubmissionControllerClient(private val mockMvc: MockMvc, private val objec
             }
             .param("groupIdsFilter", groupIdsFilter?.joinToString(",") { it.toString() })
             .param("statusesFilter", statusesFilter?.joinToString(",") { it.name })
+            .param("accessionVersionsFilter", accessionVersionsFilter?.joinToString(","))
             .param("fields", fields?.joinToString(",")),
     )
 

--- a/ingest/scripts/call_loculus.py
+++ b/ingest/scripts/call_loculus.py
@@ -106,7 +106,15 @@ def submit_to_loculus(metadata, sequences, mode, log_level, config_file, output,
 
     if mode == "get-submitted":
         logger.info("Getting submitted sequences")
-        get_submitted(config, output)
+        if config.segmented:
+            insdc_key = [
+                "insdcAccessionBase" + "_" + segment for segment in config.nucleotide_sequences
+            ]
+        else:
+            insdc_key = ["insdcAccessionBase"]
+
+        fields = ["hash", *insdc_key]
+        get_submitted(config, output, fields)
 
 
 if __name__ == "__main__":

--- a/ingest/scripts/compare_hashes.py
+++ b/ingest/scripts/compare_hashes.py
@@ -9,7 +9,7 @@ import click
 import orjsonl
 import requests
 import yaml
-from loculus_client import get_submitted
+from loculus_client import Config, get_submitted
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(
@@ -20,20 +20,9 @@ logging.basicConfig(
 )
 
 
-@dataclass
-class Config:
-    organism: str
-    segmented: bool
-    nucleotide_sequences: list[str]
-    group_name: str
-    batch_chunk_size: int
-    backend_url: str
-    keycloak_token_url: str
-    keycloak_client_id: str
-    username: str
-    password: str
+@dataclass(kw_only=True)
+class CompareHashesConfig(Config):
     slack_hook: str = ""
-    backend_request_timeout_seconds: int = 600
 
 
 InsdcAccession = str  # one per segment
@@ -59,7 +48,7 @@ class SequenceUpdateManager:
     # i.e. loculus accessions (to be revoked) and their corresponding old joint insdc accessions
     sampled_out: list[JointInsdcAccession]
     hashes: list[float]
-    config: Config
+    config: CompareHashesConfig
 
 
 @dataclass
@@ -72,7 +61,7 @@ class LatestLoculusVersion:
     jointAccession: JointInsdcAccession  # noqa: N815
 
 
-def notify(config: Config, text: str):
+def notify(config: CompareHashesConfig, text: str):
     """Send slack notification with text"""
     if config.slack_hook:
         try:
@@ -96,10 +85,10 @@ def sample_out_hashed_records(
 
 
 def calculate_metadata_diff(
-    config: Config, new_metadata: dict[str, Any], previous_entry: LatestLoculusVersion
+    config: CompareHashesConfig, new_metadata: dict[str, Any], previous_entry: LatestLoculusVersion
 ) -> dict[str, Any]:
     previous_metadata_list = get_submitted(
-        config,  # type: ignore
+        config,
         None,
         fields=None,
         accessionVersionsFilter=[
@@ -254,7 +243,7 @@ def get_loculus_accession_to_latest_version_map(
 
 
 def construct_submitted_dict(
-    old_hashes: str, insdc_keys: list[str], config: Config
+    old_hashes: str, insdc_keys: list[str], config: CompareHashesConfig
 ) -> dict[InsdcAccession, LatestLoculusVersion]:
     # Get the latest version for each loculus accession
     loculus_accession_to_latest_version_map: dict[LoculusAccession, dict[str, Any]] = (
@@ -359,9 +348,11 @@ def main(
     with open(config_file, encoding="utf-8") as file:
         full_config = yaml.safe_load(file)
         relevant_config = {
-            key: full_config[key] for key in Config.__annotations__ if key in full_config
+            key: full_config[key]
+            for key in CompareHashesConfig.__annotations__
+            if key in full_config
         }
-        config = Config(**relevant_config)
+        config = CompareHashesConfig(**relevant_config)
 
     insdc_keys = [f"insdcAccessionBase_{segment}" for segment in config.nucleotide_sequences]
 

--- a/ingest/scripts/compare_hashes.py
+++ b/ingest/scripts/compare_hashes.py
@@ -124,11 +124,9 @@ def calculate_metadata_diff(
         key_in_old = key in previous_metadata
 
         if not key_in_new:
-            print(f"Key only exists in previous metadata: {key}")
             diff[key] = {"new": None, "old": previous_metadata[key]}
 
         elif not key_in_old:
-            print(f"Key only exists in new metadata: {key}")
             diff[key] = {"new": new_metadata[key], "old": None}
 
         else:

--- a/ingest/scripts/compare_hashes.py
+++ b/ingest/scripts/compare_hashes.py
@@ -21,11 +21,6 @@ logging.basicConfig(
 )
 
 
-@dataclass
-class CompareHashesConfig(Config):
-    slack_hook: str = ""
-
-
 InsdcAccession = str  # one per segment
 JointInsdcAccession = str  # for single segmented this is equal to the InsdcAccession,
 # for multi-segmented it is a concatenation of the base INSDC accessions all segments with their segment
@@ -49,7 +44,7 @@ class SequenceUpdateManager:
     # i.e. loculus accessions (to be revoked) and their corresponding old joint insdc accessions
     sampled_out: list[JointInsdcAccession]
     hashes: list[float]
-    config: CompareHashesConfig
+    config: Config
 
 
 @dataclass
@@ -62,7 +57,7 @@ class LatestLoculusVersion:
     jointAccession: JointInsdcAccession  # noqa: N815
 
 
-def notify(config: CompareHashesConfig, text: str):
+def notify(config: Config, text: str):
     """Send slack notification with text"""
     if config.slack_hook:
         try:
@@ -86,7 +81,7 @@ def sample_out_hashed_records(
 
 
 def calculate_metadata_diff(
-    config: CompareHashesConfig, new_metadata: dict[str, Any], previous_entry: LatestLoculusVersion
+    config: Config, new_metadata: dict[str, Any], previous_entry: LatestLoculusVersion
 ) -> dict[str, Any]:
     previous_metadata_list = get_submitted(
         config,
@@ -244,7 +239,7 @@ def get_loculus_accession_to_latest_version_map(
 
 
 def construct_submitted_dict(
-    old_hashes: str, insdc_keys: list[str], config: CompareHashesConfig
+    old_hashes: str, insdc_keys: list[str], config: Config
 ) -> dict[InsdcAccession, LatestLoculusVersion]:
     # Get the latest version for each loculus accession
     loculus_accession_to_latest_version_map: dict[LoculusAccession, dict[str, Any]] = (
@@ -348,13 +343,8 @@ def main(
     logging.getLogger("urllib3").setLevel(logging.WARNING)
     with open(config_file, encoding="utf-8") as file:
         full_config = yaml.safe_load(file)
-        relevant_config = {
-            key: full_config[key]
-            for key in CompareHashesConfig.__annotations__
-            if key in full_config
-        }
-        relevant_config = {f.name: full_config.get(f.name, []) for f in dataclasses.fields(CompareHashesConfig)}
-        config = CompareHashesConfig(**relevant_config)
+        relevant_config = {f.name: full_config.get(f.name, []) for f in dataclasses.fields(Config)}
+        config = Config(**relevant_config)
 
     insdc_keys = [f"insdcAccessionBase_{segment}" for segment in config.nucleotide_sequences]
 

--- a/ingest/scripts/compare_hashes.py
+++ b/ingest/scripts/compare_hashes.py
@@ -112,7 +112,7 @@ def calculate_metadata_diff(
             f"version {previous_entry.latest_version} to calculate metadata diff"
         )
         return {}
-    previous_metadata = previous_metadata_list[0]
+    previous_metadata = previous_metadata_list[0].get("unprocessedMetadata", {})
 
     diff = {}
 

--- a/ingest/scripts/compare_hashes.py
+++ b/ingest/scripts/compare_hashes.py
@@ -27,7 +27,13 @@ class Config:
     nucleotide_sequences: list[str]
     group_name: str
     batch_chunk_size: int
+    backend_url: str
+    keycloak_token_url: str
+    keycloak_client_id: str
+    username: str
+    password: str
     slack_hook: str = ""
+    backend_request_timeout_seconds: int = 600
 
 
 InsdcAccession = str  # one per segment

--- a/ingest/scripts/compare_hashes.py
+++ b/ingest/scripts/compare_hashes.py
@@ -20,7 +20,7 @@ logging.basicConfig(
 )
 
 
-@dataclass(kw_only=True)
+@dataclass
 class CompareHashesConfig(Config):
     slack_hook: str = ""
 

--- a/ingest/scripts/compare_hashes.py
+++ b/ingest/scripts/compare_hashes.py
@@ -9,6 +9,7 @@ import click
 import orjsonl
 import requests
 import yaml
+from loculus_client import get_submitted
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(
@@ -22,8 +23,10 @@ logging.basicConfig(
 @dataclass
 class Config:
     organism: str
-    segmented: str
+    segmented: bool
     nucleotide_sequences: list[str]
+    group_name: str
+    batch_chunk_size: int
     slack_hook: str = ""
 
 
@@ -86,16 +89,63 @@ def sample_out_hashed_records(
     return not keep
 
 
+def calculate_metadata_diff(
+    config: Config, new_metadata: dict[str, Any], previous_entry: LatestLoculusVersion
+) -> dict[str, Any]:
+    previous_metadata_list = get_submitted(
+        config,  # type: ignore
+        None,
+        fields=None,
+        accessionVersionsFilter=[
+            f"{previous_entry.loculus_accession}.{previous_entry.latest_version}"
+        ],
+    )
+    if not previous_metadata_list or len(previous_metadata_list) != 1:
+        logger.warning(
+            f"Could not retrieve previous metadata for {previous_entry.loculus_accession} "
+            f"version {previous_entry.latest_version} to calculate metadata diff"
+        )
+        return {}
+    previous_metadata = previous_metadata_list[0]
+
+    diff = {}
+
+    new_keys = set(new_metadata.keys())
+    old_keys = set(previous_metadata.keys())
+
+    for key in new_keys | old_keys:
+        key_in_new = key in new_metadata
+        key_in_old = key in previous_metadata
+
+        if not key_in_new:
+            print(f"Key only exists in previous metadata: {key}")
+            diff[key] = {"new": None, "old": previous_metadata[key]}
+
+        elif not key_in_old:
+            print(f"Key only exists in new metadata: {key}")
+            diff[key] = {"new": new_metadata[key], "old": None}
+
+        else:
+            new_value = new_metadata[key]
+            old_value = previous_metadata[key]
+
+            if new_value != old_value:
+                diff[key] = {"new": new_value, "old": old_value}
+
+    return diff
+
+
 def process_hashes(
     ingested_insdc_accession: InsdcAccession,
     metadata_id: SubmissionId,
-    newly_ingested_hash: float | None,
+    new_metadata: dict[str, Any],
     submitted: dict[InsdcAccession, LatestLoculusVersion],
     update_manager: SequenceUpdateManager,
 ):
     """
     Decide if metadata_id should be submitted, revised, or noop
     """
+    newly_ingested_hash: float | None = new_metadata.get("hash")
 
     if ingested_insdc_accession not in submitted:
         update_manager.submit.append(metadata_id)
@@ -114,12 +164,15 @@ def process_hashes(
         return update_manager
 
     if previously_submitted_entry.curated:
+        metadata_diff = calculate_metadata_diff(
+            update_manager.config, new_metadata, previously_submitted_entry
+        )
         # Sequence has been curated before - special case
         notification = (
             f"Ingest: Sequence {corresponding_loculus_accession} with INSDC "
             f"accession {ingested_insdc_accession} has been curated before "
             f"- do not know how to proceed. New hash: {newly_ingested_hash}, "
-            f"old hash: {previously_submitted_entry.hash}."
+            f"old hash: {previously_submitted_entry.hash}. Metadata diff: {metadata_diff}"
         )
         logger.warning(notification)
         notify(update_manager.config, notification)
@@ -328,7 +381,6 @@ def main(
     for field in orjsonl.stream(metadata):
         metadata_id: SubmissionId = field["id"]
         record: dict[str, Any] = field["metadata"]
-        ingested_hash: float | None = record.get("hash")
         if not config.segmented:
             insdc_accession_base = record["insdcAccessionBase"]
             if not insdc_accession_base:
@@ -337,9 +389,7 @@ def main(
             if sample_out_hashed_records(insdc_accession_base, subsample_fraction):
                 update_manager.sampled_out.append(insdc_accession_base)
                 continue
-            process_hashes(
-                insdc_accession_base, metadata_id, ingested_hash, submitted, update_manager
-            )
+            process_hashes(insdc_accession_base, metadata_id, record, submitted, update_manager)
             current_ingested_accessions.add(insdc_accession_base)
             continue
 
@@ -366,7 +416,7 @@ def main(
         ):
             # grouping is the same, can just look at first segment in group
             accession = insdc_accession_base_list[0]
-            process_hashes(accession, metadata_id, ingested_hash, submitted, update_manager)
+            process_hashes(accession, metadata_id, record, submitted, update_manager)
             continue
         # old group is subset of new group, new group has new segments
         old_submitted = [
@@ -381,7 +431,7 @@ def main(
         ):
             # has a new segment, must be revised
             accession = old_submitted[0]
-            process_hashes(accession, metadata_id, ingested_hash, submitted, update_manager)
+            process_hashes(accession, metadata_id, record, submitted, update_manager)
             continue
         old_accessions: dict[LoculusAccession, JointInsdcAccession] = {
             submitted[a].loculus_accession: submitted[a].jointAccession

--- a/ingest/scripts/compare_hashes.py
+++ b/ingest/scripts/compare_hashes.py
@@ -1,3 +1,4 @@
+import dataclasses
 import json
 import logging
 from collections import defaultdict
@@ -352,6 +353,7 @@ def main(
             for key in CompareHashesConfig.__annotations__
             if key in full_config
         }
+        relevant_config = {f.name: full_config.get(f.name, []) for f in dataclasses.fields(CompareHashesConfig)}
         config = CompareHashesConfig(**relevant_config)
 
     insdc_keys = [f"insdcAccessionBase_{segment}" for segment in config.nucleotide_sequences]

--- a/ingest/scripts/compare_hashes.py
+++ b/ingest/scripts/compare_hashes.py
@@ -99,29 +99,14 @@ def calculate_metadata_diff(
         return {}
     previous_metadata = previous_metadata_list[0].get("unprocessedMetadata", {})
 
-    diff = {}
-
-    new_keys = set(new_metadata.keys())
-    old_keys = set(previous_metadata.keys())
-
-    for key in new_keys | old_keys:
-        key_in_new = key in new_metadata
-        key_in_old = key in previous_metadata
-
-        if not key_in_new:
-            diff[key] = {"new": None, "old": previous_metadata[key]}
-
-        elif not key_in_old:
-            diff[key] = {"new": new_metadata[key], "old": None}
-
-        else:
-            new_value = new_metadata[key]
-            old_value = previous_metadata[key]
-
-            if new_value != old_value:
-                diff[key] = {"new": new_value, "old": old_value}
-
-    return diff
+    return {
+        key: {
+            "old": previous_metadata.get(key),
+            "new": new_metadata.get(key),
+        }
+        for key in new_metadata.keys() | previous_metadata.keys()
+        if new_metadata.get(key) != previous_metadata.get(key)
+    }
 
 
 def process_hashes(

--- a/ingest/scripts/loculus_client.py
+++ b/ingest/scripts/loculus_client.py
@@ -28,6 +28,7 @@ class ApproveConfig:
     username: str
     password: str
     backend_request_timeout_seconds: int = 600
+    slack_hook: str = ""
 
 
 @dataclass(kw_only=True)
@@ -451,7 +452,7 @@ def get_submitted(
     config: Config,
     output: str | None,
     fields: list[str] | None = None,
-    accessionVersionsFilter: list[str] | None = None,
+    accessionVersionsFilter: list[str] | None = None,  # noqa: N803
 ):
     """Get previously submitted sequences as ndjson
     This way we can avoid submitting the same sequences again

--- a/ingest/scripts/loculus_client.py
+++ b/ingest/scripts/loculus_client.py
@@ -28,7 +28,6 @@ class ApproveConfig:
     username: str
     password: str
     backend_request_timeout_seconds: int = 600
-    slack_hook: str = ""
 
 
 @dataclass(kw_only=True)
@@ -37,6 +36,7 @@ class Config(ApproveConfig):
     nucleotide_sequences: list[str]
     segmented: bool
     batch_chunk_size: int
+    slack_hook: str = ""
 
 
 def backend_url(config: ApproveConfig) -> str:

--- a/ingest/scripts/loculus_client.py
+++ b/ingest/scripts/loculus_client.py
@@ -447,7 +447,12 @@ def get_sequence_status(config: Config):
     return result
 
 
-def get_submitted(config: Config, output: str | None, fields: list[str] | None = None, accessionVersionsFilter: list[str] | None = None):
+def get_submitted(
+    config: Config,
+    output: str | None,
+    fields: list[str] | None = None,
+    accessionVersionsFilter: list[str] | None = None,
+):
     """Get previously submitted sequences as ndjson
     This way we can avoid submitting the same sequences again
     Adds status to the output (as this is not returned by get-unprocessed-metadata)
@@ -468,6 +473,8 @@ def get_submitted(config: Config, output: str | None, fields: list[str] | None =
         logger.info("Getting previously submitted sequences")
 
         response = make_request(HTTPMethod.GET, url, config, params=params)
+        logger.info(f"Params: {params}")
+        logger.info(f"Response: {response}")
         expected_record_count = int(response.headers["x-total-records"])
 
         entries: list[dict[str, Any]] = []

--- a/ingest/scripts/loculus_client.py
+++ b/ingest/scripts/loculus_client.py
@@ -473,8 +473,6 @@ def get_submitted(
         logger.info("Getting previously submitted sequences")
 
         response = make_request(HTTPMethod.GET, url, config, params=params)
-        logger.info(f"Params: {params}")
-        logger.info(f"Response: {response}")
         expected_record_count = int(response.headers["x-total-records"])
 
         entries: list[dict[str, Any]] = []

--- a/ingest/scripts/loculus_client.py
+++ b/ingest/scripts/loculus_client.py
@@ -447,7 +447,7 @@ def get_sequence_status(config: Config):
     return result
 
 
-def get_submitted(config: Config, output: str):
+def get_submitted(config: Config, output: str | None, fields: list[str] | None = None, accessionVersionsFilter: list[str] | None = None):
     """Get previously submitted sequences as ndjson
     This way we can avoid submitting the same sequences again
     Adds status to the output (as this is not returned by get-unprocessed-metadata)
@@ -455,20 +455,14 @@ def get_submitted(config: Config, output: str):
 
     url = f"{organism_url(config)}/get-unprocessed-metadata"
 
-    if config.segmented:
-        insdc_key = [
-            "insdcAccessionBase" + "_" + segment for segment in config.nucleotide_sequences
-        ]
-    else:
-        insdc_key = ["insdcAccessionBase"]
-
-    fields = ["hash", *insdc_key]
-
     params = {
-        "fields": fields,
         "groupIdsFilter": [],
         "statusesFilter": [],
     }
+    if fields:
+        params["fields"] = fields
+    if accessionVersionsFilter:
+        params["accessionVersionsFilter"] = accessionVersionsFilter
 
     while True:
         logger.info("Getting previously submitted sequences")
@@ -499,6 +493,9 @@ def get_submitted(config: Config, output: str):
     statuses: dict[str, dict[int, str]] = get_sequence_status(config)
     logger.info(f"Got info on {len(statuses.keys())} previously submitted sequences/accessions")
 
+    if not output:
+        return entries
+
     for entry in entries:
         status = statuses.get(entry["accession"], {}).get(entry["version"], "UNKNOWN")
         entry_with_status = entry.copy()
@@ -508,3 +505,4 @@ def get_submitted(config: Config, output: str):
     if len(entries) == 0:
         with open(output, "w", encoding="utf-8"):
             pass
+    return None

--- a/ingest/scripts/loculus_client.py
+++ b/ingest/scripts/loculus_client.py
@@ -495,11 +495,11 @@ def get_submitted(
         )
         sleep(60)
 
-    statuses: dict[str, dict[int, str]] = get_sequence_status(config)
-    logger.info(f"Got info on {len(statuses.keys())} previously submitted sequences/accessions")
-
     if not output:
         return entries
+
+    statuses: dict[str, dict[int, str]] = get_sequence_status(config)
+    logger.info(f"Got info on {len(statuses.keys())} previously submitted sequences/accessions")
 
     for entry in entries:
         status = statuses.get(entry["accession"], {}).get(entry["version"], "UNKNOWN")


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/3084

Adds the option to filter by AccessionVersion on the `get-unprocessed-metadata` endpoint. Have ingest call this endpoint to get all previous metadata (includes sequence hashes, so it will indirectly tell us if a sequence has been changed) when we get into the case where ingest would like to revise a curated sequence. 

Ingest will then add a diff of the curated metadata and the metadata it would like to revise to the notification so that curators can decide better to to handle the situation.

### PR Checklist
- [x] All necessary documentation has been adapted for backend endpoints
- [x] The backend endpoint updates are covered by unit tests
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
1. Ingest sequences from the INSDC with initial hash
2. Curate a sequence from the INSDC as a superuser (add a revision, do not change hash)
3. Ingest ignores revision as the hash has not changed
4. Log into database and manually modify the hash of the curated entry (unprocessed data not original data)
5. Run the ingest cronjob and verify that an informative message is sent to the loculus notifications slack:
<img width="2254" height="204" alt="image" src="https://github.com/user-attachments/assets/2e91f1b8-6b94-4801-9624-c6fc53cecaaf" />

🚀 Preview: https://curation-warning-add-diff.loculus.org