### PR TITLE
feat(prepro): make tests more readable

### DIFF
--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1638,7 +1638,10 @@ class ProcessingFunctions:
             )
 
         regex_pattern = args.get("regex_pattern")
-        if regex_pattern is not None and "<identifier>" not in str(regex_pattern):
+        if (
+            regex_pattern is not None
+            and "identifier" not in re.compile(str(regex_pattern)).groupindex
+        ):
             return ProcessingResult(
                 datum=None,
                 warnings=warnings,

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1591,7 +1591,7 @@ class ProcessingFunctions:
         input_fields: list[str],
         args: FunctionArgs,
     ) -> ProcessingResult:
-        """Wraps concatenate() to resolve the IDENTIFIER slot in args['order']/args['type'].
+        """Create a display name by wrapping concatenate() and resolving the IDENTIFIER slot.
 
         The IDENTIFIER slot is filled by the best available sample identifier:
           1. specimenCollectorSampleId — used as-is if it contains no slashes or spaces;
@@ -2145,7 +2145,7 @@ DISPLAY_NAME_SEPARATORS = [" ", "/"]
 
 
 def has_display_name_separators(input: str) -> bool:
-    """Check if the input string contains any characters that are not allowed in a displayName."""
+    """Check if the input string contains any characters that are used as displayName separators."""
     return any(char in input for char in DISPLAY_NAME_SEPARATORS)
 
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -2149,13 +2149,11 @@ def has_display_name_separators(input: str) -> bool:
     return any(char in input for char in DISPLAY_NAME_SEPARATORS)
 
 
-def parse_identifier_string(
-    input: str, regex_pattern: str
-) -> str | None:
+def parse_identifier_string(input: str, regex_pattern: str) -> str | None:
     """Extract a usable display-name identifier from `input`, or return None.
 
-    Returns input as-is if it contains no displayName separators (space, slash, …).
-    If it contains separators, attempts to extract a usable identifier 
+    Returns input as-is if it contains no DISPLAY_NAME_SEPARATORS.
+    If it contains separators, attempts to extract a usable identifier
     using the provided regex_pattern.
     """
     if not has_display_name_separators(input):

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1591,21 +1591,22 @@ class ProcessingFunctions:
         input_fields: list[str],
         args: FunctionArgs,
     ) -> ProcessingResult:
-        """Builds a displayName from input_fields. The identifier field in the displayName is
-        based on specimenCollectorSampleId; if that cannot be parsed we fall back to submissionId,
-        and only if neither can be parsed do we fall back to ACCESSION_VERSION.
+        """Wraps concatenate() to resolve the IDENTIFIER slot in args['order']/args['type'].
 
-        This method wraps ProcessingFunctions.concatenate(). Thus, it has the same required input
-        args, as well as adding some additional checks and requirements:
-            - submissionId and specimenCollectorSampleId must be in the input_data
-            - IDENTIFIER keyword must be in args['order'] and args['type']
-            - the IDENTIFIER is resolved by trying specimenCollectorSampleId first, then
-              submissionId; if neither yields a usable value it is replaced with ACCESSION_VERSION
-            - if fallback_value is not in args, { 'fallback_value': 'unknown' } is added to the args
-              before passing them on to concatenate()
-            - for sequences ingested from INSDC, we do not try to parse the IDENTIFIER field using
-              regex. We will use the Isolate Name as IDENTIFIER field if it contains no slashes or
-              spaces (otherwise we fall back to ACCESSION_VERSION)
+        The IDENTIFIER slot is filled by the best available sample identifier:
+          1. specimenCollectorSampleId — used as-is if it contains no slashes or spaces;
+             otherwise the regex_pattern (required) is applied to extract the named
+             'identifier' capture group.
+          2. submissionId — same rules as above, tried only if step 1 fails.
+          3. ACCESSION_VERSION — used as a last resort if neither ID can be resolved;
+             a warning is emitted (non-INSDC sequences only).
+
+        INSDC sequences skip regex extraction entirely: specimenCollectorSampleId is used
+        as-is only if it has no slashes or spaces, otherwise ACCESSION_VERSION is used.
+
+        Required args: ACCESSION_VERSION, is_insdc_ingest_group, order (must contain
+        'IDENTIFIER'), type (same length as order), regex_pattern.
+        Falls back to fallback_value='unknown' for empty fields if not set in args.
         """
         collector_id = input_data.get("specimenCollectorSampleId")
         submission_id = input_data.get("submissionId")
@@ -1641,9 +1642,10 @@ class ProcessingFunctions:
         if insdc_ingested:
             # For INSDC ingested sequences the submissionId is the INSDC accession
             # - do not use it in the displayName;
-            # use the collector_id as-is unless it contains a ' ' or '/'
-            has_forbidden_char = " " in str(collector_id) or "/" in str(collector_id)
-            identifier = None if has_forbidden_char else collector_id
+            # use the collector_id as-is unless it already contains displayName separators
+            identifier = (
+                None if has_display_name_separators(str(collector_id)) else str(collector_id)
+            )
         else:
             identifier = parse_identifier_string(collector_id, str(regex_pattern))
             if identifier is None:
@@ -2139,6 +2141,14 @@ def process_phenotype_values(input: str | None, args: FunctionArgs | None) -> In
     return InputData(datum=None)
 
 
+DISPLAY_NAME_SEPARATORS = [" ", "/"]
+
+
+def has_display_name_separators(input: str) -> bool:
+    """Check if the input string contains any characters that are not allowed in a displayName."""
+    return any(char in input for char in DISPLAY_NAME_SEPARATORS)
+
+
 def parse_identifier_string(
     input: ProcessedMetadataValue, regex_pattern: str | None = None
 ) -> str | None:
@@ -2147,9 +2157,8 @@ def parse_identifier_string(
     """
     if not isinstance(input, str):
         return None
-    has_forbidden_char = " " in input or "/" in input
 
-    if not has_forbidden_char:
+    if not has_display_name_separators(input):
         # Direct submission without forbidden_char: use the value as-is, no regex parsing
         return input
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -2145,7 +2145,7 @@ DISPLAY_NAME_SEPARATORS = [" ", "/"]
 
 
 def has_display_name_separators(input: str) -> bool:
-    """Check if the input string contains any characters that are used as displayName separators."""
+    """Check if the input string contains any DISPLAY_NAME_SEPARATORS characters."""
     return any(char in input for char in DISPLAY_NAME_SEPARATORS)
 
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -236,6 +236,21 @@ def regex_error(
     )
 
 
