### PR TITLE
fix(helm): persistence-gated valuesHash for dev database standins

### DIFF
--- a/kubernetes/loculus/templates/keycloak-database-standin.yaml
+++ b/kubernetes/loculus/templates/keycloak-database-standin.yaml
@@ -1,4 +1,3 @@
-{{- $dockerTag := include "loculus.dockerTag" .Values }}
 {{- if .Values.runDevelopmentKeycloakDatabase }}
 apiVersion: apps/v1
 kind: Deployment
@@ -17,8 +16,10 @@ spec:
     type: Recreate
   template:
     metadata:
+      {{- if not .Values.developmentDatabasePersistence }}
       annotations:
         valuesHash: {{ .Values | toJson | sha256sum | quote }}
+      {{- end }}
       labels:
         app: loculus
         component: keycloak-database
@@ -44,8 +45,4 @@ spec:
               value: "keycloak"
             - name: POSTGRES_HOST_AUTH_METHOD
               value: "trust"
-            {{ if not .Values.developmentDatabasePersistence }}
-            - name: LOCULUS_VERSION
-              value: {{ $dockerTag }}
-            {{- end }}
 {{- end }}

--- a/kubernetes/loculus/templates/loculus-database-standin.yaml
+++ b/kubernetes/loculus/templates/loculus-database-standin.yaml
@@ -1,4 +1,3 @@
-{{- $dockerTag := include "loculus.dockerTag" .Values }}
 {{- if .Values.runDevelopmentMainDatabase }}
 apiVersion: apps/v1
 kind: Deployment
@@ -17,8 +16,10 @@ spec:
     type: Recreate
   template:
     metadata:
+      {{- if not .Values.developmentDatabasePersistence }}
       annotations:
         valuesHash: {{ .Values | toJson | sha256sum | quote }}
+      {{- end }}
       labels:
         app: loculus
         component: database
@@ -49,10 +50,6 @@ spec:
           value: "loculus"
         - name: POSTGRES_HOST_AUTH_METHOD
           value: "trust"
-        {{ if not .Values.developmentDatabasePersistence }}
-        - name: LOCULUS_VERSION
-          value: {{ $dockerTag }}
-        {{- end }}
         volumeMounts:
         - name: init-scripts
           mountPath: /docker-entrypoint-initdb.d

--- a/kubernetes/loculus/templates/loculus-database-standin.yaml
+++ b/kubernetes/loculus/templates/loculus-database-standin.yaml
@@ -17,6 +17,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        valuesHash: {{ .Values | toJson | sha256sum | quote }}
       labels:
         app: loculus
         component: database


### PR DESCRIPTION
## What

Reworks how the development database standins (`loculus-database` and `loculus-keycloak-database`) trigger redeploys:

1. **Add `valuesHash` to `loculus-database`** — it was the only one of the dev-database / app deployments missing the `valuesHash: {{ .Values | toJson | sha256sum | quote }}` pod-template annotation that `keycloak-database`, `keycloak`, and `backend` all carry.
2. **Drop the `LOCULUS_VERSION` env** from both database standins. It was a narrow hack to force the ephemeral dev DBs to redeploy on a version bump; `valuesHash` already covers that (and any other values change) more broadly. The now-unused `$dockerTag` is removed too.
3. **Gate `valuesHash` on `not .Values.developmentDatabasePersistence`**, mirroring how `LOCULUS_VERSION` was gated.

## Why

Both standins use `argocd.argoproj.io/sync-options: Replace=true` + `strategy: Recreate`. Forcing a roll on every values change (via `valuesHash`) is fine for an **ephemeral** database, but undesirable for a **persistent** one — `Recreate` tears the pod down before starting the new one, so a config-only change would cause needless downtime. Gating the annotation on non-persistence means:

- **Ephemeral DBs** redeploy on any values change (broader and more consistent than the old version-only `LOCULUS_VERSION` trigger).
- **Persistent DBs** are left alone on config changes — no forced recreate.

## Verification

`helm template` renders cleanly for both settings:
- `developmentDatabasePersistence=false` → `valuesHash` present on both, no `LOCULUS_VERSION`.
- `developmentDatabasePersistence=true` → no `valuesHash`, and no empty `annotations:` block left on the pod template.

Noticed while debugging why `loculus-database` had no `valuesHash` annotation in a preview environment while `keycloak-database`/`backend` did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)