### PR TITLE
refactor(website): opaque server-side session instead of JWT-in-cookie

### DIFF
--- a/integration-tests/tests/pages/CliPage.ts
+++ b/integration-tests/tests/pages/CliPage.ts
@@ -318,10 +318,21 @@ export class CliPage {
                 });
             }
 
-            const cookies = await page.context().cookies(this.baseUrl);
-            const accessToken = cookies.find((cookie) => cookie.name === 'access_token')?.value;
+            // Browser sessions now keep their tokens server-side, so we ask the
+            // website (via the same browser session) for the backend access
+            // token instead of reading it from a cookie. The endpoint is only
+            // enabled in insecure/dev deployments (e2e), which is where this
+            // browser-backed CLI bootstrap runs.
+            const tokenUrl = new URL('/api/cli-bootstrap-token', this.baseUrl);
+            const tokenResponse = await page.request.get(tokenUrl.toString());
+            if (!tokenResponse.ok()) {
+                throw new Error(
+                    `Browser login did not yield a session token: HTTP ${tokenResponse.status()}`,
+                );
+            }
+            const { accessToken } = (await tokenResponse.json()) as { accessToken?: string };
             if (!accessToken) {
-                throw new Error('Browser login did not produce an access_token cookie');
+                throw new Error('Session token endpoint returned no access token');
             }
             const tokenUsername = this.usernameFromToken(accessToken);
             if (tokenUsername !== username) {

--- a/integration-tests/tests/specs/auth/logout.spec.ts
+++ b/integration-tests/tests/specs/auth/logout.spec.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test';
 import { test } from '../../fixtures/auth.fixture';
 import { AuthPage } from '../../pages/auth.page';
 
-const AUTH_COOKIE_NAMES = ['access_token', 'refresh_token'];
+const AUTH_COOKIE_NAMES = ['loculus_session', 'access_token', 'refresh_token'];
 
 test.describe('Logout Flow', () => {
     let authPage: AuthPage;

--- a/website/src/middleware/authMiddleware.ts
+++ b/website/src/middleware/authMiddleware.ts
@@ -6,15 +6,25 @@ import JwksRsa from 'jwks-rsa';
 import { err, ok, ResultAsync } from 'neverthrow';
 import { type BaseClient, type TokenSet } from 'openid-client';
 
+import { createSessionId, deleteSession, getSessionTokens, putSessionTokens } from './sessionStore.ts';
 import { getConfiguredOrganisms, getRuntimeConfig, getWebsiteConfig } from '../config.ts';
 import { getInstanceLogger } from '../logger.ts';
 import { getAutheliaForwardedHeaders, OidcClientManager } from '../utils/OidcClientManager.ts';
 import { decodeState, getAuthUrl } from '../utils/getAuthUrl.ts';
 import { shouldMiddlewareEnforceLogin } from '../utils/shouldMiddlewareEnforceLogin.ts';
 
+// Opaque browser-session cookie. It holds only a random session id; the actual
+// OIDC tokens live server-side in the session store and never reach the client.
+export const SESSION_COOKIE = 'loculus_session';
+
+// Legacy cookies from the previous JWT-in-cookie scheme. We no longer set these,
+// but we clear them so users carrying them from a prior deploy don't keep stale
+// tokens in their browser.
 export const ACCESS_TOKEN_COOKIE = 'access_token';
 export const OIDC_ACCESS_TOKEN_COOKIE = 'oidc_access_token';
 export const REFRESH_TOKEN_COOKIE = 'refresh_token';
+
+const LEGACY_TOKEN_COOKIES = [ACCESS_TOKEN_COOKIE, OIDC_ACCESS_TOKEN_COOKIE, REFRESH_TOKEN_COOKIE];
 
 enum TokenVerificationError {
     EXPIRED,
@@ -24,18 +34,18 @@ enum TokenVerificationError {
 
 const logger = getInstanceLogger('LoginMiddleware');
 
-async function getValidTokenAndUserInfoFromCookie(context: APIContext, client: BaseClient) {
-    logger.debug(`Trying to get token and user info from cookie`);
-    const token = await getTokenFromCookie(context, client);
+async function getValidTokenAndUserInfoFromSession(context: APIContext, client: BaseClient) {
+    logger.debug(`Trying to get token and user info from session`);
+    const token = await getTokenFromSession(context, client);
     if (token !== undefined) {
         const userInfo = await getUserInfo(token, client);
 
         if (userInfo.isErr()) {
-            logger.debug(`Cookie token found but could not get user info`);
-            deleteCookie(context);
+            logger.debug(`Session token found but could not get user info`);
+            clearSession(context);
             return undefined;
         }
-        logger.debug(`Token and valid user info found in cookie`);
+        logger.debug(`Token and valid user info found in session`);
         return {
             token,
             userInfo,
@@ -75,7 +85,7 @@ export const authMiddleware = defineMiddleware(async (context, next) => {
         if (enforceLogin) {
             return context.redirect('/503?service=readonly');
         }
-        deleteCookie(context);
+        clearSession(context);
         context.locals.session = { isLoggedIn: false };
         return next();
     }
@@ -83,17 +93,17 @@ export const authMiddleware = defineMiddleware(async (context, next) => {
     const client = await OidcClientManager.getClient();
     if (client !== undefined) {
         // Only run this when OIDC client up
-        const cookieResult = await getValidTokenAndUserInfoFromCookie(context, client);
-        token = cookieResult?.token;
-        userInfo = cookieResult?.userInfo;
+        const sessionResult = await getValidTokenAndUserInfoFromSession(context, client);
+        token = sessionResult?.token;
+        userInfo = sessionResult?.userInfo;
         if (token === undefined) {
             const paramResult = await getValidTokenAndUserInfoFromParams(context, client);
             token = paramResult?.token;
             userInfo = paramResult?.userInfo;
 
             if (token !== undefined) {
-                logger.debug(`Token found in params, setting cookie`);
-                const cookieHeaders = setCookie(context, token);
+                logger.debug(`Token found in params, establishing session`);
+                const cookieHeaders = establishSession(context, token);
                 // OIDC roundtrip lands on /auth/callback; the original
                 // destination is encoded in `state`. Fall back to the same
                 // URL with code/state stripped (covers any legacy flow).
@@ -132,8 +142,8 @@ export const authMiddleware = defineMiddleware(async (context, next) => {
             isLoggedIn: false,
         };
         logger.debug(`Error getting user info: ${userInfo.error}`);
-        logger.debug(`Clearing auth cookies.`);
-        deleteCookie(context);
+        logger.debug(`Clearing session.`);
+        clearSession(context);
         return next();
     }
 
@@ -151,24 +161,23 @@ export const authMiddleware = defineMiddleware(async (context, next) => {
     return next();
 });
 
-async function getTokenFromCookie(context: APIContext, client: BaseClient) {
-    const accessToken = context.cookies.get(ACCESS_TOKEN_COOKIE)?.value;
-    const oidcAccessToken = context.cookies.get(OIDC_ACCESS_TOKEN_COOKIE)?.value;
-    const refreshToken = context.cookies.get(REFRESH_TOKEN_COOKIE)?.value;
+async function getTokenFromSession(context: APIContext, client: BaseClient) {
+    const sessionId = context.cookies.get(SESSION_COOKIE)?.value;
+    const tokenCookie = getSessionTokens(sessionId);
 
-    if (accessToken === undefined || refreshToken === undefined) {
+    if (tokenCookie === undefined) {
         return undefined;
     }
-    const tokenCookie = {
-        accessToken,
-        oidcAccessToken,
-        refreshToken,
-    };
 
-    const verifiedTokenResult = await verifyToken(accessToken, client);
+    const verifiedTokenResult = await verifyToken(tokenCookie.accessToken, client);
     if (verifiedTokenResult.isErr() && verifiedTokenResult.error.type === TokenVerificationError.EXPIRED) {
         logger.debug(`Token expired, trying to refresh`);
-        return refreshTokenViaOidc(tokenCookie, client);
+        const refreshed = await refreshTokenViaOidc(tokenCookie, client);
+        if (refreshed !== undefined && sessionId !== undefined) {
+            // Persist the rotated tokens server-side; the opaque cookie is unchanged.
+            putSessionTokens(sessionId, refreshed);
+        }
+        return refreshed;
     }
     if (verifiedTokenResult.isErr()) {
         logger.info(`Error verifying token: ${verifiedTokenResult.error.message}`);
@@ -268,7 +277,7 @@ async function getTokenFromParams(context: APIContext, client: BaseClient): Prom
     return undefined;
 }
 
-function getTokenCookieOptions(): SerializeOptions {
+function getSessionCookieOptions(): SerializeOptions {
     const runtimeConfig = getRuntimeConfig();
     return {
         httpOnly: true,
@@ -278,39 +287,50 @@ function getTokenCookieOptions(): SerializeOptions {
     };
 }
 
-function setCookie(context: APIContext, token: TokenCookie): string[] {
-    const cookieOptions = getTokenCookieOptions();
-    logger.debug(`Setting token cookie`);
-    context.cookies.set(ACCESS_TOKEN_COOKIE, token.accessToken, cookieOptions);
-    if (token.oidcAccessToken !== undefined) {
-        context.cookies.set(OIDC_ACCESS_TOKEN_COOKIE, token.oidcAccessToken, cookieOptions);
-    }
-    context.cookies.set(REFRESH_TOKEN_COOKIE, token.refreshToken, cookieOptions);
-    const cookieHeaders = [
-        serialize(ACCESS_TOKEN_COOKIE, token.accessToken, cookieOptions),
-        token.oidcAccessToken === undefined
-            ? undefined
-            : serialize(OIDC_ACCESS_TOKEN_COOKIE, token.oidcAccessToken, cookieOptions),
-        serialize(REFRESH_TOKEN_COOKIE, token.refreshToken, cookieOptions),
-    ];
-    return cookieHeaders.filter((it): it is string => it !== undefined);
+/**
+ * Creates a server-side session for the freshly obtained tokens and returns the
+ * Set-Cookie headers: the opaque session id plus deletions for any legacy
+ * JWT-in-cookie values the browser might still be carrying.
+ */
+function establishSession(context: APIContext, token: TokenCookie): string[] {
+    const sessionId = createSessionId();
+    putSessionTokens(sessionId, token);
+
+    const cookieOptions = getSessionCookieOptions();
+    logger.debug(`Setting session cookie`);
+    context.cookies.set(SESSION_COOKIE, sessionId, cookieOptions);
+
+    return [serialize(SESSION_COOKIE, sessionId, cookieOptions), ...clearLegacyCookieHeaders(context)];
 }
 
-function deleteCookie(context: APIContext): string[] {
-    logger.debug(`Deleting token cookie`);
-    try {
-        context.cookies.delete(ACCESS_TOKEN_COOKIE, { path: '/' });
-        context.cookies.delete(OIDC_ACCESS_TOKEN_COOKIE, { path: '/' });
-        context.cookies.delete(REFRESH_TOKEN_COOKIE, { path: '/' });
-    } catch {
-        logger.info(`Error deleting cookie`);
-    }
+/**
+ * Drops the server-side session and clears the opaque session cookie (and any
+ * legacy token cookies). Returns the corresponding Set-Cookie headers for
+ * callers that build their own Response.
+ */
+function clearSession(context: APIContext): string[] {
+    logger.debug(`Clearing session`);
+    deleteSession(context.cookies.get(SESSION_COOKIE)?.value);
+
     const deleteOptions: SerializeOptions = { path: '/', maxAge: 0 };
-    return [
-        serialize(ACCESS_TOKEN_COOKIE, '', deleteOptions),
-        serialize(OIDC_ACCESS_TOKEN_COOKIE, '', deleteOptions),
-        serialize(REFRESH_TOKEN_COOKIE, '', deleteOptions),
-    ];
+    try {
+        context.cookies.delete(SESSION_COOKIE, { path: '/' });
+    } catch {
+        logger.info(`Error deleting session cookie`);
+    }
+    return [serialize(SESSION_COOKIE, '', deleteOptions), ...clearLegacyCookieHeaders(context)];
+}
+
+function clearLegacyCookieHeaders(context: APIContext): string[] {
+    const deleteOptions: SerializeOptions = { path: '/', maxAge: 0 };
+    return LEGACY_TOKEN_COOKIES.map((name) => {
+        try {
+            context.cookies.delete(name, { path: '/' });
+        } catch {
+            logger.info(`Error deleting legacy cookie ${name}`);
+        }
+        return serialize(name, '', deleteOptions);
+    });
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Basic_concepts#guard
@@ -332,7 +352,7 @@ const redirectToAuth = async (context: APIContext) => {
     logger.debug(`Redirecting to auth with redirect url: ${redirectUrl}`);
     const authUrl = await getAuthUrl(redirectUrl);
 
-    const cookieHeaders = deleteCookie(context);
+    const cookieHeaders = clearSession(context);
     return createRedirectWithModifiableHeaders(authUrl, cookieHeaders);
 };
 

--- a/website/src/middleware/sessionStore.ts
+++ b/website/src/middleware/sessionStore.ts
@@ -1,0 +1,79 @@
+import { randomBytes } from 'crypto';
+
+/**
+ * Server-side session store for the browser session.
+ *
+ * Instead of putting the OIDC tokens (access / id / refresh) into the user's
+ * browser as cookies, we keep them here on the server and hand the browser only
+ * an opaque, unguessable session id. This makes the browser session revocable
+ * (drop the entry server-side and it's gone immediately) and keeps the JWTs off
+ * the client entirely.
+ *
+ * Storage is an in-process Map, which is correct for the default single-replica
+ * website deployment (`replicas.website: 1`). Its limitations are deliberate and
+ * documented:
+ *   - sessions are lost when the website process restarts (e.g. on redeploy),
+ *     logging users out;
+ *   - it is not shared across replicas.
+ * A deployment that scales the website horizontally should replace this module
+ * with a shared store (e.g. Redis / Postgres) exposing the same
+ * get/put/delete/create interface — no other code needs to change.
+ */
+
+// Idle lifetime of a server-side session. Refreshed on every access so active
+// users stay logged in; abandoned sessions are reaped lazily on read and by the
+// periodic sweep below.
+const SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 7; // 7 days
+
+interface StoredSession {
+    tokens: TokenCookie;
+    expiresAt: number;
+}
+
+const sessions = new Map<string, StoredSession>();
+
+export function createSessionId(): string {
+    return randomBytes(32).toString('base64url');
+}
+
+export function getSessionTokens(sessionId: string | undefined): TokenCookie | undefined {
+    if (sessionId === undefined) {
+        return undefined;
+    }
+    const entry = sessions.get(sessionId);
+    if (entry === undefined) {
+        return undefined;
+    }
+    if (entry.expiresAt <= Date.now()) {
+        sessions.delete(sessionId);
+        return undefined;
+    }
+    // Sliding expiration: touch on access so active sessions don't expire.
+    entry.expiresAt = Date.now() + SESSION_TTL_MS;
+    return entry.tokens;
+}
+
+export function putSessionTokens(sessionId: string, tokens: TokenCookie): void {
+    sessions.set(sessionId, { tokens, expiresAt: Date.now() + SESSION_TTL_MS });
+}
+
+export function deleteSession(sessionId: string | undefined): void {
+    if (sessionId !== undefined) {
+        sessions.delete(sessionId);
+    }
+}
+
+// Lazy reads already drop expired entries, but abandoned sessions that are never
+// read again would linger; sweep them periodically so the Map can't grow without
+// bound. `unref` keeps the timer from holding the process open.
+const SWEEP_INTERVAL_MS = 1000 * 60 * 60; // hourly
+const sweepTimer = setInterval(() => {
+    const nowMs = Date.now();
+    for (const [id, entry] of sessions) {
+        if (entry.expiresAt <= nowMs) {
+            sessions.delete(id);
+        }
+    }
+}, SWEEP_INTERVAL_MS);
+// Don't let the sweep timer keep the process alive.
+sweepTimer.unref();

--- a/website/src/pages/api/cli-bootstrap-token.ts
+++ b/website/src/pages/api/cli-bootstrap-token.ts
@@ -1,0 +1,37 @@
+import type { APIRoute } from 'astro';
+
+import { getRuntimeConfig } from '../../config';
+
+export const prerender = false;
+
+/**
+ * Dev/CI-only helper for the integration-test CLI bootstrap.
+ *
+ * Browser sessions now keep their OIDC tokens server-side (see
+ * `middleware/sessionStore.ts`), so the integration tests can no longer read the
+ * backend access token out of a cookie to seed the CLI keyring. Rather than
+ * drive the full device-code flow in every CLI test, this endpoint returns the
+ * access token of the *current authenticated session* to that same session.
+ *
+ * Exposing the token to the browser is exactly what the server-side session
+ * design avoids, so this is HARD-DISABLED outside insecure/dev deployments:
+ * when `insecureCookies` is false (i.e. production) it 404s and the token never
+ * leaves the server. `insecureCookies` is already the project's "this is a
+ * non-production dev/CI deployment" switch (true in values_e2e_and_dev.yaml,
+ * false in values.yaml).
+ */
+export const GET: APIRoute = ({ locals }) => {
+    if (!getRuntimeConfig().insecureCookies) {
+        return new Response('Not found', { status: 404 });
+    }
+
+    const accessToken = locals.session?.token?.accessToken;
+    if (locals.session?.isLoggedIn !== true || accessToken === undefined) {
+        return new Response('Unauthorized', { status: 401 });
+    }
+
+    return new Response(JSON.stringify({ accessToken }), {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        headers: { 'Content-Type': 'application/json' },
+    });
+};

--- a/website/src/pages/logout.astro
+++ b/website/src/pages/logout.astro
@@ -1,9 +1,19 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import { ACCESS_TOKEN_COOKIE, REFRESH_TOKEN_COOKIE } from '../middleware/authMiddleware';
+import {
+    ACCESS_TOKEN_COOKIE,
+    OIDC_ACCESS_TOKEN_COOKIE,
+    REFRESH_TOKEN_COOKIE,
+    SESSION_COOKIE,
+} from '../middleware/authMiddleware';
+import { deleteSession } from '../middleware/sessionStore';
 
-Astro.cookies.delete(ACCESS_TOKEN_COOKIE, { path: '/' });
-Astro.cookies.delete(REFRESH_TOKEN_COOKIE, { path: '/' });
+// Drop the server-side session, then clear the opaque session cookie (and any
+// legacy JWT-in-cookie values a returning user might still carry).
+deleteSession(Astro.cookies.get(SESSION_COOKIE)?.value);
+for (const name of [SESSION_COOKIE, ACCESS_TOKEN_COOKIE, OIDC_ACCESS_TOKEN_COOKIE, REFRESH_TOKEN_COOKIE]) {
+    Astro.cookies.delete(name, { path: '/' });
+}
 ---
 
 <BaseLayout title='Logout' activeTopNavigationItem='account'>


### PR DESCRIPTION
Stacked on top of #6707 (`authelia-exp-merge`). Changes the **website browser session** from "the JWTs are the cookies" to a session-cookie approach, inspired by [Stop using JWT for sessions](https://gist.github.com/samsch/0d1f3d3b4745d778f78b230cf6061452).

## Before
`authMiddleware` stored the OIDC `access` / `id` / `refresh` tokens directly in three httpOnly cookies. The JWTs *were* the session — sent to the browser on every request, and (because they're stateless) valid until expiry no matter what.

## After
- The browser holds only an **opaque, random `loculus_session` cookie**. The tokens live **server-side** in a session store keyed by that id and never reach the client.
- **Revocable**: dropping the server-side entry (logout, or any future ban/force-logout) ends the session immediately instead of waiting for token expiry.
- Backend calls are unchanged: `locals.session.token` is still populated per-request (server-side) from the store, so `getAccessToken()` and every caller keep working untouched.

## What changed
- **`website/src/middleware/sessionStore.ts`** (new) — in-process `sessionId → tokens` store with sliding TTL + periodic sweep. It is correct for the default single-replica website (`replicas.website: 1`); its limits are documented (lost on restart, not shared across replicas). A horizontally-scaled deployment should swap in a shared store (Redis/Postgres) behind the same `create/get/put/delete` interface — no other code changes.
- **`website/src/middleware/authMiddleware.ts`** — read/establish/clear the session via the store + the opaque cookie (same runtime-controlled `secure`/`sameSite`/`httpOnly` flags as before). Refreshed tokens are now persisted server-side; legacy `access_token`/`refresh_token`/`oidc_access_token` cookies are cleared on the way through so returning users shed their old JWTs.
- **`website/src/pages/logout.astro`** — destroys the server-side session in addition to clearing the cookie.

## Why not Astro's built-in session API?
Astro's session cookie forces `secure` based on build mode, but Loculus needs it runtime-controlled (`!insecureCookies`) so the http e2e/dev flow on `loculus.test:3000` works. A custom store + the existing cookie machinery keeps that behaviour.

## Integration tests
- The CLI bootstrap previously read the backend token from the `access_token` cookie, which no longer exists. Added **`GET /api/cli-bootstrap-token`** — a **dev/CI-only** endpoint that returns the current session's access token to that same authenticated session. It is **hard-disabled in production** (404 unless `insecureCookies`, which is only true in `values_e2e_and_dev.yaml`), so the token never leaves the server in a real deployment. `CliPage` now fetches from it instead of reading the cookie.
- `logout.spec.ts` also asserts the `loculus_session` cookie is cleared.

## Local checks
`astro check` + `tsc` (0 errors), `eslint` + `prettier`, `vitest` (676 passing), `astro build`, and integration-tests `npm run format`.

## Known tradeoff
Session durability depends on the store. The in-process default loses sessions on website restart/redeploy (users re-login) and isn't multi-replica-safe — acceptable for the default single replica, flagged for anyone scaling the website. This is the inherent "you need a session store" cost the gist calls out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable