### PR TITLE
docs(deployment): bump traefikVersion default in values.schema.json to 3

### DIFF
--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1679,7 +1679,7 @@
       "groups": ["general"],
       "type": "integer",
       "enum": [2, 3],
-      "default": 2,
+      "default": 3,
       "description": "Traefik major version for CRD API group. Use 2 for traefik.containo.us/v1alpha1 (Traefik v2) or 3 for traefik.io/v1alpha1 (Traefik v3)."
     },
     "ingestLimitSeconds": {


### PR DESCRIPTION
Follow-up to #6966 (per [review discussion](https://github.com/loculus-project/loculus/pull/6966#discussion_r3631484771)).

#6966 changes the chart default for `traefikVersion` in `kubernetes/loculus/values.yaml` from `2` to `3`, but leaves the `default` in `values.schema.json` saying `2`. This PR bumps the schema default so the two agree.

## Why this matters (a bit) and why it does not (mostly)

For Helm itself the schema `default` is inert — Helm uses `values.schema.json` for *validation* only and never injects defaults from it into the values. So this change has zero effect on any deployment, and nothing was broken by the two disagreeing.

It is not purely decorative, though: the docs site reads this file. `docs/package.json` copies `values.schema.json` into `docs/src/`, and `docs/src/components/SchemaDocs.astro` renders a table with a **Default** column taken straight from `definition.default` for every property that carries a `groups` key. `traefikVersion` has `"groups": ["general"]`, so it appears in the published configuration reference — and without this change that page would tell administrators the default is Traefik 2 while the chart actually ships Traefik 3.

## Merge order

This should be merged **after** #6966. Merging it first would flip the drift around (docs saying 3 while the chart still ships 2) for as long as #6966 is open. It is docs-only either way, so nothing breaks; it is just tidier in that order. If #6966 ends up not landing the 2 → 3 switch, this PR should be closed rather than merged.

## Note for later

More generally, the schema `default` is a hand-maintained copy of the corresponding `values.yaml` value with nothing enforcing that they agree, which is exactly the drift this PR is cleaning up. If this bites again, a small CI check that every `default` in `values.schema.json` matches the value at the same key in `values.yaml` would be cheap to add. Not doing that here to keep the PR to one line.

## PR Checklist
- [x] All necessary documentation has been adapted. (this PR *is* the documentation adaptation)
- [ ] The implemented feature is covered by appropriate, automated tests. (n/a — no behaviour change; `helm lint kubernetes/loculus -f kubernetes/loculus/values.yaml` passes)
- [x] Any manual testing that has been done is documented: ran `npx prettier@3.6.2 --write kubernetes/loculus/values.schema.json` (no reformatting needed) and `helm lint kubernetes/loculus -f kubernetes/loculus/values.yaml` (1 chart linted, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable