### PR TITLE
feat(deposition): allow automatic revision of author fields in assemblies

### DIFF
--- a/ena-submission/config/defaults.yaml
+++ b/ena-submission/config/defaults.yaml
@@ -119,3 +119,4 @@ slack_retry_substrings:
   - "does not exist in ENA"
 submitting_time_threshold_min: 15
 waiting_threshold_hours: 48
+allow_revision_with_manifest_changes: true

--- a/ena-submission/scripts/test_ena_submission_integration.py
+++ b/ena-submission/scripts/test_ena_submission_integration.py
@@ -1157,6 +1157,7 @@ class TestRevisionWithManifestChangeTests(TestSubmission):
         mock_submit_external_metadata: Mock,
     ) -> None:
         self.config.set_alias_suffix = "revision" + str(uuid.uuid4())
+        self.config.allow_revision_with_manifest_changes = False
         multi_segment_submission(
             self.db_engine, self.config, mock_get_group_info, mock_submit_external_metadata
         )

--- a/ena-submission/src/ena_deposition/config.py
+++ b/ena-submission/src/ena_deposition/config.py
@@ -124,6 +124,7 @@ class Config(BaseModel):
     min_between_ena_checks: int = 5
     log_level: str = "DEBUG"
 
+    allow_revision_with_manifest_changes: bool = True
     retry_threshold_min: int = 240
     slack_retry_substrings: list[str] = field(default_factory=list)
     slack_retry_threshold_min: int = 720

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -407,7 +407,11 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
                 update_type="revision",
             )
             return False
-
+    if config.allow_retry_for_manifest_changes:
+        logger.debug(
+            "allow_retry_for_manifest_changes is True, skipping manifest field comparison for revision"
+        )
+        return True
     differing_fields = {}
     for mapping in config.manifest_fields_mapping.values():
         loculus_field_names = mapping.loculus_fields

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -346,6 +346,49 @@ def update_assembly_error(
     )
 
 
+def manifest_fields_changed(
+    config: Config,
+    db_engine: Engine,
+    submission_row: SubmissionTableEntry,
+    last_version_entry: SubmissionTableEntry,
+) -> bool:
+    differing_fields = {}
+    for mapping in config.manifest_fields_mapping.values():
+        loculus_field_names = mapping.loculus_fields
+        for loculus_field_name in loculus_field_names:
+            last_entry = last_version_entry.seq_metadata.get(loculus_field_name)
+            new_entry = submission_row.seq_metadata.get(loculus_field_name)
+            if loculus_field_name == "authors":
+                try:
+                    last_entry = get_authors(last_entry) if last_entry else last_entry
+                    new_entry = get_authors(new_entry) if new_entry else new_entry
+                except Exception as e:
+                    logger.error(
+                        f"Error formatting authors field for comparison: {e}. "
+                        f"Traceback: {traceback.format_exc()}"
+                    )
+                    differing_fields[loculus_field_name] = (
+                        f"Last: {last_entry}, New: {new_entry}, Error reformatting: {e}"
+                    )
+                    continue
+            if last_entry != new_entry:
+                differing_fields[loculus_field_name] = f"Last: {last_entry}, New: {new_entry}, "
+    if differing_fields:
+        error = (
+            "Assembly cannot be revised because metadata fields in manifest would change from "
+            f"last version: {json.dumps(differing_fields)}"
+        )
+        logger.error(error)
+        update_assembly_error(
+            db_engine,
+            [error],
+            seq_key=asdict(submission_row.pkey),
+            update_type="revision",
+        )
+        return True
+    return False
+
+
 def can_be_revised(config: Config, db_engine: Engine, submission_row: SubmissionTableEntry) -> bool:
     """
     Check if assembly can be revised
@@ -407,46 +450,12 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
                 update_type="revision",
             )
             return False
-    if config.allow_retry_for_manifest_changes:
+    if config.allow_revision_with_manifest_changes:
         logger.debug(
-            "allow_retry_for_manifest_changes is True, skipping manifest field comparison for revision"
+            "allow_revision_with_manifest_changes is True, skipping manifest field comparison for revision"
         )
         return True
-    differing_fields = {}
-    for mapping in config.manifest_fields_mapping.values():
-        loculus_field_names = mapping.loculus_fields
-        for loculus_field_name in loculus_field_names:
-            last_entry = last_version_entry.seq_metadata.get(loculus_field_name)
-            new_entry = submission_row.seq_metadata.get(loculus_field_name)
-            if loculus_field_name == "authors":
-                try:
-                    last_entry = get_authors(last_entry) if last_entry else last_entry
-                    new_entry = get_authors(new_entry) if new_entry else new_entry
-                except Exception as e:
-                    logger.error(
-                        f"Error formatting authors field for comparison: {e}. "
-                        f"Traceback: {traceback.format_exc()}"
-                    )
-                    differing_fields[loculus_field_name] = (
-                        f"Last: {last_entry}, New: {new_entry}, Error reformatting: {e}"
-                    )
-                    continue
-            if last_entry != new_entry:
-                differing_fields[loculus_field_name] = f"Last: {last_entry}, New: {new_entry}, "
-    if differing_fields:
-        error = (
-            "Assembly cannot be revised because metadata fields in manifest would change from "
-            f"last version: {json.dumps(differing_fields)}"
-        )
-        logger.error(error)
-        update_assembly_error(
-            db_engine,
-            [error],
-            seq_key=asdict(submission_row.pkey),
-            update_type="revision",
-        )
-        return False
-    return True
+    return not manifest_fields_changed(config, db_engine, submission_row, last_version_entry)
 
 
 def is_flatfile_data_changed(db_engine: Engine, submission_row: SubmissionTableEntry) -> bool:

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -452,7 +452,7 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
             return False
     if config.allow_revision_with_manifest_changes:
         logger.debug(
-            "allow_revision_with_manifest_changes is True, skipping manifest field comparison for revision"
+            "allow_revision_with_manifest_changes=True, skipping manifest field comparison"
         )
         return True
     return not manifest_fields_changed(config, db_engine, submission_row, last_version_entry)


### PR DESCRIPTION
See https://loculus.slack.com/archives/C0757PTR607/p1782745074666639 - we have been informed revision of fields in the manifest.tsv is now possible via the cli.

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable