### PR TITLE
feat(deposition): improve ena test logs

### DIFF
--- a/ena-submission/pyproject.toml
+++ b/ena-submission/pyproject.toml
@@ -23,16 +23,16 @@ build-backend = "hatchling.build"
 packages = ["src/ena_deposition"]
 
 [tool.pytest.ini_options]
-# Live logging - show INFO+ during execution
-log_cli = true
-log_cli_level = "INFO"  # Show INFO logs during execution
-log_cli_format = "%(asctime)s [%(levelname)8s] %(name)s: %(message)s (%(filename)s:%(lineno)d)"
-log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+# Logs are only printed for failing tests (under "Captured log call"),
+# instead of live-streaming (and interleaving) logs for every test.
+log_level = "INFO"
+log_format = "%(asctime)s [%(levelname)8s] [%(test_name)s] %(name)s: %(message)s (%(filename)s:%(lineno)d)"
+log_date_format = "%Y-%m-%d %H:%M:%S"
 
-# File logging - captures everything for detailed analysis
+# File logging - captures everything for detailed analysis, regardless of pass/fail
 log_file = "tests.log"
 log_file_level = "DEBUG"
-log_file_format = "%(asctime)s [%(levelname)8s] %(name)s: %(message)s (%(filename)s:%(lineno)d)"
+log_file_format = "%(asctime)s [%(levelname)8s] [%(test_name)s] %(name)s: %(message)s (%(filename)s:%(lineno)d)"
 log_file_date_format = "%Y-%m-%d %H:%M:%S"
 
 addopts = [

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -77,7 +77,6 @@ class NCBIVisibilityChecker(VisibilityChecker):
     """Checker for NCBI visibility"""
 
     def check_visibility(self, config: Config, accession: str) -> datetime | None:
-
         if accession.startswith("PRJ"):
             path = "bioproject"
         elif accession.startswith("SAM"):

--- a/ena-submission/test/conftest.py
+++ b/ena-submission/test/conftest.py
@@ -1,0 +1,24 @@
+import logging
+
+import pytest
+
+_current_test_name = "no-test"
+
+_original_log_record_factory = logging.getLogRecordFactory()
+
+
+def _log_record_factory_with_test_name(*args: object, **kwargs: object) -> logging.LogRecord:
+    record = _original_log_record_factory(*args, **kwargs)
+    record.test_name = _current_test_name
+    return record
+
+
+logging.setLogRecordFactory(_log_record_factory_with_test_name)
+
+
+@pytest.fixture(autouse=True)
+def _tag_logs_with_test_name(request: pytest.FixtureRequest):
+    global _current_test_name
+    _current_test_name = request.node.name
+    yield
+    _current_test_name = "no-test"

--- a/ena-submission/test/conftest.py
+++ b/ena-submission/test/conftest.py
@@ -2,14 +2,14 @@ import logging
 
 import pytest
 
-_current_test_name = "no-test"
+_test_context = {"name": "no-test"}
 
 _original_log_record_factory = logging.getLogRecordFactory()
 
 
 def _log_record_factory_with_test_name(*args: object, **kwargs: object) -> logging.LogRecord:
     record = _original_log_record_factory(*args, **kwargs)
-    record.test_name = _current_test_name
+    record.test_name = _test_context["name"]
     return record
 
 
@@ -18,7 +18,6 @@ logging.setLogRecordFactory(_log_record_factory_with_test_name)
 
 @pytest.fixture(autouse=True)
 def _tag_logs_with_test_name(request: pytest.FixtureRequest):
-    global _current_test_name
-    _current_test_name = request.node.name
+    _test_context["name"] = request.node.name
     yield
-    _current_test_name = "no-test"
+    _test_context["name"] = "no-test"

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -758,6 +758,7 @@ class TestSimpleSubmission(TestSubmission):
         multi_segment_submission(
             self.db_engine, self.config, mock_get_group_info, mock_submit_external_metadata
         )
+        assert True == False, "Test failed"
 
 
 class TestSingleSegmentOfMultiSegmentOrganismWithoutGCA(TestSubmission):

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -758,7 +758,6 @@ class TestSimpleSubmission(TestSubmission):
         multi_segment_submission(
             self.db_engine, self.config, mock_get_group_info, mock_submit_external_metadata
         )
-        assert True == False, "Test failed"
 
 
 class TestSingleSegmentOfMultiSegmentOrganismWithoutGCA(TestSubmission):


### PR DESCRIPTION
I noticed this while working on https://github.com/loculus-project/loculus/pull/6816

### Summary

The integration tests were showing all logs generated while running a test, even when a test succeeded, additionally some logs were interleaved making it very hard to use these logs. 

This improves the logging to only show logs when a test fails and additionally add the name of the test during the process of who's execution the logs were generated to the log prefix for easier debugging.

The log_cli/log_file/log_format settings live under [tool.pytest.ini_options] in pyproject.toml. That section is read exclusively by pytest's own logging plugin (_pytest.logging) when you run pytest — it has no effect on the actual ena_deposition application. (The real app configures its own logging independently in src/ena_deposition/__main__.py:37-46, via logging.basicConfig(...) and logging.getLogger().setLevel(config.log_level).)

### PR Checklist
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
I confirmed that when a test fails the logs are shown and that they include the test name for better debugging:
```
2026-07-10 09:49:32 [    INFO] [test_submit] ena_deposition.upload_external_metadata_to_loculus: External metadata update for AccessionVersion(accession='LOC_0001TLY', version=1) succeeded. Old data: {'biosampleAccession': 'SAMEA132119264', 'bioprojectAccession': 'PRJEB120991'}, new data: {'bioprojectAccession': 'PRJEB120991', 'biosampleAccession': 'SAMEA132119264', 'gcaAccession': 'GCA_964187725.1', 'insdcAccessionBase_L': 'OZ076380', 'insdcAccessionFull_L': 'OZ076380.1', 'insdcAccessionBase_M': 'OZ076381', 'insdcAccessionFull_M': 'OZ076381.1'} (upload_external_metadata_to_loculus.py:181)
```
Confirmed on a preview that all logs are still showing.

🚀 Preview: https://improve-ena-test-logs.loculus.org