### PR TITLE
feat(website): refresh typography & layout for docs/about/news pages

### DIFF
--- a/website/src/layouts/AboutLayout.astro
+++ b/website/src/layouts/AboutLayout.astro
@@ -17,7 +17,7 @@ const currentPageUrl = Astro.url.pathname;
             <DocsSearch client:load />
             <DocsMenu docsPages={aboutPages} currentPageUrl={currentPageUrl} title='About' client:load />
         </div>
-        <div class='mdContainer text-gray-700 leading-relaxed w-full min-w-0 max-w-2xl'>
+        <div class='mdContainer w-full min-w-0 max-w-2xl'>
             <h1>{frontmatter.title}</h1>
 
             <slot />

--- a/website/src/layouts/AboutLayout.astro
+++ b/website/src/layouts/AboutLayout.astro
@@ -12,12 +12,12 @@ const currentPageUrl = Astro.url.pathname;
 ---
 
 <BaseLayout title={frontmatter.title} activeTopNavigationItem={activeTopNavigationItem}>
-    <div class='md:flex md:justify-between max-w-5xl mx-auto items-start gap-10'>
-        <div class='md:w-64 md:flex-none'>
+    <div class='md:flex max-w-5xl mx-auto items-start gap-10 lg:gap-16'>
+        <div class='md:w-72 md:flex-none md:border-r md:border-gray-200 md:pr-12 md:-mt-3 md:pt-3'>
             <DocsSearch client:load />
             <DocsMenu docsPages={aboutPages} currentPageUrl={currentPageUrl} title='About' client:load />
         </div>
-        <div class='mdContainer mdContainerItself text-gray-700 leading-relaxed'>
+        <div class='mdContainer text-gray-700 leading-relaxed w-full min-w-0 max-w-2xl'>
             <h1>{frontmatter.title}</h1>
 
             <slot />

--- a/website/src/layouts/DocLayout.astro
+++ b/website/src/layouts/DocLayout.astro
@@ -24,7 +24,7 @@ const editUrl = `${gitHubEditLink}${fileLocation}`;
             <DocsSearch client:load />
             <DocsMenu docsPages={docsPages} currentPageUrl={currentPageUrl} title='Documentation' client:load />
         </div>
-        <div class='mdContainer text-gray-700 leading-relaxed w-full min-w-0 max-w-2xl'>
+        <div class='mdContainer w-full min-w-0 max-w-2xl'>
             <h1>{frontmatter.title}</h1>
             <slot />
             {

--- a/website/src/layouts/DocLayout.astro
+++ b/website/src/layouts/DocLayout.astro
@@ -19,12 +19,12 @@ const editUrl = `${gitHubEditLink}${fileLocation}`;
 ---
 
 <BaseLayout title={frontmatter.title} activeTopNavigationItem={activeTopNavigationItem}>
-    <div class='md:flex md:justify-between max-w-5xl mx-auto items-start gap-10'>
-        <div class='md:w-64 md:flex-none'>
+    <div class='md:flex max-w-5xl mx-auto items-start gap-10 lg:gap-16'>
+        <div class='md:w-72 md:flex-none md:border-r md:border-gray-200 md:pr-12 md:-mt-3 md:pt-3'>
             <DocsSearch client:load />
             <DocsMenu docsPages={docsPages} currentPageUrl={currentPageUrl} title='Documentation' client:load />
         </div>
-        <div class='mdContainer mdContainerItself text-gray-700 leading-relaxed'>
+        <div class='mdContainer text-gray-700 leading-relaxed w-full min-w-0 max-w-2xl'>
             <h1>{frontmatter.title}</h1>
             <slot />
             {

--- a/website/src/layouts/MdLayout.astro
+++ b/website/src/layouts/MdLayout.astro
@@ -7,7 +7,7 @@ const activeTopNavigationItem = frontmatter?.activeTopNavigationItem;
 ---
 
 <BaseLayout title={frontmatter.title} activeTopNavigationItem={activeTopNavigationItem}>
-    <div class='mdContainer mdContainerItself'>
+    <div class='mdContainer mdContainerWrap'>
         <slot />
     </div>
 </BaseLayout>

--- a/website/src/pages/[organism]/submission/metadataformat.astro
+++ b/website/src/pages/[organism]/submission/metadataformat.astro
@@ -17,7 +17,7 @@ const organismMetadata: OrganismMetadata = {
 
 <BaseLayout title='Metadata format for submissions' fullWidth>
     <h1 class='title'>Metadata format for submissions</h1>
-    <div class='mdContainer mdContainerItself'>
+    <div class='mdContainer mdContainerWrap'>
         <OrganismMetadataTable organism={organismMetadata} client:load />
     </div>
 </BaseLayout>

--- a/website/src/styles/extraStyles.css
+++ b/website/src/styles/extraStyles.css
@@ -1,0 +1,13 @@
+/*
+ * Extension point for deployment-specific markdown / prose styling.
+ *
+ * `mdcontainer.css` imports this file, so any rules added here apply wherever
+ * the shared `.mdContainer` prose styling is rendered (docs, about, news and
+ * the homepage FAQ). In stock Loculus it is intentionally empty: downstream
+ * overlays (e.g. Pathoplexus) replace this single file to add instance-specific
+ * styling -- such as a homepage FAQ card grid -- without having to fork the
+ * whole of `mdcontainer.css`.
+ *
+ * If your override uses Tailwind's `@apply`, start the file with
+ * `@reference './base.css';`.
+ */

--- a/website/src/styles/mdcontainer.css
+++ b/website/src/styles/mdcontainer.css
@@ -36,6 +36,12 @@
  * figures. Capping individual elements to a measure leaves a right-floated
  * image stranded beyond the text, so let the (already narrow) container width
  * set the measure there and have text wrap naturally around the float.
+ *
+ * `.mdContainerWrap` is a modifier on top of `.mdContainer` and must always be
+ * applied together with it (e.g. `class="mdContainer mdContainerWrap"`). These
+ * rules override the `.mdContainer` ones above via equal specificity, so they
+ * rely on source order: keep `.mdContainerWrap` declared *after* `.mdContainer`
+ * in this file or the overrides will silently stop winning.
  */
 .mdContainerWrap h1,
 .mdContainerWrap h2,

--- a/website/src/styles/mdcontainer.css
+++ b/website/src/styles/mdcontainer.css
@@ -1,47 +1,103 @@
+@import './extraStyles.css';
 @reference './base.css';
 
 .mdContainerItself {
-    @apply max-w-3xl mx-auto break-normal w-full;
+    @apply max-w-2xl mx-auto break-normal w-full;
+}
+
+/*
+ * Base reading typography for docs / about / news prose. Set here (rather than
+ * only on the layout wrappers) so news pages, which render through MdLayout
+ * without the `text-gray-700 leading-relaxed` classes, share the same colour,
+ * size and rhythm as the docs and about pages.
+ */
+.mdContainer {
+    @apply text-gray-800;
+    line-height: 1.6;
+    text-rendering: optimizeLegibility;
+}
+
+/*
+ * Constrain flowing text to a comfortable measure (~70 characters) while
+ * letting tables, images and code blocks use the full content width.
+ */
+.mdContainer h1,
+.mdContainer h2,
+.mdContainer h3,
+.mdContainer h4,
+.mdContainer p,
+.mdContainer ul,
+.mdContainer ol,
+.mdContainer blockquote {
+    max-width: 65ch;
+}
+
+/*
+ * News pages (MdLayout) render through `.mdContainerItself` and use floated
+ * figures. Capping individual elements to a measure leaves a right-floated
+ * image stranded beyond the text, so let the (already narrow) container width
+ * set the measure there and have text wrap naturally around the float.
+ */
+.mdContainerItself h1,
+.mdContainerItself h2,
+.mdContainerItself h3,
+.mdContainerItself h4,
+.mdContainerItself p,
+.mdContainerItself ul,
+.mdContainerItself ol,
+.mdContainerItself blockquote {
+    max-width: none;
 }
 
 .mdContainer h1 {
-    @apply text-2xl font-semibold text-main my-3  mt-8;
+    @apply text-3xl font-bold text-main mt-2 mb-4 tracking-tight leading-tight;
 }
 
 .mdContainer h2 {
-    @apply text-xl font-semibold text-main my-3 mt-6;
+    @apply text-2xl font-semibold text-main mt-10 mb-3 tracking-tight leading-snug;
 }
 
 .mdContainer h3 {
-    @apply text-lg font-semibold text-main my-3 mt-5;
+    @apply text-xl font-semibold text-main mt-8 mb-2 leading-snug;
 }
 
 .mdContainer h4 {
-    @apply text-base font-semibold text-main my-3 mt-4;
+    @apply text-lg font-semibold text-main mt-6 mb-2 leading-snug;
 }
 
 .mdContainer img {
-    @apply my-3 border border-gray-300 rounded-md;
+    @apply my-5 border border-gray-300 rounded-md;
 }
 
 .mdContainer p {
-    @apply my-2;
+    @apply my-4;
+    text-wrap: pretty;
 }
 
 .mdContainer a {
-    @apply text-main underline text-primary-600 hover:text-primary-700;
+    @apply text-primary-600 underline underline-offset-2 decoration-1 decoration-primary-600/40 hover:text-primary-700 hover:decoration-primary-700;
+}
+
+/* Inline code (not the highlighted `.astro-code` blocks) */
+.mdContainer :not(pre) > code {
+    @apply rounded bg-gray-100 text-gray-800 px-1.5 py-0.5 text-[0.875em] font-mono;
+}
+
+/* Inside info-box asides the gray pill clashes with the blue background, so tint it to match. */
+.mdContainer .info-box-link :not(pre) > code {
+    @apply bg-primary-100 text-primary-900;
 }
 
 .mdContainer ol {
-    @apply list-decimal list-inside my-2;
+    @apply list-decimal list-inside my-4;
 }
 
 .mdContainer ol li {
-    @apply ml-4 my-1;
+    @apply ml-4 my-1.5 marker:text-inherit;
 }
 
 .mdContainer .alternative-lists ol {
-    @apply list-decimal list-outside my-2;
+    @apply list-decimal list-outside my-4;
 }
 
 .mdContainer .alternative-lists ol li {
@@ -50,45 +106,50 @@
 
 .mdContainer ul {
     list-style-type: disc;
-    margin: 8px 0;
+    margin: 1rem 0;
     padding-left: 0;
+}
+
+.mdContainer li {
+    @apply marker:text-gray-400;
+    text-wrap: pretty;
 }
 
 /* Level 1 - Direct children of .mdContainer */
 .mdContainer > ul {
     list-style-type: disc;
-    margin: 8px 0;
+    margin: 1rem 0;
     padding-left: 0;
 }
 
 .mdContainer > ul > li {
     margin-left: 16px;
-    margin-top: 4px;
-    margin-bottom: 4px;
+    margin-top: 6px;
+    margin-bottom: 6px;
 }
 
 /* Level 2 - UL nested within LI of the first level UL */
 .mdContainer > ul > li > ul {
     list-style-type: circle;
-    margin: 8px 0;
+    margin: 6px 0;
 }
 
 .mdContainer > ul > li > ul > li {
     margin-left: 32px;
-    margin-top: 4px;
-    margin-bottom: 4px;
+    margin-top: 6px;
+    margin-bottom: 6px;
 }
 
 /* Level 3 - UL nested within LI of the second level UL */
 .mdContainer > ul > li > ul > li > ul {
     list-style-type: square;
-    margin: 8px 0;
+    margin: 6px 0;
 }
 
 .mdContainer > ul > li > ul > li > ul > li {
     margin-left: 48px;
-    margin-top: 4px;
-    margin-bottom: 4px;
+    margin-top: 6px;
+    margin-bottom: 6px;
 }
 
 .mdContainer li p {
@@ -112,7 +173,7 @@
 }
 
 .mdContainer table {
-    @apply w-full table-auto border-collapse mt-6 mb-6;
+    @apply w-full max-w-full table-auto border-collapse mt-6 mb-6 text-[0.9375rem];
 }
 
 .mdContainer th,
@@ -137,9 +198,9 @@
 }
 
 .mdContainer blockquote {
-    @apply my-4 pl-4 border-l-4 border-gray-300 text-gray-600 italic;
+    @apply my-5 pl-4 border-l-4 border-primary-200 text-gray-600 italic;
 }
 
 .astro-code {
-    @apply p-2;
+    @apply p-3 rounded-md my-4 text-[0.9375rem];
 }

--- a/website/src/styles/mdcontainer.css
+++ b/website/src/styles/mdcontainer.css
@@ -14,7 +14,6 @@
 .mdContainer {
     @apply text-gray-800;
     line-height: 1.6;
-    text-rendering: optimizeLegibility;
 }
 
 /*

--- a/website/src/styles/mdcontainer.css
+++ b/website/src/styles/mdcontainer.css
@@ -1,7 +1,7 @@
 @import './extraStyles.css';
 @reference './base.css';
 
-.mdContainerItself {
+.mdContainerWrap {
     @apply max-w-2xl mx-auto break-normal w-full;
 }
 
@@ -32,19 +32,19 @@
 }
 
 /*
- * News pages (MdLayout) render through `.mdContainerItself` and use floated
+ * News pages (MdLayout) render through `.mdContainerWrap` and use floated
  * figures. Capping individual elements to a measure leaves a right-floated
  * image stranded beyond the text, so let the (already narrow) container width
  * set the measure there and have text wrap naturally around the float.
  */
-.mdContainerItself h1,
-.mdContainerItself h2,
-.mdContainerItself h3,
-.mdContainerItself h4,
-.mdContainerItself p,
-.mdContainerItself ul,
-.mdContainerItself ol,
-.mdContainerItself blockquote {
+.mdContainerWrap h1,
+.mdContainerWrap h2,
+.mdContainerWrap h3,
+.mdContainerWrap h4,
+.mdContainerWrap p,
+.mdContainerWrap ul,
+.mdContainerWrap ol,
+.mdContainerWrap blockquote {
     max-width: none;
 }
 


### PR DESCRIPTION
see https://preview-design-refresh-overlay.pathoplexus.org/ / https://loculus.slack.com/archives/C061ZQQM3N1/p1780659618788189

## Summary

Refreshes the reading experience on Loculus's long-form pages — **docs**, **about** and **news** — by reworking the shared `.mdContainer` prose styling and tidying the docs/about sidebar layout. Also adds a small, optional hook so a downstream instance can extend the prose styling without forking the shared stylesheet.

These are generic, deployment-agnostic changes, so every Loculus-based instance gets the improved typography. They're the upstream foundation for the Pathoplexus design refresh, which layers its own content and homepage FAQ styling on top via the overlay (companion PR: pathoplexus/pathoplexus#1042).

## What changed

**Prose typography — `website/src/styles/mdcontainer.css`**
- Larger, tighter headings (h1 `text-3xl`, h2 `text-2xl`, …) with more deliberate vertical rhythm.
- Comfortable `line-height: 1.6` and a ~`65ch` measure on flowing text (paragraphs, lists, headings, blockquotes), while tables, images and code blocks keep the full content width.
- News pages (`MdLayout` → `.mdContainerItself`) opt out of the per-element measure so prose still wraps around right-floated figures.
- Softer, underlined links; styled inline `code` pills (with a tinted variant inside info-box asides); refreshed blockquote and `.astro-code` block styling.

**Sidebar layout — `website/src/layouts/AboutLayout.astro` & `DocLayout.astro`**
- Wider sidebar (`w-72`) with a vertical divider between navigation and content.
- Content column constrained to a readable measure (`max-w-2xl`).

**Prose styling hook — `website/src/styles/extraStyles.css` (new)**
- Intentionally **empty** in stock Loculus. `mdcontainer.css` imports it, so a downstream overlay can replace this single file to add instance-specific prose styling (e.g. a homepage FAQ card grid) without forking the shared stylesheet. The Pathoplexus PR uses it to supply its `.faqCards` styling.

## Notes
- `npx prettier --check` passes on the changed files. A full `astro build` couldn't be run in my environment (a pre-existing, unrelated broken `flowbite-react` install) — CI will validate the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable