### PR TITLE
feat(website): time-scale, stepped group submission graph with markers

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -54,7 +54,7 @@ ingestLimitSeconds: 1800
 getSubmissionListLimitSeconds: 600
 preprocessingTimeout: 600
 accessionPrefix: "LOC_"
-dateFieldForGroupGraph: null
+dateFieldForGroupGraph: date # TEMP(pr-6696): force-enabled to capture preview screenshots — REVERT before merge
 zstdCompressionLevel: 10
 pipelineVersionUpgradeCheckIntervalSeconds: 10
 dataUseTerms:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -54,7 +54,7 @@ ingestLimitSeconds: 1800
 getSubmissionListLimitSeconds: 600
 preprocessingTimeout: 600
 accessionPrefix: "LOC_"
-dateFieldForGroupGraph: date # TEMP(pr-6696): force-enabled to capture preview screenshots — REVERT before merge
+dateFieldForGroupGraph: null
 zstdCompressionLevel: 10
 pipelineVersionUpgradeCheckIntervalSeconds: 10
 dataUseTerms:

--- a/website/src/components/User/CumulativeSubmissionsChart.tsx
+++ b/website/src/components/User/CumulativeSubmissionsChart.tsx
@@ -1,20 +1,31 @@
-import {
-    Chart as ChartJS,
-    CategoryScale,
-    LinearScale,
-    PointElement,
-    LineElement,
-    Title,
-    Tooltip,
-    Legend,
-} from 'chart.js';
+import { Chart as ChartJS, TimeScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend } from 'chart.js';
+import 'chartjs-adapter-date-fns';
 import { type FC, useMemo } from 'react';
 import { Line } from 'react-chartjs-2';
 
 import type { Organism } from '../../config.ts';
 import { Spinner } from '../common/Spinner';
 
-ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
+ChartJS.register(TimeScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
+
+// Padding applied to the x-axis when every submission falls on a single date,
+// so the lone point isn't rendered on a zero-width time axis.
+const SINGLE_POINT_PADDING_MS = 15 * 24 * 60 * 60 * 1000;
+
+// Parse a metadata date string ('2024', '2024-03' or '2024-03-15') into a
+// local-midnight timestamp. Local (rather than UTC) avoids the rendered date
+// shifting by a day in negative-offset timezones. Returns null if unparseable.
+function parseDateToLocalTs(dateStr: string): number | null {
+    const parts = dateStr.split('-');
+    const year = Number(parts[0]);
+    const month = parts.length > 1 ? Number(parts[1]) - 1 : 0;
+    const day = parts.length > 2 ? Number(parts[2]) : 1;
+    if (!Number.isInteger(year) || Number.isNaN(month) || Number.isNaN(day)) {
+        return null;
+    }
+    const timestamp = new Date(year, month, day).getTime();
+    return Number.isNaN(timestamp) ? null : timestamp;
+}
 
 export type TimeSeriesDataPoint = {
     date: string;
@@ -37,46 +48,55 @@ export const CumulativeSubmissionsChart: FC<CumulativeSubmissionsChartProps> = (
     organisms,
     isLoading,
 }) => {
-    const chartData = useMemo(() => {
-        const allDates = new Set<string>();
-        for (const organism of organisms) {
-            const data = timeSeriesData[organism.key] ?? [];
-            for (const point of data) {
-                allDates.add(point.date);
+    const { chartData, xBounds } = useMemo(() => {
+        const datasets = organisms
+            .map((organism, index) => {
+                const data = [...(timeSeriesData[organism.key] ?? [])].sort((a, b) => a.date.localeCompare(b.date));
+
+                let cumulative = 0;
+                const points: { x: number; y: number }[] = [];
+                for (const point of data) {
+                    const timestamp = parseDateToLocalTs(point.date);
+                    if (timestamp === null) {
+                        continue;
+                    }
+                    cumulative += point.count;
+                    points.push({ x: timestamp, y: cumulative });
+                }
+
+                return {
+                    label: organism.displayName,
+                    data: points,
+                    borderColor: ORGANISM_COLORS[index % ORGANISM_COLORS.length],
+                    backgroundColor: ORGANISM_COLORS[index % ORGANISM_COLORS.length],
+                    borderWidth: 1.5,
+                    // Cumulative counts only change on dates with submissions, so a
+                    // step ('before') line is more faithful than linear interpolation:
+                    // the total stays flat and jumps up exactly on each release date.
+                    stepped: 'before' as const,
+                    fill: false,
+                    // Show a marker on every data point so individual submission dates
+                    // are visible — in particular a group with a single submission
+                    // would otherwise render an invisible zero-length line.
+                    pointRadius: 3,
+                    pointHoverRadius: 5,
+                };
+            })
+            .filter((ds) => ds.data.length > 0 && ds.data[ds.data.length - 1].y > 0);
+
+        // Determine x-axis bounds. When all submissions share a single date the
+        // time axis would otherwise collapse to zero width, so pad either side.
+        const allTimestamps = datasets.flatMap((ds) => ds.data.map((p) => p.x));
+        let bounds: { min: number; max: number } | undefined;
+        if (allTimestamps.length > 0) {
+            const min = Math.min(...allTimestamps);
+            const max = Math.max(...allTimestamps);
+            if (min === max) {
+                bounds = { min: min - SINGLE_POINT_PADDING_MS, max: max + SINGLE_POINT_PADDING_MS };
             }
         }
-        const sortedDates = Array.from(allDates).sort();
 
-        if (sortedDates.length === 0) {
-            return { labels: [], datasets: [] };
-        }
-
-        const datasets = organisms.map((organism, index) => {
-            const data = timeSeriesData[organism.key] ?? [];
-            const dateToCount = new Map(data.map((d) => [d.date, d.count]));
-
-            let cumulative = 0;
-            const cumulativeData = sortedDates.map((date) => {
-                cumulative += dateToCount.get(date) ?? 0;
-                return cumulative;
-            });
-
-            return {
-                label: organism.displayName,
-                data: cumulativeData,
-                borderColor: ORGANISM_COLORS[index % ORGANISM_COLORS.length],
-                backgroundColor: ORGANISM_COLORS[index % ORGANISM_COLORS.length],
-                borderWidth: 1.5,
-                tension: 0.1,
-                fill: false,
-                pointRadius: 0,
-            };
-        });
-
-        return {
-            labels: sortedDates,
-            datasets: datasets.filter((ds) => ds.data[ds.data.length - 1] > 0),
-        };
+        return { chartData: { datasets }, xBounds: bounds };
     }, [timeSeriesData, organisms]);
 
     if (isLoading) {
@@ -108,6 +128,12 @@ export const CumulativeSubmissionsChart: FC<CumulativeSubmissionsChartProps> = (
                     },
                     scales: {
                         x: {
+                            type: 'time',
+                            min: xBounds?.min,
+                            max: xBounds?.max,
+                            time: {
+                                tooltipFormat: 'yyyy-MM-dd',
+                            },
                             title: {
                                 display: true,
                                 text: 'Release date',

--- a/website/src/components/User/CumulativeSubmissionsChart.tsx
+++ b/website/src/components/User/CumulativeSubmissionsChart.tsx
@@ -148,6 +148,11 @@ export const CumulativeSubmissionsChart: FC<CumulativeSubmissionsChartProps> = (
                                 text: 'Cumulative submissions',
                             },
                             beginAtZero: true,
+                            // Cumulative submission counts are whole numbers, so
+                            // never label the y-axis with fractional values.
+                            ticks: {
+                                precision: 0,
+                            },
                         },
                     },
                 }}


### PR DESCRIPTION
resolves #6701

## Summary

The "Cumulative submissions over time" chart on group pages (`CumulativeSubmissionsChart`) didn't render usefully in a couple of cases:

- **A group with a single submission showed a blank chart.** The line had hidden points (`pointRadius: 0`) and a single data point draws no line segment, so nothing was visible.
- **The x-axis wasn't proportional to time.** It used a Chart.js *category* scale, so submission dates were spaced evenly regardless of the real gaps between them — a one-day gap and a six-month gap looked identical.
- The line used smoothed (`tension`) interpolation, which misrepresents a cumulative count that only changes on discrete submission dates.

This PR reworks the chart:

1. **Time scale** — the x-axis is now a Chart.js `time` scale (via the already-present `chartjs-adapter-date-fns`), so the line is proportional to elapsed time.
2. **Per-series points** — each organism's series is built as `{x: timestamp, y: cumulative}` points at its own submission dates, instead of a shared category-label array. Markers therefore land on real submission dates.
3. **Markers on every submission** — `pointRadius: 3` (with a larger hover radius) so individual submissions are visible, including the single-submission case.
4. **Step ('before') line** — the cumulative total now holds flat and jumps up exactly on each release date (a staircase), which is the faithful shape for a cumulative count.
5. **Single-date padding** — when every submission shares one date, the time axis would collapse to zero width, so the axis is padded ±15 days around the lone point.
6. **Date parsing** — metadata date strings (`2024`, `2024-03`, `2024-03-15`) are parsed to **local** midnight, avoiding a timezone off-by-one in the rendered/tooltip date.

## Before / after

Identical data rendered with the old config (top) and the new config (bottom). Left = a group with a single submission (the Canada-style case); right = several submissions with uneven time gaps (note Feb→Jul is ~5.5 months).

| | |
| --- | --- |
| **Before** | ![before](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-group-graph/before.png) |
| **After** | ![after](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-group-graph/after.png) |

In *Before*, the single-submission chart is blank and the multi-submission line spaces all four dates evenly. In *After*, the single submission shows a clear marker on a padded axis, and the staircase is time-proportional — the three early submissions cluster at the left and the long gap shows as a flat plateau.

> These are faithful renders of the exact Chart.js dataset/scale options from each version (the component just feeds them real LAPIS data).

## Changes

- `website/src/components/User/CumulativeSubmissionsChart.tsx` — only file changed. Swaps `CategoryScale` for `TimeScale` + date-fns adapter, restructures the data transform to per-series `{x, y}` points with a local-midnight date parser, switches the line to `stepped: 'before'` with visible markers, and pads the x-axis for the single-date case.

## Verification

- `npm run check-types` — 0 errors
- `npx eslint` on the changed file — clean
- `npm run format` / prettier — clean
- Rendered the exact before/after Chart.js config in an isolated browser harness to confirm the single-point, padding, staircase direction, and time-proportional spacing behave as intended (screenshots above).

## Notes / possible follow-ups

- The chart only appears when `dateFieldForGroupGraph` is configured for the instance, so behaviour is unchanged where it's disabled.
- With many submission dates the markers could look busy; left as-is since the request was explicitly to show a marker per submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable