### PR TITLE
refactor(backend): centralize accession version parsing

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.loculus.backend.controller.UnprocessableEntityException
 import org.loculus.backend.model.FastaId
 import org.loculus.backend.model.SubmissionId
 import org.loculus.backend.service.files.FileId
@@ -26,7 +27,27 @@ interface AccessionVersionInterface {
 }
 
 data class AccessionVersion(override val accession: Accession, override val version: Version) :
-    AccessionVersionInterface
+    AccessionVersionInterface {
+    companion object {
+        fun fromString(value: String): AccessionVersion {
+            val accession = value.substringBeforeLast('.', missingDelimiterValue = "")
+            val versionString = value.substringAfterLast('.', missingDelimiterValue = "")
+
+            if (accession.isEmpty() || versionString.isEmpty() || '.' in accession) {
+                throw UnprocessableEntityException(
+                    "Invalid accession version format '$value', expected 'accession.version'",
+                )
+            }
+
+            val version = versionString.toLongOrNull()
+                ?: throw UnprocessableEntityException(
+                    "Invalid version in accession version '$value', expected a number",
+                )
+
+            return AccessionVersion(accession, version)
+        }
+    }
+}
 
 data class SubmissionIdMapping(
     override val accession: Accession,

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -437,13 +437,7 @@ open class SubmissionController(
         }
 
         val parsedAccessionVersions = accessionVersionsFilter?.takeIf { it.isNotEmpty() }?.map {
-            val lastDot = it.lastIndexOf('.')
-            if (lastDot <= 0 || lastDot == it.length - 1) {
-                throw BadRequestException("Invalid accession version format '$it', expected 'accession.version'")
-            }
-            val version = it.substring(lastDot + 1).toLongOrNull()
-                ?: throw BadRequestException("Invalid version in accession version '$it', expected a number")
-            AccessionVersion(it.substring(0, lastDot), version)
+            AccessionVersion.fromString(it)
         }
 
         val totalRecords = submissionDatabaseService.countUnprocessedMetadata(

--- a/backend/src/main/kotlin/org/loculus/backend/service/seqsetcitations/SeqSetCitationsDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/seqsetcitations/SeqSetCitationsDatabaseService.kt
@@ -482,20 +482,7 @@ class SeqSetCitationsDatabaseService(
         }
         val accessionsWithVersions = mutableListOf<AccessionVersion>()
         for (record in seqSetRecords.filter { it.accession.contains('.') }) {
-            val parts = record.accession.split('.')
-            if (parts.size != 2) {
-                throw UnprocessableEntityException(
-                    "Invalid accession format '${record.accession}': expected format 'ACCESSION.VERSION'",
-                )
-            }
-            val versionString = parts[1]
-            val version = versionString.toLongOrNull()
-            if (version == null) {
-                throw UnprocessableEntityException(
-                    "Invalid version in accession '${record.accession}': '$versionString' is not a valid integer",
-                )
-            }
-            accessionsWithVersions.add(AccessionVersion(parts[0], version))
+            accessionsWithVersions.add(AccessionVersion.fromString(record.accession))
         }
 
         for (chunk in accessionsWithVersions.chunked(1000)) {

--- a/backend/src/test/kotlin/org/loculus/backend/api/SubmissionTypesTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/api/SubmissionTypesTest.kt
@@ -1,0 +1,35 @@
+package org.loculus.backend.api
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.loculus.backend.controller.UnprocessableEntityException
+
+class SubmissionTypesTest {
+    @Test
+    fun `GIVEN valid accession version string THEN parses accession and version`() {
+        assertThat(AccessionVersion.fromString("LOC_123.42"), `is`(AccessionVersion("LOC_123", 42)))
+    }
+
+    @Test
+    fun `GIVEN accession version with invalid format THEN throws format exception`() {
+        listOf("LOC_123", ".1", "LOC_123.", "LOC.123.1").forEach {
+            assertThrows<UnprocessableEntityException> {
+                AccessionVersion.fromString(it)
+            }
+        }
+    }
+
+    @Test
+    fun `GIVEN non-numeric version THEN throws version exception`() {
+        val exception = assertThrows<UnprocessableEntityException> {
+            AccessionVersion.fromString("LOC_123.invalid")
+        }
+
+        assertThat(
+            exception.message,
+            `is`("Invalid version in accession version 'LOC_123.invalid', expected a number"),
+        )
+    }
+}

--- a/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/SeqSetValidationEndpointsTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/SeqSetValidationEndpointsTest.kt
@@ -67,7 +67,7 @@ class SeqSetValidationEndpointsTest(
                 jsonPath(
                     "\$.detail",
                     containsString(
-                        "Invalid version in accession 'ABCD.EF'",
+                        "Invalid version in accession version 'ABCD.EF', expected a number",
                     ),
                 ),
             )

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetUnprocessedMetadataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetUnprocessedMetadataEndpointTest.kt
@@ -207,10 +207,10 @@ class GetUnprocessedMetadataEndpointTest(
     }
 
     @Test
-    fun `WHEN I filter by accessionVersions with invalid format THEN returns 400`() {
+    fun `WHEN I filter by accessionVersions with invalid format THEN returns 422`() {
         submissionControllerClient.getUnprocessedMetadata(
             accessionVersionsFilter = listOf("not-a-valid-accession-version"),
-        ).andExpect(status().isBadRequest)
+        ).andExpect(status().isUnprocessableEntity)
     }
 
     // Regression test for https://github.com/loculus-project/loculus/issues/4036


### PR DESCRIPTION
## Summary

This introduces a single strict parser for Loculus accession-version strings and uses it in both backend locations that previously parsed `accession.version` values independently.

`AccessionVersion.fromString()` now validates that the input contains exactly one separator, that both accession and version are present, and that the version is numeric. Accessions containing dots are rejected as invalid input. Parsing failures surface as `UnprocessableEntityException` with a message that distinguishes malformed structure from a non-numeric version.

The submission metadata filter and sequence-set validation now delegate to this centralized parser. This removes duplicated parsing logic and ensures both endpoints apply the same validation rules. Invalid accession-version filters consequently return HTTP 422 rather than HTTP 400.

## Validation

- `./gradlew ktlintFormat --console=plain`
- `./gradlew test --console=plain -x checkDocker --tests org.loculus.backend.api.SubmissionTypesTest`
- Kotlin main and test compilation completed successfully as part of the focused test run.

The endpoint test suites could not run in this environment: Docker is unavailable, while `USE_NONDOCKER_INFRA=true` requires the missing `runuser` binary.

🚀 Preview: Add `preview` label to enable