### PR TITLE
fix(website): Wrap search buttons on narrow screen widths

### DIFF
--- a/website/src/components/DataUseTerms/EditDataUseTermsModal.tsx
+++ b/website/src/components/DataUseTerms/EditDataUseTermsModal.tsx
@@ -136,7 +136,7 @@ export const EditDataUseTermsModal: FC<EditDataUseTermsModalProps> = ({
 
     return (
         <>
-            <Button className='mr-4 underline text-primary-700 hover:text-primary-500' onClick={openDialog}>
+            <Button className='mr-2 underline text-primary-700 hover:text-primary-500' onClick={openDialog}>
                 {buttonText}
             </Button>
             <BaseDialog title='Edit data use terms' isOpen={isOpen} onClose={closeDialog}>

--- a/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
@@ -203,7 +203,7 @@ export const LinkOutMenu: FC<LinkOutMenuProps> = ({
 
     return (
         <>
-            <Menu as='div' className='ml-2 relative inline-block text-left'>
+            <Menu as='div' className='relative inline-block text-left'>
                 <MenuButton
                     className={buttonClasses({
                         variant: 'outline',

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -368,7 +368,7 @@ const InnerSearchFullUI = ({
                             </Button>
                             {sequencesSelected ? (
                                 <Button
-                                    className='underline text-primary-700 hover:text-primary-500'
+                                    className='mr-2 underline text-primary-700 hover:text-primary-500'
                                     onClick={clearSelectedSeqs}
                                 >
                                     Clear selection

--- a/website/src/components/SearchPage/SearchFullUI.tsx
+++ b/website/src/components/SearchPage/SearchFullUI.tsx
@@ -339,7 +339,7 @@ const InnerSearchFullUI = ({
                             <ActiveFilters sequenceFilter={tableFilter} removeFilter={removeFilter} />
                         </div>
                     )}
-                    <div className='text-sm text-gray-800 mb-6 justify-between flex flex-col sm:flex-row items-baseline gap-4'>
+                    <div className='text-sm text-gray-800 mb-6 justify-between flex flex-wrap gap-4'>
                         <div className='mt-auto'>
                             {buildSequenceCountText(totalSequences, oldCount, initialCount)}
                             {detailsHook.isPending ||
@@ -351,7 +351,7 @@ const InnerSearchFullUI = ({
                                 </span>
                             ) : null}
                         </div>
-                        <div className='flex'>
+                        <div className='flex flex-wrap justify-start gap-2'>
                             {showEditDataUseTermsControls && dataUseTermsEnabled && (
                                 <EditDataUseTermsModal
                                     lapisUrl={lapisUrl}
@@ -361,14 +361,14 @@ const InnerSearchFullUI = ({
                                 />
                             )}
                             <Button
-                                className='mr-4 underline text-primary-700 hover:text-primary-500'
+                                className='mr-2 underline text-primary-700 hover:text-primary-500'
                                 onClick={() => setIsColumnModalOpen(true)}
                             >
                                 Customize columns
                             </Button>
                             {sequencesSelected ? (
                                 <Button
-                                    className='mr-4 underline text-primary-700 hover:text-primary-500'
+                                    className='underline text-primary-700 hover:text-primary-500'
                                     onClick={clearSelectedSeqs}
                                 >
                                     Clear selection
@@ -388,17 +388,15 @@ const InnerSearchFullUI = ({
                                 referenceIdentifierField={schema.referenceIdentifierField}
                             />
                             {isReleasedPage && accessToken !== undefined && groupId !== undefined && (
-                                <div className='ml-2'>
-                                    <DownloadSubmittedDataButton
-                                        sequenceFilter={downloadFilter}
-                                        backendUrl={clientConfig.backendUrl}
-                                        accessToken={accessToken}
-                                        organism={organism}
-                                        groupId={groupId}
-                                        totalSequences={totalSequences}
-                                        fetchAccessions={fetchAccessions}
-                                    />
-                                </div>
+                                <DownloadSubmittedDataButton
+                                    sequenceFilter={downloadFilter}
+                                    backendUrl={clientConfig.backendUrl}
+                                    accessToken={accessToken}
+                                    organism={organism}
+                                    groupId={groupId}
+                                    totalSequences={totalSequences}
+                                    fetchAccessions={fetchAccessions}
+                                />
                             )}
                             {linkOuts !== undefined && linkOuts.length > 0 && (
                                 <LinkOutMenu


### PR DESCRIPTION
### Summary

Adds wrapping of buttons on narrow screen widths to fix issue with text overflowing, primarily noticeable on the groups released sequences page.

### Screenshot

Before:

<img width="862" height="1350" alt="image" src="https://github.com/user-attachments/assets/9f517bf5-d37a-4bb5-8b4c-e73180818910" />

After:

<img width="862" height="1194" alt="image" src="https://github.com/user-attachments/assets/b7b6df7d-0ad1-4d19-995b-f071dcfcf52e" />

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://search-ui-button-wrapping.loculus.org