### PR TITLE
refactor(website): migrate data use terms history modal to BaseDialog

### DIFF
--- a/website/src/components/SequenceDetailsPage/DataUseTermsHistoryModal.tsx
+++ b/website/src/components/SequenceDetailsPage/DataUseTermsHistoryModal.tsx
@@ -9,11 +9,11 @@ export type DataUseTermsHistoryProps = {
     dataUseTermsHistory: DataUseTermsHistoryEntry[];
 };
 
+const formatDate = (dateString: string) =>
+    DateTime.fromISO(dateString, { zone: FixedOffsetZone.utcInstance }).setLocale('en').toFormat('yyyy-MM-dd T');
+
 export const DataUseTermsHistoryModal: FC<DataUseTermsHistoryProps> = ({ dataUseTermsHistory }) => {
     const [isOpen, setIsOpen] = useState(false);
-
-    const formatDate = (dateString: string) =>
-        DateTime.fromISO(dateString, { zone: FixedOffsetZone.utcInstance }).setLocale('en').toFormat('yyyy-MM-dd T');
 
     return (
         <>
@@ -27,7 +27,7 @@ export const DataUseTermsHistoryModal: FC<DataUseTermsHistoryProps> = ({ dataUse
                 isOpen={isOpen}
                 onClose={() => setIsOpen(false)}
                 fullWidth={false}
-                className='relative max-w-md'
+                className='max-w-md'
             >
                 <table className='w-full text-sm [&_:where(th,td)]:px-3 [&_:where(th,td)]:py-2 [&_:where(th,td)]:text-left [&_th]:font-semibold [&_tbody_tr]:border-t [&_tbody_tr]:border-base-200'>
                     <thead>

--- a/website/src/components/SequenceDetailsPage/DataUseTermsHistoryModal.tsx
+++ b/website/src/components/SequenceDetailsPage/DataUseTermsHistoryModal.tsx
@@ -27,7 +27,7 @@ export const DataUseTermsHistoryModal: FC<DataUseTermsHistoryProps> = ({ dataUse
                 isOpen={isOpen}
                 onClose={() => setIsOpen(false)}
                 fullWidth={false}
-                className='max-w-md'
+                className='relative max-w-md'
             >
                 <table className='w-full text-sm [&_:where(th,td)]:px-3 [&_:where(th,td)]:py-2 [&_:where(th,td)]:text-left [&_th]:font-semibold [&_tbody_tr]:border-t [&_tbody_tr]:border-base-200'>
                     <thead>

--- a/website/src/components/SequenceDetailsPage/DataUseTermsHistoryModal.tsx
+++ b/website/src/components/SequenceDetailsPage/DataUseTermsHistoryModal.tsx
@@ -1,81 +1,58 @@
 import { DateTime, FixedOffsetZone } from 'luxon';
-import { type FC, useRef } from 'react';
+import { type FC, useState } from 'react';
 
 import { type DataUseTermsHistoryEntry, restrictedDataUseTermsOption } from '../../types/backend.ts';
+import { BaseDialog } from '../common/BaseDialog';
 import { Button } from '../common/Button';
-import { ModalBox } from '../common/ModalBox';
 
 export type DataUseTermsHistoryProps = {
     dataUseTermsHistory: DataUseTermsHistoryEntry[];
 };
 
 export const DataUseTermsHistoryModal: FC<DataUseTermsHistoryProps> = ({ dataUseTermsHistory }) => {
-    const dialogRef = useRef<HTMLDialogElement>(null);
+    const [isOpen, setIsOpen] = useState(false);
 
-    const handleOpenHistoryDialog = () => {
-        if (dialogRef.current) {
-            dialogRef.current.showModal();
-        }
-    };
-
-    return (
-        <>
-            <dialog ref={dialogRef} className='bg-transparent p-0 backdrop:bg-black/40'>
-                <DataUseTermsHistoryDialog dataUseTermsHistory={dataUseTermsHistory} />
-            </dialog>
-            <span>
-                <Button className='underline' onClick={handleOpenHistoryDialog}>
-                    (history)
-                </Button>
-            </span>
-        </>
-    );
-};
-
-type DataUseTermsHistoryContainerProps = {
-    dataUseTermsHistory: DataUseTermsHistoryEntry[];
-};
-
-const DataUseTermsHistoryDialog: FC<DataUseTermsHistoryContainerProps> = ({ dataUseTermsHistory }) => {
     const formatDate = (dateString: string) =>
         DateTime.fromISO(dateString, { zone: FixedOffsetZone.utcInstance }).setLocale('en').toFormat('yyyy-MM-dd T');
 
     return (
-        <ModalBox className='w-auto max-w-md'>
-            <form method='dialog'>
-                <Button circle size='sm' variant='ghost' className='absolute right-2 top-2'>
-                    ✕
+        <>
+            <span>
+                <Button className='underline' onClick={() => setIsOpen(true)}>
+                    (history)
                 </Button>
-            </form>
-            <h3 className='font-bold text-lg'>Data use terms history</h3>
-            <table className='w-full text-sm [&_:where(th,td)]:px-3 [&_:where(th,td)]:py-2 [&_:where(th,td)]:text-left [&_th]:font-semibold [&_tbody_tr]:border-t [&_tbody_tr]:border-base-200'>
-                <thead>
-                    <tr>
-                        <th>Changed</th>
-                        <th>User</th>
-                        <th>Data use terms</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {dataUseTermsHistory.map((row, index) => (
-                        <tr key={index}>
-                            <td>{formatDate(row.changeDate)}</td>
-                            <td>{row.userName}</td>
-                            <td>
-                                {row.dataUseTerms.type}
-                                {row.dataUseTerms.type === restrictedDataUseTermsOption
-                                    ? ' until ' + row.dataUseTerms.restrictedUntil
-                                    : ''}
-                            </td>
+            </span>
+            <BaseDialog
+                title='Data use terms history'
+                isOpen={isOpen}
+                onClose={() => setIsOpen(false)}
+                fullWidth={false}
+                className='max-w-md'
+            >
+                <table className='w-full text-sm [&_:where(th,td)]:px-3 [&_:where(th,td)]:py-2 [&_:where(th,td)]:text-left [&_th]:font-semibold [&_tbody_tr]:border-t [&_tbody_tr]:border-base-200'>
+                    <thead>
+                        <tr>
+                            <th>Changed</th>
+                            <th>User</th>
+                            <th>Data use terms</th>
                         </tr>
-                    ))}
-                </tbody>
-            </table>
-            <div className='flex justify-end gap-4 mt-4'>
-                <form method='dialog'>
-                    <Button variant='neutral'>Close</Button>
-                </form>
-            </div>
-        </ModalBox>
+                    </thead>
+                    <tbody>
+                        {dataUseTermsHistory.map((row, index) => (
+                            <tr key={index}>
+                                <td>{formatDate(row.changeDate)}</td>
+                                <td>{row.userName}</td>
+                                <td>
+                                    {row.dataUseTerms.type}
+                                    {row.dataUseTerms.type === restrictedDataUseTermsOption
+                                        ? ' until ' + row.dataUseTerms.restrictedUntil
+                                        : ''}
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </BaseDialog>
+        </>
     );
 };

--- a/website/src/components/common/BaseDialog.tsx
+++ b/website/src/components/common/BaseDialog.tsx
@@ -27,7 +27,7 @@ export const BaseDialog: React.FC<BaseDialogProps> = ({
             <div className='fixed inset-0 overflow-y-auto'>
                 <div className='flex min-h-full items-center justify-center p-4 text-center'>
                     <DialogPanel
-                        className={`${fullWidthClasses} transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl ${className ?? ''}`}
+                        className={`${fullWidthClasses} relative transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl ${className ?? ''}`}
                     >
                         <DialogTitle as='h3' className='text-2xl font-bold leading-6 text-gray-900 mb-4'>
                             {title}


### PR DESCRIPTION
relates to https://github.com/loculus-project/loculus/issues/6512

## Summary

The data use terms history modal (opened via the **(history)** link on a sequence's data use terms) used a native `<dialog>` element wrapped in a plain `ModalBox` div. That meant:
- no click-outside-to-close behaviour, and
- a hand-rolled close button, title, and open/close wiring.

This migrates it to the shared HeadlessUI-based **`BaseDialog`**, matching the other modals in the app (`FieldSelectorModal`, `LinkOutMenu`, `ColumnMappingModal`, `SeqPreviewModal`, `ReviewPage`, …).

## Changes

- **Click-outside** and **Escape** now close the modal (handled automatically by HeadlessUI's `Dialog` `onClose`).
- Removed the redundant bottom **"Close"** button — `BaseDialog` provides a single ✕ close button plus the title.
- Open/close state moved from a `dialog` ref + `showModal()` to React `useState` (`isOpen` / `onClose`).
- No change to the history table contents.

## Verification

- `eslint` clean on the changed file.
- `npm run check-types` reports no new errors in the file or its consumer (`DataTableEntryValue.tsx`).
- Component is mounted in an already-hydrated React tree, so interactivity is unchanged.


## Screenshots

The migrated modal now closes on **click-outside** and **Escape**, keeps a single ✕ close button (the redundant bottom "Close" button is removed).

| Before (`main` — native `<dialog>` + `ModalBox`, bottom "Close" button) | After (this PR — `BaseDialog`) |
|---|---|
| ![before](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6742/before-history-modal.png) | ![after](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6742/after-history-modal.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: https://chore-datausetermshistory.loculus.org