### PR TITLE
fix(website): restore toasts in astro dev after v6 upgrade

### DIFF
--- a/website/src/components/common/AppToastContainer.tsx
+++ b/website/src/components/common/AppToastContainer.tsx
@@ -5,17 +5,8 @@ import 'react-toastify/dist/ReactToastify.css';
 // Wrapping `ToastContainer` in a local component (rather than using
 // `react-toastify`'s `ToastContainer` directly as a `client:*` island in an
 // `.astro` file) keeps it on the same react-toastify module instance as the
-// `toast()` callers.
+// `toast()` callers when running in dev mode.
 //
-// In `astro dev`, a bare framework import referenced directly by a client
-// directive in an `.astro` file is served as raw source
-// (`/node_modules/react-toastify/dist/index.mjs`), while imports inside
-// `.tsx`/`.jsx` islands go through Vite's dependency optimizer
-// (`/node_modules/.vite/deps/react-toastify.js`). Those are two different
-// module instances, each with its own module-level toast store, so
-// `toast()` calls never reach the `ToastContainer` and no toast is shown.
-// The production build bundles everything into one chunk, so it only breaks
-// in dev. See https://github.com/loculus-project/loculus/issues/6850
 export default function AppToastContainer() {
     return <ToastContainer />;
 }

--- a/website/src/components/common/AppToastContainer.tsx
+++ b/website/src/components/common/AppToastContainer.tsx
@@ -1,0 +1,21 @@
+import { ToastContainer } from 'react-toastify';
+
+import 'react-toastify/dist/ReactToastify.css';
+
+// Wrapping `ToastContainer` in a local component (rather than using
+// `react-toastify`'s `ToastContainer` directly as a `client:*` island in an
+// `.astro` file) keeps it on the same react-toastify module instance as the
+// `toast()` callers.
+//
+// In `astro dev`, a bare framework import referenced directly by a client
+// directive in an `.astro` file is served as raw source
+// (`/node_modules/react-toastify/dist/index.mjs`), while imports inside
+// `.tsx`/`.jsx` islands go through Vite's dependency optimizer
+// (`/node_modules/.vite/deps/react-toastify.js`). Those are two different
+// module instances, each with its own module-level toast store, so
+// `toast()` calls never reach the `ToastContainer` and no toast is shown.
+// The production build bundles everything into one chunk, so it only breaks
+// in dev. See https://github.com/loculus-project/loculus/issues/6850
+export default function AppToastContainer() {
+    return <ToastContainer />;
+}

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -1,9 +1,8 @@
 ---
 import '../styles/base.css';
 import '../styles/custom-colors.css';
-import 'react-toastify/dist/ReactToastify.css';
-import { ToastContainer } from 'react-toastify';
 
+import AppToastContainer from '../components/common/AppToastContainer';
 import Navigation from '../components/Navigation/Navigation.astro';
 import OrganismSubmenu from '../components/Navigation/OrganismSubmenu.astro';
 import { cleanOrganism } from '../components/Navigation/cleanOrganism';
@@ -74,7 +73,7 @@ const lastTimeBannerWasClosed = Astro.cookies.get('lastTimeBannerWasClosed')?.va
             serverTime={Date.now()}
             client:load
         />
-        <ToastContainer client:load />
+        <AppToastContainer client:load />
         <div class='flex flex-col min-h-screen'>
             <header class={`bg-white h-fit z-30 ${!currentOrganism ? 'border-b-[1.5px] border-gray-200' : ''}`}>
                 <nav class='flex justify-between items-end px-4 pt-3 pb-0 mx-4'>

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -2,10 +2,10 @@
 import '../styles/base.css';
 import '../styles/custom-colors.css';
 
-import AppToastContainer from '../components/common/AppToastContainer';
 import Navigation from '../components/Navigation/Navigation.astro';
 import OrganismSubmenu from '../components/Navigation/OrganismSubmenu.astro';
 import { cleanOrganism } from '../components/Navigation/cleanOrganism';
+import AppToastContainer from '../components/common/AppToastContainer';
 import { Banner } from '../components/common/Banner';
 import { getWebsiteConfig } from '../config';
 import { navigationItems } from '../routes/navigationItems';


### PR DESCRIPTION
Fixes #6850.

## Summary

Toasts stopped rendering under `astro dev` — but not in a production build (`npm run build` && `npm run preview`) — since the Astro v6 upgrade (#6779). This restores them.

## Root cause

A react-toastify **module-instance split** in Vite's dev server.

`ToastContainer` was imported from `react-toastify` and used directly as a `client:load` island in `BaseLayout.astro`. In `astro dev`:

- A bare framework import referenced **directly by a client directive in an `.astro` file** is served as **raw source**: `/node_modules/react-toastify/dist/index.mjs`.
- The `toast()` callers live in `.tsx` islands, whose imports go through **Vite's dependency optimizer**: `/node_modules/.vite/deps/react-toastify.js`.

These are two different module instances. react-toastify keeps its toast queue in module-level state, so `toast()` pushes into the optimized-dep instance's store while `ToastContainer` (raw-source instance) subscribes to a *different* store — nothing renders.

The production build bundles everything into a single chunk, so the store is shared and toasts work. That's exactly why only dev was affected.

I confirmed this in the running dev server by inspecting the island hydration scripts:

```
# before the fix
ToastContainer island  -> component-url="/node_modules/react-toastify/dist/index.mjs"   (raw source)
toast() caller (.tsx)  -> import { toast } from "/node_modules/.vite/deps/react-toastify.js?v=..."   (optimized)
```

## Fix

Wrap `ToastContainer` in a local `AppToastContainer.tsx` component and use that as the island. Its import now goes through the same optimized dependency as the `toast()` callers, so they share one store. The react-toastify CSS import moves into the wrapper alongside it.

```
# after the fix — both resolve to the same instance
AppToastContainer.tsx  -> import { ToastContainer } from "/node_modules/.vite/deps/react-toastify.js?v=..."
toast() caller (.tsx)  -> import { toast }          from "/node_modules/.vite/deps/react-toastify.js?v=..."
```

## Testing

Reproduced and verified end-to-end in `astro dev` with a headless browser on a minimal two-island page (a button calling `toast()` + the container):

- **Direct `ToastContainer` island** (the previous pattern): clicking the button rendered **no** toast (`.Toastify__toast` absent).
- **Wrapped `AppToastContainer` island** (this fix): the toast rendered with its text.

Also verified against a real `BaseLayout` page that the toast island now resolves to the optimized dependency, and that `astro check` + `tsc` pass with 0 errors.

🚀 Preview: Add `preview` label to enable