### PR TITLE
feat(website): Simplify seqset citations section and align with sequence details page display 

### DIFF
--- a/website/src/components/SeqSetCitations/CitationList.tsx
+++ b/website/src/components/SeqSetCitations/CitationList.tsx
@@ -26,25 +26,22 @@ const CitationList: FC<CitationListProps> = ({ citations, maxDisplayedCitations,
             >
                 <CitationTable isLoading={false} error={null} citations={citations} />
             </BaseDialog>
-            {citations.length > 0 && (
-                <div className='space-y-2'>
-                    <ul className='space-y-4'>
-                        {(maxDisplayedCitations !== undefined
-                            ? citations.slice(0, maxDisplayedCitations)
-                            : citations
-                        ).map((citation: SeqSetCitation | SequenceCitation) => (
+            <div className='space-y-2'>
+                <ul className='space-y-4'>
+                    {(maxDisplayedCitations !== undefined ? citations.slice(0, maxDisplayedCitations) : citations).map(
+                        (citation: SeqSetCitation | SequenceCitation) => (
                             <li key={citation.source.sourceDOI}>
                                 <CitationDetails citation={citation} className='text-sm' displayYear />
                             </li>
-                        ))}
-                    </ul>
-                    {displayCitationsModalButton && (
-                        <Button className='text-sm hover:underline' onClick={() => setIsOpen(true)}>
-                            View all citations ({citations.length})...
-                        </Button>
+                        ),
                     )}
-                </div>
-            )}
+                </ul>
+                {displayCitationsModalButton && (
+                    <Button className='text-sm hover:underline' onClick={() => setIsOpen(true)}>
+                        View all citations ({citations.length})...
+                    </Button>
+                )}
+            </div>
         </div>
     );
 };

--- a/website/src/components/SeqSetCitations/CitationList.tsx
+++ b/website/src/components/SeqSetCitations/CitationList.tsx
@@ -26,7 +26,7 @@ const CitationList: FC<CitationListProps> = ({ citations, maxDisplayedCitations,
             >
                 <CitationTable isLoading={false} error={null} citations={citations} />
             </BaseDialog>
-            {citations.length > 0 ? (
+            {citations.length > 0 && (
                 <div className='space-y-2'>
                     <ul className='space-y-4'>
                         {(maxDisplayedCitations !== undefined
@@ -43,10 +43,6 @@ const CitationList: FC<CitationListProps> = ({ citations, maxDisplayedCitations,
                             View all citations ({citations.length})...
                         </Button>
                     )}
-                </div>
-            ) : (
-                <div className='py-8 text-center'>
-                    <span>No citations found.</span>
                 </div>
             )}
         </div>

--- a/website/src/components/SeqSetCitations/CitationList.tsx
+++ b/website/src/components/SeqSetCitations/CitationList.tsx
@@ -24,6 +24,7 @@ const CitationList: FC<CitationListProps> = ({ citations, maxDisplayedCitations,
                 fullWidth={false}
                 className='min-h-[60vh]'
             >
+                <div className='w-[1000px]'></div>
                 <CitationTable isLoading={false} error={null} citations={citations} />
             </BaseDialog>
             <ul className='space-y-4'>

--- a/website/src/components/SeqSetCitations/CitationList.tsx
+++ b/website/src/components/SeqSetCitations/CitationList.tsx
@@ -26,22 +26,20 @@ const CitationList: FC<CitationListProps> = ({ citations, maxDisplayedCitations,
             >
                 <CitationTable isLoading={false} error={null} citations={citations} />
             </BaseDialog>
-            <div className='space-y-2'>
-                <ul className='space-y-4'>
-                    {(maxDisplayedCitations !== undefined ? citations.slice(0, maxDisplayedCitations) : citations).map(
-                        (citation: SeqSetCitation | SequenceCitation) => (
-                            <li key={citation.source.sourceDOI}>
-                                <CitationDetails citation={citation} className='text-sm' displayYear />
-                            </li>
-                        ),
-                    )}
-                </ul>
-                {displayCitationsModalButton && (
-                    <Button className='text-sm hover:underline' onClick={() => setIsOpen(true)}>
-                        View all citations ({citations.length})...
-                    </Button>
+            <ul className='space-y-4'>
+                {(maxDisplayedCitations !== undefined ? citations.slice(0, maxDisplayedCitations) : citations).map(
+                    (citation: SeqSetCitation | SequenceCitation) => (
+                        <li key={citation.source.sourceDOI}>
+                            <CitationDetails citation={citation} className='text-sm' displayYear />
+                        </li>
+                    ),
                 )}
-            </div>
+            </ul>
+            {displayCitationsModalButton && (
+                <Button className='text-sm hover:underline' onClick={() => setIsOpen(true)}>
+                    View all citations ({citations.length})...
+                </Button>
+            )}
         </div>
     );
 };

--- a/website/src/components/SeqSetCitations/SeqSetItem.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItem.tsx
@@ -1,8 +1,9 @@
 import MUIPagination from '@mui/material/Pagination';
 import { AxiosError } from 'axios';
-import { type FC, useMemo, useState } from 'react';
+import { type FC, useState } from 'react';
 import { toast } from 'react-toastify';
 
+import CitationList from './CitationList.tsx';
 import { DatePlot, CategoryPlot } from './SeqSetPlots.tsx';
 import { SeqSetRecordsTableWithMetadata } from './SeqSetRecordsTableWithMetadata';
 import type { AggregateRow } from './getSeqSetStatistics.ts';
@@ -11,12 +12,11 @@ import { seqSetCitationClientHooks } from '../../services/serviceHooks';
 import type { ProblemDetail } from '../../types/backend.ts';
 import type { SeqSetGraph } from '../../types/config.ts';
 import type { ClientConfig } from '../../types/runtimeConfig';
-import { type SeqSet, type SeqSetRecord } from '../../types/seqSetCitation';
+import { type SeqSet, type SeqSetCitation, type SeqSetRecord } from '../../types/seqSetCitation';
 import { createAuthorizationHeader } from '../../utils/createAuthorizationHeader';
 import { getThemeColor } from '../../utils/getThemeColor';
 import { displayConfirmationDialog } from '../ConfirmationDialog.tsx';
 import { Button } from '../common/Button.tsx';
-import { Spinner } from '../common/Spinner';
 import { withQueryProvider } from '../common/withQueryProvider.tsx';
 import MdiDotsGrid from '~icons/mdi/dots-grid';
 import MdiViewGrid from '~icons/mdi/view-grid';
@@ -53,6 +53,7 @@ type SeqSetItemProps = {
     seqSetAccessionVersion: string;
     seqSet: SeqSet;
     seqSetRecords: SeqSetRecord[];
+    seqSetCitations: SeqSetCitation[];
     seqSetGraphs: SeqSetGraph[];
     seqSetGraphsData: Record<string, AggregateRow[]>;
     isAdminView?: boolean;
@@ -66,6 +67,7 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
     seqSetAccessionVersion,
     seqSet,
     seqSetRecords,
+    seqSetCitations,
     seqSetGraphs,
     seqSetGraphsData,
     isAdminView = false,
@@ -75,34 +77,6 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
     const [page, setPage] = useState(1);
     const [wideGraphs, setWideGraphs] = useState(false);
     const sequencesPerPage = 10;
-
-    const {
-        isLoading: isSeqSetCitationsLoading,
-        error: seqSetCitationsError,
-        data: seqSetCitations,
-    } = seqSetCitationClientHooks(clientConfig).useGetSeqSetCitations({
-        params: { seqSetId: seqSet.seqSetId, version: seqSet.seqSetVersion },
-    });
-
-    const totalCitations = useMemo(() => {
-        if (isSeqSetCitationsLoading || seqSetCitationsError) return 0;
-
-        return seqSetCitations.length;
-    }, [isSeqSetCitationsLoading, seqSetCitationsError, seqSetCitations]);
-
-    const citationDates: AggregateRow[] = useMemo(() => {
-        if (isSeqSetCitationsLoading || seqSetCitationsError) return [];
-
-        const citationDatesAggregate = new Map<string, number>();
-        seqSetCitations.forEach((citation) => {
-            const year = String(citation.source.year);
-            citationDatesAggregate.set(year, (citationDatesAggregate.get(year) ?? 0) + 1);
-        });
-        return Array.from(citationDatesAggregate.entries()).map(([year, citations]) => ({
-            value: year,
-            count: citations,
-        }));
-    }, [isSeqSetCitationsLoading, seqSetCitationsError, seqSetCitations]);
 
     const { mutate: createSeqSetDOI } = useCreateSeqSetDOIAction(
         clientConfig,
@@ -182,26 +156,17 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
                 <SeqSetSection title='Citations'>
                     <SeqSetSectionEntry label='DOI' value={renderDOI()} />
                     <SeqSetSectionEntry
-                        label='Total citations'
+                        label='Cited in'
                         value={
-                            isSeqSetCitationsLoading ? (
-                                <Spinner size='xs' />
-                            ) : seqSetCitationsError ? (
-                                <span>Failed to load citations.</span>
+                            seqSetCitations.length > 0 ? (
+                                <CitationList
+                                    citations={seqSetCitations}
+                                    maxDisplayedCitations={3}
+                                    modalTitle='SeqSet Citations'
+                                />
                             ) : (
-                                <span>Cited by {totalCitations}</span>
+                                <span>No citations found.</span>
                             )
-                        }
-                    />
-                    <SeqSetSectionEntry
-                        label='Citations over time'
-                        value={
-                            <DatePlot
-                                data={citationDates}
-                                description='Number of times this SeqSet has been cited by a publication'
-                                barColor={barPlotColor}
-                                dateFormat='yyyy'
-                            />
                         }
                     />
                 </SeqSetSection>

--- a/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
@@ -11,7 +11,6 @@ import type { AuthorProfile, SeqSetRecord, SeqSet } from '../../types/seqSetCita
 import { createAuthorizationHeader } from '../../utils/createAuthorizationHeader';
 import { getAccessionVersionString } from '../../utils/extractAccessionVersion.ts';
 import { displayConfirmationDialog } from '../ConfirmationDialog.tsx';
-import { CitationTable } from './CitationTable.tsx';
 import { BaseDialog } from '../common/BaseDialog.tsx';
 import { Button } from '../common/Button';
 import { withQueryProvider } from '../common/withQueryProvider.tsx';
@@ -19,7 +18,6 @@ import MdiDelete from '~icons/mdi/delete';
 import MdiDownload from '~icons/mdi/download';
 import MdiInformationOutline from '~icons/mdi/information-outline';
 import MdiPencil from '~icons/mdi/pencil';
-import MdiViewListOutline from '~icons/mdi/view-list-outline';
 
 const logger = getClientLogger('SeqSetItemActions');
 
@@ -56,16 +54,7 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
 
     const [editModalVisible, setEditModalVisible] = useState(false);
     const [exportModalVisible, setExportModalVisible] = useState(false);
-    const [citationsModalVisible, setCitationsModalVisible] = useState(false);
     const [creatorInfoVisible, setCreatorInfoVisible] = useState(false);
-
-    const {
-        isLoading: isSeqSetCitationsLoading,
-        error: seqSetCitationsError,
-        data: seqSetCitations,
-    } = seqSetCitationClientHooks(clientConfig).useGetSeqSetCitations({
-        params: { seqSetId: seqSet.seqSetId, version: seqSet.seqSetVersion },
-    });
 
     const { mutate: deleteSeqSet } = useDeleteSeqSetAction(
         clientConfig,
@@ -114,14 +103,6 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
                     >
                         <MdiInformationOutline className='w-4 h-4' />
                         <span className='hidden sm:block'>More details</span>
-                    </Button>
-                    <Button
-                        variant='outline'
-                        className='flex items-center gap-2'
-                        onClick={() => setCitationsModalVisible(true)}
-                    >
-                        <MdiViewListOutline className='w-4 h-4' />
-                        <span className='hidden sm:block'>View Citations ({seqSetCitations?.length ?? 0})</span>
                     </Button>
                     {isAdminView ? (
                         <Button
@@ -174,20 +155,6 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
             >
                 <div className='min-w-[1000px]'></div>
                 <ExportSeqSet seqSet={seqSet} seqSetRecords={seqSetRecords} databaseName={databaseName} />
-            </BaseDialog>
-            <BaseDialog
-                isOpen={citationsModalVisible}
-                onClose={() => setCitationsModalVisible(false)}
-                title='SeqSet Citations'
-                fullWidth={false}
-                className='min-h-[60vh]'
-            >
-                <div className='min-w-3xl'></div>
-                <CitationTable
-                    isLoading={isSeqSetCitationsLoading}
-                    error={seqSetCitationsError}
-                    citations={seqSetCitations ?? []}
-                />
             </BaseDialog>
             <BaseDialog
                 title='Creator details'

--- a/website/src/pages/seqsets/[seqSetId].[version].astro
+++ b/website/src/pages/seqsets/[seqSetId].[version].astro
@@ -34,6 +34,7 @@ if (!seqSetsAreEnabled()) {
 const seqSetClient = SeqSetCitationClient.create();
 const seqSetVersionsResponse = await seqSetClient.call('getSeqSetVersions', { params: { seqSetId } });
 const seqSetRecordsResponse = await seqSetClient.call('getSeqSetRecords', { params: { seqSetId, version } });
+const seqSetCitationsResponse = await seqSetClient.call('getSeqSetCitations', { params: { seqSetId, version } });
 
 const getSeqSetByVersion = (seqSetVersions: SeqSet[], version: string) => {
     const matchedVersion = seqSetVersions.find((obj) => {
@@ -59,6 +60,7 @@ const seqSetGraphResponses = await Promise.all(
     seqSetGraphs.map((graph) => getSeqSetStatistics(accessions, graph.fields)),
 );
 
+const seqSetCitations = seqSetCitationsResponse.unwrapOr([]);
 const seqSetAuthor = seqSetAuthorResponse.unwrapOr(undefined);
 const seqSetGraphsData = Object.fromEntries(
     seqSetGraphs.map((graph, i) => [graph.name, seqSetGraphResponses[i].unwrapOr([])]),
@@ -67,6 +69,7 @@ const seqSetGraphsData = Object.fromEntries(
 const secondaryErrors = (
     [
         [seqSetAuthorResponse, 'Error while fetching author profile'],
+        [seqSetCitationsResponse, 'Error while fetching seqSet citations'],
         ...seqSetGraphResponses.map((response) => [response, 'Error while fetching seqSet statistics']),
     ] as [Result<unknown, ProblemDetail>, string][]
 ).flatMap(([response, message]) => (response.isErr() ? [`${message}: ${JSON.stringify(response.error)}`] : []));
@@ -119,6 +122,7 @@ const secondaryErrors = (
                     seqSetAccessionVersion={seqSetAccessionVersion}
                     seqSet={seqSetResponse.value}
                     seqSetRecords={seqSetRecordsResponse.value}
+                    seqSetCitations={seqSetCitations}
                     seqSetGraphs={seqSetGraphs}
                     seqSetGraphsData={seqSetGraphsData}
                     isAdminView={seqSetResponse.value.createdBy === username}


### PR DESCRIPTION
### Summary

- Simplifies the display of seqset citations and brings them more in line with how they are displayed on the sequence details page.
- The first three citations are displayed directly on the page, any more and it requires clicking 'View all citations' - which prompts a modal to open.
-  I decided to remove the graph for citations over time, as in practice an individual seqset will likely be cited only a couple of times at most making this graph a bit redundant IMO. Same for the 'total citations' entry. I also removed the 'view citations' modal button as again I now think this is redundant.

### Screenshot

#### Before

<img width="1763" height="634" alt="image" src="https://github.com/user-attachments/assets/fecd77a6-e352-4dbe-9dc7-b7ed8be403dd" />

#### After

<img width="1763" height="493" alt="image" src="https://github.com/user-attachments/assets/30b65844-8a26-464a-a2be-4e575649a5c6" />

<img width="1763" height="632" alt="image" src="https://github.com/user-attachments/assets/16af4171-9e6d-4a16-8700-bfca31509282" />

After clicking on the 'view citations' prompt at >3 citations:

<img width="1778" height="1128" alt="image" src="https://github.com/user-attachments/assets/99ccfd71-ffd7-4fa8-a740-9c27d9c7377d" />



### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable