### PR TITLE
feat!(prepro): use submissionId for displayName if specimenCollectorSampleId cannot be parsed

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1662,6 +1662,7 @@ defaultOrganisms:
               # - Last field is a date in format YYYY, YYYY-MM, or YYYY-MM-DD
               # - Identifier is the second to last field (extracted through named capture group)
               regex_pattern: '^(?:[^/]+/)?[^/]+/(?P<identifier>[^/]+)/\d{4}(?:-\d{2}){0,2}$'
+              human_readable_pattern: "<any>/<any>/<identifier>/<date>"
         - <<: *hostTaxonIdConfig
           required: true
           hierarchicalFilter: *taxonomy_service_url

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1181,21 +1181,17 @@ class ProcessingFunctions:
             concatenate_field_types = replace_identifier(field_types, "string")
             input_data["IDENTIFIER"] = identifier
         else:
-            # Unable to parse specimenCollectorSampleId or submissionID, use ACCESSION_VERSION
+            # Unable to parse specimenCollectorSampleId and submissionID, use ACCESSION_VERSION
             if not insdc_ingested and regex_pattern is not None:
-                failed_source = (
-                    collector_id
-                    if isinstance(collector_id, str) and collector_id
-                    else submission_id
-                )
                 warnings.append(
                     ProcessingAnnotation.from_fields(
                         input_fields,
                         [output_field],
                         AnnotationSourceType.METADATA,
                         message=(
-                            f"identifier string '{failed_source}' could not be parsed,"
-                            " using ACCESSION_VERSION in displayName instead"
+                            f"specimencollectorSampleId '{collector_id}' and submissionId"
+                            f" '{submission_id}' could not be parsed, using ACCESSION_VERSION"
+                            f" in displayName instead"
                         ),
                     )
                 )
@@ -1580,7 +1576,7 @@ def process_phenotype_values(input: str | None, args: FunctionArgs | None) -> In
 def parse_identifier_string(
     input: ProcessedMetadataValue, insdc_ingested: bool, regex_pattern: str | None = None
 ) -> str | None:
-    """Return a IDENTIFIER string to use in the displayName or None if `input` cannot be used
+    """Return an IDENTIFIER string to use in the displayName or None if `input` cannot be used
     as an identifier.
     """
     if not isinstance(input, str):

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1196,7 +1196,7 @@ class ProcessingFunctions:
                 warnings.append(
                     f"specimenCollectorSampleId and submissionId could not be parsed, using "
                     f"ACCESSION_VERSION in displayName instead. To include your own identifier, "
-                    f"remove whitespace and '/' characters or use format '{human_readable_pattern}'"
+                    f"remove whitespace and '/' characters or use the format '{human_readable_pattern}' and we will parse the `identifier` from the submission."
                 )
             concatenate_order = replace_identifier(order, "ACCESSION_VERSION")
             concatenate_field_types = replace_identifier(field_types, "ACCESSION_VERSION")

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1114,7 +1114,7 @@ class ProcessingFunctions:
         return RawProcessingResult()
 
     @staticmethod
-    def build_display_name(  # noqa: C901
+    def build_display_name(
         input_data: InputMetadata,
         output_field: str,
         input_fields: list[str],
@@ -1127,12 +1127,13 @@ class ProcessingFunctions:
         args, as well as adding some additional checks and requirements:
             - submissionId and specimenCollectorSampleId must be in the input_data
             - IDENTIFIER keyword must be in args['order'] and args['type']
-            - if the IDENTIFIER is in an unrecognized format, it will be replaced with the ACCESSION_VERSION
-            - if fallback_value is not in args, { 'fallback_value': 'unknown' } is added to the args before passing
-              them on to concatenate()
-            - for sequences ingested from INSDC, we do not try to parse the IDENTIFIER field using regex. We
-              will use the Isolate Name as IDENTIFIER field if it contains no slashes or spaces (otherwise we fall back to
-              ACCESSION_VERSION)
+            - the IDENTIFIER is resolved by trying specimenCollectorSampleId first, then
+              submissionId; if neither yields a usable value it is replaced with ACCESSION_VERSION
+            - if fallback_value is not in args, { 'fallback_value': 'unknown' } is added to the args
+              before passing them on to concatenate()
+            - for sequences ingested from INSDC, we do not try to parse the IDENTIFIER field using
+              regex. We will use the Isolate Name as IDENTIFIER field if it contains no slashes or
+              spaces (otherwise we fall back to ACCESSION_VERSION)
         """
         collector_id = input_data.get("specimenCollectorSampleId", None)
         submission_id = input_data.get("submissionId", None)
@@ -1167,40 +1168,39 @@ class ProcessingFunctions:
         def replace_identifier(values, replacement):
             return [replacement if v == "IDENTIFIER" else v for v in values]
 
-        identifier: ProcessedMetadataValue = collector_id or submission_id
-        if not isinstance(identifier, str):
-            identifier = None
-        elif args["is_insdc_ingest_group"]:
-            # For INSDC ingested sequence: use ID as is unless it contains ' ' or '/'
-            # If it does: fall back to ACCESSION_VERSION
-            if " " in identifier or "/" in identifier:
-                identifier = None
-        elif "/" in identifier:
-            # For direct submissions with "/": try to extract ID field using regex
-            if regex_pattern is None:
-                identifier = None
-            else:
-                extract_result = ProcessingFunctions.extract_regex(
-                    input_data={"regex_field": identifier},
-                    output_field="IDENTIFIER",
-                    input_fields=[],
-                    args={"pattern": regex_pattern, "capture_group": "identifier"},
-                )
-                if extract_result.datum is None:
-                    # regex extraction of ID field failed, fall back to ACCESSION_VERSION
-                    warnings.append(
-                        f"identifier string '{identifier}' could not be parsed, using ACCESSION_VERSION in displayName instead"
-                    )
-                identifier = extract_result.datum
+        insdc_ingested = bool(args["is_insdc_ingest_group"])
+        pattern = str(regex_pattern) if regex_pattern is not None else None
 
+        # Try specimenCollectorSampleId first, fall back to submissionId.
+        identifier = parse_identifier_string(collector_id, insdc_ingested, pattern)
         if identifier is None:
-            # Use ACCESSION_VERSION instead of IDENTIFIER
+            identifier = parse_identifier_string(submission_id, insdc_ingested, pattern)
+
+        if identifier is not None:
+            # We were able to parse an IDENTIFIER, treat it as a string
+            concatenate_field_types = replace_identifier(field_types, "string")
+            input_data["IDENTIFIER"] = identifier
+        else:
+            # Unable to parse specimenCollectorSampleId or submissionID, use ACCESSION_VERSION
+            if not insdc_ingested and regex_pattern is not None:
+                failed_source = (
+                    collector_id
+                    if isinstance(collector_id, str) and collector_id
+                    else submission_id
+                )
+                warnings.append(
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
+                        message=(
+                            f"identifier string '{failed_source}' could not be parsed,"
+                            " using ACCESSION_VERSION in displayName instead"
+                        ),
+                    )
+                )
             concatenate_order = replace_identifier(order, "ACCESSION_VERSION")
             concatenate_field_types = replace_identifier(field_types, "ACCESSION_VERSION")
-        else:
-            # Keep IDENTIFIER but treat it as string
-            concatenate_field_types = replace_identifier(field_types, "string")
-            input_data["IDENTIFIER"] = str(identifier)
 
         new_args = args.copy()
         new_args.update(
@@ -1575,6 +1575,36 @@ def process_phenotype_values(input: str | None, args: FunctionArgs | None) -> In
             ),
         )
     return InputData(datum=None)
