### PR TITLE
chore(website): fix false positive Astro warning about unused local variable

### DIFF
--- a/website/src/pages/seqsets/[seqSetId].astro
+++ b/website/src/pages/seqsets/[seqSetId].astro
@@ -17,8 +17,7 @@ try {
     if (response.ok) {
         const versions = seqSets.parse(await response.json());
         if (versions.length > 0) {
-            const latestVersion = Math.max(...versions.map((s) => s.seqSetVersion));
-            return Astro.redirect(`/seqsets/${seqSetId}.${latestVersion}`);
+            return Astro.redirect(`/seqsets/${seqSetId}.${Math.max(...versions.map((s) => s.seqSetVersion))}`);
         }
     }
 } catch (error) {


### PR DESCRIPTION
## Summary

This PR fixes false positive Astro lint:

```
16:10:33 [check] Getting diagnostics for Astro files in /Users/cr/code/loculus-main/website...
src/pages/seqsets/[seqSetId].astro:20:19 - warning ts(6133): 'latestVersion' is declared but its value is never read.

20             const latestVersion = Math.max(...versions.map((s) => s.seqSetVersion));
                     ~~~~~~~~~~~~~
```
