### PR TITLE
chore(e2e): deflake known rare console error about CORS policy

### DIFF
--- a/integration-tests/tests/fixtures/console-warnings.fixture.ts
+++ b/integration-tests/tests/fixtures/console-warnings.fixture.ts
@@ -12,6 +12,7 @@ export const test = base.extend({
                     'ERR_INCOMPLETE_CHUNKED_ENCODING',
                     "Response to preflight request doesn't pass access control check", // LAPIS sometimes hangs up preflight requests for unknown reasons
                     'has been externalized for browser compatibility.',
+                    "from origin 'http://localhost:3000' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header",
                 ];
 
                 const isHarmless = harmlessMessages.some((harmless) =>


### PR DESCRIPTION
Rare console errors that are not due to clear underlying problems. Possibly related to LAPIS or SILO dropping requests when switching to new dataVersion.

Console errors like this will no longer fail reducing flakiness:

```
Error: Unexpected console error: Access to XMLHttpRequest at 'http://10.1.1.126:8080/ebola-sudan/sample/aggregated' from origin 'http://localhost:3000' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

🚀 Preview: Add `preview` label to enable