+
+
+def parse_identifier_string(
+    input: ProcessedMetadataValue, insdc_ingested: bool, regex_pattern: str | None = None
+) -> str | None:
+    """Return a IDENTIFIER string to use in the displayName or None if `input` cannot be used
+    as an identifier.
+    """
+    if not isinstance(input, str):
+        return None
+    has_forbidden_char = " " in input or "/" in input
+
+    if insdc_ingested:
+        # For INSDC ingested sequences: use the value as-is unless it contains a ' ' or '/'
+        return None if has_forbidden_char else input
+
+    if not has_forbidden_char:
+        # Direct submission without forbidden_char: use the value as-is, no regex parsing
+        return input
+
+    # Direct submission containing forbidden_char: attempt regex extraction of identifier field
+    if regex_pattern is None:
+        return None
+    extract_result = ProcessingFunctions.extract_regex(
+        input_data={"regex_field": input},
+        output_field="IDENTIFIER",
+        input_fields=[],
+        args={"pattern": regex_pattern, "capture_group": "identifier"},
+    )
+    return None if extract_result.datum is None else str(extract_result.datum)
 
 
 def trim_ns(sequence: str) -> str:

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1120,8 +1120,8 @@ class ProcessingFunctions:
         input_fields: list[str],
         args: FunctionArgs,
     ) -> RawProcessingResult:
-        """Builds a displayName from input_fields. The identifier field in the displayName is based on
-        specimenCollectorSampleId or - if it is not set - submissionId.
+        """Builds a displayName from input_fields. The identifier field in the displayName is based
+        on specimenCollectorSampleId or - if it is not set - submissionId (direct submissions only).
 
         This method wraps ProcessingFunctions.concatenate(). Thus, it has the same required input
         args, as well as adding some additional checks and requirements:
@@ -1138,8 +1138,6 @@ class ProcessingFunctions:
         collector_id = input_data.get("specimenCollectorSampleId", None)
         submission_id = input_data.get("submissionId", None)
         warnings: list[str] = []
-        if submission_id is None:
-            return raw_internal_error("'submissionId' must not be None for build_display_name().")
 
         order = args.get("order")
         field_types = args.get("type")
@@ -1163,9 +1161,6 @@ class ProcessingFunctions:
         concatenate_order = order.copy()
         concatenate_field_types = field_types.copy()
 
-        def replace_identifier(values, replacement):
-            return [replacement if v == "IDENTIFIER" else v for v in values]
-
         insdc_ingested = bool(args["is_insdc_ingest_group"])
 
         # Try to parse the specimenCollectorSampleId first
@@ -1173,6 +1168,9 @@ class ProcessingFunctions:
         if identifier is None and not insdc_ingested:
             # For direct submissions only: try to parse the submissionId
             identifier = parse_identifier_string(submission_id, insdc_ingested, regex_pattern)
+
+        def replace_identifier(values, replacement):
+            return [replacement if v == "IDENTIFIER" else v for v in values]
 
         if identifier is not None:
             # We were able to parse an IDENTIFIER, treat it as a string

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1134,6 +1134,9 @@ class ProcessingFunctions:
             - for sequences ingested from INSDC, we do not try to parse the IDENTIFIER field using
               regex. We will use the Isolate Name as IDENTIFIER field if it contains no slashes or
               spaces (otherwise we fall back to ACCESSION_VERSION)
+            - if regex_pattern is provided, human_readable_pattern must also be provided. It is a
+              submitter-friendly rendering of the pattern to show in error messages
+              (e.g. '<any>/<any>/<identifier>/<date>')
         """
         collector_id = input_data.get("specimenCollectorSampleId", None)
         submission_id = input_data.get("submissionId", None)
@@ -1156,6 +1159,15 @@ class ProcessingFunctions:
         if regex_pattern is not None and "identifier" not in re.compile(regex_pattern).groupindex:
             return raw_internal_error(
                 "If provided, 'regex_pattern' must contain a named capture group called 'identifier'."
+            )
+
+        human_readable_pattern = args.get("human_readable_pattern")
+        human_readable_pattern = (
+            str(human_readable_pattern) if human_readable_pattern is not None else None
+        )
+        if regex_pattern is not None and human_readable_pattern is None:
+            return raw_internal_error(
+                "If 'regex_pattern' is provided, 'human_readable_pattern' must also be provided."
             )
 
         concatenate_order = order.copy()
@@ -1182,11 +1194,9 @@ class ProcessingFunctions:
             # Unable to parse specimenCollectorSampleId and submissionID, use ACCESSION_VERSION
             if not insdc_ingested and regex_pattern is not None:
                 warnings.append(
-                    f"specimenCollectorSampleId '{collector_id}' and submissionId"
-                    f" '{submission_id}' could not be parsed, using ACCESSION_VERSION"
-                    f" in displayName instead. Alternatively, you may edit the"
-                    f" specimenCollectorSampleId or submissionId to not contain any whitespace"
-                    f" or '/' characters so it can be incorporated in the displayName."
+                    f"specimenCollectorSampleId and submissionId could not be parsed, using "
+                    f"ACCESSION_VERSION in displayName instead. To include your own identifier, "
+                    f"remove whitespace and '/' characters or use format '{human_readable_pattern}'"
                 )
             concatenate_order = replace_identifier(order, "ACCESSION_VERSION")
             concatenate_field_types = replace_identifier(field_types, "ACCESSION_VERSION")

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1154,10 +1154,8 @@ class ProcessingFunctions:
             )
 
         regex_pattern = args.get("regex_pattern")
-        if (
-            regex_pattern is not None
-            and "identifier" not in re.compile(str(regex_pattern)).groupindex
-        ):
+        regex_pattern = str(regex_pattern) if regex_pattern is not None else None
+        if regex_pattern is not None and "identifier" not in re.compile(regex_pattern).groupindex:
             return raw_internal_error(
                 "If provided, 'regex_pattern' must contain a named capture group called 'identifier'."
             )
@@ -1169,12 +1167,12 @@ class ProcessingFunctions:
             return [replacement if v == "IDENTIFIER" else v for v in values]
 
         insdc_ingested = bool(args["is_insdc_ingest_group"])
-        pattern = str(regex_pattern) if regex_pattern is not None else None
 
-        # Try specimenCollectorSampleId first, fall back to submissionId.
-        identifier = parse_identifier_string(collector_id, insdc_ingested, pattern)
-        if identifier is None:
-            identifier = parse_identifier_string(submission_id, insdc_ingested, pattern)
+        # Try to parse the specimenCollectorSampleId first
+        identifier = parse_identifier_string(collector_id, insdc_ingested, regex_pattern)
+        if identifier is None and not insdc_ingested:
+            # For direct submissions only: try to parse the submissionId
+            identifier = parse_identifier_string(submission_id, insdc_ingested, regex_pattern)
 
         if identifier is not None:
             # We were able to parse an IDENTIFIER, treat it as a string
@@ -1189,7 +1187,7 @@ class ProcessingFunctions:
                         [output_field],
                         AnnotationSourceType.METADATA,
                         message=(
-                            f"specimencollectorSampleId '{collector_id}' and submissionId"
+                            f"specimenCollectorSampleId '{collector_id}' and submissionId"
                             f" '{submission_id}' could not be parsed, using ACCESSION_VERSION"
                             f" in displayName instead"
                         ),

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1182,16 +1182,9 @@ class ProcessingFunctions:
             # Unable to parse specimenCollectorSampleId and submissionID, use ACCESSION_VERSION
             if not insdc_ingested and regex_pattern is not None:
                 warnings.append(
-                    ProcessingAnnotation.from_fields(
-                        input_fields,
-                        [output_field],
-                        AnnotationSourceType.METADATA,
-                        message=(
-                            f"specimenCollectorSampleId '{collector_id}' and submissionId"
-                            f" '{submission_id}' could not be parsed, using ACCESSION_VERSION"
-                            f" in displayName instead"
-                        ),
-                    )
+                    f"specimenCollectorSampleId '{collector_id}' and submissionId"
+                    f" '{submission_id}' could not be parsed, using ACCESSION_VERSION"
+                    f" in displayName instead"
                 )
             concatenate_order = replace_identifier(order, "ACCESSION_VERSION")
             concatenate_field_types = replace_identifier(field_types, "ACCESSION_VERSION")

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1167,6 +1167,8 @@ class ProcessingFunctions:
         identifier = parse_identifier_string(collector_id, insdc_ingested, regex_pattern)
         if identifier is None and not insdc_ingested:
             # For direct submissions only: try to parse the submissionId
+            # Don't do this for ingested since there the submissionId is just the
+            # (concatenation of) nuccore accession(s) of the sequence(s)
             identifier = parse_identifier_string(submission_id, insdc_ingested, regex_pattern)
 
         def replace_identifier(values, replacement):

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1183,8 +1183,8 @@ class ProcessingFunctions:
                     f"specimenCollectorSampleId '{collector_id}' and submissionId"
                     f" '{submission_id}' could not be parsed, using ACCESSION_VERSION"
                     f" in displayName instead. Alternatively, you may edit the"
-                    f" specimenCollectorSampleId to not contain any whitespace or '/' characters"
-                    f" so it can be incorporated in the displayName of this sequence."
+                    f" specimenCollectorSampleId or submissionId to not contain any whitespace"
+                    f" or '/' characters so it can be incorporated in the displayName."
                 )
             concatenate_order = replace_identifier(order, "ACCESSION_VERSION")
             concatenate_field_types = replace_identifier(field_types, "ACCESSION_VERSION")

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1182,7 +1182,9 @@ class ProcessingFunctions:
                 warnings.append(
                     f"specimenCollectorSampleId '{collector_id}' and submissionId"
                     f" '{submission_id}' could not be parsed, using ACCESSION_VERSION"
-                    f" in displayName instead"
+                    f" in displayName instead. Alternatively, you may edit the"
+                    f" specimenCollectorSampleId to not contain any whitespace or '/' characters"
+                    f" so it can be incorporated in the displayName of this sequence."
                 )
             concatenate_order = replace_identifier(order, "ACCESSION_VERSION")
             concatenate_field_types = replace_identifier(field_types, "ACCESSION_VERSION")

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1582,7 +1582,7 @@ def parse_identifier_string(
     """Return an IDENTIFIER string to use in the displayName or None if `input` cannot be used
     as an identifier.
     """
-    if not isinstance(input, str):
+    if not isinstance(input, str) or not input.strip():
         return None
     has_forbidden_char = any(c.isspace() for c in input) or "/" in input
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1574,10 +1574,11 @@ def parse_identifier_string(
     """
     if not isinstance(input, str):
         return None
