### PR TITLE
demo exploration: rev files

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -478,3 +478,21 @@ fun FileCategoryFilesMap.getDuplicateFileNames(category: FileCategory): Set<Stri
 
     return nameCounts.filterValues { it > 1 }.keys
 }
+
+/**
+ * Merge two file maps, with [override] taking priority over [base] per (category, file name).
+ *
+ * Used when revising: existing files referenced in the metadata `existingFiles_<category>` columns are
+ * the [base], and freshly uploaded files are the [override]. If the same file name appears in both for a
+ * given category, the freshly uploaded file wins.
+ */
+fun mergeFileCategoryFilesMaps(base: FileCategoryFilesMap?, override: FileCategoryFilesMap?): FileCategoryFilesMap? {
+    if (base.isNullOrEmpty()) return override?.ifEmpty { null }
+    if (override.isNullOrEmpty()) return base.ifEmpty { null }
+
+    return (base.keys + override.keys).associateWith { category ->
+        val overrideFiles = override[category].orEmpty()
+        val overrideNames = overrideFiles.map { it.name }.toSet()
+        base[category].orEmpty().filter { it.name !in overrideNames } + overrideFiles
+    }
+}

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -527,6 +527,11 @@ open class SubmissionController(
         val instanceConfig = backendConfig.getInstanceConfig(organism)
         val hasConsensusSequences = instanceConfig.schema.submissionDataTypes.consensusSequences
         val isMultiSegmented = instanceConfig.referenceGenome.nucleotideSequences.size > 1
+        val submissionFileCategories = if (instanceConfig.schema.submissionDataTypes.files.enabled) {
+            instanceConfig.schema.submissionDataTypes.files.categories.map { it.name }
+        } else {
+            emptyList()
+        }
 
         val streamBody = StreamingResponseBody { responseBodyStream ->
             val startTime = System.currentTimeMillis()
@@ -556,6 +561,7 @@ open class SubmissionController(
                             uniqueFastaIdsByEntry,
                             zipOut,
                             isMultiSegmented,
+                            submissionFileCategories,
                         )
                         zipOut.closeEntry()
 

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionControllerDescriptions.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionControllerDescriptions.kt
@@ -118,9 +118,14 @@ The version will increase by one in respect to the original accession version.
 
 const val REVISED_METADATA_FILE_DESCRIPTION = """
 A TSV (tab separated values) file containing the metadata of the revised data.
-The first row must contain the column names. The column '$METADATA_ID_HEADER' is required and must be unique within the 
+The first row must contain the column names. The column '$METADATA_ID_HEADER' is required and must be unique within the
 provided dataset. It is used to associate metadata to the sequences in the sequences fasta file.
 Additionally, the column 'accession' is required and must match the accession of the original sequence entry.
+For organisms with file submission enabled, optional 'existingFiles_<category>' columns can list the files (as a
+'|'-separated list of 'name:fileId' tokens) that should remain attached to each entry. Files in these columns are kept;
+removing a token removes that file; blanking the cell removes all files of that category. Newly uploaded files provided
+via 'fileMapping' are merged in and take priority over an existing file with the same name and category. These columns
+are included in the download from the 'get-submitted-data' endpoint.
 """
 
 const val SUBMIT_DESCRIPTION = """

--- a/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
@@ -34,6 +34,15 @@ const val FASTA_IDS_HEADER = "fastaIds"
 const val FASTA_IDS_SEPARATOR = " "
 
 const val ACCESSION_HEADER = "accession"
+
+/**
+ * Prefix for the per-category metadata columns that list the files currently attached to an entry, used
+ * when revising to keep/remove existing files. The category name follows the prefix, e.g.
+ * `existingFiles_raw_reads`. Each cell holds a `|`-separated list of `name:fileId` tokens.
+ */
+const val EXISTING_FILES_COLUMN_PREFIX = "existingFiles_"
+const val EXISTING_FILES_ENTRY_SEPARATOR = "|"
+
 private val log = KotlinLogging.logger { }
 
 typealias SubmissionId = String
@@ -110,6 +119,9 @@ class SubmitModel(
             "Processing submission (type: ${submissionParams.uploadType.name}) with uploadId $uploadId"
         }
 
+        // Validate the freshly uploaded files (the `fileMapping` param). Files kept via the
+        // `existingFiles_<category>` metadata columns of a revision are only known after parsing the metadata
+        // into the aux table, so they are validated further down.
         submissionIdFilesMappingPreconditionValidator
             .validateFilenameCharacters(submissionParams.files)
             .validateFilenamesAreUnique(submissionParams.files)
@@ -144,10 +156,26 @@ class SubmitModel(
             )
         }
 
+        // Freshly uploaded files: their submission ids must be present in the metadata and they must belong to the
+        // submission's group (group ownership is only known after association above).
         submissionParams.files?.let { submittedFiles ->
-            val fileSubmissionIds = submittedFiles.keys
-            validateSubmissionIdSetsForFiles(metadataSubmissionIds, fileSubmissionIds)
+            validateSubmissionIdSetsForFiles(metadataSubmissionIds, submittedFiles.keys)
             validateFileGroupOwnership(submittedFiles, submissionParams, uploadId)
+        }
+
+        // For revisions, validate the effective files attached to each entry, i.e. the files kept via the
+        // `existingFiles_<category>` metadata columns merged with the freshly uploaded ones (read back from the aux
+        // table). This also catches references to files that don't exist or belong to another group.
+        if (submissionParams is SubmissionParams.RevisionSubmissionParams) {
+            uploadDatabaseService.getFilesForUpload(uploadId).ifEmpty { null }?.let { mergedFiles ->
+                submissionIdFilesMappingPreconditionValidator
+                    .validateFilenameCharacters(mergedFiles)
+                    .validateFilenamesAreUnique(mergedFiles)
+                    .validateCategoriesMatchSchema(mergedFiles, submissionParams.organism)
+                    .validateMultipartUploads(mergedFiles)
+                    .validateFilesExist(mergedFiles)
+                validateFileGroupOwnership(mergedFiles, submissionParams, uploadId)
+            }
         }
 
         if (submissionParams is SubmissionParams.OriginalSubmissionParams) {

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
@@ -16,6 +16,7 @@ import org.loculus.backend.api.Organism
 import org.loculus.backend.api.Status
 import org.loculus.backend.api.SubmissionIdFilesMap
 import org.loculus.backend.api.SubmissionIdMapping
+import org.loculus.backend.api.mergeFileCategoryFilesMaps
 import org.loculus.backend.auth.AuthenticatedUser
 import org.loculus.backend.controller.UnprocessableEntityException
 import org.loculus.backend.log.AuditLogger
@@ -120,7 +121,9 @@ class UploadDatabaseService(
                     this[submissionIdColumn] = it.submissionId
                     this[fastaIdsColumn] = it.fastaIds?.toList()
                     this[metadataColumn] = it.metadata
-                    this[filesColumn] = files?.get(it.submissionId)
+                    // Existing files referenced in the metadata columns are kept, freshly uploaded files
+                    // (the `files` param) override them per (category, file name).
+                    this[filesColumn] = mergeFileCategoryFilesMaps(it.existingFiles, files?.get(it.submissionId))
                     this[organismColumn] = submittedOrganism.name
                     this[uploadIdColumn] = uploadId
                 }
@@ -165,6 +168,21 @@ class UploadDatabaseService(
         )
         .where { uploadIdColumn eq uploadId }
         .map { it[submissionIdColumn] }
+
+    /**
+     * The effective file map per submission for an upload, i.e. the result of merging the files referenced in the
+     * metadata `existingFiles_<category>` columns with the freshly uploaded files. Used to validate the files that
+     * will actually be attached after a revision.
+     */
+    fun getFilesForUpload(uploadId: String): SubmissionIdFilesMap = MetadataUploadAuxTable
+        .select(
+            uploadIdColumn,
+            submissionIdColumn,
+            filesColumn,
+        )
+        .where { uploadIdColumn eq uploadId }
+        .mapNotNull { row -> row[filesColumn]?.let { row[submissionIdColumn] to it } }
+        .toMap()
 
     fun getFastaIdsForMetadata(uploadId: String): List<List<String>> = MetadataUploadAuxTable
         .select(

--- a/backend/src/main/kotlin/org/loculus/backend/utils/GetSubmittedDataHelpers.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/GetSubmittedDataHelpers.kt
@@ -2,6 +2,8 @@ package org.loculus.backend.utils
 
 import org.loculus.backend.api.SubmittedDataDownloadEntry
 import org.loculus.backend.model.ACCESSION_HEADER
+import org.loculus.backend.model.EXISTING_FILES_COLUMN_PREFIX
+import org.loculus.backend.model.EXISTING_FILES_ENTRY_SEPARATOR
 import org.loculus.backend.model.FASTA_IDS_HEADER
 import org.loculus.backend.model.FASTA_IDS_SEPARATOR
 import org.loculus.backend.model.FastaId
@@ -47,27 +49,39 @@ object GetSubmittedDataHelpers {
         fastaIdsByEntry: List<UniqueFastaIdsForEntry>,
         outputStream: java.io.OutputStream,
         isMultiSegmented: Boolean,
+        fileCategories: List<String> = emptyList(),
     ) {
         val metadataKeys = data.flatMapTo(mutableSetOf()) { it.submittedData.metadata.keys }.sorted()
+        val fileColumnHeaders = fileCategories.map { "$EXISTING_FILES_COLUMN_PREFIX$it" }
         val headers = if (isMultiSegmented) {
-            listOf(METADATA_ID_HEADER, ACCESSION_HEADER, FASTA_IDS_HEADER) + metadataKeys
+            listOf(METADATA_ID_HEADER, ACCESSION_HEADER, FASTA_IDS_HEADER) + metadataKeys + fileColumnHeaders
         } else {
-            listOf(METADATA_ID_HEADER, ACCESSION_HEADER) + metadataKeys
+            listOf(METADATA_ID_HEADER, ACCESSION_HEADER) + metadataKeys + fileColumnHeaders
         }
 
         TsvWriter(outputStream, headers).use { writer ->
             for ((index, entry) in data.withIndex()) {
                 val metadataValues = metadataKeys.map { entry.submittedData.metadata[it] ?: "" }
+                val fileValues = fileCategories.map { category ->
+                    formatExistingFilesCell(entry.submittedData.files?.get(category))
+                }
                 val row = if (isMultiSegmented) {
                     val fastaIds = fastaIdsByEntry[index].joinedUniqueFastaIds(FASTA_IDS_SEPARATOR)
-                    listOf(metadataIds[index], entry.accession, fastaIds) + metadataValues
+                    listOf(metadataIds[index], entry.accession, fastaIds) + metadataValues + fileValues
                 } else {
-                    listOf(metadataIds[index], entry.accession) + metadataValues
+                    listOf(metadataIds[index], entry.accession) + metadataValues + fileValues
                 }
                 writer.writeRow(row)
             }
         }
     }
+
+    /**
+     * Render the files of one category as a `|`-separated list of `name:fileId` tokens for the
+     * `existingFiles_<category>` download column. Mirrors [parseExistingFilesCell].
+     */
+    private fun formatExistingFilesCell(files: List<org.loculus.backend.api.FileIdAndName>?): String =
+        files.orEmpty().joinToString(" $EXISTING_FILES_ENTRY_SEPARATOR ") { "${it.name}:${it.fileId}" }
 
     fun writeSequencesFasta(
         data: List<SubmittedDataDownloadEntry>,

--- a/backend/src/main/kotlin/org/loculus/backend/utils/MetadataEntry.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/MetadataEntry.kt
@@ -4,8 +4,12 @@ import org.apache.commons.csv.CSVException
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVParser
 import org.apache.commons.csv.CSVRecord
+import org.loculus.backend.api.FileCategoryFilesMap
+import org.loculus.backend.api.FileIdAndName
 import org.loculus.backend.controller.UnprocessableEntityException
 import org.loculus.backend.model.ACCESSION_HEADER
+import org.loculus.backend.model.EXISTING_FILES_COLUMN_PREFIX
+import org.loculus.backend.model.EXISTING_FILES_ENTRY_SEPARATOR
 import org.loculus.backend.model.FASTA_IDS_HEADER
 import org.loculus.backend.model.FASTA_IDS_SEPARATOR
 import org.loculus.backend.model.FastaId
@@ -14,6 +18,7 @@ import org.loculus.backend.model.METADATA_ID_HEADER_ALTERNATE_FOR_BACKCOMPAT
 import org.loculus.backend.model.SubmissionId
 import java.io.InputStream
 import java.io.InputStreamReader
+import java.util.UUID
 
 data class MetadataEntry(
     val submissionId: SubmissionId,
@@ -76,6 +81,59 @@ fun extractAndValidateFastaIds(record: CSVRecord, submissionId: String, recordNu
             setOf(submissionId)
         }
     }
+}
+
+/**
+ * Build a [FileCategoryFilesMap] from the `existingFiles_<category>` columns of a record (used when revising to
+ * keep/remove the files attached to an entry). Returns null when no such columns are present or all are empty.
+ */
+fun extractExistingFiles(record: CSVRecord, recordNumber: Int): FileCategoryFilesMap? {
+    val fileColumns = record.parser.headerNames.filter { it.startsWith(EXISTING_FILES_COLUMN_PREFIX) }
+    if (fileColumns.isEmpty()) {
+        return null
+    }
+
+    val map = fileColumns.associate { header ->
+        val category = header.removePrefix(EXISTING_FILES_COLUMN_PREFIX)
+        category to parseExistingFilesCell(record[header], category, recordNumber)
+    }.filterValues { it.isNotEmpty() }
+
+    return map.ifEmpty { null }
+}
+
+/**
+ * Parse a single `existingFiles_<category>` cell into a list of files. The cell is a `|`-separated list of
+ * `name:fileId` tokens, e.g. `reads_1.fastq:8d8ac610-... | reads_2.fastq:41ewsa-...`. The file id is a UUID
+ * (which never contains a colon), so each token is split on its last colon.
+ */
+fun parseExistingFilesCell(cell: String?, category: String, recordNumber: Int): List<FileIdAndName> {
+    if (cell.isNullOrBlank()) {
+        return emptyList()
+    }
+    val columnName = "$EXISTING_FILES_COLUMN_PREFIX$category"
+    return cell.split(EXISTING_FILES_ENTRY_SEPARATOR)
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .map { token ->
+            val separatorIndex = token.lastIndexOf(':')
+            if (separatorIndex <= 0 || separatorIndex == token.length - 1) {
+                throw UnprocessableEntityException(
+                    "In metadata file: record #$recordNumber, column '$columnName': could not parse file " +
+                        "reference '$token'. Expected format 'name:fileId'.",
+                )
+            }
+            val name = token.substring(0, separatorIndex)
+            val fileIdString = token.substring(separatorIndex + 1)
+            val fileId = try {
+                UUID.fromString(fileIdString)
+            } catch (e: IllegalArgumentException) {
+                throw UnprocessableEntityException(
+                    "In metadata file: record #$recordNumber, column '$columnName': '$fileIdString' is not a " +
+                        "valid file id. Full reference: '$token'.",
+                )
+            }
+            FileIdAndName(fileId, name)
+        }
 }
 
 private fun setUpCsvParser(metadataInputStream: InputStream): CSVParser {
@@ -156,6 +214,7 @@ data class RevisionEntry(
     val accession: Accession,
     val metadata: Map<String, String>,
     val fastaIds: Set<FastaId>? = null,
+    val existingFiles: FileCategoryFilesMap? = null,
 )
 
 fun revisionEntryStreamAsSequence(metadataInputStream: InputStream): Sequence<RevisionEntry> {
@@ -180,13 +239,16 @@ fun revisionEntryStreamAsSequence(metadataInputStream: InputStream): Sequence<Re
 
                 val fastaIds = extractAndValidateFastaIds(record, submissionId, recordNumber)
 
+                val existingFiles = extractExistingFiles(record, recordNumber)
+
                 val metadata = record.toMap().filterKeys {
                     it != submissionIdHeader && it != ACCESSION_HEADER &&
-                        it != FASTA_IDS_HEADER
+                        it != FASTA_IDS_HEADER &&
+                        !it.startsWith(EXISTING_FILES_COLUMN_PREFIX)
                 }
                 validateMetadataNotEmpty(metadata, submissionId, recordNumber)
 
-                yield(RevisionEntry(submissionId, accession, metadata, fastaIds))
+                yield(RevisionEntry(submissionId, accession, metadata, fastaIds, existingFiles))
             }
         } catch (e: java.io.UncheckedIOException) {
             throwWithCsvExceptionUnwrapped(e)

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetSubmittedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetSubmittedDataEndpointTest.kt
@@ -176,6 +176,8 @@ class GetSubmittedDataEndpointTest(
 
         assertThat(header[0], `is`("id"))
         assertThat(header[1], `is`("accession"))
+        // Files are disabled for the default organism, so no existingFiles_<category> columns are added.
+        assertThat(header.none { it.startsWith("existingFiles_") }, `is`(true))
 
         val firstDataRow = lines[1].split("\t")
         assertThat(firstDataRow[0], `is`(SubmitFiles.DefaultFiles.submissionIds[0]))

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ReviseReuseExistingFilesTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ReviseReuseExistingFilesTest.kt
@@ -1,0 +1,228 @@
+package org.loculus.backend.controller.submission
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Test
+import org.loculus.backend.api.AccessionVersion
+import org.loculus.backend.api.FileIdAndName
+import org.loculus.backend.config.BackendSpringProperty
+import org.loculus.backend.controller.DEFAULT_ORGANISM
+import org.loculus.backend.controller.DEFAULT_SIMPLE_FILE_CONTENT
+import org.loculus.backend.controller.EndpointTest
+import org.loculus.backend.controller.S3_CONFIG
+import org.loculus.backend.controller.files.FilesClient
+import org.loculus.backend.controller.files.andGetFileIdsAndUrls
+import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
+import org.loculus.backend.controller.groupmanagement.andGetGroupId
+import org.loculus.backend.controller.jwtForAlternativeUser
+import org.loculus.backend.controller.jwtForDefaultUser
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.shaded.org.awaitility.Awaitility.await
+import java.util.UUID
+
+private const val FILE_CATEGORY = "myFileCategory"
+private const val EXISTING_FILES_COLUMN = "existingFiles_$FILE_CATEGORY"
+
+@EndpointTest(
+    properties = ["${BackendSpringProperty.BACKEND_CONFIG_PATH}=$S3_CONFIG"],
+)
+class ReviseReuseExistingFilesTest(
+    @Autowired val submissionControllerClient: SubmissionControllerClient,
+    @Autowired val convenienceClient: SubmissionConvenienceClient,
+    @Autowired val groupManagementClient: GroupManagementControllerClient,
+    @Autowired val filesClient: FilesClient,
+) {
+    @Test
+    fun `WHEN revising with existingFiles columns THEN files are kept, added, removed and overridden`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        val submissionResult = convenienceClient.submitDefaultFiles(groupId = groupId, includeFileMapping = true)
+        processAndApproveAll()
+
+        // The original files attached at submission, keyed by submission id (each is `hello.txt`).
+        val originalFileIds = submissionResult.submissionIdFilesMap!!
+            .mapValues { (_, categories) -> categories.getValue(FILE_CATEGORY).single().fileId }
+
+        val (metadataTsv, sequencesFasta) = downloadSubmittedData(groupId)
+        val table = MetadataTable.parse(metadataTsv)
+
+        // The download lists the currently attached file for every entry.
+        table.ids.forEach { id ->
+            assertThat(
+                table.row(id).files(),
+                `is`(setOf("hello.txt" to originalFileIds.getValue(id))),
+            )
+        }
+
+        // Upload the new files that will be added / used to override during the revision.
+        val (addedFileId, overrideFileId) = uploadFiles(groupId, "added", "override")
+
+        // custom1: remove all files by blanking the cell. custom2..9 keep their file unchanged.
+        table.setCell("custom1", EXISTING_FILES_COLUMN, "")
+
+        val fileMapping = mapOf(
+            // custom0: keep `hello.txt` (untouched column) and add a brand-new file.
+            "custom0" to mapOf(FILE_CATEGORY to listOf(FileIdAndName(addedFileId, "added.txt"))),
+            // custom2: a freshly uploaded file with the same name as the kept one must win.
+            "custom2" to mapOf(FILE_CATEGORY to listOf(FileIdAndName(overrideFileId, "hello.txt"))),
+        )
+
+        submissionControllerClient.reviseSequenceEntries(
+            metadataFile = MockMultipartFile(
+                "metadataFile",
+                "metadata.tsv",
+                MediaType.TEXT_PLAIN_VALUE,
+                table.render().toByteArray(),
+            ),
+            sequencesFile = MockMultipartFile(
+                "sequenceFile",
+                "sequences.fasta",
+                MediaType.TEXT_PLAIN_VALUE,
+                sequencesFasta.toByteArray(),
+            ),
+            fileMapping = fileMapping,
+            jwt = jwtForDefaultUser,
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("\$.length()").value(SubmitFiles.DefaultFiles.NUMBER_OF_SEQUENCES))
+
+        processAndApproveAll()
+
+        val revisedTable = MetadataTable.parse(downloadSubmittedData(groupId).first)
+
+        assertThat(
+            revisedTable.row("custom0").files(),
+            `is`(setOf("hello.txt" to originalFileIds.getValue("custom0"), "added.txt" to addedFileId)),
+        )
+        assertThat(revisedTable.row("custom1").files(), `is`(emptySet()))
+        assertThat(revisedTable.row("custom2").files(), `is`(setOf("hello.txt" to overrideFileId)))
+        assertThat(
+            revisedTable.row("custom3").files(),
+            `is`(setOf("hello.txt" to originalFileIds.getValue("custom3"))),
+        )
+    }
+
+    @Test
+    fun `GIVEN existingFiles referencing a file from another group WHEN revised THEN the request is rejected`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        convenienceClient.submitDefaultFiles(groupId = groupId, includeFileMapping = true)
+        processAndApproveAll()
+
+        val otherGroupId = groupManagementClient.createNewGroup(jwt = jwtForAlternativeUser).andGetGroupId()
+        val otherGroupFile = filesClient.requestUploads(groupId = otherGroupId, jwt = jwtForAlternativeUser)
+            .andGetFileIdsAndUrls()[0]
+        convenienceClient.uploadFile(
+            otherGroupFile.presignedWriteUrl,
+            DEFAULT_SIMPLE_FILE_CONTENT,
+            otherGroupFile.headers,
+        )
+
+        val (metadataTsv, sequencesFasta) = downloadSubmittedData(groupId)
+        val table = MetadataTable.parse(metadataTsv)
+        table.setCell("custom0", EXISTING_FILES_COLUMN, "stolen.txt:${otherGroupFile.fileId}")
+
+        submissionControllerClient.reviseSequenceEntries(
+            metadataFile = MockMultipartFile(
+                "metadataFile",
+                "metadata.tsv",
+                MediaType.TEXT_PLAIN_VALUE,
+                table.render().toByteArray(),
+            ),
+            sequencesFile = MockMultipartFile(
+                "sequenceFile",
+                "sequences.fasta",
+                MediaType.TEXT_PLAIN_VALUE,
+                sequencesFasta.toByteArray(),
+            ),
+            jwt = jwtForDefaultUser,
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("\$.detail").value("File ${otherGroupFile.fileId} does not belong to group $groupId."))
+    }
+
+    private fun uploadFiles(groupId: Int, vararg names: String): List<UUID> {
+        val fileIdsAndUrls = filesClient.requestUploads(groupId, names.size).andGetFileIdsAndUrls()
+        return names.mapIndexed { index, name ->
+            convenienceClient.uploadFile(
+                fileIdsAndUrls[index].presignedWriteUrl,
+                "$name content",
+                fileIdsAndUrls[index].headers,
+            )
+            fileIdsAndUrls[index].fileId
+        }
+    }
+
+    /** Extract released sequences to processing, submit processed data preserving the submitted files, and approve. */
+    private fun processAndApproveAll() {
+        val unprocessed = convenienceClient.extractUnprocessedData()
+        val processed = unprocessed.map { entry ->
+            val base = PreparedProcessedData.successfullyProcessed(accession = entry.accession, version = entry.version)
+            val files = entry.data.files?.mapValues { (_, list) -> list.map { FileIdAndName(it.fileId, it.name) } }
+            base.copy(data = base.data.copy(files = files))
+        }
+        convenienceClient.submitProcessedData(processed)
+        convenienceClient.approveProcessedSequenceEntries(
+            unprocessed.map {
+                AccessionVersion(it.accession, it.version)
+            },
+        )
+    }
+
+    private fun downloadSubmittedData(groupId: Int): Pair<String, String> {
+        val response = submissionControllerClient.getSubmittedData(groupId = groupId)
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+        await().until { response.isCommitted }
+        return extractSubmittedDataZipContents(response.contentAsByteArray)
+    }
+}
+
+/** A minimal editable view of a downloaded metadata TSV, keyed by the `id` column. */
+private class MetadataTable(val headers: List<String>, val rows: List<MutableList<String>>) {
+    private val idIndex = headers.indexOf("id").also { require(it >= 0) { "metadata is missing the 'id' column" } }
+    private val fileColumnIndex = headers.indexOf(EXISTING_FILES_COLUMN)
+        .also { require(it >= 0) { "metadata is missing the '$EXISTING_FILES_COLUMN' column" } }
+
+    inner class Row(private val cells: List<String>) {
+        /** The (name, fileId) pairs encoded in the `existingFiles_<category>` cell. */
+        fun files(): Set<Pair<String, UUID>> = cells[fileColumnIndex]
+            .split("|")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .map {
+                val separator = it.lastIndexOf(':')
+                it.substring(0, separator) to UUID.fromString(it.substring(separator + 1))
+            }
+            .toSet()
+    }
+
+    fun row(id: String): Row = Row(rows.first { it[idIndex] == id })
+
+    val ids: List<String> get() = rows.map { it[idIndex] }
+
+    fun setCell(id: String, column: String, value: String) {
+        val columnIndex = headers.indexOf(column)
+        rows.first { it[idIndex] == id }[columnIndex] = value
+    }
+
+    fun render(): String = (listOf(headers) + rows).joinToString("\n") { it.joinToString("\t") }
+
+    companion object {
+        fun parse(tsv: String): MetadataTable {
+            val lines = tsv.lines().filter { it.isNotBlank() }
+            val headers = lines[0].split("\t")
+            val rows = lines.drop(1).map { line ->
+                line.split("\t").toMutableList().apply {
+                    while (size < headers.size) add("")
+                }
+            }
+            return MetadataTable(headers, rows)
+        }
+    }
+}

--- a/backend/src/test/kotlin/org/loculus/backend/utils/MetadataEntryTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/utils/MetadataEntryTest.kt
@@ -4,10 +4,13 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.loculus.backend.api.FileIdAndName
 import org.loculus.backend.controller.UnprocessableEntityException
 import java.io.ByteArrayInputStream
+import java.util.UUID
 
 class MetadataEntryTest {
     @Test
@@ -303,5 +306,82 @@ class RevisionEntryTest {
         }
         assertThat(exception.message, containsString("duplicate fasta ids"))
         assertThat(exception.message, containsString("seq1"))
+    }
+
+    private val fileId1 = UUID.fromString("8d8ac610-566d-4ef0-9c22-186b2a5ed793")
+    private val fileId2 = UUID.fromString("41ad1234-566d-4ef0-9c22-186b2a5ed111")
+
+    @Test
+    fun `existingFiles columns are parsed and excluded from metadata`() {
+        val str = """
+            submissionId${'\t'}accession${'\t'}Country${'\t'}existingFiles_raw_reads${'\t'}existingFiles_logs
+            foo${'\t'}ACC123${'\t'}bar${'\t'}reads_1.fastq:$fileId1 | reads_2.fastq:$fileId2${'\t'}run.log:$fileId1
+        """.trimIndent()
+        val entries = revisionEntryStreamAsSequence(ByteArrayInputStream(str.toByteArray())).toList()
+
+        assertThat(entries, hasSize(1))
+        assertThat(entries[0].metadata, equalTo(mapOf("Country" to "bar")))
+        assertThat(
+            entries[0].existingFiles,
+            equalTo(
+                mapOf(
+                    "raw_reads" to listOf(
+                        FileIdAndName(fileId1, "reads_1.fastq"),
+                        FileIdAndName(fileId2, "reads_2.fastq"),
+                    ),
+                    "logs" to listOf(FileIdAndName(fileId1, "run.log")),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `blank existingFiles cell results in no existing files`() {
+        val str = """
+            submissionId${'\t'}accession${'\t'}Country${'\t'}existingFiles_raw_reads
+            foo${'\t'}ACC123${'\t'}bar${'\t'}
+        """.trimIndent()
+        val entries = revisionEntryStreamAsSequence(ByteArrayInputStream(str.toByteArray())).toList()
+
+        assertThat(entries[0].existingFiles, nullValue())
+    }
+
+    @Test
+    fun `existingFiles supports file names containing spaces`() {
+        val str = """
+            submissionId${'\t'}accession${'\t'}Country${'\t'}existingFiles_raw_reads
+            foo${'\t'}ACC123${'\t'}bar${'\t'}my reads file.fastq:$fileId1
+        """.trimIndent()
+        val entries = revisionEntryStreamAsSequence(ByteArrayInputStream(str.toByteArray())).toList()
+
+        assertThat(
+            entries[0].existingFiles?.get("raw_reads"),
+            equalTo(listOf(FileIdAndName(fileId1, "my reads file.fastq"))),
+        )
+    }
+
+    @Test
+    fun `existingFiles with a malformed file id is rejected`() {
+        val str = """
+            submissionId${'\t'}accession${'\t'}Country${'\t'}existingFiles_raw_reads
+            foo${'\t'}ACC123${'\t'}bar${'\t'}reads_1.fastq:not-a-uuid
+        """.trimIndent()
+        val exception = assertThrows<UnprocessableEntityException> {
+            revisionEntryStreamAsSequence(ByteArrayInputStream(str.toByteArray())).toList()
+        }
+        assertThat(exception.message, containsString("existingFiles_raw_reads"))
+        assertThat(exception.message, containsString("not a valid file id"))
+    }
+
+    @Test
+    fun `existingFiles with a token missing the file id is rejected`() {
+        val str = """
+            submissionId${'\t'}accession${'\t'}Country${'\t'}existingFiles_raw_reads
+            foo${'\t'}ACC123${'\t'}bar${'\t'}reads_1.fastq
+        """.trimIndent()
+        val exception = assertThrows<UnprocessableEntityException> {
+            revisionEntryStreamAsSequence(ByteArrayInputStream(str.toByteArray())).toList()
+        }
+        assertThat(exception.message, containsString("Expected format 'name:fileId'"))
     }
 }

--- a/docs/src/content/docs/for-users/revise-sequences.md
+++ b/docs/src/content/docs/for-users/revise-sequences.md
@@ -27,6 +27,23 @@ The metadata file should include all the metadata fields that were originally in
 
 The metadata file should only have rows of data for the sequences in the FASTA file. It needs to include an `accession` column, which includes the Loculus accessions assigned at initial submission. You should also include the `id` column, which will match the sequence ids in your FASTA file. (In the case of segmented organisms, the FASTA ids will additionally contain segment suffix, e.g. `_L` for segment L)
 
+## Reusing previously uploaded files
+
+For organisms that support file uploads (e.g. raw reads), you do not need to re-upload files that should stay attached to an entry. When you download the originally submitted data, the `metadata.tsv` includes one column per file category named `existingFiles_<category>` (for example `existingFiles_raw_reads`). Each cell lists the files currently attached to that entry as a `|`-separated list of `name:fileId` pairs, for example:
+
+```
+reads_1.fastq:8d8ac610-566d-4ef0-9c22-186b2a5ed793 | reads_2.fastq:41ad1234-566d-4ef0-9c22-186b2a5ed111
+```
+
+When revising, you control these files by editing the column:
+
+- **Keep files** – leave the column untouched.
+- **Remove a file** – delete its `name:fileId` entry from the cell.
+- **Remove all files** – empty the cell.
+- **Add files** – upload a folder of new files exactly as during an original submission. New uploads are added alongside the files kept in the column. If an uploaded file has the same name and category as a kept file, the newly uploaded file takes priority.
+
+You can only reference files that belong to your group.
+
 ## Preparing the FASTA file
 
 Create a FASTA file that contains only the sequences you'd like to revise, with whatever changes you'd like to make. There is no reason to edit the sequence names in the FASTA file, as long as they still match those in your metadata file.

--- a/website/src/components/Submission/FileUpload/ColumnMapping.spec.ts
+++ b/website/src/components/Submission/FileUpload/ColumnMapping.spec.ts
@@ -113,4 +113,20 @@ describe('ColumnMapping', () => {
 
         expect(remappedContent).toBe('location\tdate\n' + '"U\nS\nA"\t2023-01-01\n' + 'Canada\t2023-01-02');
     });
+
+    it('should pass through existingFiles_<category> columns even when unmapped', async () => {
+        const sourceColumns = ['loc', 'existingFiles_raw_reads'];
+        const inputFields = [{ name: 'location', displayName: 'Location' }];
+        const mapping = ColumnMapping.fromColumns(sourceColumns, inputFields).updateWith('loc', 'location');
+
+        const tsvContent =
+            'loc\texistingFiles_raw_reads\n' + 'USA\treads_1.fastq:abc | reads_2.fastq:def\n' + 'Canada\t\n';
+
+        const remappedFile = await mapping.applyTo(new RawFile(new File([tsvContent], 'input.tsv')));
+        const remappedContent = await remappedFile.text();
+
+        expect(remappedContent).toBe(
+            'location\texistingFiles_raw_reads\n' + 'USA\treads_1.fastq:abc | reads_2.fastq:def\n' + 'Canada\t',
+        );
+    });
 });

--- a/website/src/components/Submission/FileUpload/ColumnMapping.ts
+++ b/website/src/components/Submission/FileUpload/ColumnMapping.ts
@@ -4,6 +4,13 @@ import { type ProcessedFile } from './fileProcessing';
 import type { InputField } from '../../../types/config';
 import stringSimilarity from '../../../utils/stringSimilarity';
 
+/**
+ * Prefix of the per-category columns (`existingFiles_<category>`) that list the files currently attached to an entry
+ * when revising. They are not regular metadata fields: the backend parses them directly, so they must survive column
+ * mapping untouched rather than be dropped as unmapped columns.
+ */
+export const EXISTING_FILES_COLUMN_PREFIX = 'existingFiles_';
+
 export class ColumnMapping {
     private constructor(private readonly map: ReadonlyMap<string, string | null>) {}
 
@@ -97,10 +104,20 @@ export class ColumnMapping {
         const headersInFile = inputRows.splice(0, 1)[0];
         const headers: string[] = [];
         const indices: number[] = [];
+        const mappedSourceColumns = new Set<string>();
         this.entries().forEach(([sourceCol, targetCol]) => {
             if (targetCol === null) return;
+            mappedSourceColumns.add(sourceCol);
             headers.push(targetCol);
             indices.push(headersInFile.findIndex((sourceHeader) => sourceHeader === sourceCol));
+        });
+        // Pass through any `existingFiles_<category>` columns unchanged so they reach the backend, which parses
+        // them to determine which previously-uploaded files to keep on a revision.
+        headersInFile.forEach((sourceHeader, sourceIndex) => {
+            if (sourceHeader.startsWith(EXISTING_FILES_COLUMN_PREFIX) && !mappedSourceColumns.has(sourceHeader)) {
+                headers.push(sourceHeader);
+                indices.push(sourceIndex);
+            }
         });
         const newRows = inputRows.map((row) => indices.map((i) => row[i]));
         const newFileContent = Papa.unparse([headers, ...newRows], { delimiter: '\t', newline: '\n' });


### PR DESCRIPTION
Implements [#5820](https://github.com/loculus-project/loculus/issues/5820): reuse previously-uploaded files when revising in bulk, so submitters don't have to re-upload every file.

## Design

Following the discussion on the issue (one column per file category; the backend parses the columns directly rather than the website turning them into the `fileMapping` JSON param):

- **Download** — `get-submitted-data`'s `metadata.tsv` gains one `existingFiles_<category>` column per configured submission file category (only when files are enabled for the organism). Each cell lists the files currently attached to an entry as a `|`-separated list of `name:fileId` tokens, e.g. `reads_1.fastq:8d8ac610-… | reads_2.fastq:41ad…`.
- **Edit** — keep files (leave the column), remove a file (delete its token), remove all (blank the cell), add files (upload a folder as during submission).
- **Revise** — the backend parses the columns, merges them with freshly uploaded files (the `fileMapping` param), and **new uploads win** per `(category, filename)`.

### Separator choice
Filenames forbid `<>:"/\|?*` but **allow spaces**, so the space-separated form floated in the issue isn't safe. Tokens are therefore separated by `|`, and `name`/`fileId` are split on the last `:` (UUIDs contain no colon).

## Changes

**Backend**
- `GetSubmittedDataHelpers.kt` + `SubmissionController.kt`: emit `existingFiles_<category>` columns.
- `MetadataEntry.kt`: parse the columns into `RevisionEntry.existingFiles` (`parseExistingFilesCell`), excluding them from the metadata map.
- `UploadDatabaseService.kt`: merge column files with uploaded files into the aux table; add `getFilesForUpload`.
- `SubmissionTypes.kt`: `mergeFileCategoryFilesMaps` (override-by-name).
- `SubmitModel.kt`: validate the merged file set with the existing precondition + group-ownership validators — a `fileId` from another group is rejected.
- API description updated.

**Website**
- `ColumnMapping.ts`: pass `existingFiles_<category>` columns through column mapping unchanged so they reach the backend (otherwise they'd be dropped as unmapped). No other client changes needed.

**Docs**
- `revise-sequences.md`: new "Reusing previously uploaded files" section.

## Tests
- Unit tests for cell parsing (multiple files, blank cell, filename with spaces, malformed token/UUID).
- New `ReviseReuseExistingFilesTest` endpoint test: keep + add + remove + override round-trip, and cross-group rejection.
- `GetSubmittedDataEndpointTest`: columns absent when files disabled.
- Re-ran the affected revise / file-sharing / journey suites (green); `ColumnMapping.spec.ts` + full `FileUpload` suite, `check-types`, `format` clean.

## Out of scope (later steps from the issue)
- Inline UI to browse/select a submission's files (issue step 3).
- Single-entry edit-page file reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable