### PR TITLE
fix(website): trust forwarded hosts from ingress

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -10,6 +10,10 @@ import flowbiteReact from 'flowbite-react/plugin/astro';
 export default defineConfig({
     output: 'server',
     integrations: [react(), mdx(), flowbiteReact()],
+    security: {
+        // Loculus deployments terminate public traffic at the trusted ingress/proxy.
+        allowedDomains: [{}],
+    },
     adapter: node({
         mode: 'standalone',
     }),

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -11,7 +11,9 @@ export default defineConfig({
     output: 'server',
     integrations: [react(), mdx(), flowbiteReact()],
     security: {
-        // Loculus deployments terminate public traffic at the trusted ingress/proxy.
+        // Allow any forwarded host/proto (required for ingress-terminated deployments with dynamic hostnames).
+        // This intentionally disables Astro's host allowlist hardening; rely on network-level controls (ClusterIP + ingress).
+        // See https://docs.astro.build/en/reference/configuration-reference/#security and https://github.com/withastro/astro/issues/15713
         allowedDomains: [{}],
     },
     adapter: node({


### PR DESCRIPTION
Resolves #6530

Required to be able to upgrade Astro. This just maintains the status quo and opts out of Astro's hardening which we don't need for our type of deployments.

## Summary

This configures Astro's `security.allowedDomains` to trust forwarded host information from the deployment ingress/proxy. Loculus production deployments expose the website through the Kubernetes ingress and route traffic to the internal `loculus-website-service`, so the app receives public requests through a trusted terminating proxy rather than directly from arbitrary clients.

Using `allowedDomains: [{}]` keeps Astro's forwarded host/proto handling compatible with our dynamic deployment hostnames without requiring every instance domain to be enumerated in the website build. This avoids generated URLs such as login return URLs falling back to the socket host, which can appear as `localhost` behind the proxy after Astro's v5 host-header hardening.

## Testing

Tested that login works still manually on preview

## Notes

The deployment chart confirms the production website service is `ClusterIP` in `environment: server` and is exposed publicly through the Traefik-backed ingress.

🚀 Preview: https://chore-astro-6-migration-p.loculus.org