### PR TITLE
feat(website): Add confirmation dialog for citation deletion

### DIFF
--- a/integration-tests/tests/pages/admin.page.ts
+++ b/integration-tests/tests/pages/admin.page.ts
@@ -40,6 +40,7 @@ export class AdminPage {
     async deleteCitation(sourceDOI: string) {
         const row = this.getCitationRow(sourceDOI);
         await row.getByTestId('delete-citation-button').click();
+        await this.page.getByRole('button', { name: 'Confirm' }).click();
         await expect(row).toBeHidden();
     }
 }

--- a/website/src/components/AdminDashboard/AdminSeqSetCitationsSection.tsx
+++ b/website/src/components/AdminDashboard/AdminSeqSetCitationsSection.tsx
@@ -6,6 +6,7 @@ import { AdminSeqSetCitationsTable } from './AdminSeqSetCitationsTable';
 import { BackendClient } from '../../services/backendClient';
 import type { ClientConfig } from '../../types/runtimeConfig';
 import type { AdminSeqSetCitation } from '../../types/seqSetCitation';
+import { displayConfirmationDialog } from '../ConfirmationDialog';
 
 interface Props {
     citations: AdminSeqSetCitation[];
@@ -25,7 +26,7 @@ export const AdminSeqSetCitationsSection: FC<Props> = ({ citations, clientConfig
         ]);
     };
 
-    const handleDelete = async (sourceDOI: string) => {
+    const deleteCitation = async (sourceDOI: string) => {
         const result = await backendClient.deleteSeqSetCitation(accessToken, sourceDOI);
         result.match(
             () => {
@@ -41,14 +42,19 @@ export const AdminSeqSetCitationsSection: FC<Props> = ({ citations, clientConfig
         );
     };
 
+    const handleDelete = (sourceDOI: string) => {
+        const citation = citationList.find((c) => c.source.sourceDOI === sourceDOI);
+        const citationLabel = citation?.source.title ?? sourceDOI;
+        displayConfirmationDialog({
+            dialogText: `Are you sure you want to remove the citation "${citationLabel}"?`,
+            onConfirmation: () => deleteCitation(sourceDOI),
+        });
+    };
+
     return (
         <>
             <div className='overflow-x-auto'>
-                <AdminSeqSetCitationsTable
-                    citations={citationList}
-                    // eslint-disable-next-line @typescript-eslint/no-misused-promises
-                    onDelete={handleDelete}
-                />
+                <AdminSeqSetCitationsTable citations={citationList} onDelete={handleDelete} />
             </div>
             <AddSeqSetCitationForm
                 clientConfig={clientConfig}


### PR DESCRIPTION
resolves #

### Description
Added a confirmation dialog that appears when users attempt to delete a citation from the admin dashboard. This prevents accidental deletions by requiring explicit confirmation before the deletion is processed.

**Changes:**
- Refactored `handleDelete` to display a confirmation dialog before deletion
- Renamed the async deletion logic to `deleteCitation` for clarity
- The confirmation dialog displays the citation title (or DOI if title is unavailable) for better user context
- Removed unnecessary ESLint disable comment since `handleDelete` is now synchronous
- Updated integration tests to click the confirmation button in the deletion flow

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

### Test Plan
The integration test `deleteCitation` has been updated to verify the complete deletion flow including the confirmation dialog. The test now clicks the "Confirm" button and verifies the citation row is hidden, ensuring the feature works end-to-end.

https://claude.ai/code/session_011J2KqZ78uAwuMYZL2J6gCV

🚀 Preview: Add `preview` label to enable