### PR TITLE
chore(website): Upgrade astro from v6 to v7, vite from v7 to v8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,6 @@ updates:
       - dependency-name: "change-case"
       - dependency-name: "@types/node"
         versions: [">=23"] # Increase when we update node version in .nvmrc
-      - dependency-name: "vite"
-        versions: [">=8.0.0"] # Astro 6 uses Vite 7; relax when upgrading to Astro 7: https://github.com/loculus-project/loculus/issues/6781
       - dependency-name: "zod"
         versions: [">=4.0.0"] #https://github.com/loculus-project/loculus/issues/3295
       - dependency-name: "react"

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -27,6 +27,7 @@ export default defineConfig({
         optimizeDeps: {
             exclude: ['fsevents', 'msw/node', 'msw', 'chromium-bidi'],
         },
+        ssr: { noExternal: ['cookie'] },
         plugins: [tailwindcss(), Icons({ compiler: 'jsx', jsx: 'react' })],
     },
 });

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -27,6 +27,9 @@ export default defineConfig({
         optimizeDeps: {
             exclude: ['fsevents', 'msw/node', 'msw', 'chromium-bidi'],
         },
+        // Required after upgrading Astro to v7. Astro v7 and msw v2.15 use different versions of this package.
+        // The msw version was being hoisted, but then removed for prod builds as msw is a dev dependency.
+        // This led to a build failure as the cookie package could not be found - including it in the server bundle fixes that.
         ssr: { noExternal: ['cookie'] },
         plugins: [tailwindcss(), Icons({ compiler: 'jsx', jsx: 'react' })],
     },

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -30,6 +30,8 @@ export default defineConfig({
         // Required after upgrading Astro to v7. Astro v7 and msw v2.15 use different versions of this package.
         // The msw version was being hoisted, but then removed for prod builds as msw is a dev dependency.
         // This led to a build failure as the cookie package could not be found - including it in the server bundle fixes that.
+        // This was an issue for this package specifically, as it is a transitive dependency used by Astro in the built dist/.
+        // For more information, see https://github.com/loculus-project/loculus/issues/6945#issuecomment-5036776254
         ssr: { noExternal: ['cookie'] },
         plugins: [tailwindcss(), Icons({ compiler: 'jsx', jsx: 'react' })],
     },

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,8 +8,8 @@
             "name": "loculus-website",
             "version": "0.0.1",
             "dependencies": {
-                "@astrojs/mdx": "^5.0.6",
-                "@astrojs/node": "^10.1.4",
+                "@astrojs/mdx": "^7.0.3",
+                "@astrojs/node": "^11.0.2",
                 "@emotion/react": "^11.14.0",
                 "@headlessui/react": "^2.2.10",
                 "@lokalise/xlsx": "^0.20.3",
@@ -20,7 +20,7 @@
                 "@types/sanitize-html": "^2.16.1",
                 "@zodios/core": "^10.9.6",
                 "@zodios/react": "^10.4.5",
-                "astro": "^6.4.8",
+                "astro": "^7.1.2",
                 "axios": "^1.18.1",
                 "change-case": "~5.3.0",
                 "chart.js": "^4.5.1",
@@ -138,13 +138,196 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@astrojs/internal-helpers": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.1.tgz",
-            "integrity": "sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ==",
+        "node_modules/@astrojs/compiler-binding": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.3.1.tgz",
+            "integrity": "sha512-DaAUj29AIBU2XdJ8uwcab8lW5O2pk9pY8AXkcMw0sw77nVa3oeTYRcO+Dvbbpoexf6ThMc0FMWYCQ/wN1/T7oQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@astrojs/compiler-binding-darwin-arm64": "0.3.1",
+                "@astrojs/compiler-binding-darwin-x64": "0.3.1",
+                "@astrojs/compiler-binding-linux-arm64-gnu": "0.3.1",
+                "@astrojs/compiler-binding-linux-arm64-musl": "0.3.1",
+                "@astrojs/compiler-binding-linux-x64-gnu": "0.3.1",
+                "@astrojs/compiler-binding-linux-x64-musl": "0.3.1",
+                "@astrojs/compiler-binding-wasm32-wasi": "0.3.1",
+                "@astrojs/compiler-binding-win32-arm64-msvc": "0.3.1",
+                "@astrojs/compiler-binding-win32-x64-msvc": "0.3.1"
+            }
+        },
+        "node_modules/@astrojs/compiler-binding-darwin-arm64": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.3.1.tgz",
+            "integrity": "sha512-IEmEF2fUIlTHtpeE/isyEGVOB14cEyh/LZOFYt6wn3jNyVpdC8aR5OZ+RzFUR/f+8ZDM1LaMwZKvoA7eMyJeFw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@astrojs/compiler-binding-darwin-x64": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.3.1.tgz",
+            "integrity": "sha512-GF2kIxjpPDLsn94zbZNMsxEmkU828QqnmM7kiQJnaooS3jmI+I7kk6+oI6EpwOsK3femCMdcm+wmOsEqtGrmjQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@astrojs/compiler-binding-linux-arm64-gnu": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.3.1.tgz",
+            "integrity": "sha512-XJL3SDmOtVrqFhCirNcHwE91+IesJqlgNo23I4qW9QUYfwzm/TBZuH61fgqsb1ttgR1mMYz6ooPWs0JDhwMqpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@astrojs/compiler-binding-linux-arm64-musl": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.3.1.tgz",
+            "integrity": "sha512-xqE8BVbDoBueK/B47w30PtkVofUWJKGkwoMVE+EOMLf11rnoANxIAdA9FPqY+rng4oNI5ndHGsri1yPj2k8vZQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@astrojs/compiler-binding-linux-x64-gnu": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.3.1.tgz",
+            "integrity": "sha512-1y0StU1qiCuDFH3rmbRJXcxdfHxFPrES1Rd+RLffosvUR7I2cH5SF5SFnBN9vXpzpkmyElZm3Yr47iJBPN7vVA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@astrojs/compiler-binding-linux-x64-musl": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.3.1.tgz",
+            "integrity": "sha512-16q0fYf7kpbmdObZEeZJEup8hQv/whgNwVjrSvT8umrKwLDSnNIWiQpm09lQQu6bweZB0XyIvHwlPitvJhC+hg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@astrojs/compiler-binding-wasm32-wasi": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.3.1.tgz",
+            "integrity": "sha512-cB456shIwDv/PrVT+2QG7LFndpHkVge5HjqADKZgGaAc9JHVktCtjSrcdkRQ+3tbkPazNKaTLRjXLIiz2NIx9g==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@astrojs/compiler-binding-win32-arm64-msvc": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.3.1.tgz",
+            "integrity": "sha512-ur/9+If/yTE69mmeX5MqSZndL0HOyx67GeNZUy3N7wVdWpLz9UTJXwyWS4UR2PUQHitghjsM5xoX0Ge56WRVQQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@astrojs/compiler-binding-win32-x64-msvc": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.3.1.tgz",
+            "integrity": "sha512-k0W+kDBzDkNZOqu4kElDvCOIbKw5Ut9S1WZ1Krj3KTgNuBERNKXsMMsRLLcbgfdMdbe7bTekQLshZrrvmYpmwA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@astrojs/compiler-rs": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.3.1.tgz",
+            "integrity": "sha512-aT7xkgsbNoS6nriY5qKpbihK43slFHO41iqgHCTdOvn1ifaQxLCc5yXy+6GzAtiafoaC1zA7OwVXCXMsvUZOkg==",
             "license": "MIT",
             "dependencies": {
-                "picomatch": "^4.0.4"
+                "@astrojs/compiler-binding": "0.3.1"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            }
+        },
+        "node_modules/@astrojs/internal-helpers": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.1.tgz",
+            "integrity": "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.4",
+                "@types/mdast": "^4.0.4",
+                "js-yaml": "^4.1.1",
+                "picomatch": "^4.0.4",
+                "retext-smartypants": "^6.2.0",
+                "shiki": "^4.0.2",
+                "smol-toml": "^1.6.0",
+                "unified": "^11.0.5"
             }
         },
         "node_modules/@astrojs/language-server": {
@@ -190,17 +373,16 @@
             }
         },
         "node_modules/@astrojs/markdown-remark": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.2.tgz",
-            "integrity": "sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q==",
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.1.tgz",
+            "integrity": "sha512-jPVNIqTvk+yKviikszv/Y1U4jGUSKpp/Nw48QZV4qjWgp70j4Lkq3lhSDRbWwCfgKvEyO9GHuVbV1dM2WYXy1w==",
             "license": "MIT",
             "dependencies": {
-                "@astrojs/internal-helpers": "0.9.1",
+                "@astrojs/internal-helpers": "0.10.1",
                 "@astrojs/prism": "4.0.2",
                 "github-slugger": "^2.0.0",
                 "hast-util-from-html": "^2.0.3",
                 "hast-util-to-text": "^4.0.2",
-                "js-yaml": "^4.1.1",
                 "mdast-util-definitions": "^6.0.0",
                 "rehype-raw": "^7.0.0",
                 "rehype-stringify": "^10.0.1",
@@ -208,9 +390,6 @@
                 "remark-parse": "^11.0.0",
                 "remark-rehype": "^11.1.2",
                 "remark-smartypants": "^3.0.2",
-                "retext-smartypants": "^6.2.0",
-                "shiki": "^4.0.0",
-                "smol-toml": "^1.6.0",
                 "unified": "^11.0.5",
                 "unist-util-remove-position": "^5.0.0",
                 "unist-util-visit": "^5.1.0",
@@ -218,13 +397,27 @@
                 "vfile": "^6.0.3"
             }
         },
-        "node_modules/@astrojs/mdx": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-5.0.6.tgz",
-            "integrity": "sha512-4dKe0ZMmqujofPNDHahzClkwinn9f8jHPcaXcgdGvPAlboD2mjzkUCofli2cBnxYAkdfhC6d50gBJ8i/cH8gHw==",
+        "node_modules/@astrojs/markdown-satteri": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.4.tgz",
+            "integrity": "sha512-6Lvt/bQZEBW+zzdhPblvfZEy5PGEYJaUsUqaCgwHeRPxZJL1gc9I+DRLKWJjjYTWDzVUTzXlMq4WwSK+X34CVw==",
             "license": "MIT",
             "dependencies": {
-                "@astrojs/markdown-remark": "7.1.2",
+                "@astrojs/internal-helpers": "0.10.1",
+                "@astrojs/prism": "4.0.2",
+                "github-slugger": "^2.0.0",
+                "hast-util-from-html": "^2.0.3",
+                "satteri": "^0.9.1"
+            }
+        },
+        "node_modules/@astrojs/mdx": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.3.tgz",
+            "integrity": "sha512-RxyIwU0uFam5ftwqKOjpIdhnFxZ/kEikeimLyQy3eGXbHT8WgRGzzesOIHVU8+m9TY8ag5WVOyvV24/GyqPdPQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@astrojs/internal-helpers": "0.10.1",
+                "@astrojs/markdown-remark": "7.2.1",
                 "@mdx-js/mdx": "^3.1.1",
                 "acorn": "^8.16.0",
                 "es-module-lexer": "^2.0.0",
@@ -242,37 +435,27 @@
                 "node": ">=22.12.0"
             },
             "peerDependencies": {
-                "astro": "^6.0.0"
+                "@astrojs/markdown-satteri": "^0.3.1",
+                "astro": "^7.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@astrojs/markdown-satteri": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@astrojs/node": {
-            "version": "10.1.4",
-            "resolved": "https://registry.npmjs.org/@astrojs/node/-/node-10.1.4.tgz",
-            "integrity": "sha512-itV568ttlrpwNsutO+KPziqKfzTPlAIXMADlpBi3VeQ3liivRKKKG+jm+IjLMKvYGkxd0QnClKVCBP4i3gpwQQ==",
+            "version": "11.0.2",
+            "resolved": "https://registry.npmjs.org/@astrojs/node/-/node-11.0.2.tgz",
+            "integrity": "sha512-/ijULxT+A5Cm8wSwWZ2vgqfim1b05D6B8n/a9l6MMA4FCotIH73g7fL7y76XojKXpTe75FVvQH92OxsMqea9kQ==",
             "license": "MIT",
             "dependencies": {
-                "@astrojs/internal-helpers": "0.10.0",
+                "@astrojs/internal-helpers": "0.10.1",
                 "send": "^1.2.1",
                 "server-destroy": "^1.0.1"
             },
             "peerDependencies": {
-                "astro": "^6.3.0"
-            }
-        },
-        "node_modules/@astrojs/node/node_modules/@astrojs/internal-helpers": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.0.tgz",
-            "integrity": "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/hast": "^3.0.4",
-                "@types/mdast": "^4.0.4",
-                "js-yaml": "^4.1.1",
-                "picomatch": "^4.0.4",
-                "retext-smartypants": "^6.2.0",
-                "shiki": "^4.0.2",
-                "smol-toml": "^1.6.0",
-                "unified": "^11.0.5"
+                "astro": "^7.0.0"
             }
         },
         "node_modules/@astrojs/prism": {
@@ -308,23 +491,6 @@
                 "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
                 "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
                 "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@astrojs/react/node_modules/@astrojs/internal-helpers": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.1.tgz",
-            "integrity": "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/hast": "^3.0.4",
-                "@types/mdast": "^4.0.4",
-                "js-yaml": "^4.1.1",
-                "picomatch": "^4.0.4",
-                "retext-smartypants": "^6.2.0",
-                "shiki": "^4.0.2",
-                "smol-toml": "^1.6.0",
-                "unified": "^11.0.5"
             }
         },
         "node_modules/@astrojs/react/node_modules/vite": {
@@ -406,16 +572,15 @@
             }
         },
         "node_modules/@astrojs/telemetry": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.2.tgz",
-            "integrity": "sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.3.tgz",
+            "integrity": "sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ==",
             "license": "MIT",
             "dependencies": {
                 "ci-info": "^4.4.0",
                 "dset": "^3.1.4",
                 "is-docker": "^4.0.0",
-                "is-wsl": "^3.1.1",
-                "which-pm-runs": "^1.1.0"
+                "package-manager-detector": "^1.6.0"
             },
             "engines": {
                 "node": "18.20.8 || ^20.3.0 || >=22.0.0"
@@ -714,6 +879,128 @@
             "engines": {
                 "node": ">=6.9.0"
             }
+        },
+        "node_modules/@bruits/satteri-darwin-arm64": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.9.5.tgz",
+            "integrity": "sha512-iw4nZgx9v30lWo/MTngQqi1pI78KI0DnkSm+lVJGYdmPLgAyDNJigVhpG42/Iq55A6c1Ll8q66ljyyRiQUxwow==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@bruits/satteri-darwin-x64": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.9.5.tgz",
+            "integrity": "sha512-6T26Z5Kf3cFW2PSlk9p7zT7yVxvuBSiJvYyz9u8KjYwMTqZyIDOj2wDyNpxKV4+6yUVG7rddq2QwvG/8LJA2+Q==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@bruits/satteri-linux-arm64-gnu": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.9.5.tgz",
+            "integrity": "sha512-u51id17uJwNEMK9nBlICsq6U31c+XVqQueVBkwRIzZG+gMpS8TOJctt5h5Wz33Z8xnMdTd+adtACVz0yHgGuOA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@bruits/satteri-linux-arm64-musl": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.9.5.tgz",
+            "integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@bruits/satteri-linux-x64-gnu": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.9.5.tgz",
+            "integrity": "sha512-F3uO8uFp3pAP5ZGXttwvh57GS7s0lL953tnNdyI2gRyP4kOOkp6pyGojNJzCjkDvWI2Cvb9iNrKok3aqQPauAw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@bruits/satteri-linux-x64-musl": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.9.5.tgz",
+            "integrity": "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@bruits/satteri-wasm32-wasi": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.9.5.tgz",
+            "integrity": "sha512-zauAuMwfPnKPUkd4AFixRFpXdgKwP2mKgxrIIo2gJzW0/ZneF9dbHnLkojSpaBnCCp7VUL1hIi5WWZvB1CqmAQ==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.11.1",
+                "@emnapi/runtime": "1.11.1",
+                "@napi-rs/wasm-runtime": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@bruits/satteri-win32-arm64-msvc": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.9.5.tgz",
+            "integrity": "sha512-SrfE7NEsgZjBvU3c+RR6oQRu0ToXY5uVJEbieXEF0YTctIV2zAVlbaMjWLts074QCgh3a+XHWkR/lWh2VH2LUg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@bruits/satteri-win32-x64-msvc": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.9.5.tgz",
+            "integrity": "sha512-5Kw9ZAtTGS8WHizyn+CJhjjfIQrw+7jcZodpmpXJjefnO15M8UexIi6JR2E5thyvsmHyhL6ZDDMUNR4bKJPd4g==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/@capsizecss/unpack": {
             "version": "4.0.0",
@@ -1025,9 +1312,9 @@
             "license": "MIT"
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+            "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -1041,9 +1328,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+            "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
             "cpu": [
                 "arm"
             ],
@@ -1057,9 +1344,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+            "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
             "cpu": [
                 "arm64"
             ],
@@ -1073,9 +1360,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+            "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
             "cpu": [
                 "x64"
             ],
@@ -1089,9 +1376,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+            "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1105,9 +1392,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+            "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
             "cpu": [
                 "x64"
             ],
@@ -1121,9 +1408,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
             "cpu": [
                 "arm64"
             ],
@@ -1137,9 +1424,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+            "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
             "cpu": [
                 "x64"
             ],
@@ -1153,9 +1440,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+            "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
             "cpu": [
                 "arm"
             ],
@@ -1169,9 +1456,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+            "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
             "cpu": [
                 "arm64"
             ],
@@ -1185,9 +1472,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+            "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
             "cpu": [
                 "ia32"
             ],
@@ -1201,9 +1488,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+            "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
             "cpu": [
                 "loong64"
             ],
@@ -1217,9 +1504,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+            "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
             "cpu": [
                 "mips64el"
             ],
@@ -1233,9 +1520,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+            "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -1249,9 +1536,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+            "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -1265,9 +1552,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+            "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
             "cpu": [
                 "s390x"
             ],
@@ -1281,9 +1568,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+            "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
             "cpu": [
                 "x64"
             ],
@@ -1297,9 +1584,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
             "cpu": [
                 "arm64"
             ],
@@ -1313,9 +1600,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+            "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
             "cpu": [
                 "x64"
             ],
@@ -1329,9 +1616,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1345,9 +1632,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+            "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
             "cpu": [
                 "x64"
             ],
@@ -1361,9 +1648,9 @@
             }
         },
         "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+            "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
             "cpu": [
                 "arm64"
             ],
@@ -1377,9 +1664,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+            "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
             "cpu": [
                 "x64"
             ],
@@ -1393,9 +1680,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+            "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
             "cpu": [
                 "arm64"
             ],
@@ -1409,9 +1696,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+            "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
             "cpu": [
                 "ia32"
             ],
@@ -1425,9 +1712,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+            "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
             "cpu": [
                 "x64"
             ],
@@ -3204,13 +3491,12 @@
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
-            "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+            "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3221,13 +3507,12 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
-            "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+            "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3238,13 +3523,12 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
-            "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+            "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3255,13 +3539,12 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
-            "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+            "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3272,13 +3555,12 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
-            "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+            "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3289,15 +3571,11 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
-            "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+            "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
             "cpu": [
                 "arm64"
-            ],
-            "dev": true,
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -3309,15 +3587,11 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
-            "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+            "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
             "cpu": [
                 "arm64"
-            ],
-            "dev": true,
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -3329,15 +3603,11 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
-            "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+            "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
             "cpu": [
                 "ppc64"
-            ],
-            "dev": true,
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -3349,15 +3619,11 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
-            "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+            "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
             "cpu": [
                 "s390x"
-            ],
-            "dev": true,
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -3369,15 +3635,11 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
-            "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+            "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
             "cpu": [
                 "x64"
-            ],
-            "dev": true,
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -3389,15 +3651,11 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
-            "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+            "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
             "cpu": [
                 "x64"
-            ],
-            "dev": true,
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -3409,13 +3667,12 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
-            "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+            "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3426,13 +3683,12 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
-            "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+            "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
             "cpu": [
                 "wasm32"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -3445,13 +3701,12 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
-            "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+            "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3462,13 +3717,12 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
-            "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+            "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3520,6 +3774,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3533,6 +3788,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3546,6 +3802,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3559,6 +3816,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3572,6 +3830,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3585,6 +3844,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3598,6 +3858,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3611,6 +3872,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3624,6 +3886,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3637,6 +3900,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3650,6 +3914,7 @@
             "cpu": [
                 "loong64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3663,6 +3928,7 @@
             "cpu": [
                 "loong64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3676,6 +3942,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3689,6 +3956,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3702,6 +3970,7 @@
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3715,6 +3984,7 @@
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3728,6 +3998,7 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3754,6 +4025,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3767,6 +4039,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3780,6 +4053,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3793,6 +4067,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3806,6 +4081,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3819,6 +4095,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3832,6 +4109,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4396,9 +4674,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4416,9 +4691,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4436,9 +4708,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4456,9 +4725,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5675,6 +5941,18 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/am-i-vibing": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/am-i-vibing/-/am-i-vibing-0.4.0.tgz",
+            "integrity": "sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg==",
+            "license": "MIT",
+            "dependencies": {
+                "process-ancestry": "^0.1.0"
+            },
+            "bin": {
+                "am-i-vibing": "dist/cli.mjs"
+            }
+        },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -6025,30 +6303,31 @@
             }
         },
         "node_modules/astro": {
-            "version": "6.4.8",
-            "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.8.tgz",
-            "integrity": "sha512-KK5lX90uU9EeVaTjINyj3sy9/NFXVa59aowaqbWBDDKLXZh4rr7GwIaCFYVetE22MJtsCNFerQXn0vlCLmpP/Q==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/astro/-/astro-7.1.2.tgz",
+            "integrity": "sha512-rn7bsh2n2/Wm/blS7QO6+aKstNfEOygX35cACGQJP8tM2uLRfeNTTEawrUR6NpVr27mOMGnl6CSWQ0CNb8iGZA==",
             "license": "MIT",
             "dependencies": {
-                "@astrojs/compiler": "^4.0.0",
-                "@astrojs/internal-helpers": "0.10.0",
-                "@astrojs/markdown-remark": "7.2.0",
-                "@astrojs/telemetry": "3.3.2",
+                "@astrojs/compiler-rs": "^0.3.1",
+                "@astrojs/internal-helpers": "0.10.1",
+                "@astrojs/markdown-satteri": "0.3.4",
+                "@astrojs/telemetry": "3.3.3",
                 "@capsizecss/unpack": "^4.0.0",
                 "@clack/prompts": "^1.1.0",
                 "@oslojs/encoding": "^1.1.0",
                 "@rollup/pluginutils": "^5.3.0",
+                "am-i-vibing": "^0.4.0",
                 "aria-query": "^5.3.2",
                 "axobject-query": "^4.1.0",
                 "ci-info": "^4.4.0",
                 "clsx": "^2.1.1",
                 "common-ancestor-path": "^2.0.0",
-                "cookie": "^1.1.1",
+                "cookie": "^2.0.1",
                 "devalue": "^5.8.1",
                 "diff": "^8.0.3",
                 "dset": "^3.1.4",
                 "es-module-lexer": "^2.0.0",
-                "esbuild": "^0.27.3",
+                "esbuild": "^0.28.0",
                 "flattie": "^1.1.1",
                 "fontace": "~0.4.1",
                 "get-tsconfig": "5.0.0-beta.4",
@@ -6060,14 +6339,13 @@
                 "magic-string": "^0.30.21",
                 "magicast": "^0.5.2",
                 "mrmime": "^2.0.1",
-                "neotraverse": "^0.6.18",
+                "neotraverse": "^1.0.1",
                 "obug": "^2.1.1",
                 "p-limit": "^7.3.0",
                 "p-queue": "^9.1.0",
                 "package-manager-detector": "^1.6.0",
                 "piccolore": "^0.1.3",
                 "picomatch": "^4.0.4",
-                "rehype": "^13.0.2",
                 "semver": "^7.7.4",
                 "shiki": "^4.0.2",
                 "smol-toml": "^1.6.0",
@@ -6077,10 +6355,8 @@
                 "tinyglobby": "^0.2.15",
                 "ultrahtml": "^1.6.0",
                 "unifont": "~0.7.4",
-                "unist-util-visit": "^5.1.0",
                 "unstorage": "^1.17.5",
-                "vfile": "^6.0.3",
-                "vite": "^7.3.2",
+                "vite": "^8.0.13",
                 "vitefu": "^1.1.2",
                 "xxhash-wasm": "^1.1.0",
                 "yargs-parser": "^22.0.0",
@@ -6099,7 +6375,15 @@
                 "url": "https://opencollective.com/astrodotbuild"
             },
             "optionalDependencies": {
-                "sharp": "^0.34.0"
+                "sharp": "^0.34.0 || ^0.35.0"
+            },
+            "peerDependencies": {
+                "@astrojs/markdown-remark": "7.2.1"
+            },
+            "peerDependenciesMeta": {
+                "@astrojs/markdown-remark": {
+                    "optional": true
+                }
             }
         },
         "node_modules/astro-eslint-parser": {
@@ -6168,53 +6452,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/astro/node_modules/@astrojs/compiler": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-4.0.0.tgz",
-            "integrity": "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==",
-            "license": "MIT"
-        },
-        "node_modules/astro/node_modules/@astrojs/internal-helpers": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.0.tgz",
-            "integrity": "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/hast": "^3.0.4",
-                "@types/mdast": "^4.0.4",
-                "js-yaml": "^4.1.1",
-                "picomatch": "^4.0.4",
-                "retext-smartypants": "^6.2.0",
-                "shiki": "^4.0.2",
-                "smol-toml": "^1.6.0",
-                "unified": "^11.0.5"
-            }
-        },
-        "node_modules/astro/node_modules/@astrojs/markdown-remark": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.0.tgz",
-            "integrity": "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==",
-            "license": "MIT",
-            "dependencies": {
-                "@astrojs/internal-helpers": "0.10.0",
-                "@astrojs/prism": "4.0.2",
-                "github-slugger": "^2.0.0",
-                "hast-util-from-html": "^2.0.3",
-                "hast-util-to-text": "^4.0.2",
-                "mdast-util-definitions": "^6.0.0",
-                "rehype-raw": "^7.0.0",
-                "rehype-stringify": "^10.0.1",
-                "remark-gfm": "^4.0.1",
-                "remark-parse": "^11.0.0",
-                "remark-rehype": "^11.1.2",
-                "remark-smartypants": "^3.0.2",
-                "unified": "^11.0.5",
-                "unist-util-remove-position": "^5.0.0",
-                "unist-util-visit": "^5.1.0",
-                "unist-util-visit-parents": "^6.0.2",
-                "vfile": "^6.0.3"
-            }
-        },
         "node_modules/astro/node_modules/aria-query": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -6237,6 +6474,19 @@
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/astro/node_modules/cookie": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.1.tgz",
+            "integrity": "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/astro/node_modules/jsonc-parser": {
@@ -6371,6 +6621,83 @@
                     "optional": true
                 },
                 "uploadthing": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/astro/node_modules/vite": {
+            "version": "8.1.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+            "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+            "license": "MIT",
+            "dependencies": {
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.5",
+                "postcss": "^8.5.17",
+                "rolldown": "~1.1.5",
+                "tinyglobby": "^0.2.17"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.3.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
                     "optional": true
                 }
             }
@@ -7180,6 +7507,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
             "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -8104,9 +8432,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+            "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
@@ -8116,32 +8444,32 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.27.7",
-                "@esbuild/android-arm": "0.27.7",
-                "@esbuild/android-arm64": "0.27.7",
-                "@esbuild/android-x64": "0.27.7",
-                "@esbuild/darwin-arm64": "0.27.7",
-                "@esbuild/darwin-x64": "0.27.7",
-                "@esbuild/freebsd-arm64": "0.27.7",
-                "@esbuild/freebsd-x64": "0.27.7",
-                "@esbuild/linux-arm": "0.27.7",
-                "@esbuild/linux-arm64": "0.27.7",
-                "@esbuild/linux-ia32": "0.27.7",
-                "@esbuild/linux-loong64": "0.27.7",
-                "@esbuild/linux-mips64el": "0.27.7",
-                "@esbuild/linux-ppc64": "0.27.7",
-                "@esbuild/linux-riscv64": "0.27.7",
-                "@esbuild/linux-s390x": "0.27.7",
-                "@esbuild/linux-x64": "0.27.7",
-                "@esbuild/netbsd-arm64": "0.27.7",
-                "@esbuild/netbsd-x64": "0.27.7",
-                "@esbuild/openbsd-arm64": "0.27.7",
-                "@esbuild/openbsd-x64": "0.27.7",
-                "@esbuild/openharmony-arm64": "0.27.7",
-                "@esbuild/sunos-x64": "0.27.7",
-                "@esbuild/win32-arm64": "0.27.7",
-                "@esbuild/win32-ia32": "0.27.7",
-                "@esbuild/win32-x64": "0.27.7"
+                "@esbuild/aix-ppc64": "0.28.1",
+                "@esbuild/android-arm": "0.28.1",
+                "@esbuild/android-arm64": "0.28.1",
+                "@esbuild/android-x64": "0.28.1",
+                "@esbuild/darwin-arm64": "0.28.1",
+                "@esbuild/darwin-x64": "0.28.1",
+                "@esbuild/freebsd-arm64": "0.28.1",
+                "@esbuild/freebsd-x64": "0.28.1",
+                "@esbuild/linux-arm": "0.28.1",
+                "@esbuild/linux-arm64": "0.28.1",
+                "@esbuild/linux-ia32": "0.28.1",
+                "@esbuild/linux-loong64": "0.28.1",
+                "@esbuild/linux-mips64el": "0.28.1",
+                "@esbuild/linux-ppc64": "0.28.1",
+                "@esbuild/linux-riscv64": "0.28.1",
+                "@esbuild/linux-s390x": "0.28.1",
+                "@esbuild/linux-x64": "0.28.1",
+                "@esbuild/netbsd-arm64": "0.28.1",
+                "@esbuild/netbsd-x64": "0.28.1",
+                "@esbuild/openbsd-arm64": "0.28.1",
+                "@esbuild/openbsd-x64": "0.28.1",
+                "@esbuild/openharmony-arm64": "0.28.1",
+                "@esbuild/sunos-x64": "0.28.1",
+                "@esbuild/win32-arm64": "0.28.1",
+                "@esbuild/win32-ia32": "0.28.1",
+                "@esbuild/win32-x64": "0.28.1"
             }
         },
         "node_modules/escalade": {
@@ -10438,39 +10766,6 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/is-inside-container": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-            "license": "MIT",
-            "dependencies": {
-                "is-docker": "^3.0.0"
-            },
-            "bin": {
-                "is-inside-container": "cli.js"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-inside-container/node_modules/is-docker": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-            "license": "MIT",
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-map": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -10698,21 +10993,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-wsl": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-            "license": "MIT",
-            "dependencies": {
-                "is-inside-container": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/isarray": {
@@ -11145,7 +11425,6 @@
             "version": "1.32.0",
             "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
             "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-            "devOptional": true,
             "license": "MPL-2.0",
             "dependencies": {
                 "detect-libc": "^2.0.3"
@@ -11395,7 +11674,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
             "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-            "devOptional": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=8"
@@ -13012,9 +13290,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.15",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "funding": [
                 {
                     "type": "github",
@@ -13037,9 +13315,9 @@
             "license": "MIT"
         },
         "node_modules/neotraverse": {
-            "version": "0.6.18",
-            "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
-            "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-1.0.1.tgz",
+            "integrity": "sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w==",
             "license": "MIT",
             "engines": {
                 "node": ">= 10"
@@ -13720,9 +13998,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -13753,9 +14031,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.16",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-            "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+            "version": "8.5.20",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+            "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -13772,7 +14050,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -13877,6 +14155,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/process-ancestry": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/process-ancestry/-/process-ancestry-0.1.0.tgz",
+            "integrity": "sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/process-nextick-args": {
@@ -14370,37 +14657,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/rehype": {
-            "version": "13.0.2",
-            "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
-            "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "rehype-parse": "^9.0.0",
-                "rehype-stringify": "^10.0.0",
-                "unified": "^11.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/rehype-parse": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
-            "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "hast-util-from-html": "^2.0.0",
-                "unified": "^11.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
         "node_modules/rehype-raw": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
@@ -14706,13 +14962,12 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
-            "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
-            "dev": true,
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+            "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.138.0",
+                "@oxc-project/types": "=0.139.0",
                 "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
@@ -14722,28 +14977,27 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.1.4",
-                "@rolldown/binding-darwin-arm64": "1.1.4",
-                "@rolldown/binding-darwin-x64": "1.1.4",
-                "@rolldown/binding-freebsd-x64": "1.1.4",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
-                "@rolldown/binding-linux-arm64-gnu": "1.1.4",
-                "@rolldown/binding-linux-arm64-musl": "1.1.4",
-                "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
-                "@rolldown/binding-linux-s390x-gnu": "1.1.4",
-                "@rolldown/binding-linux-x64-gnu": "1.1.4",
-                "@rolldown/binding-linux-x64-musl": "1.1.4",
-                "@rolldown/binding-openharmony-arm64": "1.1.4",
-                "@rolldown/binding-wasm32-wasi": "1.1.4",
-                "@rolldown/binding-win32-arm64-msvc": "1.1.4",
-                "@rolldown/binding-win32-x64-msvc": "1.1.4"
+                "@rolldown/binding-android-arm64": "1.1.5",
+                "@rolldown/binding-darwin-arm64": "1.1.5",
+                "@rolldown/binding-darwin-x64": "1.1.5",
+                "@rolldown/binding-freebsd-x64": "1.1.5",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+                "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+                "@rolldown/binding-linux-arm64-musl": "1.1.5",
+                "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+                "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-musl": "1.1.5",
+                "@rolldown/binding-openharmony-arm64": "1.1.5",
+                "@rolldown/binding-wasm32-wasi": "1.1.5",
+                "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+                "@rolldown/binding-win32-x64-msvc": "1.1.5"
             }
         },
         "node_modules/rolldown/node_modules/@oxc-project/types": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
-            "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
-            "dev": true,
+            "version": "0.139.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+            "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
@@ -14753,13 +15007,13 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
             "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/rollup": {
             "version": "4.59.0",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
             "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "1.0.8"
@@ -15094,6 +15348,29 @@
             "license": "MIT",
             "dependencies": {
                 "suf-log": "^2.5.3"
+            }
+        },
+        "node_modules/satteri": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.5.tgz",
+            "integrity": "sha512-ZuWVl+vnM64y+/TtX8Kosv2c00W+hLQiiwnEL6H0UKVVrxFqMw4D2CJHHQaouVd89OAhtBBfjWLqhKi3TVUV4w==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree-jsx": "^1.0.5",
+                "@types/hast": "^3.0.4",
+                "@types/mdast": "^4.0.4",
+                "@types/unist": "^3.0.3"
+            },
+            "optionalDependencies": {
+                "@bruits/satteri-darwin-arm64": "0.9.5",
+                "@bruits/satteri-darwin-x64": "0.9.5",
+                "@bruits/satteri-linux-arm64-gnu": "0.9.5",
+                "@bruits/satteri-linux-arm64-musl": "0.9.5",
+                "@bruits/satteri-linux-x64-gnu": "0.9.5",
+                "@bruits/satteri-linux-x64-musl": "0.9.5",
+                "@bruits/satteri-wasm32-wasi": "0.9.5",
+                "@bruits/satteri-win32-arm64-msvc": "0.9.5",
+                "@bruits/satteri-win32-x64-msvc": "0.9.5"
             }
         },
         "node_modules/sax": {
@@ -16801,6 +17078,7 @@
             "version": "7.3.6",
             "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
             "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.27.0 || ^0.28.0",
@@ -17355,15 +17633,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/which-pm-runs": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
-            "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/which-typed-array": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -88,7 +88,7 @@
                 "tailwindcss": "^4.3.0",
                 "typescript": "^5.9.3",
                 "typescript-eslint": "^8.64.0",
-                "vite": "^7.3.6",
+                "vite": "^8.0.13",
                 "vitest": "4.1.10"
             }
         },
@@ -491,84 +491,6 @@
                 "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
                 "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
                 "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@astrojs/react/node_modules/vite": {
-            "version": "8.1.3",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
-            "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "lightningcss": "^1.32.0",
-                "picomatch": "^4.0.4",
-                "postcss": "^8.5.16",
-                "rolldown": "~1.1.3",
-                "tinyglobby": "^0.2.17"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.3.0",
-                "esbuild": "^0.27.0 || ^0.28.0",
-                "jiti": ">=1.21.0",
-                "less": "^4.0.0",
-                "sass": "^1.70.0",
-                "sass-embedded": "^1.70.0",
-                "stylus": ">=0.54.8",
-                "sugarss": "^5.0.0",
-                "terser": "^5.16.0",
-                "tsx": "^4.8.1",
-                "yaml": "^2.4.2"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "@vitejs/devtools": {
-                    "optional": true
-                },
-                "esbuild": {
-                    "optional": true
-                },
-                "jiti": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                },
-                "tsx": {
-                    "optional": true
-                },
-                "yaml": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@astrojs/telemetry": {
@@ -3774,12 +3696,12 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "android"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-android-arm64": {
             "version": "4.59.0",
@@ -3788,12 +3710,12 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "android"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
             "version": "4.59.0",
@@ -3802,12 +3724,12 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-darwin-x64": {
             "version": "4.59.0",
@@ -3816,12 +3738,12 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
             "version": "4.59.0",
@@ -3830,12 +3752,12 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
             "version": "4.59.0",
@@ -3844,12 +3766,12 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
             "version": "4.59.0",
@@ -3858,12 +3780,12 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
             "version": "4.59.0",
@@ -3872,12 +3794,12 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
             "version": "4.59.0",
@@ -3886,12 +3808,12 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
             "version": "4.59.0",
@@ -3900,12 +3822,12 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
             "version": "4.59.0",
@@ -3914,12 +3836,12 @@
             "cpu": [
                 "loong64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
             "version": "4.59.0",
@@ -3928,12 +3850,12 @@
             "cpu": [
                 "loong64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
             "version": "4.59.0",
@@ -3942,12 +3864,12 @@
             "cpu": [
                 "ppc64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
             "version": "4.59.0",
@@ -3956,12 +3878,12 @@
             "cpu": [
                 "ppc64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
             "version": "4.59.0",
@@ -3970,12 +3892,12 @@
             "cpu": [
                 "riscv64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
             "version": "4.59.0",
@@ -3984,12 +3906,12 @@
             "cpu": [
                 "riscv64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
             "version": "4.59.0",
@@ -3998,12 +3920,12 @@
             "cpu": [
                 "s390x"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
             "version": "4.59.0",
@@ -4025,12 +3947,12 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
             "version": "4.59.0",
@@ -4039,12 +3961,12 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "openbsd"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
             "version": "4.59.0",
@@ -4053,12 +3975,12 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "openharmony"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
             "version": "4.59.0",
@@ -4067,12 +3989,12 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
             "version": "4.59.0",
@@ -4081,12 +4003,12 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
             "version": "4.59.0",
@@ -4095,12 +4017,12 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
             "version": "4.59.0",
@@ -4109,12 +4031,12 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rsuite/icon-font": {
             "version": "4.1.0",
@@ -6621,83 +6543,6 @@
                     "optional": true
                 },
                 "uploadthing": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/astro/node_modules/vite": {
-            "version": "8.1.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
-            "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
-            "license": "MIT",
-            "dependencies": {
-                "lightningcss": "^1.32.0",
-                "picomatch": "^4.0.5",
-                "postcss": "^8.5.17",
-                "rolldown": "~1.1.5",
-                "tinyglobby": "^0.2.17"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.3.0",
-                "esbuild": "^0.27.0 || ^0.28.0",
-                "jiti": ">=1.21.0",
-                "less": "^4.0.0",
-                "sass": "^1.70.0",
-                "sass-embedded": "^1.70.0",
-                "stylus": ">=0.54.8",
-                "sugarss": "^5.0.0",
-                "terser": "^5.16.0",
-                "tsx": "^4.8.1",
-                "yaml": "^2.4.2"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "@vitejs/devtools": {
-                    "optional": true
-                },
-                "esbuild": {
-                    "optional": true
-                },
-                "jiti": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                },
-                "tsx": {
-                    "optional": true
-                },
-                "yaml": {
                     "optional": true
                 }
             }
@@ -15013,8 +14858,9 @@
             "version": "4.59.0",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
             "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -17075,18 +16921,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "7.3.6",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
-            "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
-            "devOptional": true,
+            "version": "8.1.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+            "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
             "license": "MIT",
             "dependencies": {
-                "esbuild": "^0.27.0 || ^0.28.0",
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.3",
-                "postcss": "^8.5.6",
-                "rollup": "^4.43.0",
-                "tinyglobby": "^0.2.15"
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.5",
+                "postcss": "^8.5.17",
+                "rolldown": "~1.1.5",
+                "tinyglobby": "^0.2.17"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -17102,9 +16946,10 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.3.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
-                "lightningcss": "^1.21.0",
                 "sass": "^1.70.0",
                 "sass-embedded": "^1.70.0",
                 "stylus": ">=0.54.8",
@@ -17117,13 +16962,16 @@
                 "@types/node": {
                     "optional": true
                 },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
                 "jiti": {
                     "optional": true
                 },
                 "less": {
-                    "optional": true
-                },
-                "lightningcss": {
                     "optional": true
                 },
                 "sass": {

--- a/website/package.json
+++ b/website/package.json
@@ -18,8 +18,8 @@
         "test-fast": "vitest --bail=1"
     },
     "dependencies": {
-        "@astrojs/mdx": "^5.0.6",
-        "@astrojs/node": "^10.1.4",
+        "@astrojs/mdx": "^7.0.3",
+        "@astrojs/node": "^11.0.2",
         "@emotion/react": "^11.14.0",
         "@headlessui/react": "^2.2.10",
         "@lokalise/xlsx": "^0.20.3",
@@ -30,7 +30,7 @@
         "@types/sanitize-html": "^2.16.1",
         "@zodios/core": "^10.9.6",
         "@zodios/react": "^10.4.5",
-        "astro": "^6.4.8",
+        "astro": "^7.1.2",
         "axios": "^1.18.1",
         "change-case": "~5.3.0",
         "chart.js": "^4.5.1",

--- a/website/package.json
+++ b/website/package.json
@@ -98,7 +98,7 @@
         "tailwindcss": "^4.3.0",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.64.0",
-        "vite": "^7.3.6",
+        "vite": "^8.0.13",
         "vitest": "4.1.10"
     },
     "comments": {

--- a/website/src/components/IndexPage/OrganismCard.astro
+++ b/website/src/components/IndexPage/OrganismCard.astro
@@ -30,14 +30,12 @@ const { key, image, displayName, organismStatistics, numberDaysAgoStatistics } =
         <p class='text-sm leading-7'>
             <span class='font-bold'>
                 {formatNumberWithDefaultLocale(organismStatistics.totalSequences)}
-            </span>
-            sequences
+            </span> sequences
             <br />
             <span class='text-slate-400 text-sm'>
                 <span class='text-slate-500'>
                     +{formatNumberWithDefaultLocale(organismStatistics.recentSequences)}
-                </span>
-                in last {numberDaysAgoStatistics} days
+                </span> in last {numberDaysAgoStatistics} days
             </span>
             <span class='hidden'
                 >{

--- a/website/src/pages/api-documentation/index.astro
+++ b/website/src/pages/api-documentation/index.astro
@@ -73,7 +73,7 @@ const BUTTON_CLASS =
                 View backend API documentation
             </a>
             <div class='mt-8'>
-                <span class='font-medium'>URL of backend server:</span>
+                <span class='font-medium'>URL of backend server: </span>
                 <code>{clientConfig.backendUrl}</code>
             </div>
         </div>
@@ -109,7 +109,7 @@ const BUTTON_CLASS =
                 We use the open source software <a href='https://www.keycloak.org/'>Keycloak</a> for authentication.
             </div>
             <div class='mt-2'>
-                <span class='font-medium'>URL of Keycloak server:</span>
+                <span class='font-medium'>URL of Keycloak server: </span>
                 <code>{keycloakUrl}</code>
             </div>
         </div>

--- a/website/src/pages/api-documentation/index.astro
+++ b/website/src/pages/api-documentation/index.astro
@@ -28,15 +28,15 @@ const BUTTON_CLASS =
 
         <div class='mb-10'>
             <p class='mt-4 mb-4'>
-                There is a
+                There is a{' '}
                 <a
                     href='https://swagger.io/tools/swagger-ui/'
                     class='underline text-primary-900 hover:text-primary-800 hover:no-underline'
                 >
                     Swagger UI
-                </a>
+                </a>{' '}
                 for documentation and direct interaction with the APIs. For more tips on how to use the API, it is recommended
-                to start with the
+                to start with the{' '}
                 <a
                     href={authenticationApiDocsUrl}
                     class='underline text-primary-900 hover:text-primary-800 hover:no-underline'
@@ -51,7 +51,7 @@ const BUTTON_CLASS =
             {
                 dataUseTermsAreEnabled() && (
                     <p class='mt-4 mb-4'>
-                        By using our API you agree to our
+                        By using our API you agree to our{' '}
                         <a
                             href={routes.datauseTermsPage()}
                             class='underline text-primary-900 hover:text-primary-800 hover:no-underline'

--- a/website/src/pages/seqsets/index.astro
+++ b/website/src/pages/seqsets/index.astro
@@ -65,7 +65,7 @@ const editAccountUrl = (await getUrlForKeycloakAccountPage()) + '/#/personal-inf
                                     can in turn be used in publications, public communications etc.
                                 </p>
                                 <p class='py-4'>
-                                    You can learn how to generate SeqSets
+                                    You can learn how to generate SeqSets{' '}
                                     <a href='/docs/how-to/generate-seqset' class='text-primary-700 opacity-90'>
                                         here.
                                     </a>


### PR DESCRIPTION
resolves #6781, replaces #6915

### Summary
- Astro `6.4.8 -> 7.1.2`
- Vite `7.3.6 -> 8.0.13`
- Astro v7 now uses [JSX rules for stripping whitespace](https://docs.astro.build/en/guides/upgrade-to/v7/#new-default-whitespace-handling-compresshtml-jsx) (in the same way as react). This meant I had to add some explicit spaces that weren't previously there - I have looked on the website and can't see any more missing spaces, but there could be some.
- Astro v7 also uses a new [markdown processor](https://docs.astro.build/en/guides/upgrade-to/v7/#new-default-markdown-processor-s%C3%A4tteri) - I have looked through a local build of Pathoplexus with astro v7 and can't see any immediate problems.

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://upgrade-astro-v6-to-v7.loculus.org