+def _config_error(input_fields: list[str], output_field: str, message: str) -> ProcessingResult:
+    return ProcessingResult(
+        datum=None,
+        warnings=[],
+        errors=[
+            ProcessingAnnotation.from_fields(
+                input_fields,
+                [output_field],
+                AnnotationSourceType.METADATA,
+                message=message,
+            )
+        ],
+    )
+
+
 def missing_taxonomy_service_error(input_fields: list[str], output_field: str) -> ProcessingResult:
     return ProcessingResult(
         datum=None,
@@ -1592,25 +1607,8 @@ class ProcessingFunctions:
               regex. We will use the Isolate Name as IDENTIFIER field if it contains no slashes or
               spaces (otherwise we fall back to ACCESSION_VERSION)
         """
-        collector_id = input_data.get("specimenCollectorSampleId", None)
-        submission_id = input_data.get("submissionId", None)
-        warnings: list[ProcessingAnnotation] = []
-        if submission_id is None:
-            return ProcessingResult(
-                datum=None,
-                warnings=warnings,
-                errors=[
-                    ProcessingAnnotation.from_fields(
-                        input_fields,
-                        [output_field],
-                        AnnotationSourceType.METADATA,
-                        message=(
-                            "Internal Error: 'submissionId' must not be None for"
-                            " build_display_name(). Please contact the administrator."
-                        ),
-                    )
-                ],
-            )
+        collector_id = input_data.get("specimenCollectorSampleId")
+        submission_id = input_data.get("submissionId")
 
         order = args.get("order")
         field_types = args.get("type")
@@ -1620,21 +1618,12 @@ class ProcessingFunctions:
             or len(order) != len(field_types)
             or "IDENTIFIER" not in order
         ):
-            return ProcessingResult(
-                datum=None,
-                warnings=warnings,
-                errors=[
-                    ProcessingAnnotation.from_fields(
-                        input_fields,
-                        [output_field],
-                        AnnotationSourceType.METADATA,
-                        message=(
-                            "Internal Error: 'order' and 'type' must be lists of equal length, and"
-                            " 'order' must contain IDENTIFIER - this is required for"
-                            " build_display_name. Please contact the administrator."
-                        ),
-                    )
-                ],
+            return _config_error(
+                input_fields,
+                output_field,
+                "Internal Error: 'order' and 'type' must be lists of equal length, and"
+                " 'order' must contain IDENTIFIER - this is required for"
+                " build_display_name. Please contact the administrator.",
             )
 
         regex_pattern = args.get("regex_pattern")
@@ -1642,39 +1631,30 @@ class ProcessingFunctions:
             regex_pattern is not None
             and "identifier" not in re.compile(str(regex_pattern)).groupindex
         ):
-            return ProcessingResult(
-                datum=None,
-                warnings=warnings,
-                errors=[
-                    ProcessingAnnotation.from_fields(
-                        input_fields,
-                        [output_field],
-                        AnnotationSourceType.METADATA,
-                        message=regex_error("extract_regex", "capture_group", input_data, args),
-                    )
-                ],
+            return _config_error(
+                input_fields,
+                output_field,
+                regex_error("extract_regex", "capture_group", input_data, args),
             )
 
-        concatenate_order = order.copy()
-        concatenate_field_types = field_types.copy()
-
-        def replace_identifier(values, replacement):
-            return [replacement if v == "IDENTIFIER" else v for v in values]
-
         insdc_ingested = bool(args["is_insdc_ingest_group"])
-        pattern = str(regex_pattern) if regex_pattern is not None else None
+        if insdc_ingested:
+            # For INSDC ingested sequences the submissionId is the INSDC accession
+            # - do not use it in the displayName;
+            # use the collector_id as-is unless it contains a ' ' or '/'
+            has_forbidden_char = " " in str(collector_id) or "/" in str(collector_id)
+            identifier = None if has_forbidden_char else collector_id
+        else:
+            identifier = parse_identifier_string(collector_id, str(regex_pattern))
+            if identifier is None:
+                identifier = parse_identifier_string(submission_id, str(regex_pattern))
 
-        # Try specimenCollectorSampleId first, fall back to submissionId.
-        identifier = parse_identifier_string(collector_id, insdc_ingested, pattern)
-        if identifier is None:
-            identifier = parse_identifier_string(submission_id, insdc_ingested, pattern)
-
+        warnings: list[ProcessingAnnotation] = []
         if identifier is not None:
-            # We were able to parse an IDENTIFIER, treat it as a string
-            concatenate_field_types = replace_identifier(field_types, "string")
+            resolved_order = list(order)
+            resolved_types = ["string" if t == "IDENTIFIER" else t for t in field_types]
             input_data["IDENTIFIER"] = identifier
         else:
-            # Unable to parse specimenCollectorSampleId and submissionID, use ACCESSION_VERSION
             if not insdc_ingested and regex_pattern is not None:
                 warnings.append(
                     ProcessingAnnotation.from_fields(
@@ -1688,24 +1668,19 @@ class ProcessingFunctions:
                         ),
                     )
                 )
-            concatenate_order = replace_identifier(order, "ACCESSION_VERSION")
-            concatenate_field_types = replace_identifier(field_types, "ACCESSION_VERSION")
-
-        new_args = args.copy()
-        new_args.update(
-            {
-                "order": concatenate_order,
-                "type": concatenate_field_types,
-                "fallback_value": args.get("fallback_value", "unknown"),
-                "ACCESSION_VERSION": args["ACCESSION_VERSION"],
-            }
-        )
+            resolved_order = ["ACCESSION_VERSION" if v == "IDENTIFIER" else v for v in order]
+            resolved_types = ["ACCESSION_VERSION" if t == "IDENTIFIER" else t for t in field_types]
 
         concat_result = ProcessingFunctions.concatenate(
             input_data,
             output_field,
             input_fields,
-            new_args,
+            {
+                **args,
+                "order": resolved_order,
+                "type": resolved_types,
+                "fallback_value": args.get("fallback_value", "unknown"),
+            },
         )
 
         return ProcessingResult(
@@ -2165,7 +2140,7 @@ def process_phenotype_values(input: str | None, args: FunctionArgs | None) -> In
 
 
 def parse_identifier_string(
-    input: ProcessedMetadataValue, insdc_ingested: bool, regex_pattern: str | None = None
+    input: ProcessedMetadataValue, regex_pattern: str | None = None
 ) -> str | None:
     """Return an IDENTIFIER string to use in the displayName or None if `input` cannot be used
     as an identifier.
@@ -2173,10 +2148,6 @@ def parse_identifier_string(
     if not isinstance(input, str):
         return None
     has_forbidden_char = " " in input or "/" in input
-
-    if insdc_ingested:
-        # For INSDC ingested sequences: use the value as-is unless it contains a ' ' or '/'
-        return None if has_forbidden_char else input
 
     if not has_forbidden_char:
         # Direct submission without forbidden_char: use the value as-is, no regex parsing

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1674,21 +1674,17 @@ class ProcessingFunctions:
             concatenate_field_types = replace_identifier(field_types, "string")
             input_data["IDENTIFIER"] = identifier
         else:
-            # Unable to parse specimenCollectorSampleId or submissionID, use ACCESSION_VERSION
+            # Unable to parse specimenCollectorSampleId and submissionID, use ACCESSION_VERSION
             if not insdc_ingested and regex_pattern is not None:
-                failed_source = (
-                    collector_id
-                    if isinstance(collector_id, str) and collector_id
-                    else submission_id
-                )
                 warnings.append(
                     ProcessingAnnotation.from_fields(
                         input_fields,
                         [output_field],
                         AnnotationSourceType.METADATA,
                         message=(
-                            f"identifier string '{failed_source}' could not be parsed,"
-                            " using ACCESSION_VERSION in displayName instead"
+                            f"specimencollectorSampleId '{collector_id}' and submissionId"
+                            f" '{submission_id}' could not be parsed, using ACCESSION_VERSION"
+                            f" in displayName instead"
                         ),
                     )
                 )
@@ -2171,7 +2167,7 @@ def process_phenotype_values(input: str | None, args: FunctionArgs | None) -> In
 def parse_identifier_string(
     input: ProcessedMetadataValue, insdc_ingested: bool, regex_pattern: str | None = None
 ) -> str | None:
-    """Return a IDENTIFIER string to use in the displayName or None if `input` cannot be used
+    """Return an IDENTIFIER string to use in the displayName or None if `input` cannot be used
     as an identifier.
     """
     if not isinstance(input, str):

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1570,25 +1570,27 @@ class ProcessingFunctions:
         return ProcessingResult(datum=None, warnings=[], errors=[])
 
     @staticmethod
-    def build_display_name(  # noqa: C901
+    def build_display_name(
         input_data: InputMetadata,
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
     ) -> ProcessingResult:
-        """Builds a displayName from input_fields. The identifier field in the displayName is based on
-        specimenCollectorSampleId or - if it is not set - submissionId.
+        """Builds a displayName from input_fields. The identifier field in the displayName is
+        based on specimenCollectorSampleId; if that cannot be parsed we fall back to submissionId,
+        and only if neither can be parsed do we fall back to ACCESSION_VERSION.
 
         This method wraps ProcessingFunctions.concatenate(). Thus, it has the same required input
         args, as well as adding some additional checks and requirements:
             - submissionId and specimenCollectorSampleId must be in the input_data
             - IDENTIFIER keyword must be in args['order'] and args['type']
-            - if the IDENTIFIER is in an unrecognized format, it will be replaced with the ACCESSION_VERSION
-            - if fallback_value is not in args, { 'fallback_value': 'unknown' } is added to the args before passing
-              them on to concatenate()
-            - for sequences ingested from INSDC, we do not try to parse the IDENTIFIER field using regex. We
-              will use the Isolate Name as IDENTIFIER field if it contains no slashes or spaces (otherwise we fall back to
-              ACCESSION_VERSION)
+            - the IDENTIFIER is resolved by trying specimenCollectorSampleId first, then
+              submissionId; if neither yields a usable value it is replaced with ACCESSION_VERSION
+            - if fallback_value is not in args, { 'fallback_value': 'unknown' } is added to the args
+              before passing them on to concatenate()
+            - for sequences ingested from INSDC, we do not try to parse the IDENTIFIER field using
+              regex. We will use the Isolate Name as IDENTIFIER field if it contains no slashes or
+              spaces (otherwise we fall back to ACCESSION_VERSION)
         """
         collector_id = input_data.get("specimenCollectorSampleId", None)
         submission_id = input_data.get("submissionId", None)
@@ -1596,14 +1598,15 @@ class ProcessingFunctions:
         if submission_id is None:
             return ProcessingResult(
                 datum=None,
-                warnings=[],
+                warnings=warnings,
                 errors=[
                     ProcessingAnnotation.from_fields(
                         input_fields,
                         [output_field],
                         AnnotationSourceType.METADATA,
                         message=(
-                            "Internal Error: 'submissionId' must not be None for build_display_name(). Please contact the administrator."
+                            "Internal Error: 'submissionId' must not be None for"
+                            " build_display_name(). Please contact the administrator."
                         ),
                     )
                 ],
@@ -1619,35 +1622,32 @@ class ProcessingFunctions:
         ):
             return ProcessingResult(
                 datum=None,
-                warnings=[],
+                warnings=warnings,
                 errors=[
                     ProcessingAnnotation.from_fields(
                         input_fields,
                         [output_field],
                         AnnotationSourceType.METADATA,
                         message=(
-                            "Internal Error: 'order' and 'type' must be lists of equal length, and 'order' must contain IDENTIFIER - this is required for build_display_name to function. Please contact the administrator."
+                            "Internal Error: 'order' and 'type' must be lists of equal length, and"
+                            " 'order' must contain IDENTIFIER - this is required for"
+                            " build_display_name. Please contact the administrator."
                         ),
                     )
                 ],
             )
 
         regex_pattern = args.get("regex_pattern")
-        if (
-            regex_pattern is not None
-            and "identifier" not in re.compile(str(regex_pattern)).groupindex
-        ):
+        if regex_pattern is not None and "<identifier>" not in str(regex_pattern):
             return ProcessingResult(
                 datum=None,
-                warnings=[],
+                warnings=warnings,
                 errors=[
                     ProcessingAnnotation.from_fields(
                         input_fields,
                         [output_field],
                         AnnotationSourceType.METADATA,
-                        message=(
-                            "Internal Error: if provided, 'regex_pattern' must contain a named capture group called 'identifier'"
-                        ),
+                        message=regex_error("extract_regex", "capture_group", input_data, args),
                     )
                 ],
             )
@@ -1658,47 +1658,39 @@ class ProcessingFunctions:
         def replace_identifier(values, replacement):
             return [replacement if v == "IDENTIFIER" else v for v in values]
 
-        identifier: ProcessedMetadataValue = collector_id or submission_id
-        if not isinstance(identifier, str):
-            identifier = None
-        elif args["is_insdc_ingest_group"]:
-            # For INSDC ingested sequence: use ID as is unless it contains ' ' or '/'
-            # If it does: fall back to ACCESSION_VERSION
-            if " " in identifier or "/" in identifier:
-                identifier = None
-        elif "/" in identifier:
-            # For direct submissions with "/": try to extract ID field using regex
-            if regex_pattern is None:
-                identifier = None
-            else:
-                extract_result = ProcessingFunctions.extract_regex(
-                    input_data={"regex_field": identifier},
-                    output_field="IDENTIFIER",
-                    input_fields=[],
-                    args={"pattern": regex_pattern, "capture_group": "identifier"},
-                )
-                if extract_result.datum is None:
-                    # regex extraction of ID field failed, fall back to ACCESSION_VERSION
-                    warnings.append(
-                        ProcessingAnnotation.from_fields(
-                            input_fields,
-                            [output_field],
-                            AnnotationSourceType.METADATA,
-                            message=(
-                                f"identifier string '{identifier}' could not be parsed, using ACCESSION_VERSION in displayName instead"
-                            ),
-                        )
-                    )
-                identifier = extract_result.datum
+        insdc_ingested = bool(args["is_insdc_ingest_group"])
+        pattern = str(regex_pattern) if regex_pattern is not None else None
 
+        # Try specimenCollectorSampleId first, fall back to submissionId.
+        identifier = parse_identifier_string(collector_id, insdc_ingested, pattern)
         if identifier is None:
-            # Use ACCESSION_VERSION instead of IDENTIFIER
+            identifier = parse_identifier_string(submission_id, insdc_ingested, pattern)
+
+        if identifier is not None:
+            # We were able to parse an IDENTIFIER, treat it as a string
+            concatenate_field_types = replace_identifier(field_types, "string")
+            input_data["IDENTIFIER"] = identifier
+        else:
+            # Unable to parse specimenCollectorSampleId or submissionID, use ACCESSION_VERSION
+            if not insdc_ingested and regex_pattern is not None:
+                failed_source = (
+                    collector_id
+                    if isinstance(collector_id, str) and collector_id
+                    else submission_id
+                )
+                warnings.append(
+                    ProcessingAnnotation.from_fields(
+                        input_fields,
+                        [output_field],
+                        AnnotationSourceType.METADATA,
+                        message=(
+                            f"identifier string '{failed_source}' could not be parsed,"
+                            " using ACCESSION_VERSION in displayName instead"
+                        ),
+                    )
+                )
             concatenate_order = replace_identifier(order, "ACCESSION_VERSION")
             concatenate_field_types = replace_identifier(field_types, "ACCESSION_VERSION")
-        else:
-            # Keep IDENTIFIER but treat it as string
-            concatenate_field_types = replace_identifier(field_types, "string")
-            input_data["IDENTIFIER"] = str(identifier)
 
         new_args = args.copy()
         new_args.update(
@@ -2171,6 +2163,36 @@ def process_phenotype_values(input: str | None, args: FunctionArgs | None) -> In
             ),
         )
     return InputData(datum=None)
+
+
+def parse_identifier_string(
+    input: ProcessedMetadataValue, insdc_ingested: bool, regex_pattern: str | None = None
+) -> str | None:
+    """Return a IDENTIFIER string to use in the displayName or None if `input` cannot be used
+    as an identifier.
+    """
+    if not isinstance(input, str):
+        return None
+    has_forbidden_char = " " in input or "/" in input
+
+    if insdc_ingested:
+        # For INSDC ingested sequences: use the value as-is unless it contains a ' ' or '/'
+        return None if has_forbidden_char else input
+
+    if not has_forbidden_char:
+        # Direct submission without forbidden_char: use the value as-is, no regex parsing
+        return input
+
+    # Direct submission containing forbidden_char: attempt regex extraction of identifier field
+    if regex_pattern is None:
+        return None
+    extract_result = ProcessingFunctions.extract_regex(
+        input_data={"regex_field": input},
+        output_field="IDENTIFIER",
+        input_fields=[],
+        args={"pattern": regex_pattern, "capture_group": "identifier"},
+    )
+    return None if extract_result.datum is None else str(extract_result.datum)
 
 
 def trim_ns(sequence: str) -> str:

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1647,9 +1647,9 @@ class ProcessingFunctions:
                 None if has_display_name_separators(str(collector_id)) else str(collector_id)
             )
         else:
-            identifier = parse_identifier_string(collector_id, str(regex_pattern))
+            identifier = parse_identifier_string(str(collector_id), str(regex_pattern))
             if identifier is None:
-                identifier = parse_identifier_string(submission_id, str(regex_pattern))
+                identifier = parse_identifier_string(str(submission_id), str(regex_pattern))
 
         warnings: list[ProcessingAnnotation] = []
         if identifier is not None:
@@ -2150,21 +2150,17 @@ def has_display_name_separators(input: str) -> bool:
 
 
 def parse_identifier_string(
-    input: ProcessedMetadataValue, regex_pattern: str | None = None
+    input: str, regex_pattern: str
 ) -> str | None:
-    """Return an IDENTIFIER string to use in the displayName or None if `input` cannot be used
-    as an identifier.
-    """
-    if not isinstance(input, str):
-        return None
+    """Extract a usable display-name identifier from `input`, or return None.
 
+    Returns input as-is if it contains no displayName separators (space, slash, …).
+    If it contains separators, attempts to extract a usable identifier 
+    using the provided regex_pattern.
+    """
     if not has_display_name_separators(input):
-        # Direct submission without forbidden_char: use the value as-is, no regex parsing
         return input
 
-    # Direct submission containing forbidden_char: attempt regex extraction of identifier field
-    if regex_pattern is None:
-        return None
     extract_result = ProcessingFunctions.extract_regex(
         input_data={"regex_field": input},
         output_field="IDENTIFIER",

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -1335,7 +1335,7 @@ def test_display_name_construction() -> None:  # noqa: PLR0915
         input_data, output_field, input_fields(), args_with_prefix()
     )
     assert res.datum == "DENV-1/Switzerland/myExtractedSample/2025"
