### PR TITLE
fix(website): prevent Tools button label wrapping on mobile

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.spec.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.spec.tsx
@@ -50,6 +50,21 @@ const linkOuts = [
 ];
 
 describe('LinkOutMenu with enabled data use terms', () => {
+    test('prevents the tools button label from wrapping', () => {
+        render(
+            <LinkOutMenu
+                downloadUrlGenerator={realDownloadUrlGenerator}
+                sequenceFilter={mockSequenceFilter}
+                sequenceCount={1}
+                linkOuts={linkOuts}
+                dataUseTermsEnabled={true}
+                referenceGenomesInfo={SINGLE_SEG_SINGLE_REF_REFERENCEGENOMES}
+            />,
+        );
+
+        expect(screen.getByRole('button', { name: /Tools/ })).toHaveClass('whitespace-nowrap');
+    });
+
     test('opens modal when a tool is clicked', () => {
         render(
             <LinkOutMenu

--- a/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.spec.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.spec.tsx
@@ -50,21 +50,6 @@ const linkOuts = [
 ];
 
 describe('LinkOutMenu with enabled data use terms', () => {
-    test('prevents the tools button label from wrapping', () => {
-        render(
-            <LinkOutMenu
-                downloadUrlGenerator={realDownloadUrlGenerator}
-                sequenceFilter={mockSequenceFilter}
-                sequenceCount={1}
-                linkOuts={linkOuts}
-                dataUseTermsEnabled={true}
-                referenceGenomesInfo={SINGLE_SEG_SINGLE_REF_REFERENCEGENOMES}
-            />,
-        );
-
-        expect(screen.getByRole('button', { name: /Tools/ })).toHaveClass('whitespace-nowrap');
-    });
-
     test('opens modal when a tool is clicked', () => {
         render(
             <LinkOutMenu

--- a/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
@@ -207,7 +207,7 @@ export const LinkOutMenu: FC<LinkOutMenuProps> = ({
                 <MenuButton
                     className={buttonClasses({
                         variant: 'outline',
-                        className: 'flex items-center min-w-[100px] justify-between',
+                        className: 'flex items-center min-w-[100px] justify-between whitespace-nowrap',
                     })}
                     onClick={() => setIsOpen(!isOpen)}
                 >


### PR DESCRIPTION
Resolves https://github.com/loculus-project/loculus/issues/6802

Before:

<img width="1080" height="1003" alt="image" src="https://github.com/user-attachments/assets/8616c5cb-07e2-4c83-b9ee-c379c8dc1019" />

After:

<img width="1080" height="885" alt="Screenshot_20260701-030433" src="https://github.com/user-attachments/assets/0240f5c2-3193-414c-bc39-a51bceb15616" />

Supercedes #6805

🚀 Preview: https://fix-tools-button.loculus.org