### PR TITLE
feat(deposition, deployment): add a health probe to the ENA deposition service and use stop_event.wait() instead of sleep

### DIFF
--- a/ena-submission/src/ena_deposition/api.py
+++ b/ena-submission/src/ena_deposition/api.py
@@ -5,7 +5,7 @@ from typing import cast
 import uvicorn
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-from sqlalchemy import Engine, select
+from sqlalchemy import Engine, select, text
 from sqlalchemy.orm import Session
 
 from .config import Config
@@ -56,6 +56,11 @@ def init_app(config: Config):
 @app.get("/")
 def read_root():
     return {"message": "ENA Deposition Pod API is running"}
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
 
 
 @app.get("/submitted", response_model=SubmittedAccessionsResponse)

--- a/ena-submission/src/ena_deposition/api.py
+++ b/ena-submission/src/ena_deposition/api.py
@@ -5,7 +5,7 @@ from typing import cast
 import uvicorn
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-from sqlalchemy import Engine, select, text
+from sqlalchemy import Engine, select
 from sqlalchemy.orm import Session
 
 from .config import Config

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -354,4 +354,6 @@ def check_and_update_visibility(config: Config, stop_event: threading.Event):
         if elapsed_time < 60 * config.min_between_publicness_checks:
             wait_time = 60 * config.min_between_publicness_checks - elapsed_time
             logger.debug(f"Waiting {wait_time:.2f} seconds before next iteration")
-            time.sleep(wait_time)
+            if stop_event.wait(timeout=wait_time):
+                logger.info("check_and_update_visibility stopped due to exception in another task")
+                return

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -3,7 +3,6 @@ import logging
 import random
 import string
 import threading
-import time
 import traceback
 from dataclasses import asdict
 from datetime import datetime, timedelta

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -816,4 +816,6 @@ def create_assembly(config: Config, stop_event: threading.Event):
         last_retry_time = assembly_table_handle_errors(
             db_engine, config, slack_config, last_retry_time
         )
-        time.sleep(config.time_between_iterations)
+        if stop_event.wait(timeout=config.time_between_iterations):
+            logger.info("create_assembly stopped due to exception in another task")
+            return

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -375,4 +375,6 @@ def create_project(config: Config, stop_event: threading.Event):
         last_retry_time = project_table_handle_errors(
             db_engine, config, slack_config, last_retry_time
         )
-        time.sleep(config.time_between_iterations)
+        if stop_event.wait(timeout=config.time_between_iterations):
+            logger.info("create_project stopped due to exception in another task")
+            return

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -1,6 +1,5 @@
 import logging
 import threading
-import time
 from dataclasses import asdict
 from datetime import datetime
 

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -1,7 +1,6 @@
 import logging
 import re
 import threading
-import time
 from dataclasses import asdict
 from datetime import datetime
 

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -396,4 +396,6 @@ def create_sample(config: Config, stop_event: threading.Event):
         last_retry_time = sample_table_handle_errors(
             db_engine, config, slack_config, last_retry_time
         )
-        time.sleep(config.time_between_iterations)
+        if stop_event.wait(timeout=config.time_between_iterations):
+            logger.info("create_sample stopped due to exception in another task")
+            return

--- a/ena-submission/src/ena_deposition/trigger_submission_to_ena.py
+++ b/ena-submission/src/ena_deposition/trigger_submission_to_ena.py
@@ -68,7 +68,9 @@ def trigger_submission_to_ena(
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"Failed to retrieve file due to requests exception: {e}")
-            time.sleep(config.min_between_github_requests * 60)
+            if stop_event.wait(timeout=config.min_between_github_requests * 60):
+                logger.info("trigger_submission_to_ena stopped due to exception in another task")
+                return
             continue
         try:
             sequences_to_upload = response.json()
@@ -76,6 +78,5 @@ def trigger_submission_to_ena(
         except Exception as upload_error:
             logger.error(f"Failed to upload sequences: {upload_error}")
         finally:
-            time.sleep(
-                config.min_between_github_requests * 60
-            )  # Sleep for x min to not overwhelm github
+            if stop_event.wait(timeout=config.min_between_github_requests * 60):
+                logger.info("trigger_submission_to_ena stopped due to exception in another task")

--- a/ena-submission/src/ena_deposition/trigger_submission_to_ena.py
+++ b/ena-submission/src/ena_deposition/trigger_submission_to_ena.py
@@ -58,24 +58,15 @@ def trigger_submission_to_ena(
             logger.warning("trigger_submission_to_ena stopped due to exception in another task")
             return
         logger.debug("Checking for new sequences to upload to submission_table")
-        # In a loop get approved sequences uploaded to Github and upload to submission_table
         try:
-            response = requests.get(
-                config.approved_list_url,
-                timeout=60,
-            )
+            response = requests.get(config.approved_list_url, timeout=60)
             response.raise_for_status()
-        except requests.exceptions.RequestException as e:
-            logger.error(f"Failed to retrieve file due to requests exception: {e}")
-            if stop_event.wait(timeout=config.min_between_github_requests * 60):
-                logger.info("trigger_submission_to_ena stopped due to exception in another task")
-                return
-            continue
-        try:
             sequences_to_upload = response.json()
             upload_sequences(db_engine, sequences_to_upload)
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Failed to retrieve file due to requests exception: {e}")
         except Exception as upload_error:
             logger.error(f"Failed to upload sequences: {upload_error}")
-        finally:
-            if stop_event.wait(timeout=config.min_between_github_requests * 60):
-                logger.info("trigger_submission_to_ena stopped due to exception in another task")
+        if stop_event.wait(timeout=config.min_between_github_requests * 60):
+            logger.info("trigger_submission_to_ena stopped due to exception in another task")
+            return

--- a/ena-submission/src/ena_deposition/trigger_submission_to_ena.py
+++ b/ena-submission/src/ena_deposition/trigger_submission_to_ena.py
@@ -4,7 +4,6 @@
 import json
 import logging
 import threading
-import time
 from typing import Any
 
 import requests

--- a/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
+++ b/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
@@ -283,4 +283,6 @@ def upload_external_metadata(config: Config, stop_event: threading.Event):
             config,
             slack_config,
         )
-        time.sleep(config.time_between_iterations)
+        if stop_event.wait(timeout=config.time_between_iterations):
+            logger.info("upload_external_metadata stopped due to exception in another task")
+            return

--- a/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
+++ b/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
@@ -2,7 +2,6 @@
 
 import logging
 import threading
-import time
 from dataclasses import asdict
 from datetime import datetime
 from typing import Any

--- a/kubernetes/loculus/templates/ena-submission-deployment.yaml
+++ b/kubernetes/loculus/templates/ena-submission-deployment.yaml
@@ -101,8 +101,17 @@ spec:
                 secretKeyRef:
                   name: ena-submission
                   key: password
+          ports:
+            - containerPort: 5000
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 5000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
           args:
-            - ena_deposition 
+            - ena_deposition
             - "--config-file=/config/config.yaml"
           volumeMounts:
             - name: loculus-ena-submission-config-volume


### PR DESCRIPTION
partially resolves https://github.com/loculus-project/loculus/issues/6806 

The issue was caused because one task kept running because it was sleeping and didnt "see" the stop event (created by an exception in another task)

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable