### PR TITLE
feat!(config): Loculus now expects traefik v3 by default (+ upgrades the k3s version used in integration tests)

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -34,10 +34,7 @@ HELM_RELEASE_NAME = "preview"
 HELM_CHART_DIR = ROOT_DIR / "kubernetes" / "loculus"
 WEBSITE_ORGANISM_CONFIGMAP_PREFIX = "loculus-web-org-config-"
 
-# By default, uses K3s v1.31: https://hub.docker.com/r/rancher/k3s/tags?name=v1.31
-# K3s v1.31 is the latest version which installs Traefik v2 (Traefik v3 is not yet supported by Loculus)
-# Also see: https://docs.k3s.io/upgrades#version-specific-caveats
-DEFAULT_K3S_IMAGE = "rancher/k3s:v1.31.14-k3s1"
+DEFAULT_K3S_IMAGE = "rancher/k3s:v1.35.6-k3s1"
 
 WEBSITE_PORT_MAPPING = "-p 127.0.0.1:3000:30081@agent:0"
 BACKEND_PORT_MAPPING = "-p 127.0.0.1:8079:30082@agent:0"

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1679,7 +1679,7 @@
       "groups": ["general"],
       "type": "integer",
       "enum": [2, 3],
-      "default": 2,
+      "default": 3,
       "description": "Traefik major version for CRD API group. Use 2 for traefik.containo.us/v1alpha1 (Traefik v2) or 3 for traefik.io/v1alpha1 (Traefik v3)."
     },
     "ingestLimitSeconds": {

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2696,7 +2696,7 @@ runDevelopmentMainDatabase: true
 runDevelopmentS3: true
 developmentDatabasePersistence: false
 enforceHTTPS: true
-traefikVersion: 2
+traefikVersion: 3
 registrationTermsMessage: >
   You must agree to the <a href="http://main.loculus.org/terms">terms of use</a>.
 

--- a/kubernetes/loculus/values_preview_server.yaml
+++ b/kubernetes/loculus/values_preview_server.yaml
@@ -1,5 +1,4 @@
 createTestAccounts: true
-traefikVersion: 3
 secrets:
   smtp-password:
     type: sealedsecret


### PR DESCRIPTION
This PR makes Loculus default to expect Traefik v3 rather than Traefik v2.

It also upgrades the k3s version used by default in the deploy script (used by integration tests and for local development), using the same version used on loculus previews and pathoplexus. Upgrade from `v1.31.14` to `v1.35.6, which is what necessitates the change to v3 since later versions are bundled with traefik v3 rather than v2.

### Breaking Changes
Pathoplexus does not need to make any changes. Other users of Loculus can continue to stay on earlier versions of traefik (which are bundled in early versions of k3s) but to do so should overwrite the declared traefik version in their values.yaml to `traefikVersion: 2` in order to continue to use the previous k3s version. However, we would recommend Loculus users to upgrade their traefik version, as traefik v2 may be deprecated or have support removed in future.

🚀 Preview: Add `preview` label to enable