### PR TITLE
fix(prepro): Pass noInput from config to prepro, use to construct error message

### DIFF
--- a/kubernetes/loculus/templates/_preprocessingFromValues.tpl
+++ b/kubernetes/loculus/templates/_preprocessingFromValues.tpl
@@ -54,6 +54,9 @@
   {{- if .required}}
   required: true
   {{- end }}
+  {{- if .noInput}}
+  no_input: true
+  {{- end }}
 {{- end }}
 
 {{/* Expects an object { metadata: [...], referenceGenomes: {...} }

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -24,6 +24,9 @@ logger = logging.getLogger(__name__)
 CLI_TYPES = [str, int, float, bool]
 
 METADATA_DEPENDENCY_PREFIX = "processed."
+NEXTCLADE_PREFIX = "nextclade."
+ASSIGNED_REFERENCE_PREFIX = "ASSIGNED_REFERENCE"
+INTERNAL_INPUT_PREFIXES = (NEXTCLADE_PREFIX, ASSIGNED_REFERENCE_PREFIX)
 
 
 class EmblInfoMetadataPropertyNames(BaseModel):
@@ -186,10 +189,11 @@ class Config(BaseModel):
             raise Exception
         return datasets[0]
 
-    def is_submittable(self, field: str) -> bool:
-        if (spec := self.processing_spec.get(field)) is None:
-            return False
-        return not spec.no_input
+    def is_user_input(self, field: str) -> bool:
+        if (spec := self.processing_spec.get(field)) is not None:
+            return not spec.no_input
+        # fields without a spec may be `extraInputFields` and therefore still user input
+        return not field.startswith(INTERNAL_INPUT_PREFIXES)
 
 
 def set_sequence_name(

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -39,6 +39,7 @@ class ProcessingSpec(BaseModel):
     inputs: FunctionInputs
     function: FunctionName = "identity"
     required: bool = False
+    no_input: bool = False
     args: FunctionArgs | None = None
 
 
@@ -184,6 +185,11 @@ class Config(BaseModel):
         if len(datasets) > 1:
             raise Exception
         return datasets[0]
+
+    def is_submittable(self, field: str) -> bool:
+        if (spec := self.processing_spec.get(field)) is None:
+            return False
+        return not spec.no_input
 
 
 def set_sequence_name(

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -420,9 +420,12 @@ def get_output_metadata(
             and group_id != config.insdc_ingest_group_id
         ):
             message = f"Metadata field `{output_field}` is required."
-            additional_inputs = [i for i in input_fields if i != output_field]
-            if additional_inputs:
-                message += f" Please provide input metadata field(s): {', '.join(f'`{field}`' for field in additional_inputs)}"
+            submittable_inputs = [field for field in input_fields if config.is_submittable(field)]
+            if any(field != output_field for field in submittable_inputs):
+                message += (
+                    f" Please provide input metadata field(s): "
+                    f"{', '.join(f'`{field}`' for field in submittable_inputs)}"
+                )
             errors.append(
                 ProcessingAnnotation.from_fields(
                     spec.inputs.values(),

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -14,7 +14,9 @@ from .backend import (
     upload_embl_file_to_presigned_url,
 )
 from .config import (
+    ASSIGNED_REFERENCE_PREFIX,
     METADATA_DEPENDENCY_PREFIX,
+    NEXTCLADE_PREFIX,
     AlignmentRequirement,
     Config,
     ProcessingSpec,
@@ -233,12 +235,11 @@ def add_input_metadata(
     config: Config,
 ) -> InputData:
     """Returns value of input_path in unprocessed metadata"""
-    if input_path.startswith("ASSIGNED_REFERENCE"):
+    if input_path.startswith(ASSIGNED_REFERENCE_PREFIX):
         return add_assigned_reference(spec, unprocessed, config=config)
     # If field starts with "nextclade.", take from nextclade metadata
-    nextclade_prefix = "nextclade."
-    if input_path.startswith(nextclade_prefix):
-        nextclade_path = input_path[len(nextclade_prefix) :]
+    if input_path.startswith(NEXTCLADE_PREFIX):
+        nextclade_path = input_path[len(NEXTCLADE_PREFIX) :]
         return add_nextclade_metadata(spec, unprocessed, nextclade_path, config=config)
     if input_path not in unprocessed.inputMetadata:
         return InputData(datum=None)
@@ -420,11 +421,11 @@ def get_output_metadata(
             and group_id != config.insdc_ingest_group_id
         ):
             message = f"Metadata field `{output_field}` is required."
-            submittable_inputs = [field for field in input_fields if config.is_submittable(field)]
-            if any(field != output_field for field in submittable_inputs):
+            user_inputs = [field for field in input_fields if config.is_user_input(field)]
+            if any(field != output_field for field in user_inputs):
                 message += (
                     f" Please provide input metadata field(s): "
-                    f"{', '.join(f'`{field}`' for field in submittable_inputs)}"
+                    f"{', '.join(f'`{field}`' for field in user_inputs)}"
                 )
             errors.append(
                 ProcessingAnnotation.from_fields(

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -49,7 +49,7 @@ test_case_definitions = [
                 ProcessingAnnotationHelper(
                     ["ncbi_required_collection_date"],
                     ["required_collection_date"],
-                    "Metadata field `required_collection_date` is required.",
+                    "Metadata field `required_collection_date` is required. Please provide input metadata field(s): `ncbi_required_collection_date`",
                 ),
             ]
         ),
@@ -67,7 +67,7 @@ test_case_definitions = [
                 ProcessingAnnotationHelper(
                     ["ncbi_required_collection_date"],
                     ["required_collection_date"],
-                    "Metadata field `required_collection_date` is required.",
+                    "Metadata field `required_collection_date` is required. Please provide input metadata field(s): `ncbi_required_collection_date`",
                 ),
             ]
         ),
@@ -772,19 +772,24 @@ def test_preprocessing_metadata_dependencies(test_case_def: Case, config_depende
     assert processed_entry.data.metadata != test_case.expected_output.data.metadata
 
 
-def test_required_field_message_lists_only_submittable_inputs() -> None:
+def test_required_field_message_lists_only_user_input_fields() -> None:
     config = get_config(NO_ALIGNMENT_CONFIG, ignore_args=True)
     config.processing_spec.update(
         {
-            "submittable_input": ProcessingSpec(
-                function="identity", inputs={"input": "submittable_input"}
-            ),
-            "unsubmittable_input": ProcessingSpec(
-                function="identity", inputs={"input": "unsubmittable_input"}, no_input=True
+            "user_input": ProcessingSpec(function="identity", inputs={"input": "user_input"}),
+            "non_user_input": ProcessingSpec(
+                function="identity", inputs={"input": "non_user_input"}, no_input=True
             ),
             "required_field": ProcessingSpec(
                 function="identity",
-                inputs={"input": "submittable_input", "fallback": "unsubmittable_input"},
+                inputs={
+                    "input": "user_input",
+                    # extraInputField without a processing spec, must be part of message
+                    "extra": "extra_user_input",
+                    "fallback": "non_user_input",
+                    # Internal source with no spec, must not be part of message
+                    "internal": "ASSIGNED_REFERENCE",
+                },
                 required=True,
             ),
         }
@@ -805,7 +810,7 @@ def test_required_field_message_lists_only_submittable_inputs() -> None:
     }
     assert messages["required_field"] == (
         "Metadata field `required_field` is required. "
-        "Please provide input metadata field(s): `submittable_input`"
+        "Please provide input metadata field(s): `user_input`, `extra_user_input`"
     )
 
 

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -5,12 +5,13 @@ from factory_methods import (
     ProcessedEntryFactory,
     ProcessingAnnotationHelper,
     ProcessingTestCase,
+    UnprocessedEntryFactory,
     build_processing_annotations,
     ts_from_ymd,
     verify_processed_entry,
 )
 
-from loculus_preprocessing.config import Config, get_config, get_processing_order
+from loculus_preprocessing.config import Config, ProcessingSpec, get_config, get_processing_order
 from loculus_preprocessing.datatypes import (
     AnnotationSource,
     AnnotationSourceType,
@@ -48,7 +49,7 @@ test_case_definitions = [
                 ProcessingAnnotationHelper(
                     ["ncbi_required_collection_date"],
                     ["required_collection_date"],
-                    "Metadata field `required_collection_date` is required. Please provide input metadata field(s): `ncbi_required_collection_date`",
+                    "Metadata field `required_collection_date` is required.",
                 ),
             ]
         ),
@@ -66,7 +67,7 @@ test_case_definitions = [
                 ProcessingAnnotationHelper(
                     ["ncbi_required_collection_date"],
                     ["required_collection_date"],
-                    "Metadata field `required_collection_date` is required. Please provide input metadata field(s): `ncbi_required_collection_date`",
+                    "Metadata field `required_collection_date` is required.",
                 ),
             ]
         ),
@@ -769,6 +770,43 @@ def test_preprocessing_metadata_dependencies(test_case_def: Case, config_depende
     config_dependency.processing_order = wrong_order
     processed_entry = process_single_entry(test_case, config_dependency)
     assert processed_entry.data.metadata != test_case.expected_output.data.metadata
+
+
+def test_required_field_message_lists_only_submittable_inputs() -> None:
+    config = get_config(NO_ALIGNMENT_CONFIG, ignore_args=True)
+    config.processing_spec.update(
+        {
+            "submittable_input": ProcessingSpec(
+                function="identity", inputs={"input": "submittable_input"}
+            ),
+            "unsubmittable_input": ProcessingSpec(
+                function="identity", inputs={"input": "unsubmittable_input"}, no_input=True
+            ),
+            "required_field": ProcessingSpec(
+                function="identity",
+                inputs={"input": "submittable_input", "fallback": "unsubmittable_input"},
+                required=True,
+            ),
+        }
+    )
+    config.processing_order = get_processing_order(config)
+
+    entry = UnprocessedEntryFactory.create_unprocessed_entry(
+        metadata_dict={"submissionId": "no_input_filtering", "name_required": "name"},
+        accession_id="0",
+        sequences={"main": None},
+    )
+    processed_entry = process_all([entry], "temp_dataset_dir", config)[0].processed_entry
+
+    messages = {
+        annotation.processedFields[0].name: annotation.message
+        for annotation in processed_entry.errors
+        if annotation.processedFields
+    }
+    assert messages["required_field"] == (
+        "Metadata field `required_field` is required. "
+        "Please provide input metadata field(s): `submittable_input`"
+    )
 
 
 def test_preprocessing_without_consensus_sequences(config: Config) -> None:

--- a/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
+++ b/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
@@ -1526,7 +1526,7 @@ multi_reference_cases = [
                 ProcessingAnnotationHelper(
                     ["ASSIGNED_REFERENCE"],
                     ["subtype"],
-                    "Metadata field `subtype` is required. Please provide input metadata field(s): `ASSIGNED_REFERENCE`",
+                    "Metadata field `subtype` is required.",
                 ),
             ]
         ),
@@ -1656,7 +1656,7 @@ multi_segment_multi_reference_cases = [
                 ProcessingAnnotationHelper(
                     ["ASSIGNED_REFERENCE"],
                     ["subtype_S"],
-                    "Metadata field `subtype_S` is required. Please provide input metadata field(s): `ASSIGNED_REFERENCE`",
+                    "Metadata field `subtype_S` is required.",
                 ),
             ]
         ),


### PR DESCRIPTION
resolves #6793

## Background 

When a required metadata field is not provided, the submission is rejected and an error message is shown. If the required field has other input_fields besides the output_field itself, those are included in the error message to tell users what inputs they need to provide. 

This can lead to an unhelpful & misleading error message in cases where one of the input_fields is actually not a field that can be provided by users. See below, where the user is asked to provide `ncbiReleaseDate`, which is not a field they can input:

<img width="2272" height="998" alt="grafik" src="https://github.com/user-attachments/assets/a655688a-8d15-4285-91e4-68e48ad344ea" />


## Solution

This PR threads the `noInput` field from the confiug through to preprocessing, where this information is used to construct an error message that only asks users to provide data they can actually specify. I also added a test that covers this behaviour.

<img width="2272" height="956" alt="image" src="https://github.com/user-attachments/assets/aaa6490e-3ef1-4993-8f72-dcbdea06d7a7" />



### Screenshot

### PR Checklist
~- [ ] All necessary documentation has been adapted.~
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://fix-prepro-error-messages.loculus.org