### PR TITLE
fix(config): Allow `crossRef` to be set to `null` in configuration

### DIFF
--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1258,7 +1258,7 @@
         },
         "crossRef": {
           "groups": ["general"],
-          "type": "object",
+          "type": ["object", "null"],
           "additionalProperties": false,
           "description": "Configuration for CrossRef integration. Set to `null` to disable CrossRef integration (you can still use SeqSets without CrossRef DOIs).",
           "properties": {


### PR DESCRIPTION
Removing the dummy crossref values caused validation to fail for the helm charts for pathoplexus demo and main: https://github.com/pathoplexus/pathoplexus/actions/runs/27816600899/job/82319231237?pr=1045

This is because the schema doesn't actually support it being set to null - this update adds this to fix the validation errors.

Alternative to #6718 

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable