### PR TITLE
feat(website,backend): notification bell for sequences awaiting review [WIP]

### DIFF
--- a/architecture_docs/notification-bell-review-counts.md
+++ b/architecture_docs/notification-bell-review-counts.md
@@ -1,0 +1,79 @@
+# Notification bell: sequences awaiting review
+
+## Motivation
+
+New users don't discover the submission **approval** step. After uploading, sequences sit
+unapproved (not released) and users are surprised they don't appear (see
+[#6669](https://github.com/loculus-project/loculus/issues/6669)). Reaching the review page today
+takes several clicks and requires first selecting the correct organism, then Submit, then Review —
+2–3 extra clicks if you start on the wrong organism, and new users don't know the path exists.
+
+A notification bell in the top-right header (a familiar web pattern) collapses this to one click:
+click the bell → drawer lists organism/group pairs with unapproved submissions → click a row →
+deep-link straight to that group's review page.
+
+## Scope of the first version
+
+- **Bell + drawer only.** No badge on the Submit button; no mobile sandwich-menu bell (follow-up).
+- **Muted bell always shown when logged in.** Grey bell with no badge when there is nothing to
+  review; primary-coloured bell with a red count badge when there is. Not rendered at all when
+  logged out, to avoid layout shift.
+- **No dismissal.** The bell always reflects current state. See "Future: dismissal" below.
+
+## Count semantics (deliberately cheap)
+
+The count is computed from the base `sequence_entries` table with `released_at IS NULL`, grouped by
+`organism` + `group_id`. This **avoids the join** on `sequence_entries_preprocessed_data` that the
+`sequence_entries_view` status derivation requires, keeping it cheap and index-friendly.
+
+Trade-off: the count includes everything not yet released (RECEIVED / IN_PROCESSING / PROCESSED), so
+some counted sequences may still be processing rather than strictly awaiting approval. This is
+acceptable for a "you have pending work here" nudge. If an exact "awaiting approval" count is ever
+needed, narrow the query to `Status.PROCESSED` via `SequenceEntriesView` instead (documented in code
+on `ReviewCount` and `getReviewCounts`).
+
+A partial index backs the query:
+`migration V1.34__index_unreleased_sequence_entries.sql` →
+`CREATE INDEX ... ON sequence_entries (organism, group_id) WHERE released_at IS NULL;`
+
+## Backend
+
+- **Endpoint:** `GET /my/review-counts` (root-level, not organism-scoped). New controller
+  `NotificationController.kt`, modelled on `AdminDashboardController` (the existing
+  `SubmissionController` is locked to `@RequestMapping("/{organism}")`).
+- **Response:** `List<ReviewCount>` where `ReviewCount(organism, groupId, count)`
+  (`api/SubmissionTypes.kt`). Only groups with count > 0 are returned (a by-product of `GROUP BY`).
+- **Service:** `SubmissionDatabaseService.getReviewCounts(authenticatedUser)`. Scopes to the user's
+  groups (super users see all) — the same group-visibility rule as `getSequences`, but the condition
+  is built against `SequenceEntriesTable` (not the view) so the SQL stays on the base table.
+- **Tests:** `GetReviewCountsEndpointTest.kt` (unauthorized, empty, count-per-group, non-member
+  isolation).
+
+## Website
+
+- **Component:** `components/Navigation/NotificationBell.tsx`, wrapped in `withQueryProvider`.
+  - `backendClientHooks(clientConfig).useGetReviewCounts(...)` polled every 30 s — a single
+    aggregated call (no per-organism fan-out).
+  - `groupManagementClientHooks(clientConfig).useGetGroupsOfUser(...)` to label rows with group
+    names (added `groupManagementClientHooks` to `services/serviceHooks.ts`).
+  - Headless-UI `Menu` popover (same pattern as `OrganismNavigation.tsx`). Each row deep-links via
+    `routes.userSequenceReviewPage(organism, groupId)` — never hand-built.
+  - `MenuButton` is `disabled` until hydration (`useClientFlag`) to avoid flaky Playwright races.
+- **Endpoint definition:** `getReviewCounts` in `services/backendApi.ts`; `reviewCount` /
+  `reviewCountsResponse` zod schemas in `types/backend.ts`.
+- **Mount:** `components/Navigation/Navigation.astro`, in the desktop right-hand nav cluster, gated
+  on `isLoggedIn && accessToken !== undefined`.
+
+## Future: dismissal (not implemented)
+
+To add later without reworking the above: have `getReviewCounts` also return `latestSubmittedAt` per
+(organism, group) — `max(submitted_at)` over the unreleased rows, still base-table only. The
+frontend stores in `localStorage` a map of `"{organism}:{groupId}" → dismissedAt`; a row is "seen"
+(excluded from the badge, still listed in the drawer) when `latestSubmittedAt <= dismissedAt`.
+Clicking a row or a "mark all read" control writes `dismissedAt = now`; a newer submission
+re-surfaces it. No backend state or extra endpoint needed.
+
+## Follow-ups
+
+- Add the bell to the mobile `SandwichMenu`.
+- Optional numeric badge on the Submit nav item.

--- a/backend/docs/db/schema.sql
+++ b/backend/docs/db/schema.sql
@@ -1028,6 +1028,13 @@ CREATE INDEX sequence_entries_submitter_idx ON public.sequence_entries USING btr
 
 
 --
+-- Name: sequence_entries_unreleased_by_organism_group_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sequence_entries_unreleased_by_organism_group_idx ON public.sequence_entries USING btree (organism, group_id) WHERE (released_at IS NULL);
+
+
+--
 -- Name: user_groups_table_user_name_idx; Type: INDEX; Schema: public; Owner: postgres
 --
 

--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -292,6 +292,16 @@ data class GetSequenceResponse(
     val processingResultCounts: Map<ProcessingResult, Int>,
 )
 
+/**
+ * The number of unreleased sequence entries a user has in one group of one organism, used to power the
+ * "sequences awaiting review" notification bell. The count includes everything not yet released
+ * (RECEIVED / IN_PROCESSING / PROCESSED), so some counted entries may still be processing rather than
+ * strictly awaiting approval. This is intentional: it is computed from the base sequence_entries table
+ * only (no join on preprocessed data), which keeps it cheap. If an exact "awaiting approval" count is
+ * ever needed, this could be narrowed to Status.PROCESSED by querying SequenceEntriesView instead.
+ */
+data class ReviewCount(val organism: String, val groupId: Int, val count: Int)
+
 data class SequenceEntryStatus(
     override val accession: Accession,
     override val version: Version,

--- a/backend/src/main/kotlin/org/loculus/backend/controller/NotificationController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/NotificationController.kt
@@ -1,0 +1,24 @@
+package org.loculus.backend.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import org.loculus.backend.api.ReviewCount
+import org.loculus.backend.auth.AuthenticatedUser
+import org.loculus.backend.auth.HiddenParam
+import org.loculus.backend.service.submission.SubmissionDatabaseService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/my")
+@SecurityRequirement(name = "bearerAuth")
+class NotificationController(private val submissionDatabaseService: SubmissionDatabaseService) {
+    @Operation(
+        summary = "Get the number of unreleased sequence entries awaiting review, per organism and group, " +
+            "across all groups the authenticated user belongs to. Powers the notification bell.",
+    )
+    @GetMapping("/review-counts")
+    fun getReviewCounts(@HiddenParam authenticatedUser: AuthenticatedUser): List<ReviewCount> =
+        submissionDatabaseService.getReviewCounts(authenticatedUser)
+}

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -62,6 +62,7 @@ import org.loculus.backend.api.ProcessingResult
 import org.loculus.backend.api.ProcessingResult.HAS_ERRORS
 import org.loculus.backend.api.ProcessingResult.HAS_WARNINGS
 import org.loculus.backend.api.ProcessingResult.NO_ISSUES
+import org.loculus.backend.api.ReviewCount
 import org.loculus.backend.api.SequenceEntryStatus
 import org.loculus.backend.api.SequenceEntryVersionToEdit
 import org.loculus.backend.api.Status
@@ -923,6 +924,37 @@ class SubmissionDatabaseService(
             statusCounts = statusCounts,
             processingResultCounts = processingResultCounts,
         )
+    }
+
+    /**
+     * Counts of unreleased sequence entries per (organism, group) across all of the user's groups, powering the
+     * "sequences awaiting review" notification bell. Only groups with at least one unreleased entry are returned.
+     *
+     * Deliberately queries the base [SequenceEntriesTable] (released_at IS NULL) rather than SequenceEntriesView,
+     * so it avoids the join on preprocessed data and stays cheap (backed by a partial index on the same predicate).
+     * The trade-off is that the count also includes entries that are still RECEIVED / IN_PROCESSING, not only those
+     * PROCESSED and awaiting approval. See [ReviewCount] for details.
+     */
+    fun getReviewCounts(authenticatedUser: AuthenticatedUser): List<ReviewCount> {
+        val groupCondition: Op<Boolean> = if (authenticatedUser.isSuperUser) {
+            Op.TRUE
+        } else {
+            SequenceEntriesTable.groupIdColumn inList
+                groupManagementDatabaseService.getGroupIdsOfUser(authenticatedUser)
+        }
+        val countColumn = Count(stringLiteral("*"))
+
+        return SequenceEntriesTable
+            .select(SequenceEntriesTable.organismColumn, SequenceEntriesTable.groupIdColumn, countColumn)
+            .where { SequenceEntriesTable.releasedAtTimestampColumn.isNull() and groupCondition }
+            .groupBy(SequenceEntriesTable.organismColumn, SequenceEntriesTable.groupIdColumn)
+            .map {
+                ReviewCount(
+                    organism = it[SequenceEntriesTable.organismColumn],
+                    groupId = it[SequenceEntriesTable.groupIdColumn],
+                    count = it[countColumn].toInt(),
+                )
+            }
     }
 
     private fun getStatusCounts(organism: Organism, groupCondition: Op<Boolean>): Map<Status, Int> {

--- a/backend/src/main/resources/db/migration/V1.34__index_unreleased_sequence_entries.sql
+++ b/backend/src/main/resources/db/migration/V1.34__index_unreleased_sequence_entries.sql
@@ -1,0 +1,5 @@
+-- Partial index backing the "sequences awaiting review" notification bell (GET /my/review-counts),
+-- which counts unreleased sequence entries grouped by organism and group.
+CREATE INDEX IF NOT EXISTS sequence_entries_unreleased_by_organism_group_idx
+    ON sequence_entries (organism, group_id)
+    WHERE released_at IS NULL;

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReviewCountsEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReviewCountsEndpointTest.kt
@@ -1,0 +1,72 @@
+package org.loculus.backend.controller.submission
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.keycloak.representations.idm.UserRepresentation
+import org.loculus.backend.controller.ALTERNATIVE_DEFAULT_USER_NAME
+import org.loculus.backend.controller.DEFAULT_ORGANISM
+import org.loculus.backend.controller.DEFAULT_USER_NAME
+import org.loculus.backend.controller.EndpointTest
+import org.loculus.backend.controller.expectUnauthorizedResponse
+import org.loculus.backend.controller.generateJwtFor
+import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
+import org.loculus.backend.controller.groupmanagement.andGetGroupId
+import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles.NUMBER_OF_SEQUENCES
+import org.loculus.backend.service.KeycloakAdapter
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@EndpointTest
+class GetReviewCountsEndpointTest(
+    @Autowired private val client: SubmissionControllerClient,
+    @Autowired private val convenienceClient: SubmissionConvenienceClient,
+    @Autowired private val groupManagementClient: GroupManagementControllerClient,
+) {
+    @MockkBean
+    lateinit var keycloakAdapter: KeycloakAdapter
+
+    @BeforeEach
+    fun setup() {
+        every { keycloakAdapter.getUsersWithName(any()) } returns listOf(UserRepresentation())
+    }
+
+    @Test
+    fun `GIVEN invalid authorization token THEN returns 401 Unauthorized`() {
+        expectUnauthorizedResponse { client.getReviewCounts(jwt = it) }
+    }
+
+    @Test
+    fun `GIVEN no submissions THEN returns empty list`() {
+        client.getReviewCounts()
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("\$", hasSize<Any>(0)))
+    }
+
+    @Test
+    fun `GIVEN unreleased submissions THEN returns count for the organism and group`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        convenienceClient.submitDefaultFiles(username = DEFAULT_USER_NAME, groupId = groupId)
+
+        client.getReviewCounts()
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("\$", hasSize<Any>(1)))
+            .andExpect(jsonPath("\$[0].organism", `is`(DEFAULT_ORGANISM)))
+            .andExpect(jsonPath("\$[0].groupId", `is`(groupId)))
+            .andExpect(jsonPath("\$[0].count", `is`(NUMBER_OF_SEQUENCES)))
+    }
+
+    @Test
+    fun `GIVEN submissions of another group THEN a non-member does not see them`() {
+        val groupId = groupManagementClient.createNewGroup().andGetGroupId()
+        convenienceClient.submitDefaultFiles(username = DEFAULT_USER_NAME, groupId = groupId)
+
+        client.getReviewCounts(jwt = generateJwtFor(ALTERNATIVE_DEFAULT_USER_NAME))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("\$", hasSize<Any>(0)))
+    }
+}

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmissionControllerClient.kt
@@ -172,6 +172,10 @@ class SubmissionControllerClient(private val mockMvc: MockMvc, private val objec
             .param("size", size?.toString()),
     )
 
+    fun getReviewCounts(jwt: String? = jwtForDefaultUser): ResultActions = mockMvc.perform(
+        get("/my/review-counts").withAuth(jwt),
+    )
+
     fun getSequenceEntryToEdit(
         accession: Accession,
         version: Long,

--- a/website/src/components/Navigation/Navigation.astro
+++ b/website/src/components/Navigation/Navigation.astro
@@ -1,11 +1,13 @@
 ---
 import AccessionSearchBox from './AccessionSearchBox.tsx';
 import { NavigationTab } from './NavigationTab.tsx';
+import { NotificationBell } from './NotificationBell.tsx';
 import { OrganismNavigation } from './OrganismNavigation.tsx';
 import { SandwichMenu } from './SandwichMenu.tsx';
 import { cleanOrganism } from './cleanOrganism';
-import { getWebsiteConfig } from '../../config';
+import { getRuntimeConfig, getWebsiteConfig } from '../../config';
 import { navigationItems } from '../../routes/navigationItems';
+import { getAccessToken } from '../../utils/getAccessToken';
 import { getAuthUrl } from '../../utils/getAuthUrl';
 
 interface Props {
@@ -27,6 +29,10 @@ const loginUrl = await getAuthUrl(Astro.url.toString());
 
 const topNavigationItems = navigationItems.top(isLoggedIn, loginUrl);
 const accessionPrefix = getWebsiteConfig().accessionPrefix;
+
+// Only rendered when logged in, so the bell does not cause layout shift for logged-out visitors.
+const accessToken = getAccessToken(Astro.locals.session);
+const clientConfig = getRuntimeConfig().public;
 ---
 
 <div class='flex justify-end relative'>
@@ -49,6 +55,16 @@ const accessionPrefix = getWebsiteConfig().accessionPrefix;
             }
         </div>
         <AccessionSearchBox client:load accessionPrefix={accessionPrefix} />
+        {
+            isLoggedIn && accessToken !== undefined && (
+                <NotificationBell
+                    client:load
+                    accessToken={accessToken}
+                    clientConfig={clientConfig}
+                    knownOrganisms={knownOrganisms}
+                />
+            )
+        }
     </div>
 
     <div class='lg:hidden flex items-center pb-3'>

--- a/website/src/components/Navigation/NotificationBell.tsx
+++ b/website/src/components/Navigation/NotificationBell.tsx
@@ -1,0 +1,122 @@
+import { Menu, MenuButton, MenuItem, MenuItems, Transition } from '@headlessui/react';
+import { Fragment, useMemo } from 'react';
+
+import type { Organism } from '../../config';
+import useClientFlag from '../../hooks/isClient';
+import { routes } from '../../routes/routes';
+import { backendClientHooks, groupManagementClientHooks } from '../../services/serviceHooks';
+import type { ClientConfig } from '../../types/runtimeConfig';
+import { createAuthorizationHeader } from '../../utils/createAuthorizationHeader';
+import { withQueryProvider } from '../common/withQueryProvider';
+import BellIcon from '~icons/mdi/bell-outline';
+
+interface NotificationBellProps {
+    accessToken: string;
+    clientConfig: ClientConfig;
+    knownOrganisms: Organism[];
+}
+
+// How often to poll the backend for the number of sequences awaiting review.
+const REFETCH_INTERVAL_MS = 30_000;
+
+const NotificationBellInner = ({ accessToken, clientConfig, knownOrganisms }: NotificationBellProps) => {
+    const isClient = useClientFlag();
+    const backendHooks = useMemo(() => backendClientHooks(clientConfig), [clientConfig]);
+    const groupHooks = useMemo(() => groupManagementClientHooks(clientConfig), [clientConfig]);
+
+    const reviewCountsQuery = backendHooks.useGetReviewCounts(
+        { headers: createAuthorizationHeader(accessToken) },
+        { refetchInterval: REFETCH_INTERVAL_MS },
+    );
+    const groupsQuery = groupHooks.useGetGroupsOfUser({ headers: createAuthorizationHeader(accessToken) });
+
+    const reviewCounts = useMemo(
+        () => (reviewCountsQuery.data ?? []).filter((entry) => entry.count > 0),
+        [reviewCountsQuery.data],
+    );
+
+    const organismDisplayNames = useMemo(
+        () => new Map(knownOrganisms.map((organism) => [organism.key, organism.displayName])),
+        [knownOrganisms],
+    );
+    const groupNames = useMemo(
+        () => new Map((groupsQuery.data ?? []).map((group) => [group.groupId, group.groupName])),
+        [groupsQuery.data],
+    );
+
+    const totalCount = reviewCounts.reduce((sum, entry) => sum + entry.count, 0);
+    const hasNotifications = totalCount > 0;
+
+    return (
+        <Menu as='div' className='relative'>
+            <MenuButton
+                disabled={!isClient}
+                className='relative flex items-center p-1 rounded-full text-gray-500 hover:text-gray-700 focus:outline-hidden disabled:opacity-50'
+                aria-label={
+                    hasNotifications ? `${totalCount} sequences awaiting review` : 'No sequences awaiting review'
+                }
+                title={hasNotifications ? `${totalCount} sequences awaiting review` : 'No sequences awaiting review'}
+            >
+                <BellIcon className={`w-6 h-6 ${hasNotifications ? 'text-primary-600' : 'text-gray-400'}`} />
+                {hasNotifications && (
+                    <span className='absolute -top-0.5 -right-0.5 inline-flex items-center justify-center min-w-4 h-4 px-1 text-[10px] font-semibold leading-none text-white bg-red-500 rounded-full'>
+                        {totalCount > 99 ? '99+' : totalCount}
+                    </span>
+                )}
+            </MenuButton>
+
+            <Transition
+                as={Fragment}
+                enter='transition ease-out duration-100'
+                enterFrom='transform opacity-0 scale-95'
+                enterTo='transform opacity-100 scale-100'
+                leave='transition ease-in duration-75'
+                leaveFrom='transform opacity-100 scale-100'
+                leaveTo='transform opacity-0 scale-95'
+            >
+                <MenuItems className='absolute right-0 mt-2 w-80 max-w-[90vw] bg-white rounded-lg shadow-lg border border-gray-200 z-50 focus:outline-hidden'>
+                    <div className='px-4 py-2 border-b border-gray-100 text-sm font-semibold text-gray-700'>
+                        Sequences awaiting review
+                    </div>
+                    {!hasNotifications ? (
+                        <div className='px-4 py-4 text-sm text-gray-500'>You have no sequences awaiting review.</div>
+                    ) : (
+                        <div className='py-1 max-h-96 overflow-y-auto'>
+                            {reviewCounts.map((entry) => {
+                                const organismName = organismDisplayNames.get(entry.organism) ?? entry.organism;
+                                const groupName = groupNames.get(entry.groupId) ?? `Group ${entry.groupId}`;
+
+                                return (
+                                    <MenuItem key={`${entry.organism}-${entry.groupId}`}>
+                                        {({ focus }) => (
+                                            <a
+                                                href={routes.userSequenceReviewPage(entry.organism, entry.groupId)}
+                                                className={`flex items-start justify-between gap-3 px-4 py-2 text-sm ${
+                                                    focus ? 'bg-gray-50' : ''
+                                                }`}
+                                            >
+                                                <span className='min-w-0'>
+                                                    <span className='block font-medium text-gray-900 truncate'>
+                                                        {organismName}
+                                                    </span>
+                                                    <span className='block text-xs text-gray-500 truncate'>
+                                                        {groupName}
+                                                    </span>
+                                                </span>
+                                                <span className='shrink-0 inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full bg-primary-50 text-primary-700 border border-primary-200'>
+                                                    {entry.count}
+                                                </span>
+                                            </a>
+                                        )}
+                                    </MenuItem>
+                                );
+                            })}
+                        </div>
+                    )}
+                </MenuItems>
+            </Transition>
+        </Menu>
+    );
+};
+
+export const NotificationBell = withQueryProvider(NotificationBellInner);

--- a/website/src/services/backendApi.ts
+++ b/website/src/services/backendApi.ts
@@ -11,6 +11,7 @@ import {
     editedSequenceEntryData,
     getSequencesResponse,
     problemDetail,
+    reviewCountsResponse,
     revocationRequest,
     sequenceEntryToEdit,
     submissionIdMapping,
@@ -146,6 +147,15 @@ const getSequencesEndpoint = makeEndpoint({
     errors: [notAuthorizedError, { status: 404, schema: problemDetail }],
 });
 
+const getReviewCountsEndpoint = makeEndpoint({
+    method: 'get',
+    path: '/my/review-counts',
+    alias: 'getReviewCounts',
+    parameters: [authorizationHeader],
+    response: reviewCountsResponse,
+    errors: [notAuthorizedError],
+});
+
 const approveProcessedDataEndpoint = makeEndpoint({
     method: 'post',
     path: withOrganismPathSegment('/approve-processed-data'),
@@ -260,6 +270,7 @@ export const backendApi = makeApi([
     revokeSequencesEndpoint,
     submitReviewedSequenceEndpoint,
     getSequencesEndpoint,
+    getReviewCountsEndpoint,
     approveProcessedDataEndpoint,
     deleteSequencesEndpoint,
     extractUnprocessedDataEndpoint,

--- a/website/src/services/serviceHooks.ts
+++ b/website/src/services/serviceHooks.ts
@@ -3,6 +3,7 @@ import { ZodiosHooks, type ZodiosHooksInstance } from '@zodios/react';
 import { isAxiosError } from 'axios';
 
 import { backendApi } from './backendApi.ts';
+import { groupManagementApi } from './groupManagementApi.ts';
 import { lapisApi } from './lapisApi.ts';
 import { seqSetCitationApi } from './seqSetCitationApi.ts';
 import { problemDetail } from '../types/backend.ts';
@@ -24,6 +25,10 @@ const LAPIS_RETRY_OPTIONS = {
 
 export function backendClientHooks(clientConfig: ClientConfig) {
     return new ZodiosHooks('loculus', new Zodios(clientConfig.backendUrl, backendApi));
+}
+
+export function groupManagementClientHooks(clientConfig: ClientConfig) {
+    return new ZodiosHooks('loculus', new Zodios(clientConfig.backendUrl, groupManagementApi));
 }
 
 export function lapisClientHooks(lapisUrl: string) {

--- a/website/src/types/backend.ts
+++ b/website/src/types/backend.ts
@@ -165,6 +165,15 @@ export const getSequencesResponse = z.object({
 });
 export type GetSequencesResponse = z.infer<typeof getSequencesResponse>;
 
+export const reviewCount = z.object({
+    organism: z.string(),
+    groupId: z.number(),
+    count: z.number(),
+});
+export type ReviewCount = z.infer<typeof reviewCount>;
+
+export const reviewCountsResponse = z.array(reviewCount);
+
 export const submissionIdMapping = accessionVersion.merge(
     z.object({
         submissionId: z.string(),


### PR DESCRIPTION
Claude generated prototype

No integration test yet.

Resolves #6670

<img width="1828" height="1184" alt="2026-07-05 16 24 14" src="https://github.com/user-attachments/assets/7336afce-51fa-4ba3-863b-b6bedf923ddb" />

<details>

<summary>
Claude generated description
</summary>

## What & why

New users don't discover the submission **approval** step. After uploading, sequences sit unapproved (not released) and users are surprised they don't appear (see #6669). Reaching the review page today takes several clicks and requires first selecting the right organism, then Submit, then Review — 2–3 extra clicks if you start on the wrong organism, and new users don't know the path exists.

This PR adds a **notification bell** to the top-right nav (a familiar web pattern) that collapses this to one click: click the bell → drawer lists organism/group pairs with unapproved submissions → click a row → deep-link straight to that group's review page.

**WIP / draft** — opened for preview testing.

## Behaviour

- Bell only rendered when logged in (avoids layout shift for logged-out visitors).
- **Muted grey bell** with no badge when nothing is pending; **primary-coloured bell + red count badge** when there are sequences to review.
- Drawer lists one row per (organism, group) with a count, deep-linking via `routes.userSequenceReviewPage`.
- Polls every 30s via a single aggregated backend call.

## Backend

- New `GET /my/review-counts` endpoint (`NotificationController`, root-scoped like `AdminDashboardController` — `SubmissionController` is locked to `/{organism}`), scoped to the authenticated user's groups (super users see all).
- `SubmissionDatabaseService.getReviewCounts()` counts **unreleased** entries (`released_at IS NULL`) grouped by organism + group, querying the **base `sequence_entries` table** to avoid the preprocessed-data join and stay cheap.
  - Trade-off: the count includes still-processing (RECEIVED / IN_PROCESSING) entries, not strictly "awaiting approval". Documented on `ReviewCount` / `getReviewCounts`; narrowable to `Status.PROCESSED` later if exactness is wanted.
- Partial index migration `V1.34` (`ON sequence_entries (organism, group_id) WHERE released_at IS NULL`) backs the query.
- `GetReviewCountsEndpointTest` covers unauthorized / empty / per-group counts / non-member isolation.

## Website

- `NotificationBell.tsx` island (wrapped in `withQueryProvider`): headless-ui `Menu` drawer reusing the `OrganismNavigation` pattern; button disabled until hydration to avoid Playwright races.
- Endpoint + zod schemas wired into `backendApi.ts` / `types/backend.ts`; added `groupManagementClientHooks` for group-name labels.
- Mounted in `Navigation.astro`, gated on `isLoggedIn`.

## Not in this PR (documented as follow-ups)

- Bell in the mobile `SandwichMenu`.
- Optional numeric badge on the Submit nav item.
- **Dismissal** — a deferred localStorage-based design (keyed on a future `latestSubmittedAt`) is written up in `architecture_docs/notification-bell-review-counts.md`.

## Tests

- Backend: `GetReviewCountsEndpointTest` (4 tests) pass.
- Website: `check-types`, `format`, and full unit suite (694 tests) pass.

Not yet visually verified in a running browser — hence preview label for manual testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

🚀 Preview: Add `preview` label to enable