### PR TITLE
wip(deposition): Allow notifying on manifest changes if policy is warn

### DIFF
--- a/ena-submission/config/defaults.yaml
+++ b/ena-submission/config/defaults.yaml
@@ -119,3 +119,4 @@ slack_retry_substrings:
   - "does not exist in ENA"
 submitting_time_threshold_min: 15
 waiting_threshold_hours: 48
+allow_revision_with_manifest_changes: true

--- a/ena-submission/src/ena_deposition/config.py
+++ b/ena-submission/src/ena_deposition/config.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from dataclasses import field
+from enum import StrEnum
 
 import dotenv
 import yaml
@@ -58,6 +59,12 @@ class EnaOrganismDetails(BaseModel):
 
 
 type EnaOrganismName = str
+
+
+class ManifestChangePolicy(StrEnum):
+    ERROR = "error"
+    WARN = "warn"
+    ALLOW = "allow"
 
 
 class Config(BaseModel):
@@ -123,8 +130,7 @@ class Config(BaseModel):
     min_between_publicness_checks: int = 12 * 60  # 12 hours
     min_between_ena_checks: int = 5
     log_level: str = "DEBUG"
-
-    allow_revision_with_manifest_changes: bool = True
+    revision_manifest_change_policy: ManifestChangePolicy = ManifestChangePolicy.ERROR
     retry_threshold_min: int = 240
     slack_retry_substrings: list[str] = field(default_factory=list)
     slack_retry_threshold_min: int = 720

--- a/ena-submission/src/ena_deposition/config.py
+++ b/ena-submission/src/ena_deposition/config.py
@@ -124,6 +124,7 @@ class Config(BaseModel):
     min_between_ena_checks: int = 5
     log_level: str = "DEBUG"
 
+    allow_revision_with_manifest_changes: bool = True
     retry_threshold_min: int = 240
     slack_retry_substrings: list[str] = field(default_factory=list)
     slack_retry_threshold_min: int = 720

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -407,7 +407,11 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
                 update_type="revision",
             )
             return False
-
+    if config.allow_retry_for_manifest_changes:
+        logger.debug(
+            "allow_retry_for_manifest_changes is True, skipping manifest field comparison for revision"
+        )
+        return True
     differing_fields = {}
     for mapping in config.manifest_fields_mapping.values():
         loculus_field_names = mapping.loculus_fields

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -346,6 +346,49 @@ def update_assembly_error(
     )
 
 