-    has_forbidden_char = " " in input or "/" in input
+    has_forbidden_char = any(c.isspace() for c in input) or "/" in input
 
     if insdc_ingested:
-        # For INSDC ingested sequences: use the value as-is unless it contains a ' ' or '/'
+        # For INSDC ingested sequences: use the value as-is unless it contains whitespace or '/'
+        # Don't attempt to parse these as the format on INSDC isolate names is very inconsistent
         return None if has_forbidden_char else input
 
     if not has_forbidden_char:

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -1359,7 +1359,7 @@ def _assert_display_name_warnings(warnings: list, expected_message: str | None) 
         assert len(warnings) == 0
     else:
         assert len(warnings) == 1
-        assert warnings[0].message == expected_message
+        assert warnings[0] == expected_message
 
 
 input_fields = [

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -1198,7 +1198,7 @@ concatenate_cases = [
         expected="2021-01-01_TO_2021-12-31/USA",
     ),
     ConcatenateCase(
-        name="empty_int_field_skipped",
+        name="empty_fields_at_start_dropped",
         input_data={"someInt": "", "geoLocCountry": "", "sampleCollectionDate": "2025"},
         input_fields=["geoLocCountry", "sampleCollectionDate"],
         concatenate_args={
@@ -1209,7 +1209,7 @@ concatenate_cases = [
         expected="accession.1/2025-01-01",
     ),
     ConcatenateCase(
-        name="present_int_field_and_empty_string_field_with_no_fallback",
+        name="empty_field_in_middle_with_no_fallback_results_is_not_dropped",
         input_data={"someInt": "0", "geoLocCountry": "", "sampleCollectionDate": "2025"},
         input_fields=["geoLocCountry", "sampleCollectionDate"],
         concatenate_args={
@@ -1220,7 +1220,7 @@ concatenate_cases = [
         expected="0//accession.1/2025-01-01",
     ),
     ConcatenateCase(
-        name="empty_string_field_uses_fallback_value",
+        name="empty_field_uses_fallback_value",
         input_data={"someInt": "0", "geoLocCountry": "", "sampleCollectionDate": "2025"},
         input_fields=["geoLocCountry", "sampleCollectionDate"],
         concatenate_args={
@@ -1232,7 +1232,7 @@ concatenate_cases = [
         expected="0/unknown/accession.1/2025-01-01",
     ),
     ConcatenateCase(
-        name="accession_version_omitted_from_order",
+        name="concatenate_only_uses_fields_in_list",
         input_data={"someInt": "0", "geoLocCountry": "", "sampleCollectionDate": "2025"},
         input_fields=["geoLocCountry", "sampleCollectionDate"],
         concatenate_args={

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -1276,7 +1276,8 @@ class DisplayNameCase:
 unparseable_identifier_warning = (
     "specimenCollectorSampleId and submissionId could not be parsed, using "
     "ACCESSION_VERSION in displayName instead. To include your own identifier, "
-    "remove whitespace and '/' characters or use format '<any>/<any>/<identifier>/<date>'"
+    "remove whitespace and '/' characters or use the format '<any>/<any>/<identifier>/<date>' "
+    "and we will parse the `identifier` from the submission."
 )
 
 
@@ -1335,25 +1336,25 @@ display_name_cases = [
         warning_prefix=unparseable_identifier_warning,
     ),
     DisplayNameCase(
-        name="empty_country_uses_default_fallback",
+        name="empty_fields_use_default_fallback",
         specimen_collector_id="hDENV1/Germany/myExtractedSample/2025",
         submission_id="hDENV1/Germany/myExtractedSample/2025",
         geo_loc_country="",
-        sample_collection_date="2025",
-        expected_regular="DENV-1/unknown/myExtractedSample/2025",
-        expected_insdc="DENV-1/unknown/accession.1/2025",  # INSDC never uses regex
-        expected_prefix="hYF/unknown/myExtractedSample/2025",
+        sample_collection_date="",
+        expected_regular="DENV-1/unknown/myExtractedSample/unknown",
+        expected_insdc="DENV-1/unknown/accession.1/unknown",  # INSDC never uses regex
+        expected_prefix="hYF/unknown/myExtractedSample/unknown",
     ),
     DisplayNameCase(
-        name="custom_fallback_value_replaces_unknown_country",
+        name="custom_fallback_value_replaces_empty_fields",
         specimen_collector_id="hDENV1/Germany/myExtractedSample/2025",
         submission_id="hDENV1/Germany/myExtractedSample/2025",
         geo_loc_country="",
-        sample_collection_date="2025",
+        sample_collection_date="",
         extra_args={"fallback_value": "another_fallback"},
-        expected_regular="DENV-1/another_fallback/myExtractedSample/2025",
-        expected_insdc="DENV-1/another_fallback/accession.1/2025",  # INSDC never uses regex
-        expected_prefix="hYF/another_fallback/myExtractedSample/2025",
+        expected_regular="DENV-1/another_fallback/myExtractedSample/another_fallback",
+        expected_insdc="DENV-1/another_fallback/accession.1/another_fallback",  # INSDC never uses regex
+        expected_prefix="hYF/another_fallback/myExtractedSample/another_fallback",
     ),
 ]
 

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -1361,16 +1361,16 @@ def test_display_name_construction() -> None:  # noqa: PLR0915
     assert res.datum == "DENV-1/unknown/version.1/2025"
     assert len(res.warnings) == 1
     assert (
-        res.warnings[0]
-        == "identifier string 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
+        res.warnings[0].message
+        == "specimencollectorSampleId 'hDENV1/myExtractedSample/2025' and submissionId 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
     )
     assert res_insdc.datum == "DENV-1/unknown/version.1/2025"
     assert len(res_insdc.warnings) == 0
     assert res_prefix.datum == "hYF/unknown/version.1/2025"
     assert len(res_prefix.warnings) == 1
     assert (
-        res_prefix.warnings[0]
-        == "identifier string 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
+        res_prefix.warnings[0].message
+        == "specimencollectorSampleId 'hDENV1/myExtractedSample/2025' and submissionId 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
     )
 
     input_data["specimenCollectorSampleId"] = submission_id_formatted_unexpected
@@ -1395,16 +1395,16 @@ def test_display_name_construction() -> None:  # noqa: PLR0915
     assert res.datum == "DENV-1/another_fallback/version.1/2025"
     assert len(res.warnings) == 1
     assert (
-        res.warnings[0]
-        == "identifier string 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
+        res.warnings[0].message
+        == "specimencollectorSampleId 'hDENV1/myExtractedSample/2025' and submissionId 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
     )
     assert res_insdc.datum == "DENV-1/another_fallback/version.1/2025"
     assert len(res_insdc.warnings) == 0
     assert res_prefix.datum == "hYF/another_fallback/version.1/2025"
     assert len(res_prefix.warnings) == 1
     assert (
-        res_prefix.warnings[0]
-        == "identifier string 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
+        res_prefix.warnings[0].message
+        == "specimencollectorSampleId 'hDENV1/myExtractedSample/2025' and submissionId 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
     )
 
 

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -1274,11 +1274,9 @@ class DisplayNameCase:
 
 
 unparseable_identifier_warning = (
-    "specimenCollectorSampleId 'hDENV1/Germany/somethingElse/myExtractedSample/2025' "
-    "and submissionId 'hDENV1/Germany/somethingElse/myExtractedSample/2025' could not be "
-    "parsed, using ACCESSION_VERSION in displayName instead. Alternatively, you may edit "
-    "the specimenCollectorSampleId or submissionId to not contain any whitespace or '/' "
-    "characters so it can be incorporated in the displayName."
+    "specimenCollectorSampleId and submissionId could not be parsed, using "
+    "ACCESSION_VERSION in displayName instead. To include your own identifier, "
+    "remove whitespace and '/' characters or use format '<any>/<any>/<identifier>/<date>'"
 )
 
 
@@ -1322,6 +1320,19 @@ display_name_cases = [
         expected_regular="DENV-1/Switzerland/mySample/2025",
         expected_insdc="DENV-1/Switzerland/accession.1/2025",  # INSDC never uses regex
         expected_prefix="hYF/Switzerland/mySample/2025",
+    ),
+    DisplayNameCase(
+        name="both_ids_unparseable_falls_back_to_accession_version_with_warning",
+        specimen_collector_id="hDENV1/Germany/somethingElse/myExtractedSample/2025",
+        submission_id="hDENV1/Germany/somethingElse/myExtractedSample/2025",
+        geo_loc_country="Switzerland",
+        sample_collection_date="2025",
+        expected_regular="DENV-1/Switzerland/accession.1/2025",
+        expected_insdc="DENV-1/Switzerland/accession.1/2025",  # INSDC never uses regex
+        expected_prefix="hYF/Switzerland/accession.1/2025",
+        warning_regular=unparseable_identifier_warning,
+        warning_insdc=None,  # warning is only emitted for direct (non-INSDC) submissions
+        warning_prefix=unparseable_identifier_warning,
     ),
     DisplayNameCase(
         name="empty_country_uses_default_fallback",
@@ -1373,6 +1384,7 @@ base_args: FunctionArgs = {
     # - Last field is a date in format YYYY, YYYY-MM, or YYYY-MM-DD
     # - Identifier is the second to last field (extracted through named capture group)
     "regex_pattern": r"^(?:[^/]+/)?[^/]+/(?P<identifier>[^/]+)/\d{4}(?:-\d{2}){0,2}$",
+    "human_readable_pattern": "<any>/<any>/<identifier>/<date>",
 }
 insdc_args: FunctionArgs = {**base_args, "is_insdc_ingest_group": True}
 prefix_args: FunctionArgs = {

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -1287,7 +1287,9 @@ class DisplayNameCase:
 unparseable_identifier_warning = (
     "specimenCollectorSampleId 'hDENV1/myExtractedSample/2025' and submissionId "
     "'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION "
-    "in displayName instead"
+    "in displayName instead. Alternatively, you may edit the specimenCollectorSampleId "
+    "or submissionId to not contain any whitespace or '/' characters so it can be "
+    "incorporated in the displayName."
 )
 
 

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -1221,7 +1221,7 @@ concatenate_cases = [
     ),
     ConcatenateCase(
         name="empty_field_uses_fallback_value",
-        input_data={"someInt": "0", "geoLocCountry": "", "sampleCollectionDate": "2025"},
+        input_data={"someInt": "", "geoLocCountry": "", "sampleCollectionDate": ""},
         input_fields=["geoLocCountry", "sampleCollectionDate"],
         concatenate_args={
             "ACCESSION_VERSION": "accession.1",
@@ -1229,7 +1229,7 @@ concatenate_cases = [
             "type": ["integer", "string", "ACCESSION_VERSION", "date"],
             "fallback_value": "unknown",
         },
-        expected="0/unknown/accession.1/2025-01-01",
+        expected="unknown/unknown/accession.1/unknown",
     ),
     ConcatenateCase(
         name="concatenate_only_uses_fields_in_list",
@@ -1242,18 +1242,6 @@ concatenate_cases = [
             "fallback_value": "unknown",
         },
         expected="0/unknown/2025-01-01",
-    ),
-    ConcatenateCase(
-        name="null_date_field_uses_fallback_value",
-        input_data={"someInt": "0", "geoLocCountry": "", "sampleCollectionDate": None},
-        input_fields=["geoLocCountry", "sampleCollectionDate"],
-        concatenate_args={
-            "ACCESSION_VERSION": "accession.1",
-            "order": ["someInt", "geoLocCountry", "ACCESSION_VERSION", "sampleCollectionDate"],
-            "type": ["integer", "string", "ACCESSION_VERSION", "date"],
-            "fallback_value": "unknown",
-        },
-        expected="0/unknown/accession.1/unknown",
     ),
 ]
 
@@ -1275,6 +1263,7 @@ class DisplayNameCase:
     specimen_collector_id: str | None
     submission_id: str
     geo_loc_country: str
+    sample_collection_date: str
     extra_args: FunctionArgs = field(default_factory=dict)
     expected_regular: str = ""
     expected_insdc: str = ""
@@ -1285,11 +1274,11 @@ class DisplayNameCase:
 
 
 unparseable_identifier_warning = (
-    "specimenCollectorSampleId 'hDENV1/myExtractedSample/2025' and submissionId "
-    "'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION "
-    "in displayName instead. Alternatively, you may edit the specimenCollectorSampleId "
-    "or submissionId to not contain any whitespace or '/' characters so it can be "
-    "incorporated in the displayName."
+    "specimenCollectorSampleId 'hDENV1/Germany/somethingElse/myExtractedSample/2025' "
+    "and submissionId 'hDENV1/Germany/somethingElse/myExtractedSample/2025' could not be "
+    "parsed, using ACCESSION_VERSION in displayName instead. Alternatively, you may edit "
+    "the specimenCollectorSampleId or submissionId to not contain any whitespace or '/' "
+    "characters so it can be incorporated in the displayName."
 )
 
 
@@ -1299,6 +1288,7 @@ display_name_cases = [
         specimen_collector_id=None,
         submission_id="mySample",
         geo_loc_country="Switzerland",
+        sample_collection_date="2025",
         expected_regular="DENV-1/Switzerland/mySample/2025",
         expected_insdc="DENV-1/Switzerland/accession.1/2025",
         expected_prefix="hYF/Switzerland/mySample/2025",
@@ -1308,6 +1298,7 @@ display_name_cases = [
         specimen_collector_id="myCollectorSample",
         submission_id="mySample",
         geo_loc_country="Switzerland",
+        sample_collection_date="2025",
         expected_regular="DENV-1/Switzerland/myCollectorSample/2025",
         expected_insdc="DENV-1/Switzerland/myCollectorSample/2025",
         expected_prefix="hYF/Switzerland/myCollectorSample/2025",
@@ -1317,41 +1308,41 @@ display_name_cases = [
         specimen_collector_id="hDENV1/Germany/myExtractedSample/2025",
         submission_id="mySample",
         geo_loc_country="Switzerland",
+        sample_collection_date="2025",
         expected_regular="DENV-1/Switzerland/myExtractedSample/2025",
-        expected_insdc="DENV-1/Switzerland/accession.1/2025",  # INSDC skips submissionId
+        expected_insdc="DENV-1/Switzerland/accession.1/2025",  # INSDC never uses regex
         expected_prefix="hYF/Switzerland/myExtractedSample/2025",
     ),
     DisplayNameCase(
         name="specimen_collector_id_no_regex_match_falls_back_to_submission_id",
-        specimen_collector_id="hDENV1/myExtractedSample/2025",
+        specimen_collector_id="hDENV1/Germany/somethingElse/myExtractedSample/2025",
         submission_id="mySample",
         geo_loc_country="Switzerland",
+        sample_collection_date="2025",
         expected_regular="DENV-1/Switzerland/mySample/2025",
-        expected_insdc="DENV-1/Switzerland/accession.1/2025",  # INSDC skips submissionId
+        expected_insdc="DENV-1/Switzerland/accession.1/2025",  # INSDC never uses regex
         expected_prefix="hYF/Switzerland/mySample/2025",
     ),
     DisplayNameCase(
-        name="both_ids_unparseable_empty_country_uses_accession_version",
-        specimen_collector_id="hDENV1/myExtractedSample/2025",
-        submission_id="hDENV1/myExtractedSample/2025",
+        name="empty_country_uses_default_fallback",
+        specimen_collector_id="hDENV1/Germany/myExtractedSample/2025",
+        submission_id="hDENV1/Germany/myExtractedSample/2025",
         geo_loc_country="",
-        expected_regular="DENV-1/unknown/accession.1/2025",
-        expected_insdc="DENV-1/unknown/accession.1/2025",
-        expected_prefix="hYF/unknown/accession.1/2025",
-        warning_regular=unparseable_identifier_warning,
-        warning_prefix=unparseable_identifier_warning,
+        sample_collection_date="2025",
+        expected_regular="DENV-1/unknown/myExtractedSample/2025",
+        expected_insdc="DENV-1/unknown/accession.1/2025",  # INSDC never uses regex
+        expected_prefix="hYF/unknown/myExtractedSample/2025",
     ),
     DisplayNameCase(
-        name="fallback_value_replaces_unknown_country_when_ids_unparseable",
-        specimen_collector_id="hDENV1/myExtractedSample/2025",
-        submission_id="hDENV1/myExtractedSample/2025",
+        name="custom_fallback_value_replaces_unknown_country",
+        specimen_collector_id="hDENV1/Germany/myExtractedSample/2025",
+        submission_id="hDENV1/Germany/myExtractedSample/2025",
         geo_loc_country="",
+        sample_collection_date="2025",
         extra_args={"fallback_value": "another_fallback"},
-        expected_regular="DENV-1/another_fallback/accession.1/2025",
-        expected_insdc="DENV-1/another_fallback/accession.1/2025",
-        expected_prefix="hYF/another_fallback/accession.1/2025",
-        warning_regular=unparseable_identifier_warning,
-        warning_prefix=unparseable_identifier_warning,
+        expected_regular="DENV-1/another_fallback/myExtractedSample/2025",
+        expected_insdc="DENV-1/another_fallback/accession.1/2025",  # INSDC never uses regex
+        expected_prefix="hYF/another_fallback/myExtractedSample/2025",
     ),
 ]
 
@@ -1376,7 +1367,12 @@ base_args: FunctionArgs = {
     "is_insdc_ingest_group": False,
     "order": ["nextclade.clade", "geoLocCountry", "IDENTIFIER", "sampleCollectionDate"],
     "type": ["string", "string", "IDENTIFIER", "string"],
-    "regex_pattern": r"^[^\/][^/]*/[^/]+/(?P<identifier>[^/]+)/\d{4}(?:-\d{2}){0,2}$",
+    # regex pattern constraints:
+    # - Cannot start with a slash
+    # - Four or three fields, separated by exactly two or three slashes
+    # - Last field is a date in format YYYY, YYYY-MM, or YYYY-MM-DD
+    # - Identifier is the second to last field (extracted through named capture group)
+    "regex_pattern": r"^(?:[^/]+/)?[^/]+/(?P<identifier>[^/]+)/\d{4}(?:-\d{2}){0,2}$",
 }
 insdc_args: FunctionArgs = {**base_args, "is_insdc_ingest_group": True}
 prefix_args: FunctionArgs = {
@@ -1394,7 +1390,7 @@ def test_display_name_construction(case: DisplayNameCase) -> None:
         return {
             "nextclade.clade": "DENV-1",
             "geoLocCountry": case.geo_loc_country,
-            "sampleCollectionDate": "2025",
+            "sampleCollectionDate": case.sample_collection_date,
             "submissionId": case.submission_id,
             "specimenCollectorSampleId": case.specimen_collector_id,
         }

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -1,4 +1,6 @@
 # ruff: noqa: S101
+from dataclasses import dataclass, field
+
 import pytest
 from factory_methods import (
     Case,
@@ -1174,238 +1176,253 @@ def test_parse_date_into_range() -> None:
     ), "dateRangeUpper: lucene range upper bound should be tightened by submittedAt."
 
 
-def test_concatenate() -> None:
-    assert (
-        ProcessingFunctions.concatenate(
-            {"date": "2021-01-01/2021-12-31", "country": "USA"},
-            "field_name",
-            ["date", "country"],
-            {
-                "type": ["dateRangeString", "string"],
-                "order": ["date", "country"],
-                "ACCESSION_VERSION": "version.1",
-            },
-        ).datum
-        == "2021-01-01_TO_2021-12-31/USA"
-    ), "ISO date range is converted to lucene format for displayNames."
-    input_data: InputMetadata = {
-        "someInt": "",
-        "geoLocCountry": "",
-        "sampleCollectionDate": "2025",
-    }
-    output_field: str = "displayName"
-    input_fields: list[str] = ["geoLocCountry", "sampleCollectionDate"]
-    args: FunctionArgs = {
-        "ACCESSION_VERSION": "version.1",
-        "order": ["someInt", "geoLocCountry", "ACCESSION_VERSION", "sampleCollectionDate"],
-        "type": ["integer", "string", "ACCESSION_VERSION", "date"],
-    }
-    args_no_accession_version: FunctionArgs = {
-        "ACCESSION_VERSION": "version.1",
-        "order": ["someInt", "geoLocCountry", "sampleCollectionDate"],
-        "type": ["integer", "string", "date"],
-        "fallback_value": "unknown",
-    }
+@dataclass
+class ConcatenateCase:
+    name: str
+    input_data: InputMetadata
+    input_fields: list[str]
+    concatenate_args: FunctionArgs
+    expected: str
 
-    res_no_fallback_no_int = ProcessingFunctions.concatenate(
-        input_data,
-        output_field,
-        input_fields,
-        args,
+
+concatenate_cases = [
+    ConcatenateCase(
+        name="date_range_converted_to_lucene",
+        input_data={"date": "2021-01-01/2021-12-31", "country": "USA"},
+        input_fields=["date", "country"],
+        concatenate_args={
+            "ACCESSION_VERSION": "accession.1",
+            "order": ["date", "country"],
+            "type": ["dateRangeString", "string"],
+        },
+        expected="2021-01-01_TO_2021-12-31/USA",
+    ),
+    ConcatenateCase(
+        name="empty_int_field_skipped",
+        input_data={"someInt": "", "geoLocCountry": "", "sampleCollectionDate": "2025"},
+        input_fields=["geoLocCountry", "sampleCollectionDate"],
+        concatenate_args={
+            "ACCESSION_VERSION": "accession.1",
+            "order": ["someInt", "geoLocCountry", "ACCESSION_VERSION", "sampleCollectionDate"],
+            "type": ["integer", "string", "ACCESSION_VERSION", "date"],
+        },
+        expected="accession.1/2025-01-01",
+    ),
+    ConcatenateCase(
+        name="present_int_field_and_empty_string_field_with_no_fallback",
+        input_data={"someInt": "0", "geoLocCountry": "", "sampleCollectionDate": "2025"},
+        input_fields=["geoLocCountry", "sampleCollectionDate"],
+        concatenate_args={
+            "ACCESSION_VERSION": "accession.1",
+            "order": ["someInt", "geoLocCountry", "ACCESSION_VERSION", "sampleCollectionDate"],
+            "type": ["integer", "string", "ACCESSION_VERSION", "date"],
+        },
+        expected="0//accession.1/2025-01-01",
+    ),
+    ConcatenateCase(
+        name="empty_string_field_uses_fallback_value",
+        input_data={"someInt": "0", "geoLocCountry": "", "sampleCollectionDate": "2025"},
+        input_fields=["geoLocCountry", "sampleCollectionDate"],
+        concatenate_args={
+            "ACCESSION_VERSION": "accession.1",
+            "order": ["someInt", "geoLocCountry", "ACCESSION_VERSION", "sampleCollectionDate"],
+            "type": ["integer", "string", "ACCESSION_VERSION", "date"],
+            "fallback_value": "unknown",
+        },
+        expected="0/unknown/accession.1/2025-01-01",
+    ),
+    ConcatenateCase(
+        name="accession_version_omitted_from_order",
+        input_data={"someInt": "0", "geoLocCountry": "", "sampleCollectionDate": "2025"},
+        input_fields=["geoLocCountry", "sampleCollectionDate"],
+        concatenate_args={
+            "ACCESSION_VERSION": "accession.1",
+            "order": ["someInt", "geoLocCountry", "sampleCollectionDate"],
+            "type": ["integer", "string", "date"],
+            "fallback_value": "unknown",
+        },
+        expected="0/unknown/2025-01-01",
+    ),
+    ConcatenateCase(
+        name="null_date_field_uses_fallback_value",
+        input_data={"someInt": "0", "geoLocCountry": "", "sampleCollectionDate": None},
+        input_fields=["geoLocCountry", "sampleCollectionDate"],
+        concatenate_args={
+            "ACCESSION_VERSION": "accession.1",
+            "order": ["someInt", "geoLocCountry", "ACCESSION_VERSION", "sampleCollectionDate"],
+            "type": ["integer", "string", "ACCESSION_VERSION", "date"],
+            "fallback_value": "unknown",
+        },
+        expected="0/unknown/accession.1/unknown",
+    ),
+]
+
+
+@pytest.mark.parametrize("case", concatenate_cases, ids=lambda c: c.name)
+def test_concatenate(case: ConcatenateCase) -> None:
+    result = ProcessingFunctions.concatenate(
+        input_data=case.input_data,
+        output_field="displayName",
+        input_fields=case.input_fields,
+        args=case.concatenate_args,
     )
-
-    input_data["someInt"] = "0"
-    res_no_fallback = ProcessingFunctions.concatenate(
-        input_data,
-        output_field,
-        input_fields,
-        args,
-    )
-
-    args["fallback_value"] = "unknown"
-    res_fallback = ProcessingFunctions.concatenate(
-        input_data,
-        output_field,
-        input_fields,
-        args,
-    )
-
-    res_fallback_no_accession_version = ProcessingFunctions.concatenate(
-        input_data,
-        output_field,
-        input_fields,
-        args_no_accession_version,
-    )
-
-    input_data["sampleCollectionDate"] = None
-    res_fallback_explicit_null = ProcessingFunctions.concatenate(
-        input_data,
-        output_field,
-        input_fields,
-        args,
-    )
-
-    assert res_no_fallback_no_int.datum == "version.1/2025-01-01"
-    assert res_no_fallback.datum == "0//version.1/2025-01-01"
-    assert res_fallback.datum == "0/unknown/version.1/2025-01-01"
-    assert res_fallback_no_accession_version.datum == "0/unknown/2025-01-01"
-    assert res_fallback_explicit_null.datum == "0/unknown/version.1/unknown"
+    assert result.datum == case.expected
 
 
-def test_display_name_construction() -> None:  # noqa: PLR0915
-    submission_id = "mySample"
-    submission_id_formatted = "hDENV1/Germany/myExtractedSample/2025"
-    submission_id_formatted_unexpected = "hDENV1/myExtractedSample/2025"
-    input_data: InputMetadata = {
-        "nextclade.clade": "DENV-1",
-        "geoLocCountry": "Switzerland",
-        "sampleCollectionDate": "2025",
-        "submissionId": submission_id,
-    }
-    output_field: str = "displayName"
+@dataclass
+class DisplayNameCase:
+    name: str
+    specimen_collector_id: str | None
+    submission_id: str
+    geo_loc_country: str
+    extra_args: FunctionArgs = field(default_factory=dict)
+    expected_regular: str = ""
+    expected_insdc: str = ""
+    expected_prefix: str = ""
+    warning_regular: str | None = None
+    warning_insdc: str | None = None
+    warning_prefix: str | None = None
 
-    def input_fields():
-        return [
-            "nextclade.clade",
-            "geoLocCountry",
-            "specimenCollectorSampleId",
-            "submissionId",
-            "sampleCollectionDate",
-        ]
 
-    def args():
+unparseable_identifier_warning = (
+    "specimenCollectorSampleId 'hDENV1/myExtractedSample/2025' and submissionId "
+    "'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION "
+    "in displayName instead"
+)
+
+
+display_name_cases = [
+    DisplayNameCase(
+        name="no_specimen_collector_id",
+        specimen_collector_id=None,
+        submission_id="mySample",
+        geo_loc_country="Switzerland",
+        expected_regular="DENV-1/Switzerland/mySample/2025",
+        expected_insdc="DENV-1/Switzerland/accession.1/2025",
+        expected_prefix="hYF/Switzerland/mySample/2025",
+    ),
+    DisplayNameCase(
+        name="specimen_collector_id_plain",
+        specimen_collector_id="myCollectorSample",
+        submission_id="mySample",
+        geo_loc_country="Switzerland",
+        expected_regular="DENV-1/Switzerland/myCollectorSample/2025",
+        expected_insdc="DENV-1/Switzerland/myCollectorSample/2025",
+        expected_prefix="hYF/Switzerland/myCollectorSample/2025",
+    ),
+    DisplayNameCase(
+        name="specimen_collector_id_matches_regex_extracts_identifier",
+        specimen_collector_id="hDENV1/Germany/myExtractedSample/2025",
+        submission_id="mySample",
+        geo_loc_country="Switzerland",
+        expected_regular="DENV-1/Switzerland/myExtractedSample/2025",
+        expected_insdc="DENV-1/Switzerland/accession.1/2025",  # INSDC skips submissionId
+        expected_prefix="hYF/Switzerland/myExtractedSample/2025",
+    ),
+    DisplayNameCase(
+        name="specimen_collector_id_no_regex_match_falls_back_to_submission_id",
+        specimen_collector_id="hDENV1/myExtractedSample/2025",
+        submission_id="mySample",
+        geo_loc_country="Switzerland",
+        expected_regular="DENV-1/Switzerland/mySample/2025",
+        expected_insdc="DENV-1/Switzerland/accession.1/2025",  # INSDC skips submissionId
+        expected_prefix="hYF/Switzerland/mySample/2025",
+    ),
+    DisplayNameCase(
+        name="both_ids_unparseable_empty_country_uses_accession_version",
+        specimen_collector_id="hDENV1/myExtractedSample/2025",
+        submission_id="hDENV1/myExtractedSample/2025",
+        geo_loc_country="",
+        expected_regular="DENV-1/unknown/accession.1/2025",
+        expected_insdc="DENV-1/unknown/accession.1/2025",
+        expected_prefix="hYF/unknown/accession.1/2025",
+        warning_regular=unparseable_identifier_warning,
+        warning_prefix=unparseable_identifier_warning,
+    ),
+    DisplayNameCase(
+        name="fallback_value_replaces_unknown_country_when_ids_unparseable",
+        specimen_collector_id="hDENV1/myExtractedSample/2025",
+        submission_id="hDENV1/myExtractedSample/2025",
+        geo_loc_country="",
+        extra_args={"fallback_value": "another_fallback"},
+        expected_regular="DENV-1/another_fallback/accession.1/2025",
+        expected_insdc="DENV-1/another_fallback/accession.1/2025",
+        expected_prefix="hYF/another_fallback/accession.1/2025",
+        warning_regular=unparseable_identifier_warning,
+        warning_prefix=unparseable_identifier_warning,
+    ),
+]
+
+
+def _assert_display_name_warnings(warnings: list, expected_message: str | None) -> None:
+    if expected_message is None:
+        assert len(warnings) == 0
+    else:
+        assert len(warnings) == 1
+        assert warnings[0].message == expected_message
+
+
+input_fields = [
+    "nextclade.clade",
+    "geoLocCountry",
+    "specimenCollectorSampleId",
+    "submissionId",
+    "sampleCollectionDate",
+]
+base_args: FunctionArgs = {
+    "ACCESSION_VERSION": "accession.1",
+    "is_insdc_ingest_group": False,
+    "order": ["nextclade.clade", "geoLocCountry", "IDENTIFIER", "sampleCollectionDate"],
+    "type": ["string", "string", "IDENTIFIER", "string"],
+    "regex_pattern": r"^[^\/][^/]*/[^/]+/(?P<identifier>[^/]+)/\d{4}(?:-\d{2}){0,2}$",
+}
+insdc_args: FunctionArgs = {**base_args, "is_insdc_ingest_group": True}
+prefix_args: FunctionArgs = {
+    **base_args,
+    "order": ["ARG:prefix", "geoLocCountry", "IDENTIFIER", "sampleCollectionDate"],
+    "type": ["ARG:prefix", "string", "IDENTIFIER", "string"],
+    "prefix": "hYF",
+}
+
+
+@pytest.mark.parametrize("case", display_name_cases, ids=lambda c: c.name)
+def test_display_name_construction(case: DisplayNameCase) -> None:
+    def input_data() -> InputMetadata:
+        # make new input data each time: build_display_name mutates
         return {
-            "ACCESSION_VERSION": "version.1",
-            "is_insdc_ingest_group": False,
-            "order": ["nextclade.clade", "geoLocCountry", "IDENTIFIER", "sampleCollectionDate"],
-            "type": ["string", "string", "IDENTIFIER", "string"],
-            "regex_pattern": r"^[^\/][^/]*/[^/]+/(?P<identifier>[^/]+)/\d{4}(?:-\d{2}){0,2}$",
+            "nextclade.clade": "DENV-1",
+            "geoLocCountry": case.geo_loc_country,
+            "sampleCollectionDate": "2025",
+            "submissionId": case.submission_id,
+            "specimenCollectorSampleId": case.specimen_collector_id,
         }
 
-    def args_with_prefix():
-        return {
-            "ACCESSION_VERSION": "version.1",
-            "is_insdc_ingest_group": False,
-            "order": ["ARG:prefix", "geoLocCountry", "IDENTIFIER", "sampleCollectionDate"],
-            "type": ["ARG:prefix", "string", "IDENTIFIER", "string"],
-            "prefix": "hYF",
-            "regex_pattern": r"^[^\/][^/]*/[^/]+/(?P<identifier>[^/]+)/\d{4}(?:-\d{2}){0,2}$",
-        }
-
-    def args_insdc():
-        return {
-            "ACCESSION_VERSION": "version.1",
-            "is_insdc_ingest_group": True,
-            "order": ["nextclade.clade", "geoLocCountry", "IDENTIFIER", "sampleCollectionDate"],
-            "type": ["string", "string", "IDENTIFIER", "string"],
-            "regex_pattern": r"^[^\/][^/]*/[^/]+/(?P<identifier>[^/]+)/\d{4}(?:-\d{2}){0,2}$",
-        }
-
-    res = ProcessingFunctions.build_display_name(input_data, output_field, input_fields(), args())
-    res_insdc = ProcessingFunctions.build_display_name(
-        input_data, output_field, input_fields(), args_insdc()
-    )
-    res_prefix = ProcessingFunctions.build_display_name(
-        input_data, output_field, input_fields(), args_with_prefix()
-    )
-    assert res.datum == "DENV-1/Switzerland/mySample/2025"
-    assert res_insdc.datum == "DENV-1/Switzerland/mySample/2025"
-    assert res_prefix.datum == "hYF/Switzerland/mySample/2025"
-
-    input_data["specimenCollectorSampleId"] = "myCollectorSample"
-    res = ProcessingFunctions.build_display_name(input_data, output_field, input_fields(), args())
-    res_insdc = ProcessingFunctions.build_display_name(
-        input_data, output_field, input_fields(), args_insdc()
-    )
-    res_prefix = ProcessingFunctions.build_display_name(
-        input_data, output_field, input_fields(), args_with_prefix()
-    )
-    assert res.datum == "DENV-1/Switzerland/myCollectorSample/2025"
-    assert res_insdc.datum == "DENV-1/Switzerland/myCollectorSample/2025"
-    assert res_prefix.datum == "hYF/Switzerland/myCollectorSample/2025"
-
-    input_data["specimenCollectorSampleId"] = submission_id_formatted
-    res = ProcessingFunctions.build_display_name(input_data, output_field, input_fields(), args())
-    res_insdc = ProcessingFunctions.build_display_name(
-        input_data, output_field, input_fields(), args_insdc()
-    )
-    res_prefix = ProcessingFunctions.build_display_name(
-        input_data, output_field, input_fields(), args_with_prefix()
-    )
-    assert res.datum == "DENV-1/Switzerland/myExtractedSample/2025"
-    assert res_insdc.datum == "DENV-1/Switzerland/mySample/2025"
-    assert res_prefix.datum == "hYF/Switzerland/myExtractedSample/2025"
-
-    input_data["specimenCollectorSampleId"] = submission_id_formatted_unexpected
-    res = ProcessingFunctions.build_display_name(input_data, output_field, input_fields(), args())
-    res_insdc = ProcessingFunctions.build_display_name(
-        input_data, output_field, input_fields(), args_insdc()
-    )
-    res_prefix = ProcessingFunctions.build_display_name(
-        input_data, output_field, input_fields(), args_with_prefix()
-    )
-    assert res.datum == "DENV-1/Switzerland/mySample/2025"
-    assert res_insdc.datum == "DENV-1/Switzerland/mySample/2025"
-    assert res_prefix.datum == "hYF/Switzerland/mySample/2025"
-
-    input_data["specimenCollectorSampleId"] = submission_id_formatted_unexpected
-    input_data["submissionId"] = submission_id_formatted_unexpected
-    input_data["geoLocCountry"] = ""
-    res = ProcessingFunctions.build_display_name(input_data, output_field, input_fields(), args())
-    res_insdc = ProcessingFunctions.build_display_name(
-        input_data, output_field, input_fields(), args_insdc()
-    )
-    res_prefix = ProcessingFunctions.build_display_name(
-        input_data, output_field, input_fields(), args_with_prefix()
-    )
-    assert res.datum == "DENV-1/unknown/version.1/2025"
-    assert len(res.warnings) == 1
-    assert (
-        res.warnings[0].message
-        == "specimencollectorSampleId 'hDENV1/myExtractedSample/2025' and submissionId 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
-    )
-    assert res_insdc.datum == "DENV-1/unknown/version.1/2025"
-    assert len(res_insdc.warnings) == 0
-    assert res_prefix.datum == "hYF/unknown/version.1/2025"
-    assert len(res_prefix.warnings) == 1
-    assert (
-        res_prefix.warnings[0].message
-        == "specimencollectorSampleId 'hDENV1/myExtractedSample/2025' and submissionId 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
-    )
-
-    input_data["specimenCollectorSampleId"] = submission_id_formatted_unexpected
     res = ProcessingFunctions.build_display_name(
-        input_data,
-        output_field,
-        input_fields(),
-        {"fallback_value": "another_fallback"} | args(),  # type: ignore
+        input_data(),
+        "displayName",
+        input_fields,
+        base_args | case.extra_args,
     )
     res_insdc = ProcessingFunctions.build_display_name(
-        input_data,
-        output_field,
-        input_fields(),
-        {"fallback_value": "another_fallback"} | args_insdc(),  # type: ignore
+        input_data(),
+        "displayName",
+        input_fields,
+        insdc_args | case.extra_args,
     )
     res_prefix = ProcessingFunctions.build_display_name(
-        input_data,
-        output_field,
-        input_fields(),
-        {"fallback_value": "another_fallback"} | args_with_prefix(),  # type: ignore
+        input_data(),
+        "displayName",
+        input_fields,
+        prefix_args | case.extra_args,
     )
-    assert res.datum == "DENV-1/another_fallback/version.1/2025"
-    assert len(res.warnings) == 1
-    assert (
-        res.warnings[0].message
-        == "specimencollectorSampleId 'hDENV1/myExtractedSample/2025' and submissionId 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
-    )
-    assert res_insdc.datum == "DENV-1/another_fallback/version.1/2025"
-    assert len(res_insdc.warnings) == 0
-    assert res_prefix.datum == "hYF/another_fallback/version.1/2025"
-    assert len(res_prefix.warnings) == 1
-    assert (
-        res_prefix.warnings[0].message
-        == "specimencollectorSampleId 'hDENV1/myExtractedSample/2025' and submissionId 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
-    )
+
+    assert res.datum == case.expected_regular
+    assert res_insdc.datum == case.expected_insdc
+    assert res_prefix.datum == case.expected_prefix
+
+    _assert_display_name_warnings(res.warnings, case.warning_regular)
+    _assert_display_name_warnings(res_insdc.warnings, case.warning_insdc)
+    _assert_display_name_warnings(res_prefix.warnings, case.warning_prefix)
 
 
 def test_call_function_converts_raw_errors_to_annotations() -> None:

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -1283,7 +1283,7 @@ unparseable_identifier_warning = (
 display_name_cases = [
     DisplayNameCase(
         name="no_specimen_collector_id",
-        specimen_collector_id=None,
+        specimen_collector_id="",
         submission_id="mySample",
         geo_loc_country="Switzerland",
         sample_collection_date="2025",

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -1333,7 +1333,7 @@ def test_display_name_construction() -> None:  # noqa: PLR0915
         input_data, output_field, input_fields(), args_with_prefix()
     )
     assert res.datum == "DENV-1/Switzerland/myExtractedSample/2025"
-    assert res_insdc.datum == "DENV-1/Switzerland/version.1/2025"
+    assert res_insdc.datum == "DENV-1/Switzerland/mySample/2025"
     assert res_prefix.datum == "hYF/Switzerland/myExtractedSample/2025"
 
     input_data["specimenCollectorSampleId"] = submission_id_formatted_unexpected
@@ -1344,11 +1344,12 @@ def test_display_name_construction() -> None:  # noqa: PLR0915
     res_prefix = ProcessingFunctions.build_display_name(
         input_data, output_field, input_fields(), args_with_prefix()
     )
-    assert res.datum == "DENV-1/Switzerland/version.1/2025"
-    assert res_insdc.datum == "DENV-1/Switzerland/version.1/2025"
-    assert res_prefix.datum == "hYF/Switzerland/version.1/2025"
+    assert res.datum == "DENV-1/Switzerland/mySample/2025"
+    assert res_insdc.datum == "DENV-1/Switzerland/mySample/2025"
+    assert res_prefix.datum == "hYF/Switzerland/mySample/2025"
 
     input_data["specimenCollectorSampleId"] = submission_id_formatted_unexpected
+    input_data["submissionId"] = submission_id_formatted_unexpected
     input_data["geoLocCountry"] = ""
     res = ProcessingFunctions.build_display_name(input_data, output_field, input_fields(), args())
     res_insdc = ProcessingFunctions.build_display_name(


### PR DESCRIPTION
resolves #6763

`build_display_name` now attempts to use the `submissionId` as the identifier field in displayName when `specimenCollectorSampleId` is present but cannot be parsed (see extended description in the issue). It also introduces the `human_readable_pattern` arg to `build_display_name` (see breaking changes below)

Additionally, this PR extracts the identifier string parsing logic into its own function.

## Breaking changes

If you configure the `build_display_name` preprocessing function with a `regex_pattern`, you must now also provide a `human_readable_pattern`. This is a human-readable representation of the format the `regex_pattern` parses and will be shown to users in a warning message if the regex parsing fails.

```yaml
        - name: displayName
          ...
          preprocessing:
            function: build_display_name
            inputs:
              ...
            args:
              ...
              regex_pattern: '^(?:[^/]+/)?[^/]+/(?P<identifier>[^/]+)/\d{4}(?:-\d{2}){0,2}$'
              human_readable_pattern: "<any>/<any>/<identifier>/<date>"
```

## Screenshots

Three different cases showing new fallback behaviour:

1. specimenCollectorSampleId 'INYO_2_2011' does not need to be parsed and is used director
2. No isolate name -> fall back to submissionId, which is 'test_WNV/Bakersfield_CA_USA/W417/2010-07-08' -> parse this and pull out the identifier 
3. No isolate name -> fall back to submissionId, which is 'test_WNV/mosquito/Larimer-CO-USA/2016-06-27/W1819' -> cannot be parsed, show new warning message with supported format for regex

<img width="1907" height="483" alt="grafik" src="https://github.com/user-attachments/assets/6606c3d6-0834-48d7-bf0f-7aadcaa05e07" />

## Examples of less nice displayNames

I tested this new approach of generating displayNames on all sequences currently in Pathoplexus. Overall it looks good and my opinion is that this is an improvement over the current state. However, there are instances where the new displayNames are less nice. These broadly fall into three classes from what I've seen:

1) **Redundancy in displayName (examples PP_006XBKH.2, PP_000UMND.2)**
    - old: `France/PP_006XBKH.2/2026-05-10`, new: `France/26-0090|France|Homo_sapiens|2026-05-10/2026-05-10`
    - old: `USA/PP_000UMND.2/2022-07`, new: `USA/MPXV_USA_2022_NJ0016/2022-07`
2) **Uninformative/short identifier (example PP_003HM09.1)**
    - old: `Gabon/PP_003HM09.1/2017`, new: `Gabon/3/2017`
3) **Just adding `unknown` (example PP_0021GXK.1)**
    - old: `PP_0021GXK.1`, new: `unknown/PP_0021GXK.1/unknown`

To address 1), we'd have to alter our regex or extend our set of forbidden characters to either start parsing these types of identifiers (hard, esp. if there's multiple separators in the same identifer) or to reject them and just use accessionVersion (which has the downside of rejecting good identifiers). For 2) we could consider having a minimum length for identifier fields. For 3) we could consider not adding the `unknown` placeholder, but in general I think it's nice that we now have a consistent meaning for each position in the displayName for each sequence. All this does not mean we can't upate/tweak displayName creation in the future, but for now I think this is a good starting point

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable