### PR TITLE
fix(backend,website): remove broken, unused `/get-user-cited-by-seqset` endpoint

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/api/SeqSetCitations.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SeqSetCitations.kt
@@ -117,21 +117,6 @@ data class SequenceCitation(val source: CitationSource, val seqSets: List<SeqSet
 
 data class ResponseSeqSet(val seqSetId: String, val seqSetVersion: Long)
 
-data class CitedBy(
-    @Schema(
-        description = "The years in which the SeqSet or sequence was cited.",
-        type = "array",
-        example = "[2000, 2001, 2002]",
-    )
-    val years: MutableList<Long>,
-    @Schema(
-        description = "The number of citations per year.",
-        type = "array",
-        example = "[1, 2, 3]",
-    )
-    val citations: MutableList<Long>,
-)
-
 data class AuthorProfile(
     val username: String,
     val firstName: String,

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SeqSetCitationsController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SeqSetCitationsController.kt
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import org.loculus.backend.api.AccessionVersion
 import org.loculus.backend.api.AuthorProfile
-import org.loculus.backend.api.CitedBy
 import org.loculus.backend.api.ResponseSeqSet
 import org.loculus.backend.api.SeqSet
 import org.loculus.backend.api.SeqSetCitation
@@ -19,7 +18,6 @@ import org.loculus.backend.config.BackendSpringProperty
 import org.loculus.backend.config.ENABLE_SEQSETS_TRUE_VALUE
 import org.loculus.backend.service.KeycloakAdapter
 import org.loculus.backend.service.seqsetcitations.SeqSetCitationsDatabaseService
-import org.loculus.backend.service.submission.SubmissionDatabaseService
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -39,7 +37,6 @@ import org.springframework.web.bind.annotation.RestController
 )
 class SeqSetCitationsController(
     private val seqSetCitationsService: SeqSetCitationsDatabaseService,
-    private val submissionDatabaseService: SubmissionDatabaseService,
     private val keycloakAdapter: KeycloakAdapter,
 ) {
     @Operation(description = "Get a SeqSet")
@@ -98,13 +95,6 @@ class SeqSetCitationsController(
         @RequestParam seqSetId: String,
         @RequestParam version: Long,
     ): ResponseSeqSet = seqSetCitationsService.createSeqSetDOI(authenticatedUser, seqSetId, version)
-
-    @Operation(description = "Get count of user sequences cited by SeqSets")
-    @GetMapping("/get-user-cited-by-seqset")
-    fun getUserCitedBySeqSet(@HiddenParam authenticatedUser: AuthenticatedUser): CitedBy =
-        seqSetCitationsService.getUserCitedBySeqSet(
-            submissionDatabaseService.getApprovedUserAccessionVersions(authenticatedUser),
-        )
 
     @Operation(description = "Get citations for a SeqSet from publications or other sources")
     @GetMapping("/get-seqset-citations")

--- a/backend/src/main/kotlin/org/loculus/backend/service/seqsetcitations/SeqSetCitationsDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/seqsetcitations/SeqSetCitationsDatabaseService.kt
@@ -6,14 +6,12 @@ import kotlinx.datetime.toJavaLocalDateTime
 import kotlinx.datetime.toLocalDateTime
 import mu.KotlinLogging
 import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.JoinType
 import org.jetbrains.exposed.sql.LikePattern
 import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.inList
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
-import org.jetbrains.exposed.sql.alias
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.andWhere
 import org.jetbrains.exposed.sql.batchInsert
@@ -29,7 +27,6 @@ import org.loculus.backend.api.AccessionVersion
 import org.loculus.backend.api.AuthorProfile
 import org.loculus.backend.api.CitationOrigin
 import org.loculus.backend.api.CitationSource
-import org.loculus.backend.api.CitedBy
 import org.loculus.backend.api.ResponseSeqSet
 import org.loculus.backend.api.SeqSet
 import org.loculus.backend.api.SeqSetCitation
@@ -440,73 +437,6 @@ class SeqSetCitationsDatabaseService(
 
         // Return upserted citation sources
         return CitationSourcesUpdateResult(matchedSources.mapTo(mutableSetOf()) { it.source.sourceDOI })
-    }
-
-    fun getUserCitedBySeqSet(accessionVersions: List<AccessionVersion>): CitedBy {
-        log.info { "Get user cited by seqSet" }
-
-        data class SeqSetWithAccession(
-            val accession: String,
-            val seqSetId: String,
-            val seqSetVersion: Long,
-            val createdAt: Timestamp,
-        )
-
-        val userAccessionStrings = accessionVersions
-            .flatMap { listOf(it.accession, it.displayAccessionVersion()) }
-            .toSet()
-
-        val maxSeqSetVersion = SeqSetsTable.seqSetVersion.max().alias("max_version")
-        val maxVersionPerSeqSet = SeqSetsTable
-            .select(SeqSetsTable.seqSetId, maxSeqSetVersion)
-            .groupBy(SeqSetsTable.seqSetId)
-            .alias("maxVersionPerSeqSet")
-
-        val latestSeqSetWithUserAccession = SeqSetRecordsTable
-            .innerJoin(SeqSetToRecordsTable)
-            .innerJoin(SeqSetsTable)
-            .join(
-                maxVersionPerSeqSet,
-                JoinType.INNER,
-                additionalConstraint = {
-                    (SeqSetToRecordsTable.seqSetId eq maxVersionPerSeqSet[SeqSetsTable.seqSetId]) and
-                        (SeqSetToRecordsTable.seqSetVersion eq maxVersionPerSeqSet[maxSeqSetVersion])
-                },
-            )
-            .selectAll()
-            .where { (SeqSetRecordsTable.accession inList userAccessionStrings) }
-            .map {
-                SeqSetWithAccession(
-                    it[SeqSetRecordsTable.accession],
-                    it[SeqSetToRecordsTable.seqSetId],
-                    it[SeqSetToRecordsTable.seqSetVersion],
-                    Timestamp.valueOf(it[SeqSetsTable.createdAt].toJavaLocalDateTime()),
-                )
-            }
-
-        val citedBy = CitedBy(
-            mutableListOf(),
-            mutableListOf(),
-        )
-
-        val uniqueSeqSetIds = latestSeqSetWithUserAccession.map { it.seqSetId }.toSet()
-        for (seqSetId in uniqueSeqSetIds) {
-            val year = latestSeqSetWithUserAccession
-                .first { it.seqSetId == seqSetId }
-                .createdAt.toLocalDateTime().year.toLong()
-            if (citedBy.years.contains(year)) {
-                val index = citedBy.years.indexOf(year)
-                while (index >= citedBy.citations.size) {
-                    citedBy.citations.add(0)
-                }
-                citedBy.citations[index] = citedBy.citations[index] + 1
-            } else {
-                citedBy.years.add(year)
-                citedBy.citations.add(1)
-            }
-        }
-
-        return citedBy
     }
 
     fun getSeqSetCitations(seqSetId: String, version: Long): List<SeqSetCitation> {

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -1244,24 +1244,6 @@ class SubmissionDatabaseService(
         )
     }
 
-    /**
-     * Returns AccessionVersions submitted by groups that the given user is part of
-     * and that are approved for release.
-     */
-    fun getApprovedUserAccessionVersions(authenticatedUser: AuthenticatedUser): List<AccessionVersion> =
-        SequenceEntriesView.select(
-            SequenceEntriesView.accessionColumn,
-            SequenceEntriesView.versionColumn,
-        )
-            .where(SequenceEntriesView.statusIs(APPROVED_FOR_RELEASE))
-            .groupBy(getGroupCondition(null, authenticatedUser))
-            .map {
-                AccessionVersion(
-                    it[SequenceEntriesView.accessionColumn],
-                    it[SequenceEntriesView.versionColumn],
-                )
-            }
-
     private fun submittedMetadataFilter(
         authenticatedUser: AuthenticatedUser,
         organism: Organism,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/CitationEndpointsTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/CitationEndpointsTest.kt
@@ -10,22 +10,17 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import org.loculus.backend.api.AccessionVersion
 import org.loculus.backend.api.CitationContributor
 import org.loculus.backend.api.CitationSource
 import org.loculus.backend.api.SeqSetCitationSource
-import org.loculus.backend.controller.DEFAULT_USER_NAME
 import org.loculus.backend.controller.EndpointTest
-import org.loculus.backend.controller.expectUnauthorizedResponse
 import org.loculus.backend.service.crossref.CrossRefCitedByResult
 import org.loculus.backend.service.crossref.CrossRefService
 import org.loculus.backend.service.scheduler.TASK_LOCK_TABLE_NAME
 import org.loculus.backend.service.seqsetcitations.SeqSetCrossRefCitationsTask
 import org.loculus.backend.service.submission.AccessionPreconditionValidator
-import org.loculus.backend.service.submission.SubmissionDatabaseService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
-import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -36,9 +31,6 @@ class CitationEndpointsTest(
     @Autowired private val seqSetCrossRefCitationsTask: SeqSetCrossRefCitationsTask,
 ) {
     @MockkBean
-    lateinit var submissionDatabaseService: SubmissionDatabaseService
-
-    @MockkBean
     lateinit var accessionPreconditionValidator: AccessionPreconditionValidator
 
     @MockkBean
@@ -46,62 +38,12 @@ class CitationEndpointsTest(
 
     @BeforeEach
     fun setup() {
-        every {
-            submissionDatabaseService.getApprovedUserAccessionVersions(
-                match { it.username == DEFAULT_USER_NAME },
-            )
-        } returns listOf(AccessionVersion(MOCK_SEQ_ACCESSION, MOCK_SEQ_VERSION))
         every { accessionPreconditionValidator.validate(any()) } returns Unit
         every { crossRefService.doiPrefix } returns MOCK_DOI_PREFIX
         every { crossRefService.isActive } returns true
         every { crossRefService.isWriteEnabled } returns true
         every { crossRefService.generateCrossRefXML(any()) } returns "<doi_batch/>"
         every { crossRefService.postCrossRefXML(any()) } returns "Crossref API response"
-    }
-
-    @ParameterizedTest
-    @MethodSource("authorizationTestCases")
-    fun `GIVEN invalid authorization token WHEN performing action THEN returns 401 Unauthorized`(scenario: Scenario) {
-        expectUnauthorizedResponse(isModifyingRequest = scenario.isModifying) {
-            scenario.testFunction(it, client)
-        }
-    }
-
-    @Test
-    fun `WHEN calling get user cited by seqSet for user sequences not in any seqSet THEN returns empty results`() {
-        client.getUserCitedBySeqSet()
-            .andExpect(status().isOk)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(jsonPath("\$.years").isArray)
-            .andExpect(jsonPath("\$.years").isEmpty)
-            .andExpect(jsonPath("\$.citations").isArray)
-            .andExpect(jsonPath("\$.citations").isEmpty)
-    }
-
-    @Test
-    fun `WHEN calling get user cited by seqSet for user sequences in a seqSet THEN returns results`() {
-        val seqSetResult = client.createSeqSet()
-            .andExpect(status().isOk)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(jsonPath("\$.seqSetId").isString)
-            .andExpect(jsonPath("\$.seqSetVersion").value(1))
-            .andReturn()
-
-        client.getUserCitedBySeqSet()
-            .andExpect(status().isOk)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(jsonPath("\$.years").isArray)
-            .andExpect(jsonPath("\$.years").isNotEmpty)
-            .andExpect(jsonPath("\$.years[0]").isNumber)
-            .andExpect(jsonPath("\$.citations").isArray)
-            .andExpect(jsonPath("\$.citations").isNotEmpty)
-            .andExpect(jsonPath("\$.citations[0]").value(1))
-
-        val seqSetId = JsonPath.read<String>(seqSetResult.response.contentAsString, "$.seqSetId")
-        val seqSetVersion = JsonPath.read<Int>(seqSetResult.response.contentAsString, "$.seqSetVersion").toLong()
-
-        client.deleteSeqSet(seqSetId, seqSetVersion)
-            .andExpect(status().isOk)
     }
 
     @Test
@@ -287,11 +229,6 @@ class CitationEndpointsTest(
     }
 
     companion object {
-        data class Scenario(
-            val testFunction: (String?, SeqSetCitationsControllerClient) -> ResultActions,
-            val isModifying: Boolean,
-        )
-
         data class SequenceCitationVersionCase(
             val description: String,
             val citationsMap: Map<String, String>,
@@ -301,11 +238,6 @@ class CitationEndpointsTest(
         ) {
             override fun toString() = description
         }
-
-        @JvmStatic
-        fun authorizationTestCases(): List<Scenario> = listOf(
-            Scenario({ jwt, client -> client.getUserCitedBySeqSet(jwt = jwt) }, false),
-        )
 
         @JvmStatic
         fun sequenceCitationVersionCases(): List<SequenceCitationVersionCase> {

--- a/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/SeqSetCitationsControllerClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/SeqSetCitationsControllerClient.kt
@@ -114,11 +114,6 @@ class SeqSetCitationsControllerClient(private val mockMvc: MockMvc) {
             .withAuth(jwt),
     )
 
-    fun getUserCitedBySeqSet(jwt: String? = jwtForDefaultUser): ResultActions = mockMvc.perform(
-        get("/get-user-cited-by-seqset")
-            .withAuth(jwt),
-    )
-
     fun getSeqSetCitations(
         seqSetId: String = MOCK_SEQSET_ID,
         seqSetVersion: Long = MOCK_SEQSET_VERSION,

--- a/website/src/services/seqSetCitationApi.ts
+++ b/website/src/services/seqSetCitationApi.ts
@@ -2,14 +2,7 @@ import { makeApi, makeEndpoint } from '@zodios/core';
 import z from 'zod';
 
 import { authorizationHeader, notAuthorizedError } from './commonApiTypes.ts';
-import {
-    authorProfile,
-    seqSets,
-    seqSetRecords,
-    citedByResult,
-    seqSetCitations,
-    sequenceCitations,
-} from '../types/seqSetCitation.ts';
+import { authorProfile, seqSets, seqSetRecords, seqSetCitations, sequenceCitations } from '../types/seqSetCitation.ts';
 
 const getSeqSetsOfUserEndpoint = makeEndpoint({
     method: 'get',
@@ -17,15 +10,6 @@ const getSeqSetsOfUserEndpoint = makeEndpoint({
     alias: 'getSeqSetsOfUser',
     parameters: [authorizationHeader],
     response: seqSets,
-    errors: [notAuthorizedError],
-});
-
-const getUserCitedByEndpoint = makeEndpoint({
-    method: 'get',
-    path: '/get-user-cited-by-seqset?username=:username',
-    alias: 'getUserCitedBy',
-    parameters: [authorizationHeader],
-    response: citedByResult,
     errors: [notAuthorizedError],
 });
 
@@ -194,7 +178,6 @@ const getAuthorEndpoint = makeEndpoint({
 
 export const seqSetCitationApi = makeApi([
     getSeqSetsOfUserEndpoint,
-    getUserCitedByEndpoint,
     getSeqSetCitationsEndpoint,
     getSequenceCitationsEndpoint,
     getSeqSetEndpoint,

--- a/website/src/services/seqSetCitationClient.ts
+++ b/website/src/services/seqSetCitationClient.ts
@@ -23,13 +23,6 @@ export class SeqSetCitationClient extends ZodiosWrapperClient<typeof seqSetCitat
         });
     }
 
-    public getUserCitedBy(username: string, accessToken: string) {
-        return this.call('getUserCitedBy', {
-            params: { username },
-            headers: createAuthorizationHeader(accessToken),
-        });
-    }
-
     public getAuthor(username: string) {
         return this.call('getAuthor', { params: { username } });
     }

--- a/website/src/types/seqSetCitation.ts
+++ b/website/src/types/seqSetCitation.ts
@@ -24,12 +24,6 @@ export const seqSet = z.object({
 export const seqSets = z.array(seqSet);
 export type SeqSet = z.infer<typeof seqSet>;
 
-export const citedByResult = z.object({
-    years: z.array(z.number()),
-    citations: z.array(z.number()),
-});
-export type CitedByResult = z.infer<typeof citedByResult>;
-
 export const authorProfile = z.object({
     username: z.string(),
     firstName: z.string(),


### PR DESCRIPTION
Resolves #6819
Resolves #6497

The endpoint is broken and unused for more than a year. Removing it makes it easier to understand the codebase. Even if bug is fixed we wouldn't use it.

🚀 Preview: Add `preview` label to enable