### PR TITLE
feat(prepro): new conditional metadata field requirements flag

### DIFF
--- a/kubernetes/loculus/templates/_preprocessingFromValues.tpl
+++ b/kubernetes/loculus/templates/_preprocessingFromValues.tpl
@@ -54,6 +54,9 @@
   {{- if .required}}
   required: true
   {{- end }}
+  {{- if .required_when}}
+  required_when: {{- toYaml .requiredWhen | nindent 4 }}
+  {{- end }}
   {{- if .noInput}}
   no_input: true
   {{- end }}

--- a/kubernetes/loculus/templates/_preprocessingFromValues.tpl
+++ b/kubernetes/loculus/templates/_preprocessingFromValues.tpl
@@ -54,7 +54,7 @@
   {{- if .required}}
   required: true
   {{- end }}
-  {{- if .required_when}}
+  {{- if .requiredWhen}}
   required_when: {{- toYaml .requiredWhen | nindent 4 }}
   {{- end }}
   {{- if .noInput}}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -346,6 +346,16 @@
             },
             "errorMessage": "When rangeOverlapSearch is set, type must be numeric or date ('int', 'float', 'number', or 'date')"
           }
+        },
+        {
+          "if": {
+            "properties": { "required": { "const": true } },
+            "required": ["required"]
+          },
+          "then": {
+            "not": { "required": ["requiredWhen"] },
+            "errorMessage": "A field with required: true cannot also set requiredWhen (it is already always required)."
+          }
         }
       ]
     },

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -33,7 +33,7 @@
           "type": "boolean",
           "description": "Whether the field is required by backend."
         },
-        "required_when": {
+        "requiredWhen": {
           "groups": ["metadata"],
           "type": "array",
           "description": "Array of conditions under which this metadata field is required. Conditions can be the presence of a file category, specified as files.<file_category>, or another metadata fields, specified as processed.<field_name>"

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -36,7 +36,7 @@
         "requiredWhen": {
           "groups": ["metadata"],
           "type": "array",
-          "description": "Array of conditions under which this metadata field is required. Conditions can be the presence of a file category - specified as files.<file_category>, or another metadata field - specified as <field_name>"
+          "description": "Array of conditions under which this metadata field is required. Conditions can be: the presence of a file category - specified as files.<file_category>; the input value of another metadata field - specified as <field_name>; or the processed value of another metadata field - specified as processed.<field_name>"
         },
         "desired": {
           "groups": ["metadata"],

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -36,7 +36,7 @@
         "requiredWhen": {
           "groups": ["metadata"],
           "type": "array",
-          "description": "Array of conditions under which this metadata field is required. Conditions can be: the presence of a file category - specified as files.<file_category>; the input value of another metadata field - specified as <field_name>; or the processed value of another metadata field - specified as processed.<field_name>"
+          "description": "Array of conditions under which this metadata field is required. When multiple conditions are provided they are ORed; a submission is rejected if at least one condition is not met. Conditions can be: the presence of a file category - specified as files.<file_category>; the input value of another metadata field - specified as <field_name>; or the processed value of another metadata field - specified as processed.<field_name>"
         },
         "desired": {
           "groups": ["metadata"],

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -36,7 +36,7 @@
         "requiredWhen": {
           "groups": ["metadata"],
           "type": "array",
-          "description": "Array of conditions under which this metadata field is required. Conditions can be the presence of a file category - specified as files.<file_category>, or another metadata field - specified as processed.<field_name>"
+          "description": "Array of conditions under which this metadata field is required. Conditions can be the presence of a file category - specified as files.<file_category>, or another metadata field - specified as <field_name>"
         },
         "desired": {
           "groups": ["metadata"],
@@ -354,7 +354,7 @@
           },
           "then": {
             "not": { "required": ["requiredWhen"] },
-            "errorMessage": "A field with required: true cannot also set requiredWhen (it is already always required)."
+            "errorMessage": "A field with 'required: true' cannot also set 'requiredWhen' (it is already always required)."
           }
         }
       ]

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -36,7 +36,7 @@
         "requiredWhen": {
           "groups": ["metadata"],
           "type": "array",
-          "description": "Array of conditions under which this metadata field is required. Conditions can be the presence of a file category, specified as files.<file_category>, or another metadata fields, specified as processed.<field_name>"
+          "description": "Array of conditions under which this metadata field is required. Conditions can be the presence of a file category - specified as files.<file_category>, or another metadata field - specified as processed.<field_name>"
         },
         "desired": {
           "groups": ["metadata"],

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -33,6 +33,11 @@
           "type": "boolean",
           "description": "Whether the field is required by backend."
         },
+        "required_when": {
+          "groups": ["metadata"],
+          "type": "array",
+          "description": "Array of conditions under which this metadata field is required. Conditions can be the presence of a file category, specified as files.<file_category>, or another metadata fields, specified as processed.<field_name>"
+        },
         "desired": {
           "groups": ["metadata"],
           "type": "boolean",

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -619,7 +619,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         header: Sample details
         orderOnDetailsPage: 500
         ### TO REVERT
-        required_when: 
+        requiredWhen: 
           - processed.geoLocCountry
       - name: geoLocSite
         ontology_id: GENEPIO:0100436

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -619,7 +619,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         header: Sample details
         orderOnDetailsPage: 500
         ### TO REVERT
-        requiredWhen: 
+        required_when: 
           - processed.geoLocCountry
       - name: geoLocSite
         ontology_id: GENEPIO:0100436

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1062,6 +1062,8 @@ defaultOrganismConfig: &defaultOrganismConfig
         header: Sequencing
         desired: true
         orderOnDetailsPage: 2080
+        required_when:
+          - files.raw_reads
       - name: sequencingProtocol
         ontology_id: GENEPIO:0001454
         definition: The protocol used to generate the sequence.

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1063,7 +1063,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         desired: true
         orderOnDetailsPage: 2080
         requiredWhen:
-          - files.raw_reads
+          - files.rawReads
       - name: sequencingProtocol
         ontology_id: GENEPIO:0001454
         definition: The protocol used to generate the sequence.

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1062,7 +1062,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         header: Sequencing
         desired: true
         orderOnDetailsPage: 2080
-        required_when:
+        requiredWhen:
           - files.raw_reads
       - name: sequencingProtocol
         ontology_id: GENEPIO:0001454

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -618,9 +618,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         autocomplete: true
         header: Sample details
         orderOnDetailsPage: 500
-        ### TO REVERT
-        required_when: 
-          - processed.geoLocCountry
       - name: geoLocSite
         ontology_id: GENEPIO:0100436
         definition: The name of a specific geographical location e.g. Credit River (rather than river).

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -618,6 +618,9 @@ defaultOrganismConfig: &defaultOrganismConfig
         autocomplete: true
         header: Sample details
         orderOnDetailsPage: 500
+        ### TO REVERT
+        required_when: 
+          - processed.geoLocCountry
       - name: geoLocSite
         ontology_id: GENEPIO:0100436
         definition: The name of a specific geographical location e.g. Credit River (rather than river).

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -271,17 +271,23 @@ def validate_required_when(config: Config) -> None:
                         f"condition referencing non-existing metadata field '{field}'"
                     )
                     raise ValueError(msg)
+                if field == output_field:
+                    msg = (
+                        f"invalid configuration: field '{output_field}' lists itself "
+                        "in `requiredWhen`"
+                    )
+                    raise ValueError(msg)
             elif condition.startswith(FILES_PREFIX):
                 category = condition.removeprefix(FILES_PREFIX)
                 if category not in FileCategory:
                     msg = (
-                        f"invalid configuration: field '{output_field}' has a required_when "
-                        f"condition referencing unknown file category '{category}'. "
+                        f"invalid configuration: field '{output_field}' has a requiredWhen "
+                        f"condition referencing unknown file category '{category}'."
                     )
                     raise ValueError(msg)
             else:
                 msg = (
-                    f"invalid configuration: field '{output_field}' has an invalid required_when "
+                    f"invalid configuration: field '{output_field}' has an invalid requiredWhen "
                     f"condition '{condition}'. Conditions must start with "
                     f"'{PROCESSED_PREFIX}' or '{FILES_PREFIX}'."
                 )

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -1,5 +1,6 @@
 import argparse
 import graphlib
+import itertools
 import logging
 import os
 from enum import StrEnum
@@ -255,11 +256,7 @@ def generate_argparse_from_model(config_cls: type[BaseModel]) -> argparse.Argume
 
 
 def validate_required_when(config: Config) -> None:
-    """Validate every `required_when` condition in the processing spec.
-
-    Each condition must be either `<field>` (an existing metadata field)
-    or `files.<category>` (a valid FileCategory).
-    """
+    """Validate every `required_when` condition in the processing spec."""
     for output_field, spec in config.processing_spec.items():
         if spec.required and spec.required_when:
             msg = (
@@ -276,14 +273,19 @@ def validate_required_when(config: Config) -> None:
                         f"condition referencing unknown file category '{category}'."
                     )
                     raise ValueError(msg)
-            elif condition not in config.processing_spec:
+                continue
+            field = (
+                condition.removeprefix(PROCESSED_PREFIX)
+                if condition.startswith(PROCESSED_PREFIX)
+                else condition
+            )
+            if field not in config.processing_spec:
                 msg = (
-                    f"invalid configuration: field '{output_field}' has an invalid requiredWhen "
-                    f"condition '{condition}'. Conditions must start with "
-                    f"'{FILES_PREFIX}' or be a valid input field."
+                    f"invalid configuration: field '{output_field}' has a requiredWhen "
+                    f"condition referencing non-existing metadata field '{field}'"
                 )
                 raise ValueError(msg)
-            elif condition == output_field:
+            if field == output_field:
                 msg = (
                     f"invalid configuration: field '{output_field}' lists itself in `requiredWhen`"
                 )
@@ -305,7 +307,7 @@ def get_processing_order(config: Config) -> tuple[str, ...]:
     """
     dag: dict[str, set[str]] = {k: set() for k in config.processing_spec}
     for output_field, spec in config.processing_spec.items():
-        for input in spec.inputs.values():
+        for input in itertools.chain(spec.inputs.values(), spec.required_when):
             if not input.startswith(PROCESSED_PREFIX):
                 continue
             dependency = input.removeprefix(PROCESSED_PREFIX)

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -1,6 +1,5 @@
 import argparse
 import graphlib
-import itertools
 import logging
 import os
 from enum import StrEnum
@@ -258,7 +257,7 @@ def generate_argparse_from_model(config_cls: type[BaseModel]) -> argparse.Argume
 def validate_required_when(config: Config) -> None:
     """Validate every `required_when` condition in the processing spec.
 
-    Each condition must be either `processed.<field>` (an existing metadata field)
+    Each condition must be either `<field>` (an existing metadata field)
     or `files.<category>` (a valid FileCategory).
     """
     for output_field, spec in config.processing_spec.items():
@@ -269,21 +268,7 @@ def validate_required_when(config: Config) -> None:
             )
             raise ValueError(msg)
         for condition in spec.required_when:
-            if condition.startswith(PROCESSED_PREFIX):
-                field = condition.removeprefix(PROCESSED_PREFIX)
-                if field not in config.processing_spec:
-                    msg = (
-                        f"invalid configuration: field '{output_field}' has a requiredWhen "
-                        f"condition referencing non-existing metadata field '{field}'"
-                    )
-                    raise ValueError(msg)
-                if field == output_field:
-                    msg = (
-                        f"invalid configuration: field '{output_field}' lists itself "
-                        "in `requiredWhen`"
-                    )
-                    raise ValueError(msg)
-            elif condition.startswith(FILES_PREFIX):
+            if condition.startswith(FILES_PREFIX):
                 category = condition.removeprefix(FILES_PREFIX)
                 if category not in FileCategory:
                     msg = (
@@ -291,11 +276,16 @@ def validate_required_when(config: Config) -> None:
                         f"condition referencing unknown file category '{category}'."
                     )
                     raise ValueError(msg)
-            else:
+            elif condition not in config.processing_spec:
                 msg = (
                     f"invalid configuration: field '{output_field}' has an invalid requiredWhen "
                     f"condition '{condition}'. Conditions must start with "
-                    f"'{PROCESSED_PREFIX}' or '{FILES_PREFIX}'."
+                    f"'{FILES_PREFIX}' or be a valid input field."
+                )
+                raise ValueError(msg)
+            elif condition == output_field:
+                msg = (
+                    f"invalid configuration: field '{output_field}' lists itself in `requiredWhen`"
                 )
                 raise ValueError(msg)
 
@@ -315,7 +305,7 @@ def get_processing_order(config: Config) -> tuple[str, ...]:
     """
     dag: dict[str, set[str]] = {k: set() for k in config.processing_spec}
     for output_field, spec in config.processing_spec.items():
-        for input in itertools.chain(spec.inputs.values(), spec.required_when):
+        for input in spec.inputs.values():
             if not input.startswith(PROCESSED_PREFIX):
                 continue
             dependency = input.removeprefix(PROCESSED_PREFIX)

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -43,6 +43,7 @@ class ProcessingSpec(BaseModel):
     inputs: FunctionInputs
     function: FunctionName = "identity"
     required: bool = False
+    required_when: list[str] = []
     no_input: bool = False
     args: FunctionArgs | None = None
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -301,7 +301,7 @@ def validate_required_when(config: Config) -> None:
 def get_processing_order(config: Config) -> tuple[str, ...]:
     """Return a valid order for processing metadata fields based on their dependencies.
 
-    Dependencies are derived from input fields in `config.processing_spec`.
+    Dependencies are derived from input fields and requiredWhen fields in `config.processing_spec`.
 
     A DAG is constructed and topologically sorted to ensure each field is processed after the
     fields it depends on.
@@ -321,7 +321,7 @@ def get_processing_order(config: Config) -> tuple[str, ...]:
             if dependency not in config.processing_spec:
                 msg = (
                     f"invalid configuration: metadata field '{output_field}' requested "
-                    f"non-existing field '{dependency}' as input."
+                    f"non-existing field '{dependency}' as input or as a requiredWhen condition."
                 )
                 raise ValueError(msg)
             dag[output_field].add(dependency)

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -275,30 +275,7 @@ def validate_required_when(config: Config) -> None:
                     raise ValueError(msg)
                 continue
 
-            if condition.startswith(PROCESSED_PREFIX):
-                field = condition.removeprefix(PROCESSED_PREFIX)
-                not_exist_msg = (
-                    f"invalid configuration: field '{output_field}' has a requiredWhen "
-                    f"condition referencing non-existing metadata field '{field}'"
-                )
-            else:
-                field = condition
-                not_exist_msg = (
-                    f"invalid configuration: field '{output_field}' has a requiredWhen "
-                    f"condition referencing non-existing input field '{field}'"
-                )
-
-            if (referenced_spec := config.processing_spec.get(field)) is None:
-                raise ValueError(not_exist_msg)
-
-            if referenced_spec.no_input and not condition.startswith(PROCESSED_PREFIX):
-                msg = (
-                    f"invalid configuration: field '{output_field}' has a requiredWhen "
-                    f"condition referencing the input value of noInput metadata field '{field}'"
-                )
-                raise ValueError(msg)
-
-            if field == output_field:
+            if condition.removeprefix(PROCESSED_PREFIX) == output_field:
                 msg = (
                     f"invalid configuration: field '{output_field}' lists itself in `requiredWhen`"
                 )

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -270,27 +270,34 @@ def validate_required_when(config: Config) -> None:
                 if category not in FileCategory:
                     msg = (
                         f"invalid configuration: field '{output_field}' has a requiredWhen "
-                        f"condition referencing unknown file category '{category}'."
+                        f"condition referencing non-existing file category '{category}'."
                     )
                     raise ValueError(msg)
                 continue
-            field = (
-                condition.removeprefix(PROCESSED_PREFIX)
-                if condition.startswith(PROCESSED_PREFIX)
-                else condition
-            )
-            if (referenced_spec := config.processing_spec.get(field)) is None:
-                msg = (
+
+            if condition.startswith(PROCESSED_PREFIX):
+                field = condition.removeprefix(PROCESSED_PREFIX)
+                not_exist_msg = (
                     f"invalid configuration: field '{output_field}' has a requiredWhen "
                     f"condition referencing non-existing metadata field '{field}'"
                 )
-                raise ValueError(msg)
+            else:
+                field = condition
+                not_exist_msg = (
+                    f"invalid configuration: field '{output_field}' has a requiredWhen "
+                    f"condition referencing non-existing input field '{field}'"
+                )
+
+            if (referenced_spec := config.processing_spec.get(field)) is None:
+                raise ValueError(not_exist_msg)
+
             if referenced_spec.no_input and not condition.startswith(PROCESSED_PREFIX):
                 msg = (
                     f"invalid configuration: field '{output_field}' has a requiredWhen "
-                    f"condition referencing the input value of a noInput metadata field '{field}'"
+                    f"condition referencing the input value of noInput metadata field '{field}'"
                 )
                 raise ValueError(msg)
+
             if field == output_field:
                 msg = (
                     f"invalid configuration: field '{output_field}' lists itself in `requiredWhen`"

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -273,7 +273,7 @@ def validate_required_when(config: Config) -> None:
                 field = condition.removeprefix(PROCESSED_PREFIX)
                 if field not in config.processing_spec:
                     msg = (
-                        f"invalid configuration: field '{output_field}' has a required_when "
+                        f"invalid configuration: field '{output_field}' has a requiredWhen "
                         f"condition referencing non-existing metadata field '{field}'"
                     )
                     raise ValueError(msg)

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -279,10 +279,16 @@ def validate_required_when(config: Config) -> None:
                 if condition.startswith(PROCESSED_PREFIX)
                 else condition
             )
-            if field not in config.processing_spec:
+            if (referenced_spec := config.processing_spec.get(field)) is None:
                 msg = (
                     f"invalid configuration: field '{output_field}' has a requiredWhen "
                     f"condition referencing non-existing metadata field '{field}'"
+                )
+                raise ValueError(msg)
+            if referenced_spec.no_input and not condition.startswith(PROCESSED_PREFIX):
+                msg = (
+                    f"invalid configuration: field '{output_field}' has a requiredWhen "
+                    f"condition referencing the input value of a noInput metadata field '{field}'"
                 )
                 raise ValueError(msg)
             if field == output_field:

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -262,6 +262,12 @@ def validate_required_when(config: Config) -> None:
     or `files.<category>` (a valid FileCategory).
     """
     for output_field, spec in config.processing_spec.items():
+        if spec.required and spec.required_when:
+            msg = (
+                f"invalid configuration: field '{output_field}' sets both 'required: true' and "
+                "'requiredWhen'. This is not allowed."
+            )
+            raise ValueError(msg)
         for condition in spec.required_when:
             if condition.startswith(PROCESSED_PREFIX):
                 field = condition.removeprefix(PROCESSED_PREFIX)

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -1,5 +1,6 @@
 import argparse
 import graphlib
+import itertools
 import logging
 import os
 from enum import StrEnum
@@ -10,6 +11,7 @@ import yaml
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
 from loculus_preprocessing.datatypes import (
+    FileCategory,
     FunctionArgs,
     FunctionInputs,
     FunctionName,
@@ -24,7 +26,8 @@ logger = logging.getLogger(__name__)
 # Dataclass types for which we can generate CLI arguments
 CLI_TYPES = [str, int, float, bool]
 
-METADATA_DEPENDENCY_PREFIX = "processed."
+PROCESSED_PREFIX = "processed."
+FILES_PREFIX = "files."
 NEXTCLADE_PREFIX = "nextclade."
 ASSIGNED_REFERENCE_PREFIX = "ASSIGNED_REFERENCE"
 INTERNAL_INPUT_PREFIXES = (NEXTCLADE_PREFIX, ASSIGNED_REFERENCE_PREFIX)
@@ -148,6 +151,7 @@ class Config(BaseModel):
         if not self.backend_host:  # Set here so we can use organism
             self.backend_host = f"http://127.0.0.1:8079/{self.organism}"
 
+        validate_required_when(self)
         self.processing_order = get_processing_order(self)
         self._taxonomy_service = TaxonomyService(self.taxonomy_service_url)
 
@@ -251,6 +255,39 @@ def generate_argparse_from_model(config_cls: type[BaseModel]) -> argparse.Argume
     return parser
 
 
+def validate_required_when(config: Config) -> None:
+    """Validate every `required_when` condition in the processing spec.
+
+    Each condition must be either `processed.<field>` (an existing metadata field)
+    or `files.<category>` (a valid FileCategory).
+    """
+    for output_field, spec in config.processing_spec.items():
+        for condition in spec.required_when:
+            if condition.startswith(PROCESSED_PREFIX):
+                field = condition.removeprefix(PROCESSED_PREFIX)
+                if field not in config.processing_spec:
+                    msg = (
+                        f"invalid configuration: field '{output_field}' has a required_when "
+                        f"condition referencing non-existing metadata field '{field}'"
+                    )
+                    raise ValueError(msg)
+            elif condition.startswith(FILES_PREFIX):
+                category = condition.removeprefix(FILES_PREFIX)
+                if category not in FileCategory:
+                    msg = (
+                        f"invalid configuration: field '{output_field}' has a required_when "
+                        f"condition referencing unknown file category '{category}'. "
+                    )
+                    raise ValueError(msg)
+            else:
+                msg = (
+                    f"invalid configuration: field '{output_field}' has an invalid required_when "
+                    f"condition '{condition}'. Conditions must start with "
+                    f"'{PROCESSED_PREFIX}' or '{FILES_PREFIX}'."
+                )
+                raise ValueError(msg)
+
+
 def get_processing_order(config: Config) -> tuple[str, ...]:
     """Return a valid order for processing metadata fields based on their dependencies.
 
@@ -264,25 +301,30 @@ def get_processing_order(config: Config) -> tuple[str, ...]:
     E.g.: `processed.collection_date` will look for `collection_date` in the processed metadata,
     whereas `collection_date` will use the unprocessed version
     """
-    dag: dict[str, set[str]] = {k: set() for k in config.processing_spec.keys()}
+    dag: dict[str, set[str]] = {k: set() for k in config.processing_spec}
     for output_field, spec in config.processing_spec.items():
-        for input in spec.inputs.values():
-            if not input.startswith(METADATA_DEPENDENCY_PREFIX):
+        for input in itertools.chain(spec.inputs.values(), spec.required_when):
+            if not input.startswith(PROCESSED_PREFIX):
                 continue
-            dependency = input.replace(METADATA_DEPENDENCY_PREFIX, "", 1)
+            dependency = input.removeprefix(PROCESSED_PREFIX)
+
             if dependency not in config.processing_spec:
-                raise ValueError(
-                    f"invalid configuration: metadata field '{output_field}' requested non-existing field '{dependency}' as input"
+                msg = (
+                    f"invalid configuration: metadata field '{output_field}' requested "
+                    f"non-existing field '{dependency}' as input."
                 )
+                raise ValueError(msg)
             dag[output_field].add(dependency)
 
     ts = graphlib.TopologicalSorter(dag)
     try:
         processing_order = tuple(ts.static_order())
     except graphlib.CycleError as e:
-        raise ValueError(
-            f"invalid configuration: computation of metadata processing order resulted in a Cycle error: {e}"
-        ) from e
+        msg = (
+            f"invalid configuration: computation of metadata processing order resulted in a "
+            f"Cycle error: {e}"
+        )
+        raise ValueError(msg) from e
 
     return processing_order
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
@@ -26,9 +26,14 @@ ProcessedMetadata = dict[str, ProcessedMetadataValue]
 InputMetadataValue = str | None
 InputMetadata = dict[str, InputMetadataValue]
 FastaId = str
-FileCategory = str
 
 ProcessingAnnotationAlignment: Final = "alignment"
+
+
+@unique
+class FileCategory(StrEnum):
+    RAW_READS = "rawReads"
+    ANNOTATIONS = "annotations"
 
 
 @unique

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -16,8 +16,8 @@ from .backend import (
 from .config import (
     ASSIGNED_REFERENCE_PREFIX,
     FILES_PREFIX,
-    PROCESSED_PREFIX,
     NEXTCLADE_PREFIX,
+    PROCESSED_PREFIX,
     AlignmentRequirement,
     Config,
     ProcessingSpec,

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -445,9 +445,9 @@ def get_output_metadata(  # noqa: C901, PLR0912, PLR0915
                 spec.inputs.values(),
                 [output_field],
                 AnnotationSourceType.METADATA,
-                message=msg,
+                message=message,
             )
-            for msg in requirement_errors
+            for message in requirement_errors
         )
 
     logger.debug(f"Processed {accession_version}: {output_metadata}")

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -29,6 +29,7 @@ from .datatypes import (
     AminoAcidSequence,
     AnnotationSource,
     AnnotationSourceType,
+    FileCategory,
     FileIdAndName,
     GeneName,
     InputData,

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -726,7 +726,7 @@ def upload_flatfiles(processed: Sequence[SubmissionData], config: Config) -> Non
             file_id = upload_info.fileId
             upload_embl_file_to_presigned_url(file_content, upload_info.url, upload_info.headers)
             processed_files = submission_data.processed_entry.data.files or {}
-            processed_files.setdefault("annotations", []).append(
+            processed_files.setdefault(FileCategory.ANNOTATIONS, []).append(
                 FileIdAndName(fileId=file_id, name=file_name)
             )
             submission_data.processed_entry.data.files = processed_files

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -324,7 +324,7 @@ def get_sequence_length(
     return len(sequence) if sequence else 0
 
 
-def get_output_metadata(
+def get_output_metadata(  # noqa: C901, PLR0912, PLR0915
     accession_version: AccessionVersion,
     unprocessed: UnprocessedData | UnprocessedAfterNextclade,
     config: Config,
@@ -419,61 +419,83 @@ def get_output_metadata(
         errors.extend(processing_result.errors)
         warnings.extend(processing_result.warnings)
 
-        if group_id == config.insdc_ingest_group_id:
-            # don't enforce required and required_when conditions for INSDC ingested data
+        if (
+            not null_per_backend(processing_result.datum)
+            or group_id == config.insdc_ingest_group_id
+        ):
+            # skip requirement checks when the field has a value, or for INSDC ingested data.
             continue
 
-        is_null = null_per_backend(processing_result.datum)
-        if is_null and spec.required:
-            message = f"Metadata field `{output_field}` is required."
-            user_inputs = [field for field in input_fields if config.is_user_input(field)]
-            if any(field != output_field for field in user_inputs):
-                message += (
-                    f" Please provide input metadata field(s): "
-                    f"{', '.join(f'`{field}`' for field in user_inputs)}"
-                )
-            errors.append(
-                ProcessingAnnotation.from_fields(
-                    spec.inputs.values(),
-                    [output_field],
-                    AnnotationSourceType.METADATA,
-                    message=message,
-                )
+        requirement_errors: list[str] = []
+        if spec.required:
+            requirement_errors.append(
+                build_missing_required_msg(output_field, input_fields, config)
             )
 
-        if isinstance(unprocessed, UnprocessedAfterNextclade):
-            unprocessed_metadata = unprocessed.inputMetadata
-        else:
-            unprocessed_metadata = unprocessed.metadata
         for condition in spec.required_when:
-            error_message = None
-            if condition.startswith(FILES_PREFIX):
-                file_category = condition.removeprefix(FILES_PREFIX)
-                if (
-                    is_null
-                    and unprocessed.files
-                    and unprocessed.files.get(FileCategory(file_category))
-                ):
-                    error_message = (
-                        f"Metadata field `{output_field}` is required when "
-                        f"`{file_category}` files are provided."
-                    )
-            elif is_null and not null_per_backend(unprocessed_metadata.get(condition)):
-                error_message = (
-                    f"Metadata field `{output_field}` is required when `{condition}` is provided."
+            if (
+                msg := check_required_when_condition(
+                    condition, output_field, unprocessed, output_metadata
                 )
-            if error_message:
-                errors.append(
-                    ProcessingAnnotation.from_fields(
-                        spec.inputs.values(),
-                        [output_field],
-                        AnnotationSourceType.METADATA,
-                        message=error_message,
-                    )
-                )
+            ) is not None:
+                requirement_errors.append(msg)
+
+        errors.extend(
+            ProcessingAnnotation.from_fields(
+                spec.inputs.values(),
+                [output_field],
+                AnnotationSourceType.METADATA,
+                message=msg,
+            )
+            for msg in requirement_errors
+        )
 
     logger.debug(f"Processed {accession_version}: {output_metadata}")
     return output_metadata, errors, warnings
+
+
+def build_missing_required_msg(output_field: str, input_fields: list[str], config: Config):
+    message = f"Metadata field `{output_field}` is required."
+    user_inputs = [field for field in input_fields if config.is_user_input(field)]
+    if any(field != output_field for field in user_inputs):
+        message += (
+            f" Please provide input metadata field(s): "
+            f"{', '.join(f'`{field}`' for field in user_inputs)}"
+        )
+    return message
+
+
+def check_required_when_condition(
+    condition: str,
+    output_field: str,
+    unprocessed: UnprocessedData | UnprocessedAfterNextclade,
+    output_metadata: ProcessedMetadata,
+) -> str | None:
+    input_metadata = (
+        unprocessed.inputMetadata
+        if isinstance(unprocessed, UnprocessedAfterNextclade)
+        else unprocessed.metadata
+    )
+    error_message = None
+    if condition.startswith(FILES_PREFIX):
+        file_category = condition.removeprefix(FILES_PREFIX)
+        if unprocessed.files and unprocessed.files.get(FileCategory(file_category)):
+            error_message = (
+                f"Metadata field `{output_field}` is required when "
+                f"`{file_category}` files are provided."
+            )
+    elif condition.startswith(PROCESSED_PREFIX):
+        field_name = condition.removeprefix(PROCESSED_PREFIX)
+        if not null_per_backend(output_metadata.get(field_name)):
+            error_message = (
+                f"Metadata field `{output_field}` is required when `{field_name}` is provided."
+            )
+    elif not null_per_backend(input_metadata.get(condition)):
+        error_message = (
+            f"Metadata field `{output_field}` is required when `{condition}` is provided."
+        )
+
+    return error_message
 
 
 def alignment_errors_warnings(

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -15,7 +15,8 @@ from .backend import (
 )
 from .config import (
     ASSIGNED_REFERENCE_PREFIX,
-    METADATA_DEPENDENCY_PREFIX,
+    FILES_PREFIX,
+    PROCESSED_PREFIX,
     NEXTCLADE_PREFIX,
     AlignmentRequirement,
     Config,
@@ -369,8 +370,8 @@ def get_output_metadata(
 
         for arg_name, input_path in spec.inputs.items():
             get_from_processed = False
-            if input_path.startswith(METADATA_DEPENDENCY_PREFIX):
-                resolved_path = input_path.replace(METADATA_DEPENDENCY_PREFIX, "", 1)
+            if input_path.startswith(PROCESSED_PREFIX):
+                resolved_path = input_path.removeprefix(PROCESSED_PREFIX)
                 get_from_processed = True
             else:
                 resolved_path = input_path
@@ -417,11 +418,9 @@ def get_output_metadata(
         output_metadata[output_field] = processing_result.datum
         errors.extend(processing_result.errors)
         warnings.extend(processing_result.warnings)
-        if (
-            null_per_backend(processing_result.datum)
-            and spec.required
-            and group_id != config.insdc_ingest_group_id
-        ):
+
+        is_null = null_per_backend(processing_result.datum)
+        if is_null and spec.required and group_id != config.insdc_ingest_group_id:
             message = f"Metadata field `{output_field}` is required."
             user_inputs = [field for field in input_fields if config.is_user_input(field)]
             if any(field != output_field for field in user_inputs):
@@ -437,6 +436,32 @@ def get_output_metadata(
                     message=message,
                 )
             )
+        for condition in spec.required_when:
+            error_message = None
+            if condition.startswith(PROCESSED_PREFIX):
+                field_name = condition.removeprefix(PROCESSED_PREFIX)
+                if is_null and not null_per_backend(output_metadata[field_name]):
+                    error_message = (
+                        f"Metadata field `{output_field}` is required when "
+                        f"`{field_name}` is provided."
+                    )
+            elif unprocessed.files and condition.startswith(FILES_PREFIX):
+                file_category = condition.removeprefix(FILES_PREFIX)
+                if is_null and unprocessed.files.get(FileCategory(file_category)):
+                    error_message = (
+                        f"Metadata field `{output_field}` is required when "
+                        f"`{file_category}` files are provided."
+                    )
+            if error_message:
+                errors.append(
+                    ProcessingAnnotation.from_fields(
+                        spec.inputs.values(),
+                        [output_field],
+                        AnnotationSourceType.METADATA,
+                        message=error_message,
+                    )
+                )
+
     logger.debug(f"Processed {accession_version}: {output_metadata}")
     return output_metadata, errors, warnings
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -479,8 +479,8 @@ def check_required_when_condition(
     )
     error_message = None
     if condition.startswith(FILES_PREFIX):
-        file_category = condition.removeprefix(FILES_PREFIX)
-        if unprocessed.files and unprocessed.files.get(FileCategory(file_category)):
+        file_category = FileCategory(condition.removeprefix(FILES_PREFIX))
+        if unprocessed.files and unprocessed.files.get(file_category):
             error_message = (
                 f"Metadata field `{output_field}` is required when "
                 f"`{file_category}` files are provided."

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -419,8 +419,12 @@ def get_output_metadata(
         errors.extend(processing_result.errors)
         warnings.extend(processing_result.warnings)
 
+        if group_id == config.insdc_ingest_group_id:
+            # don't enforce required and required_when conditions for INSDC ingested data
+            continue
+
         is_null = null_per_backend(processing_result.datum)
-        if is_null and spec.required and group_id != config.insdc_ingest_group_id:
+        if is_null and spec.required:
             message = f"Metadata field `{output_field}` is required."
             user_inputs = [field for field in input_fields if config.is_user_input(field)]
             if any(field != output_field for field in user_inputs):

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -434,20 +434,20 @@ def get_output_metadata(  # noqa: C901, PLR0912, PLR0915
 
         for condition in spec.required_when:
             if (
-                msg := check_required_when_condition(
+                required_when_error := check_required_when_condition(
                     condition, output_field, unprocessed, output_metadata
                 )
             ) is not None:
-                requirement_errors.append(msg)
+                requirement_errors.append(required_when_error)
 
         errors.extend(
             ProcessingAnnotation.from_fields(
                 spec.inputs.values(),
                 [output_field],
                 AnnotationSourceType.METADATA,
-                message=message,
+                message=msg,
             )
-            for message in requirement_errors
+            for msg in requirement_errors
         )
 
     logger.debug(f"Processed {accession_version}: {output_metadata}")

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -489,7 +489,7 @@ def check_required_when_condition(
         field_name = condition.removeprefix(PROCESSED_PREFIX)
         if not null_per_backend(output_metadata.get(field_name)):
             error_message = (
-                f"Metadata field `{output_field}` is required when `{field_name}` is provided."
+                f"Metadata field `{output_field}` is required when `{field_name}` exists."
             )
     elif not null_per_backend(input_metadata.get(condition)):
         error_message = (

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -440,22 +440,28 @@ def get_output_metadata(
                     message=message,
                 )
             )
+
+        if isinstance(unprocessed, UnprocessedAfterNextclade):
+            unprocessed_metadata = unprocessed.inputMetadata
+        else:
+            unprocessed_metadata = unprocessed.metadata
         for condition in spec.required_when:
             error_message = None
-            if condition.startswith(PROCESSED_PREFIX):
-                field_name = condition.removeprefix(PROCESSED_PREFIX)
-                if is_null and not null_per_backend(output_metadata[field_name]):
-                    error_message = (
-                        f"Metadata field `{output_field}` is required when "
-                        f"`{field_name}` is provided."
-                    )
-            elif unprocessed.files and condition.startswith(FILES_PREFIX):
+            if condition.startswith(FILES_PREFIX):
                 file_category = condition.removeprefix(FILES_PREFIX)
-                if is_null and unprocessed.files.get(FileCategory(file_category)):
+                if (
+                    is_null
+                    and unprocessed.files
+                    and unprocessed.files.get(FileCategory(file_category))
+                ):
                     error_message = (
                         f"Metadata field `{output_field}` is required when "
                         f"`{file_category}` files are provided."
                     )
+            elif is_null and not null_per_backend(unprocessed_metadata.get(condition)):
+                error_message = (
+                    f"Metadata field `{output_field}` is required when `{condition}` is provided."
+                )
             if error_message:
                 errors.append(
                     ProcessingAnnotation.from_fields(

--- a/preprocessing/nextclade/tests/metadata_dependency.yaml
+++ b/preprocessing/nextclade/tests/metadata_dependency.yaml
@@ -24,6 +24,12 @@ processing_spec:
     function: identity
     inputs:
       input: B
+  required_when_processed_B:
+    function: identity
+    inputs:
+      input: required_when_processed_B
+    required_when:
+      - processed.B
   required_when_raw_reads:
     function: identity
     inputs:

--- a/preprocessing/nextclade/tests/metadata_dependency.yaml
+++ b/preprocessing/nextclade/tests/metadata_dependency.yaml
@@ -14,3 +14,19 @@ processing_spec:
     function: parse_and_assert_past_date
     inputs:
       date: A
+  required_when_B:
+    function: identity
+    inputs:
+      input: required_when_B
+    required_when:
+      - processed.B
+  B:
+    function: identity
+    inputs:
+      input: B
+  required_when_raw_reads:
+    function: identity
+    inputs:
+      input: required_when_raw_reads
+    required_when:
+      - files.raw_reads

--- a/preprocessing/nextclade/tests/metadata_dependency.yaml
+++ b/preprocessing/nextclade/tests/metadata_dependency.yaml
@@ -8,31 +8,34 @@ processing_spec:
       continent: continent
       A: processed.A
       required_collection_date: ncbi_required_collection_date
+  required_when_processed_A:
+    function: identity
+    inputs:
+      input: required_when_processed_A
+    required_when:
+      - processed.A
+  required_when_input_A:
+    function: identity
+    inputs:
+      input: required_when_input_A
+    required_when:
+      - A
   A:
     args:
       type: date
     function: parse_and_assert_past_date
     inputs:
       date: A
-  required_when_B:
-    function: identity
-    inputs:
-      input: required_when_B
-    required_when:
-      - B
-  B:
-    function: identity
-    inputs:
-      input: B
-  required_when_processed_B:
-    function: identity
-    inputs:
-      input: required_when_processed_B
-    required_when:
-      - processed.B
   required_when_raw_reads:
     function: identity
     inputs:
       input: required_when_raw_reads
     required_when:
       - files.raw_reads
+  multi_dep:
+    function: identity
+    inputs:
+      input: multi_dep
+    required_when:
+      - files.raw_reads
+      - processed.A

--- a/preprocessing/nextclade/tests/metadata_dependency.yaml
+++ b/preprocessing/nextclade/tests/metadata_dependency.yaml
@@ -19,7 +19,7 @@ processing_spec:
     inputs:
       input: required_when_B
     required_when:
-      - processed.B
+      - B
   B:
     function: identity
     inputs:

--- a/preprocessing/nextclade/tests/metadata_dependency.yaml
+++ b/preprocessing/nextclade/tests/metadata_dependency.yaml
@@ -31,11 +31,11 @@ processing_spec:
     inputs:
       input: required_when_raw_reads
     required_when:
-      - files.raw_reads
+      - files.rawReads
   multi_dep:
     function: identity
     inputs:
       input: multi_dep
     required_when:
-      - files.raw_reads
+      - files.rawReads
       - processed.A

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -705,7 +705,9 @@ test_metadata_dependency_test_definitions = [
             "multi_dep": "present",
             "required_when_input_A": "present",
             "required_when_processed_A": "present",
+            "required_when_raw_reads": "present",
         },
+        input_files=RAW_READS_FILES,
         accession_id="18",
         expected_metadata={
             "name_required": "name",
@@ -717,7 +719,9 @@ test_metadata_dependency_test_definitions = [
             "multi_dep": "present",
             "required_when_input_A": "present",
             "required_when_processed_A": "present",
+            "required_when_raw_reads": "present",
         },
+        expected_files=RAW_READS_FILES,
         expected_errors=[],
         expected_warnings=build_processing_annotations(
             [
@@ -765,37 +769,6 @@ test_metadata_dependency_test_definitions = [
                 ),
             ]
         ),
-        expected_warnings=[],
-    ),
-    Case(
-        name="raw_reads_prerequisite_present",
-        input_metadata={
-            "submissionId": "raw_reads_prerequisite_present",
-            "name_required": "name",
-            "ncbi_required_collection_date": "2022-11-01",
-            "continent": "Asia",
-            "A": "2022-11-01",
-            "required_when_raw_reads": "present",
-            "multi_dep": "present",
-            "required_when_input_A": "present",
-            "required_when_processed_A": "present",
-        },
-        input_files=RAW_READS_FILES,
-        accession_id="31",
-        expected_metadata={
-            "name_required": "name",
-            "required_collection_date": "2022-11-01",
-            "concatenated_string": "Asia/LOC_31.1/2022-11-01",
-            "continent": "Asia",
-            "A": "2022-11-01",
-            "depends_on_A": "Asia/LOC_31.1/2022-11-01",
-            "required_when_raw_reads": "present",
-            "multi_dep": "present",
-            "required_when_input_A": "present",
-            "required_when_processed_A": "present",
-        },
-        expected_files=RAW_READS_FILES,
-        expected_errors=[],
         expected_warnings=[],
     ),
     Case(

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -702,6 +702,9 @@ test_metadata_dependency_test_definitions = [
             "ncbi_required_collection_date": "2022-11-01",
             "continent": "Asia",
             "A": "2022",
+            "multi_dep": "present",
+            "required_when_input_A": "present",
+            "required_when_processed_A": "present",
         },
         accession_id="18",
         expected_metadata={
@@ -711,6 +714,9 @@ test_metadata_dependency_test_definitions = [
             "continent": "Asia",
             "A": "2022-01-01",
             "depends_on_A": "Asia/LOC_18.1/2022-01-01",
+            "multi_dep": "present",
+            "required_when_input_A": "present",
+            "required_when_processed_A": "present",
         },
         expected_errors=[],
         expected_warnings=build_processing_annotations(
@@ -732,6 +738,9 @@ test_metadata_dependency_test_definitions = [
             "continent": "Asia",
             "A": "2022-11-01",
             "required_when_raw_reads": "",
+            "multi_dep": "present",
+            "required_when_input_A": "present",
+            "required_when_processed_A": "present",
         },
         input_files=RAW_READS_FILES,
         accession_id="30",
@@ -742,6 +751,9 @@ test_metadata_dependency_test_definitions = [
             "continent": "Asia",
             "A": "2022-11-01",
             "depends_on_A": "Asia/LOC_30.1/2022-11-01",
+            "multi_dep": "present",
+            "required_when_input_A": "present",
+            "required_when_processed_A": "present",
         },
         expected_files=RAW_READS_FILES,
         expected_errors=build_processing_annotations(
@@ -764,6 +776,9 @@ test_metadata_dependency_test_definitions = [
             "continent": "Asia",
             "A": "2022-11-01",
             "required_when_raw_reads": "present",
+            "multi_dep": "present",
+            "required_when_input_A": "present",
+            "required_when_processed_A": "present",
         },
         input_files=RAW_READS_FILES,
         accession_id="31",
@@ -775,22 +790,25 @@ test_metadata_dependency_test_definitions = [
             "A": "2022-11-01",
             "depends_on_A": "Asia/LOC_31.1/2022-11-01",
             "required_when_raw_reads": "present",
+            "multi_dep": "present",
+            "required_when_input_A": "present",
+            "required_when_processed_A": "present",
         },
         expected_files=RAW_READS_FILES,
         expected_errors=[],
         expected_warnings=[],
     ),
     Case(
-        name="metadata_field_prerequisite_missing",
+        name="processed_field_prerequisite_missing",
         input_metadata={
-            "submissionId": "metadata_field_prerequisite_missing",
+            "submissionId": "processed_field_prerequisite_missing",
             "name_required": "name",
             "ncbi_required_collection_date": "2022-11-01",
             "continent": "Asia",
             "A": "2022-11-01",
-            "B": "present",
-            "required_when_B": "",
-            "required_when_processed_B": "",
+            "required_when_processed_A": "",
+            "multi_dep": "present",
+            "required_when_input_A": "present",
         },
         accession_id="32",
         expected_metadata={
@@ -800,21 +818,124 @@ test_metadata_dependency_test_definitions = [
             "continent": "Asia",
             "A": "2022-11-01",
             "depends_on_A": "Asia/LOC_32.1/2022-11-01",
-            "B": "present",
+            "multi_dep": "present",
+            "required_when_input_A": "present",
         },
         expected_errors=build_processing_annotations(
             [
-                # plain `B` checks the input value
                 ProcessingAnnotationHelper(
-                    ["required_when_B"],
-                    ["required_when_B"],
-                    "Metadata field `required_when_B` is required when `B` is provided.",
+                    ["required_when_processed_A"],
+                    ["required_when_processed_A"],
+                    "Metadata field `required_when_processed_A` is required when `A` is provided.",
                 ),
-                # `processed.B` checks the processed value of the same field
+            ]
+        ),
+        expected_warnings=[],
+    ),
+    Case(
+        name="required_when_input_A",
+        input_metadata={
+            "submissionId": "required_when_input_A",
+            "name_required": "name",
+            "ncbi_required_collection_date": "2022-11-01",
+            "continent": "Asia",
+            "A": "not_a_date",
+        },
+        accession_id="32",
+        expected_metadata={
+            "name_required": "name",
+            "required_collection_date": "2022-11-01",
+            "concatenated_string": "Asia/LOC_32.1/2022-11-01",
+            "continent": "Asia",
+            "depends_on_A": "Asia/LOC_32.1",
+            "A": None,
+        },
+        expected_errors=build_processing_annotations(
+            [
                 ProcessingAnnotationHelper(
-                    ["required_when_processed_B"],
-                    ["required_when_processed_B"],
-                    "Metadata field `required_when_processed_B` is required when `B` is provided.",
+                    ["A"],
+                    ["A"],
+                    "Metadata field A: Date format is not recognized.",
+                ),
+                ProcessingAnnotationHelper(
+                    ["required_when_input_A"],
+                    ["required_when_input_A"],
+                    "Metadata field `required_when_input_A` is required when `A` is provided.",
+                ),
+            ]
+        ),
+        expected_warnings=[],
+    ),
+    Case(
+        name="multi_dep_fails_when_one_present",
+        input_metadata={
+            "submissionId": "multi_dep_fails_when_one_present",
+            "name_required": "name",
+            "ncbi_required_collection_date": "2022-11-01",
+            "continent": "Asia",
+            "A": "2022-11-01",
+            "required_when_input_A": "present",
+            "required_when_processed_A": "present",
+        },
+        accession_id="32",
+        expected_metadata={
+            "name_required": "name",
+            "required_collection_date": "2022-11-01",
+            "concatenated_string": "Asia/LOC_32.1/2022-11-01",
+            "continent": "Asia",
+            "A": "2022-11-01",
+            "required_when_input_A": "present",
+            "required_when_processed_A": "present",
+            "depends_on_A": "Asia/LOC_32.1/2022-11-01",
+        },
+        expected_errors=build_processing_annotations(
+            [
+                ProcessingAnnotationHelper(
+                    ["multi_dep"],
+                    ["multi_dep"],
+                    "Metadata field `multi_dep` is required when `A` is provided.",
+                ),
+            ]
+        ),
+        expected_warnings=[],
+    ),
+    Case(
+        name="multi_dep_fails_when_all_present",
+        input_metadata={
+            "submissionId": "multi_dep_fails_when_all_present",
+            "name_required": "name",
+            "ncbi_required_collection_date": "2022-11-01",
+            "continent": "Asia",
+            "A": "2022-11-01",
+            "required_when_input_A": "present",
+            "required_when_processed_A": "present",
+            "required_when_raw_reads": "present",
+        },
+        input_files=RAW_READS_FILES,
+        accession_id="32",
+        expected_metadata={
+            "name_required": "name",
+            "required_collection_date": "2022-11-01",
+            "concatenated_string": "Asia/LOC_32.1/2022-11-01",
+            "continent": "Asia",
+            "A": "2022-11-01",
+            "required_when_input_A": "present",
+            "depends_on_A": "Asia/LOC_32.1/2022-11-01",
+            "required_when_processed_A": "present",
+            "required_when_raw_reads": "present",
+        },
+        expected_files=RAW_READS_FILES,
+        expected_errors=build_processing_annotations(
+            [
+                ProcessingAnnotationHelper(
+                    ["multi_dep"],
+                    ["multi_dep"],
+                    "Metadata field `multi_dep` is required when `A` is provided.",
+                ),
+                ProcessingAnnotationHelper(
+                    ["multi_dep"],
+                    ["multi_dep"],
+                    "Metadata field `multi_dep` is required when `raw_reads` files are provided.",
                 ),
             ]
         ),
@@ -876,13 +997,15 @@ def test_preprocessing_metadata_dependencies(test_case_def: Case):
         ("processed.field", "lists itself"),
         ("does_not_exist", "has a requiredWhen condition referencing non-existing metadata field"),
         ("field", "lists itself"),
+        ("no_input_field", "noInput metadata field"),
     ],
 )
 def test_required_when_validation(condition: str, match: str) -> None:
     with pytest.raises(ValueError, match=match):
         Config(
             processing_spec={
-                "field": ProcessingSpec(inputs={"input": "field"}, required_when=[condition])
+                "field": ProcessingSpec(inputs={"input": "field"}, required_when=[condition]),
+                "no_input_field": ProcessingSpec(inputs={}, no_input=True),
             }
         )
 

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -966,10 +966,7 @@ def test_preprocessing_metadata_dependencies(test_case_def: Case):
     ("condition", "match"),
     [
         ("files.not_a_category", "non-existing file category"),
-        ("processed.does_not_exist", "non-existing metadata field"),
-        ("does_not_exist", "has a requiredWhen condition referencing non-existing input field"),
         ("processed.field", "lists itself"),
-        ("no_input_field", "noInput metadata field"),
     ],
 )
 def test_required_when_validation(condition: str, match: str) -> None:

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -965,11 +965,10 @@ def test_preprocessing_metadata_dependencies(test_case_def: Case):
 @pytest.mark.parametrize(
     ("condition", "match"),
     [
-        ("files.not_a_category", "unknown file category"),
+        ("files.not_a_category", "non-existing file category"),
         ("processed.does_not_exist", "non-existing metadata field"),
+        ("does_not_exist", "has a requiredWhen condition referencing non-existing input field"),
         ("processed.field", "lists itself"),
-        ("does_not_exist", "has a requiredWhen condition referencing non-existing metadata field"),
-        ("field", "lists itself"),
         ("no_input_field", "noInput metadata field"),
     ],
 )

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -17,6 +17,8 @@ from loculus_preprocessing.config import Config, ProcessingSpec, get_config, get
 from loculus_preprocessing.datatypes import (
     AnnotationSource,
     AnnotationSourceType,
+    FileCategory,
+    FileIdAndName,
     FunctionArgs,
     InputMetadata,
     ProcessedEntry,
@@ -687,6 +689,10 @@ not_accepted_authors = [
     "Count4th, EwanMcGregor, Count4th",
 ]
 
+RAW_READS_FILES = {
+    FileCategory.RAW_READS: [FileIdAndName(fileId="file-raw-reads", name="reads.fastq.gz")]
+}
+
 test_metadata_dependency_test_definitions = [
     Case(
         name="metadata_dependency",
@@ -716,6 +722,97 @@ test_metadata_dependency_test_definitions = [
                 ),
             ]
         ),
+    ),
+    Case(
+        name="raw_reads_prerequisite_missing",
+        input_metadata={
+            "submissionId": "raw_reads_prerequisite_missing",
+            "name_required": "name",
+            "ncbi_required_collection_date": "2022-11-01",
+            "continent": "Asia",
+            "A": "2022-11-01",
+            "required_when_raw_reads": "",
+        },
+        input_files=RAW_READS_FILES,
+        accession_id="30",
+        expected_metadata={
+            "name_required": "name",
+            "required_collection_date": "2022-11-01",
+            "concatenated_string": "Asia/LOC_30.1/2022-11-01",
+            "continent": "Asia",
+            "A": "2022-11-01",
+            "depends_on_A": "Asia/LOC_30.1/2022-11-01",
+        },
+        expected_files=RAW_READS_FILES,
+        expected_errors=build_processing_annotations(
+            [
+                ProcessingAnnotationHelper(
+                    ["required_when_raw_reads"],
+                    ["required_when_raw_reads"],
+                    "Metadata field `required_when_raw_reads` is required when `raw_reads` files are provided.",
+                ),
+            ]
+        ),
+        expected_warnings=[],
+    ),
+    Case(
+        name="required_when_reads_provided",
+        input_metadata={
+            "submissionId": "required_when_reads_provided",
+            "name_required": "name",
+            "ncbi_required_collection_date": "2022-11-01",
+            "continent": "Asia",
+            "A": "2022-11-01",
+            "required_when_raw_reads": "present",
+        },
+        input_files=RAW_READS_FILES,
+        accession_id="31",
+        expected_metadata={
+            "name_required": "name",
+            "required_collection_date": "2022-11-01",
+            "concatenated_string": "Asia/LOC_31.1/2022-11-01",
+            "continent": "Asia",
+            "A": "2022-11-01",
+            "depends_on_A": "Asia/LOC_31.1/2022-11-01",
+            "required_when_raw_reads": "present",
+        },
+        expected_files=RAW_READS_FILES,
+        expected_errors=[],
+        expected_warnings=[],
+    ),
+    # required_when with a `processed.<field>` condition: the trigger field has a processed
+    # value but the conditionally-required field is missing -> error. Also exercises the
+    # ordering guarantee (required_when_B must be processed before B).
+    Case(
+        name="required_when_processed_field_missing",
+        input_metadata={
+            "submissionId": "required_when_processed_field_missing",
+            "name_required": "name",
+            "ncbi_required_collection_date": "2022-11-01",
+            "continent": "Asia",
+            "A": "2022-11-01",
+            "B": "present",
+        },
+        accession_id="32",
+        expected_metadata={
+            "name_required": "name",
+            "required_collection_date": "2022-11-01",
+            "concatenated_string": "Asia/LOC_32.1/2022-11-01",
+            "continent": "Asia",
+            "A": "2022-11-01",
+            "depends_on_A": "Asia/LOC_32.1/2022-11-01",
+            "B": "present",
+        },
+        expected_errors=build_processing_annotations(
+            [
+                ProcessingAnnotationHelper(
+                    ["required_when_B"],
+                    ["required_when_B"],
+                    "Metadata field `required_when_B` is required when `B` is provided.",
+                ),
+            ]
+        ),
+        expected_warnings=[],
     ),
 ]
 
@@ -766,12 +863,34 @@ def test_preprocessing_metadata_dependencies(test_case_def: Case, config_depende
     processed_entry = process_single_entry(test_case, config_dependency)
     verify_processed_entry(processed_entry, test_case.expected_output, test_case.name)
 
-    wrong_order = tuple(
-        ["depends_on_A"] + [i for i in config_dependency.processing_order if i != "depends_on_A"]
-    )
-    config_dependency.processing_order = wrong_order
-    processed_entry = process_single_entry(test_case, config_dependency)
-    assert processed_entry.data.metadata != test_case.expected_output.data.metadata
+
+@pytest.mark.parametrize(
+    ("condition", "match"),
+    [
+        ("files.not_a_category", "unknown file category"),
+        ("processed.does_not_exist", "non-existing metadata field"),
+        ("collection_date", "Conditions must start with"),
+        ("processed.field", "lists itself"),
+    ],
+)
+def test_required_when_validation(condition: str, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        Config(
+            processing_spec={
+                "field": ProcessingSpec(inputs={"input": "field"}, required_when=[condition])
+            }
+        )
+
+
+def test_required_when_conflicts_with_required() -> None:
+    with pytest.raises(ValueError, match="both 'required: true' and 'requiredWhen'"):
+        Config(
+            processing_spec={
+                "field": ProcessingSpec(
+                    inputs={"input": "field"}, required=True, required_when=["files.raw_reads"]
+                )
+            }
+        )
 
 
 def test_required_field_message_lists_only_user_input_fields() -> None:

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -756,9 +756,9 @@ test_metadata_dependency_test_definitions = [
         expected_warnings=[],
     ),
     Case(
-        name="required_when_reads_provided",
+        name="raw_reads_prerequisite_present",
         input_metadata={
-            "submissionId": "required_when_reads_provided",
+            "submissionId": "raw_reads_prerequisite_present",
             "name_required": "name",
             "ncbi_required_collection_date": "2022-11-01",
             "continent": "Asia",
@@ -780,18 +780,16 @@ test_metadata_dependency_test_definitions = [
         expected_errors=[],
         expected_warnings=[],
     ),
-    # required_when with a `processed.<field>` condition: the trigger field has a processed
-    # value but the conditionally-required field is missing -> error. Also exercises the
-    # ordering guarantee (required_when_B must be processed before B).
     Case(
-        name="required_when_processed_field_missing",
+        name="metadata_field_prerequisite_missing",
         input_metadata={
-            "submissionId": "required_when_processed_field_missing",
+            "submissionId": "metadata_field_prerequisite_missing",
             "name_required": "name",
             "ncbi_required_collection_date": "2022-11-01",
             "continent": "Asia",
             "A": "2022-11-01",
             "B": "present",
+            "required_when_B": "",
         },
         accession_id="32",
         expected_metadata={
@@ -822,9 +820,8 @@ def config():
     return get_config(NO_ALIGNMENT_CONFIG, ignore_args=True)
 
 
-@pytest.fixture(scope="module")
-def config_dependency(config: Config):
-    # Add metadata dependency to config, recompute processing order
+def generate_config_with_deps() -> Config:
+    config = get_config(NO_ALIGNMENT_CONFIG, ignore_args=True)
     dependency_fields = get_config(METADATA_DEPENDENCY_CONFIG, ignore_args=True).processing_spec
     config.processing_spec.update(dependency_fields)
     config.processing_order = get_processing_order(config)
@@ -855,12 +852,11 @@ def test_preprocessing(test_case_def: Case, config: Config, factory_custom: Proc
     test_metadata_dependency_test_definitions,
     ids=lambda tc: f"metadata fields with dependencies use processed fields {tc.name}",
 )
-def test_preprocessing_metadata_dependencies(test_case_def: Case, config_dependency: Config):
-    factory_custom = ProcessedEntryFactory(
-        all_metadata_fields=list(config_dependency.processing_spec.keys())
-    )
+def test_preprocessing_metadata_dependencies(test_case_def: Case):
+    config = generate_config_with_deps()
+    factory_custom = ProcessedEntryFactory(all_metadata_fields=list(config.processing_spec.keys()))
     test_case = test_case_def.create_test_case(factory_custom)
-    processed_entry = process_single_entry(test_case, config_dependency)
+    processed_entry = process_single_entry(test_case, config)
     verify_processed_entry(processed_entry, test_case.expected_output, test_case.name)
 
 
@@ -891,6 +887,26 @@ def test_required_when_conflicts_with_required() -> None:
                 )
             }
         )
+
+
+def test_processing_order() -> None:
+    """`depends_on_A` reads the processed value of `A`, so `A` must be processed first."""
+    config = generate_config_with_deps()
+    test_case = Case(
+        name="processing_order",
+        input_metadata={"continent": "Asia", "A": "2022-11-01"},
+        accession_id="40",
+    ).create_test_case(ProcessedEntryFactory())
+
+    # Correct order includes the processed value of A; the wrong order builds depends_on_A first.
+    correct_order = process_single_entry(test_case, config)
+    assert correct_order.data.metadata["depends_on_A"] == "Asia/LOC_40.1/2022-11-01"
+
+    config.processing_order = tuple(
+        ["depends_on_A"] + [f for f in config.processing_order if f != "depends_on_A"]
+    )
+    wrong_order = process_single_entry(test_case, config)
+    assert wrong_order.data.metadata["depends_on_A"] == "Asia/LOC_40.1"
 
 
 def test_required_field_message_lists_only_user_input_fields() -> None:

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -790,6 +790,7 @@ test_metadata_dependency_test_definitions = [
             "A": "2022-11-01",
             "B": "present",
             "required_when_B": "",
+            "required_when_processed_B": "",
         },
         accession_id="32",
         expected_metadata={
@@ -803,10 +804,17 @@ test_metadata_dependency_test_definitions = [
         },
         expected_errors=build_processing_annotations(
             [
+                # plain `B` checks the input value
                 ProcessingAnnotationHelper(
                     ["required_when_B"],
                     ["required_when_B"],
                     "Metadata field `required_when_B` is required when `B` is provided.",
+                ),
+                # `processed.B` checks the processed value of the same field
+                ProcessingAnnotationHelper(
+                    ["required_when_processed_B"],
+                    ["required_when_processed_B"],
+                    "Metadata field `required_when_processed_B` is required when `B` is provided.",
                 ),
             ]
         ),
@@ -864,8 +872,9 @@ def test_preprocessing_metadata_dependencies(test_case_def: Case):
     ("condition", "match"),
     [
         ("files.not_a_category", "unknown file category"),
-        ("does_not_exist", "has an invalid requiredWhen condition"),
-        ("collection_date", "Conditions must start with"),
+        ("processed.does_not_exist", "non-existing metadata field"),
+        ("processed.field", "lists itself"),
+        ("does_not_exist", "has a requiredWhen condition referencing non-existing metadata field"),
         ("field", "lists itself"),
     ],
 )

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -695,7 +695,7 @@ RAW_READS_FILES = {
 
 test_metadata_dependency_test_definitions = [
     Case(
-        name="metadata_dependency",
+        name="metadata_dependencies_all_present",
         input_metadata={
             "submissionId": "metadata_dependency",
             "name_required": "name",
@@ -867,7 +867,7 @@ test_metadata_dependency_test_definitions = [
         expected_warnings=[],
     ),
     Case(
-        name="multi_dep_fails_when_one_present",
+        name="missing_multi_dep_fails_when_one_requiredWhen_condition_present",
         input_metadata={
             "submissionId": "multi_dep_fails_when_one_present",
             "name_required": "name",
@@ -900,7 +900,7 @@ test_metadata_dependency_test_definitions = [
         expected_warnings=[],
     ),
     Case(
-        name="multi_dep_fails_when_all_present",
+        name="missing_multi_dep_fails_when_all_requiredWhen_condition_present",
         input_metadata={
             "submissionId": "multi_dep_fails_when_all_present",
             "name_required": "name",

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -864,9 +864,9 @@ def test_preprocessing_metadata_dependencies(test_case_def: Case):
     ("condition", "match"),
     [
         ("files.not_a_category", "unknown file category"),
-        ("processed.does_not_exist", "non-existing metadata field"),
+        ("does_not_exist", "has an invalid requiredWhen condition"),
         ("collection_date", "Conditions must start with"),
-        ("processed.field", "lists itself"),
+        ("field", "lists itself"),
     ],
 )
 def test_required_when_validation(condition: str, match: str) -> None:

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -799,7 +799,7 @@ test_metadata_dependency_test_definitions = [
                 ProcessingAnnotationHelper(
                     ["required_when_processed_A"],
                     ["required_when_processed_A"],
-                    "Metadata field `required_when_processed_A` is required when `A` is provided.",
+                    "Metadata field `required_when_processed_A` is required when `A` exists.",
                 ),
             ]
         ),
@@ -866,7 +866,7 @@ test_metadata_dependency_test_definitions = [
                 ProcessingAnnotationHelper(
                     ["multi_dep"],
                     ["multi_dep"],
-                    "Metadata field `multi_dep` is required when `A` is provided.",
+                    "Metadata field `multi_dep` is required when `A` exists.",
                 ),
             ]
         ),
@@ -903,7 +903,7 @@ test_metadata_dependency_test_definitions = [
                 ProcessingAnnotationHelper(
                     ["multi_dep"],
                     ["multi_dep"],
-                    "Metadata field `multi_dep` is required when `A` is provided.",
+                    "Metadata field `multi_dep` is required when `A` exists.",
                 ),
                 ProcessingAnnotationHelper(
                     ["multi_dep"],

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -761,7 +761,7 @@ test_metadata_dependency_test_definitions = [
                 ProcessingAnnotationHelper(
                     ["required_when_raw_reads"],
                     ["required_when_raw_reads"],
-                    "Metadata field `required_when_raw_reads` is required when `raw_reads` files are provided.",
+                    "Metadata field `required_when_raw_reads` is required when `rawReads` files are provided.",
                 ),
             ]
         ),
@@ -935,7 +935,7 @@ test_metadata_dependency_test_definitions = [
                 ProcessingAnnotationHelper(
                     ["multi_dep"],
                     ["multi_dep"],
-                    "Metadata field `multi_dep` is required when `raw_reads` files are provided.",
+                    "Metadata field `multi_dep` is required when `rawReads` files are provided.",
                 ),
             ]
         ),
@@ -1015,7 +1015,7 @@ def test_required_when_conflicts_with_required() -> None:
         Config(
             processing_spec={
                 "field": ProcessingSpec(
-                    inputs={"input": "field"}, required=True, required_when=["files.raw_reads"]
+                    inputs={"input": "field"}, required=True, required_when=["files.rawReads"]
                 )
             }
         )

--- a/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
+++ b/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
@@ -26,6 +26,7 @@ from loculus_preprocessing.config import (
 )
 from loculus_preprocessing.datatypes import (
     AnnotationSourceType,
+    FileCategory,
     FileIdAndName,
     SegmentClassificationMethod,
     SubmissionData,
@@ -289,7 +290,7 @@ single_segment_case_definitions = [
         name="with file",
         input_metadata={},
         input_files={
-            "rawReads": [
+            FileCategory.RAW_READS: [
                 FileIdAndName(fileId="file-id-0001", name="reads_R1.fastq"),
                 FileIdAndName(fileId="file-id-0002", name="reads_R2.fastq"),
             ]
@@ -306,7 +307,7 @@ single_segment_case_definitions = [
             "variant": True,
         },
         expected_files={
-            "rawReads": [
+            FileCategory.RAW_READS: [
                 FileIdAndName(fileId="file-id-0001", name="reads_R1.fastq"),
                 FileIdAndName(fileId="file-id-0002", name="reads_R2.fastq"),
             ]


### PR DESCRIPTION
resolves #6886 

We currently have `required: true`, which makes a metadata field required. However, some fields are only required in context. With us adding support for raw-reads, an example came up where we only need `sequencingInstrument` to be provided when raw reads files are submitted (so we can submit to ENA): https://github.com/loculus-project/loculus/issues/6886

## Summary

- New optional `requiredWhen` config key on metadata fields: a list of conditions under
  which the field is required. Three condition types are supported:
  - `files.<category>` — required when files of that category are submitted
    (e.g. `files.raw_reads`)
  - `processed.<field>` — required when another metadata field has a non-null value after processing
  - `<field>` — required when another metadata field has a non-null input value
- `required` and `requiredWhen` are mutually exclusive, enforced both in the Helm
  `values.schema.json` (fails `helm lint`/install) and in the preprocessing config
  validator.
- Enabled by default in `defaultOrganismConfig`: `sequencingInstrument` is now
  `requiredWhen: [files.raw_reads]`.
- INSDC-ingested sequences are exempt from `requiredWhen` checks (just like they already are for `required: true`)

## Alternatives considered

I thought about extending the existing `required` config field to cover this behaviour. In theory, we could rework this so that `required: ["always"]` captures what is currently achieved by `required: true`, and then also allow for stuff like `required: ["files.raw_reads"]`. However, this would be a breaking change and would make checking whether a field is required more annoying in prepro than is the case currently.

## Manual testing

Created a preview with a requiredWhen condition that `sequencingInstrument` should be provided with raw reads, and another requirement saying that `geoLocCity` is required when `geoLocCountry` is provided (this last one has been reverted).

I then submitted test data to a preview which showed that (also see image below):
1) sequence with raw_reads and no `sequencingInstrument` is rejected
2) sequence with `geoLocCountry` but no `geoLocCity` is rejected
3) sequence with raw_reads and `sequencingInstrument: Illumina` gets accepted

<img width="1241" height="516" alt="grafik" src="https://github.com/user-attachments/assets/115634e7-579e-4a2c-9140-85025052dcbd" />

### PR Checklist
- [x] All necessary documentation has been adapted: values schema is updated
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://metadata-requirements.loculus.org