### PR TITLE
refactor(website): Split fetching of backend and lapis sequence details in `findOrganismAndData`

### DIFF
--- a/website/src/pages/seq/[accessionVersion]/details.json.ts
+++ b/website/src/pages/seq/[accessionVersion]/details.json.ts
@@ -2,24 +2,15 @@ import { type APIRoute } from 'astro';
 
 import { findOrganismAndData } from './findOrganismAndData';
 import { SequenceDetailsTableResultType } from './getSequenceDetailsTableData';
-import { getRuntimeConfig, getSchema, seqSetsAreEnabled } from '../../../config';
+import { getRuntimeConfig, getSchema } from '../../../config';
 import { getInstanceLogger } from '../../../logger.ts';
-import { SeqSetCitationClient } from '../../../services/seqSetCitationClient.ts';
 import type { DetailsJson } from '../../../types/detailsJson';
-import { parseAccessionVersionFromString } from '../../../utils/extractAccessionVersion.ts';
 
 const logger = getInstanceLogger('details.json');
 
 export const GET: APIRoute = async (req) => {
     const params = req.params as { accessionVersion: string; accessToken?: string };
     const { accessionVersion } = params;
-    const { accession } = parseAccessionVersionFromString(accessionVersion);
-
-    const sequenceCitationsPromise = seqSetsAreEnabled()
-        ? SeqSetCitationClient.create().call('getSequenceCitations', {
-              params: { accession }, // Display citations across all accession versions
-          })
-        : undefined;
 
     const sequenceDetailsTableData = await findOrganismAndData(accessionVersion);
 
@@ -40,8 +31,6 @@ export const GET: APIRoute = async (req) => {
         });
     }
 
-    const sequenceCitations = (await sequenceCitationsPromise)?.unwrapOr(undefined);
-
     const clientConfig = getRuntimeConfig().public;
 
     const schema = getSchema(organism);
@@ -56,7 +45,7 @@ export const GET: APIRoute = async (req) => {
         segmentReferences: result.segmentReferences,
         isRevocation: result.isRevocation,
         sequenceEntryHistory: result.sequenceEntryHistory,
-        sequenceCitations,
+        sequenceCitations: result.sequenceCitations,
     };
 
     return new Response(JSON.stringify(detailsDataUIProps), {

--- a/website/src/pages/seq/[accessionVersion]/findOrganismAndData.ts
+++ b/website/src/pages/seq/[accessionVersion]/findOrganismAndData.ts
@@ -1,4 +1,4 @@
-import { err, ok } from 'neverthrow';
+import { err } from 'neverthrow';
 
 import { getSequenceDetailsTableData } from './getSequenceDetailsTableData.ts';
 import { getConfiguredOrganisms } from '../../../config.ts';
@@ -6,17 +6,11 @@ import { getConfiguredOrganisms } from '../../../config.ts';
 export async function findOrganismAndData(accessionVersion: string) {
     const organisms = getConfiguredOrganisms();
 
-    const promises = organisms.map(({ key }) =>
-        getSequenceDetailsTableData(accessionVersion, key).then((result) =>
-            result.isOk()
-                ? ok({ organism: key, result: result.value })
-                : Promise.reject(new Error(`${key}: '${result.error.detail}'`)),
-        ),
-    );
-
     try {
-        const firstSuccess = await Promise.any(promises);
-        return firstSuccess;
+        const result = await getSequenceDetailsTableData(accessionVersion, organisms);
+        return result
+            .map((value) => ({ organism: value.organism, result: value }))
+            .mapErr((error) => ({ message: error.detail }));
     } catch (error) {
         const message =
             error instanceof AggregateError

--- a/website/src/pages/seq/[accessionVersion]/getSequenceDetailsTableData.ts
+++ b/website/src/pages/seq/[accessionVersion]/getSequenceDetailsTableData.ts
@@ -90,12 +90,14 @@ const getBackendSequenceDetails = async (accessionVersion: string): Promise<Back
             : ok(undefined),
     ]);
 
-    return Result.combine([dataUseHistoryResult, sequenceCitationsResult]).map(
-        ([dataUseTermsHistory, sequenceCitations]) => ({
-            dataUseTermsHistory,
-            sequenceCitations,
-        }),
-    );
+    return Result.combine([
+        dataUseHistoryResult,
+        // Return undefined if citations request fails
+        ok(sequenceCitationsResult.unwrapOr(undefined)),
+    ]).map(([dataUseTermsHistory, sequenceCitations]) => ({
+        dataUseTermsHistory,
+        sequenceCitations,
+    }));
 };
 
 export const getSequenceDetailsTableData = async (

--- a/website/src/pages/seq/[accessionVersion]/getSequenceDetailsTableData.ts
+++ b/website/src/pages/seq/[accessionVersion]/getSequenceDetailsTableData.ts
@@ -18,7 +18,7 @@ export enum SequenceDetailsTableResultType {
     REDIRECT = 'redirect',
 }
 
-type LapisData = {
+type LapisSequenceDetails = {
     organism: string;
     tableData: TableDataEntry[];
     sequenceEntryHistory: SequenceEntryHistory;
@@ -26,7 +26,7 @@ type LapisData = {
     isRevocation: boolean;
 };
 
-type BackendData = {
+type BackendSequenceDetails = {
     dataUseTermsHistory: DataUseTermsHistoryEntry[];
     sequenceCitations?: SequenceCitation[];
 };
@@ -48,11 +48,14 @@ export type Redirect = {
     redirectUrl: string;
 };
 
-type LapisDataResult = Result<LapisData, ProblemDetail>;
-type BackendDataResult = Result<BackendData, ProblemDetail>;
+type LapisSequenceDetailsResult = Result<LapisSequenceDetails, ProblemDetail>;
+type BackendSequenceDetailsResult = Result<BackendSequenceDetails, ProblemDetail>;
 type SequenceDetailsTableDataResult = Result<TableData | Redirect, ProblemDetail>;
 
-const getLapisData = async (accessionVersion: string, organism: string): Promise<LapisDataResult> => {
+const getLapisSequenceDetails = async (
+    accessionVersion: string,
+    organism: string,
+): Promise<LapisSequenceDetailsResult> => {
     const { accession } = parseAccessionVersionFromString(accessionVersion);
     const lapisClient = LapisClient.createForOrganism(organism);
     const schema = getSchema(organism);
@@ -72,7 +75,7 @@ const getLapisData = async (accessionVersion: string, organism: string): Promise
     }));
 };
 
-const getBackendData = async (accessionVersion: string): Promise<BackendDataResult> => {
+const getBackendSequenceDetails = async (accessionVersion: string): Promise<BackendSequenceDetailsResult> => {
     const { accession } = parseAccessionVersionFromString(accessionVersion);
     const backendClient = createBackendClient();
     const seqSetCitationClient = SeqSetCitationClient.create();
@@ -119,21 +122,16 @@ export const getSequenceDetailsTableData = async (
         }));
     }
 
-    // getLapisData resolves to a Result and never rejects, so wrap it to reject on error.
-    // This lets Promise.any return the first organism that *succeeds*, rather than the first to settle.
-    const backendDataPromise = getBackendData(accessionVersion);
-    const lapisDataPromises = organisms.map((organism) =>
-        getLapisData(accessionVersion, organism.key).then((result) =>
+    const backendPromise = getBackendSequenceDetails(accessionVersion);
+    const lapisPromises = organisms.map((organism) =>
+        getLapisSequenceDetails(accessionVersion, organism.key).then((result) =>
             result.isOk() ? result : Promise.reject(new Error(`${organism.key}: '${result.error.detail}'`)),
         ),
     );
 
-    const [backendDataResult, lapisDataResult] = await Promise.all([
-        backendDataPromise,
-        Promise.any(lapisDataPromises),
-    ]);
+    const [backendResult, lapisResult] = await Promise.all([backendPromise, Promise.any(lapisPromises)]);
 
-    return Result.combine([backendDataResult, lapisDataResult]).map(([backendData, lapisData]) => ({
+    return Result.combine([backendResult, lapisResult]).map(([backendData, lapisData]) => ({
         organism: lapisData.organism,
         type: SequenceDetailsTableResultType.TABLE_DATA as const,
         tableData: lapisData.tableData,

--- a/website/src/pages/seq/[accessionVersion]/getSequenceDetailsTableData.ts
+++ b/website/src/pages/seq/[accessionVersion]/getSequenceDetailsTableData.ts
@@ -1,13 +1,15 @@
-import { Result } from 'neverthrow';
+import { ok, Result } from 'neverthrow';
 
 import { getTableData } from '../../../components/SequenceDetailsPage/getTableData';
 import { type TableDataEntry } from '../../../components/SequenceDetailsPage/types.ts';
-import { getReferenceGenomes, getSchema } from '../../../config.ts';
+import { getReferenceGenomes, getSchema, seqSetsAreEnabled, type Organism } from '../../../config.ts';
 import { routes } from '../../../routes/routes.ts';
 import { createBackendClient } from '../../../services/backendClientFactory.ts';
 import { LapisClient } from '../../../services/lapisClient.ts';
+import { SeqSetCitationClient } from '../../../services/seqSetCitationClient.ts';
 import type { DataUseTermsHistoryEntry, ProblemDetail } from '../../../types/backend.ts';
 import type { SequenceEntryHistory } from '../../../types/lapis.ts';
+import type { SequenceCitation } from '../../../types/seqSetCitation.ts';
 import { parseAccessionVersionFromString } from '../../../utils/extractAccessionVersion.ts';
 import type { SegmentReferenceSelections } from '../../../utils/sequenceTypeHelpers.ts';
 
@@ -16,56 +18,129 @@ export enum SequenceDetailsTableResultType {
     REDIRECT = 'redirect',
 }
 
-export type TableData = {
-    type: SequenceDetailsTableResultType.TABLE_DATA;
+type LapisData = {
+    organism: string;
     tableData: TableDataEntry[];
     sequenceEntryHistory: SequenceEntryHistory;
-    dataUseTermsHistory: DataUseTermsHistoryEntry[];
     segmentReferences?: SegmentReferenceSelections;
     isRevocation: boolean;
 };
 
+type BackendData = {
+    dataUseTermsHistory: DataUseTermsHistoryEntry[];
+    sequenceCitations?: SequenceCitation[];
+};
+
+type TableData = {
+    organism: string;
+    type: SequenceDetailsTableResultType.TABLE_DATA;
+    tableData: TableDataEntry[];
+    sequenceEntryHistory: SequenceEntryHistory;
+    segmentReferences?: SegmentReferenceSelections;
+    isRevocation: boolean;
+    dataUseTermsHistory: DataUseTermsHistoryEntry[];
+    sequenceCitations?: SequenceCitation[];
+};
+
 export type Redirect = {
+    organism: string;
     type: SequenceDetailsTableResultType.REDIRECT;
     redirectUrl: string;
 };
 
-export type SequenceDetailsTableDataResult = Promise<Result<TableData | Redirect, ProblemDetail>>;
+type LapisDataResult = Result<LapisData, ProblemDetail>;
+type BackendDataResult = Result<BackendData, ProblemDetail>;
+type SequenceDetailsTableDataResult = Result<TableData | Redirect, ProblemDetail>;
 
-export const getSequenceDetailsTableData = async (
-    accessionVersion: string,
-    organism: string,
-): SequenceDetailsTableDataResult => {
-    const { accession, version } = parseAccessionVersionFromString(accessionVersion);
-
+const getLapisData = async (accessionVersion: string, organism: string): Promise<LapisDataResult> => {
+    const { accession } = parseAccessionVersionFromString(accessionVersion);
     const lapisClient = LapisClient.createForOrganism(organism);
-    const backendClient = createBackendClient();
-
-    if (version === undefined) {
-        const latestVersionResult = await lapisClient.getLatestAccessionVersion(accession);
-        return latestVersionResult.map((latestVersion) => ({
-            type: SequenceDetailsTableResultType.REDIRECT,
-            redirectUrl: routes.sequenceEntryDetailsPage(latestVersion),
-        }));
-    }
-
     const schema = getSchema(organism);
     const referenceGenomesInfo = getReferenceGenomes(organism);
 
-    const [tableDataResult, sequenceEntryHistoryResult, dataUseHistoryResult] = await Promise.all([
+    const [tableDataResult, sequenceEntryHistoryResult] = await Promise.all([
         getTableData(accessionVersion, schema, referenceGenomesInfo, lapisClient),
         lapisClient.getAllSequenceEntryHistoryForAccession(accession),
-        backendClient.getDataUseTermsHistory(accession),
     ]);
 
-    return Result.combine([tableDataResult, sequenceEntryHistoryResult, dataUseHistoryResult]).map(
-        ([tableData, sequenceEntryHistory, dataUseTermsHistory]) => ({
-            type: SequenceDetailsTableResultType.TABLE_DATA as const,
-            tableData: tableData.data,
-            sequenceEntryHistory,
+    return Result.combine([tableDataResult, sequenceEntryHistoryResult]).map(([tableData, sequenceEntryHistory]) => ({
+        organism,
+        tableData: tableData.data,
+        sequenceEntryHistory,
+        segmentReferences: tableData.segmentReferences,
+        isRevocation: tableData.isRevocation,
+    }));
+};
+
+const getBackendData = async (accessionVersion: string): Promise<BackendDataResult> => {
+    const { accession } = parseAccessionVersionFromString(accessionVersion);
+    const backendClient = createBackendClient();
+    const seqSetCitationClient = SeqSetCitationClient.create();
+
+    const [dataUseHistoryResult, sequenceCitationsResult] = await Promise.all([
+        backendClient.getDataUseTermsHistory(accession),
+        // If enabled, fetch citations across all versions of the accession
+        seqSetsAreEnabled()
+            ? seqSetCitationClient.call('getSequenceCitations', {
+                  params: { accession },
+              })
+            : ok(undefined),
+    ]);
+
+    return Result.combine([dataUseHistoryResult, sequenceCitationsResult]).map(
+        ([dataUseTermsHistory, sequenceCitations]) => ({
             dataUseTermsHistory,
-            segmentReferences: tableData.segmentReferences,
-            isRevocation: tableData.isRevocation,
+            sequenceCitations,
         }),
     );
+};
+
+export const getSequenceDetailsTableData = async (
+    accessionVersion: string,
+    organisms: Organism[],
+): Promise<SequenceDetailsTableDataResult> => {
+    const { accession, version } = parseAccessionVersionFromString(accessionVersion);
+
+    if (version === undefined) {
+        const latestVersions = organisms.map((organism) =>
+            LapisClient.createForOrganism(organism.key)
+                .getLatestAccessionVersion(accession)
+                .then((result) =>
+                    result.isOk()
+                        ? ok({ organism: organism.key, result: result.value })
+                        : Promise.reject(new Error(`${organism.key}: '${result.error.detail}'`)),
+                ),
+        );
+        const latestVersionResult = await Promise.any(latestVersions);
+        return latestVersionResult.map((latestVersion) => ({
+            organism: latestVersion.organism,
+            type: SequenceDetailsTableResultType.REDIRECT,
+            redirectUrl: routes.sequenceEntryDetailsPage(latestVersion.result),
+        }));
+    }
+
+    // getLapisData resolves to a Result and never rejects, so wrap it to reject on error.
+    // This lets Promise.any return the first organism that *succeeds*, rather than the first to settle.
+    const backendDataPromise = getBackendData(accessionVersion);
+    const lapisDataPromises = organisms.map((organism) =>
+        getLapisData(accessionVersion, organism.key).then((result) =>
+            result.isOk() ? result : Promise.reject(new Error(`${organism.key}: '${result.error.detail}'`)),
+        ),
+    );
+
+    const [backendDataResult, lapisDataResult] = await Promise.all([
+        backendDataPromise,
+        Promise.any(lapisDataPromises),
+    ]);
+
+    return Result.combine([backendDataResult, lapisDataResult]).map(([backendData, lapisData]) => ({
+        organism: lapisData.organism,
+        type: SequenceDetailsTableResultType.TABLE_DATA as const,
+        tableData: lapisData.tableData,
+        sequenceEntryHistory: lapisData.sequenceEntryHistory,
+        dataUseTermsHistory: backendData.dataUseTermsHistory,
+        sequenceCitations: backendData.sequenceCitations,
+        segmentReferences: lapisData.segmentReferences,
+        isRevocation: lapisData.isRevocation,
+    }));
 };

--- a/website/src/pages/seq/[accessionVersion]/index.astro
+++ b/website/src/pages/seq/[accessionVersion]/index.astro
@@ -6,23 +6,14 @@ import { SequenceDataUI } from '../../../components/SequenceDetailsPage/Sequence
 import SequencesBanner from '../../../components/SequenceDetailsPage/SequencesBanner.tsx';
 import SequencesDataTableTitle from '../../../components/SequenceDetailsPage/SequencesDataTableTitle.astro';
 import ErrorBox from '../../../components/common/ErrorBox.tsx';
-import { getSchema, getRuntimeConfig, getWebsiteConfig, getReferenceGenomes, seqSetsAreEnabled } from '../../../config';
+import { getSchema, getRuntimeConfig, getWebsiteConfig, getReferenceGenomes } from '../../../config';
 import BaseLayout from '../../../layouts/BaseLayout.astro';
-import { SeqSetCitationClient } from '../../../services/seqSetCitationClient';
 import { type Group } from '../../../types/backend';
-import { parseAccessionVersionFromString } from '../../../utils/extractAccessionVersion.ts';
 import { getAccessToken } from '../../../utils/getAccessToken';
 import { getMyGroups } from '../../../utils/getMyGroups';
 import { getSegmentNames } from '../../../utils/sequenceTypeHelpers';
 
 const accessionVersion = Astro.params.accessionVersion!;
-const { accession } = parseAccessionVersionFromString(accessionVersion);
-
-const sequenceCitationsPromise = seqSetsAreEnabled()
-    ? SeqSetCitationClient.create().call('getSequenceCitations', {
-          params: { accession }, // Display citations across all accession versions
-      })
-    : undefined;
 
 const sequenceDetailsTableData = await findOrganismAndData(accessionVersion);
 
@@ -32,8 +23,6 @@ if (
 ) {
     return Astro.redirect(sequenceDetailsTableData.value.result.redirectUrl);
 }
-
-const sequenceCitations = (await sequenceCitationsPromise)?.unwrapOr(undefined);
 
 const session = Astro.locals.session;
 const accessToken = getAccessToken(session);
@@ -103,7 +92,7 @@ const sequenceFlaggingConfig = getWebsiteConfig().sequenceFlagging;
                                     myGroups={myGroups}
                                     accessToken={accessToken}
                                     sequenceFlaggingConfig={showDownloadAndReport ? sequenceFlaggingConfig : undefined}
-                                    sequenceCitations={sequenceCitations}
+                                    sequenceCitations={result.sequenceCitations}
                                     client:load
                                 />
                             ))}


### PR DESCRIPTION
### Summary

- The `findOrganismAndData` function is used in the website to retrieve sequence details when viewing sequences both in the search UI and on an individual sequence details page for an accession. Previously, this function called `getSequenceDetailsTableData` for each organism, which would query LAPIS (for sequence details) and the backend (for data use terms history). The backend calls were duplicated across organisms when only a single call needs to be made.
- This PR refactors the `findOrganismAndData` and `getSequenceDetailsTableData` to keep the fan-out approach for LAPIS queries, but have a single call to all required backend endpoints. It does this by splitting the LAPIS and backend data fetching into separate `getLapisSequenceDetails` and `getBackendSequenceDetails` functions. 
- With the `getBackendSequenceDetails` now called once rather than per-organism, we add the sequence citation fetching to the `getBackendSequenceDetails`, to remove some duplicated code. 

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable