### PR TITLE
feat(backend, config): configure S3 to use IAM roles

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/config/BackendSpringConfig.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/BackendSpringConfig.kt
@@ -104,13 +104,19 @@ class BackendSpringConfig {
         @Value("\${${BackendSpringProperty.S3_BUCKET_INTERNAL_ENDPOINT}:#{null}}") internalEndpoint: String? = null,
         @Value("\${${BackendSpringProperty.S3_BUCKET_REGION}}") region: String? = null,
         @Value("\${${BackendSpringProperty.S3_BUCKET_BUCKET}}") bucket: String? = null,
-        @Value("\${${BackendSpringProperty.S3_BUCKET_ACCESS_KEY}}") accessKey: String? = null,
-        @Value("\${${BackendSpringProperty.S3_BUCKET_SECRET_KEY}}") secretKey: String? = null,
+        @Value("\${${BackendSpringProperty.S3_BUCKET_ACCESS_KEY}:#{null}}") accessKey: String? = null,
+        @Value("\${${BackendSpringProperty.S3_BUCKET_SECRET_KEY}:#{null}}") secretKey: String? = null,
     ): S3Config {
         if (!enabled) {
             return S3Config(false, null)
         }
-        if (endpoint != null && bucket != null && accessKey != null && secretKey != null) {
+        if ((accessKey == null) != (secretKey == null)) {
+            throw IllegalStateException(
+                "S3 bucket access-key and secret-key must either both be set (static credentials) " +
+                    "or both be omitted (to use IAM role credentials instead, e.g. IRSA on EKS).",
+            )
+        }
+        if (endpoint != null && bucket != null) {
             return S3Config(true, S3BucketConfig(endpoint, internalEndpoint, region, bucket, accessKey, secretKey))
         }
         throw IllegalStateException("S3 bucket configurations are incomplete.")

--- a/backend/src/main/kotlin/org/loculus/backend/config/S3Config.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/config/S3Config.kt
@@ -7,6 +7,9 @@ data class S3BucketConfig(
     val internalEndpoint: String?,
     val region: String?,
     val bucket: String,
-    val accessKey: String,
-    val secretKey: String,
+    // accessKey/secretKey are only set when using static credentials (e.g. MinIO). When both
+    // are null, S3Service falls back to the AWS SDK's default credential chain, e.g. IAM role
+    // credentials from IRSA on EKS.
+    val accessKey: String?,
+    val secretKey: String?,
 )

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/S3Service.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/S3Service.kt
@@ -6,6 +6,8 @@ import org.loculus.backend.controller.BadRequestException
 import org.loculus.backend.controller.UnprocessableEntityException
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
@@ -218,9 +220,16 @@ class S3Service(private val s3Config: S3Config) {
         .serviceConfiguration(createServiceConfiguration())
         .build()
 
-    private fun createCredentialProvider(bucketConfig: S3BucketConfig) = StaticCredentialsProvider.create(
-        AwsBasicCredentials.create(bucketConfig.accessKey, bucketConfig.secretKey),
-    )
+    private fun createCredentialProvider(bucketConfig: S3BucketConfig): AwsCredentialsProvider {
+        val accessKey = bucketConfig.accessKey
+        val secretKey = bucketConfig.secretKey
+        if (accessKey != null && secretKey != null) {
+            return StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey))
+        }
+        // No static credentials configured: fall back to the AWS SDK's default credential chain,
+        // e.g. IAM role credentials from IRSA on EKS.
+        return DefaultCredentialsProvider.create()
+    }
 
     private fun createServiceConfiguration() = S3Configuration.builder()
         .pathStyleAccessEnabled(true)

--- a/kubernetes/loculus/templates/loculus-backend.yaml
+++ b/kubernetes/loculus/templates/loculus-backend.yaml
@@ -1,5 +1,14 @@
 {{- $dockerTag := include "loculus.dockerTag" .Values }}
 {{- if not .Values.disableBackend }}
+{{- if $.Values.s3.serviceAccountAnnotations }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loculus-backend
+  annotations:
+{{ $.Values.s3.serviceAccountAnnotations | toYaml | indent 4 }}
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -21,6 +30,9 @@ spec:
         app: loculus
         component: backend
     spec:
+      {{- if $.Values.s3.serviceAccountAnnotations }}
+      serviceAccountName: loculus-backend
+      {{- end }}
       {{- include "possiblePriorityClassName" . | nindent 6 }}
       {{- include "loculus.podScheduling" . | nindent 6 }}
       initContainers:
@@ -80,8 +92,10 @@ spec:
             - "--loculus.s3.bucket.internal-endpoint=$(S3_BUCKET_INTERNAL_ENDPOINT)"
             - "--loculus.s3.bucket.region=$(S3_BUCKET_REGION)"
             - "--loculus.s3.bucket.bucket=$(S3_BUCKET_BUCKET)"
+            {{- if $.Values.s3.credentialsSecretName }}
             - "--loculus.s3.bucket.access-key=$(S3_BUCKET_ACCESS_KEY)"
             - "--loculus.s3.bucket.secret-key=$(S3_BUCKET_SECRET_KEY)"
+            {{- end }}
             {{- end }}
             {{- if .Values.backendExtraArgs }}
               {{- .Values.backendExtraArgs | toYaml | nindent 12 }}
@@ -152,16 +166,18 @@ spec:
               value: {{$.Values.s3.bucket.region | quote }}
             - name: S3_BUCKET_BUCKET
               value: {{$.Values.s3.bucket.bucket | quote }}
+            {{- if $.Values.s3.credentialsSecretName }}
             - name: S3_BUCKET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: s3-bucket
+                  name: {{ $.Values.s3.credentialsSecretName }}
                   key: accessKey
             - name: S3_BUCKET_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: s3-bucket
+                  name: {{ $.Values.s3.credentialsSecretName }}
                   key: secretKey
+            {{- end }}
             {{- end }}
           volumeMounts:
             - name: loculus-backend-config-processed

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1769,6 +1769,19 @@
           "default": 10080,
           "description": "Files uploaded to S3 but never attached to a sequence entry are garbage-collected after this many minutes."
         },
+        "credentialsSecretName": {
+          "groups": ["s3"],
+          "type": "string",
+          "default": "s3-bucket",
+          "description": "Name of a k8s secret with `accessKey`/`secretKey` keys, used to authenticate to S3 with static credentials (e.g. MinIO). Set to \"\" to omit static credentials and instead rely on IAM role credentials (e.g. IRSA on EKS)."
+        },
+        "serviceAccountAnnotations": {
+          "groups": ["s3"],
+          "type": "object",
+          "default": {},
+          "additionalProperties": { "type": "string" },
+          "description": "Annotations to add to the backend's ServiceAccount, e.g. to attach an IAM role via IRSA on EKS."
+        },
         "bucket": {
           "type": "object",
           "properties": {

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -67,6 +67,14 @@ s3:
   gcEnabled: false
   gcFrequencyMinutes: 1440
   gcOrphanRetentionPeriodMinutes: 10080
+  # Name of a k8s secret with `accessKey`/`secretKey` keys, used to authenticate to S3 with
+  # static credentials (e.g. MinIO). Set to "" to omit static credentials and instead rely on
+  # IAM role credentials (e.g. IRSA on EKS) - in that case also set serviceAccountAnnotations
+  # below to attach the IAM role to the backend pod.
+  credentialsSecretName: s3-bucket
+  # Annotations to add to the backend's ServiceAccount, e.g. to attach an IAM role via IRSA
+  # on EKS: {eks.amazonaws.com/role-arn: "arn:aws:iam::<account-id>:role/<role-name>"}.
+  serviceAccountAnnotations: {}
   bucket:
     region: us-east-1
     bucket: loculus-preview-private


### PR DESCRIPTION
Access is scoped not cluster-wide. Two things enforce the scoping, one on each side:

  AWS side (the actual security boundary): the IAM role's trust policy restricts who can assume it via a condition on
  the OIDC token's sub claim, tied to your cluster's specific OIDC provider and one exact namespace:serviceaccount-name
  pair:
```
  {
    "Version": "2012-10-17",
    "Statement": [
      {
        "Effect": "Allow",
        "Principal": {
          "Federated": "arn:aws:iam::<account-id>:oidc-provider/oidc.eks.<region>.amazonaws.com/id/<oidc-id>"
        },
        "Action": "sts:AssumeRoleWithWebIdentity",
        "Condition": {
          "StringEquals": {
            "oidc.eks.<region>.amazonaws.com/id/<oidc-id>:sub": "system:serviceaccount:<namespace>:loculus-backend",
            "oidc.eks.<region>.amazonaws.com/id/<oidc-id>:aud": "sts.amazonaws.com"
          }
        }
      }
    ]
  }
```
  Only a pod whose ServiceAccount token has that exact sub claim can exchange it for this role's credentials — nothing
  else in the cluster can, regardless of what IAM policy is attached.

  K8s side (what I already set up): the eks.amazonaws.com/role-arn annotation lives on the standalone loculus-backend
  ServiceAccount, and serviceAccountName: loculus-backend is only set on the backend Deployment's pod spec — every other
  workload in the chart (website, preprocessing, ingest, etc.) still runs under default, so the EKS Pod Identity
  webhook never injects the web-identity token into them, and they have no way to assume the role. You can confirm this
  yourself: helm template ... | grep -B5 serviceAccountName shows it appears exactly once, on the backend Deployment.

  One caveat worth knowing: this ServiceAccount is namespace-scoped, so any pod deployed into the same namespace that
  explicitly sets serviceAccountName: loculus-backend in its own spec would also get these credentials — a pod can't
  reference a ServiceAccount from a different namespace, but within the namespace, referencing the SA name is all it
  takes (same trust model as any k8s Secret). If that namespace is exclusively used by this Helm release, that's a
  non-issue in practice.

🚀 Preview: Add `preview` label to enable