### PR TITLE
feat(website): rename "Submit" button and Review page title

### DIFF
--- a/integration-tests/tests/pages/review.page.ts
+++ b/integration-tests/tests/pages/review.page.ts
@@ -26,12 +26,12 @@ export class ReviewPage {
     private sequenceTabs = () => this.page.getByRole('tab');
 
     public readonly approveAllButton = () =>
-        this.page.getByRole('button', { name: 'Release', exact: false });
+        this.page.getByRole('button', { name: 'Approve', exact: false });
     public readonly discardOpenMenuButton = () =>
         this.page.getByRole('button', { name: 'Discard sequences', exact: false });
     public readonly discardAllButton = () => this.page.getByText('Discard all', { exact: false });
     public readonly confirmReleaseButton = () =>
-        this.page.getByRole('button', { name: 'Release', exact: true });
+        this.page.getByRole('button', { name: 'Approve', exact: true });
     public readonly confirmDiscardButton = () =>
         this.page.getByRole('button', { name: 'Discard', exact: true });
 
@@ -146,9 +146,9 @@ export class ReviewPage {
     }
 
     async releaseValidSequences() {
-        await this.page.getByRole('button', { name: /Release \d+ valid sequence/ }).click();
-        await this.page.getByRole('button', { name: 'Release', exact: true }).click();
-        await expect(this.page.getByText('released successfully')).toBeVisible();
+        await this.page.getByRole('button', { name: /Approve \d+ valid sequence/ }).click();
+        await this.page.getByRole('button', { name: 'Approve', exact: true }).click();
+        await expect(this.page.getByText(/(Sequence|have been) approved/)).toBeVisible();
     }
 
     async goToReleasedSequences(): Promise<SearchPage> {

--- a/integration-tests/tests/pages/revision.page.ts
+++ b/integration-tests/tests/pages/revision.page.ts
@@ -52,10 +52,10 @@ export class RevisionPage {
     }
 
     /**
-     * Click the Submit button
+     * Click the Upload (submit) button
      */
     async clickSubmit() {
-        await this.page.getByRole('button', { name: 'Submit' }).click();
+        await this.page.getByRole('button', { name: 'Upload and proceed to Approval' }).click();
     }
 
     /**

--- a/integration-tests/tests/pages/submission.page.ts
+++ b/integration-tests/tests/pages/submission.page.ts
@@ -50,7 +50,7 @@ class SubmissionPage {
     // TODO #5357: improve this function by passing in whether we accepted open terms to simplify and also test modal appearance/absence
     async submitSequence(): Promise<ReviewPage> {
         await this.page
-            .getByRole('button', { name: 'Submit sequences' })
+            .getByRole('button', { name: 'Upload (and proceed to Approval)' })
             .click({ timeout: 10_000 });
 
         // 'Continue under Open terms' only shows if we are submitting under open terms - but we don't know in this function

--- a/integration-tests/tests/pages/submission.page.ts
+++ b/integration-tests/tests/pages/submission.page.ts
@@ -50,7 +50,7 @@ class SubmissionPage {
     // TODO #5357: improve this function by passing in whether we accepted open terms to simplify and also test modal appearance/absence
     async submitSequence(): Promise<ReviewPage> {
         await this.page
-            .getByRole('button', { name: 'Upload (and proceed to Approval)' })
+            .getByRole('button', { name: 'Upload and proceed to Approval' })
             .click({ timeout: 10_000 });
 
         // 'Continue under Open terms' only shows if we are submitting under open terms - but we don't know in this function

--- a/integration-tests/tests/specs/features/review-page.spec.ts
+++ b/integration-tests/tests/specs/features/review-page.spec.ts
@@ -10,7 +10,7 @@ test.describe('Review page functionality', () => {
         const reviewPage = new ReviewPage(page);
         await reviewPage.navigateToReviewPage();
         await expect(
-            page.getByRole('heading', { name: 'Review current submissions' }),
+            page.getByRole('heading', { name: 'Approve pending submissions' }),
         ).toBeVisible();
     });
 

--- a/integration-tests/tests/specs/features/review-page.spec.ts
+++ b/integration-tests/tests/specs/features/review-page.spec.ts
@@ -10,7 +10,7 @@ test.describe('Review page functionality', () => {
         const reviewPage = new ReviewPage(page);
         await reviewPage.navigateToReviewPage();
         await expect(
-            page.getByRole('heading', { name: 'Approve pending submissions' }),
+            page.getByRole('heading', { name: 'Review pending submissions' }),
         ).toBeVisible();
     });
 

--- a/integration-tests/tests/specs/features/search/override-hidden-fields.spec.ts
+++ b/integration-tests/tests/specs/features/search/override-hidden-fields.spec.ts
@@ -62,7 +62,7 @@ test('Override hidden fields', async ({ page, groupId }) => {
     await page.getByLabel('Collection date').fill('2012-12-13');
     await page.getByRole('button', { name: 'Submit' }).click();
     await page.getByRole('button', { name: 'Confirm' }).click();
-    await expect(page.getByText('Approve pending submissions')).toBeVisible();
+    await expect(page.getByText('Review pending submissions')).toBeVisible();
 
     search = new SearchPage(page);
     await search.ebolaSudan();

--- a/integration-tests/tests/specs/features/search/override-hidden-fields.spec.ts
+++ b/integration-tests/tests/specs/features/search/override-hidden-fields.spec.ts
@@ -62,7 +62,7 @@ test('Override hidden fields', async ({ page, groupId }) => {
     await page.getByLabel('Collection date').fill('2012-12-13');
     await page.getByRole('button', { name: 'Submit' }).click();
     await page.getByRole('button', { name: 'Confirm' }).click();
-    await expect(page.getByText('Review current submissions')).toBeVisible();
+    await expect(page.getByText('Approve pending submissions')).toBeVisible();
 
     search = new SearchPage(page);
     await search.ebolaSudan();

--- a/integration-tests/tests/specs/features/sequence-version-banners.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-version-banners.spec.ts
@@ -83,7 +83,7 @@ test.describe('Sequence version banners', () => {
         await page.getByLabel('Collection date').fill('2023-06-15');
         await page.getByRole('button', { name: 'Submit' }).click();
         await page.getByRole('button', { name: 'Confirm' }).click();
-        await expect(page.getByText('Review current submissions')).toBeVisible();
+        await expect(page.getByText('Approve pending submissions')).toBeVisible();
 
         // Find and revoke the Germany sequence
         await search.ebolaSudan();

--- a/integration-tests/tests/specs/features/sequence-version-banners.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-version-banners.spec.ts
@@ -83,7 +83,7 @@ test.describe('Sequence version banners', () => {
         await page.getByLabel('Collection date').fill('2023-06-15');
         await page.getByRole('button', { name: 'Submit' }).click();
         await page.getByRole('button', { name: 'Confirm' }).click();
-        await expect(page.getByText('Approve pending submissions')).toBeVisible();
+        await expect(page.getByText('Review pending submissions')).toBeVisible();
 
         // Find and revoke the Germany sequence
         await search.ebolaSudan();

--- a/integration-tests/tests/specs/features/sequence-view.dependent.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-view.dependent.spec.ts
@@ -32,7 +32,7 @@ test.describe('Sequence view in review card', () => {
         await submissionPage.submitSequence();
 
         await expect(
-            page.getByRole('heading', { name: 'Review current submissions' }),
+            page.getByRole('heading', { name: 'Approve pending submissions' }),
         ).toBeVisible();
 
         const reviewPage = new ReviewPage(page);

--- a/integration-tests/tests/specs/features/sequence-view.dependent.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-view.dependent.spec.ts
@@ -32,7 +32,7 @@ test.describe('Sequence view in review card', () => {
         await submissionPage.submitSequence();
 
         await expect(
-            page.getByRole('heading', { name: 'Approve pending submissions' }),
+            page.getByRole('heading', { name: 'Review pending submissions' }),
         ).toBeVisible();
 
         const reviewPage = new ReviewPage(page);

--- a/integration-tests/tests/specs/features/submission-flow.spec.ts
+++ b/integration-tests/tests/specs/features/submission-flow.spec.ts
@@ -39,7 +39,7 @@ test.describe('Submission flow', () => {
         await page.getByRole('button', { name: 'Continue under Open terms' }).click();
 
         await expect(
-            page.getByRole('heading', { name: 'Approve pending submissions' }),
+            page.getByRole('heading', { name: 'Review pending submissions' }),
         ).toBeVisible();
 
         const reviewPage = new ReviewPage(page);
@@ -87,7 +87,7 @@ test.describe('Submission flow', () => {
         const reviewPage = await submissionPage.submitSequence();
 
         await expect(
-            page.getByRole('heading', { name: 'Approve pending submissions' }),
+            page.getByRole('heading', { name: 'Review pending submissions' }),
         ).toBeVisible();
 
         await reviewPage.releaseAndGoToReleasedSequences();

--- a/integration-tests/tests/specs/features/submission-flow.spec.ts
+++ b/integration-tests/tests/specs/features/submission-flow.spec.ts
@@ -35,11 +35,11 @@ test.describe('Submission flow', () => {
         await page.getByLabel('I confirm that the data').check();
         await page.getByLabel('I confirm I have not and will').check();
 
-        await page.getByRole('button', { name: 'Submit sequences' }).click();
+        await page.getByRole('button', { name: 'Upload (and proceed to Approval)' }).click();
         await page.getByRole('button', { name: 'Continue under Open terms' }).click();
 
         await expect(
-            page.getByRole('heading', { name: 'Review current submissions' }),
+            page.getByRole('heading', { name: 'Approve pending submissions' }),
         ).toBeVisible();
 
         const reviewPage = new ReviewPage(page);
@@ -87,7 +87,7 @@ test.describe('Submission flow', () => {
         const reviewPage = await submissionPage.submitSequence();
 
         await expect(
-            page.getByRole('heading', { name: 'Review current submissions' }),
+            page.getByRole('heading', { name: 'Approve pending submissions' }),
         ).toBeVisible();
 
         await reviewPage.releaseAndGoToReleasedSequences();

--- a/integration-tests/tests/specs/features/submission-flow.spec.ts
+++ b/integration-tests/tests/specs/features/submission-flow.spec.ts
@@ -35,7 +35,7 @@ test.describe('Submission flow', () => {
         await page.getByLabel('I confirm that the data').check();
         await page.getByLabel('I confirm I have not and will').check();
 
-        await page.getByRole('button', { name: 'Upload (and proceed to Approval)' }).click();
+        await page.getByRole('button', { name: 'Upload and proceed to Approval' }).click();
         await page.getByRole('button', { name: 'Continue under Open terms' }).click();
 
         await expect(

--- a/integration-tests/tests/specs/features/trim-ns.spec.ts
+++ b/integration-tests/tests/specs/features/trim-ns.spec.ts
@@ -30,7 +30,7 @@ test.describe('Sequence N trimming functionality', () => {
         const reviewPage = await submissionPage.submitSequence();
 
         await expect(
-            page.getByRole('heading', { name: 'Approve pending submissions' }),
+            page.getByRole('heading', { name: 'Review pending submissions' }),
         ).toBeVisible();
 
         await reviewPage.waitForZeroProcessing();

--- a/integration-tests/tests/specs/features/trim-ns.spec.ts
+++ b/integration-tests/tests/specs/features/trim-ns.spec.ts
@@ -30,7 +30,7 @@ test.describe('Sequence N trimming functionality', () => {
         const reviewPage = await submissionPage.submitSequence();
 
         await expect(
-            page.getByRole('heading', { name: 'Review current submissions' }),
+            page.getByRole('heading', { name: 'Approve pending submissions' }),
         ).toBeVisible();
 
         await reviewPage.waitForZeroProcessing();

--- a/website/src/components/ReviewPage/ReviewCard.tsx
+++ b/website/src/components/ReviewPage/ReviewCard.tsx
@@ -30,11 +30,11 @@ import Note from '~icons/fluent/note-24-filled';
 import QuestionMark from '~icons/fluent/tag-question-mark-24-filled';
 import Locked from '~icons/fluent-emoji-high-contrast/locked';
 import Unlocked from '~icons/fluent-emoji-high-contrast/unlocked';
+import FormkitSubmit from '~icons/formkit/submit';
 import EmptyCircle from '~icons/grommet-icons/empty-circle';
 import Files from '~icons/lucide/files';
 import RiDna from '~icons/mdi/dna';
 import TickOutline from '~icons/mdi/tick-outline';
-import FormkitSubmit from '~icons/formkit/submit';
 
 type ReviewCardProps = {
     sequenceEntryStatus: SequenceEntryStatus;

--- a/website/src/components/ReviewPage/ReviewCard.tsx
+++ b/website/src/components/ReviewPage/ReviewCard.tsx
@@ -211,9 +211,9 @@ const ButtonBar: FC<ButtonBarProps> = ({
                     id={'approve-tooltip' + sequenceEntryStatus.accession}
                     content={
                         approvable
-                            ? 'Release this sequence entry'
+                            ? 'Approve this sequence entry'
                             : sequenceEntryStatus.processingResult === errorsProcessingResult
-                              ? 'You need to fix the errors before releasing this sequence entry'
+                              ? 'You need to fix the errors before approving this sequence entry'
                               : 'Still awaiting preprocessing'
                     }
                 />
@@ -301,7 +301,7 @@ const Errors: FC<ErrorsProps> = ({ errors, accession, metadataDisplayNames }) =>
                             </p>
                             <CustomTooltip
                                 id={'error-tooltip-' + accession + '-' + uniqueKey}
-                                content='You must fix this error before releasing this sequence entry'
+                                content='You must fix this error before approving this sequence entry'
                             />
                         </div>
                     );

--- a/website/src/components/ReviewPage/ReviewCard.tsx
+++ b/website/src/components/ReviewPage/ReviewCard.tsx
@@ -34,7 +34,7 @@ import EmptyCircle from '~icons/grommet-icons/empty-circle';
 import Files from '~icons/lucide/files';
 import RiDna from '~icons/mdi/dna';
 import TickOutline from '~icons/mdi/tick-outline';
-import WpfPaperPlane from '~icons/wpf/paper-plane';
+import FormkitSubmit from '~icons/formkit/submit';
 
 type ReviewCardProps = {
     sequenceEntryStatus: SequenceEntryStatus;
@@ -205,7 +205,7 @@ const ButtonBar: FC<ButtonBarProps> = ({
                     key={'approve-button-' + sequenceEntryStatus.accession}
                     disabled={!approvable}
                 >
-                    <WpfPaperPlane />
+                    <FormkitSubmit />
                 </Button>
                 <CustomTooltip
                     id={'approve-tooltip' + sequenceEntryStatus.accession}

--- a/website/src/components/ReviewPage/ReviewPage.spec.tsx
+++ b/website/src/components/ReviewPage/ReviewPage.spec.tsx
@@ -183,18 +183,18 @@ describe('ReviewPage', () => {
 
         await waitFor(() => {
             expect(getByText((text) => text.includes('Discard 1 sequence with errors'))).toBeDefined();
-            expect(getByText((text) => text.includes('Release 1 valid sequence'))).toBeDefined();
+            expect(getByText((text) => text.includes('Approve 1 valid sequence'))).toBeDefined();
         });
 
         mockRequest.backend.getSequences(200, generateGetSequencesResponse([]));
 
-        await userEvent.click(getByText((text) => text.includes('Release 1 valid sequence')));
+        await userEvent.click(getByText((text) => text.includes('Approve 1 valid sequence')));
 
         await waitFor(() => {
-            expect(getByText('Release')).toBeDefined();
+            expect(getByText('Approve')).toBeDefined();
         });
 
-        await userEvent.click(getByText('Release'));
+        await userEvent.click(getByText('Approve'));
 
         await waitFor(() => {
             expect(getByText(unreleasedSequencesRegex)).toBeDefined();

--- a/website/src/components/ReviewPage/ReviewPage.tsx
+++ b/website/src/components/ReviewPage/ReviewPage.tsx
@@ -321,7 +321,8 @@ const InnerReviewPage: FC<ReviewPageProps> = ({
                     className='border rounded-md p-1 bg-primary-600 text-white px-2'
                     onClick={() =>
                         displayConfirmationDialog({
-                            dialogText: 'Are you sure you want to approve all valid sequences?',
+                            dialogText:
+                                'Are you sure you want to approve all valid sequences? This is the final step and will release them to the public.',
                             confirmButtonText: 'Approve',
                             onConfirmation: () => {
                                 hooks.approveProcessedData({

--- a/website/src/components/ReviewPage/ReviewPage.tsx
+++ b/website/src/components/ReviewPage/ReviewPage.tsx
@@ -322,7 +322,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({
                     onClick={() =>
                         displayConfirmationDialog({
                             dialogText:
-                                'Are you sure you want to approve all valid sequences? This is the final step and will release them to the public.',
+                                'Are you sure you want to approve all valid sequences for release?',
                             confirmButtonText: 'Approve',
                             onConfirmation: () => {
                                 hooks.approveProcessedData({

--- a/website/src/components/ReviewPage/ReviewPage.tsx
+++ b/website/src/components/ReviewPage/ReviewPage.tsx
@@ -321,8 +321,8 @@ const InnerReviewPage: FC<ReviewPageProps> = ({
                     className='border rounded-md p-1 bg-primary-600 text-white px-2'
                     onClick={() =>
                         displayConfirmationDialog({
-                            dialogText: 'Are you sure you want to release all valid sequences?',
-                            confirmButtonText: 'Release',
+                            dialogText: 'Are you sure you want to approve all valid sequences?',
+                            confirmButtonText: 'Approve',
                             onConfirmation: () => {
                                 hooks.approveProcessedData({
                                     groupIdsFilter: [group.groupId],
@@ -335,7 +335,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({
                     }
                 >
                     <WpfPaperPlane className='inline-block w-4 h-4 -mt-0.5 mr-1.5' />
-                    Release {validCount} valid sequence
+                    Approve {validCount} valid sequence
                     {validCount > 1 ? 's' : ''}
                 </Button>
             )}

--- a/website/src/components/ReviewPage/ReviewPage.tsx
+++ b/website/src/components/ReviewPage/ReviewPage.tsx
@@ -30,9 +30,9 @@ import { Button } from '../common/Button';
 import { Spinner } from '../common/Spinner';
 import { withQueryProvider } from '../common/withQueryProvider.tsx';
 import BiTrash from '~icons/bi/trash';
+import FormkitSubmit from '~icons/formkit/submit';
 import IwwaArrowDown from '~icons/iwwa/arrow-down';
 import LucideFilter from '~icons/lucide/filter';
-import FormkitSubmit from '~icons/formkit/submit';
 
 const menuItemClassName = `group flex rounded-md items-center w-full px-2 py-2 text-sm
 hover:bg-primary-500 bg-primary-600 text-white text-left mb-1`;

--- a/website/src/components/ReviewPage/ReviewPage.tsx
+++ b/website/src/components/ReviewPage/ReviewPage.tsx
@@ -321,8 +321,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({
                     className='border rounded-md p-1 bg-primary-600 text-white px-2'
                     onClick={() =>
                         displayConfirmationDialog({
-                            dialogText:
-                                'Are you sure you want to approve all valid sequences for release?',
+                            dialogText: 'Are you sure you want to approve all valid sequences for release?',
                             confirmButtonText: 'Approve',
                             onConfirmation: () => {
                                 hooks.approveProcessedData({

--- a/website/src/components/ReviewPage/ReviewPage.tsx
+++ b/website/src/components/ReviewPage/ReviewPage.tsx
@@ -32,7 +32,7 @@ import { withQueryProvider } from '../common/withQueryProvider.tsx';
 import BiTrash from '~icons/bi/trash';
 import IwwaArrowDown from '~icons/iwwa/arrow-down';
 import LucideFilter from '~icons/lucide/filter';
-import WpfPaperPlane from '~icons/wpf/paper-plane';
+import FormkitSubmit from '~icons/formkit/submit';
 
 const menuItemClassName = `group flex rounded-md items-center w-full px-2 py-2 text-sm
 hover:bg-primary-500 bg-primary-600 text-white text-left mb-1`;
@@ -334,7 +334,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({
                         })
                     }
                 >
-                    <WpfPaperPlane className='inline-block w-4 h-4 -mt-0.5 mr-1.5' />
+                    <FormkitSubmit className='inline-block w-4 h-4 -mt-0.5 mr-1.5' />
                     Approve {validCount} valid sequence
                     {validCount > 1 ? 's' : ''}
                 </Button>

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -226,7 +226,7 @@ const InnerDataUploadForm = ({
                             <Spinner size='sm' />
                         </div>
                         <span className='flex-1 text-center mx-8'>
-                            {action === 'submit' ? 'Upload (and proceed to Approval)' : 'Submit sequences'}
+                            {action === 'submit' ? 'Upload and proceed to Approval' : 'Submit sequences'}
                         </span>
                     </Button>
                 </div>

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -225,7 +225,9 @@ const InnerDataUploadForm = ({
                         <div className={`absolute ml-1.5 inline-flex ${isPending ? 'visible' : 'invisible'}`}>
                             <Spinner size='sm' />
                         </div>
-                        <span className='flex-1 text-center mx-8'>Submit sequences</span>
+                        <span className='flex-1 text-center mx-8'>
+                            {action === 'submit' ? 'Upload (and proceed to Approval)' : 'Submit sequences'}
+                        </span>
                     </Button>
                 </div>
             </div>

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -225,9 +225,7 @@ const InnerDataUploadForm = ({
                         <div className={`absolute ml-1.5 inline-flex ${isPending ? 'visible' : 'invisible'}`}>
                             <Spinner size='sm' />
                         </div>
-                        <span className='flex-1 text-center mx-8'>
-                            {action === 'submit' ? 'Upload and proceed to Approval' : 'Submit sequences'}
-                        </span>
+                        <span className='flex-1 text-center mx-8'>Upload and proceed to Approval</span>
                     </Button>
                 </div>
             </div>

--- a/website/src/components/Submission/SubmissionForm.spec.tsx
+++ b/website/src/components/Submission/SubmissionForm.spec.tsx
@@ -120,7 +120,7 @@ describe('SubmitForm', () => {
                 getByLabelText(/I confirm that the data submitted is not sensitive or human-identifiable/i),
             );
 
-            const submitButton = getByRole('button', { name: 'Upload (and proceed to Approval)' });
+            const submitButton = getByRole('button', { name: 'Upload and proceed to Approval' });
             await userEvent.click(submitButton);
             await userEvent.click(await findByRole('button', { name: 'Continue under Open terms' }));
 
@@ -144,7 +144,7 @@ describe('SubmitForm', () => {
             getByLabelText(/I confirm that the data submitted is not sensitive or human-identifiable/i),
         );
 
-        const submitButton = getByRole('button', { name: 'Upload (and proceed to Approval)' });
+        const submitButton = getByRole('button', { name: 'Upload and proceed to Approval' });
         await userEvent.click(submitButton);
 
         await waitFor(() => {
@@ -170,7 +170,7 @@ describe('SubmitForm', () => {
             getByLabelText(/I confirm that the data submitted is not sensitive or human-identifiable/i),
         );
 
-        const submitButton = getByRole('button', { name: 'Upload (and proceed to Approval)' });
+        const submitButton = getByRole('button', { name: 'Upload and proceed to Approval' });
         await userEvent.click(submitButton);
 
         await waitFor(() => {
@@ -196,7 +196,7 @@ describe('SubmitForm', () => {
             getByLabelText(/I confirm that the data submitted is not sensitive or human-identifiable/i),
         );
 
-        const submitButton = getByRole('button', { name: 'Upload (and proceed to Approval)' });
+        const submitButton = getByRole('button', { name: 'Upload and proceed to Approval' });
         await userEvent.click(submitButton);
 
         await waitFor(() => {
@@ -248,7 +248,7 @@ describe('SubmitForm', () => {
             getByLabelText(/I confirm that the data submitted is not sensitive or human-identifiable/i),
         );
 
-        const submitButton = getByRole('button', { name: 'Upload (and proceed to Approval)' });
+        const submitButton = getByRole('button', { name: 'Upload and proceed to Approval' });
         await userEvent.click(submitButton);
         await waitFor(() => {
             expect(toast.error).toHaveBeenCalledWith(
@@ -281,7 +281,7 @@ describe('SubmitForm', () => {
             getByLabelText(/I confirm that the data submitted is not sensitive or human-identifiable/i),
         );
 
-        const submitButton = getByRole('button', { name: 'Upload (and proceed to Approval)' });
+        const submitButton = getByRole('button', { name: 'Upload and proceed to Approval' });
         await userEvent.click(submitButton);
         await userEvent.click(await findByRole('button', { name: 'Continue under Open terms' }));
 
@@ -309,7 +309,7 @@ describe('SubmitForm', () => {
             getByLabelText(/I confirm that the data submitted is not sensitive or human-identifiable/i),
         );
 
-        const submitButton = getByRole('button', { name: 'Upload (and proceed to Approval)' });
+        const submitButton = getByRole('button', { name: 'Upload and proceed to Approval' });
         await userEvent.click(submitButton);
         await userEvent.click(await findByRole('button', { name: 'Continue under Open terms' }));
 
@@ -340,7 +340,7 @@ describe('SubmitForm', () => {
                 }
             }
 
-            const submitButton = getByRole('button', { name: 'Upload (and proceed to Approval)' });
+            const submitButton = getByRole('button', { name: 'Upload and proceed to Approval' });
             await userEvent.click(submitButton);
 
             await waitFor(() => {

--- a/website/src/components/Submission/SubmissionForm.spec.tsx
+++ b/website/src/components/Submission/SubmissionForm.spec.tsx
@@ -120,7 +120,7 @@ describe('SubmitForm', () => {
                 getByLabelText(/I confirm that the data submitted is not sensitive or human-identifiable/i),
             );
 
-            const submitButton = getByRole('button', { name: 'Submit sequences' });
+            const submitButton = getByRole('button', { name: 'Upload (and proceed to Approval)' });
             await userEvent.click(submitButton);
             await userEvent.click(await findByRole('button', { name: 'Continue under Open terms' }));
 
@@ -144,7 +144,7 @@ describe('SubmitForm', () => {
             getByLabelText(/I confirm that the data submitted is not sensitive or human-identifiable/i),
         );
 
-        const submitButton = getByRole('button', { name: 'Submit sequences' });
+        const submitButton = getByRole('button', { name: 'Upload (and proceed to Approval)' });
         await userEvent.click(submitButton);
 
         await waitFor(() => {
@@ -170,7 +170,7 @@ describe('SubmitForm', () => {
             getByLabelText(/I confirm that the data submitted is not sensitive or human-identifiable/i),
         );
 
-        const submitButton = getByRole('button', { name: 'Submit sequences' });
+        const submitButton = getByRole('button', { name: 'Upload (and proceed to Approval)' });
         await userEvent.click(submitButton);
 
         await waitFor(() => {
@@ -196,7 +196,7 @@ describe('SubmitForm', () => {
             getByLabelText(/I confirm that the data submitted is not sensitive or human-identifiable/i),
         );
 
-        const submitButton = getByRole('button', { name: 'Submit sequences' });
+        const submitButton = getByRole('button', { name: 'Upload (and proceed to Approval)' });
         await userEvent.click(submitButton);
 
         await waitFor(() => {
@@ -248,7 +248,7 @@ describe('SubmitForm', () => {
             getByLabelText(/I confirm that the data submitted is not sensitive or human-identifiable/i),
         );
 
-        const submitButton = getByRole('button', { name: 'Submit sequences' });
+        const submitButton = getByRole('button', { name: 'Upload (and proceed to Approval)' });
         await userEvent.click(submitButton);
         await waitFor(() => {
             expect(toast.error).toHaveBeenCalledWith(
@@ -281,7 +281,7 @@ describe('SubmitForm', () => {
             getByLabelText(/I confirm that the data submitted is not sensitive or human-identifiable/i),
         );
 
-        const submitButton = getByRole('button', { name: 'Submit sequences' });
+        const submitButton = getByRole('button', { name: 'Upload (and proceed to Approval)' });
         await userEvent.click(submitButton);
         await userEvent.click(await findByRole('button', { name: 'Continue under Open terms' }));
 
@@ -309,7 +309,7 @@ describe('SubmitForm', () => {
             getByLabelText(/I confirm that the data submitted is not sensitive or human-identifiable/i),
         );
 
-        const submitButton = getByRole('button', { name: 'Submit sequences' });
+        const submitButton = getByRole('button', { name: 'Upload (and proceed to Approval)' });
         await userEvent.click(submitButton);
         await userEvent.click(await findByRole('button', { name: 'Continue under Open terms' }));
 
@@ -340,7 +340,7 @@ describe('SubmitForm', () => {
                 }
             }
 
-            const submitButton = getByRole('button', { name: 'Submit sequences' });
+            const submitButton = getByRole('button', { name: 'Upload (and proceed to Approval)' });
             await userEvent.click(submitButton);
 
             await waitFor(() => {

--- a/website/src/hooks/useSubmissionOperations.ts
+++ b/website/src/hooks/useSubmissionOperations.ts
@@ -68,7 +68,7 @@ export function useSubmissionOperations(
         { headers: createAuthorizationHeader(accessToken), params: { organism } },
         {
             onMutate: () => {
-                const toastId = toast.loading('Releasing sequences...');
+                const toastId = toast.loading('Approving sequences...');
                 return { toastId };
             },
             onSuccess: (data, _variables, context) => {
@@ -78,8 +78,8 @@ export function useSubmissionOperations(
                     const isBatchRelease = data.length > 1;
                     toast.update(ctx.toastId, {
                         render: isBatchRelease
-                            ? '🎉 All sequences have been released successfully!'
-                            : 'Sequence released successfully.',
+                            ? '🎉 All sequences have been approved. They will appear on the website shortly.'
+                            : 'Sequence approved. It will appear on the website shortly.',
                         type: 'success',
                         isLoading: false,
                         autoClose: isBatchRelease ? false : 4000,

--- a/website/src/pages/[organism]/submission/[groupId]/review.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/review.astro
@@ -15,7 +15,7 @@ const metadataDisplayNames: Map<string, string> = getMetadataDisplayNames(organi
 const referenceGenomesInfo = getReferenceGenomes(organism);
 ---
 
-<SubmissionPageWrapper title='Approve pending submissions' groupsResult={groupsResult}>
+<SubmissionPageWrapper title='Review pending submissions' groupsResult={groupsResult}>
     {
         groupsResult.match(
             ({ currentGroup: group }) => (

--- a/website/src/pages/[organism]/submission/[groupId]/review.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/review.astro
@@ -15,7 +15,7 @@ const metadataDisplayNames: Map<string, string> = getMetadataDisplayNames(organi
 const referenceGenomesInfo = getReferenceGenomes(organism);
 ---
 
-<SubmissionPageWrapper title='Review pending submissions' groupsResult={groupsResult}>
+<SubmissionPageWrapper title='Approve pending submissions' groupsResult={groupsResult}>
     {
         groupsResult.match(
             ({ currentGroup: group }) => (

--- a/website/src/pages/[organism]/submission/[groupId]/review.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/review.astro
@@ -15,7 +15,7 @@ const metadataDisplayNames: Map<string, string> = getMetadataDisplayNames(organi
 const referenceGenomesInfo = getReferenceGenomes(organism);
 ---
 
-<SubmissionPageWrapper title='Review current submissions' groupsResult={groupsResult}>
+<SubmissionPageWrapper title='Review pending submissions' groupsResult={groupsResult}>
     {
         groupsResult.match(
             ({ currentGroup: group }) => (


### PR DESCRIPTION
https://loculus.slack.com/archives/C061ZQQM3N1/p1781652478145729

## Summary

This PR clarifies the wording of the sequence submission → approval workflow on the website, making the two-step nature of the process explicit:

1. **Submit & revise pages** — the form's primary action button is relabelled from **"Submit sequences"** to **"Upload and proceed to Approval"**. This signals that uploading is the first step and is followed by an approval step, rather than implying the action immediately finalises the submission. Revisions also enter the review/approval queue, so the *revise* page uses the same label.

2. **Review/approval page heading** — the page heading is renamed from **"Review current submissions"** to **"Review pending submissions"**, matching the language above and better describing the page, which lists submissions awaiting review/approval.

3. **Review/approval page actions** — the user-facing **"Release"** actions on the review page are renamed to **"Approve"**, so the approval step uses one consistent verb throughout. The success messages shown after approving now also tell the user that the sequences will appear on the website shortly. 

## Changes

**Submit & revise pages / review heading**

- `website/src/components/Submission/DataUploadForm.tsx`: the primary button now reads `'Upload and proceed to Approval'` for both the submit and revise actions.
- `website/src/pages/[organism]/submission/[groupId]/review.astro`: `SubmissionPageWrapper` title → `'Review pending submissions'` (rendered as the page `<h1>`).
- `website/src/components/Submission/SubmissionForm.spec.tsx`: unit test button-name lookups updated to the new label.
- `integration-tests/`: updated the submit-page button name in the page object and submission flow spec, pointed the revise page object's `clickSubmit()` at the new button name, and updated review-page heading/text assertions across the affected specs to `'Review pending submissions'`.

**Review page "Release" → "Approve" actions**

- `website/src/components/ReviewPage/ReviewPage.tsx`: the bulk button `'Release N valid sequences'` → `'Approve N valid sequences'`, plus its confirmation dialog text and confirm button.
- `website/src/components/ReviewPage/ReviewCard.tsx`: the per-card approve tooltip (`'Release this sequence entry'` → `'Approve this sequence entry'`) and the two "before releasing" error tooltips → "approving".
- `website/src/hooks/useSubmissionOperations.ts`: the action-feedback toasts now read `'Approving sequences…'` and the success toasts read `'🎉 All sequences have been approved. They will appear on the website shortly.'` / `'Sequence approved. It will appear on the website shortly.'`.
- `website/src/components/ReviewPage/ReviewPage.spec.tsx`: unit-test lookups updated to the new labels.
- `integration-tests/tests/pages/review.page.ts`: the page-object selectors and the post-approval success assertion updated to match the new copy.

## Screenshots

Captured on the `main` deployment (before) and this PR's preview deployment (after).

### Submit & revise pages — primary action button

The revise page's button mirrors the submit page; the screenshots below show the submit page.

| Before | After |
| --- | --- |
| ![Submit page button before](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6679/before-submit-button.png) | ![Submit page button after](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6679/after-submit-button.png) |
| "Submit sequences" | "Upload and proceed to Approval" |

### Review page — heading

| Before | After |
| --- | --- |
| ![Review page heading before](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6679/before-review-heading.png) | ![Review page heading after](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6679/after-review-heading.png) |
| "Review current submissions" | "Review pending submissions" |

### Review page — "Release" → "Approve" actions

Captured by driving a real submission of two sequences on each deployment (`main` = before, this PR's preview = after) and approving them.

Bulk action button:

| Before | After |
| --- | --- |
| ![Action bar before](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6679/before-approve-action-bar.png) | ![Action bar after](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6679/after-approve-action-bar-formkit.png) |
| "Release 2 valid sequences" | "Approve 2 valid sequences" |

Confirmation dialog (also shows the renamed page heading, bulk button, and per-entry tooltip):

| Before | After |
| --- | --- |
| ![Confirm dialog before](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6679/before-approve-confirm-dialog.png) | ![Confirm dialog after](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6679/after-approve-confirm-dialog-formkit.png) |
| "Are you sure you want to release all valid sequences?" / "Release" | "Are you sure you want to approve all valid sequences?" / "Approve" |

Per-entry action tooltip:

| Before | After |
| --- | --- |
| ![Tooltip before](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6679/before-approve-page-tooltip.png) | ![Tooltip after](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6679/after-approve-page-tooltip-formkit.png) |
| "Release this sequence entry" | "Approve this sequence entry" |

Success toast:

| Before | After |
| --- | --- |
| ![Toast before](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6679/before-approve-success-toast.png) | ![Toast after](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6679/after-approve-success-toast-formkit.png) |
| "🎉 All sequences have been released successfully!" | "🎉 All sequences have been approved. They will appear on the website shortly." |

## Verification

- `npm run check-types` (website) — passes (0 errors)
- `CI=1 npm run test src/components/Submission/SubmissionForm.spec.tsx` — 13 passed
- `CI=1 npm run test src/components/ReviewPage/ReviewPage.spec.tsx` — 12 passed
- `npm run format:check` (integration-tests, eslint + prettier) — clean; `tsc --noEmit` — 0 errors
- Prettier — clean (website + integration-tests)

These are user-facing copy changes plus the corresponding test updates; no application behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: https://review-pending-submission.loculus.org