### PR TITLE
feat(config): fix host name scientific search for CCHF

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1253,8 +1253,6 @@ defaultOrganismConfig: &defaultOrganismConfig
           function: resolve_host_taxon_id
           inputs:
             host: host
-            hostNameScientific: hostNameScientific
-            hostTaxonId: hostTaxonId
           args:
             taxonomy_service_url: &taxonomy_service_url http://loculus-taxonomy-service:5000
       - name: hostNameScientific
@@ -1274,7 +1272,6 @@ defaultOrganismConfig: &defaultOrganismConfig
           function: scientific_name_from_id
           inputs:
             hostTaxonId: processed.hostTaxonId
-            hostNameScientific: hostNameScientific
           args:
             taxonomy_service_url: *taxonomy_service_url
       - name: hostNameCommon
@@ -2027,18 +2024,6 @@ defaultOrganisms:
         - name: "Nextclade (S)"
           url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:S+rich|fasta]}}&dataset-name=community/pathoplexus/cchfv/S"
       metadataAdd:
-        - name: hostNameScientific
-          displayName: Host name - scientific
-          definition: "The scientific name of the host from which the sample was collected."
-          generateIndex: true
-          autocomplete: true
-          customDisplay:
-            type: hostSpecies
-            displayGroup: hostSpecies
-            label: Host
-          header: "Host"
-          ingest: ncbiHostName
-          initiallyVisible: true
         - name: lineage
           isSequenceFilter: true
           relatesToSegment: S
@@ -2168,18 +2153,6 @@ defaultOrganisms:
             S: 2to5
           category: "S"
       metadataAdd:
-        - name: hostNameScientific
-          displayName: Host name - scientific
-          definition: "The scientific name of the host from which the sample was collected."
-          generateIndex: true
-          autocomplete: true
-          customDisplay:
-            type: hostSpecies
-            displayGroup: hostSpecies
-            label: Host
-          header: "Host"
-          ingest: ncbiHostName
-          initiallyVisible: true
         - name: variant_L
           isSequenceFilter: true
           header: "Clade & Lineage"


### PR DESCRIPTION
resolves https://loculus.slack.com/archives/C05G172HL6L/p1781079401799899

### Screenshot
The CCHF config overwrote hostScientificName - assuming it would be in the ingest metadata, this is no longer true. Additionally, the config still passes hostScientificName and hostTaxonId as fallback values but these no longer will exist in standard metadata submissions and can thus be removed

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://fix-host.loculus.org