### PR TITLE
feat(config): add back crossRef defaults to the values.yaml config

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -11,7 +11,7 @@ localHost: localhost
 robotsNoindexHeader: false
 seqSets:
   enabled: true
-  crossRef: 
+  crossRef:
     DOIPrefix: "placeholder"
     endpoint: "https://test.crossref.org"
   fieldsToDisplay:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -11,6 +11,9 @@ localHost: localhost
 robotsNoindexHeader: false
 seqSets:
   enabled: true
+  crossRef: 
+    DOIPrefix: "placeholder"
+    endpoint: "https://test.crossref.org"
   fieldsToDisplay:
     - field: "geoLocCountry"
       displayName: "Country"
@@ -2651,6 +2654,11 @@ secrets:
       username: "postgres"
       password: "unsecure"
       port: "5432"
+  crossref:
+    type: raw
+    data:
+      username: "dummy"
+      password: "dummy"
   service-accounts:
     type: autogen
     data:


### PR DESCRIPTION
In https://github.com/loculus-project/loculus/pull/6714 we removed the crossref placeholders, this is causing errors for users of loculus due to 
```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
loculus:
- seqSets.crossRef: Invalid type. Expected: object, given: null
```

this adds back the defaults, they will be overwritten by previews/instances with actual crossref fields

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable