### PR TITLE
fix(deposition): update bioprojects using unique project_id key

### DIFF
--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -247,7 +247,7 @@ def project_table_create(
     )
     logger.debug(f"Found {len(ready_to_submit_project)} entries in project_table in status READY")
     for row in ready_to_submit_project:
-        group_key = {"group_id": row.group_id, "organism": row.organism}
+        project_key = {"project_id": row.project_id}
 
         try:
             group_info = call_loculus.get_group_info(config, row.group_id)
@@ -270,7 +270,7 @@ def project_table_create(
         number_rows_updated = update_db_where_conditions(
             db_engine,
             model_class=ProjectTableEntry,
-            conditions=group_key,
+            conditions=project_key,
             update_values=update_values,
         )
         if number_rows_updated != 1:
@@ -283,7 +283,7 @@ def project_table_create(
             )
             continue
         logger.info(
-            f"Starting Project creation for group_id {row.group_id} organism {row.organism}"
+            f"Starting Project creation for project_key {row.project_id} organism {row.organism}"
         )
         # Actual HTTP request to ENA happens here
         project_creation_results: CreationResult = create_ena_project(config, project_set)
@@ -294,7 +294,7 @@ def project_table_create(
                 "finished_at": datetime.now(tz=pytz.utc),
             }
             logger.info(
-                f"Project creation succeeded for group_id {row.group_id} organism {row.organism}"
+                f"Project creation succeeded for project_key {row.project_id} organism {row.organism}"
             )
         else:
             update_values = {
@@ -303,11 +303,11 @@ def project_table_create(
                 "started_at": datetime.now(tz=pytz.utc),
             }
             logger.error(
-                f"Project creation failed for group_id {row.group_id} organism {row.organism}"
+                f"Project creation failed for project_key {row.project_id} organism {row.organism}"
             )
         update_with_retry(
             db_engine=db_engine,
-            conditions=group_key,
+            conditions=project_key,
             update_values=update_values,
             model_class=ProjectTableEntry,
         )

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -294,7 +294,8 @@ def project_table_create(
                 "finished_at": datetime.now(tz=pytz.utc),
             }
             logger.info(
-                f"Project creation succeeded for project_key {row.project_id} organism {row.organism}"
+                f"Project creation succeeded for project_key {row.project_id} "
+                f"organism {row.organism}"
             )
         else:
             update_values = {


### PR DESCRIPTION
partially resolves: https://github.com/loculus-project/loculus/issues/6882

The code now tries to update a bioproject using its (group_id, organism) as a unique key, however the unique key is now the project_id and we can have multiple bioprojects for a group. This means that in such cases submissions would fail due to the update failing.

The code now switches to updating the db using the unique project_id.

🚀 Preview: Add `preview` label to enable