### PR TITLE
fix(website): Fix radio display on export seqset and data use terms selector

### DIFF
--- a/website/src/components/DataUseTerms/DataUseTermsSelector.tsx
+++ b/website/src/components/DataUseTerms/DataUseTermsSelector.tsx
@@ -80,7 +80,7 @@ const DataUseTermsSelector: FC<DataUseTermsSelectorProps> = ({
                     onChange={() => setSelectedOption(openDataUseTermsOption)}
                     type='radio'
                     checked={selectedOption === openDataUseTermsOption}
-                    className='h-4 w-4 p-2 border-gray-300 text-primary-600 focus:ring-primary-600 inline-block'
+                    className='h-4 w-4 p-2 text-primary-600 focus:ring-primary-600 inline-block'
                 />
                 <label htmlFor='data-use-open' className='ml-2 h-4 p-2 text-sm font-medium leading-6 text-gray-900'>
                     <Unlocked className='h-4 w-4 inline-block mr-2 -mt-1' />
@@ -102,7 +102,7 @@ const DataUseTermsSelector: FC<DataUseTermsSelectorProps> = ({
                     onChange={() => setSelectedOption(restrictedDataUseTermsOption)}
                     type='radio'
                     checked={selectedOption === restrictedDataUseTermsOption}
-                    className='h-4 w-4 border-gray-300 text-primary-600 focus:ring-primary-600 inline-block'
+                    className='h-4 w-4 p-2 text-primary-600 focus:ring-primary-600 inline-block'
                 />
                 <label
                     htmlFor='data-use-restricted'

--- a/website/src/components/DataUseTerms/DataUseTermsSelector.tsx
+++ b/website/src/components/DataUseTerms/DataUseTermsSelector.tsx
@@ -80,7 +80,7 @@ const DataUseTermsSelector: FC<DataUseTermsSelectorProps> = ({
                     onChange={() => setSelectedOption(openDataUseTermsOption)}
                     type='radio'
                     checked={selectedOption === openDataUseTermsOption}
-                    className='h-4 w-4 p-2 text-primary-600 focus:ring-primary-600 inline-block'
+                    className='h-4 w-4 p-2 text-primary-600 border-gray-300 checked:border-primary-600 focus:ring-primary-600 inline-block'
                 />
                 <label htmlFor='data-use-open' className='ml-2 h-4 p-2 text-sm font-medium leading-6 text-gray-900'>
                     <Unlocked className='h-4 w-4 inline-block mr-2 -mt-1' />
@@ -102,7 +102,7 @@ const DataUseTermsSelector: FC<DataUseTermsSelectorProps> = ({
                     onChange={() => setSelectedOption(restrictedDataUseTermsOption)}
                     type='radio'
                     checked={selectedOption === restrictedDataUseTermsOption}
-                    className='h-4 w-4 p-2 text-primary-600 focus:ring-primary-600 inline-block'
+                    className='h-4 w-4 p-2 text-primary-600 border-gray-300 checked:border-primary-600 focus:ring-primary-600 inline-block'
                 />
                 <label
                     htmlFor='data-use-restricted'

--- a/website/src/components/SeqSetCitations/ExportSeqSet.tsx
+++ b/website/src/components/SeqSetCitations/ExportSeqSet.tsx
@@ -122,7 +122,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                                 data-testid='json-radio'
                                 checked={selectedDownload === 0}
                                 type='radio'
-                                className='h-4 w-4 p-2 border-gray-300 text-primary-600 focus:ring-primary-600 inline-block'
+                                className='h-4 w-4 p-2 text-primary-600 focus:ring-primary-600 inline-block'
                                 onChange={() => setSelectedDownload(0)}
                             />
                             <label
@@ -138,7 +138,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                                 data-testid='tsv-radio'
                                 type='radio'
                                 checked={selectedDownload === 1}
-                                className='h-4 w-4 p-2 border-gray-300 text-primary-600 focus:ring-primary-600 inline-block'
+                                className='h-4 w-4 p-2 text-primary-600 focus:ring-primary-600 inline-block'
                                 onChange={() => setSelectedDownload(1)}
                             />
                             <label
@@ -163,7 +163,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                             checked={selectedCitation === 0}
                             type='radio'
                             name='inline-radio-group'
-                            className='h-4 w-4 p-2 border-gray-300 text-primary-600 focus:ring-primary-600 inline-block'
+                            className='h-4 w-4 p-2 text-primary-600 focus:ring-primary-600 inline-block'
                             onChange={() => setSelectedCitation(0)}
                         />
                         <label
@@ -179,7 +179,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                             type='radio'
                             checked={selectedCitation === 1}
                             name='inline-radio-group'
-                            className='h-4 w-4 p-2 border-gray-300 text-primary-600 focus:ring-primary-600 inline-block'
+                            className='h-4 w-4 p-2 text-primary-600 focus:ring-primary-600 inline-block'
                             onChange={() => setSelectedCitation(1)}
                         />
                         <label
@@ -195,7 +195,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                             type='radio'
                             checked={selectedCitation === 2}
                             name='inline-radio-group'
-                            className='h-4 w-4 p-2 border-gray-300 text-primary-600 focus:ring-primary-600 inline-block'
+                            className='h-4 w-4 p-2 text-primary-600 focus:ring-primary-600 inline-block'
                             onChange={() => setSelectedCitation(2)}
                         />
                         <label

--- a/website/src/components/SeqSetCitations/ExportSeqSet.tsx
+++ b/website/src/components/SeqSetCitations/ExportSeqSet.tsx
@@ -122,7 +122,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                                 data-testid='json-radio'
                                 checked={selectedDownload === 0}
                                 type='radio'
-                                className='h-4 w-4 p-2 text-primary-600 focus:ring-primary-600 inline-block'
+                                className='h-4 w-4 p-2 text-primary-600 border-gray-300 checked:border-primary-600 focus:ring-primary-600 inline-block'
                                 onChange={() => setSelectedDownload(0)}
                             />
                             <label
@@ -138,7 +138,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                                 data-testid='tsv-radio'
                                 type='radio'
                                 checked={selectedDownload === 1}
-                                className='h-4 w-4 p-2 text-primary-600 focus:ring-primary-600 inline-block'
+                                className='h-4 w-4 p-2 text-primary-600 border-gray-300 checked:border-primary-600 focus:ring-primary-600 inline-block'
                                 onChange={() => setSelectedDownload(1)}
                             />
                             <label
@@ -163,7 +163,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                             checked={selectedCitation === 0}
                             type='radio'
                             name='inline-radio-group'
-                            className='h-4 w-4 p-2 text-primary-600 focus:ring-primary-600 inline-block'
+                            className='h-4 w-4 p-2 text-primary-600 border-gray-300 checked:border-primary-600 focus:ring-primary-600 inline-block'
                             onChange={() => setSelectedCitation(0)}
                         />
                         <label
@@ -179,7 +179,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                             type='radio'
                             checked={selectedCitation === 1}
                             name='inline-radio-group'
-                            className='h-4 w-4 p-2 text-primary-600 focus:ring-primary-600 inline-block'
+                            className='h-4 w-4 p-2 text-primary-600 border-gray-300 checked:border-primary-600 focus:ring-primary-600 inline-block'
                             onChange={() => setSelectedCitation(1)}
                         />
                         <label
@@ -195,7 +195,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                             type='radio'
                             checked={selectedCitation === 2}
                             name='inline-radio-group'
-                            className='h-4 w-4 p-2 text-primary-600 focus:ring-primary-600 inline-block'
+                            className='h-4 w-4 p-2 text-primary-600 border-gray-300 checked:border-primary-600 focus:ring-primary-600 inline-block'
                             onChange={() => setSelectedCitation(2)}
                         />
                         <label

--- a/website/src/components/SeqSetCitations/ExportSeqSet.tsx
+++ b/website/src/components/SeqSetCitations/ExportSeqSet.tsx
@@ -122,7 +122,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                                 data-testid='json-radio'
                                 checked={selectedDownload === 0}
                                 type='radio'
-                                className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
+                                className='h-4 w-4 p-2 border-gray-300 text-primary-600 focus:ring-primary-600 inline-block'
                                 onChange={() => setSelectedDownload(0)}
                             />
                             <label
@@ -138,7 +138,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                                 data-testid='tsv-radio'
                                 type='radio'
                                 checked={selectedDownload === 1}
-                                className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
+                                className='h-4 w-4 p-2 border-gray-300 text-primary-600 focus:ring-primary-600 inline-block'
                                 onChange={() => setSelectedDownload(1)}
                             />
                             <label
@@ -163,7 +163,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                             checked={selectedCitation === 0}
                             type='radio'
                             name='inline-radio-group'
-                            className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
+                            className='h-4 w-4 p-2 border-gray-300 text-primary-600 focus:ring-primary-600 inline-block'
                             onChange={() => setSelectedCitation(0)}
                         />
                         <label
@@ -179,7 +179,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                             type='radio'
                             checked={selectedCitation === 1}
                             name='inline-radio-group'
-                            className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
+                            className='h-4 w-4 p-2 border-gray-300 text-primary-600 focus:ring-primary-600 inline-block'
                             onChange={() => setSelectedCitation(1)}
                         />
                         <label
@@ -195,7 +195,7 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
                             type='radio'
                             checked={selectedCitation === 2}
                             name='inline-radio-group'
-                            className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
+                            className='h-4 w-4 p-2 border-gray-300 text-primary-600 focus:ring-primary-600 inline-block'
                             onChange={() => setSelectedCitation(2)}
                         />
                         <label


### PR DESCRIPTION
The `bg-gray-100` style was causing issues with the radios in the `ExportSeqSet` component, and the use of `border-gray-300` was making some radios look a bit odd when selected (in the data use terms selector). This PR updates those radios to use the same styling, with issues removed. There is also a `RadioOptionBlock` component which I guess could be used, or a separate radio component added, but I figured this is a quick fix for the moment!

(Alternate PR to #6746, opened before I realised that one existed - this one additionally fixes the gray border issue when checking some of the radios, but happy to close this one and do that as a follow up - whatever works!)

### Screenshot
Before:
<img width="1000" height="519" alt="image" src="https://github.com/user-attachments/assets/aec08ad7-c38f-4e9c-84e8-2172851b9e8b" />

After:

<img width="1000" height="519" alt="image" src="https://github.com/user-attachments/assets/a7e98cc3-f29b-4691-be8e-800159154ab1" />

Before:

<img width="117" height="55" alt="image" src="https://github.com/user-attachments/assets/c8599e0b-97d8-4f04-b792-1cc182970e7b" />


After:

<img width="141" height="62" alt="image" src="https://github.com/user-attachments/assets/c5f8bfe4-d9d1-4fb3-b402-01a3def6a7a8" />



### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable