### PR TITLE
test(integration-tests): fix flaky revoke-button click race

### DIFF
--- a/integration-tests/tests/pages/search.page.ts
+++ b/integration-tests/tests/pages/search.page.ts
@@ -153,22 +153,30 @@ export class SearchPage {
         await this.getSequenceRows().filter({ hasText: accessionVersion }).click();
     }
 
-    async reviseSequence() {
-        // Sometimes clicking revise button doesn't register, so let's wait for sequence viewer to be visible first
-        // See #5447
+    /**
+     * Clicks a control (button/link) in the "Sequence management" panel of the details view.
+     *
+     * The panel re-renders as sequence data loads, which can cause a click to be silently dropped:
+     * React delegates events to the island root and can't resolve a handler for a DOM node that was
+     * just re-rendered out from under the click. Waiting for the sequence viewer to render first
+     * ensures the panel has settled before we click. See #5447.
+     */
+    private async clickSettledManagementControl(control: Locator) {
         await expect(this.page.getByTestId('fixed-length-text-viewer')).toBeVisible();
+        await expect(control).toBeVisible();
+        await control.click();
+    }
 
+    async reviseSequence() {
         const reviseButton = this.page.getByRole('link', { name: 'Revise this sequence' });
-        await expect(reviseButton).toBeVisible();
-        await reviseButton.click();
+        await this.clickSettledManagementControl(reviseButton);
         await expect(this.page.getByText(/^Create new revision from LOC_\w+\.\d+$/)).toBeVisible();
         return new EditPage(this.page);
     }
 
     async revokeSequence(revocationReason: string = 'Test revocation') {
         const revokeButton = this.page.getByRole('button', { name: 'Revoke this sequence' });
-        await expect(revokeButton).toBeVisible();
-        await revokeButton.click();
+        await this.clickSettledManagementControl(revokeButton);
 
         await expect(
             this.page.getByText('Are you sure you want to revoke this sequence?'),

--- a/integration-tests/tests/specs/features/search/override-hidden-fields.spec.ts
+++ b/integration-tests/tests/specs/features/search/override-hidden-fields.spec.ts
@@ -75,9 +75,7 @@ test('Override hidden fields', async ({ page, groupId }) => {
     const revokedAccession = revokedId.split('.')[0];
     const expectedRevocationAccessionVersion = `${revokedAccession}.2`;
     await page.getByRole('cell', { name: 'Uganda' }).click();
-    await page.getByRole('button', { name: 'Revoke this sequence' }).click();
-    await page.getByRole('button', { name: 'Confirm' }).click();
-    await expect(page.getByText('Sequence revoked successfully.')).toBeVisible();
+    await search.revokeSequence();
 
     // The revocation is auto-approved; only the revision still needs to be released
     reviewPage = new ReviewPage(page);

--- a/integration-tests/tests/specs/features/sequence-version-banners.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-version-banners.spec.ts
@@ -113,9 +113,7 @@ test.describe('Sequence version banners', () => {
 
         // Click on the sequence and revoke it (auto-approves on confirmation)
         await page.getByRole('cell', { name: 'Germany' }).click();
-        await page.getByRole('button', { name: 'Revoke this sequence' }).click();
-        await page.getByRole('button', { name: 'Confirm' }).click();
-        await expect(page.getByText('Sequence revoked successfully.')).toBeVisible();
+        await search.revokeSequence();
 
         // Release the revision (the revocation is already approved automatically)
         const reviewPage2 = new ReviewPage(page);


### PR DESCRIPTION
Deflake revoke button click by waiting for sequence container to have loaded so as not to race, put shared code into utility and ensure it's used wherever we revoke/revise.

Applies fix for issue #5447 implemented in #5666 consistently

<details>

## Problem

The **Revoke this sequence** button in the sequence details preview modal intermittently received a Playwright click that had no effect — the click registered but the *"Are you sure you want to revoke this sequence?"* confirmation dialog never opened, failing the test.

## Root cause

Not a missing hydration guard — `RevokeButton` already builds on the hydration-safe `Button` (disabled until `useClientFlag()` flips, which Playwright waits for). The cause is the same class of flake documented for the sibling **Revise** button in #5447:

- React (v17+) **delegates** click events to the island root; it does not attach listeners to individual `<button>` elements. A handler only runs if the clicked DOM node is still part of React's current fiber tree.
- The **Sequence management** panel re-renders as sequence data loads (`SequencesContainer` kicks off its own async load right after the details fetch), shifting layout.
- A click dispatched in that window can land on a node that was just reconciled out from under it → React finds no fiber → the click is silently dropped.

`reviseSequence()` already worked around this by waiting for the sequence viewer to render before clicking; `revokeSequence()` clicked immediately, which is why revoke was the flaky one.

## Change

- Extract the "wait until the panel has settled, then click" logic into a shared `clickSettledManagementControl()` helper in `search.page.ts`, used by **both** `reviseSequence()` and `revokeSequence()` so they can't drift.
- Route the two inline revoke call sites (`sequence-version-banners.spec.ts`, `override-hidden-fields.spec.ts`) through `search.revokeSequence()` so they pick up the same guard instead of duplicating the unguarded click.

No application code changes — the fragility lives entirely at the test/automation boundary; delegated events plus conditional re-rendering is correct, idiomatic React.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

🚀 Preview: Add `preview` label to enable