### PR TITLE
fix(website): reserve space for file upload progress percentage

### DIFF
--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
@@ -555,7 +555,9 @@ const FileListItem: FC<FileListeItemProps> = ({ file }) => {
                 ) : (
                     <span className='text-xs text-gray-400 ml-2 whitespace-nowrap'>({formatFileSize(file.size)})</span>
                 )}
-                {showProgress && <span className='text-xs text-blue-500 ml-2'>{percentage}%</span>}
+                <span className='text-xs text-blue-500 ml-2 w-9 shrink-0 text-right whitespace-nowrap'>
+                    {showProgress ? `${percentage}%` : ''}
+                </span>
             </div>
             {/* Status icon */}
             <div className='ml-2 w-5 flex justify-center'>{getStatusIcon(file.type)}</div>


### PR DESCRIPTION
Fixes #6791

The upload progress percentage was rendered conditionally and without a
fixed width, so it wrapped across multiple rows when squished and caused
layout shift (including the Discard button moving left) when it appeared
and disappeared. Always render a fixed-width, no-wrap span sized for
"100%" so the row width stays constant throughout the upload.

<img width="947" height="348" alt="2026-06-29 22 32 50" src="https://github.com/user-attachments/assets/2f1568f7-1c17-4f98-917d-dcb1cd2ffae1" />

🚀 Preview: Add `preview` label to enable