### PR TITLE
fix(backend): scope current pipeline etag tracker by organism

### DIFF
--- a/backend/docs/db/schema.sql
+++ b/backend/docs/db/schema.sql
@@ -51,6 +51,27 @@ CREATE FUNCTION public.jsonb_concat(a jsonb, b jsonb) RETURNS jsonb
 ALTER FUNCTION public.jsonb_concat(a jsonb, b jsonb) OWNER TO postgres;
 
 --
+-- Name: update_current_processing_pipeline_tracker(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.update_current_processing_pipeline_tracker() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated)
+    SELECT TG_TABLE_NAME, cr.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP)
+    FROM changed_rows cr
+    GROUP BY cr.organism
+    ON CONFLICT (table_name, organism, pipeline_version)
+    DO UPDATE SET last_time_updated = timezone('UTC', CURRENT_TIMESTAMP);
+    RETURN NULL;
+END;
+$$;
+
+
+ALTER FUNCTION public.update_current_processing_pipeline_tracker() OWNER TO postgres;
+
+--
 -- Name: update_data_use_terms_table_tracker(); Type: FUNCTION; Schema: public; Owner: postgres
 --
 
@@ -985,13 +1006,6 @@ CREATE INDEX user_groups_table_user_name_idx ON public.user_groups_table USING b
 
 
 --
--- Name: current_processing_pipeline update_tracker_trigger; Type: TRIGGER; Schema: public; Owner: postgres
---
-
-CREATE TRIGGER update_tracker_trigger AFTER INSERT OR DELETE OR UPDATE OR TRUNCATE ON public.current_processing_pipeline FOR EACH STATEMENT EXECUTE FUNCTION public.update_table_tracker();
-
-
---
 -- Name: groups_table update_tracker_trigger; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
@@ -1017,6 +1031,13 @@ CREATE TRIGGER update_tracker_trigger AFTER INSERT OR DELETE OR UPDATE OR TRUNCA
 --
 
 CREATE TRIGGER update_tracker_trigger AFTER INSERT OR DELETE OR UPDATE OR TRUNCATE ON public.user_groups_table FOR EACH STATEMENT EXECUTE FUNCTION public.update_table_tracker();
+
+
+--
+-- Name: current_processing_pipeline update_tracker_trigger_del; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER update_tracker_trigger_del AFTER DELETE ON public.current_processing_pipeline REFERENCING OLD TABLE AS changed_rows FOR EACH STATEMENT EXECUTE FUNCTION public.update_current_processing_pipeline_tracker();
 
 
 --
@@ -1048,6 +1069,13 @@ CREATE TRIGGER update_tracker_trigger_del AFTER DELETE ON public.sequence_entrie
 
 
 --
+-- Name: current_processing_pipeline update_tracker_trigger_ins; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER update_tracker_trigger_ins AFTER INSERT ON public.current_processing_pipeline REFERENCING NEW TABLE AS changed_rows FOR EACH STATEMENT EXECUTE FUNCTION public.update_current_processing_pipeline_tracker();
+
+
+--
 -- Name: data_use_terms_table update_tracker_trigger_ins; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
@@ -1073,6 +1101,13 @@ CREATE TRIGGER update_tracker_trigger_ins AFTER INSERT ON public.sequence_entrie
 --
 
 CREATE TRIGGER update_tracker_trigger_ins AFTER INSERT ON public.sequence_entries_preprocessed_data REFERENCING NEW TABLE AS changed_rows FOR EACH STATEMENT EXECUTE FUNCTION public.update_preprocessed_data_tracker();
+
+
+--
+-- Name: current_processing_pipeline update_tracker_trigger_upd; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER update_tracker_trigger_upd AFTER UPDATE ON public.current_processing_pipeline REFERENCING NEW TABLE AS changed_rows FOR EACH STATEMENT EXECUTE FUNCTION public.update_current_processing_pipeline_tracker();
 
 
 --

--- a/backend/src/main/resources/db/migration/V1.31__scope_current_processing_pipeline_tracker_by_organism.sql
+++ b/backend/src/main/resources/db/migration/V1.31__scope_current_processing_pipeline_tracker_by_organism.sql
@@ -1,0 +1,35 @@
+-- Scope current_processing_pipeline tracker updates by organism.
+-- current_processing_pipeline has one row per organism, so changing the current
+-- pipeline for one organism should not invalidate released-data ETags for all
+-- organisms.
+
+
+DROP TRIGGER IF EXISTS update_tracker_trigger ON current_processing_pipeline;
+
+CREATE OR REPLACE FUNCTION update_current_processing_pipeline_tracker()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated)
+    SELECT TG_TABLE_NAME, cr.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP)
+    FROM changed_rows cr
+    GROUP BY cr.organism
+    ON CONFLICT (table_name, organism, pipeline_version)
+    DO UPDATE SET last_time_updated = timezone('UTC', CURRENT_TIMESTAMP);
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER update_tracker_trigger_ins
+AFTER INSERT ON current_processing_pipeline
+REFERENCING NEW TABLE AS changed_rows
+FOR EACH STATEMENT EXECUTE FUNCTION update_current_processing_pipeline_tracker();
+
+CREATE TRIGGER update_tracker_trigger_upd
+AFTER UPDATE ON current_processing_pipeline
+REFERENCING NEW TABLE AS changed_rows
+FOR EACH STATEMENT EXECUTE FUNCTION update_current_processing_pipeline_tracker();
+
+CREATE TRIGGER update_tracker_trigger_del
+AFTER DELETE ON current_processing_pipeline
+REFERENCING OLD TABLE AS changed_rows
+FOR EACH STATEMENT EXECUTE FUNCTION update_current_processing_pipeline_tracker();

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
@@ -324,6 +324,37 @@ class GetReleasedDataEndpointTest(
     }
 
     @Test
+    fun `GIVEN current pipeline changes for another organism THEN this organism's released-data etag is unchanged`() {
+        convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(organism = DEFAULT_ORGANISM)
+        val otherAccessionVersions =
+            convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(organism = OTHER_ORGANISM)
+
+        val initialEtag = submissionControllerClient.getReleasedData(organism = DEFAULT_ORGANISM)
+            .andReturn()
+            .response
+            .getHeader(ETAG)
+
+        convenienceClient.extractUnprocessedData(organism = OTHER_ORGANISM, pipelineVersion = 2)
+
+        convenienceClient.submitProcessedData(
+            otherAccessionVersions.map {
+                PreparedProcessedData.successfullyProcessedOtherOrganismData(
+                    accession = it.accession,
+                    version = it.version,
+                )
+            },
+            organism = OTHER_ORGANISM,
+            pipelineVersion = 2,
+        )
+
+        submissionDatabaseService.useNewerProcessingPipelineIfPossible()
+
+        // The etag for the default organism should not have changed, since the current pipeline version for that organism has not changed.
+        submissionControllerClient.getReleasedData(organism = DEFAULT_ORGANISM, ifNoneMatch = initialEtag)
+            .andExpect(status().isNotModified)
+    }
+
+    @Test
     fun `GIVEN released data exists in multiple versions THEN the 'versionStatus' flag is set correctly`() {
         val (
             accession,


### PR DESCRIPTION
Fixes released-data ETag invalidation for `current_processing_pipeline`.

Pipeline changes for one organism no longer invalidate released-data cache checks for other organisms.

Fixes #6698 and related to #5110

🚀 Preview: Add `preview` label to enable