+def manifest_fields_changed(
+    config: Config,
+    db_engine: Engine,
+    submission_row: SubmissionTableEntry,
+    last_version_entry: SubmissionTableEntry,
+) -> bool:
+    differing_fields = {}
+    for mapping in config.manifest_fields_mapping.values():
+        loculus_field_names = mapping.loculus_fields
+        for loculus_field_name in loculus_field_names:
+            last_entry = last_version_entry.seq_metadata.get(loculus_field_name)
+            new_entry = submission_row.seq_metadata.get(loculus_field_name)
+            if loculus_field_name == "authors":
+                try:
+                    last_entry = get_authors(last_entry) if last_entry else last_entry
+                    new_entry = get_authors(new_entry) if new_entry else new_entry
+                except Exception as e:
+                    logger.error(
+                        f"Error formatting authors field for comparison: {e}. "
+                        f"Traceback: {traceback.format_exc()}"
+                    )
+                    differing_fields[loculus_field_name] = (
+                        f"Last: {last_entry}, New: {new_entry}, Error reformatting: {e}"
+                    )
+                    continue
+            if last_entry != new_entry:
+                differing_fields[loculus_field_name] = f"Last: {last_entry}, New: {new_entry}, "
+    if differing_fields:
+        error = (
+            "Assembly cannot be revised because metadata fields in manifest would change from "
+            f"last version: {json.dumps(differing_fields)}"
+        )
+        logger.error(error)
+        update_assembly_error(
+            db_engine,
+            [error],
+            seq_key=asdict(submission_row.pkey),
+            update_type="revision",
+        )
+        return True
+    return False
+
+
 def can_be_revised(config: Config, db_engine: Engine, submission_row: SubmissionTableEntry) -> bool:
     """
     Check if assembly can be revised
@@ -407,46 +450,12 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
                 update_type="revision",
             )
             return False
-    if config.allow_retry_for_manifest_changes:
+    if config.allow_revision_with_manifest_changes:
         logger.debug(
-            "allow_retry_for_manifest_changes is True, skipping manifest field comparison for revision"
+            "allow_revision_with_manifest_changes is True, skipping manifest field comparison for revision"
         )
         return True
-    differing_fields = {}
-    for mapping in config.manifest_fields_mapping.values():
-        loculus_field_names = mapping.loculus_fields
-        for loculus_field_name in loculus_field_names:
-            last_entry = last_version_entry.seq_metadata.get(loculus_field_name)
-            new_entry = submission_row.seq_metadata.get(loculus_field_name)
-            if loculus_field_name == "authors":
-                try:
-                    last_entry = get_authors(last_entry) if last_entry else last_entry
-                    new_entry = get_authors(new_entry) if new_entry else new_entry
-                except Exception as e:
-                    logger.error(
-                        f"Error formatting authors field for comparison: {e}. "
-                        f"Traceback: {traceback.format_exc()}"
-                    )
-                    differing_fields[loculus_field_name] = (
-                        f"Last: {last_entry}, New: {new_entry}, Error reformatting: {e}"
-                    )
-                    continue
-            if last_entry != new_entry:
-                differing_fields[loculus_field_name] = f"Last: {last_entry}, New: {new_entry}, "
-    if differing_fields:
-        error = (
-            "Assembly cannot be revised because metadata fields in manifest would change from "
-            f"last version: {json.dumps(differing_fields)}"
-        )
-        logger.error(error)
-        update_assembly_error(
-            db_engine,
-            [error],
-            seq_key=asdict(submission_row.pkey),
-            update_type="revision",
-        )
-        return False
-    return True
+    return not manifest_fields_changed(config, db_engine, submission_row, last_version_entry)
 
 
 def is_flatfile_data_changed(db_engine: Engine, submission_row: SubmissionTableEntry) -> bool:

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -7,6 +7,7 @@ import time
 import traceback
 from dataclasses import asdict
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Any, Literal, cast
 
 import pytz
@@ -14,7 +15,7 @@ from sqlalchemy import Engine
 
 from ena_deposition import call_loculus
 
-from .config import Config, EnaOrganismDetails
+from .config import Config, EnaOrganismDetails, ManifestChangePolicy
 from .ena_submission_helper import (
     CreationResult,
     accession_exists,
@@ -35,7 +36,12 @@ from .ena_types import (
     AssemblyManifest,
     ChromosomeType,
 )
-from .notifications import SlackConfig, send_slack_notification, slack_conn_init
+from .notifications import (
+    SlackConfig,
+    send_slack_notification,
+    slack_conn_init,
+    upload_file_with_comment,
+)
 from .submission_db_helper import (
     AccessionVersion,
     AssemblyTableEntry,
@@ -348,10 +354,9 @@ def update_assembly_error(
 
 def manifest_fields_changed(
     config: Config,
-    db_engine: Engine,
     submission_row: SubmissionTableEntry,
     last_version_entry: SubmissionTableEntry,
-) -> bool:
+) -> dict:
     differing_fields = {}
     for mapping in config.manifest_fields_mapping.values():
         loculus_field_names = mapping.loculus_fields
@@ -373,23 +378,12 @@ def manifest_fields_changed(
                     continue
             if last_entry != new_entry:
                 differing_fields[loculus_field_name] = f"Last: {last_entry}, New: {new_entry}, "
-    if differing_fields:
-        error = (
-            "Assembly cannot be revised because metadata fields in manifest would change from "
-            f"last version: {json.dumps(differing_fields)}"
-        )
-        logger.error(error)
-        update_assembly_error(
-            db_engine,
-            [error],
-            seq_key=asdict(submission_row.pkey),
-            update_type="revision",
-        )
-        return True
-    return False
+    return differing_fields
 
 
-def can_be_revised(config: Config, db_engine: Engine, submission_row: SubmissionTableEntry) -> bool:
+def can_be_revised(
+    config: Config, db_engine: Engine, submission_row: SubmissionTableEntry
+) -> tuple[bool, str]:
     """
     Check if assembly can be revised
     1. Last version exists in submission_table, otherwise throw RuntimeError
@@ -398,9 +392,11 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
     3. metadata fields in manifest haven't changed since previous version, otherwise
        requires manual revision
     """
+    notification = ""
     seq_key = submission_row.pkey
     if not is_latest_revision(db_engine, seq_key):
-        return False
+        return False, ""
+
     version_to_revise = previous_version(db_engine, seq_key)
     last_version_rows = find_conditions_in_db(
         db_engine,
@@ -410,9 +406,7 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
     if len(last_version_rows) == 0:
         error_msg = f"Last version {version_to_revise} not found in submission_table"
         raise RuntimeError(error_msg)
-
     last_version_entry = last_version_rows[0]
-
     previous_sample_accession, previous_study_accession = get_project_and_sample_results(
         db_engine, last_version_entry
     )
@@ -420,6 +414,7 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
         f"Previous sample accession: {previous_sample_accession}, "
         f"previous study accession: {previous_study_accession}"
     )
+
     if submission_row.seq_metadata.get("biosampleAccession"):
         new_sample_accession = submission_row.seq_metadata["biosampleAccession"]
         if previous_sample_accession != new_sample_accession:
@@ -434,7 +429,8 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
                 seq_key=asdict(submission_row.pkey),
                 update_type="revision",
             )
-            return False
+            return False, ""
+
     if submission_row.seq_metadata.get("bioprojectAccession"):
         new_project_accession = submission_row.seq_metadata["bioprojectAccession"]
         if new_project_accession != previous_study_accession:
@@ -449,13 +445,37 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
                 seq_key=asdict(submission_row.pkey),
                 update_type="revision",
             )
-            return False
-    if config.allow_revision_with_manifest_changes:
-        logger.debug(
-            "allow_revision_with_manifest_changes=True, skipping manifest field comparison"
-        )
-        return True
-    return not manifest_fields_changed(config, db_engine, submission_row, last_version_entry)
+            return False, ""
+
+    if config.revision_manifest_change_policy != ManifestChangePolicy.ALLOW and (
+        differing_fields := manifest_fields_changed(config, submission_row, last_version_entry)
+    ):
+        match config.revision_manifest_change_policy:
+            case ManifestChangePolicy.ERROR:
+                error = (
+                    "Assembly cannot be revised because metadata fields in manifest would change"
+                    f" from last version: {json.dumps(differing_fields)}"
+                )
+                logger.error(error)
+                update_assembly_error(
+                    db_engine,
+                    [error],
+                    seq_key=asdict(submission_row.pkey),
+                    update_type="revision",
+                )
+                return False, ""
+            case ManifestChangePolicy.WARN:
+                logger.warning(
+                    "Manifest fields have changed since last version, but continuing "
+                    "because revision_manifest_change_policy=WARN"
+                )
+                notification = "Manifest fields have changed since last version: " + json.dumps(
+                    differing_fields
+                )
+            case ManifestChangePolicy.ALLOW:
+                pass
+
+    return True, notification
 
 
 def is_flatfile_data_changed(db_engine: Engine, submission_row: SubmissionTableEntry) -> bool:
@@ -586,6 +606,7 @@ def assembly_table_create(db_engine: Engine, config: Config):
         logger.debug(
             f"Found {len(ready_to_submit_assembly)} entries in assembly_table in status READY"
         )
+    notifications = {}
     for row in ready_to_submit_assembly:
         seq_key = row.pkey
         submission_rows = find_conditions_in_db(
@@ -603,7 +624,9 @@ def assembly_table_create(db_engine: Engine, config: Config):
 
         if is_revision(db_engine, seq_key):
             logger.debug(f"Entry {row.accession} is a revision, checking if it can be revised")
-            if not can_be_revised(config, db_engine, submission_row):
+            can_revise, notification = can_be_revised(config, db_engine, submission_row)
+            notifications[seq_key.accession] = notification
+            if not can_revise:
                 continue
             if not is_flatfile_data_changed(db_engine, submission_row):
                 update_assembly_results_with_latest_version(db_engine, seq_key)
@@ -666,6 +689,22 @@ def assembly_table_create(db_engine: Engine, config: Config):
                 seq_key=asdict(row.pkey),
                 update_type="creation",
             )
+
+    if len(notifications) > 0:
+        file_path = "assembly_creation_notifications.json"
+        Path(file_path).write_text(json.dumps(notifications, indent=2), encoding="utf-8")
+        upload_file_with_comment(
+            config=slack_conn_init(
+                slack_hook_default=config.slack_hook,
+                slack_token_default=config.slack_token,
+                slack_channel_id_default=config.slack_channel_id,
+            ),
+            file_path=file_path,
+            comment=(
+                f"Assembly creation notifications for {len(notifications)} "
+                "entries in assembly_table"
+            ),
+        )
 
 
 _last_ena_check: datetime | None = None

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -452,7 +452,7 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
             return False
     if config.allow_revision_with_manifest_changes:
         logger.debug(
-            "allow_revision_with_manifest_changes is True, skipping manifest field comparison for revision"
+            "allow_revision_with_manifest_changes=True, skipping manifest field comparison"
         )
         return True
     return not manifest_fields_changed(config, db_engine, submission_row, last_version_entry)


### PR DESCRIPTION
Working out how hard it would be to send extra notifications for actually submitted sequences - right now we can only report errors via Slack.

Example in this case is manifest changes in revision: how to tell us on slack so we can watch out for whether it propagates.

This is more PoC, it's probably not worth the hassle right now.

Sidenote: I think slack config could be made part of Config to not have to create at every usage point.

 elated to #6808

🚀 Preview: Add `preview` label to enable