### PR TITLE
refactor(website): make confirmation dialog a global singleton

### DIFF
--- a/website/src/components/ConfirmationDialog.tsx
+++ b/website/src/components/ConfirmationDialog.tsx
@@ -1,32 +1,60 @@
-import { type ReactNode, useCallback, useState } from 'react';
+import { type ReactNode, useSyncExternalStore } from 'react';
 
 import { BaseDialog } from './common/BaseDialog';
 import { Button } from './common/Button';
 
-type ConfirmOptions = {
+export type ConfirmOptions = {
     dialogText: ReactNode;
     confirmButtonText?: string;
     closeButtonText?: string;
     onConfirmation: () => Promise<void> | void;
 };
 
-/**
- * Declarative confirmation dialog built on {@link BaseDialog}.
- *
- * Render `confirmDialog` once in your component and call `confirm({...})` (e.g.
- * from an `onClick`) to open it. Only one confirmation can be shown at a time,
- * so a single hook instance covers any number of confirm actions in a component.
- *
- * The dialog is not dismissible by backdrop click (it is a confirmation); the
- * user must pick an action or use the close button.
+/*
+ * Global confirmation dialog, driven by a module-level store and rendered by a
+ * single host (`ConfirmDialogContainer`) at the app root — call
+ * `displayConfirmation({...})` from anywhere. A store rather than React context
+ * is required because each Astro `client:*` island is an isolated React tree
+ * that context cannot cross.
+ * The host renders in-tree (not a detached `createRoot`), so Headless UI keeps
+ * the background inert.
  */
-export function useConfirmDialog() {
-    const [options, setOptions] = useState<ConfirmOptions | null>(null);
 
-    const confirm = useCallback((newOptions: ConfirmOptions) => setOptions(newOptions), []);
-    const close = useCallback(() => setOptions(null), []);
+let currentOptions: ConfirmOptions | null = null;
+const listeners = new Set<() => void>();
 
-    const confirmDialog = (
+function emit() {
+    for (const listener of listeners) {
+        listener();
+    }
+}
+
+function subscribe(listener: () => void) {
+    listeners.add(listener);
+    return () => {
+        listeners.delete(listener);
+    };
+}
+
+function getSnapshot() {
+    return currentOptions;
+}
+
+export function displayConfirmation(options: ConfirmOptions) {
+    currentOptions = options;
+    emit();
+}
+
+function close() {
+    currentOptions = null;
+    emit();
+}
+
+/** Mount exactly once at the app root. */
+export function ConfirmDialogContainer() {
+    const options = useSyncExternalStore(subscribe, getSnapshot, () => null);
+
+    return (
         <BaseDialog title='' isOpen={options !== null} onClose={close} fullWidth={false} dismissible={false}>
             {options !== null && (
                 <>
@@ -51,6 +79,4 @@ export function useConfirmDialog() {
             )}
         </BaseDialog>
     );
-
-    return { confirm, confirmDialog };
 }

--- a/website/src/components/ConfirmationDialog.tsx
+++ b/website/src/components/ConfirmationDialog.tsx
@@ -33,6 +33,12 @@ function subscribe(listener: () => void) {
     listeners.add(listener);
     return () => {
         listeners.delete(listener);
+        // No host mounted means there can be no pending confirmation. (In the app
+        // the single host lives for the whole session, so this never fires there;
+        // it keeps state from leaking between tests that remount the host.)
+        if (listeners.size === 0) {
+            currentOptions = null;
+        }
     };
 }
 

--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -14,7 +14,7 @@ import { type InputField, type SubmissionDataTypes } from '../../types/config.ts
 import type { ClientConfig } from '../../types/runtimeConfig.ts';
 import { createAuthorizationHeader } from '../../utils/createAuthorizationHeader.ts';
 import { getAccessionVersionString } from '../../utils/extractAccessionVersion.ts';
-import { useConfirmDialog } from '../ConfirmationDialog.tsx';
+import { displayConfirmation } from '../ConfirmationDialog.tsx';
 import { ExtraFilesUpload } from '../Submission/DataUploadForm.tsx';
 import { Button } from '../common/Button';
 import { Spinner } from '../common/Spinner';
@@ -56,7 +56,6 @@ const InnerEditPage: FC<EditPageProps> = ({
     const [editableSequences, setEditableSequences] = useState(
         EditableSequences.fromInitialData(dataToEdit, submissionDataTypes.maxSequencesPerEntry),
     );
-    const { confirm, confirmDialog } = useConfirmDialog();
 
     const extraFilesEnabled = submissionDataTypes.files?.enabled ?? false;
     const [fileMapping, setFileMapping] = useState<FilesBySubmissionId | undefined>(() =>
@@ -182,7 +181,7 @@ const InnerEditPage: FC<EditPageProps> = ({
                 <Button
                     variant='primary'
                     onClick={() =>
-                        confirm({
+                        displayConfirmation({
                             dialogText: 'Do you really want to submit?',
                             onConfirmation: submitEditedDataForAccessionVersion,
                         })
@@ -193,7 +192,6 @@ const InnerEditPage: FC<EditPageProps> = ({
                     Submit
                 </Button>
             </div>
-            {confirmDialog}
         </>
     );
 };

--- a/website/src/components/ReviewPage/ReviewPage.spec.tsx
+++ b/website/src/components/ReviewPage/ReviewPage.spec.tsx
@@ -17,6 +17,7 @@ import {
     openDataUseTermsOption,
 } from '../../types/backend.ts';
 import { SINGLE_SEG_SINGLE_REF_REFERENCEGENOMES } from '../../types/referenceGenomes.spec.ts';
+import { ConfirmDialogContainer } from '../ConfirmationDialog.tsx';
 
 const openDataUseTerms = { type: openDataUseTermsOption } as const;
 
@@ -26,15 +27,18 @@ const testGroup = testGroups[0];
 
 function renderReviewPage() {
     return render(
-        <ReviewPage
-            group={testGroup}
-            organism={testOrganism}
-            metadataDisplayNames={new Map()}
-            accessToken={testAccessToken}
-            clientConfig={testConfig.public}
-            filesEnabled={false}
-            referenceGenomesInfo={SINGLE_SEG_SINGLE_REF_REFERENCEGENOMES}
-        />,
+        <>
+            <ReviewPage
+                group={testGroup}
+                organism={testOrganism}
+                metadataDisplayNames={new Map()}
+                accessToken={testAccessToken}
+                clientConfig={testConfig.public}
+                filesEnabled={false}
+                referenceGenomesInfo={SINGLE_SEG_SINGLE_REF_REFERENCEGENOMES}
+            />
+            <ConfirmDialogContainer />
+        </>,
     );
 }
 

--- a/website/src/components/ReviewPage/ReviewPage.tsx
+++ b/website/src/components/ReviewPage/ReviewPage.tsx
@@ -24,7 +24,7 @@ import {
 import { type ReferenceGenomesInfo } from '../../types/referencesGenomes.ts';
 import { type ClientConfig } from '../../types/runtimeConfig.ts';
 import { getAccessionVersionString } from '../../utils/extractAccessionVersion.ts';
-import { useConfirmDialog } from '../ConfirmationDialog.tsx';
+import { displayConfirmation } from '../ConfirmationDialog.tsx';
 import { getLastApprovalTimeKey } from '../SearchPage/RecentSequencesBanner.tsx';
 import { Button } from '../common/Button';
 import { Spinner } from '../common/Spinner';
@@ -90,7 +90,6 @@ const InnerReviewPage: FC<ReviewPageProps> = ({
     const [pageQuery, setPageQuery] = useState<PageQuery>({ pageOneIndexed: 1, size: pageSizeOptions[2] });
 
     const hooks = useSubmissionOperations(organism, group, clientConfig, accessToken, toast.error, pageQuery);
-    const { confirm, confirmDialog } = useConfirmDialog();
 
     const showNoIssues = hooks.includedProcessingResults.includes(noIssuesProcessingResult);
     const showWarnings = hooks.includedProcessingResults.includes(warningsProcessingResult);
@@ -275,7 +274,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({
                                     <Button
                                         className={menuItemClassName}
                                         onClick={() =>
-                                            confirm({
+                                            displayConfirmation({
                                                 dialogText:
                                                     'Are you sure you want to discard all sequences with errors?',
                                                 confirmButtonText: 'Discard',
@@ -297,7 +296,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({
                                 <Button
                                     className={menuItemClassName}
                                     onClick={() =>
-                                        confirm({
+                                        displayConfirmation({
                                             dialogText: `Are you sure you want to discard all ${processedCount} processed sequences?`,
                                             confirmButtonText: 'Discard',
                                             onConfirmation: () => {
@@ -321,7 +320,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({
                 <Button
                     className='border rounded-md p-1 bg-primary-600 text-white px-2'
                     onClick={() =>
-                        confirm({
+                        displayConfirmation({
                             dialogText: 'Are you sure you want to approve all valid sequences for release?',
                             confirmButtonText: 'Approve',
                             onConfirmation: () => {
@@ -352,7 +351,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({
                             sequenceEntryStatus={sequence}
                             metadataDisplayNames={metadataDisplayNames}
                             approveAccessionVersion={() =>
-                                confirm({
+                                displayConfirmation({
                                     dialogText: `Are you sure you want to approve ${getAccessionVersionString(sequence)}?`,
                                     confirmButtonText: 'Approve',
                                     onConfirmation: () => {
@@ -366,7 +365,7 @@ const InnerReviewPage: FC<ReviewPageProps> = ({
                                 })
                             }
                             deleteAccessionVersion={() =>
-                                confirm({
+                                displayConfirmation({
                                     dialogText: `Are you sure you want to discard ${getAccessionVersionString(sequence)}?`,
                                     confirmButtonText: 'Discard',
                                     onConfirmation: () => {
@@ -409,7 +408,6 @@ const InnerReviewPage: FC<ReviewPageProps> = ({
             </div>
             {reviewCards}
             {pagination}
-            {confirmDialog}
         </div>
     );
 };

--- a/website/src/components/SeqSetCitations/SeqSetItem.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItem.tsx
@@ -14,7 +14,7 @@ import type { ClientConfig } from '../../types/runtimeConfig';
 import { type SeqSet, type SeqSetRecord } from '../../types/seqSetCitation';
 import { createAuthorizationHeader } from '../../utils/createAuthorizationHeader';
 import { getThemeColor } from '../../utils/getThemeColor';
-import { useConfirmDialog } from '../ConfirmationDialog.tsx';
+import { displayConfirmation } from '../ConfirmationDialog.tsx';
 import { Button } from '../common/Button.tsx';
 import { Spinner } from '../common/Spinner';
 import { withQueryProvider } from '../common/withQueryProvider.tsx';
@@ -74,7 +74,6 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
 }) => {
     const [page, setPage] = useState(1);
     const [wideGraphs, setWideGraphs] = useState(false);
-    const { confirm, confirmDialog } = useConfirmDialog();
     const sequencesPerPage = 10;
 
     const {
@@ -147,7 +146,7 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
             <a
                 className='mr-4 cursor-pointer font-medium text-blue-600 hover:text-blue-800'
                 onClick={() =>
-                    confirm({
+                    displayConfirmation({
                         dialogText: `Are you sure you want to create a DOI for this version of your seqSet?`,
                         onConfirmation: handleCreateDOI,
                     })
@@ -263,7 +262,6 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
                     />
                 ) : null}
             </SeqSetSection>
-            {confirmDialog}
         </div>
     );
 };

--- a/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
@@ -10,7 +10,7 @@ import type { ClientConfig } from '../../types/runtimeConfig';
 import type { AuthorProfile, SeqSetRecord, SeqSet } from '../../types/seqSetCitation';
 import { createAuthorizationHeader } from '../../utils/createAuthorizationHeader';
 import { getAccessionVersionString } from '../../utils/extractAccessionVersion.ts';
-import { useConfirmDialog } from '../ConfirmationDialog.tsx';
+import { displayConfirmation } from '../ConfirmationDialog.tsx';
 import { CitationTable } from './CitationTable.tsx';
 import { BaseDialog } from '../common/BaseDialog.tsx';
 import { Button } from '../common/Button';
@@ -58,7 +58,6 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
     const [exportModalVisible, setExportModalVisible] = useState(false);
     const [citationsModalVisible, setCitationsModalVisible] = useState(false);
     const [creatorInfoVisible, setCreatorInfoVisible] = useState(false);
-    const { confirm, confirmDialog } = useConfirmDialog();
 
     const {
         isLoading: isSeqSetCitationsLoading,
@@ -139,7 +138,7 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
                             variant='outline'
                             className='flex items-center gap-2'
                             onClick={() =>
-                                confirm({
+                                displayConfirmation({
                                     dialogText: `Are you sure you want to delete this seqSet version?`,
                                     onConfirmation: handleDeleteSeqSet,
                                 })
@@ -204,7 +203,6 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
                 <CreatorDetailEntry label='Created by' value={createdByValue} />
                 <CreatorDetailEntry label='Created date' value={formatDate(seqSet.createdAt)} />
             </BaseDialog>
-            {confirmDialog}
         </div>
     );
 };

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -23,7 +23,7 @@ import type { ClientConfig } from '../../types/runtimeConfig.ts';
 import { dateTimeInMonths } from '../../utils/DateTimeInMonths.tsx';
 import { createAuthorizationHeader } from '../../utils/createAuthorizationHeader.ts';
 import { stringifyMaybeAxiosError } from '../../utils/stringifyMaybeAxiosError.ts';
-import { useConfirmDialog } from '../ConfirmationDialog.tsx';
+import { displayConfirmation } from '../ConfirmationDialog.tsx';
 import { Button } from '../common/Button';
 import { Checkbox } from '../common/Checkbox';
 import { Spinner } from '../common/Spinner';
@@ -73,7 +73,6 @@ const InnerDataUploadForm = ({
     const [agreedToINSDCUploadTerms, setAgreedToINSDCUploadTerms] = useState(false);
 
     const [confirmedNoPII, setConfirmedNoPII] = useState(false);
-    const { confirm, confirmDialog } = useConfirmDialog();
 
     const handleSubmit = async (event: FormEvent) => {
         event.preventDefault();
@@ -138,7 +137,7 @@ const InnerDataUploadForm = ({
         };
 
         if (action === 'submit' && dataUseTermsEnabled && dataUseTermsType === openDataUseTermsOption) {
-            confirm({
+            displayConfirmation({
                 dialogText:
                     'You have selected the Open Data Use Terms. Once released under the Open Data Use Terms sequences will be deposited to INSDC and cannot be changed to the Restricted-Use Data Use Terms.',
                 confirmButtonText: 'Continue under Open terms',
@@ -231,7 +230,6 @@ const InnerDataUploadForm = ({
                     </Button>
                 </div>
             </div>
-            {confirmDialog}
         </div>
     );
 };

--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.spec.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.spec.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import { FolderUploadComponent } from './FolderUploadComponent';
 import * as multipartUpload from '../../../utils/multipartUpload';
+import { ConfirmDialogContainer } from '../../ConfirmationDialog';
 
 const mockRequestMultipartUpload = vi.fn();
 const mockCompleteMultipartUpload = vi.fn();
@@ -225,7 +226,12 @@ describe('FolderUploadComponent', () => {
     });
 
     it('shows a dialog before discarding all files and discards after confirmation', async () => {
-        render(<FolderUploadComponent {...defaultPropsWithFiles} />);
+        render(
+            <>
+                <FolderUploadComponent {...defaultPropsWithFiles} />
+                <ConfirmDialogContainer />
+            </>,
+        );
 
         await userEvent.click(screen.getByTestId('discard_extraFiles'));
         await waitFor(() => expect(screen.getByText(/are you sure you want to discard/i)).toBeInTheDocument());
@@ -288,7 +294,12 @@ describe('FolderUploadComponent', () => {
     it('confirms before overwriting an existing file with the same name', async () => {
         mockRequestMultipartUpload.mockReturnValue(ok([{ fileId: 'replacement-id', urls: ['http://test.com/url1'] }]));
 
-        render(<FolderUploadComponent {...defaultPropsWithFiles} />);
+        render(
+            <>
+                <FolderUploadComponent {...defaultPropsWithFiles} />
+                <ConfirmDialogContainer />
+            </>,
+        );
 
         const file = new File(['content'], 'file-a.txt', { type: 'text/plain' });
         Object.defineProperty(file, 'webkitRelativePath', { value: '', writable: false });

--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
@@ -8,7 +8,7 @@ import type { FilesBySubmissionId } from '../../../types/backend';
 import { type FileCategory } from '../../../types/config';
 import type { ClientConfig } from '../../../types/runtimeConfig';
 import { calculatePartSizeAndCount, splitFileIntoParts, uploadPart } from '../../../utils/multipartUpload';
-import { useConfirmDialog } from '../../ConfirmationDialog';
+import { displayConfirmation } from '../../ConfirmationDialog';
 import { Button } from '../../common/Button';
 import type { InputMode } from '../FormOrUploadWrapper';
 import LucideFile from '~icons/lucide/file';
@@ -109,7 +109,6 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
     onError,
 }) => {
     const isClient = useClientFlag();
-    const { confirm, confirmDialog } = useConfirmDialog();
     const [fileUploadState, setFileUploadState] = useState<FileUploadState | undefined>(() => {
         if (fileMapping === undefined) return undefined;
 
@@ -384,7 +383,7 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
 
         // If there are collisions, show a confirmation dialog before proceeding
         if (existingFileCollisions.length > 0) {
-            confirm({
+            displayConfirmation({
                 dialogText:
                     'The following file(s) already exist and will be replaced: ' +
                     existingFileCollisions.map((file) => file.name).join(', '),
@@ -396,7 +395,6 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
 
     return (
         <>
-            {confirmDialog}
             {fileUploadState === undefined || fileUploadState.type === 'awaitingUrls' ? (
                 <div
                     className={`flex flex-col items-center justify-center flex-1 py-2 px-4 border rounded-lg ${fileUploadState !== undefined ? 'border-hidden' : isDragging ? 'border-dashed border-yellow-400 bg-yellow-50' : 'border-dashed border-gray-900/25'}`}
@@ -526,7 +524,7 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
                         )}
                         <Button
                             onClick={() =>
-                                confirm({
+                                displayConfirmation({
                                     dialogText: 'Are you sure you want to discard all files?',
                                     confirmButtonText: 'Discard',
                                     onConfirmation: handleDiscardAllFiles,

--- a/website/src/components/Submission/SubmissionForm.spec.tsx
+++ b/website/src/components/Submission/SubmissionForm.spec.tsx
@@ -8,6 +8,7 @@ import { SubmissionForm } from './SubmissionForm';
 import { mockRequest, testAccessToken, testConfig, testGroups, testOrganism } from '../../../vitest.setup.ts';
 import { SUBMISSION_ID_INPUT_FIELD } from '../../settings.ts';
 import type { Group, ProblemDetail, SubmissionIdMapping } from '../../types/backend.ts';
+import { ConfirmDialogContainer } from '../ConfirmationDialog.tsx';
 
 vi.mock('../../api', () => ({
     getClientLogger: () => ({
@@ -50,31 +51,34 @@ function renderSubmissionForm({
     dataUseTermsEnabled?: boolean;
 } = {}) {
     return render(
-        <SubmissionForm
-            instanceName={INSTANCE_NAME}
-            inputMode={inputMode}
-            accessToken={testAccessToken}
-            organism={testOrganism}
-            clientConfig={testConfig.public}
-            group={group}
-            metadataTemplateFields={
-                new Map([
-                    [
-                        'fooSection',
+        <>
+            <SubmissionForm
+                instanceName={INSTANCE_NAME}
+                inputMode={inputMode}
+                accessToken={testAccessToken}
+                organism={testOrganism}
+                clientConfig={testConfig.public}
+                group={group}
+                metadataTemplateFields={
+                    new Map([
                         [
-                            { name: SUBMISSION_ID_INPUT_FIELD, displayName: 'ID', noEdit: true },
-                            { name: 'foo', displayName: 'Foo' },
-                            { name: 'bar', displayName: 'Bar' },
+                            'fooSection',
+                            [
+                                { name: SUBMISSION_ID_INPUT_FIELD, displayName: 'ID', noEdit: true },
+                                { name: 'foo', displayName: 'Foo' },
+                                { name: 'bar', displayName: 'Bar' },
+                            ],
                         ],
-                    ],
-                ])
-            }
-            submissionDataTypes={{
-                consensusSequences: allowSubmissionOfConsensusSequences,
-                maxSequencesPerEntry: 1,
-            }}
-            dataUseTermsEnabled={dataUseTermsEnabled}
-        />,
+                    ])
+                }
+                submissionDataTypes={{
+                    consensusSequences: allowSubmissionOfConsensusSequences,
+                    maxSequencesPerEntry: 1,
+                }}
+                dataUseTermsEnabled={dataUseTermsEnabled}
+            />
+            <ConfirmDialogContainer />
+        </>,
     );
 }
 

--- a/website/src/components/User/GroupPage.tsx
+++ b/website/src/components/User/GroupPage.tsx
@@ -12,7 +12,7 @@ import { GROUP_ID_FIELD, IS_REVOCATION_FIELD, VERSION_STATUS_FIELD } from '../..
 import type { Address, Group, GroupDetails } from '../../types/backend.ts';
 import { versionStatuses } from '../../types/lapis.ts';
 import { type ClientConfig } from '../../types/runtimeConfig.ts';
-import { useConfirmDialog } from '../ConfirmationDialog.js';
+import { displayConfirmation } from '../ConfirmationDialog.js';
 import { ErrorFeedback } from '../ErrorFeedback.tsx';
 import { Button } from '../common/Button';
 import { DropdownMenu, DropdownMenuItem } from '../common/DropdownMenu';
@@ -61,8 +61,6 @@ const InnerGroupPage: FC<GroupPageProps> = ({
         setErrorMessage,
         prefetchedGroupDetails,
     });
-
-    const { confirm, confirmDialog } = useConfirmDialog();
 
     const handleAddUser = async (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
@@ -179,7 +177,7 @@ const InnerGroupPage: FC<GroupPageProps> = ({
                                         'You are the last user in this group. Leaving will leave the group without any members, meaning that nobody is able to add future members. ';
                                     const dialogText = `${isLastMember ? lastMemberWarning : ''}Are you sure you want to leave the ${groupName} group?`;
 
-                                    confirm({
+                                    displayConfirmation({
                                         dialogText,
                                         onConfirmation: async () => {
                                             await removeFromGroup(username);
@@ -289,7 +287,7 @@ const InnerGroupPage: FC<GroupPageProps> = ({
                                     {user.name !== username && (
                                         <Button
                                             onClick={() => {
-                                                confirm({
+                                                displayConfirmation({
                                                     dialogText: `Are you sure you want to remove ${user.name} from the group ${groupName}?`,
                                                     onConfirmation: async () => {
                                                         await removeFromGroup(user.name);
@@ -309,7 +307,6 @@ const InnerGroupPage: FC<GroupPageProps> = ({
                     </div>
                 </>
             )}
-            {confirmDialog}
         </div>
     );
 };

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -4,6 +4,7 @@ import '../styles/custom-colors.css';
 import 'react-toastify/dist/ReactToastify.css';
 import { ToastContainer } from 'react-toastify';
 
+import { ConfirmDialogContainer } from '../components/ConfirmationDialog';
 import Navigation from '../components/Navigation/Navigation.astro';
 import OrganismSubmenu from '../components/Navigation/OrganismSubmenu.astro';
 import { cleanOrganism } from '../components/Navigation/cleanOrganism';
@@ -76,6 +77,7 @@ const lastTimeBannerWasClosed = Astro.cookies.get('lastTimeBannerWasClosed')?.va
         />
         <div class='flex flex-col min-h-screen'>
             <ToastContainer client:load />
+            <ConfirmDialogContainer client:load />
             <header class={`bg-white h-fit z-30 ${!currentOrganism ? 'border-b-[1.5px] border-gray-200' : ''}`}>
                 <nav class='flex justify-between items-end px-4 pt-3 pb-0 mx-4'>
                     <div class='flex items-end gap-3 mb-2'>


### PR DESCRIPTION
PR to Cornelius's PR https://github.com/loculus-project/loculus/pull/6780

Replace the useConfirmDialog() hook (which returned { confirm, confirmDialog } and required every call site to both call confirm() and render {confirmDialog}) with a module-level store and a single ConfirmDialogContainer host mounted once in BaseLayout. Call sites now just import and call confirm() — no element to render, and no risk of an early return omitting the dialog.

A module-level store rather than React context is required because each Astro client:* island is an isolated React tree that context cannot cross. The host renders in-tree (not a detached createRoot), so Headless UI still makes the background inert and traps focus.

🚀 Preview: https://confirmation.loculus.org