### PR TITLE
fix(website): style primary action buttons as primary, not grey

### DIFF
--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -174,7 +174,7 @@ const InnerEditPage: FC<EditPageProps> = ({
             )}
             <div className='flex items-center gap-4 mt-4'>
                 <Button
-                    variant='neutral'
+                    variant='primary'
                     onClick={() =>
                         displayConfirmationDialog({
                             dialogText: 'Do you really want to submit?',

--- a/website/src/components/SeqSetCitations/ExportSeqSet.tsx
+++ b/website/src/components/SeqSetCitations/ExportSeqSet.tsx
@@ -150,7 +150,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                         </div>
                     </div>
                     <div className='pb-8 pt-4'>
-                        <Button variant='neutral' onClick={downloadSeqSet} disabled={isDownloading}>
+                        <Button variant='primary' onClick={downloadSeqSet} disabled={isDownloading}>
                             Download
                         </Button>
                     </div>
@@ -218,7 +218,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                     />
                 </div>
                 <div className='pb-8'>
-                    <Button variant='neutral' onClick={() => void copyToClipboard()} disabled={isDownloading}>
+                    <Button variant='primary' onClick={() => void copyToClipboard()} disabled={isDownloading}>
                         Copy to clipboard
                     </Button>
                 </div>


### PR DESCRIPTION
## Summary

Several primary actions were rendered with the default grey (`neutral`) button variant instead of the `primary` variant. This makes them `primary`:

- **Edit page** (review / edit a sequence): the bottom **Submit** button — `EditPage.tsx`
- **SeqSet export** dialog: the **Download** and **Copy to clipboard** buttons — `ExportSeqSet.tsx`

These were identified while auditing `variant='neutral'` usages; the remaining neutral buttons (Close / Cancel actions) are intentionally secondary and left unchanged.

## Notes

Pure styling change — no behaviour or logic changes.


## Screenshots

The primary actions now render in the primary (blue) style.

**SeqSet export — Download & Copy to clipboard:**

![seqset export buttons](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6743/seqset-export-buttons.png)

(Demo SeqSet used for the screenshot: [https://chore-primary-button-styl.loculus.org/seqsets/LOC_SS_1.1](https://chore-primary-button-styl.loculus.org/seqsets/LOC_SS_1.1))

**Edit page — Submit:**

![edit page submit button](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6743/edit-page-submit-button.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable