### PR TITLE
fix(website): fix ButtonBar oscillation bug

### DIFF
--- a/website/src/components/ReviewPage/ReviewCard.tsx
+++ b/website/src/components/ReviewPage/ReviewCard.tsx
@@ -161,7 +161,7 @@ const ButtonBar: FC<ButtonBarProps> = ({
 
     return (
         <div className='flex mb-auto pt-3.5 items-center'>
-            <div className='flex space-x-4'>
+            <div className='flex gap-x-4'>
                 {filesEnabled && viewFiles && (
                     <>
                         <Button


### PR DESCRIPTION
I encountered the following on the submission review page:

https://github.com/user-attachments/assets/53f89fc9-4887-403b-bfbf-bf3d1bae8801

I set Claude on it, and it came up with the following:

```md
Root cause: It's an interaction between Tailwind v4's space-x implementation and react-tooltip's mounting behavior:
  1. In Tailwind v4, space-x-4 compiles to > :not(:last-child) { margin-inline-end: 1rem } (in v3 it was the old "margin-left on following siblings" rule, which didn't have this problem).
  2. react-tooltip v6 only mounts the tooltip's DOM node while the tooltip is showing, and unmounts it ~150ms after hide (website/node_modules/react-tooltip/dist/react-tooltip.mjs:1538).
  3. The delete button's <CustomTooltip> is rendered as the last sibling inside the space-x-4 flex row. While no tooltip is shown, that component renders nothing, so the delete button is    the :last-child and has no right margin.

  So: hover the delete button → tooltip node mounts after it → the button is no longer :last-child → it gains a 16px right margin → since the ButtonBar is pinned to the card's right edge
  by the flex-grow sibling, the button shifts 16px left → the cursor (in that rightmost 16px band, which is why approaching slowly from the right triggers it) is no longer over the button   → tooltip unmounts → button shifts back right → hover again → infinite oscillation.

  Fix: I changed space-x-4 to gap-x-4 on the ButtonBar container (ReviewCard.tsx:164). Flex gap only applies between actual flex items, and the tooltip node is position: fixed (so it's not
  a flex item and takes no flow space) — mounting/unmounting it no longer affects any spacing. Visual spacing between the buttons stays 16px, identical to before; the spacing around the
  mx-3 separator actually becomes slightly more symmetric (28px both sides instead of 28px/16px).
  One thing to keep in mind beyond this fix: this trap exists anywhere a conditionally-rendered element (like these tooltips) is the last child of a Tailwind v4 space-x/space-y container —
  preferring gap in flex/grid layouts avoids it generally.
```

So looks like this was something that was introduced when moving to Tailwind v4. It may make sense to look at other places where we use `space-x/y` to look for similar bugs, but I don't know enough about Tailwind to say whether we generally should use `gap` over `space`.

## Manual testing
I deployed a preview from this branch and confirmed the jittering back and forth is no longer there.

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://fix-review-card-jitter.loculus.org