### PR TITLE
Remove npm dependabot updates for docs directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,15 +33,6 @@ updates:
       patch:
         update-types:
           - "patch"
-  - package-ecosystem: npm
-    directory: docs/
-    schedule:
-      interval: weekly
-    groups:
-      minorAndPatch:
-        update-types:
-          - "minor"
-          - "patch"
   - package-ecosystem: gradle
     directory: backend/
     schedule:


### PR DESCRIPTION
### Description
Removes the npm package ecosystem configuration from Dependabot for the `docs/` directory. This disables automated dependency updates for npm packages in the documentation folder.

### Changes
- Removed the npm Dependabot configuration block that was set to check for minor and patch updates weekly in the `docs/` directory

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

**Note:** This is a configuration change with no testing required. Dependabot will simply stop creating PRs for npm dependency updates in the docs folder.

https://claude.ai/code/session_01VsowarouQCAGyQo7aSq7s1

🚀 Preview: Add `preview` label to enable