### PR TITLE
fix(website): stop collection date range fields bouncing between values while typing

### DIFF
--- a/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
+++ b/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
@@ -101,7 +101,7 @@ describe('DateRangeField', () => {
         }
     });
 
-    it('derives switches mode correctly', async () => {
+    it('does not write to query params on mount', () => {
         render(
             <DateRangeField
                 field={field}
@@ -110,11 +110,19 @@ describe('DateRangeField', () => {
             />,
         );
 
-        expect(setSomeFieldValues).toHaveBeenCalledWith(
-            ['collectionDateRangeLowerFrom', '2024-01-01'],
-            ['collectionDateRangeUpperTo', '2024-12-31'],
-            ['collectionDateRangeUpperFrom', null],
-            ['collectionDateRangeLowerTo', null],
+        // Rendering must not push values back into the query state — only real user interaction
+        // (typing a date or toggling strictness) should. This avoids the feedback loop that made
+        // the date inputs bounce between two values while typing.
+        expect(setSomeFieldValues).not.toHaveBeenCalled();
+    });
+
+    it('derives switches mode correctly', async () => {
+        render(
+            <DateRangeField
+                field={field}
+                fieldValues={{ collectionDateRangeLowerFrom: '2024-01-01', collectionDateRangeUpperTo: '2024-12-31' }}
+                setSomeFieldValues={setSomeFieldValues}
+            />,
         );
 
         const strictCheckbox = screen.getByRole('checkbox');
@@ -131,13 +139,34 @@ describe('DateRangeField', () => {
     });
 
     it('updates query params if user types in new dates', async () => {
-        render(
-            <DateRangeField
-                field={field}
-                fieldValues={{ collectionDateRangeLowerFrom: '2024-01-01', collectionDateRangeUpperTo: '2024-12-31' }}
-                setSomeFieldValues={setSomeFieldValues}
-            />,
-        );
+        const lastValues: { current: FieldValues } = { current: {} };
+
+        function Wrapper() {
+            const [values, _setValues] = useState<FieldValues>({
+                collectionDateRangeLowerFrom: '2024-01-01',
+                collectionDateRangeUpperTo: '2024-12-31',
+            });
+            lastValues.current = values;
+
+            const setValues: SetSomeFieldValues = useCallback((...fieldValuesToSet) => {
+                _setValues((state) => {
+                    const newState = { ...state };
+                    fieldValuesToSet.forEach(([k, v]) => {
+                        // mirror the production behaviour of useSearchPageState: null/'' deletes
+                        if (v === null || v === '') {
+                            delete newState[k];
+                        } else {
+                            newState[k] = v;
+                        }
+                    });
+                    return newState;
+                });
+            }, []);
+
+            return <DateRangeField field={field} fieldValues={values} setSomeFieldValues={setValues} />;
+        }
+
+        render(<Wrapper />);
 
         const fromInput = screen.getByText('From').closest('div')?.querySelector('input');
         const toInput = screen.getByText('To').closest('div')?.querySelector('input');
@@ -150,12 +179,11 @@ describe('DateRangeField', () => {
         await userEvent.type(toInput!, '{backspace}');
         await userEvent.type(toInput!, '20141013');
 
-        expect(setSomeFieldValues).toHaveBeenLastCalledWith(
-            ['collectionDateRangeLowerFrom', '1987-04-23'],
-            ['collectionDateRangeUpperTo', '2014-10-13'],
-            ['collectionDateRangeUpperFrom', null],
-            ['collectionDateRangeLowerTo', null],
-        );
+        // The edits to both fields are retained — neither value bounces back to its previous value.
+        expect(lastValues.current).toEqual({
+            collectionDateRangeLowerFrom: '1987-04-23',
+            collectionDateRangeUpperTo: '2014-10-13',
+        });
     });
 
     it('does not snap back to strict when user toggles without having entered dates', async () => {

--- a/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
+++ b/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useCallback, useState, type ReactNode } from 'react';
+import { useCallback, useState } from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import { DateRangeField } from './DateRangeField';
@@ -52,53 +52,6 @@ describe('DateRangeField', () => {
         setSomeFieldValues.mockClear();
     });
 
-    /**
-     * Renders DateRangeField wired to real React state instead of a `vi.fn()` mock.
-     *
-     * A plain `vi.fn()` can't catch the bug these tests guard against: DateRangeField shows
-     * whatever is in its `fieldValues` prop, so a value can only "bounce" if edits actually feed
-     * back into that prop on the next render. A mock never updates it, so the field would appear to
-     * work even with the buggy two-way mirror. This harness mimics production
-     * `useSearchPageState.setSomeFieldValues` (null/'' deletes the key), so typed edits round-trip
-     * through `fieldValues` exactly as they do in the app.
-     *
-     * Pass `valuesRef` to observe the latest state, and `children` to render extra controls (e.g. a
-     * button that clears the fields externally).
-     */
-    function StatefulDateRangeField({
-        initialValues = {},
-        valuesRef,
-        children,
-    }: {
-        initialValues?: FieldValues;
-        valuesRef?: { current: FieldValues };
-        children?: (setSomeFieldValues: SetSomeFieldValues) => ReactNode;
-    }) {
-        const [values, setValues] = useState<FieldValues>(initialValues);
-        if (valuesRef) valuesRef.current = values;
-
-        const setValuesLikeProduction: SetSomeFieldValues = useCallback((...fieldValuesToSet) => {
-            setValues((state) => {
-                const newState = { ...state };
-                fieldValuesToSet.forEach(([key, value]) => {
-                    if (value === null || value === '') {
-                        delete newState[key];
-                    } else {
-                        newState[key] = value;
-                    }
-                });
-                return newState;
-            });
-        }, []);
-
-        return (
-            <>
-                <DateRangeField field={field} fieldValues={values} setSomeFieldValues={setValuesLikeProduction} />
-                {children?.(setValuesLikeProduction)}
-            </>
-        );
-    }
-
     it('renders the component', () => {
         render(<DateRangeField field={field} fieldValues={fieldValues} setSomeFieldValues={setSomeFieldValues} />);
 
@@ -148,20 +101,6 @@ describe('DateRangeField', () => {
         }
     });
 
-    it('does not write to query params on mount', () => {
-        render(
-            <DateRangeField
-                field={field}
-                fieldValues={{ collectionDateRangeLowerFrom: '2024-01-01', collectionDateRangeUpperTo: '2024-12-31' }}
-                setSomeFieldValues={setSomeFieldValues}
-            />,
-        );
-
-        // Rendering must not push values back into query state — avoids the feedback loop that
-        // made the inputs bounce between two values while typing.
-        expect(setSomeFieldValues).not.toHaveBeenCalled();
-    });
-
     it('derives switches mode correctly', async () => {
         render(
             <DateRangeField
@@ -184,40 +123,30 @@ describe('DateRangeField', () => {
         );
     });
 
-    it('updates query params if user types in new dates', async () => {
-        const lastValues: { current: FieldValues } = { current: {} };
-
-        render(
-            <StatefulDateRangeField
-                initialValues={{
-                    collectionDateRangeLowerFrom: '2024-01-01',
-                    collectionDateRangeUpperTo: '2024-12-31',
-                }}
-                valuesRef={lastValues}
-            />,
-        );
-
-        const fromInput = screen.getByText('From').closest('div')?.querySelector('input');
-        const toInput = screen.getByText('To').closest('div')?.querySelector('input');
-
-        expect(fromInput).toHaveValue('2024-01-01');
-        expect(toInput).toHaveValue('2024-12-31');
-
-        await userEvent.type(fromInput!, '{backspace}');
-        await userEvent.type(fromInput!, '19870423');
-        await userEvent.type(toInput!, '{backspace}');
-        await userEvent.type(toInput!, '20141013');
-
-        // The edits to both fields are retained — neither value bounces back to its previous value.
-        expect(lastValues.current).toEqual({
-            collectionDateRangeLowerFrom: '1987-04-23',
-            collectionDateRangeUpperTo: '2014-10-13',
-        });
-    });
-
     it('does not snap back to strict when user toggles without having entered dates', async () => {
+        function Wrapper() {
+            const [values, _setValues] = useState<FieldValues>({});
+
+            const setValues: SetSomeFieldValues = useCallback((...fieldValuesToSet) => {
+                _setValues((state) => {
+                    const newState = { ...state };
+                    fieldValuesToSet.forEach(([k, v]) => {
+                        // mirror the production behaviour of useSearchPageState: null/'' deletes
+                        if (v === null || v === '') {
+                            delete newState[k];
+                        } else {
+                            newState[k] = v;
+                        }
+                    });
+                    return newState;
+                });
+            }, []);
+
+            return <DateRangeField field={field} fieldValues={values} setSomeFieldValues={setValues} />;
+        }
+
         const user = userEvent.setup();
-        render(<StatefulDateRangeField />);
+        render(<Wrapper />);
 
         const strictCheckbox = screen.getByRole('checkbox');
         expect(strictCheckbox).toBeChecked();
@@ -227,29 +156,37 @@ describe('DateRangeField', () => {
     });
 
     it('setting fieldValue to empty string clears date field', async () => {
-        const user = userEvent.setup();
+        function Wrapper() {
+            const [values, _setValues] = useState<FieldValues>({
+                collectionDateRangeLowerFrom: '2024-01-01',
+                collectionDateRangeUpperTo: '2024-12-31',
+            });
 
-        render(
-            <StatefulDateRangeField
-                initialValues={{
-                    collectionDateRangeLowerFrom: '2024-01-01',
-                    collectionDateRangeUpperTo: '2024-12-31',
-                }}
-            >
-                {(setSomeFieldValues) => (
+            const setValues: SetSomeFieldValues = useCallback((...fieldValuesToSet) => {
+                _setValues((state) => {
+                    const newState = { ...state };
+                    fieldValuesToSet.forEach(([k, v]) => (newState[k] = v));
+                    return newState;
+                });
+            }, []);
+
+            return (
+                <div>
+                    <DateRangeField field={field} fieldValues={values} setSomeFieldValues={setValues} />
                     <Button
                         onClick={() =>
-                            setSomeFieldValues(
-                                ['collectionDateRangeLowerFrom', null],
-                                ['collectionDateRangeUpperTo', null],
-                            )
+                            setValues(['collectionDateRangeLowerFrom', null], ['collectionDateRangeUpperTo', null])
                         }
                     >
                         Update Dates
                     </Button>
-                )}
-            </StatefulDateRangeField>,
-        );
+                </div>
+            );
+        }
+
+        const user = userEvent.setup();
+
+        render(<Wrapper />);
 
         const getFromInput = () => screen.getByText('From').closest('div')?.querySelector('input');
         const getToInput = () => screen.getByText('To').closest('div')?.querySelector('input');

--- a/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
+++ b/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useCallback, useState } from 'react';
+import { useCallback, useState, type ReactNode } from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import { DateRangeField } from './DateRangeField';
@@ -51,6 +51,53 @@ describe('DateRangeField', () => {
     beforeEach(() => {
         setSomeFieldValues.mockClear();
     });
+
+    /**
+     * Renders DateRangeField wired to real React state instead of a `vi.fn()` mock.
+     *
+     * A plain `vi.fn()` can't catch the bug these tests guard against: DateRangeField shows
+     * whatever is in its `fieldValues` prop, so a value can only "bounce" if edits actually feed
+     * back into that prop on the next render. A mock never updates it, so the field would appear to
+     * work even with the buggy two-way mirror. This harness mimics production
+     * `useSearchPageState.setSomeFieldValues` (null/'' deletes the key), so typed edits round-trip
+     * through `fieldValues` exactly as they do in the app.
+     *
+     * Pass `valuesRef` to observe the latest state, and `children` to render extra controls (e.g. a
+     * button that clears the fields externally).
+     */
+    function StatefulDateRangeField({
+        initialValues = {},
+        valuesRef,
+        children,
+    }: {
+        initialValues?: FieldValues;
+        valuesRef?: { current: FieldValues };
+        children?: (setSomeFieldValues: SetSomeFieldValues) => ReactNode;
+    }) {
+        const [values, setValues] = useState<FieldValues>(initialValues);
+        if (valuesRef) valuesRef.current = values;
+
+        const setValuesLikeProduction: SetSomeFieldValues = useCallback((...fieldValuesToSet) => {
+            setValues((state) => {
+                const newState = { ...state };
+                fieldValuesToSet.forEach(([key, value]) => {
+                    if (value === null || value === '') {
+                        delete newState[key];
+                    } else {
+                        newState[key] = value;
+                    }
+                });
+                return newState;
+            });
+        }, []);
+
+        return (
+            <>
+                <DateRangeField field={field} fieldValues={values} setSomeFieldValues={setValuesLikeProduction} />
+                {children?.(setValuesLikeProduction)}
+            </>
+        );
+    }
 
     it('renders the component', () => {
         render(<DateRangeField field={field} fieldValues={fieldValues} setSomeFieldValues={setSomeFieldValues} />);
@@ -140,32 +187,15 @@ describe('DateRangeField', () => {
     it('updates query params if user types in new dates', async () => {
         const lastValues: { current: FieldValues } = { current: {} };
 
-        function Wrapper() {
-            const [values, _setValues] = useState<FieldValues>({
-                collectionDateRangeLowerFrom: '2024-01-01',
-                collectionDateRangeUpperTo: '2024-12-31',
-            });
-            lastValues.current = values;
-
-            const setValues: SetSomeFieldValues = useCallback((...fieldValuesToSet) => {
-                _setValues((state) => {
-                    const newState = { ...state };
-                    fieldValuesToSet.forEach(([k, v]) => {
-                        // mirror the production behaviour of useSearchPageState: null/'' deletes
-                        if (v === null || v === '') {
-                            delete newState[k];
-                        } else {
-                            newState[k] = v;
-                        }
-                    });
-                    return newState;
-                });
-            }, []);
-
-            return <DateRangeField field={field} fieldValues={values} setSomeFieldValues={setValues} />;
-        }
-
-        render(<Wrapper />);
+        render(
+            <StatefulDateRangeField
+                initialValues={{
+                    collectionDateRangeLowerFrom: '2024-01-01',
+                    collectionDateRangeUpperTo: '2024-12-31',
+                }}
+                valuesRef={lastValues}
+            />,
+        );
 
         const fromInput = screen.getByText('From').closest('div')?.querySelector('input');
         const toInput = screen.getByText('To').closest('div')?.querySelector('input');
@@ -186,29 +216,8 @@ describe('DateRangeField', () => {
     });
 
     it('does not snap back to strict when user toggles without having entered dates', async () => {
-        function Wrapper() {
-            const [values, _setValues] = useState<FieldValues>({});
-
-            const setValues: SetSomeFieldValues = useCallback((...fieldValuesToSet) => {
-                _setValues((state) => {
-                    const newState = { ...state };
-                    fieldValuesToSet.forEach(([k, v]) => {
-                        // mirror the production behaviour of useSearchPageState: null/'' deletes
-                        if (v === null || v === '') {
-                            delete newState[k];
-                        } else {
-                            newState[k] = v;
-                        }
-                    });
-                    return newState;
-                });
-            }, []);
-
-            return <DateRangeField field={field} fieldValues={values} setSomeFieldValues={setValues} />;
-        }
-
         const user = userEvent.setup();
-        render(<Wrapper />);
+        render(<StatefulDateRangeField />);
 
         const strictCheckbox = screen.getByRole('checkbox');
         expect(strictCheckbox).toBeChecked();
@@ -218,37 +227,29 @@ describe('DateRangeField', () => {
     });
 
     it('setting fieldValue to empty string clears date field', async () => {
-        function Wrapper() {
-            const [values, _setValues] = useState<FieldValues>({
-                collectionDateRangeLowerFrom: '2024-01-01',
-                collectionDateRangeUpperTo: '2024-12-31',
-            });
+        const user = userEvent.setup();
 
-            const setValues: SetSomeFieldValues = useCallback((...fieldValuesToSet) => {
-                _setValues((state) => {
-                    const newState = { ...state };
-                    fieldValuesToSet.forEach(([k, v]) => (newState[k] = v));
-                    return newState;
-                });
-            }, []);
-
-            return (
-                <div>
-                    <DateRangeField field={field} fieldValues={values} setSomeFieldValues={setValues} />
+        render(
+            <StatefulDateRangeField
+                initialValues={{
+                    collectionDateRangeLowerFrom: '2024-01-01',
+                    collectionDateRangeUpperTo: '2024-12-31',
+                }}
+            >
+                {(setSomeFieldValues) => (
                     <Button
                         onClick={() =>
-                            setValues(['collectionDateRangeLowerFrom', null], ['collectionDateRangeUpperTo', null])
+                            setSomeFieldValues(
+                                ['collectionDateRangeLowerFrom', null],
+                                ['collectionDateRangeUpperTo', null],
+                            )
                         }
                     >
                         Update Dates
                     </Button>
-                </div>
-            );
-        }
-
-        const user = userEvent.setup();
-
-        render(<Wrapper />);
+                )}
+            </StatefulDateRangeField>,
+        );
 
         const getFromInput = () => screen.getByText('From').closest('div')?.querySelector('input');
         const getToInput = () => screen.getByText('To').closest('div')?.querySelector('input');

--- a/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
+++ b/website/src/components/SearchPage/fields/DateRangeField.spec.tsx
@@ -110,9 +110,8 @@ describe('DateRangeField', () => {
             />,
         );
 
-        // Rendering must not push values back into the query state — only real user interaction
-        // (typing a date or toggling strictness) should. This avoids the feedback loop that made
-        // the date inputs bounce between two values while typing.
+        // Rendering must not push values back into query state — avoids the feedback loop that
+        // made the inputs bounce between two values while typing.
         expect(setSomeFieldValues).not.toHaveBeenCalled();
     });
 

--- a/website/src/components/SearchPage/fields/DateRangeField.tsx
+++ b/website/src/components/SearchPage/fields/DateRangeField.tsx
@@ -49,11 +49,8 @@ export const DateRangeField = ({ field, fieldValues, setSomeFieldValues }: DateR
         isStrictMode(lowerFromDefined, lowerToDefined, upperFromDefined, upperToDefined),
     );
 
-    // Keep strictMode in sync when the underlying fieldValues change from outside the component
-    // (e.g. URL navigation or the active-filter pills). We only re-derive when at least one bound
-    // is actually defined: when the user toggles strictness without having entered any dates we
-    // clear all four fields, which would otherwise feed back into isStrictMode and collapse
-    // strictMode back to its default `true` — making the checkbox appear stuck on.
+    // Only re-derive strictMode when at least one bound is defined, otherwise toggling strictness
+    // with no dates entered would feed back into isStrictMode and snap the checkbox back to `true`.
     useEffect(() => {
         if (lowerFromDefined || lowerToDefined || upperFromDefined || upperToDefined) {
             setStrictMode(isStrictMode(lowerFromDefined, lowerToDefined, upperFromDefined, upperToDefined));
@@ -63,13 +60,9 @@ export const DateRangeField = ({ field, fieldValues, setSomeFieldValues }: DateR
     const lowerField = strictMode ? lowerFromField : upperFromField;
     const upperField = strictMode ? upperToField : lowerToField;
 
-    // Extract single values from fieldValues (date ranges should never be arrays).
-    // The displayed values are derived directly from `fieldValues` — the single source of truth —
-    // rather than mirrored into local state. Keeping a local copy that is continuously written back
-    // and forth with `fieldValues` caused a race: while typing, `fieldValues` lags one round-trip
-    // behind (each keystroke goes through setSomeFieldValues -> URL state -> re-derived fieldValues),
-    // so a stale `fieldValues` could overwrite a freshly typed value, making the field bounce
-    // between two values.
+    // Derive displayed values directly from `fieldValues` (the single source of truth) instead of
+    // mirroring into local state — a local copy synced both ways with the lagging `fieldValues`
+    // would let a stale value overwrite a freshly typed one, making the field bounce while typing.
     const getFieldValue = (fieldName: string): string => {
         return validateSingleValue(fieldValues[fieldName], fieldName);
     };
@@ -77,9 +70,8 @@ export const DateRangeField = ({ field, fieldValues, setSomeFieldValues }: DateR
     const lowerValue = getFieldValue(lowerField.name);
     const upperValue = getFieldValue(upperField.name);
 
-    // Write the lower/upper values into the underlying fields for the given mode, clearing the
-    // fields that belong to the other mode. This only runs in response to real user interaction
-    // (typing a date or toggling strictness), never from an effect, so there is no feedback loop.
+    // Write into the underlying fields for the given mode, clearing the other mode's fields. Only
+    // called from user interaction, never an effect, so there is no feedback loop.
     const commit = (strict: boolean, newLowerValue: string, newUpperValue: string) => {
         if (strict) {
             setSomeFieldValues(
@@ -141,9 +133,7 @@ export const DateRangeField = ({ field, fieldValues, setSomeFieldValues }: DateR
                 }}
                 fieldValue={lowerValue}
                 setSomeFieldValues={([_, value]) => {
-                    // DateField passes a single tuple [fieldName, value]
-                    const validatedValue = validateSingleValue(value, `${field.name}-from`);
-                    commit(strictMode, validatedValue, upperValue);
+                    commit(strictMode, validateSingleValue(value, `${field.name}-from`), upperValue);
                 }}
             />
             <DateField
@@ -154,9 +144,7 @@ export const DateRangeField = ({ field, fieldValues, setSomeFieldValues }: DateR
                 }}
                 fieldValue={upperValue}
                 setSomeFieldValues={([_, value]) => {
-                    // DateField passes a single tuple [fieldName, value]
-                    const validatedValue = validateSingleValue(value, `${field.name}-to`);
-                    commit(strictMode, lowerValue, validatedValue);
+                    commit(strictMode, lowerValue, validateSingleValue(value, `${field.name}-to`));
                 }}
             />
         </div>

--- a/website/src/components/SearchPage/fields/DateRangeField.tsx
+++ b/website/src/components/SearchPage/fields/DateRangeField.tsx
@@ -40,68 +40,68 @@ export const DateRangeField = ({ field, fieldValues, setSomeFieldValues }: DateR
     const upperFromField = getField('upper', 'From');
     const upperToField = getField('upper', 'To');
 
+    const lowerFromDefined = lowerFromField.name in fieldValues;
+    const lowerToDefined = lowerToField.name in fieldValues;
+    const upperFromDefined = upperFromField.name in fieldValues;
+    const upperToDefined = upperToField.name in fieldValues;
+
     const [strictMode, setStrictMode] = useState(
-        isStrictMode(
-            lowerFromField.name in fieldValues,
-            lowerToField.name in fieldValues,
-            upperFromField.name in fieldValues,
-            upperToField.name in fieldValues,
-        ),
+        isStrictMode(lowerFromDefined, lowerToDefined, upperFromDefined, upperToDefined),
     );
+
+    // Keep strictMode in sync when the underlying fieldValues change from outside the component
+    // (e.g. URL navigation or the active-filter pills). We only re-derive when at least one bound
+    // is actually defined: when the user toggles strictness without having entered any dates we
+    // clear all four fields, which would otherwise feed back into isStrictMode and collapse
+    // strictMode back to its default `true` — making the checkbox appear stuck on.
+    useEffect(() => {
+        if (lowerFromDefined || lowerToDefined || upperFromDefined || upperToDefined) {
+            setStrictMode(isStrictMode(lowerFromDefined, lowerToDefined, upperFromDefined, upperToDefined));
+        }
+    }, [lowerFromDefined, lowerToDefined, upperFromDefined, upperToDefined]);
 
     const lowerField = strictMode ? lowerFromField : upperFromField;
     const upperField = strictMode ? upperToField : lowerToField;
 
-    // Extract single values from fieldValues (date ranges should never be arrays)
+    // Extract single values from fieldValues (date ranges should never be arrays).
+    // The displayed values are derived directly from `fieldValues` — the single source of truth —
+    // rather than mirrored into local state. Keeping a local copy that is continuously written back
+    // and forth with `fieldValues` caused a race: while typing, `fieldValues` lags one round-trip
+    // behind (each keystroke goes through setSomeFieldValues -> URL state -> re-derived fieldValues),
+    // so a stale `fieldValues` could overwrite a freshly typed value, making the field bounce
+    // between two values.
     const getFieldValue = (fieldName: string): string => {
         return validateSingleValue(fieldValues[fieldName], fieldName);
     };
 
-    const [lowerValue, setLowerValue] = useState(getFieldValue(lowerField.name));
-    const [upperValue, setUpperValue] = useState(getFieldValue(upperField.name));
+    const lowerValue = getFieldValue(lowerField.name);
+    const upperValue = getFieldValue(upperField.name);
 
-    useEffect(() => {
-        const lowerFromDefined = lowerFromField.name in fieldValues;
-        const lowerToDefined = lowerToField.name in fieldValues;
-        const upperFromDefined = upperFromField.name in fieldValues;
-        const upperToDefined = upperToField.name in fieldValues;
-        // Only re-derive strictMode from fieldValues when at least one bound is actually defined.
-        // When the user toggles strictness without having entered any dates the other effect
-        // below clears all four fields, which would otherwise feed back into isStrictMode and
-        // collapse strictMode back to its default `true` — making the checkbox appear stuck on.
-        if (lowerFromDefined || lowerToDefined || upperFromDefined || upperToDefined) {
-            setStrictMode(isStrictMode(lowerFromDefined, lowerToDefined, upperFromDefined, upperToDefined));
-        }
-        setLowerValue(validateSingleValue(fieldValues[lowerField.name], lowerField.name));
-        setUpperValue(validateSingleValue(fieldValues[upperField.name], upperField.name));
-    }, [field, fieldValues]);
-
-    useEffect(() => {
-        if (strictMode) {
+    // Write the lower/upper values into the underlying fields for the given mode, clearing the
+    // fields that belong to the other mode. This only runs in response to real user interaction
+    // (typing a date or toggling strictness), never from an effect, so there is no feedback loop.
+    const commit = (strict: boolean, newLowerValue: string, newUpperValue: string) => {
+        if (strict) {
             setSomeFieldValues(
-                [lowerFromField.name, lowerValue],
-                [upperToField.name, upperValue],
+                [lowerFromField.name, newLowerValue],
+                [upperToField.name, newUpperValue],
                 [upperFromField.name, null],
                 [lowerToField.name, null],
             );
         } else {
             setSomeFieldValues(
-                [upperFromField.name, lowerValue],
-                [lowerToField.name, upperValue],
+                [upperFromField.name, newLowerValue],
+                [lowerToField.name, newUpperValue],
                 [lowerFromField.name, null],
                 [upperToField.name, null],
             );
         }
-    }, [
-        strictMode,
-        lowerValue,
-        upperValue,
-        lowerFromField,
-        lowerToField,
-        upperFromField,
-        upperToField,
-        setSomeFieldValues,
-    ]);
+    };
+
+    const handleStrictToggle = (strict: boolean) => {
+        setStrictMode(strict);
+        commit(strict, lowerValue, upperValue);
+    };
 
     return (
         <div key={field.name} className='flex flex-col border p-3 mb-3 rounded-md border-gray-300'>
@@ -128,7 +128,7 @@ export const DateRangeField = ({ field, fieldValues, setSomeFieldValues }: DateR
                         outline
                         className='checked:border-gray-300'
                         checked={strictMode}
-                        onChange={(event) => setStrictMode(event.target.checked)}
+                        onChange={(event) => handleStrictToggle(event.target.checked)}
                     />
                 </label>
             </div>
@@ -143,7 +143,7 @@ export const DateRangeField = ({ field, fieldValues, setSomeFieldValues }: DateR
                 setSomeFieldValues={([_, value]) => {
                     // DateField passes a single tuple [fieldName, value]
                     const validatedValue = validateSingleValue(value, `${field.name}-from`);
-                    setLowerValue(validatedValue);
+                    commit(strictMode, validatedValue, upperValue);
                 }}
             />
             <DateField
@@ -156,7 +156,7 @@ export const DateRangeField = ({ field, fieldValues, setSomeFieldValues }: DateR
                 setSomeFieldValues={([_, value]) => {
                     // DateField passes a single tuple [fieldName, value]
                     const validatedValue = validateSingleValue(value, `${field.name}-to`);
-                    setUpperValue(validatedValue);
+                    commit(strictMode, lowerValue, validatedValue);
                 }}
             />
         </div>


### PR DESCRIPTION
Relates to https://loculus.slack.com/archives/C05G172HL6L/p1781275386940369 - hard to reproduce the original issue to test but the new approach seems strictly better, and less code (apart from added tests)

Below written by AI


____________
## Problem

The **Collection date** From/To inputs (and any other field configured with `rangeOverlapSearch`) could intermittently **bounce back and forth between two values while typing** — a race condition reported during normal use of the search page.

## Root cause

In the default Loculus config, `collectionDate` uses `rangeOverlapSearch` (`kubernetes/loculus/values.yaml`), so the "Collection date / From / To" box is rendered by **`DateRangeField`**.

`DateRangeField` kept its **own** `lowerValue`/`upperValue` state and synced it **bidirectionally** with the global `fieldValues` via two `useEffect`s:

- **write effect:** local state → `setSomeFieldValues` → URL/query state → re-derived `fieldValues`
- **read effect:** `fieldValues` → `setLowerValue`/`setUpperValue`

`fieldValues` is recomputed from URL state on every change and **lags one round-trip behind** while typing (each keystroke goes through `setSomeFieldValues` + `setPage(1)` + a parent `useMemo`). When you type a second character before the first round-trip lands, the read effect fires with a **stale** `fieldValues` and resets the local state backward; the write effect then pushes that stale value back out — so the field ping-pongs between the freshly typed value and the lagging one. This is the classic two-effect mirror race.

This is a longstanding bug, not a regression from a recent change.

## Fix

Make `fieldValues` the **single source of truth**:

- Remove the `lowerValue`/`upperValue` local state and **both** mirroring effects.
- Derive the displayed values directly from `fieldValues`.
- Write only on **real user interaction** via a `commit(...)` helper invoked from the date inputs' `onChange` and the strict-mode toggle — never from an effect, so there is no feedback loop.
- Keep a single effect that re-derives `strictMode` from the populated fields (guarded so toggling strictness with no dates entered doesn't snap back). It is a pure function of which fields exist and cannot oscillate against the writes.

No behavioural change to how dates map onto the four underlying `Lower*/Upper*` fields, or to strict/non-strict mode switching.

## Tests

- Added a test asserting **no write happens on mount** (rendering must not push values back into query state).
- Rewrote the "updates query params" test to use a stateful wrapper that feeds values back through `fieldValues` (the old version passed only because the buggy local mirror accumulated edits without any feedback) and assert **both** edits are retained — i.e. neither value bounces back.
- All `DateRangeField` (12) and `DateField` (4) tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: https://fix-date-range-field-boun.loculus.org