### PR TITLE
refactor(website): fold `.outlineButton` CSS class into the Button `outline` variant

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/DowloadDialogButton.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DowloadDialogButton.tsx
@@ -27,7 +27,7 @@ export const DownloadDialogButton: FC<DownloadDialogButtonProps> = ({ onClick, s
         buttonWidthClass = 'w-60'; // this width is fine for up to two digit numbers
     }
     return (
-        <Button className={buttonWidthClass + ' outlineButton'} onClick={onClick}>
+        <Button variant='outline' className={buttonWidthClass} onClick={onClick}>
             {buttonText}
         </Button>
     );

--- a/website/src/components/SearchPage/DownloadDialog/DownloadSubmittedDataButton.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadSubmittedDataButton.tsx
@@ -109,7 +109,8 @@ export const DownloadSubmittedDataButton: FC<DownloadSubmittedDataButtonProps> =
         <div className='relative'>
             <div className='group relative inline-block'>
                 <Button
-                    className={`w-[18rem] outlineButton ${exceedsLimit ? 'opacity-50 cursor-not-allowed hover:bg-white hover:text-primary-600' : ''}`}
+                    variant='outline'
+                    className={`w-[18rem] ${exceedsLimit ? 'opacity-50 cursor-not-allowed hover:bg-white hover:text-primary-600' : ''}`}
                     onClick={() => void handleDownload()}
                     disabled={isDisabled}
                 >

--- a/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
@@ -12,6 +12,7 @@ import { getSegmentLapisNames } from '../../../utils/sequenceTypeHelpers';
 import { processTemplate, matchPlaceholders } from '../../../utils/templateProcessor';
 import { BaseDialog } from '../../common/BaseDialog';
 import { Button } from '../../common/Button';
+import { buttonClasses } from '../../common/buttonStyles';
 import DashiconsExternal from '~icons/dashicons/external';
 import IwwaArrowDown from '~icons/iwwa/arrow-down';
 
@@ -204,7 +205,10 @@ export const LinkOutMenu: FC<LinkOutMenuProps> = ({
         <>
             <Menu as='div' className='ml-2 relative inline-block text-left'>
                 <MenuButton
-                    className='outlineButton flex items-center min-w-[100px] justify-between h-full'
+                    className={buttonClasses({
+                        variant: 'outline',
+                        className: 'flex items-center min-w-[100px] justify-between',
+                    })}
                     onClick={() => setIsOpen(!isOpen)}
                 >
                     <span>Tools</span>

--- a/website/src/components/SearchPage/SeqPreviewModal.tsx
+++ b/website/src/components/SearchPage/SeqPreviewModal.tsx
@@ -21,7 +21,7 @@ import MdiDockBottom from '~icons/mdi/dock-bottom';
 import OouiNewWindowLtr from '~icons/ooui/new-window-ltr';
 
 const BUTTONCLASS =
-    'inline-flex justify-center px-4 py-2 text-sm font-medium text-gray-900 border border-transparent rounded-md hover:bg-blue-200 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary-500';
+    'inline-flex justify-center px-4 py-2 text-sm font-medium text-primary-700 border border-transparent rounded-md hover:bg-primary-100 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary-500';
 
 interface SeqPreviewModalProps {
     seqId: string;

--- a/website/src/components/SearchPage/SeqPreviewModal.tsx
+++ b/website/src/components/SearchPage/SeqPreviewModal.tsx
@@ -21,7 +21,7 @@ import MdiDockBottom from '~icons/mdi/dock-bottom';
 import OouiNewWindowLtr from '~icons/ooui/new-window-ltr';
 
 const BUTTONCLASS =
-    'inline-flex justify-center px-4 py-2 text-sm font-medium text-primary-700 border border-transparent rounded-md hover:bg-primary-100 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary-500';
+    'inline-flex justify-center px-4 py-2 text-sm font-medium text-gray-900 border border-transparent rounded-md hover:bg-blue-200 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary-500';
 
 interface SeqPreviewModalProps {
     seqId: string;

--- a/website/src/components/SeqSetCitations/SeqSetItem.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItem.tsx
@@ -211,7 +211,8 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
                 title='Statistics'
                 headerContent={
                     <Button
-                        className='mt-1 outlineButton flex items-center gap-2'
+                        variant='outline'
+                        className='mt-1 flex items-center gap-2'
                         onClick={() => setWideGraphs((prev) => !prev)}
                     >
                         {wideGraphs ? <MdiViewGrid /> : <MdiDotsGrid />}

--- a/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
@@ -100,21 +100,24 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
             <div className='inline-block ml-auto'>
                 <div className='flex justify-start items-center pb-8 gap-2'>
                     <Button
-                        className='outlineButton flex items-center gap-2'
+                        variant='outline'
+                        className='flex items-center gap-2'
                         onClick={() => setExportModalVisible(true)}
                     >
                         <MdiDownload className='w-4 h-4' />
                         <span className='hidden sm:block'>Export / Cite</span>
                     </Button>
                     <Button
-                        className='outlineButton flex items-center gap-2'
+                        variant='outline'
+                        className='flex items-center gap-2'
                         onClick={() => setCreatorInfoVisible(true)}
                     >
                         <MdiInformationOutline className='w-4 h-4' />
                         <span className='hidden sm:block'>More details</span>
                     </Button>
                     <Button
-                        className='outlineButton flex items-center gap-2'
+                        variant='outline'
+                        className='flex items-center gap-2'
                         onClick={() => setCitationsModalVisible(true)}
                     >
                         <MdiViewListOutline className='w-4 h-4' />
@@ -122,7 +125,8 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
                     </Button>
                     {isAdminView ? (
                         <Button
-                            className='outlineButton flex items-center gap-2'
+                            variant='outline'
+                            className='flex items-center gap-2'
                             onClick={() => setEditModalVisible(true)}
                         >
                             <MdiPencil className='w-4 h-4' />
@@ -131,7 +135,8 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
                     ) : null}
                     {isAdminView && (seqSet.seqSetDOI === null || seqSet.seqSetDOI === undefined) ? (
                         <Button
-                            className='outlineButton flex items-center gap-2'
+                            variant='outline'
+                            className='flex items-center gap-2'
                             onClick={() =>
                                 displayConfirmationDialog({
                                     dialogText: `Are you sure you want to delete this seqSet version?`,

--- a/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceEntryHistoryMenu.tsx
@@ -28,7 +28,14 @@ export const SequenceEntryHistoryMenu: React.FC<Props> = ({
                 trigger={
                     <label
                         tabIndex={0}
-                        className={buttonClasses({ size: 'sm', variant: 'outline', className: 'py-1' })}
+                        // Kept black (rather than the primary `outline` variant) to match the
+                        // dark control icons it sits next to in SeqPreviewModal.
+                        className={buttonClasses({
+                            size: 'sm',
+                            variant: 'unstyled',
+                            className:
+                                'py-1 bg-transparent border-base-content text-base-content hover:bg-base-content hover:text-base-100',
+                        })}
                     >
                         <span className='text-sm'>
                             {selectedVersion === undefined ? 'All versions' : `Version ${selectedVersion.version}`}

--- a/website/src/components/common/Button.spec.tsx
+++ b/website/src/components/common/Button.spec.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Button } from './Button';
+import { buttonClasses } from './buttonStyles';
+
+// Both Button and DisabledUntilHydrated read this hook; mocking it lets us drive
+// the pre-/post-hydration states deterministically.
+let mockIsClient = true;
+vi.mock('../../hooks/isClient', () => ({
+    default: () => mockIsClient,
+}));
+
+describe('buttonClasses', () => {
+    it('applies the variant look when not disabled', () => {
+        const cls = buttonClasses({ variant: 'primary' });
+        expect(cls).toContain('bg-[var(--color-main)]');
+        expect(cls).not.toContain('bg-base-content/10');
+    });
+
+    it('replaces the variant look with the disabled look when disabled', () => {
+        const cls = buttonClasses({ variant: 'primary', disabled: true });
+        expect(cls).toContain('bg-base-content/10');
+        expect(cls).toContain('pointer-events-none');
+        expect(cls).not.toContain('bg-[var(--color-main)]');
+    });
+});
+
+describe('Button hydration state', () => {
+    afterEach(() => {
+        mockIsClient = true;
+    });
+
+    it('shows a loading cursor and keeps the enabled look while waiting for hydration', () => {
+        mockIsClient = false;
+        render(<Button variant='primary'>Go</Button>);
+        const btn = screen.getByRole('button', { name: 'Go' });
+        expect(btn).toBeDisabled();
+        expect(btn.className).toContain('cursor-wait');
+        expect(btn.className).toContain('bg-[var(--color-main)]');
+        expect(btn.className).not.toContain('bg-base-content/10');
+    });
+
+    it('shows the disabled look (not a loading cursor) when genuinely disabled', () => {
+        mockIsClient = false; // a real disable wins even before hydration
+        render(
+            <Button variant='primary' alsoDisabledIf>
+                Go
+            </Button>,
+        );
+        const btn = screen.getByRole('button', { name: 'Go' });
+        expect(btn).toBeDisabled();
+        expect(btn.className).toContain('bg-base-content/10');
+        expect(btn.className).not.toContain('cursor-wait');
+    });
+
+    it('shows the normal enabled look once hydrated', () => {
+        mockIsClient = true;
+        render(<Button variant='primary'>Go</Button>);
+        const btn = screen.getByRole('button', { name: 'Go' });
+        expect(btn).toBeEnabled();
+        expect(btn.className).toContain('bg-[var(--color-main)]');
+        expect(btn.className).not.toContain('cursor-wait');
+        expect(btn.className).not.toContain('bg-base-content/10');
+    });
+});

--- a/website/src/components/common/Button.tsx
+++ b/website/src/components/common/Button.tsx
@@ -1,6 +1,7 @@
 import { type AnchorHTMLAttributes, type ButtonHTMLAttributes, type Ref, forwardRef } from 'react';
 
 import { type ButtonSize, type ButtonVariant, buttonClasses } from './buttonStyles';
+import useClientFlag from '../../hooks/isClient';
 import DisabledUntilHydrated from '../DisabledUntilHydrated';
 
 type StyleProps = {
@@ -22,12 +23,20 @@ type AnchorElementProps = StyleProps &
 
 export type ButtonProps = ButtonElementProps | AnchorElementProps;
 
-const resolveClassName = ({ variant, size, circle, className }: StyleProps & { className?: string }) => {
+const resolveClassName = ({
+    variant,
+    size,
+    circle,
+    className,
+    disabled = false,
+}: StyleProps & { className?: string; disabled?: boolean }) => {
     const styled = variant !== undefined || size !== undefined || circle !== undefined;
-    return styled ? buttonClasses({ variant, size, circle, className }) : className;
+    return styled ? buttonClasses({ variant, size, circle, className, disabled }) : className;
 };
 
 export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>((props, ref) => {
+    const isClient = useClientFlag();
+
     if (props.as === 'a') {
         const { as: _as, variant, size, circle, className, ...rest } = props;
         return (
@@ -40,12 +49,23 @@ export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonPr
     }
 
     const { as: _as, alsoDisabledIf, disabled, variant, size, circle, className, ...rest } = props;
+    const reallyDisabled = alsoDisabledIf ?? disabled ?? false;
+    // The button is also disabled until hydration completes (see DisabledUntilHydrated below).
+    // When that is the *only* reason it's disabled, keep the normal enabled look and just show a
+    // loading cursor, rather than flashing the greyed-out disabled style before the page is ready.
+    const hydrating = !isClient && !reallyDisabled;
     return (
         <DisabledUntilHydrated alsoDisabledIf={alsoDisabledIf ?? disabled}>
             {/* eslint-disable-next-line no-restricted-syntax -- This is the wrapper component itself */}
             <button
                 ref={ref as Ref<HTMLButtonElement>}
-                className={resolveClassName({ variant, size, circle, className })}
+                className={resolveClassName({
+                    variant,
+                    size,
+                    circle,
+                    disabled: reallyDisabled,
+                    className: [className, hydrating ? 'cursor-wait' : ''].filter(Boolean).join(' ') || undefined,
+                })}
                 {...rest}
             />
         </DisabledUntilHydrated>

--- a/website/src/components/common/buttonStyles.ts
+++ b/website/src/components/common/buttonStyles.ts
@@ -9,7 +9,7 @@ interface ButtonClassOptions {
 }
 
 const base =
-    'inline-flex items-center justify-center gap-1.5 font-semibold rounded border transition-colors duration-200 ' +
+    'inline-flex items-center justify-center gap-1.5 font-semibold rounded-md border transition-colors duration-200 ' +
     'disabled:pointer-events-none disabled:bg-base-content/10 disabled:text-base-content/20 disabled:border-transparent';
 
 const sizeClasses: Record<ButtonSize, string> = {
@@ -28,7 +28,7 @@ const variantClasses: Record<ButtonVariant, string> = {
     neutral: 'bg-base-200 text-base-content border-base-300 hover:bg-base-300',
     primary: 'bg-[var(--color-main)] text-white border-transparent hover:bg-primary-700',
     ghost: 'bg-transparent border-transparent hover:bg-base-200',
-    outline: 'bg-transparent border-base-content text-base-content hover:bg-base-content hover:text-base-100',
+    outline: 'bg-white border-primary-600 text-primary-600 hover:bg-primary-600 hover:text-white',
     unstyled: '',
 };
 

--- a/website/src/components/common/buttonStyles.ts
+++ b/website/src/components/common/buttonStyles.ts
@@ -6,11 +6,19 @@ interface ButtonClassOptions {
     variant?: ButtonVariant;
     circle?: boolean;
     className?: string;
+    disabled?: boolean;
 }
 
 const base =
-    'inline-flex items-center justify-center gap-1.5 font-semibold rounded-md border transition-colors duration-200 ' +
-    'disabled:pointer-events-none disabled:bg-base-content/10 disabled:text-base-content/20 disabled:border-transparent';
+    'inline-flex items-center justify-center gap-1.5 font-semibold rounded-md border transition-colors duration-200';
+
+/*
+ * The greyed-out look for a genuinely-disabled button. Applied explicitly via
+ * the `disabled` option rather than the `:disabled` pseudo-class, so a button
+ * that is only temporarily disabled while waiting for hydration can opt out of
+ * this look (and show a loading cursor instead) -- see `Button.tsx`.
+ */
+const disabledLook = 'pointer-events-none bg-base-content/10 text-base-content/20 border-transparent';
 
 const sizeClasses: Record<ButtonSize, string> = {
     md: 'h-10 px-4 text-sm',
@@ -37,8 +45,14 @@ export function buttonClasses({
     variant = 'neutral',
     circle = false,
     className = '',
+    disabled = false,
 }: ButtonClassOptions = {}): string {
-    return [base, circle ? circleSizeClasses[size] : sizeClasses[size], variantClasses[variant], className]
+    return [
+        base,
+        circle ? circleSizeClasses[size] : sizeClasses[size],
+        disabled ? disabledLook : variantClasses[variant],
+        className,
+    ]
         .filter(Boolean)
         .join(' ');
 }

--- a/website/src/styles/base.css
+++ b/website/src/styles/base.css
@@ -125,11 +125,6 @@ a {
 }
 
 @layer utilities {
-    .outlineButton {
-        @apply normal-case py-2 rounded-md font-semibold px-4 text-sm border-primary-600 border text-primary-600 bg-white
-    hover:bg-primary-600 hover:text-white;
-    }
-
     .outlineButtonDropdownItem {
         @apply text-primary-600 hover:text-primary-600 hover:bg-gray-100;
     }


### PR DESCRIPTION
closes #6663

## What

The Button component library (introduced in #6604) already defines an `outline` variant in `buttonStyles.ts`, but a parallel global **`.outlineButton`** CSS class in `base.css` was still the de-facto standard for outline-style buttons (~10 usages) and was never folded into the library. The two weren't even consistent: the typed `outline` variant rendered **dark/near-black**, while `.outlineButton` rendered **primary-coloured**.

This PR integrates that style into the component library so there is a canonical outline button.

Addresses #6663 (and chips away at the broader button-variety cleanup in #6662).

## Changes

- **`buttonStyles.ts`**: redefine the `outline` variant to be primary-coloured (`bg-white border-primary-600 text-primary-600 hover:bg-primary-600 hover:text-white`), matching the dominant real-world `.outlineButton` look rather than the lone dark one.
- **`buttonStyles.ts`**: standardise the shared button radius on `rounded-md` (6px) instead of `rounded` (4px). The migrated outline buttons already used 6px, so this keeps them pixel-identical and nudges every other library button (primary/neutral/ghost) to the same single radius. Circle buttons are unaffected (`rounded-full` still wins).
- Migrate every `.outlineButton` call site to `variant='outline'`:
  - `DowloadDialogButton.tsx` ("Download all entries")
  - `DownloadSubmittedDataButton.tsx`
  - `LinkOutMenu.tsx` — a Headless UI `MenuButton`, so it uses `buttonClasses({ variant: 'outline', ... })`
  - `SeqSetItemActions.tsx` (×5) and `SeqSetItem.tsx`
- Remove `.outlineButton` from `base.css`.
- **`SequenceEntryHistoryMenu.tsx`** (the version dropdown) previously used the `outline` variant, so it would have turned primary. It's kept **dark** instead — to match the black control icons it sits beside in `SeqPreviewModal` — via one-off utility classes rather than reviving a dark variant in the design system.

The related `.outlineButtonDropdownItem` class is a menu-item *text* style (not a button) and is left untouched. The broader "cut down button variety" work (#6662) is separate.

![outline button before/after](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-outline-button/outline-before-after.png)

## Bonus: no greyed-out flash before hydration

Buttons are disabled until React hydration completes (`DisabledUntilHydrated`) so Playwright can't interact with them too early. That greyed-out disabled look lived in the shared button `base` as `:disabled` pseudo-classes, so it also applied during the brief pre-hydration window — buttons flashed the disabled style on load.

Now the disabled look is applied **by intent** instead: `buttonClasses` takes a `disabled` option (swapping the variant look for the greyed-out look) and the `:disabled` pseudo-classes are removed from `base`. The Button component distinguishes "genuinely disabled" (keeps the greyed-out look) from "only waiting for hydration" (keeps the normal enabled appearance and shows a `cursor-wait` loading cursor). Covered by a new `Button.spec.tsx`.

## Notes

- `tsc` on the changed files is clean; `Button.spec.tsx`, the DownloadDialog suite, and `SequenceEntryHistoryMenu.spec.tsx` pass. The repo's `astro check` / full `tsc` currently fail in this environment on pre-existing unrelated missing-dependency issues (flowbite-react plugin, `minisearch`, `exceljs`) — present on `main` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: https://integrate-outline-button.loculus.org