-    assert res_insdc.datum == "DENV-1/Switzerland/version.1/2025"
+    assert res_insdc.datum == "DENV-1/Switzerland/mySample/2025"
     assert res_prefix.datum == "hYF/Switzerland/myExtractedSample/2025"
 
     input_data["specimenCollectorSampleId"] = submission_id_formatted_unexpected
@@ -1346,11 +1346,12 @@ def test_display_name_construction() -> None:  # noqa: PLR0915
     res_prefix = ProcessingFunctions.build_display_name(
         input_data, output_field, input_fields(), args_with_prefix()
     )
-    assert res.datum == "DENV-1/Switzerland/version.1/2025"
-    assert res_insdc.datum == "DENV-1/Switzerland/version.1/2025"
-    assert res_prefix.datum == "hYF/Switzerland/version.1/2025"
+    assert res.datum == "DENV-1/Switzerland/mySample/2025"
+    assert res_insdc.datum == "DENV-1/Switzerland/mySample/2025"
+    assert res_prefix.datum == "hYF/Switzerland/mySample/2025"
 
     input_data["specimenCollectorSampleId"] = submission_id_formatted_unexpected
+    input_data["submissionId"] = submission_id_formatted_unexpected
     input_data["geoLocCountry"] = ""
     res = ProcessingFunctions.build_display_name(input_data, output_field, input_fields(), args())
     res_insdc = ProcessingFunctions.build_display_name(

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -1364,7 +1364,7 @@ def test_display_name_construction() -> None:  # noqa: PLR0915
     assert len(res.warnings) == 1
     assert (
         res.warnings[0].message
-        == "identifier string 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
+        == "specimencollectorSampleId 'hDENV1/myExtractedSample/2025' and submissionId 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
     )
     assert res_insdc.datum == "DENV-1/unknown/version.1/2025"
     assert len(res_insdc.warnings) == 0
@@ -1372,7 +1372,7 @@ def test_display_name_construction() -> None:  # noqa: PLR0915
     assert len(res_prefix.warnings) == 1
     assert (
         res_prefix.warnings[0].message
-        == "identifier string 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
+        == "specimencollectorSampleId 'hDENV1/myExtractedSample/2025' and submissionId 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
     )
 
     input_data["specimenCollectorSampleId"] = submission_id_formatted_unexpected
@@ -1398,7 +1398,7 @@ def test_display_name_construction() -> None:  # noqa: PLR0915
     assert len(res.warnings) == 1
     assert (
         res.warnings[0].message
-        == "identifier string 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
+        == "specimencollectorSampleId 'hDENV1/myExtractedSample/2025' and submissionId 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
     )
     assert res_insdc.datum == "DENV-1/another_fallback/version.1/2025"
     assert len(res_insdc.warnings) == 0
@@ -1406,7 +1406,7 @@ def test_display_name_construction() -> None:  # noqa: PLR0915
     assert len(res_prefix.warnings) == 1
     assert (
         res_prefix.warnings[0].message
-        == "identifier string 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
+        == "specimencollectorSampleId 'hDENV1/myExtractedSample/2025' and submissionId 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
     )
 
 

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -1193,7 +1193,7 @@ _CONCATENATE_CASES = [
         input_data={"date": "2021-01-01/2021-12-31", "country": "USA"},
         input_fields=["date", "country"],
         concatenate_args={
-            "ACCESSION_VERSION": "version.1",
+            "ACCESSION_VERSION": "accession.1",
             "order": ["date", "country"],
             "type": ["dateRangeString", "string"],
         },
@@ -1204,41 +1204,41 @@ _CONCATENATE_CASES = [
         input_data={"someInt": "", "geoLocCountry": "", "sampleCollectionDate": "2025"},
         input_fields=["geoLocCountry", "sampleCollectionDate"],
         concatenate_args={
-            "ACCESSION_VERSION": "version.1",
+            "ACCESSION_VERSION": "accession.1",
             "order": ["someInt", "geoLocCountry", "ACCESSION_VERSION", "sampleCollectionDate"],
             "type": ["integer", "string", "ACCESSION_VERSION", "date"],
         },
-        expected="version.1/2025-01-01",
+        expected="accession.1/2025-01-01",
     ),
     ConcatenateCase(
         name="present_int_field_and_empty_string_field_with_no_fallback",
         input_data={"someInt": "0", "geoLocCountry": "", "sampleCollectionDate": "2025"},
         input_fields=["geoLocCountry", "sampleCollectionDate"],
         concatenate_args={
-            "ACCESSION_VERSION": "version.1",
+            "ACCESSION_VERSION": "accession.1",
             "order": ["someInt", "geoLocCountry", "ACCESSION_VERSION", "sampleCollectionDate"],
             "type": ["integer", "string", "ACCESSION_VERSION", "date"],
         },
-        expected="0//version.1/2025-01-01",
+        expected="0//accession.1/2025-01-01",
     ),
     ConcatenateCase(
         name="empty_string_field_uses_fallback_value",
         input_data={"someInt": "0", "geoLocCountry": "", "sampleCollectionDate": "2025"},
         input_fields=["geoLocCountry", "sampleCollectionDate"],
         concatenate_args={
-            "ACCESSION_VERSION": "version.1",
+            "ACCESSION_VERSION": "accession.1",
             "order": ["someInt", "geoLocCountry", "ACCESSION_VERSION", "sampleCollectionDate"],
             "type": ["integer", "string", "ACCESSION_VERSION", "date"],
             "fallback_value": "unknown",
         },
-        expected="0/unknown/version.1/2025-01-01",
+        expected="0/unknown/accession.1/2025-01-01",
     ),
     ConcatenateCase(
         name="accession_version_omitted_from_order",
         input_data={"someInt": "0", "geoLocCountry": "", "sampleCollectionDate": "2025"},
         input_fields=["geoLocCountry", "sampleCollectionDate"],
         concatenate_args={
-            "ACCESSION_VERSION": "version.1",
+            "ACCESSION_VERSION": "accession.1",
             "order": ["someInt", "geoLocCountry", "sampleCollectionDate"],
             "type": ["integer", "string", "date"],
             "fallback_value": "unknown",
@@ -1250,12 +1250,12 @@ _CONCATENATE_CASES = [
         input_data={"someInt": "0", "geoLocCountry": "", "sampleCollectionDate": None},
         input_fields=["geoLocCountry", "sampleCollectionDate"],
         concatenate_args={
-            "ACCESSION_VERSION": "version.1",
+            "ACCESSION_VERSION": "accession.1",
             "order": ["someInt", "geoLocCountry", "ACCESSION_VERSION", "sampleCollectionDate"],
             "type": ["integer", "string", "ACCESSION_VERSION", "date"],
             "fallback_value": "unknown",
         },
-        expected="0/unknown/version.1/unknown",
+        expected="0/unknown/accession.1/unknown",
     ),
 ]
 
@@ -1281,7 +1281,7 @@ _DISPLAY_NAME_INPUT_FIELDS = [
     "sampleCollectionDate",
 ]
 _DISPLAY_NAME_BASE_ARGS: FunctionArgs = {
-    "ACCESSION_VERSION": "version.1",
+    "ACCESSION_VERSION": "accession.1",
     "is_insdc_ingest_group": False,
     "order": ["nextclade.clade", "geoLocCountry", "IDENTIFIER", "sampleCollectionDate"],
     "type": ["string", "string", "IDENTIFIER", "string"],
@@ -1322,7 +1322,7 @@ _DISPLAY_NAME_CASES = [
         submission_id="mySample",
         geo_loc_country="Switzerland",
         expected_regular="DENV-1/Switzerland/mySample/2025",
-        expected_insdc="DENV-1/Switzerland/mySample/2025",
+        expected_insdc="DENV-1/Switzerland/accession.1/2025",
         expected_prefix="hYF/Switzerland/mySample/2025",
     ),
     DisplayNameCase(
@@ -1340,7 +1340,7 @@ _DISPLAY_NAME_CASES = [
         submission_id="mySample",
         geo_loc_country="Switzerland",
         expected_regular="DENV-1/Switzerland/myExtractedSample/2025",
-        expected_insdc="DENV-1/Switzerland/mySample/2025",  # INSDC skips regex extraction
+        expected_insdc="DENV-1/Switzerland/accession.1/2025",  # INSDC skips submissionId
         expected_prefix="hYF/Switzerland/myExtractedSample/2025",
     ),
     DisplayNameCase(
@@ -1349,7 +1349,7 @@ _DISPLAY_NAME_CASES = [
         submission_id="mySample",
         geo_loc_country="Switzerland",
         expected_regular="DENV-1/Switzerland/mySample/2025",
-        expected_insdc="DENV-1/Switzerland/mySample/2025",
+        expected_insdc="DENV-1/Switzerland/accession.1/2025",  # INSDC skips submissionId
         expected_prefix="hYF/Switzerland/mySample/2025",
     ),
     DisplayNameCase(
@@ -1357,9 +1357,9 @@ _DISPLAY_NAME_CASES = [
         specimen_collector_id="hDENV1/myExtractedSample/2025",
         submission_id="hDENV1/myExtractedSample/2025",
         geo_loc_country="",
-        expected_regular="DENV-1/unknown/version.1/2025",
-        expected_insdc="DENV-1/unknown/version.1/2025",
-        expected_prefix="hYF/unknown/version.1/2025",
+        expected_regular="DENV-1/unknown/accession.1/2025",
+        expected_insdc="DENV-1/unknown/accession.1/2025",
+        expected_prefix="hYF/unknown/accession.1/2025",
         warning_regular=_UNPARSEABLE_IDENTIFIER_WARNING,
         warning_prefix=_UNPARSEABLE_IDENTIFIER_WARNING,
     ),
@@ -1369,9 +1369,9 @@ _DISPLAY_NAME_CASES = [
         submission_id="hDENV1/myExtractedSample/2025",
         geo_loc_country="",
         extra_args={"fallback_value": "another_fallback"},
-        expected_regular="DENV-1/another_fallback/version.1/2025",
-        expected_insdc="DENV-1/another_fallback/version.1/2025",
-        expected_prefix="hYF/another_fallback/version.1/2025",
+        expected_regular="DENV-1/another_fallback/accession.1/2025",
+        expected_insdc="DENV-1/another_fallback/accession.1/2025",
+        expected_prefix="hYF/another_fallback/accession.1/2025",
         warning_regular=_UNPARSEABLE_IDENTIFIER_WARNING,
         warning_prefix=_UNPARSEABLE_IDENTIFIER_WARNING,
     ),

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -1,6 +1,7 @@
 # ruff: noqa: S101
-import pytest
 from dataclasses import dataclass, field
+
+import pytest
 from factory_methods import (
     Case,
     ProcessedEntryFactory,

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -1396,15 +1396,21 @@ def test_display_name_construction(case: DisplayNameCase) -> None:
     }
 
     res = ProcessingFunctions.build_display_name(
-        input_data, _DISPLAY_NAME_OUTPUT_FIELD, _DISPLAY_NAME_INPUT_FIELDS,
+        input_data,
+        _DISPLAY_NAME_OUTPUT_FIELD,
+        _DISPLAY_NAME_INPUT_FIELDS,
         _DISPLAY_NAME_BASE_ARGS | case.extra_args,
     )
     res_insdc = ProcessingFunctions.build_display_name(
-        input_data, _DISPLAY_NAME_OUTPUT_FIELD, _DISPLAY_NAME_INPUT_FIELDS,
+        input_data,
+        _DISPLAY_NAME_OUTPUT_FIELD,
+        _DISPLAY_NAME_INPUT_FIELDS,
         _DISPLAY_NAME_INSDC_ARGS | case.extra_args,
     )
     res_prefix = ProcessingFunctions.build_display_name(
-        input_data, _DISPLAY_NAME_OUTPUT_FIELD, _DISPLAY_NAME_INPUT_FIELDS,
+        input_data,
+        _DISPLAY_NAME_OUTPUT_FIELD,
+        _DISPLAY_NAME_INPUT_FIELDS,
         _DISPLAY_NAME_PREFIX_ARGS | case.extra_args,
     )
 

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -1,5 +1,6 @@
 # ruff: noqa: S101
 import pytest
+from dataclasses import dataclass, field
 from factory_methods import (
     Case,
     ProcessedEntryFactory,
@@ -1176,238 +1177,244 @@ def test_parse_date_into_range() -> None:
     ), "dateRangeUpper: lucene range upper bound should be tightened by submittedAt."
 
 
-def test_concatenate() -> None:
-    assert (
-        ProcessingFunctions.concatenate(
-            {"date": "2021-01-01/2021-12-31", "country": "USA"},
-            "field_name",
-            ["date", "country"],
-            {
-                "type": ["dateRangeString", "string"],
-                "order": ["date", "country"],
-                "ACCESSION_VERSION": "version.1",
-            },
-        ).datum
-        == "2021-01-01_TO_2021-12-31/USA"
-    ), "ISO date range is converted to lucene format for displayNames."
-    input_data: InputMetadata = {
-        "someInt": "",
-        "geoLocCountry": "",
-        "sampleCollectionDate": "2025",
-    }
-    output_field: str = "displayName"
-    input_fields: list[str] = ["geoLocCountry", "sampleCollectionDate"]
-    args: FunctionArgs = {
-        "ACCESSION_VERSION": "version.1",
-        "order": ["someInt", "geoLocCountry", "ACCESSION_VERSION", "sampleCollectionDate"],
-        "type": ["integer", "string", "ACCESSION_VERSION", "date"],
-    }
-    args_no_accession_version: FunctionArgs = {
-        "ACCESSION_VERSION": "version.1",
-        "order": ["someInt", "geoLocCountry", "sampleCollectionDate"],
-        "type": ["integer", "string", "date"],
-        "fallback_value": "unknown",
-    }
+@dataclass
+class ConcatenateCase:
+    name: str
+    input_data: InputMetadata
+    input_fields: list[str]
+    concatenate_args: FunctionArgs
+    expected: str
 
-    res_no_fallback_no_int = ProcessingFunctions.concatenate(
-        input_data,
-        output_field,
-        input_fields,
-        args,
+
+_CONCATENATE_CASES = [
+    ConcatenateCase(
+        name="date_range_converted_to_lucene",
+        input_data={"date": "2021-01-01/2021-12-31", "country": "USA"},
+        input_fields=["date", "country"],
+        concatenate_args={
+            "ACCESSION_VERSION": "version.1",
+            "order": ["date", "country"],
+            "type": ["dateRangeString", "string"],
+        },
+        expected="2021-01-01_TO_2021-12-31/USA",
+    ),
+    ConcatenateCase(
+        name="empty_int_field_skipped",
+        input_data={"someInt": "", "geoLocCountry": "", "sampleCollectionDate": "2025"},
+        input_fields=["geoLocCountry", "sampleCollectionDate"],
+        concatenate_args={
+            "ACCESSION_VERSION": "version.1",
+            "order": ["someInt", "geoLocCountry", "ACCESSION_VERSION", "sampleCollectionDate"],
+            "type": ["integer", "string", "ACCESSION_VERSION", "date"],
+        },
+        expected="version.1/2025-01-01",
+    ),
+    ConcatenateCase(
+        name="present_int_field_and_empty_string_field_with_no_fallback",
+        input_data={"someInt": "0", "geoLocCountry": "", "sampleCollectionDate": "2025"},
+        input_fields=["geoLocCountry", "sampleCollectionDate"],
+        concatenate_args={
+            "ACCESSION_VERSION": "version.1",
+            "order": ["someInt", "geoLocCountry", "ACCESSION_VERSION", "sampleCollectionDate"],
+            "type": ["integer", "string", "ACCESSION_VERSION", "date"],
+        },
+        expected="0//version.1/2025-01-01",
+    ),
+    ConcatenateCase(
+        name="empty_string_field_uses_fallback_value",
+        input_data={"someInt": "0", "geoLocCountry": "", "sampleCollectionDate": "2025"},
+        input_fields=["geoLocCountry", "sampleCollectionDate"],
+        concatenate_args={
+            "ACCESSION_VERSION": "version.1",
+            "order": ["someInt", "geoLocCountry", "ACCESSION_VERSION", "sampleCollectionDate"],
+            "type": ["integer", "string", "ACCESSION_VERSION", "date"],
+            "fallback_value": "unknown",
+        },
+        expected="0/unknown/version.1/2025-01-01",
+    ),
+    ConcatenateCase(
+        name="accession_version_omitted_from_order",
+        input_data={"someInt": "0", "geoLocCountry": "", "sampleCollectionDate": "2025"},
+        input_fields=["geoLocCountry", "sampleCollectionDate"],
+        concatenate_args={
+            "ACCESSION_VERSION": "version.1",
+            "order": ["someInt", "geoLocCountry", "sampleCollectionDate"],
+            "type": ["integer", "string", "date"],
+            "fallback_value": "unknown",
+        },
+        expected="0/unknown/2025-01-01",
+    ),
+    ConcatenateCase(
+        name="null_date_field_uses_fallback_value",
+        input_data={"someInt": "0", "geoLocCountry": "", "sampleCollectionDate": None},
+        input_fields=["geoLocCountry", "sampleCollectionDate"],
+        concatenate_args={
+            "ACCESSION_VERSION": "version.1",
+            "order": ["someInt", "geoLocCountry", "ACCESSION_VERSION", "sampleCollectionDate"],
+            "type": ["integer", "string", "ACCESSION_VERSION", "date"],
+            "fallback_value": "unknown",
+        },
+        expected="0/unknown/version.1/unknown",
+    ),
+]
+
+
+@pytest.mark.parametrize("case", _CONCATENATE_CASES, ids=lambda c: c.name)
+def test_concatenate(case: ConcatenateCase) -> None:
+    result = ProcessingFunctions.concatenate(
+        input_data=case.input_data,
+        output_field="displayName",
+        input_fields=case.input_fields,
+        args=case.concatenate_args,
     )
-
-    input_data["someInt"] = "0"
-    res_no_fallback = ProcessingFunctions.concatenate(
-        input_data,
-        output_field,
-        input_fields,
-        args,
-    )
-
-    args["fallback_value"] = "unknown"
-    res_fallback = ProcessingFunctions.concatenate(
-        input_data,
-        output_field,
-        input_fields,
-        args,
-    )
-
-    res_fallback_no_accession_version = ProcessingFunctions.concatenate(
-        input_data,
-        output_field,
-        input_fields,
-        args_no_accession_version,
-    )
-
-    input_data["sampleCollectionDate"] = None
-    res_fallback_explicit_null = ProcessingFunctions.concatenate(
-        input_data,
-        output_field,
-        input_fields,
-        args,
-    )
-
-    assert res_no_fallback_no_int.datum == "version.1/2025-01-01"
-    assert res_no_fallback.datum == "0//version.1/2025-01-01"
-    assert res_fallback.datum == "0/unknown/version.1/2025-01-01"
-    assert res_fallback_no_accession_version.datum == "0/unknown/2025-01-01"
-    assert res_fallback_explicit_null.datum == "0/unknown/version.1/unknown"
+    assert result.datum == case.expected
 
 
-def test_display_name_construction() -> None:  # noqa: PLR0915
-    submission_id = "mySample"
-    submission_id_formatted = "hDENV1/Germany/myExtractedSample/2025"
-    submission_id_formatted_unexpected = "hDENV1/myExtractedSample/2025"
+_DISPLAY_NAME_REGEX = r"^[^\/][^/]*/[^/]+/(?P<identifier>[^/]+)/\d{4}(?:-\d{2}){0,2}$"
+_DISPLAY_NAME_OUTPUT_FIELD = "displayName"
+_DISPLAY_NAME_INPUT_FIELDS = [
+    "nextclade.clade",
+    "geoLocCountry",
+    "specimenCollectorSampleId",
+    "submissionId",
+    "sampleCollectionDate",
+]
+_DISPLAY_NAME_BASE_ARGS: FunctionArgs = {
+    "ACCESSION_VERSION": "version.1",
+    "is_insdc_ingest_group": False,
+    "order": ["nextclade.clade", "geoLocCountry", "IDENTIFIER", "sampleCollectionDate"],
+    "type": ["string", "string", "IDENTIFIER", "string"],
+    "regex_pattern": _DISPLAY_NAME_REGEX,
+}
+_DISPLAY_NAME_INSDC_ARGS: FunctionArgs = {**_DISPLAY_NAME_BASE_ARGS, "is_insdc_ingest_group": True}
+_DISPLAY_NAME_PREFIX_ARGS: FunctionArgs = {
+    **_DISPLAY_NAME_BASE_ARGS,
+    "order": ["ARG:prefix", "geoLocCountry", "IDENTIFIER", "sampleCollectionDate"],
+    "type": ["ARG:prefix", "string", "IDENTIFIER", "string"],
+    "prefix": "hYF",
+}
+_UNPARSEABLE_IDENTIFIER_WARNING = (
+    "specimencollectorSampleId 'hDENV1/myExtractedSample/2025' and submissionId "
+    "'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
+)
+
+
+@dataclass
+class DisplayNameCase:
+    name: str
+    specimen_collector_id: str | None
+    submission_id: str
+    geo_loc_country: str
+    extra_args: FunctionArgs = field(default_factory=dict)
+    expected_regular: str = ""
+    expected_insdc: str = ""
+    expected_prefix: str = ""
+    warning_regular: str | None = None
+    warning_insdc: str | None = None
+    warning_prefix: str | None = None
+
+
+_DISPLAY_NAME_CASES = [
+    DisplayNameCase(
+        name="no_specimen_collector_id",
+        specimen_collector_id=None,
+        submission_id="mySample",
+        geo_loc_country="Switzerland",
+        expected_regular="DENV-1/Switzerland/mySample/2025",
+        expected_insdc="DENV-1/Switzerland/mySample/2025",
+        expected_prefix="hYF/Switzerland/mySample/2025",
+    ),
+    DisplayNameCase(
+        name="specimen_collector_id_plain",
+        specimen_collector_id="myCollectorSample",
+        submission_id="mySample",
+        geo_loc_country="Switzerland",
+        expected_regular="DENV-1/Switzerland/myCollectorSample/2025",
+        expected_insdc="DENV-1/Switzerland/myCollectorSample/2025",
+        expected_prefix="hYF/Switzerland/myCollectorSample/2025",
+    ),
+    DisplayNameCase(
+        name="specimen_collector_id_matches_regex_extracts_identifier",
+        specimen_collector_id="hDENV1/Germany/myExtractedSample/2025",
+        submission_id="mySample",
+        geo_loc_country="Switzerland",
+        expected_regular="DENV-1/Switzerland/myExtractedSample/2025",
+        expected_insdc="DENV-1/Switzerland/mySample/2025",  # INSDC skips regex extraction
+        expected_prefix="hYF/Switzerland/myExtractedSample/2025",
+    ),
+    DisplayNameCase(
+        name="specimen_collector_id_no_regex_match_falls_back_to_submission_id",
+        specimen_collector_id="hDENV1/myExtractedSample/2025",
+        submission_id="mySample",
+        geo_loc_country="Switzerland",
+        expected_regular="DENV-1/Switzerland/mySample/2025",
+        expected_insdc="DENV-1/Switzerland/mySample/2025",
+        expected_prefix="hYF/Switzerland/mySample/2025",
+    ),
+    DisplayNameCase(
+        name="both_ids_unparseable_empty_country_uses_accession_version",
+        specimen_collector_id="hDENV1/myExtractedSample/2025",
+        submission_id="hDENV1/myExtractedSample/2025",
+        geo_loc_country="",
+        expected_regular="DENV-1/unknown/version.1/2025",
+        expected_insdc="DENV-1/unknown/version.1/2025",
+        expected_prefix="hYF/unknown/version.1/2025",
+        warning_regular=_UNPARSEABLE_IDENTIFIER_WARNING,
+        warning_prefix=_UNPARSEABLE_IDENTIFIER_WARNING,
+    ),
+    DisplayNameCase(
+        name="fallback_value_replaces_unknown_country_when_ids_unparseable",
+        specimen_collector_id="hDENV1/myExtractedSample/2025",
+        submission_id="hDENV1/myExtractedSample/2025",
+        geo_loc_country="",
+        extra_args={"fallback_value": "another_fallback"},
+        expected_regular="DENV-1/another_fallback/version.1/2025",
+        expected_insdc="DENV-1/another_fallback/version.1/2025",
+        expected_prefix="hYF/another_fallback/version.1/2025",
+        warning_regular=_UNPARSEABLE_IDENTIFIER_WARNING,
+        warning_prefix=_UNPARSEABLE_IDENTIFIER_WARNING,
+    ),
+]
+
+
+def _assert_display_name_warnings(warnings: list, expected_message: str | None) -> None:
+    if expected_message is None:
+        assert len(warnings) == 0
+    else:
+        assert len(warnings) == 1
+        assert warnings[0].message == expected_message
+
+
+@pytest.mark.parametrize("case", _DISPLAY_NAME_CASES, ids=lambda c: c.name)
+def test_display_name_construction(case: DisplayNameCase) -> None:
     input_data: InputMetadata = {
         "nextclade.clade": "DENV-1",
-        "geoLocCountry": "Switzerland",
+        "geoLocCountry": case.geo_loc_country,
         "sampleCollectionDate": "2025",
-        "submissionId": submission_id,
+        "submissionId": case.submission_id,
+        "specimenCollectorSampleId": case.specimen_collector_id,
     }
-    output_field: str = "displayName"
 
-    def input_fields():
-        return [
-            "nextclade.clade",
-            "geoLocCountry",
-            "specimenCollectorSampleId",
-            "submissionId",
-            "sampleCollectionDate",
-        ]
-
-    def args():
-        return {
-            "ACCESSION_VERSION": "version.1",
-            "is_insdc_ingest_group": False,
-            "order": ["nextclade.clade", "geoLocCountry", "IDENTIFIER", "sampleCollectionDate"],
-            "type": ["string", "string", "IDENTIFIER", "string"],
-            "regex_pattern": r"^[^\/][^/]*/[^/]+/(?P<identifier>[^/]+)/\d{4}(?:-\d{2}){0,2}$",
-        }
-
-    def args_with_prefix():
-        return {
-            "ACCESSION_VERSION": "version.1",
-            "is_insdc_ingest_group": False,
-            "order": ["ARG:prefix", "geoLocCountry", "IDENTIFIER", "sampleCollectionDate"],
-            "type": ["ARG:prefix", "string", "IDENTIFIER", "string"],
-            "prefix": "hYF",
-            "regex_pattern": r"^[^\/][^/]*/[^/]+/(?P<identifier>[^/]+)/\d{4}(?:-\d{2}){0,2}$",
-        }
-
-    def args_insdc():
-        return {
-            "ACCESSION_VERSION": "version.1",
-            "is_insdc_ingest_group": True,
-            "order": ["nextclade.clade", "geoLocCountry", "IDENTIFIER", "sampleCollectionDate"],
-            "type": ["string", "string", "IDENTIFIER", "string"],
-            "regex_pattern": r"^[^\/][^/]*/[^/]+/(?P<identifier>[^/]+)/\d{4}(?:-\d{2}){0,2}$",
-        }
-
-    res = ProcessingFunctions.build_display_name(input_data, output_field, input_fields(), args())
-    res_insdc = ProcessingFunctions.build_display_name(
-        input_data, output_field, input_fields(), args_insdc()
-    )
-    res_prefix = ProcessingFunctions.build_display_name(
-        input_data, output_field, input_fields(), args_with_prefix()
-    )
-    assert res.datum == "DENV-1/Switzerland/mySample/2025"
-    assert res_insdc.datum == "DENV-1/Switzerland/mySample/2025"
-    assert res_prefix.datum == "hYF/Switzerland/mySample/2025"
-
-    input_data["specimenCollectorSampleId"] = "myCollectorSample"
-    res = ProcessingFunctions.build_display_name(input_data, output_field, input_fields(), args())
-    res_insdc = ProcessingFunctions.build_display_name(
-        input_data, output_field, input_fields(), args_insdc()
-    )
-    res_prefix = ProcessingFunctions.build_display_name(
-        input_data, output_field, input_fields(), args_with_prefix()
-    )
-    assert res.datum == "DENV-1/Switzerland/myCollectorSample/2025"
-    assert res_insdc.datum == "DENV-1/Switzerland/myCollectorSample/2025"
-    assert res_prefix.datum == "hYF/Switzerland/myCollectorSample/2025"
-
-    input_data["specimenCollectorSampleId"] = submission_id_formatted
-    res = ProcessingFunctions.build_display_name(input_data, output_field, input_fields(), args())
-    res_insdc = ProcessingFunctions.build_display_name(
-        input_data, output_field, input_fields(), args_insdc()
-    )
-    res_prefix = ProcessingFunctions.build_display_name(
-        input_data, output_field, input_fields(), args_with_prefix()
-    )
-    assert res.datum == "DENV-1/Switzerland/myExtractedSample/2025"
-    assert res_insdc.datum == "DENV-1/Switzerland/mySample/2025"
-    assert res_prefix.datum == "hYF/Switzerland/myExtractedSample/2025"
-
-    input_data["specimenCollectorSampleId"] = submission_id_formatted_unexpected
-    res = ProcessingFunctions.build_display_name(input_data, output_field, input_fields(), args())
-    res_insdc = ProcessingFunctions.build_display_name(
-        input_data, output_field, input_fields(), args_insdc()
-    )
-    res_prefix = ProcessingFunctions.build_display_name(
-        input_data, output_field, input_fields(), args_with_prefix()
-    )
-    assert res.datum == "DENV-1/Switzerland/mySample/2025"
-    assert res_insdc.datum == "DENV-1/Switzerland/mySample/2025"
-    assert res_prefix.datum == "hYF/Switzerland/mySample/2025"
-
-    input_data["specimenCollectorSampleId"] = submission_id_formatted_unexpected
-    input_data["submissionId"] = submission_id_formatted_unexpected
-    input_data["geoLocCountry"] = ""
-    res = ProcessingFunctions.build_display_name(input_data, output_field, input_fields(), args())
-    res_insdc = ProcessingFunctions.build_display_name(
-        input_data, output_field, input_fields(), args_insdc()
-    )
-    res_prefix = ProcessingFunctions.build_display_name(
-        input_data, output_field, input_fields(), args_with_prefix()
-    )
-    assert res.datum == "DENV-1/unknown/version.1/2025"
-    assert len(res.warnings) == 1
-    assert (
-        res.warnings[0].message
-        == "specimencollectorSampleId 'hDENV1/myExtractedSample/2025' and submissionId 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
-    )
-    assert res_insdc.datum == "DENV-1/unknown/version.1/2025"
-    assert len(res_insdc.warnings) == 0
-    assert res_prefix.datum == "hYF/unknown/version.1/2025"
-    assert len(res_prefix.warnings) == 1
-    assert (
-        res_prefix.warnings[0].message
-        == "specimencollectorSampleId 'hDENV1/myExtractedSample/2025' and submissionId 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
-    )
-
-    input_data["specimenCollectorSampleId"] = submission_id_formatted_unexpected
     res = ProcessingFunctions.build_display_name(
-        input_data,
-        output_field,
-        input_fields(),
-        {"fallback_value": "another_fallback"} | args(),  # type: ignore
+        input_data, _DISPLAY_NAME_OUTPUT_FIELD, _DISPLAY_NAME_INPUT_FIELDS,
+        _DISPLAY_NAME_BASE_ARGS | case.extra_args,
     )
     res_insdc = ProcessingFunctions.build_display_name(
-        input_data,
-        output_field,
-        input_fields(),
-        {"fallback_value": "another_fallback"} | args_insdc(),  # type: ignore
+        input_data, _DISPLAY_NAME_OUTPUT_FIELD, _DISPLAY_NAME_INPUT_FIELDS,
+        _DISPLAY_NAME_INSDC_ARGS | case.extra_args,
     )
     res_prefix = ProcessingFunctions.build_display_name(
-        input_data,
-        output_field,
-        input_fields(),
-        {"fallback_value": "another_fallback"} | args_with_prefix(),  # type: ignore
+        input_data, _DISPLAY_NAME_OUTPUT_FIELD, _DISPLAY_NAME_INPUT_FIELDS,
+        _DISPLAY_NAME_PREFIX_ARGS | case.extra_args,
     )
-    assert res.datum == "DENV-1/another_fallback/version.1/2025"
-    assert len(res.warnings) == 1
-    assert (
-        res.warnings[0].message
-        == "specimencollectorSampleId 'hDENV1/myExtractedSample/2025' and submissionId 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
-    )
-    assert res_insdc.datum == "DENV-1/another_fallback/version.1/2025"
-    assert len(res_insdc.warnings) == 0
-    assert res_prefix.datum == "hYF/another_fallback/version.1/2025"
-    assert len(res_prefix.warnings) == 1
-    assert (
-        res_prefix.warnings[0].message
-        == "specimencollectorSampleId 'hDENV1/myExtractedSample/2025' and submissionId 'hDENV1/myExtractedSample/2025' could not be parsed, using ACCESSION_VERSION in displayName instead"
-    )
+
+    assert res.datum == case.expected_regular
+    assert res_insdc.datum == case.expected_insdc
+    assert res_prefix.datum == case.expected_prefix
+
+    _assert_display_name_warnings(res.warnings, case.warning_regular)
+    _assert_display_name_warnings(res_insdc.warnings, case.warning_insdc)
+    _assert_display_name_warnings(res_prefix.warnings, case.warning_prefix)
 
 
 if __name__ == "__main__":

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -1187,7 +1187,7 @@ class ConcatenateCase:
     expected: str
 
 
-_CONCATENATE_CASES = [
+CONCATENATE_CASES = [
     ConcatenateCase(
         name="date_range_converted_to_lucene",
         input_data={"date": "2021-01-01/2021-12-31", "country": "USA"},
@@ -1260,7 +1260,7 @@ _CONCATENATE_CASES = [
 ]
 
 
-@pytest.mark.parametrize("case", _CONCATENATE_CASES, ids=lambda c: c.name)
+@pytest.mark.parametrize("case", CONCATENATE_CASES, ids=lambda c: c.name)
 def test_concatenate(case: ConcatenateCase) -> None:
     result = ProcessingFunctions.concatenate(
         input_data=case.input_data,


### PR DESCRIPTION
While reviewing https://github.com/loculus-project/loculus/pull/6774 I had a lot of trouble reading the tests, I think having clear test cases with descriptive names of what the test is checking makes this a lot easier to parse (or grok as @corneliusroemer would say). I got claude to reformat these tests like the other prepro test `Case` objects.

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable