### PR TITLE
fix(website): remove hardcoded loculus on SeqSet page

### DIFF
--- a/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
@@ -163,7 +163,7 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
                 fullWidth={false}
             >
                 <p className='mb-4 text-sm text-gray-500'>
-                    The creator is the person who assembled this SeqSet on Loculus. They are not necessarily the
+                    The creator is the person who assembled this SeqSet on {databaseName}. They are not necessarily the
                     originator of the underlying sequence data.
                 </p>
                 <CreatorDetailEntry label='Created by' value={createdByValue} />


### PR DESCRIPTION
Previously displayed a hardcoded 'Loculus' rather than the instance name.

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable