### PR TITLE
feat(website): improve SeqSet citation metadata

### DIFF
--- a/backend/docs/db/schema.sql
+++ b/backend/docs/db/schema.sql
@@ -1237,3 +1237,4 @@ ALTER TABLE ONLY public.user_groups_table
 --
 
 \unrestrict dummy
+

--- a/backend/docs/db/schema.sql
+++ b/backend/docs/db/schema.sql
@@ -434,6 +434,7 @@ CREATE TABLE public.seqset_citation_source (
     title text NOT NULL,
     year integer NOT NULL,
     contributors jsonb NOT NULL,
+    journal text,
     CONSTRAINT seqset_citation_source_origin_check CHECK ((origin = ANY (ARRAY['CROSSREF'::text, 'CURATED'::text])))
 );
 
@@ -1236,4 +1237,3 @@ ALTER TABLE ONLY public.user_groups_table
 --
 
 \unrestrict dummy
-

--- a/backend/src/main/kotlin/org/loculus/backend/api/SeqSetCitations.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SeqSetCitations.kt
@@ -90,6 +90,11 @@ data class CitationSource(
         description = "List of contributors to the citation source.",
     )
     val contributors: List<CitationContributor>,
+    @Schema(
+        description = "The journal in which the citation source was published, when applicable.",
+        example = "Journal of Examples",
+    )
+    val journal: String? = null,
 )
 
 data class SeqSetCitationSource(val source: CitationSource, val seqSetDOIs: Set<String> = emptySet())

--- a/backend/src/main/kotlin/org/loculus/backend/service/crossref/CrossRefService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/crossref/CrossRefService.kt
@@ -166,6 +166,7 @@ class CrossRefService(
                     CitationContributor(givenName, surname)
                 }
             }
+            val journal = citationElement.selectFirst("journal_title")?.text()?.takeIf { it.isNotBlank() }
 
             SeqSetCitationSource(
                 source = CitationSource(
@@ -173,6 +174,7 @@ class CrossRefService(
                     title = title,
                     year = year,
                     contributors = contributors,
+                    journal = journal,
                 ),
                 seqSetDOIs = setOf(seqSetDOI),
             )

--- a/backend/src/main/kotlin/org/loculus/backend/service/seqsetcitations/SeqSetCitationsDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/seqsetcitations/SeqSetCitationsDatabaseService.kt
@@ -407,6 +407,7 @@ class SeqSetCitationsDatabaseService(
                 this[SeqSetCitationSourceTable.title] = it.source.title
                 this[SeqSetCitationSourceTable.year] = it.source.year
                 this[SeqSetCitationSourceTable.contributors] = it.source.contributors
+                this[SeqSetCitationSourceTable.journal] = it.source.journal
             }
             .flatMap { result ->
                 val citationSourceId = result[SeqSetCitationSourceTable.citationSourceId]
@@ -456,6 +457,7 @@ class SeqSetCitationsDatabaseService(
                         it[SeqSetCitationSourceTable.title],
                         it[SeqSetCitationSourceTable.year],
                         it[SeqSetCitationSourceTable.contributors],
+                        it[SeqSetCitationSourceTable.journal],
                     ),
                 )
             }
@@ -494,6 +496,7 @@ class SeqSetCitationsDatabaseService(
                         title = first[SeqSetCitationSourceTable.title],
                         year = first[SeqSetCitationSourceTable.year],
                         contributors = first[SeqSetCitationSourceTable.contributors],
+                        journal = first[SeqSetCitationSourceTable.journal],
                     ),
                     seqSets = rows.map {
                         SeqSetCitingSequence(
@@ -529,6 +532,7 @@ class SeqSetCitationsDatabaseService(
                         title = first[SeqSetCitationSourceTable.title],
                         year = first[SeqSetCitationSourceTable.year],
                         contributors = first[SeqSetCitationSourceTable.contributors],
+                        journal = first[SeqSetCitationSourceTable.journal],
                     ),
                     seqSets = rows.map { it.toSeqSet() },
                     origin = first[SeqSetCitationSourceTable.origin],
@@ -584,6 +588,7 @@ class SeqSetCitationsDatabaseService(
                 this[SeqSetCitationSourceTable.title] = it.title
                 this[SeqSetCitationSourceTable.year] = it.year
                 this[SeqSetCitationSourceTable.contributors] = it.contributors
+                this[SeqSetCitationSourceTable.journal] = it.journal
             }
             .single()[SeqSetCitationSourceTable.citationSourceId]
 

--- a/backend/src/main/kotlin/org/loculus/backend/service/seqsetcitations/SeqSetsTables.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/seqsetcitations/SeqSetsTables.kt
@@ -44,6 +44,7 @@ object SeqSetCitationSourceTable : Table("seqset_citation_source") {
     val title = text("title")
     val year = integer("year")
     val contributors = jacksonSerializableJsonb<List<CitationContributor>>("contributors")
+    val journal = text("journal").nullable()
     override val primaryKey = PrimaryKey(citationSourceId)
 }
 

--- a/backend/src/main/resources/db/migration/V1.34__add_journal_to_seqset_citation_source.sql
+++ b/backend/src/main/resources/db/migration/V1.34__add_journal_to_seqset_citation_source.sql
@@ -1,0 +1,1 @@
+alter table seqset_citation_source add column journal text;

--- a/backend/src/test/kotlin/org/loculus/backend/service/crossref/CrossRefServiceTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/crossref/CrossRefServiceTest.kt
@@ -101,6 +101,7 @@ class CrossRefServiceTest(
                             CitationContributor(givenName = "Jane", surname = "Doe"),
                             CitationContributor(givenName = "John", surname = "Smith"),
                         ),
+                        journal = "Journal of Citations",
                     ),
                     seqSetDOIs = setOf("10.1234/seqset-1"),
                 ),

--- a/website/src/components/AdminDashboard/AddSeqSetCitationForm.tsx
+++ b/website/src/components/AdminDashboard/AddSeqSetCitationForm.tsx
@@ -37,6 +37,7 @@ const parseContributor = (line: string) => {
 /* eslint-disable @typescript-eslint/naming-convention */
 type CrossRefWork = {
     'title'?: string[];
+    'container-title'?: string[];
     'author'?: { given?: string; family?: string }[];
     'issued'?: { 'date-parts'?: number[][] };
     'published'?: { 'date-parts'?: number[][] };
@@ -60,6 +61,7 @@ export const AddSeqSetCitationForm: FC<Props> = ({ clientConfig, accessToken, on
     const isClient = useClientFlag();
     const [sourceDOI, setSourceDOI] = useState('');
     const [title, setTitle] = useState('');
+    const [journal, setJournal] = useState('');
     const [year, setYear] = useState('');
     const [contributorsInput, setContributorsInput] = useState('');
     const [seqSetAccessionsInput, setSeqSetAccessionsInput] = useState('');
@@ -72,6 +74,7 @@ export const AddSeqSetCitationForm: FC<Props> = ({ clientConfig, accessToken, on
     const resetForm = () => {
         setSourceDOI('');
         setTitle('');
+        setJournal('');
         setYear('');
         setContributorsInput('');
         setSeqSetAccessionsInput('');
@@ -95,6 +98,9 @@ export const AddSeqSetCitationForm: FC<Props> = ({ clientConfig, accessToken, on
 
             if (work.title?.[0] !== undefined) {
                 setTitle(work.title[0]);
+            }
+            if (work['container-title']?.[0] !== undefined) {
+                setJournal(work['container-title'][0]);
             }
             const year = extractYear(work);
             if (year !== undefined) {
@@ -146,6 +152,7 @@ export const AddSeqSetCitationForm: FC<Props> = ({ clientConfig, accessToken, on
                 title: title.trim(),
                 year: parsedYear,
                 contributors: splitLines(contributorsInput).map(parseContributor),
+                journal: journal.trim() || undefined,
             },
             seqSetAccessionVersions,
         });
@@ -223,6 +230,19 @@ export const AddSeqSetCitationForm: FC<Props> = ({ clientConfig, accessToken, on
                     className={inputStyles}
                     value={year}
                     onChange={(e) => setYear(e.target.value)}
+                    disabled={!isClient}
+                />
+            </div>
+            <div className='mb-4'>
+                <label htmlFor='citation-journal' className='block mb-1 text-sm font-medium text-gray-900'>
+                    Journal
+                </label>
+                <input
+                    id='citation-journal'
+                    type='text'
+                    className={inputStyles}
+                    value={journal}
+                    onChange={(e) => setJournal(e.target.value)}
                     disabled={!isClient}
                 />
             </div>

--- a/website/src/components/AdminDashboard/AdminSeqSetCitationsTable.tsx
+++ b/website/src/components/AdminDashboard/AdminSeqSetCitationsTable.tsx
@@ -3,17 +3,13 @@ import type { FC } from 'react';
 import { routes } from '../../routes/routes';
 import type { AdminSeqSetCitation } from '../../types/seqSetCitation';
 import { getAccessionVersionString } from '../../utils/extractAccessionVersion';
+import { formatCitationContributors } from '../SeqSetCitations/formatCitationContributors';
 import { Button } from '../common/Button';
 
 interface Props {
     citations: AdminSeqSetCitation[];
     onDelete?: (sourceDOI: string) => void;
 }
-
-const formatContributors = (contributors: AdminSeqSetCitation['source']['contributors']) =>
-    contributors
-        .map((contributor) => [contributor.givenName, contributor.surname].filter((name) => name).join(' '))
-        .join(', ');
 
 export const AdminSeqSetCitationsTable: FC<Props> = ({ citations, onDelete }) => {
     if (citations.length === 0) {
@@ -52,8 +48,11 @@ export const AdminSeqSetCitationsTable: FC<Props> = ({ citations, onDelete }) =>
                                 {citation.source.title}
                             </a>
                             <div className='text-sm text-gray-700'>
-                                {formatContributors(citation.source.contributors)}
+                                {formatCitationContributors(citation.source.contributors)}
                             </div>
+                            {citation.source.journal !== undefined && citation.source.journal !== null && (
+                                <div className='text-sm italic text-gray-700'>{citation.source.journal}</div>
+                            )}
                             <div className='text-xs text-gray-500'>{citation.source.sourceDOI}</div>
                         </td>
                         <td className='border px-2 py-1 align-top text-right'>{citation.source.year}</td>

--- a/website/src/components/SeqSetCitations/CitationTable.tsx
+++ b/website/src/components/SeqSetCitations/CitationTable.tsx
@@ -20,7 +20,7 @@ export const CitationDetails: FC<{
     displayYear?: boolean;
 }> = ({ citation, className = '', displayYear = false }) => {
     return (
-        <div className={`flex flex-col gap-2 ${className}`}>
+        <div className={`flex flex-col gap-1 ${className}`}>
             <a
                 className='text-primary-700'
                 href={`https://doi.org/${citation.source.sourceDOI}`}

--- a/website/src/components/SeqSetCitations/CitationTable.tsx
+++ b/website/src/components/SeqSetCitations/CitationTable.tsx
@@ -1,8 +1,8 @@
 import { type FC } from 'react';
 
+import { formatCitationContributors } from './formatCitationContributors';
 import { routes } from '../../routes/routes';
 import { type SeqSetCitation, type SequenceCitation } from '../../types/seqSetCitation';
-import { formatCitationContributors } from './formatCitationContributors';
 
 interface CitationTableProps {
     isLoading: boolean;

--- a/website/src/components/SeqSetCitations/CitationTable.tsx
+++ b/website/src/components/SeqSetCitations/CitationTable.tsx
@@ -30,9 +30,7 @@ export const CitationDetails: FC<{
                 {citation.source.title}
                 {displayYear && ` (${citation.source.year})`}
             </a>
-            <div className='text-sm text-gray-700'>
-                {formatCitationContributors(citation.source.contributors)}
-            </div>
+            <div className='text-sm text-gray-700'>{formatCitationContributors(citation.source.contributors)}</div>
             {citation.source.journal !== undefined && citation.source.journal !== null && (
                 <div className='text-sm italic text-gray-700'>{citation.source.journal}</div>
             )}

--- a/website/src/components/SeqSetCitations/CitationTable.tsx
+++ b/website/src/components/SeqSetCitations/CitationTable.tsx
@@ -2,6 +2,7 @@ import { type FC } from 'react';
 
 import { routes } from '../../routes/routes';
 import { type SeqSetCitation, type SequenceCitation } from '../../types/seqSetCitation';
+import { formatCitationContributors } from './formatCitationContributors';
 
 interface CitationTableProps {
     isLoading: boolean;
@@ -30,10 +31,11 @@ export const CitationDetails: FC<{
                 {displayYear && ` (${citation.source.year})`}
             </a>
             <div className='text-sm text-gray-700'>
-                {citation.source.contributors
-                    .map((contributor) => [contributor.givenName, contributor.surname].filter((name) => name).join(' '))
-                    .join(', ')}
+                {formatCitationContributors(citation.source.contributors)}
             </div>
+            {citation.source.journal !== undefined && citation.source.journal !== null && (
+                <div className='text-sm italic text-gray-700'>{citation.source.journal}</div>
+            )}
             {'seqSets' in citation && citation.seqSets.length > 0 && (
                 <span className='text-sm text-gray-500'>
                     From SeqSet{citation.seqSets.length > 1 ? 's' : ''}:

--- a/website/src/components/SeqSetCitations/formatCitationContributors.spec.ts
+++ b/website/src/components/SeqSetCitations/formatCitationContributors.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest';
+
+import { formatCitationContributors } from './formatCitationContributors';
+
+describe('formatCitationContributors', () => {
+    test('shows all contributors when there are ten or fewer', () => {
+        expect(
+            formatCitationContributors([
+                { givenName: 'Jane', surname: 'Doe' },
+                { givenName: 'John', surname: 'Smith' },
+                { givenName: 'Alex', surname: 'Jones' },
+            ]),
+        ).toBe('Jane Doe, John Smith, Alex Jones');
+    });
+
+    test('truncates contributor lists longer than ten with an ellipsis', () => {
+        expect(
+            formatCitationContributors([
+                { givenName: 'Jane', surname: 'Doe' },
+                { givenName: 'John', surname: 'Smith' },
+                { givenName: 'Alex', surname: 'Jones' },
+                { givenName: 'Sam', surname: 'Taylor' },
+                { givenName: 'Morgan', surname: 'Lee' },
+                { givenName: 'Jordan', surname: 'Patel' },
+                { givenName: 'Casey', surname: 'Brown' },
+                { givenName: 'Taylor', surname: 'Wilson' },
+                { givenName: 'Jamie', surname: 'Davis' },
+                { givenName: 'Robin', surname: 'Garcia' },
+                { givenName: 'Avery', surname: 'Martinez' },
+            ]),
+        ).toBe(
+            'Jane Doe, John Smith, Alex Jones, Sam Taylor, Morgan Lee, Jordan Patel, Casey Brown, Taylor Wilson, Jamie Davis, Robin Garcia, ...',
+        );
+    });
+});

--- a/website/src/components/SeqSetCitations/formatCitationContributors.ts
+++ b/website/src/components/SeqSetCitations/formatCitationContributors.ts
@@ -1,0 +1,16 @@
+import type { CitationContributor } from '../../types/seqSetCitation';
+
+const MAX_DISPLAYED_CONTRIBUTORS = 10;
+
+const formatContributor = ({ givenName, surname }: CitationContributor) =>
+    [givenName, surname].filter((name) => name).join(' ');
+
+export const formatCitationContributors = (contributors: CitationContributor[]) => {
+    const formattedContributors = contributors.map(formatContributor).filter((name) => name);
+
+    if (formattedContributors.length <= MAX_DISPLAYED_CONTRIBUTORS) {
+        return formattedContributors.join(', ');
+    }
+
+    return `${formattedContributors.slice(0, MAX_DISPLAYED_CONTRIBUTORS).join(', ')}, ...`;
+};

--- a/website/src/types/seqSetCitation.ts
+++ b/website/src/types/seqSetCitation.ts
@@ -33,16 +33,18 @@ export const authorProfile = z.object({
 });
 export type AuthorProfile = z.infer<typeof authorProfile>;
 
-const citationContributor = z.object({
+export const citationContributor = z.object({
     givenName: z.string(),
     surname: z.string(),
 });
+export type CitationContributor = z.infer<typeof citationContributor>;
 
 export const citationSource = z.object({
     sourceDOI: z.string(),
     title: z.string(),
     year: z.number(),
     contributors: z.array(citationContributor),
+    journal: z.string().nullish(),
 });
 
 export const citationOrigin = z.enum(['CROSSREF', 'CURATED']);


### PR DESCRIPTION
## Summary

SeqSet citation author lists now retain up to ten names and use an ellipsis when additional contributors exist. This keeps citations readable without hiding normal-sized author lists.

The citation model now retains journal metadata from Crossref, persists it in the database, exposes it through the API, and displays it in public and administrative citation views. Manually curated citations can also supply a journal, including DOI metadata lookups.

## Why

Citation views previously rendered every contributor, causing unusually long paper author lists to dominate the page. The backend also discarded Crossref journal metadata, leaving users without a key publication detail.
org.loculus.backend.service.crossref.CrossRefServiceTest --console=plain`



## Preview evidence

![Filled manual citation form](https://raw.githubusercontent.com/loculus-project/agent_store/main/loculus-pr-6920-citation-preview.png)

![Saved citation showing journal and truncated authors](https://raw.githubusercontent.com/loculus-project/agent_store/main/loculus-pr-6920-citation-saved.png)

![Sequence details “Cited in” section with truncated authors and journal](https://raw.githubusercontent.com/loculus-project/agent_store/main/loculus-pr-6920-sequence-citation-tightened.png)

🚀 Preview: https://agent-seqset-citation-aut.loculus.org