### PR TITLE
chore(deployment): richer diagnostics collection for e2e integration tests

### DIFF
--- a/.github/scripts/collect_kubernetes_logs.sh
+++ b/.github/scripts/collect_kubernetes_logs.sh
@@ -2,16 +2,97 @@
 
 set -e
 
-pods=$(kubectl get pods -l app=loculus -o jsonpath='{.items[*].metadata.name}' || true)
+mkdir -p "kubernetes_logs"
 
-echo "Collecting logs from pods: $pods"
+# Collect logs for a single container. When $previous is "true" the logs of the
+# previously terminated instance are collected instead of the current one. These
+# only exist when a container has restarted (e.g. CrashLoopBackOff), so failures
+# are expected and the (otherwise empty) file is removed afterwards.
+#
+# NOTE: `kubectl logs --previous` only exposes the immediately previous (n-1)
+# instance. Earlier instances (n-2, n-3, ...) are not reachable via kubectl. To
+# capture *every* restart we additionally copy the kubelet's per-restart log
+# files (0.log, 1.log, ...) straight off the k3d node; see collect_node_pod_logs.
+collect_container_logs() {
+  namespace="$1"
+  pod="$2"
+  container="$3"
+  previous="$4"
 
-for pod in $pods; do
-  containers=$(kubectl get pod "$pod" -o jsonpath='{.spec.containers[*].name}' || true)
-  for container in $containers; do
-    mkdir "kubernetes_logs" -p
-    file="kubernetes_logs/$pod-$container.txt"
-    echo "Logs from $pod - $container:" >> "$file"
-    kubectl logs "$pod" -c "$container" >> "$file" 2>/dev/null || true
+  if [ "$previous" = "true" ]; then
+    file="kubernetes_logs/$namespace-$pod-$container-previous.txt"
+    header="Previous (pre-restart) logs from $namespace/$pod - $container:"
+    previous_flag="--previous"
+  else
+    file="kubernetes_logs/$namespace-$pod-$container.txt"
+    header="Logs from $namespace/$pod - $container:"
+    previous_flag=""
+  fi
+
+  # Self-describing header: node, image and restart count so each log file is
+  # interpretable on its own without cross-referencing pods.yaml.
+  node=$(kubectl get pod "$pod" -n "$namespace" -o jsonpath='{.spec.nodeName}' 2>/dev/null || true)
+  uid=$(kubectl get pod "$pod" -n "$namespace" -o jsonpath='{.metadata.uid}' 2>/dev/null || true)
+  restarts=$(kubectl get pod "$pod" -n "$namespace" -o jsonpath="{.status.containerStatuses[?(@.name=='$container')].restartCount}{.status.initContainerStatuses[?(@.name=='$container')].restartCount}" 2>/dev/null || true)
+  image=$(kubectl get pod "$pod" -n "$namespace" -o jsonpath="{.status.containerStatuses[?(@.name=='$container')].imageID}{.status.initContainerStatuses[?(@.name=='$container')].imageID}" 2>/dev/null || true)
+  {
+    echo "$header"
+    echo "  node=$node podUID=$uid restartCount=$restarts"
+    echo "  image=$image"
+    echo "---"
+  } > "$file"
+
+  # --timestamps prepends an RFC3339 timestamp (from the container runtime) to
+  # every line, independent of the app's own log format. This is essential for
+  # correlating pod logs with the backend log, the Playwright network trace and
+  # pod events when debugging timing/ordering issues.
+  # shellcheck disable=SC2086 # previous_flag is intentionally unquoted (may be empty)
+  kubectl logs --timestamps=true "$pod" -n "$namespace" -c "$container" $previous_flag >> "$file" 2>/dev/null || true
+
+  # Drop the file if it only contains the header (no previous instance existed).
+  if [ "$(wc -l < "$file")" -le 4 ]; then
+    rm -f "$file"
+  fi
+}
+
+# Collect current + previous (n-1) logs for every container of every pod matching
+# a label selector in a namespace.
+collect_pods() {
+  namespace="$1"
+  selector="$2"
+  pods=$(kubectl get pods -n "$namespace" -l "$selector" -o jsonpath='{.items[*].metadata.name}' || true)
+  echo "Collecting logs from $namespace pods ($selector): $pods"
+  for pod in $pods; do
+    # Include init containers so crashes during initialisation are captured too.
+    containers=$(kubectl get pod "$pod" -n "$namespace" -o jsonpath='{.spec.initContainers[*].name} {.spec.containers[*].name}' || true)
+    for container in $containers; do
+      collect_container_logs "$namespace" "$pod" "$container" "false"
+      collect_container_logs "$namespace" "$pod" "$container" "true"
+    done
   done
-done
+}
+
+# Copy the kubelet's per-restart log files off every k3d node. This captures the
+# logs of ALL container instances (0.log = first, 1.log = second, ...) for ALL
+# pods in ALL namespaces, i.e. everything kubectl's n-1 limit hides, plus proxy /
+# system components. Best-effort: only runs when the cluster is k3d (node = docker
+# container) and docker is available.
+collect_node_pod_logs() {
+  command -v docker >/dev/null 2>&1 || return 0
+  nodes=$(docker ps --filter "name=k3d-" --format '{{.Names}}' | grep -vE 'serverlb|registry' || true)
+  for node in $nodes; do
+    dest="kubernetes_logs/node-logs/$node"
+    mkdir -p "$dest"
+    # /var/log/pods holds <ns>_<pod>_<uid>/<container>/<restart>.log for every instance.
+    docker cp "$node:/var/log/pods" "$dest/pods" 2>/dev/null || true
+  done
+}
+
+# Application pods.
+collect_pods "default" "app=loculus"
+# Traefik ingress (kube-system) — the proxy in front of backend/LAPIS/website.
+# Its logs (and access logs, if enabled) explain "CORS"-looking failures that are
+# really upstream 502/503s returned without CORS headers.
+collect_pods "kube-system" "app.kubernetes.io/name=traefik"
+# Everything, every restart, straight off the node.
+collect_node_pod_logs

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -133,20 +133,27 @@ jobs:
       - name: List running pods
         if: ${{ !cancelled() }}
         run: kubectl get pods --all-namespaces
-      - name: Describe pods
+      - name: Describe pods and collect events
         if: ${{ !cancelled() }}
         run: |
           mkdir -p pod_descriptions
           kubectl describe pods -l app=loculus | tee pod_descriptions/describe_pods.txt
+          # Structured snapshot: restartCount + per-container lastState/exitCode,
+          # node placement and start times in a greppable machine-readable form.
+          kubectl get pods -l app=loculus -o wide | tee pod_descriptions/pods_wide.txt
+          kubectl get pods -l app=loculus -o yaml > pod_descriptions/pods.yaml
+          # Node conditions (MemoryPressure/DiskPressure/evictions) that can cause
+          # restarts independent of the app itself.
+          kubectl describe nodes > pod_descriptions/describe_nodes.txt
+          # Persist cluster events (CrashLoopBackOff, OOMKilled, probe failures,
+          # image pulls, ...) so restart causes are debuggable from the artifacts.
+          kubectl get events --sort-by=.lastTimestamp -A | tee pod_descriptions/events.txt
       - name: Upload pod descriptions
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
           name: pod-descriptions-${{ matrix.browser }}
           path: pod_descriptions/
-      - name: Show events
-        if: ${{ !cancelled() }}
-        run: kubectl get events
       - name: Save logs from all containers to file
         if: ${{ !cancelled() }}
         run: ./.github/scripts/collect_kubernetes_logs.sh


### PR DESCRIPTION
Motivated by:
- Not being able to find out why enterovirus prepro was crashlooping - logs were gone
- Not being able to see why we get various console errors related to connection dropped/aborted/CORS

This PR makes us collect additional logs in e2e action runs.

<details>
Improves the artifacts uploaded on integration-test failure so pod crash-loops,
timing/ordering issues and proxy failures are debuggable from the run output
alone. Motivated by an enterovirus preprocessing crash-loop
(singleseg-multiref-submission-flow flake) whose exit-1 cause could not be
determined because the previous container's logs were never captured.

collect_kubernetes_logs.sh:
- Collect `kubectl logs --previous` for every container. The fatal error of a
  crash-looping pod lives in the terminated instance, which was not captured
  before. Best-effort; empty files (no restart) are dropped.
- Use `--timestamps=true` on all logs. Several components (e.g. preprocessing)
  emit no timestamps of their own, previously forcing timing to be reconstructed
  by cross-referencing request IDs against the timestamped backend log. Runtime
  timestamps make every stream alignable with the backend log, the Playwright
  network trace and pod events.
- Self-describing headers: node, podUID, restartCount and imageID per file, so a
  log is interpretable without cross-referencing pods.yaml.
- Also collect Traefik logs from kube-system (`app.kubernetes.io/name=traefik`);
  previously only `app=loculus` pods were gathered, so the ingress proxy produced
  no artifacts at all.
- Copy `/var/log/pods` off every k3d node (node = docker container). `kubectl
  logs --previous` only exposes the immediately previous (n-1) instance; the
  kubelet keeps per-restart files (0.log, 1.log, ...) on the node, so this
  captures ALL restarts of ALL pods in ALL namespaces.

integration-tests.yml:
- Persist `kubectl get events --sort-by=.lastTimestamp -A` to the pod-descriptions
  artifact (CrashLoopBackOff / OOMKilled / probe / image-pull reasons). Previously
  events were only printed to the ephemeral action log.
- Also save `kubectl get pods -o wide`, `-o yaml` (structured restartCount /
  per-container lastState / exitCode / node / start times) and
  `kubectl describe nodes` (MemoryPressure/DiskPressure/eviction signals).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

</details>