### PR TITLE
chore(website): drop redundant export on internal-only symbols

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/DownloadButton.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/DownloadButton.tsx
@@ -15,7 +15,7 @@ type DownloadButtonProps = {
     onClick?: () => void;
 };
 
-export const CopyUrlButton: FC<{ url: string }> = ({ url }) => {
+const CopyUrlButton: FC<{ url: string }> = ({ url }) => {
     const [copied, setCopied] = useState(false);
 
     const handleCopy = () => {

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -72,7 +72,7 @@ const buildSequenceCountText = (totalSequences: number | undefined, oldCount: nu
 };
 
 /* eslint-disable @typescript-eslint/no-unsafe-member-access -- TODO(#3451) this component is a mess a needs to be refactored */
-export const InnerSearchFullUI = ({
+const InnerSearchFullUI = ({
     accessToken,
     referenceGenomesInfo,
     myGroups,

--- a/website/src/components/SearchPage/fields/DateField.tsx
+++ b/website/src/components/SearchPage/fields/DateField.tsx
@@ -21,7 +21,7 @@ type CustomizedDatePickerProps = {
  * which converts to UTC and can shift dates (e.g., May 7 0010 becomes May 6 0010).
  * Native getFullYear/getMonth/getDate preserve the exact calendar date displayed.
  */
-export function jsDateToISOString(date: Date | null): string {
+function jsDateToISOString(date: Date | null): string {
     if (!date || !(date instanceof Date) || isNaN(date.getTime())) {
         return '';
     }
@@ -42,7 +42,7 @@ export function jsDateToISOString(date: Date | null): string {
  * Luxon to create dates with slight time offsets (e.g., 8 seconds).
  * Setting to midnight ensures we get back exactly what rsuite gave us.
  */
-export function isoStringToJsDate(value: string): Date | null {
+function isoStringToJsDate(value: string): Date | null {
     if (!value) return null;
 
     const dt = DateTime.fromFormat(value, 'yyyy-MM-dd');
@@ -60,7 +60,7 @@ export function isoStringToJsDate(value: string): Date | null {
  * This ignores actual timezone info to ensure consistent round-trip behavior.
  * Note: Years < 100 not supported (would be misinterpreted by Date constructor).
  */
-export function jsDateToTimestamp(date: Date | null, isUpperBound: boolean): string {
+function jsDateToTimestamp(date: Date | null, isUpperBound: boolean): string {
     if (!date || !(date instanceof Date) || isNaN(date.getTime())) {
         return '';
     }
@@ -82,7 +82,7 @@ export function jsDateToTimestamp(date: Date | null, isUpperBound: boolean): str
  * Converts UTC timestamp back to Date with UTC components as local components.
  * Reverses the "local as UTC" conversion for round-trip consistency.
  */
-export function timestampToJsDate(value: string): Date | null {
+function timestampToJsDate(value: string): Date | null {
     if (!value) return null;
 
     const timestamp = parseInt(value, 10);

--- a/website/src/components/SequenceDetailsPage/RevokeButton.tsx
+++ b/website/src/components/SequenceDetailsPage/RevokeButton.tsx
@@ -112,7 +112,7 @@ interface DisplayRevocationProps {
     onConfirmation: (inputValue: string) => void;
 }
 
-export const displayRevocationDialog = ({ dialogText, onConfirmation }: DisplayRevocationProps) => {
+const displayRevocationDialog = ({ dialogText, onConfirmation }: DisplayRevocationProps) => {
     confirmAlert({
         closeOnClickOutside: false,
         customUI: ({ onClose }) => (
@@ -134,7 +134,7 @@ interface RevocationDialogProps {
     onClose: () => void;
 }
 
-export const RevocationDialog: FC<RevocationDialogProps> = ({ dialogText, onConfirmation, onClose }) => {
+const RevocationDialog: FC<RevocationDialogProps> = ({ dialogText, onConfirmation, onClose }) => {
     const [inputValue, setInputValue] = useState('');
 
     return (


### PR DESCRIPTION
## Summary

[`knip`](https://knip.dev/) flagged a number of "unused exports" in the website. Investigating each, these symbols are **not** dead — they are used, but **only within their own module**. The `export` keyword was therefore unnecessary. This PR removes the redundant `export` while keeping the code; there is **no behaviour change** and nothing is deleted.

| Symbol | File | Internal use |
|---|---|---|
| `jsDateToISOString`, `isoStringToJsDate`, `jsDateToTimestamp`, `timestampToJsDate` | `SearchPage/fields/DateField.tsx` | used as the date/value converters in the same file |
| `displayRevocationDialog`, `RevocationDialog` | `SequenceDetailsPage/RevokeButton.tsx` | `displayRevocationDialog` is called in-file; it renders `RevocationDialog` |
| `InnerSearchFullUI` | `SearchPage/SearchFullUI.tsx` | rendered by the exported wrapper in the same file |
| `CopyUrlButton` | `SearchPage/DownloadDialog/DownloadButton.tsx` | rendered in the same file |

## Verification

- Each symbol has **zero importers** in loculus or in the **pathoplexus** deployment overlay (checked across `.tsx`/`.ts`/`.astro`/`.mdx`, including Astro `.mdx` frontmatter `layout:` edges).
- Each symbol is still referenced internally, so removing `export` is safe.
- `npm run check-types` shows no new errors in the touched files (pre-existing errors on `main` are unrelated: a not-yet-installed `exceljs` dep and an implicit-any in `submission/template/index.ts`).
- `eslint` and `prettier` clean on all four files.

Companion PR #6738 deletes the two genuinely-dead files found in the same knip pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable