### PR TITLE
fix(website): Disable underline for styled button variants

### DIFF
--- a/website/src/components/common/Button.tsx
+++ b/website/src/components/common/Button.tsx
@@ -39,15 +39,10 @@ export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonPr
 
     if (props.as === 'a') {
         const { as: _as, variant, size, circle, className, ...rest } = props;
-        // Disable underline on hover for anchor buttons unless the user explicitly added it to the className.
-        // ! is required because the global a:hover underline rule is unlayered and would otherwise win over this utility.
-        const anchorClassName = className?.includes('underline')
-            ? className
-            : [className, 'hover:no-underline!'].filter(Boolean).join(' ') || undefined;
         return (
             <a
                 ref={ref as Ref<HTMLAnchorElement>}
-                className={resolveClassName({ variant, size, circle, className: anchorClassName })}
+                className={resolveClassName({ variant, size, circle, className: className })}
                 {...rest}
             />
         );

--- a/website/src/components/common/Button.tsx
+++ b/website/src/components/common/Button.tsx
@@ -39,10 +39,15 @@ export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonPr
 
     if (props.as === 'a') {
         const { as: _as, variant, size, circle, className, ...rest } = props;
+        // Disable underline on hover for anchor buttons unless the user explicitly added it to the className.
+        // ! is required because the global a:hover underline rule is unlayered and would otherwise win over this utility.
+        const anchorClassName = className?.includes('underline')
+            ? className
+            : [className, 'hover:no-underline!'].filter(Boolean).join(' ') || undefined;
         return (
             <a
                 ref={ref as Ref<HTMLAnchorElement>}
-                className={resolveClassName({ variant, size, circle, className })}
+                className={resolveClassName({ variant, size, circle, className: anchorClassName })}
                 {...rest}
             />
         );

--- a/website/src/components/common/Button.tsx
+++ b/website/src/components/common/Button.tsx
@@ -42,7 +42,7 @@ export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonPr
         return (
             <a
                 ref={ref as Ref<HTMLAnchorElement>}
-                className={resolveClassName({ variant, size, circle, className: className })}
+                className={resolveClassName({ variant, size, circle, className })}
                 {...rest}
             />
         );

--- a/website/src/components/common/buttonStyles.ts
+++ b/website/src/components/common/buttonStyles.ts
@@ -33,10 +33,10 @@ const circleSizeClasses: Record<ButtonSize, string> = {
 };
 
 const variantClasses: Record<ButtonVariant, string> = {
-    neutral: 'bg-base-200 text-base-content border-base-300 hover:bg-base-300',
-    primary: 'bg-[var(--color-main)] text-white border-transparent hover:bg-primary-700',
-    ghost: 'bg-transparent border-transparent hover:bg-base-200',
-    outline: 'bg-white border-primary-600 text-primary-600 hover:bg-primary-600 hover:text-white',
+    neutral: 'bg-base-200 text-base-content border-base-300 hover:bg-base-300 no-underline!',
+    primary: 'bg-[var(--color-main)] text-white border-transparent hover:bg-primary-700 no-underline!',
+    ghost: 'bg-transparent border-transparent hover:bg-base-200 no-underline!',
+    outline: 'bg-white border-primary-600 text-primary-600 hover:bg-primary-600 hover:text-white no-underline!',
     unstyled: '',
 };
 


### PR DESCRIPTION
Currently, anchor elements which are styled as buttons show an underline on hover, contrary to non-anchor buttons. This PR explicitly disables hover on underline for the styled button variants, removing this conflict.

This also fixes a small bug with the `DownloadButton` used by the `DownloadDialog` where it would briefly flash with an underline on hover.

### Screenshot

Before:

https://github.com/user-attachments/assets/640e0893-6b49-4a93-a3e4-0d800af478bd

After:

https://github.com/user-attachments/assets/82d661e4-8c63-459f-b92e-1c84455d106f

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable