### PR TITLE
feat(website): default revision to the single sequence form

### DIFF
--- a/docs/src/content/docs/for-users/revise-sequences.md
+++ b/docs/src/content/docs/for-users/revise-sequences.md
@@ -4,7 +4,9 @@ title: Revise sequences
 
 Sequences can be corrected or updated after they have been submitted to Loculus. Submitting these changes ("revisions") will cause the [version](../../reference/glossary/#version) of the sequence to be incremented, and previous versions of the metadata and sequence data can always be accessed via previous version numbers.
 
-The process of submitting revisions is very similar to original submission. The main difference is that you must provide an `accession` column in the metadata file, which contains the Loculus [accession number(s)](../../reference/glossary/#accession) assigned when the sequences were submitted originally.
+There are two ways to revise sequences. To change a single sequence, use the **Revise single sequence** page, look up the accession you want to revise, and edit its values directly in the form. To revise many sequences at once, switch to the **Upload bulk revisions** tab and upload a metadata file and a FASTA file, as described below.
+
+The bulk process is very similar to original submission. The main difference is that you must provide an `accession` column in the metadata file, which contains the Loculus [accession number(s)](../../reference/glossary/#accession) assigned when the sequences were submitted originally.
 
 ## Downloading originally submitted data for revision
 
@@ -35,7 +37,7 @@ Even if you are not revising the sequence, you must provide a FASTA file that ma
 
 ## Submitting the revision
 
-To submit a revision, navigate to the `Submit` section of the Loculus website using the link in the top-right corner of the website. Select the correct organism if requested, or ensure you're submitting to the correct organism database via the drop-down on the top-left of the website.
+To submit a revision, navigate to the `Submit` section of the Loculus website using the link in the top-right corner of the website. Select the correct organism if requested, or ensure you're submitting to the correct organism database via the drop-down on the top-left of the website. Choose `Revise`, then select the **Upload bulk revisions** tab.
 
 Just as with an original submission, drag and drop (or select) the files where you have made the appropriate revisions. Press 'Submit'.
 

--- a/integration-tests/tests/specs/features/file-sharing.spec.ts
+++ b/integration-tests/tests/specs/features/file-sharing.spec.ts
@@ -129,7 +129,7 @@ test('bulk revise 2 seqs with files', async ({ page, groupId, tmpDir }) => {
 
     // Step 2: Bulk revise with files
     const revisionPage = new RevisionPage(page);
-    await revisionPage.goto(ORGANISM_URL_NAME, groupId);
+    await revisionPage.goto(ORGANISM_URL_NAME, groupId, 'bulk');
 
     // Upload revision metadata (with accession column)
     const revisionMetadata = [

--- a/integration-tests/tests/specs/features/revise-sequence.spec.ts
+++ b/integration-tests/tests/specs/features/revise-sequence.spec.ts
@@ -70,7 +70,7 @@ sequenceTest(
 groupTest.describe('Revision page template downloads', () => {
     groupTest('can download revision metadata templates', async ({ page, groupId }) => {
         const revisionPage = new RevisionPage(page);
-        await revisionPage.goto(TEST_ORGANISM, groupId);
+        await revisionPage.goto(TEST_ORGANISM, groupId, 'bulk');
 
         const tsvDownload = await revisionPage.downloadTsvTemplate();
         expect(tsvDownload.suggestedFilename()).toContain('.tsv');
@@ -118,7 +118,7 @@ groupTest.describe('Bulk sequence revision', () => {
         const fastaContent = createFastaContent(revisedSequences);
 
         const revisionPage = new RevisionPage(page);
-        await revisionPage.goto(TEST_ORGANISM, groupId);
+        await revisionPage.goto(TEST_ORGANISM, groupId, 'bulk');
         await revisionPage.uploadMetadataFile('revision_metadata.tsv', revisionMetadata);
         await revisionPage.uploadSequenceFile('revised_sequences.fasta', fastaContent);
         await revisionPage.acceptTerms();

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -247,28 +247,32 @@ export const InputModeTabs = ({
             inputMode,
         });
 
+    const tabs: { inputMode: InputMode; label: string }[] =
+        action === 'revise'
+            ? [
+                  { inputMode: 'form', label: 'Revise single sequence' },
+                  { inputMode: 'bulk', label: 'Upload bulk revisions' },
+              ]
+            : [
+                  { inputMode: 'bulk', label: 'Upload bulk sequences' },
+                  { inputMode: 'form', label: 'Submit individual sequence entry using a form' },
+              ];
+
     return (
         <div className='flex border-b'>
-            <a
-                className={`py-2 px-4 border-b-2 ${
-                    currentInputMode === 'bulk'
-                        ? 'border-primary-600 text-primary-600'
-                        : 'border-transparent text-gray-500'
-                } hover:text-primary-600`}
-                href={inputModeUrl('bulk')}
-            >
-                Upload bulk sequences
-            </a>
-            <a
-                className={`py-2 px-4 border-b-2 ${
-                    currentInputMode === 'form'
-                        ? 'border-primary-600 text-primary-600'
-                        : 'border-transparent text-gray-500'
-                } hover:text-primary-600`}
-                href={inputModeUrl('form')}
-            >
-                {`${action === 'submit' ? 'Submit' : 'Revise'} individual sequence entry using a form`}
-            </a>
+            {tabs.map(({ inputMode, label }) => (
+                <a
+                    key={inputMode}
+                    className={`py-2 px-4 border-b-2 ${
+                        currentInputMode === inputMode
+                            ? 'border-primary-600 text-primary-600'
+                            : 'border-transparent text-gray-500'
+                    } hover:text-primary-600`}
+                    href={inputModeUrl(inputMode)}
+                >
+                    {label}
+                </a>
+            ))}
         </div>
     );
 };

--- a/website/src/pages/[organism]/submission/[groupId]/index.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/index.astro
@@ -56,7 +56,7 @@ async function getSequenceCounts(organism: string, groupId: number) {
                     },
                     {
                         title: 'Revise',
-                        description: 'Upload revisions for existing sequences.',
+                        description: 'Update sequences that you have already submitted.',
                         route: routes.revisePage(organism, group.groupId),
                         icon: F7Arrow2Circlepath,
                     },

--- a/website/src/pages/[organism]/submission/[groupId]/index.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/index.astro
@@ -56,7 +56,7 @@ async function getSequenceCounts(organism: string, groupId: number) {
                     },
                     {
                         title: 'Revise',
-                        description: 'Update sequences that you have already submitted.',
+                        description: 'Update sequences that you have already released.',
                         route: routes.revisePage(organism, group.groupId),
                         icon: F7Arrow2Circlepath,
                     },

--- a/website/src/pages/[organism]/submission/[groupId]/revise.astro
+++ b/website/src/pages/[organism]/submission/[groupId]/revise.astro
@@ -18,7 +18,7 @@ const organism = Astro.params.organism!;
 
 const { organism: cleanedOrganism } = cleanOrganism(Astro.params.organism);
 
-const inputMode: InputMode = Astro.url.searchParams.get('inputMode') === 'form' ? 'form' : 'bulk';
+const inputMode: InputMode = Astro.url.searchParams.get('inputMode') === 'bulk' ? 'bulk' : 'form';
 const accession = Astro.url.searchParams.get('accession') || undefined;
 const version = Astro.url.searchParams.get('version') || undefined;
 

--- a/website/src/routes/SubmissionRoute.spec.ts
+++ b/website/src/routes/SubmissionRoute.spec.ts
@@ -41,6 +41,36 @@ describe('SubmissionRouteUtils', () => {
         });
     });
 
+    test('parseToRoute - valid revise route with inputMode', () => {
+        expect(SubmissionRouteUtils.parseToRoute('/cchf/submission/123/revise', '?inputMode=bulk')).toEqual({
+            name: 'revise',
+            organism: 'cchf',
+            groupId: 123,
+            inputMode: 'bulk',
+            accession: undefined,
+            version: undefined,
+        });
+    });
+
+    test('parseToRoute - revise - inputMode defaults to form', () => {
+        expect(SubmissionRouteUtils.parseToRoute('/cchf/submission/123/revise', '')).toEqual({
+            name: 'revise',
+            organism: 'cchf',
+            groupId: 123,
+            inputMode: 'form',
+            accession: undefined,
+            version: undefined,
+        });
+        expect(SubmissionRouteUtils.parseToRoute('/cchf/submission/123/revise', '?inputMode=foo')).toEqual({
+            name: 'revise',
+            organism: 'cchf',
+            groupId: 123,
+            inputMode: 'form',
+            accession: undefined,
+            version: undefined,
+        });
+    });
+
     test('parseToRoute - invalid route', () => {
         expect(SubmissionRouteUtils.parseToRoute('/invalid/path', '')).toBeUndefined();
     });

--- a/website/src/routes/SubmissionRoute.ts
+++ b/website/src/routes/SubmissionRoute.ts
@@ -60,7 +60,7 @@ export const SubmissionRouteUtils = {
                 return {
                     ...baseRoute,
                     name: 'revise',
-                    inputMode: searchParams.get('inputMode') === 'form' ? 'form' : 'bulk',
+                    inputMode: searchParams.get('inputMode') === 'bulk' ? 'bulk' : 'form',
                     accession: searchParams.get('accession') ?? undefined,
                     version: searchParams.get('version') ?? undefined,
                 };

--- a/website/src/routes/routes.ts
+++ b/website/src/routes/routes.ts
@@ -47,7 +47,7 @@ export const routes = {
     revisePage: (
         organism: string,
         groupId: number,
-        inputMode: InputMode = 'bulk',
+        inputMode: InputMode = 'form',
         accession?: string,
         version?: string,
     ) => SubmissionRouteUtils.toUrl({ name: 'revise', organism, groupId, inputMode, accession, version }),


### PR DESCRIPTION
Closes part of #6963.

## What this changes

Revising a single sequence via the form is now the default experience on the revise page, so users who want to fix one sequence no longer have to discover a tab and never have to build a metadata TSV. Bulk revision is still one click away.

Concretely:

- **The revise page defaults to `inputMode=form`.** Visiting `/<organism>/submission/<groupId>/revise` with no `inputMode` parameter (or with an unrecognised value) now lands on the single-sequence form; you get the bulk upload flow with `?inputMode=bulk`. This is the mirror image of the previous behaviour, and it is scoped to revision only — submission still defaults to bulk upload, since new submissions are much more often bulk.
- **The tab order is flipped for revision, and the labels are new.** On the revise page the tabs now read `Revise single sequence` (left, default) and `Upload bulk revisions` (right). The old label mentioned the form as an implementation detail (`Revise individual sequence entry using a form`); that reference is dropped. Submission tabs keep their existing order and labels.
- `InputModeTabs` was refactored from two hard-coded anchors into a small per-action list of `{inputMode, label}` rendered in order, which is what lets revision and submission differ in both order and wording without duplicating the anchor markup.
- The submission portal card for `Revise` said "Upload revisions for existing sequences", which no longer describes where the link takes you; it now says "Update sequences that you have already submitted."

## Screenshots

All screenshots are of the West Nile Virus revise flow for a group with sequences, at a 1280px viewport.

### The revise page you land on, before and after

Previously, `/<organism>/submission/<groupId>/revise` opened on the bulk upload tab, and the way to revise one sequence was the second tab, labelled `Revise individual sequence entry using a form`:

![Revise page before this change: the bulk upload tab is selected, and the tabs read "Upload bulk sequences" and "Revise individual sequence entry using a form"](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6964/before-revise-landing.png)

Now the same URL opens on the single-sequence form. The tab order is reversed for revision and both labels are new, so the bulk route is still visible and one click away:

![Revise page after this change: the "Revise single sequence" tab is selected and shows the accession search, with "Upload bulk revisions" as the second tab](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6964/after-revise-form.png)

### The bulk tab is unchanged apart from its label and position

`?inputMode=bulk` (or clicking the second tab) gives the same bulk upload page as before:

![Revise page with the "Upload bulk revisions" tab selected, showing the unchanged sequence file and metadata file upload panels](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6964/after-revise-bulk.png)

### Submission portal card wording

The `Revise` card used to promise an upload, which is no longer where the link goes.

Before:

![Submission portal before: the Revise card reads "Upload revisions for existing sequences."](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6964/before-portal.png)

After:

![Submission portal after: the Revise card reads "Update sequences that you have already submitted."](https://raw.githubusercontent.com/loculus-project/agent_store/main/pr-6964/after-portal.png)

## Other updates

- `routes.revisePage(...)` defaults its `inputMode` argument to `'form'` to match the page. All existing callers that care (the "Revise this sequence" button on the sequence details page, and the edit page) already pass `'form'` explicitly.
- `SubmissionRouteUtils.parseToRoute` for `revise` now treats anything other than `bulk` as `form`, with new unit tests covering both the explicit and default cases.
- Three integration tests exercised the bulk revision flow by navigating to the revise page without an `inputMode`, and would now land on the form. They pass `'bulk'` explicitly: the two template-download / bulk-upload tests in `revise-sequence.spec.ts` and the bulk file-sharing revision test in `file-sharing.spec.ts`.
- The user docs for revising sequences describe the bulk flow throughout. They now open with a short paragraph distinguishing the two routes, and the "Submitting the revision" section tells you to select the `Upload bulk revisions` tab.

## Not included

The second half of #6963 — a guide at the top of the bulk revision page explaining how to obtain the original metadata — is not addressed here. That content partly exists in the docs already ("Downloading originally submitted data for revision"), so surfacing it in the UI is worth doing as its own change.

## Test plan

- `CI=1 npm run test` (website) passes, including the new `SubmissionRoute` cases.
- `npm run check-types` passes with 0 errors.
- `npm run format` clean in both `website` and `integration-tests`.
- Integration tests were not run locally (they need a deployed cluster); the affected specs were updated to pin the bulk mode they rely on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable