### PR TITLE
feat(backend): keep only latest preprocessing pipeline version

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,10 +1,10 @@
 Kotlin dependent packages have already been installed for you.
 
-Run tests like this (if you have Docker set up properly):
+First check whether Docker is present (e.g. `docker info`). If it is, prefer running tests through Docker:
 
 ./gradlew test --console=plain
 
-If that doesn't work due to Docker issues because you're running inside a cloud environment, try this:
+Only fall back to the non-Docker route if Docker is not present or the Docker-based run fails (e.g. when running inside a cloud environment):
 
 USE_NONDOCKER_INFRA=true ./gradlew test --console=plain
 

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/UseNewerProcessingPipelineVersionTask.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/UseNewerProcessingPipelineVersionTask.kt
@@ -31,7 +31,7 @@ class UseNewerProcessingPipelineVersionTask(private val submissionDatabaseServic
 
         newVersions.forEach { (organism, latestVersion) ->
             if (latestVersion != null) {
-                submissionDatabaseService.cleanUpOutdatedPreprocessingData(organism, latestVersion - 1)
+                submissionDatabaseService.cleanUpOutdatedPreprocessingData(organism, latestVersion)
             }
         }
 

--- a/backend/src/test/kotlin/org/loculus/backend/service/submission/UseNewerProcessingPipelineVersionTaskTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/submission/UseNewerProcessingPipelineVersionTaskTest.kt
@@ -153,8 +153,9 @@ class UseNewerProcessingPipelineVersionTaskTest(
         useNewerProcessingPipelineVersionTask.task()
 
         transaction {
-            // check that nothing got deleted yet
-            assertThat(getExistingPipelineVersions(DEFAULT_ORGANISM), `is`(listOf(1L, 2L)))
+            // check that v1 for DEFAULT_ORGANISM is deleted (only the latest version is kept),
+            // but OTHER_ORGANISM is untouched
+            assertThat(getExistingPipelineVersions(DEFAULT_ORGANISM), `is`(listOf(2L)))
             assertThat(getExistingPipelineVersions(OTHER_ORGANISM), `is`(listOf(1L)))
         }
 
@@ -166,8 +167,8 @@ class UseNewerProcessingPipelineVersionTaskTest(
         assertThat(submissionDatabaseService.getCurrentProcessingPipelineVersion(Organism(DEFAULT_ORGANISM)), `is`(3L))
 
         transaction {
-            // check that v1 for DEFAULT_ORGANISM is deleted, but not for OTHER_ORGANISM
-            assertThat(getExistingPipelineVersions(DEFAULT_ORGANISM), `is`(listOf(2L, 3L)))
+            // check that only the latest version (v3) for DEFAULT_ORGANISM remains, but not for OTHER_ORGANISM
+            assertThat(getExistingPipelineVersions(DEFAULT_ORGANISM), `is`(listOf(3L)))
             assertThat(getExistingPipelineVersions(OTHER_ORGANISM), `is`(listOf(1L)))
         }
     }


### PR DESCRIPTION
## Summary

The pipeline-version garbage collector (`UseNewerProcessingPipelineVersionTask`) runs after the backend bumps an organism to a newer preprocessing pipeline version, deleting outdated preprocessed data. Previously it retained the **two most recent** pipeline versions by passing `latestVersion - 1` as the earliest version to keep.

This PR changes it to keep **only the latest** version (passing `latestVersion`), so older preprocessed data is no longer retained unnecessarily — keeping only what's needed.

## Changes

- **`UseNewerProcessingPipelineVersionTask.kt`**: pass `latestVersion` instead of `latestVersion - 1` to `cleanUpOutdatedPreprocessingData`. This is the only behavioral change; the deletion is still scoped per-organism and only triggers when a version upgrade actually happens.
- **`UseNewerProcessingPipelineVersionTaskTest.kt`**: updated the existing GC test assertions to expect only the latest version surviving (`[2L]` after the v2 bump, `[3L]` after v3), with clarified comments. The per-organism scoping assertions (`OTHER_ORGANISM` untouched) are unchanged.
- **`backend/AGENTS.md`**: clarified test instructions to check for Docker first and prefer the Docker route, falling back to `USE_NONDOCKER_INFRA=true` only when Docker is absent or its run fails.

## Testing

`./gradlew test --tests "...UseNewerProcessingPipelineVersionTaskTest"` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable