### PR TITLE
fix(website): fix invisible selection state on SeqSet export radio buttons

### DIFF
--- a/website/src/components/SeqSetCitations/ExportSeqSet.tsx
+++ b/website/src/components/SeqSetCitations/ExportSeqSet.tsx
@@ -122,7 +122,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                                 data-testid='json-radio'
                                 checked={selectedDownload === 0}
                                 type='radio'
-                                className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
+                                className='w-4 h-4 text-primary-600 border-gray-300 focus:ring-primary-600 focus:ring-2'
                                 onChange={() => setSelectedDownload(0)}
                             />
                             <label
@@ -138,7 +138,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                                 data-testid='tsv-radio'
                                 type='radio'
                                 checked={selectedDownload === 1}
-                                className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
+                                className='w-4 h-4 text-primary-600 border-gray-300 focus:ring-primary-600 focus:ring-2'
                                 onChange={() => setSelectedDownload(1)}
                             />
                             <label
@@ -163,7 +163,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                             checked={selectedCitation === 0}
                             type='radio'
                             name='inline-radio-group'
-                            className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
+                            className='w-4 h-4 text-primary-600 border-gray-300 focus:ring-primary-600 focus:ring-2'
                             onChange={() => setSelectedCitation(0)}
                         />
                         <label
@@ -179,7 +179,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                             type='radio'
                             checked={selectedCitation === 1}
                             name='inline-radio-group'
-                            className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
+                            className='w-4 h-4 text-primary-600 border-gray-300 focus:ring-primary-600 focus:ring-2'
                             onChange={() => setSelectedCitation(1)}
                         />
                         <label
@@ -195,7 +195,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                             type='radio'
                             checked={selectedCitation === 2}
                             name='inline-radio-group'
-                            className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
+                            className='w-4 h-4 text-primary-600 border-gray-300 focus:ring-primary-600 focus:ring-2'
                             onChange={() => setSelectedCitation(2)}
                         />
                         <label


### PR DESCRIPTION
## Summary

Fixes #6745 — the radio buttons in the **Export / Cite SeqSet** view (JSON/TSV and BibTeX/MLA/APA) didn't show which option was selected, so they looked broken/unstyled.

## Root cause

The app styles form controls with `@tailwindcss/forms` (`base` strategy), which renders a radio's checked state as a **white dot SVG on a `currentColor` background**. These five radios additionally carried a `bg-gray-100` utility class (Flowbite-style leftovers). Because Tailwind utilities win over the forms plugin's base layer, `bg-gray-100` overrode the plugin's `:checked { background-color: currentColor }` — so the checked background stayed light gray and the white dot was invisible. The radio therefore looked unselected even when active (the citation text/download format did change correctly underneath).

Confirmed on a live preview — the checked `#json-radio` computed to `background-color: rgb(243, 244, 246)` (gray-100) instead of the accent color.

This regressed when `flowbite-forms-compat.css` was removed during the Tailwind v4 migration.

## Fix

Replace the bespoke Flowbite classes with the same convention used by the other (working) radios across the app (`OptionBlock`, `DataUseTermsSelector`):

```
text-primary-600 border-gray-300 focus:ring-primary-600 focus:ring-2
```

This drops the conflicting `bg-gray-100` and the unused dark-mode classes, and uses the brand `primary` accent. I audited every radio/checkbox in the website — these five were the only ones with the `bg-gray-*` override bug.


## Screenshots

**Before** — on the SeqSet referenced in the issue ([pathoplexus.org/seqsets/PP_SS_199.2](https://pathoplexus.org/seqsets/PP_SS_199.2)); every radio shows as an empty circle, even the selected JSON/BibTeX options (note BibTeX content is populated below):

![before](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6746/before-radios-broken.png)

**After** — the selected radios (JSON, BibTeX) now show a filled accent dot:

![after](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6746/after-radios-fixed.png)

> Note: the "after" was rendered by applying this PR's exact radio classes (`w-4 h-4 text-primary-600 border-gray-300 focus:ring-primary-600 focus:ring-2`) to a live SeqSet export view. The PR's own preview env had a backlogged preprocessing pipeline, so no SeqSet could be created there to screenshot directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable