### PR TITLE
Fix (currently unused) not found responses

### DIFF
--- a/website/src/pages/[organism]/search/index.astro
+++ b/website/src/pages/[organism]/search/index.astro
@@ -27,10 +27,7 @@ const hiddenFieldValues = {
 const { organism: cleanedOrganism } = cleanOrganism(Astro.params.organism);
 
 if (!cleanedOrganism) {
-    return {
-        statusCode: 404,
-        body: 'Organism not found',
-    };
+    return new Response(undefined, { status: 404 });
 }
 
 const clientConfig = getRuntimeConfig().public;

--- a/website/src/pages/[organism]/search/index.astro
+++ b/website/src/pages/[organism]/search/index.astro
@@ -27,6 +27,8 @@ const hiddenFieldValues = {
 const { organism: cleanedOrganism } = cleanOrganism(Astro.params.organism);
 
 if (!cleanedOrganism) {
+    // undefined renders the configured Astro 404 page
+    // Note - this check is currently unused as middleware exists to check the organism, but useful for type-checking
     return new Response(undefined, { status: 404 });
 }
 

--- a/website/src/pages/[organism]/submission/[groupId]/released.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/released.astro
@@ -23,6 +23,8 @@ const groupsResult = await getGroupsAndCurrentGroup(Astro.params, Astro.locals.s
 const { organism: cleanedOrganism } = cleanOrganism(Astro.params.organism);
 
 if (!cleanedOrganism) {
+    // undefined renders the configured Astro 404 page
+    // Note - this check is currently unused as middleware exists to check the organism, but useful for type-checking
     return new Response(undefined, { status: 404 });
 }
 

--- a/website/src/pages/[organism]/submission/[groupId]/released.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/released.astro
@@ -23,7 +23,7 @@ const groupsResult = await getGroupsAndCurrentGroup(Astro.params, Astro.locals.s
 const { organism: cleanedOrganism } = cleanOrganism(Astro.params.organism);
 
 if (!cleanedOrganism) {
-    return new Response('Organism not found', { status: 404 });
+    return new Response(undefined, { status: 404 });
 }
 
 const clientConfig = getRuntimeConfig().public;

--- a/website/src/pages/[organism]/submission/[groupId]/revise.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/revise.astro
@@ -23,10 +23,7 @@ const accession = Astro.url.searchParams.get('accession') || undefined;
 const version = Astro.url.searchParams.get('version') || undefined;
 
 if (!cleanedOrganism) {
-    return {
-        statusCode: 404,
-        body: 'Organism not found',
-    };
+    return new Response(undefined, { status: 404 });
 }
 const schema = getSchema(cleanedOrganism.key);
 const groupedInputFields = getGroupedInputFields(cleanedOrganism.key, 'revise', true);

--- a/website/src/pages/[organism]/submission/[groupId]/revise.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/revise.astro
@@ -23,6 +23,8 @@ const accession = Astro.url.searchParams.get('accession') || undefined;
 const version = Astro.url.searchParams.get('version') || undefined;
 
 if (!cleanedOrganism) {
+    // undefined renders the configured Astro 404 page
+    // Note - this check is currently unused as middleware exists to check the organism, but useful for type-checking
     return new Response(undefined, { status: 404 });
 }
 const schema = getSchema(cleanedOrganism.key);

--- a/website/src/pages/[organism]/submission/[groupId]/submit.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/submit.astro
@@ -21,6 +21,8 @@ const { organism: cleanedOrganism } = cleanOrganism(Astro.params.organism);
 const inputMode: InputMode = Astro.url.searchParams.get('inputMode') === 'form' ? 'form' : 'bulk';
 
 if (!cleanedOrganism) {
+    // undefined renders the configured Astro 404 page
+    // Note - this check is currently unused as middleware exists to check the organism, but useful for type-checking
     return new Response(undefined, { status: 404 });
 }
 const schema = getSchema(cleanedOrganism.key);

--- a/website/src/pages/[organism]/submission/[groupId]/submit.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/submit.astro
@@ -21,10 +21,7 @@ const { organism: cleanedOrganism } = cleanOrganism(Astro.params.organism);
 const inputMode: InputMode = Astro.url.searchParams.get('inputMode') === 'form' ? 'form' : 'bulk';
 
 if (!cleanedOrganism) {
-    return {
-        statusCode: 404,
-        body: 'Organism not found',
-    };
+    return new Response(undefined, { status: 404 });
 }
 const schema = getSchema(cleanedOrganism.key);
 const groupedInputFields = getGroupedInputFields(cleanedOrganism.key, 'submit', true);

--- a/website/src/pages/[organism]/submission/edit/[accession]/[version].astro
+++ b/website/src/pages/[organism]/submission/edit/[accession]/[version].astro
@@ -13,10 +13,7 @@ const organism = Astro.params.organism!;
 const { organism: cleanedOrganism } = cleanOrganism(Astro.params.organism);
 
 if (!cleanedOrganism) {
-    return {
-        statusCode: 404,
-        body: 'Organism not found',
-    };
+    return new Response(undefined, { status: 404 });
 }
 
 const groupedInputFields = getGroupedInputFields(cleanedOrganism.key, 'revise', true);

--- a/website/src/pages/[organism]/submission/edit/[accession]/[version].astro
+++ b/website/src/pages/[organism]/submission/edit/[accession]/[version].astro
@@ -13,6 +13,8 @@ const organism = Astro.params.organism!;
 const { organism: cleanedOrganism } = cleanOrganism(Astro.params.organism);
 
 if (!cleanedOrganism) {
+    // undefined renders the configured Astro 404 page
+    // Note - this check is currently unused as middleware exists to check the organism, but useful for type-checking
     return new Response(undefined, { status: 404 });
 }
 


### PR DESCRIPTION
Adds to #6940 by fixing the other 404 response handling, and updates the released page 404 to use `undefined` so that the base astro 404 page is displayed (this is an existing pattern in the website).

This code isn't actually hit due to the `organismValidatorMiddleware`, but good to have for type checking and best for it to work in case that middleware was ever removed/changed.

### Screenshot

With the organism validator middleware disabled, and an incorrect organism in the URL, this is what would happen before:

<img width="1865" height="609" alt="image" src="https://github.com/user-attachments/assets/11bb3cc5-2024-4bc4-9c6f-37e4b1eb6fdc" />

And now:

<img width="1865" height="375" alt="image" src="https://github.com/user-attachments/assets/c2d44ae2-59a0-4510-aaba-0deff857c2b6" />



### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable