### PR TITLE
fix(website): render login prompt instead of blank page on released sequences page

### DIFF
--- a/website/src/pages/[organism]/search/index.astro
+++ b/website/src/pages/[organism]/search/index.astro
@@ -27,10 +27,9 @@ const hiddenFieldValues = {
 const { organism: cleanedOrganism } = cleanOrganism(Astro.params.organism);
 
 if (!cleanedOrganism) {
-    return {
-        statusCode: 404,
-        body: 'Organism not found',
-    };
+    // undefined renders the configured Astro 404 page
+    // Note - this check is currently unused as middleware exists to check the organism, but useful for type-checking
+    return new Response(undefined, { status: 404 });
 }
 
 const clientConfig = getRuntimeConfig().public;

--- a/website/src/pages/[organism]/submission/[groupId]/released.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/released.astro
@@ -11,6 +11,7 @@ import {
     getWebsiteConfig,
 } from '../../../../config';
 import { GROUP_ID_FIELD, VERSION_STATUS_FIELD } from '../../../../settings';
+import type { Group } from '../../../../types/backend';
 import { versionStatuses } from '../../../../types/lapis';
 import { getAccessToken } from '../../../../utils/getAccessToken';
 import { parseUrlSearchParams } from '../../../../utils/parseUrlSearchParams';
@@ -18,18 +19,11 @@ import { performLapisSearchQueries } from '../../../../utils/serversideSearch';
 import { getGroupsAndCurrentGroup } from '../../../../utils/submissionPages';
 
 const groupsResult = await getGroupsAndCurrentGroup(Astro.params, Astro.locals.session);
-if (groupsResult.isErr()) {
-    return new Response(undefined, { status: groupsResult.error.status });
-}
-const { currentGroup: group } = groupsResult.value;
 
 const { organism: cleanedOrganism } = cleanOrganism(Astro.params.organism);
 
 if (!cleanedOrganism) {
-    return {
-        statusCode: 404,
-        body: 'Organism not found',
-    };
+    return new Response('Organism not found', { status: 404 });
 }
 
 const clientConfig = getRuntimeConfig().public;
@@ -39,43 +33,54 @@ const accessToken = getAccessToken(Astro.locals.session);
 
 const referenceGenomesInfo = getReferenceGenomes(cleanedOrganism.key);
 
-const hiddenFieldValues = {
-    [VERSION_STATUS_FIELD]: versionStatuses.latestVersion,
-    [GROUP_ID_FIELD]: String(group.groupId),
-};
-
 const initialQueryDict = parseUrlSearchParams(Astro.url.searchParams);
-const { data, totalCount } = await performLapisSearchQueries(
-    initialQueryDict,
-    schema,
-    referenceGenomesInfo,
-    hiddenFieldValues,
-    cleanedOrganism.key,
-);
 
 const websiteConfig = getWebsiteConfig();
 const sequenceFlaggingConfig = websiteConfig.sequenceFlagging;
 const contactConfig = getContactConfig(websiteConfig);
+
+const loadReleasedSequences = async (group: Group) => {
+    const hiddenFieldValues = {
+        [VERSION_STATUS_FIELD]: versionStatuses.latestVersion,
+        [GROUP_ID_FIELD]: String(group.groupId),
+    };
+    const { data, totalCount } = await performLapisSearchQueries(
+        initialQueryDict,
+        schema,
+        referenceGenomesInfo,
+        hiddenFieldValues,
+        cleanedOrganism.key,
+    );
+    return { group, hiddenFieldValues, data, totalCount };
+};
+
+// The search is scoped to a group, so it can only run once we have one. Without a group
+// SubmissionPageWrapper renders the login prompt or error state instead.
+const searchProps = groupsResult.isOk() ? await loadReleasedSequences(groupsResult.value.currentGroup) : undefined;
 ---
 
 <SubmissionPageWrapper groupsResult={groupsResult} title='Released sequences'>
-    <SearchFullUI
-        client:load
-        clientConfig={clientConfig}
-        organism={cleanedOrganism.key}
-        schema={schema}
-        myGroups={[group]}
-        accessToken={accessToken}
-        referenceGenomesInfo={referenceGenomesInfo}
-        hiddenFieldValues={hiddenFieldValues}
-        initialData={data}
-        initialCount={totalCount}
-        initialQueryDict={initialQueryDict}
-        dataUseTermsEnabled={dataUseTermsAreEnabled()}
-        sequenceFlaggingConfig={sequenceFlaggingConfig}
-        contactConfig={contactConfig}
-        showEditDataUseTermsControls
-        groupId={group.groupId}
-        isReleasedPage={true}
-    />
+    {
+        searchProps !== undefined && (
+            <SearchFullUI
+                client:load
+                clientConfig={clientConfig}
+                organism={cleanedOrganism.key}
+                schema={schema}
+                myGroups={[searchProps.group]}
+                accessToken={accessToken}
+                referenceGenomesInfo={referenceGenomesInfo}
+                hiddenFieldValues={searchProps.hiddenFieldValues}
+                initialData={searchProps.data}
+                initialCount={searchProps.totalCount}
+                initialQueryDict={initialQueryDict}
+                dataUseTermsEnabled={dataUseTermsAreEnabled()}
+                sequenceFlaggingConfig={sequenceFlaggingConfig}
+                contactConfig={contactConfig}
+                showEditDataUseTermsControls
+                groupId={searchProps.group.groupId}
+                isReleasedPage={true}
+            />
+        )
+    }
 </SubmissionPageWrapper>

--- a/website/src/pages/[organism]/submission/[groupId]/released.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/released.astro
@@ -23,7 +23,9 @@ const groupsResult = await getGroupsAndCurrentGroup(Astro.params, Astro.locals.s
 const { organism: cleanedOrganism } = cleanOrganism(Astro.params.organism);
 
 if (!cleanedOrganism) {
-    return new Response('Organism not found', { status: 404 });
+    // undefined renders the configured Astro 404 page
+    // Note - this check is currently unused as middleware exists to check the organism, but useful for type-checking
+    return new Response(undefined, { status: 404 });
 }
 
 const clientConfig = getRuntimeConfig().public;

--- a/website/src/pages/[organism]/submission/[groupId]/revise.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/revise.astro
@@ -23,10 +23,9 @@ const accession = Astro.url.searchParams.get('accession') || undefined;
 const version = Astro.url.searchParams.get('version') || undefined;
 
 if (!cleanedOrganism) {
-    return {
-        statusCode: 404,
-        body: 'Organism not found',
-    };
+    // undefined renders the configured Astro 404 page
+    // Note - this check is currently unused as middleware exists to check the organism, but useful for type-checking
+    return new Response(undefined, { status: 404 });
 }
 const schema = getSchema(cleanedOrganism.key);
 const groupedInputFields = getGroupedInputFields(cleanedOrganism.key, 'revise', true);

--- a/website/src/pages/[organism]/submission/[groupId]/submit.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/submit.astro
@@ -21,10 +21,9 @@ const { organism: cleanedOrganism } = cleanOrganism(Astro.params.organism);
 const inputMode: InputMode = Astro.url.searchParams.get('inputMode') === 'form' ? 'form' : 'bulk';
 
 if (!cleanedOrganism) {
-    return {
-        statusCode: 404,
-        body: 'Organism not found',
-    };
+    // undefined renders the configured Astro 404 page
+    // Note - this check is currently unused as middleware exists to check the organism, but useful for type-checking
+    return new Response(undefined, { status: 404 });
 }
 const schema = getSchema(cleanedOrganism.key);
 const groupedInputFields = getGroupedInputFields(cleanedOrganism.key, 'submit', true);

--- a/website/src/pages/[organism]/submission/edit/[accession]/[version].astro
+++ b/website/src/pages/[organism]/submission/edit/[accession]/[version].astro
@@ -13,10 +13,9 @@ const organism = Astro.params.organism!;
 const { organism: cleanedOrganism } = cleanOrganism(Astro.params.organism);
 
 if (!cleanedOrganism) {
-    return {
-        statusCode: 404,
-        body: 'Organism not found',
-    };
+    // undefined renders the configured Astro 404 page
+    // Note - this check is currently unused as middleware exists to check the organism, but useful for type-checking
+    return new Response(undefined, { status: 404 });
 }
 
 const groupedInputFields = getGroupedInputFields(cleanedOrganism.key, 'revise', true);

--- a/website/src/utils/submissionPages.ts
+++ b/website/src/utils/submissionPages.ts
@@ -8,7 +8,6 @@ export type GetGroupsResult = Result<Group[], GetGroupsError>;
 
 export type GetGroupsError = {
     type: 'not_logged_in' | 'could_not_load_groups';
-    status: number;
 };
 
 export type GetGroupsAndCurrentGroupResult = Result<GetGroupsAndCurrentGroupValue, GetGroupsAndCurrentGroupError>;
@@ -22,7 +21,6 @@ export type GetGroupsAndCurrentGroupError =
     | GetGroupsError
     | {
           type: 'missing_group_id' | 'group_not_found';
-          status: number;
       };
 
 export const getGroups = async (session: Session | undefined): Promise<GetGroupsResult> => {
@@ -30,7 +28,6 @@ export const getGroups = async (session: Session | undefined): Promise<GetGroups
     if (accessToken === undefined) {
         return err({
             type: 'not_logged_in',
-            status: 200,
         });
     }
 
@@ -38,7 +35,6 @@ export const getGroups = async (session: Session | undefined): Promise<GetGroups
     if (groupsResult.isErr()) {
         return err({
             type: 'could_not_load_groups',
-            status: 500,
         });
     }
     const groupsOfUser: Group[] = groupsResult.value;
@@ -60,7 +56,6 @@ export const getGroupsAndCurrentGroup = async (
     if (isNaN(groupId)) {
         return err({
             type: 'missing_group_id',
-            status: 400,
         });
     }
 
@@ -68,7 +63,6 @@ export const getGroupsAndCurrentGroup = async (
     if (currentGroup === undefined) {
         return err({
             type: 'group_not_found',
-            status: 404,
         });
     }
 


### PR DESCRIPTION
Fixes #6939.

https://fix-released-page-blank-w.loculus.org/ebola-sudan/submission/1/released?column_dataUseTerms=true

vs

https://main.loculus.org/ebola-sudan/submission/1/released?column_dataUseTerms=true

## The problem

Requesting `/<organism>/submission/<groupId>/released` while logged out returns an **empty HTTP 200 with a zero-byte body**, so the browser renders a blank white page. Every other submission page under the same route renders a "You need to be logged in" prompt:

| Path | Before |
| --- | --- |
| `/ebola-sudan/submission/1/released` | `200`, **0 bytes**, blank page |
| `/ebola-sudan/submission/1/review` | `200`, ~30 KB, login prompt |
| `/ebola-sudan/submission/1/revise` | `200`, ~30 KB, login prompt |
| `/ebola-sudan/submission/1/submit` | `200`, ~30 KB, login prompt |

This is reproducible on `main.loculus.org`, not just on preview deployments, and it is long-standing — `git log -L` traces it to a27d203f6 (April 2024), when the submission paths were restructured.

## Why it happened

Two things combined.

`getGroups` reports the logged-out case with an HTTP status of `200`:

```ts
return err({ type: 'not_logged_in', status: 200 });
```

And `released.astro` was the only submission page that early-returned on a groups error, forwarding that status into a body-less response:

```ts
if (groupsResult.isErr()) {
    return new Response(undefined, { status: groupsResult.error.status });
}
```

So `not_logged_in` became a literal empty `200`. `SubmissionPageWrapper` already handles this case — its `.match()` has a `case 'not_logged_in'` arm rendering `NeedToLogin`, plus a `group_not_found` arm — but the early return meant the wrapper was never reached, so those arms could not fire.

Because it surfaced as a `200` rather than a `4xx`, the failure was also invisible to error monitoring.

## The change

**`released.astro`** now follows the same shape as `review.astro`: `groupsResult` is passed to `SubmissionPageWrapper`, which renders the login prompt or the group error, and `SearchFullUI` is rendered only when a group is actually available.

The one wrinkle versus the sibling pages is that this page does server-side work that depends on the group — `performLapisSearchQueries` needs `group.groupId` for `hiddenFieldValues`. That work moved into a `loadReleasedSequences(group)` helper called only in the `isOk()` branch, so the logged-out path no longer touches LAPIS at all. Everything group-independent (schema, reference genomes, config, parsed query params) is still computed unconditionally in the frontmatter.

**`submissionPages.ts`**: the `status` field on `GetGroupsError` / `GetGroupsAndCurrentGroupError` is removed. The early return in `released.astro` was its only reader anywhere in the codebase, so it was dead weight whose sole effect was to make this bug expressible.

Also converted the adjacent unknown-organism branch from `return { statusCode: 404, body: 'Organism not found' }` to a real `new Response('Organism not found', { status: 404 })` — Astro frontmatter requires a `Response`, so the plain object was never going to work as intended.

## Behaviour after this change

- Logged out → "You need to be logged in to submit sequences." (matches review/revise/submit)
- Logged in, group you are not a member of → "Group not found"
- Logged in, valid group → unchanged; the released sequences table renders as before

Note that error cases now return `200` with a rendered explanation rather than propagating `404`/`500` status codes. That is a deliberate trade for consistency with the sibling submission pages, which all behave this way.

🚀 Preview: Add `preview` label to enable