### PR TITLE
feat!(config, prepro): taxonomy service config refactor

### DIFF
--- a/kubernetes/loculus/templates/loculus-preprocessing-config.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-config.yaml
@@ -15,6 +15,9 @@ data:
   preprocessing-config.yaml: |
     organism: {{ $organism }}
     {{- $processingConfig.configFile | toYaml | nindent 4 }}
+    {{- if and $.Values.taxonomyService (not $.Values.disableTaxonomyService) }}
+    taxonomy_service_url: {{ $.Values.taxonomyService.taxonomy_service_url }}
+    {{- end }}
     {{- if and (hasKey $organismConfig.schema "submissionDataTypes") (hasKey $organismConfig.schema.submissionDataTypes "maxSequencesPerEntry") }}
     max_sequences_per_entry: {{ $organismConfig.schema.submissionDataTypes.maxSequencesPerEntry }}
     {{- end }}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -684,19 +684,6 @@
                 },
                 "description": "Array of Strings. Arguments passed to the preprocessing pipeline."
               },
-              "taxonomyServiceArgs": {
-                "groups": ["preprocessing"],
-                "docsIncludePrefix": false,
-                "type": "object",
-                "description": "Settings to configure the taxonomy service host and port",
-                "properties": {
-                  "taxonomy_service_url": {
-                    "groups": ["preprocessing"],
-                    "type": "string",
-                    "description": "Host and port where the taxonomy service runs"
-                  }
-                }
-              },
               "configFile": {
                 "groups": ["preprocessing"],
                 "docsIncludePrefix": false,
@@ -1891,6 +1878,10 @@
         "taxonomyDbPath": {
           "type": "string",
           "description": "Path where the taxonomy SQLite database is mounted inside the container"
+        },
+        "taxonomy_service_url": {
+          "type": "string",
+          "description": "URL where the taxonomy service is accessible"
         }
       }
     },

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -83,6 +83,10 @@ lineageSystemDefinitions:
     4: https://raw.githubusercontent.com/loculus-project/loculus/fe3b2974071acc9a25856d650350f8a952040a7c/preprocessing/dummy/lineage-alternative.yaml
   cchfS:
     1: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/cchf/S/2025-09-24--07-29-03Z/lineages.yaml
+taxonomyService:
+  dbVersion: "ncbi_taxonomy_2026-05-01"
+  taxonomyDbPath: "/data/taxonomy.sqlite" # this is where the init container mounts the database
+  taxonomy_service_url: &taxonomy_service_url http://loculus-taxonomy-service:5000
 defaultOrganismConfig: &defaultOrganismConfig
   schema: &schema
     submissionDataTypes: &defaultSubmissionDataTypes
@@ -1657,7 +1661,7 @@ defaultOrganisms:
               human_readable_pattern: "<any>/<any>/<identifier>/<date>"
         - <<: *hostTaxonIdConfig
           required: true
-          hierarchicalFilter: &taxonomy_service_url http://loculus-taxonomy-service:5000
+          hierarchicalFilter: *taxonomy_service_url
           hierarchicalSearchLabel: "include subtaxa"
           initiallyVisible: true
         - name: lineage
@@ -2698,10 +2702,6 @@ enaDeposition:
   enaUniqueSuffix: Loculus
   enaIsBroker: False
   enaSuppressedListTestUrl: "https://loculus-project.github.io/ena-submission/suppressed/ppx-accessions-suppression-list.txt"
-taxonomyService:
-  dbVersion: "ncbi_taxonomy_2026-05-01"
-  taxonomyDbPath: "/data/taxonomy.sqlite" # this is where the init container mounts the database
-  taxonomy_service_url: *taxonomy_service_url
 subdomainSeparator: "-"
 replicas:
   website: 1

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -84,7 +84,7 @@ lineageSystemDefinitions:
   cchfS:
     1: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/cchf/S/2025-09-24--07-29-03Z/lineages.yaml
 taxonomyService:
-  dbVersion: "ncbi_taxonomy_2026-05-01"
+  dbVersion: "ncbi_taxonomy_2026-06-01"
   taxonomyDbPath: "/data/taxonomy.sqlite" # this is where the init container mounts the database
   taxonomy_service_url: &taxonomy_service_url http://loculus-taxonomy-service:5000
 defaultOrganismConfig: &defaultOrganismConfig

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1261,8 +1261,6 @@ defaultOrganismConfig: &defaultOrganismConfig
           function: resolve_host_taxon_id
           inputs:
             host: host
-          args:
-            taxonomy_service_url: &taxonomy_service_url http://loculus-taxonomy-service:5000
       - name: hostNameScientific
         displayName: Host name - scientific
         definition: "The scientific name of the host from which the sample was collected."
@@ -1280,8 +1278,6 @@ defaultOrganismConfig: &defaultOrganismConfig
           function: scientific_name_from_id
           inputs:
             hostTaxonId: processed.hostTaxonId
-          args:
-            taxonomy_service_url: *taxonomy_service_url
       - name: hostNameCommon
         displayName: Host name - common
         definition: "The common name of the host from which the sample was collected."
@@ -1299,8 +1295,6 @@ defaultOrganismConfig: &defaultOrganismConfig
           function: common_name_from_id
           inputs:
             hostTaxonId: processed.hostTaxonId
-          args:
-            taxonomy_service_url: *taxonomy_service_url
       - name: isLabHost
         displayName: Is lab host
         definition: "If a laboratory host (e.g. cultured cell line) was used to propagate the sample."
@@ -1539,8 +1533,6 @@ defaultOrganismConfig: &defaultOrganismConfig
       args:
         - "prepro"
       replicas: 1
-      taxonomyServiceArgs: &preprocessingTaxonomyServiceArgs
-        taxonomy_service_url: *taxonomy_service_url
       configFile: &preprocessingConfigFile
         log_level: DEBUG
         batch_size: 100
@@ -1665,7 +1657,7 @@ defaultOrganisms:
               human_readable_pattern: "<any>/<any>/<identifier>/<date>"
         - <<: *hostTaxonIdConfig
           required: true
-          hierarchicalFilter: *taxonomy_service_url
+          hierarchicalFilter: &taxonomy_service_url http://loculus-taxonomy-service:5000
           hierarchicalSearchLabel: "include subtaxa"
           initiallyVisible: true
         - name: lineage
@@ -2709,6 +2701,7 @@ enaDeposition:
 taxonomyService:
   dbVersion: "ncbi_taxonomy_2026-05-01"
   taxonomyDbPath: "/data/taxonomy.sqlite" # this is where the init container mounts the database
+  taxonomy_service_url: *taxonomy_service_url
 subdomainSeparator: "-"
 replicas:
   website: 1

--- a/preprocessing/nextclade/README.md
+++ b/preprocessing/nextclade/README.md
@@ -126,7 +126,7 @@ However, the `preprocessing` field can be customized to take an arbitrary number
 7. `check_regex`: Validate that the input field matches the pattern in `args.pattern`.
 8. `extract_regex`: Extracts a substring from input field using the provided regex `args.pattern` with a `args.capture_group`. For example the pattern `^(?P<segment>[^-]+)-(?P<subtype>[^-]+)$` with capture group `subtype` would extract `HA` from the field `seg1-HA`. Returns an error if the pattern does not match (and internal error if capture group does not exist in pattern). If `arg.uppercase` is added the extracted string will be capitalized.
 
-Additionally, certain functions require external services to be running, we have various functions related to validating host which require a `taxonomyService` to be running, this can be configured in the `values.yaml` as:
+Additionally, certain functions require external services to be running. For example, we have various functions related to validating host which require a `taxonomyService` to be running. This can be configured in the `values.yaml` as:
 
 ```yaml
 taxonomyService:

--- a/preprocessing/nextclade/README.md
+++ b/preprocessing/nextclade/README.md
@@ -134,9 +134,9 @@ taxonomyService:
   taxonomyDbPath: "/data/taxonomy.sqlite" # this is where the init container mounts the database
   taxonomy_service_url: http://loculus-taxonomy-service:5000
 ```
-9. `resolve_host_taxon_id`: Validates that a host taxon ID or scientific name exists in the NCBI taxonomy, returning the taxon ID if validation is successful. Requires an input field called `host`.
-10. `scientific_name_from_id`: Returns a scientific name for a taxon given a taxon ID `hostTaxonId` as input.
-11. `common_name_from_id`: Returns a common name for a taxon given a taxon ID `hostTaxonId` as input.
+9. `resolve_host_taxon_id`: Validates that a host taxon ID or scientific name exists in the NCBI taxonomy, returning the taxon ID if validation is successful. Requires an input field called `host` (entries ingested from the INSDC do not error).
+10. `scientific_name_from_id`: Returns a scientific name for a taxon given a taxon ID `hostTaxonId` as input (entries ingested from the INSDC do not error).
+11. `common_name_from_id`: Returns a common name for a taxon given a taxon ID `hostTaxonId` as input (entries ingested from the INSDC do not error).
 
 
 

--- a/preprocessing/nextclade/README.md
+++ b/preprocessing/nextclade/README.md
@@ -126,6 +126,20 @@ However, the `preprocessing` field can be customized to take an arbitrary number
 7. `check_regex`: Validate that the input field matches the pattern in `args.pattern`.
 8. `extract_regex`: Extracts a substring from input field using the provided regex `args.pattern` with a `args.capture_group`. For example the pattern `^(?P<segment>[^-]+)-(?P<subtype>[^-]+)$` with capture group `subtype` would extract `HA` from the field `seg1-HA`. Returns an error if the pattern does not match (and internal error if capture group does not exist in pattern). If `arg.uppercase` is added the extracted string will be capitalized.
 
+Additionally, certain functions require external services to be running, we have various functions related to validating host which require a `taxonomyService` to be running, this can be configured in the `values.yaml` as:
+
+```yaml
+taxonomyService:
+  dbVersion: "ncbi_taxonomy_2026-05-01"
+  taxonomyDbPath: "/data/taxonomy.sqlite" # this is where the init container mounts the database
+  taxonomy_service_url: http://loculus-taxonomy-service:5000
+```
+9. `resolve_host_taxon_id`: Validates that a host taxon ID or scientific name exists in the NCBI taxonomy, returning the taxon ID if validation is successful. Requires an input field called `host`.
+10. `scientific_name_from_id`: Returns a scientific name for a taxon given a taxon ID `hostTaxonId` as input.
+11. `common_name_from_id`: Returns a common name for a taxon given a taxon ID `hostTaxonId` as input.
+
+
+
 Using these functions in your `values.yaml` will look like:
 
 ```yaml

--- a/preprocessing/nextclade/src/loculus_preprocessing/__init__.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/__init__.py
@@ -1,5 +1,6 @@
 from . import backend as backend
 from . import config as config
 from . import datatypes as datatypes
+from . import external_services as external_services
 from . import nextclade as nextclade
 from . import prepro as prepro

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -129,6 +129,9 @@ class Config(BaseModel):
     embl: EmblInfoMetadataPropertyNames = Field(default_factory=EmblInfoMetadataPropertyNames)
     insdc_ingest_group_id: int = 1
 
+    # External services
+    taxonomy_service_url: str | None = None
+
     @model_validator(mode="after")
     def finalize(self):
         if not self.segments:

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -7,7 +7,7 @@ from types import UnionType
 from typing import Any, get_args
 
 import yaml
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
 from loculus_preprocessing.datatypes import (
     FunctionArgs,
@@ -17,6 +17,7 @@ from loculus_preprocessing.datatypes import (
     SegmentClassificationMethod,
     Topology,
 )
+from loculus_preprocessing.external_services import TaxonomyService
 
 logger = logging.getLogger(__name__)
 
@@ -131,6 +132,14 @@ class Config(BaseModel):
 
     # External services
     taxonomy_service_url: str | None = None
+    _taxonomy_service: TaxonomyService | None = PrivateAttr(default=None)
+
+    @property
+    def taxonomy_service(self) -> TaxonomyService:
+        """Lazily constructed, cached for the lifetime of this Config instance."""
+        if self._taxonomy_service is None:
+            self._taxonomy_service = TaxonomyService(self.taxonomy_service_url)
+        return self._taxonomy_service
 
     @model_validator(mode="after")
     def finalize(self):

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -134,12 +134,6 @@ class Config(BaseModel):
     taxonomy_service_url: str | None = None
     _taxonomy_service: TaxonomyService | None = PrivateAttr(default=None)
 
-    @property
-    def taxonomy_service(self) -> TaxonomyService:
-        """Lazily constructed, cached for the lifetime of this Config instance."""
-        if self._taxonomy_service is None:
-            self._taxonomy_service = TaxonomyService(self.taxonomy_service_url)
-        return self._taxonomy_service
 
     @model_validator(mode="after")
     def finalize(self):
@@ -155,6 +149,7 @@ class Config(BaseModel):
             self.backend_host = f"http://127.0.0.1:8079/{self.organism}"
 
         self.processing_order = get_processing_order(self)
+        self._taxonomy_service = TaxonomyService(self.taxonomy_service_url)
 
         return self
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -132,8 +132,7 @@ class Config(BaseModel):
 
     # External services
     taxonomy_service_url: str | None = None
-    _taxonomy_service: TaxonomyService | None = PrivateAttr(default=None)
-
+    _taxonomy_service: TaxonomyService = PrivateAttr(default=TaxonomyService(None))
 
     @model_validator(mode="after")
     def finalize(self):

--- a/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
@@ -1,7 +1,10 @@
+import logging
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from enum import StrEnum, unique
 from typing import Any, Final
+
+logger = logging.getLogger(__name__)
 
 AccessionVersion = str
 GeneName = str
@@ -259,3 +262,13 @@ class MoleculeType(StrEnum):
 class Topology(StrEnum):
     LINEAR = "linear"
     CIRCULAR = "circular"
+
+
+def _internal_error_message(message: str) -> str:
+    full = f"Internal Error. {message} Please contact the administrator."
+    logger.error(full)
+    return full
+
+
+def raw_internal_error(message: str) -> RawProcessingResult:
+    return processing_error(_internal_error_message(message))

--- a/preprocessing/nextclade/src/loculus_preprocessing/external_services.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/external_services.py
@@ -118,7 +118,6 @@ class TaxonomyService:
         tax_id = taxon.get("tax_id")
         if tax_id is None:
             message = f"Host validation for '{unvalidated_host}' was successful but response json 'tax_id' was missing."
-            logger.error(message)
             return raw_internal_error(message)
         return RawProcessingResult(
             datum=str(tax_id),
@@ -151,7 +150,6 @@ class TaxonomyService:
         scientific_name = body.get("scientific_name")
         if scientific_name is None:
             message = f"'{tax_id}' is a valid taxon ID but response json had no 'scientific_name'."
-            logger.error(message)
             return raw_internal_error(message)
 
         return RawProcessingResult(datum=scientific_name)
@@ -181,7 +179,6 @@ class TaxonomyService:
         common_name = body.get("common_name")
         if common_name is None:
             message = f"Taxonomy service indicated common name was found for hostTaxonId '{tax_id}', but failed to return it."
-            logger.error(message)
             return raw_internal_error(message)
 
         return RawProcessingResult(datum=common_name)

--- a/preprocessing/nextclade/src/loculus_preprocessing/external_services.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/external_services.py
@@ -1,0 +1,168 @@
+import urllib.parse
+from collections import OrderedDict
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from loculus_preprocessing.datatypes import (
+    RawProcessingResult,
+    raw_internal_error,
+)
+
+
+class RequestCache:
+    """Class for caching requests to external services during preprocessing.
+
+    Keys are the fully formatted URLs that have already been used to make sucessful requests.
+    Values are requests.Response as they were returned by the service.
+    """
+
+    def __init__(self, max_size: int, retries=5) -> None:
+        self.cache: OrderedDict[str, requests.Response] = OrderedDict()
+        self.max_size = max_size
+        self.session = requests.Session()
+        retry = Retry(total=retries, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
+        adapter = HTTPAdapter(max_retries=retry)
+        self.session.mount("http://", adapter)
+        self.session.mount("https://", adapter)
+
+    def get(self, url: str) -> requests.Response | None:
+        if url in self.cache:
+            self.cache.move_to_end(url)
+            return self.cache[url]
+        return None
+
+    def set(self, url: str, response: requests.Response) -> None:
+        self.cache[url] = response
+        self.cache.move_to_end(url)
+
+        if len(self.cache) > self.max_size:
+            self.cache.popitem(last=False)
+
+    def get_or_fetch(self, url: str, timeout: int = 15) -> requests.Response:
+        """
+        Check if `url` already exists in the cache and return the cached Response if it does.
+
+        If `url` is not in the cache, make the actual request (with timeout and retries).
+        Add the Response to the cache (if status code in the 200s), and return the Response.
+
+        The caller should wrap this in a try/except block and handle errors.
+        """
+        response = self.get(url)
+        if response is None:
+            response = self.session.get(url, timeout=timeout)
+            if 200 <= response.status_code < 300:  # noqa: PLR2004
+                self.set(url, response)
+        return response
+
+    def clear(self) -> None:
+        self.cache.clear()
+
+
+def missing_taxonomy_service_error() -> RawProcessingResult:
+    return raw_internal_error("taxonomy_service_url was not configured.")
+
+
+def taxonomy_network_error(
+    subject: str,
+    action: str,
+    e: Exception,
+) -> RawProcessingResult:
+    return raw_internal_error(f"Network error while {action} '{subject}': {e}.")
+
+
+taxonomy_cache = RequestCache(max_size=64)
+
+
+class TaxonomyService:
+    def __init__(self, taxonomy_service_url: str | None):
+        self.taxonomy_service_url = taxonomy_service_url
+
+    def get_tax_id(self, unvalidated_host: str, error_if_failed: bool) -> RawProcessingResult:
+        if not self.taxonomy_service_url:
+            return missing_taxonomy_service_error()
+
+        if unvalidated_host.isdigit():
+            url = f"{self.taxonomy_service_url}/taxa/{unvalidated_host}"
+        else:
+            query = urllib.parse.urlencode({"scientific_name": unvalidated_host})
+            url = f"{self.taxonomy_service_url}/taxa?{query}"
+        try:
+            response = taxonomy_cache.get_or_fetch(url)
+            response.raise_for_status()
+            body = response.json()
+            if isinstance(body, list):
+                # when querying by scientific name, multiple taxa may be returned: select the most generic one
+                taxon = min(body, key=lambda x: x.get("depth", float("inf")))
+            else:
+                taxon = body
+
+            tax_id = taxon.get("tax_id")
+            if tax_id is None:
+                message = (
+                    f"Host validation for '{unvalidated_host}' failed with code "
+                    f"{response.status_code}: {taxon.get('detail', '')}"
+                )
+                return RawProcessingResult(
+                    datum=None,
+                    warnings=[message] if error_if_failed else [],
+                    errors=[message] if not error_if_failed else [],
+                )
+            return RawProcessingResult(
+                datum=str(tax_id),
+            )
+        except requests.exceptions.RequestException as e:
+            return taxonomy_network_error(
+                subject=f"taxon ID {unvalidated_host}",
+                action="fetching taxon info",
+                e=e,
+            )
+
+    def get_scientific_name(self, tax_id: str) -> RawProcessingResult:
+        if not self.taxonomy_service_url:
+            return missing_taxonomy_service_error()
+
+        url = f"{self.taxonomy_service_url}/taxa/{tax_id}"
+        try:
+            response = taxonomy_cache.get_or_fetch(url)
+            response.raise_for_status()
+            body = response.json()
+            scientific_name = body.get("scientific_name")
+            if scientific_name is None:
+                return raw_internal_error(
+                    f"'{tax_id}' is a valid taxon ID but response json had no 'scientific_name'."
+                )
+            return RawProcessingResult(
+                datum=scientific_name,
+            )
+        except requests.exceptions.RequestException as e:
+            return taxonomy_network_error(
+                subject=f"taxon ID {tax_id}",
+                action="fetching taxon scientific name",
+                e=e,
+            )
+
+    def get_common_name(self, tax_id: str) -> RawProcessingResult:
+        if not self.taxonomy_service_url:
+            return missing_taxonomy_service_error()
+
+        url = f"{self.taxonomy_service_url}/taxa/{tax_id}?find_common_name=true"
+        try:
+            response = taxonomy_cache.get_or_fetch(url)
+            response.raise_for_status()
+            body = response.json()
+            common_name = body.get("common_name")
+            if common_name is None:
+                return raw_internal_error(
+                    f"'{tax_id}' is a valid taxon ID but response json had no 'common_name'."
+                )
+            return RawProcessingResult(
+                datum=common_name,
+            )
+        except requests.exceptions.RequestException as e:
+            return taxonomy_network_error(
+                subject=f"taxon ID {tax_id}",
+                action="fetching taxon common name",
+                e=e,
+            )

--- a/preprocessing/nextclade/src/loculus_preprocessing/external_services.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/external_services.py
@@ -112,10 +112,6 @@ class TaxonomyService:
 
         tax_id = taxon.get("tax_id")
         if tax_id is None:
-            message = (
-                f"Host validation for '{unvalidated_host}' failed with code "
-                f"{response.status_code}: {taxon.get('detail', '')}"
-            )
             return raw_internal_error(
                 f"Host validation for '{unvalidated_host}' was successful but response json 'tax_id' was missing."
             )

--- a/preprocessing/nextclade/src/loculus_preprocessing/external_services.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/external_services.py
@@ -101,8 +101,8 @@ class TaxonomyService:
             message = f"Host validation for '{unvalidated_host}' failed with code {response.status_code}: {body.get('detail', '')}"
             return RawProcessingResult(
                 datum=None,
-                warnings=[message] if error_if_failed else [],
-                errors=[message] if not error_if_failed else [],
+                warnings=[message] if not error_if_failed else [],
+                errors=[message] if error_if_failed else [],
             )
         if isinstance(body, list):
             # when querying by scientific name, multiple taxa may be returned: select the most generic one
@@ -141,8 +141,8 @@ class TaxonomyService:
             message = f"Could not map '{tax_id}' to scientific name. Code {response.status_code}: {body.get('detail', '')}"
             return RawProcessingResult(
                 datum=None,
-                warnings=[message] if error_if_failed else [],
-                errors=[message] if not error_if_failed else [],
+                warnings=[message] if not error_if_failed else [],
+                errors=[message] if error_if_failed else [],
             )
 
         scientific_name = body.get("scientific_name")

--- a/preprocessing/nextclade/src/loculus_preprocessing/external_services.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/external_services.py
@@ -1,3 +1,4 @@
+import logging
 import urllib.parse
 from collections import OrderedDict
 
@@ -9,6 +10,8 @@ from loculus_preprocessing.datatypes import (
     RawProcessingResult,
     raw_internal_error,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class RequestCache:
@@ -98,7 +101,9 @@ class TaxonomyService:
                 e=e,
             )
         if response.status_code != requests.codes.ok:
-            message = f"Host validation for '{unvalidated_host}' failed with code {response.status_code}: {body.get('detail', '')}"
+            message = f"Host validation for '{unvalidated_host}' failed."
+            details = f"with code {response.status_code}: {body.get('detail', '')}"
+            logger.error(message + details)
             return RawProcessingResult(
                 datum=None,
                 warnings=[message] if not error_if_failed else [],
@@ -112,9 +117,9 @@ class TaxonomyService:
 
         tax_id = taxon.get("tax_id")
         if tax_id is None:
-            return raw_internal_error(
-                f"Host validation for '{unvalidated_host}' was successful but response json 'tax_id' was missing."
-            )
+            message = f"Host validation for '{unvalidated_host}' was successful but response json 'tax_id' was missing."
+            logger.error(message)
+            return raw_internal_error(message)
         return RawProcessingResult(
             datum=str(tax_id),
         )
@@ -134,7 +139,9 @@ class TaxonomyService:
                 e=e,
             )
         if response.status_code != requests.codes.ok:
-            message = f"Could not map '{tax_id}' to scientific name. Code {response.status_code}: {body.get('detail', '')}"
+            message = f"Could not map '{tax_id}' to scientific name."
+            details = f"Code {response.status_code}: {body.get('detail', '')}"
+            logger.error(message + details)
             return RawProcessingResult(
                 datum=None,
                 warnings=[message] if not error_if_failed else [],
@@ -143,9 +150,9 @@ class TaxonomyService:
 
         scientific_name = body.get("scientific_name")
         if scientific_name is None:
-            return raw_internal_error(
-                f"'{tax_id}' is a valid taxon ID but response json had no 'scientific_name'."
-            )
+            message = f"'{tax_id}' is a valid taxon ID but response json had no 'scientific_name'."
+            logger.error(message)
+            return raw_internal_error(message)
 
         return RawProcessingResult(datum=scientific_name)
 
@@ -164,16 +171,17 @@ class TaxonomyService:
                 e=e,
             )
         if response.status_code != requests.codes.ok:
+            message = f"Could not map '{tax_id}' to common name."
+            details = f"Code {response.status_code}: {body.get('detail', '')}"
+            logger.error(message + details)
             return RawProcessingResult(
-                warnings=[
-                    f"Could not map '{tax_id}' to common name. Code {response.status_code}: {body.get('detail', '')}"
-                ],
+                warnings=[message],
             )
 
         common_name = body.get("common_name")
         if common_name is None:
-            return raw_internal_error(
-                f"Taxonomy service indicated common name was found for hostTaxonId '{tax_id}', but failed to return it."
-            )
+            message = f"Taxonomy service indicated common name was found for hostTaxonId '{tax_id}', but failed to return it."
+            logger.error(message)
+            return raw_internal_error(message)
 
         return RawProcessingResult(datum=common_name)

--- a/preprocessing/nextclade/src/loculus_preprocessing/external_services.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/external_services.py
@@ -90,58 +90,68 @@ class TaxonomyService:
             url = f"{self.taxonomy_service_url}/taxa?{query}"
         try:
             response = taxonomy_cache.get_or_fetch(url)
-            response.raise_for_status()
             body = response.json()
-            if isinstance(body, list):
-                # when querying by scientific name, multiple taxa may be returned: select the most generic one
-                taxon = min(body, key=lambda x: x.get("depth", float("inf")))
-            else:
-                taxon = body
-
-            tax_id = taxon.get("tax_id")
-            if tax_id is None:
-                message = (
-                    f"Host validation for '{unvalidated_host}' failed with code "
-                    f"{response.status_code}: {taxon.get('detail', '')}"
-                )
-                return RawProcessingResult(
-                    datum=None,
-                    warnings=[message] if error_if_failed else [],
-                    errors=[message] if not error_if_failed else [],
-                )
-            return RawProcessingResult(
-                datum=str(tax_id),
-            )
         except requests.exceptions.RequestException as e:
             return taxonomy_network_error(
                 subject=f"taxon ID {unvalidated_host}",
                 action="fetching taxon info",
                 e=e,
             )
+        if response.status_code != requests.codes.ok:
+            message = f"Host validation for '{unvalidated_host}' failed with code {response.status_code}: {body.get('detail', '')}"
+            return RawProcessingResult(
+                datum=None,
+                warnings=[message] if error_if_failed else [],
+                errors=[message] if not error_if_failed else [],
+            )
+        if isinstance(body, list):
+            # when querying by scientific name, multiple taxa may be returned: select the most generic one
+            taxon = min(body, key=lambda x: x.get("depth", float("inf")))
+        else:
+            taxon = body
 
-    def get_scientific_name(self, tax_id: str) -> RawProcessingResult:
+        tax_id = taxon.get("tax_id")
+        if tax_id is None:
+            message = (
+                f"Host validation for '{unvalidated_host}' failed with code "
+                f"{response.status_code}: {taxon.get('detail', '')}"
+            )
+            return raw_internal_error(
+                f"Host validation for '{unvalidated_host}' was successful but response json 'tax_id' was missing."
+            )
+        return RawProcessingResult(
+            datum=str(tax_id),
+        )
+
+    def get_scientific_name(self, tax_id: str, error_if_failed: bool) -> RawProcessingResult:
         if not self.taxonomy_service_url:
             return missing_taxonomy_service_error()
 
         url = f"{self.taxonomy_service_url}/taxa/{tax_id}"
         try:
             response = taxonomy_cache.get_or_fetch(url)
-            response.raise_for_status()
             body = response.json()
-            scientific_name = body.get("scientific_name")
-            if scientific_name is None:
-                return raw_internal_error(
-                    f"'{tax_id}' is a valid taxon ID but response json had no 'scientific_name'."
-                )
-            return RawProcessingResult(
-                datum=scientific_name,
-            )
         except requests.exceptions.RequestException as e:
             return taxonomy_network_error(
                 subject=f"taxon ID {tax_id}",
                 action="fetching taxon scientific name",
                 e=e,
             )
+        if response.status_code != requests.codes.ok:
+            message = f"Could not map '{tax_id}' to scientific name. Code {response.status_code}: {body.get('detail', '')}"
+            return RawProcessingResult(
+                datum=None,
+                warnings=[message] if error_if_failed else [],
+                errors=[message] if not error_if_failed else [],
+            )
+
+        scientific_name = body.get("scientific_name")
+        if scientific_name is None:
+            return raw_internal_error(
+                f"'{tax_id}' is a valid taxon ID but response json had no 'scientific_name'."
+            )
+
+        return RawProcessingResult(datum=scientific_name)
 
     def get_common_name(self, tax_id: str) -> RawProcessingResult:
         if not self.taxonomy_service_url:
@@ -150,19 +160,24 @@ class TaxonomyService:
         url = f"{self.taxonomy_service_url}/taxa/{tax_id}?find_common_name=true"
         try:
             response = taxonomy_cache.get_or_fetch(url)
-            response.raise_for_status()
             body = response.json()
-            common_name = body.get("common_name")
-            if common_name is None:
-                return raw_internal_error(
-                    f"'{tax_id}' is a valid taxon ID but response json had no 'common_name'."
-                )
-            return RawProcessingResult(
-                datum=common_name,
-            )
         except requests.exceptions.RequestException as e:
             return taxonomy_network_error(
                 subject=f"taxon ID {tax_id}",
                 action="fetching taxon common name",
                 e=e,
             )
+        if response.status_code != requests.codes.ok:
+            return RawProcessingResult(
+                warnings=[
+                    f"Could not map '{tax_id}' to common name. Code {response.status_code}: {body.get('detail', '')}"
+                ],
+            )
+
+        common_name = body.get("common_name")
+        if common_name is None:
+            return raw_internal_error(
+                f"Taxonomy service indicated common name was found for hostTaxonId '{tax_id}', but failed to return it."
+            )
+
+        return RawProcessingResult(datum=common_name)

--- a/preprocessing/nextclade/src/loculus_preprocessing/external_services.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/external_services.py
@@ -110,14 +110,24 @@ class TaxonomyService:
                 errors=[message] if error_if_failed else [],
             )
         if isinstance(body, list):
-            # when querying by scientific name, multiple taxa may be returned: select the most generic one
+            # when querying by scientific name, multiple taxa may be returned
+            # - we select the most generic one
+            if not body:
+                message = (
+                    f"Host validation for '{unvalidated_host}' was successful "
+                    "but no taxa were returned."
+                )
+                return raw_internal_error(message)
             taxon = min(body, key=lambda x: x.get("depth", float("inf")))
         else:
             taxon = body
 
         tax_id = taxon.get("tax_id")
         if tax_id is None:
-            message = f"Host validation for '{unvalidated_host}' was successful but response json 'tax_id' was missing."
+            message = (
+                f"Host validation for '{unvalidated_host}' was successful "
+                "but response json 'tax_id' was missing."
+            )
             return raw_internal_error(message)
         return RawProcessingResult(
             datum=str(tax_id),

--- a/preprocessing/nextclade/src/loculus_preprocessing/external_services.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/external_services.py
@@ -75,7 +75,7 @@ def taxonomy_network_error(
     return raw_internal_error(f"Network error while {action} '{subject}': {e}.")
 
 
-taxonomy_cache = RequestCache(max_size=64)
+taxonomy_cache = RequestCache(max_size=1024)
 
 
 class TaxonomyService:

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -262,7 +262,7 @@ def _call_processing_function(  # noqa: PLR0913, PLR0917
     args["ACCESSION_VERSION"] = accession_version
 
     try:
-        processing_result = ProcessingFunctions.call_function(
+        processing_result = ProcessingFunctions(config=config).call_function(
             spec.function,
             args,
             input_data,

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -5,6 +5,8 @@ from collections.abc import Sequence
 from tempfile import TemporaryDirectory
 from typing import Any
 
+from loculus_preprocessing.external_services import TaxonomyService
+
 from .backend import (
     download_diamond_db,
     download_minimizer,
@@ -260,9 +262,10 @@ def _call_processing_function(  # noqa: PLR0913, PLR0917
     args["is_insdc_ingest_group"] = config.insdc_ingest_group_id == group_id
     args["submittedAt"] = submitted_at
     args["ACCESSION_VERSION"] = accession_version
+    args["taxonomy_service"] = TaxonomyService(config.taxonomy_service_url)  # type: ignore
 
     try:
-        processing_result = ProcessingFunctions(config=config).call_function(
+        processing_result = ProcessingFunctions.call_function(
             spec.function,
             args,
             input_data,

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -396,7 +396,7 @@ def get_output_metadata(
                 )
                 submitted_at = unprocessed.inputMetadata["submittedAt"]
             else:
-                input_data[arg_name] = (
+                input_data[arg_name] = (  # type: ignore
                     output_metadata.get(resolved_path)  # type: ignore
                     if get_from_processed
                     else unprocessed.metadata.get(resolved_path)

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -5,8 +5,6 @@ from collections.abc import Sequence
 from tempfile import TemporaryDirectory
 from typing import Any
 
-from loculus_preprocessing.external_services import TaxonomyService
-
 from .backend import (
     download_diamond_db,
     download_minimizer,

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -262,7 +262,7 @@ def _call_processing_function(  # noqa: PLR0913, PLR0917
     args["is_insdc_ingest_group"] = config.insdc_ingest_group_id == group_id
     args["submittedAt"] = submitted_at
     args["ACCESSION_VERSION"] = accession_version
-    args["taxonomy_service"] = TaxonomyService(config.taxonomy_service_url)  # type: ignore
+    args["taxonomy_service"] = config.taxonomy_service  # type: ignore
 
     try:
         processing_result = ProcessingFunctions.call_function(

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -260,7 +260,7 @@ def _call_processing_function(  # noqa: PLR0913, PLR0917
     args["is_insdc_ingest_group"] = config.insdc_ingest_group_id == group_id
     args["submittedAt"] = submitted_at
     args["ACCESSION_VERSION"] = accession_version
-    args["taxonomy_service"] = config.taxonomy_service  # type: ignore
+    args["taxonomy_service"] = config._taxonomy_service  # type: ignore
 
     try:
         processing_result = ProcessingFunctions.call_function(

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -10,17 +10,14 @@ import logging
 import math
 import re
 import unicodedata
-import urllib.parse
-from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
 import dateutil.parser as dateutil
 import pytz
-import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
+
+from loculus_preprocessing.external_services import TaxonomyService
 
 from .datatypes import (
     AnnotationSourceType,
@@ -31,62 +28,13 @@ from .datatypes import (
     ProcessingAnnotation,
     ProcessingResult,
     RawProcessingResult,
+    _internal_error_message,
     processing_error,
+    raw_internal_error,
 )
 
 logger = logging.getLogger(__name__)
 
-
-class RequestCache:
-    """Class for caching requests to external services during preprocessing.
-
-    Keys are the fully formatted URLs that have already been used to make sucessful requests.
-    Values are requests.Response as they were returned by the service.
-    """
-
-    def __init__(self, max_size: int, retries=5) -> None:
-        self.cache: OrderedDict[str, requests.Response] = OrderedDict()
-        self.max_size = max_size
-        self.session = requests.Session()
-        retry = Retry(total=retries, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
-        adapter = HTTPAdapter(max_retries=retry)
-        self.session.mount("http://", adapter)
-        self.session.mount("https://", adapter)
-
-    def get(self, url: str) -> None | requests.Response:
-        if url in self.cache:
-            self.cache.move_to_end(url)
-            return self.cache[url]
-        return None
-
-    def set(self, url: str, response: requests.Response) -> None:
-        self.cache[url] = response
-        self.cache.move_to_end(url)
-
-        if len(self.cache) > self.max_size:
-            self.cache.popitem(last=False)
-
-    def get_or_fetch(self, url: str, timeout: int = 15) -> requests.Response:
-        """See if `url` already exists in the cache and return the cached Response
-        if it does.
-
-        If `url` is not in the cache, make the actual request (with timeout and retries).
-        Add the Response to the cache (if status code in the 200s), and return the Response.
-
-        Since request.get can error, the caller should wrap this in a try/except block and handle errors
-        """
-        response = self.get(url)
-        if response is None:
-            response = self.session.get(url, timeout=timeout)
-            if 200 <= response.status_code < 300:
-                self.set(url, response)
-        return response
-
-    def clear(self) -> None:
-        self.cache.clear()
-
-
-taxonomy_cache = RequestCache(max_size=64)
 options_cache: dict[str, dict[str, str]] = {}
 
 
@@ -201,34 +149,12 @@ def format_authors(authors: str) -> str:
     return "; ".join(loculus_authors).strip()
 
 
-def _internal_error_message(message: str) -> str:
-    full = f"Internal Error. {message} Please contact the administrator."
-    logger.error(full)
-    return full
-
-
-def raw_internal_error(message: str) -> RawProcessingResult:
-    return processing_error(_internal_error_message(message))
-
-
 def regex_error(
     function_name: str, function_arg: str, input_data: InputMetadata, args: FunctionArgs
 ) -> RawProcessingResult:
     return raw_internal_error(
         f"{function_name} did not receive a valid {function_arg}, with input {input_data} and args {args}."
     )
-
-
-def missing_taxonomy_service_error() -> RawProcessingResult:
-    return raw_internal_error("taxonomy_service_url was not configured.")
-
-
-def taxonomy_network_error(
-    subject: str,
-    action: str,
-    e: Exception,
-) -> RawProcessingResult:
-    return raw_internal_error(f"Network error while {action} '{subject}': {e}.")
 
 
 @dataclass
@@ -321,22 +247,26 @@ def derive_date_range_string(lower: datetime, upper: datetime) -> str:
 
 
 class ProcessingFunctions:
-    @classmethod
+    taxonomy_service: TaxonomyService
+
+    def __init__(self, config):
+        self.taxonomy_service = TaxonomyService(config.taxonomy_service_url)
+
     def call_function(
-        cls,
+        self,
         function_name: str,
         args: FunctionArgs,
         input_data: InputMetadata,
         output_field: str,
         input_fields: list[str],
     ) -> ProcessingResult:
-        if not hasattr(cls, function_name):
+        if not hasattr(self, function_name):
             msg = (
                 f"CRITICAL: No processing function matches: {function_name}."
                 "This is a configuration error."
             )
             raise ValueError(msg)
-        func = getattr(cls, function_name)
+        func = getattr(self, function_name)
         try:
             result = func(input_data, output_field, input_fields=input_fields, args=args)
         except Exception as e:
@@ -1074,16 +1004,15 @@ class ProcessingFunctions:
         try:
             for i in range(1, 9):
                 segment = f"seg{i}"
-                extracted_lineages[segment] = ProcessingFunctions.call_function(  # type: ignore
-                    "extract_regex",
+                extracted_lineages[segment] = ProcessingFunctions.extract_regex(  # type: ignore
+                    {"regex_field": references.get(segment, "")},
+                    "output_field",
+                    ["segment_name"],
                     {
                         "pattern": args["pattern"],
                         "uppercase": args["uppercase"],
                         "capture_group": args["capture_group"],
                     },
-                    {"regex_field": references.get(segment, "")},
-                    "output_field",
-                    ["segment_name"],
                 ).datum
             logger.debug(f"Extracted lineages: {extracted_lineages} from references: {references}")
             if not ha_subtype or not na_subtype:
@@ -1224,8 +1153,8 @@ class ProcessingFunctions:
             errors=concat_result.errors,
         )
 
-    @staticmethod
     def resolve_host_taxon_id(
+        self,
         input_data: InputMetadata,
         output_field: str,
         input_fields: list[str],
@@ -1241,124 +1170,39 @@ class ProcessingFunctions:
         return the tax_id of the most generic taxon (i.e., the one that's closest to
         the root of the taxonomy)
         """
-        tax_service = args.get("taxonomy_service_url")
-        if not tax_service:
-            return missing_taxonomy_service_error()
-
         unvalidated_host = input_data.get("host")
         if not unvalidated_host:
             return RawProcessingResult()
 
-        if unvalidated_host.isdigit():
-            url = f"{tax_service}/taxa/{unvalidated_host}"
-        else:
-            query = urllib.parse.urlencode({"scientific_name": unvalidated_host})
-            url = f"{tax_service}/taxa?{query}"
+        return self.taxonomy_service.get_tax_id(
+            unvalidated_host, bool(args["is_insdc_ingest_group"])
+        )
 
-        try:
-            response = taxonomy_cache.get_or_fetch(url)
-            body = response.json()
-        except requests.exceptions.RequestException as e:
-            return taxonomy_network_error(unvalidated_host, "validating", e)
-
-        if response.status_code != requests.codes.ok:
-            # an invalid host organism is a warning for INSDC ingested sequences, but an error for everyone else
-            message = f"Host validation for '{unvalidated_host}' failed with code {response.status_code}: {body.get('detail', '')}"
-            return RawProcessingResult(
-                datum=None,
-                warnings=[message] if args["is_insdc_ingest_group"] else [],
-                errors=[message] if not args["is_insdc_ingest_group"] else [],
-            )
-
-        if isinstance(body, list):
-            # when querying by scientific name, multiple taxa may be returned: select the most generic one
-            taxon = min(body, key=lambda x: x.get("depth", float("inf")))
-        else:
-            taxon = body
-
-        tax_id = taxon.get("tax_id")
-        if tax_id is None:
-            return raw_internal_error(
-                f"Host validation for '{unvalidated_host}' was successful but response json 'tax_id' was missing."
-            )
-
-        return RawProcessingResult(datum=str(tax_id))
-
-    @staticmethod
     def scientific_name_from_id(
+        self,
         input_data: InputMetadata,
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
     ) -> RawProcessingResult:
-        tax_service = args.get("taxonomy_service_url")
-        if not tax_service:
-            return missing_taxonomy_service_error()
-
         tax_id: str | None = input_data.get("hostTaxonId")
         if not tax_id:
             return RawProcessingResult()
 
-        url = f"{tax_service}/taxa/{tax_id}"
-        try:
-            response = taxonomy_cache.get_or_fetch(url)
-            body = response.json()
-        except requests.exceptions.RequestException as e:
-            return taxonomy_network_error(tax_id, "validating", e)
+        return self.taxonomy_service.get_scientific_name(tax_id)
 
-        if response.status_code != requests.codes.ok:
-            message = f"Could not map '{tax_id}' to scientific name. Code {response.status_code}: {body.get('detail', '')}"
-            logger.warning(message)
-            return RawProcessingResult(
-                datum=None,
-                warnings=[message] if args["is_insdc_ingest_group"] else [],
-                errors=[message] if not args["is_insdc_ingest_group"] else [],
-            )
-
-        scientific_name = body.get("scientific_name")
-        if scientific_name is None:
-            return raw_internal_error(
-                f"'{tax_id}' is a valid taxon ID but response json had no 'scientific_name'."
-            )
-
-        return RawProcessingResult(datum=scientific_name)
-
-    @staticmethod
     def common_name_from_id(
+        self,
         input_data: InputMetadata,
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
     ) -> RawProcessingResult:
-        tax_service = args.get("taxonomy_service_url")
-        if not tax_service:
-            return missing_taxonomy_service_error()
-
         tax_id: str | None = input_data.get("hostTaxonId")
         if not tax_id:
             return RawProcessingResult()
 
-        url = f"{tax_service}/taxa/{tax_id}?find_common_name=true"
-        try:
-            response = taxonomy_cache.get_or_fetch(url)
-            body = response.json()
-        except requests.exceptions.RequestException as e:
-            return taxonomy_network_error(tax_id, "getting common name for", e)
-
-        if response.status_code != requests.codes.ok:
-            return RawProcessingResult(
-                warnings=[
-                    f"Could not map '{tax_id}' to common name. Code {response.status_code}: {body.get('detail', '')}"
-                ],
-            )
-
-        common_name = body.get("common_name")
-        if common_name is None:
-            return raw_internal_error(
-                f"Taxonomy service indicated common name was found for hostTaxonId '{tax_id}', but failed to return it."
-            )
-
-        return RawProcessingResult(datum=common_name)
+        return self.taxonomy_service.get_common_name(tax_id)
 
 
 def single_metadata_annotation(

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1172,7 +1172,9 @@ class ProcessingFunctions:
             return RawProcessingResult()
 
         taxonomy_service: TaxonomyService = args["taxonomy_service"]  # type: ignore
-        return taxonomy_service.get_tax_id(unvalidated_host, not bool(args["is_insdc_ingest_group"]))
+        return taxonomy_service.get_tax_id(
+            unvalidated_host, not bool(args["is_insdc_ingest_group"])
+        )
 
     @staticmethod
     def scientific_name_from_id(

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1172,7 +1172,7 @@ class ProcessingFunctions:
             return RawProcessingResult()
 
         taxonomy_service: TaxonomyService = args["taxonomy_service"]  # type: ignore
-        return taxonomy_service.get_tax_id(unvalidated_host, bool(args["is_insdc_ingest_group"]))
+        return taxonomy_service.get_tax_id(unvalidated_host, not bool(args["is_insdc_ingest_group"]))
 
     @staticmethod
     def scientific_name_from_id(
@@ -1186,7 +1186,7 @@ class ProcessingFunctions:
             return RawProcessingResult()
 
         taxonomy_service: TaxonomyService = args["taxonomy_service"]  # type: ignore
-        return taxonomy_service.get_scientific_name(tax_id, bool(args["is_insdc_ingest_group"]))
+        return taxonomy_service.get_scientific_name(tax_id, not bool(args["is_insdc_ingest_group"]))
 
     @staticmethod
     def common_name_from_id(

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1186,7 +1186,7 @@ class ProcessingFunctions:
             return RawProcessingResult()
 
         taxonomy_service: TaxonomyService = args["taxonomy_service"]  # type: ignore
-        return taxonomy_service.get_scientific_name(tax_id)
+        return taxonomy_service.get_scientific_name(tax_id, bool(args["is_insdc_ingest_group"]))
 
     @staticmethod
     def common_name_from_id(

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -247,26 +247,22 @@ def derive_date_range_string(lower: datetime, upper: datetime) -> str:
 
 
 class ProcessingFunctions:
-    taxonomy_service: TaxonomyService
-
-    def __init__(self, config):
-        self.taxonomy_service = TaxonomyService(config.taxonomy_service_url)
-
+    @classmethod
     def call_function(
-        self,
+        cls,
         function_name: str,
         args: FunctionArgs,
         input_data: InputMetadata,
         output_field: str,
         input_fields: list[str],
     ) -> ProcessingResult:
-        if not hasattr(self, function_name):
+        if not hasattr(cls, function_name):
             msg = (
                 f"CRITICAL: No processing function matches: {function_name}."
                 "This is a configuration error."
             )
             raise ValueError(msg)
-        func = getattr(self, function_name)
+        func = getattr(cls, function_name)
         try:
             result = func(input_data, output_field, input_fields=input_fields, args=args)
         except Exception as e:
@@ -1004,15 +1000,16 @@ class ProcessingFunctions:
         try:
             for i in range(1, 9):
                 segment = f"seg{i}"
-                extracted_lineages[segment] = ProcessingFunctions.extract_regex(  # type: ignore
-                    {"regex_field": references.get(segment, "")},
-                    "output_field",
-                    ["segment_name"],
+                extracted_lineages[segment] = ProcessingFunctions.call_function(  # type: ignore
+                    "extract_regex",
                     {
                         "pattern": args["pattern"],
                         "uppercase": args["uppercase"],
                         "capture_group": args["capture_group"],
                     },
+                    {"regex_field": references.get(segment, "")},
+                    "output_field",
+                    ["segment_name"],
                 ).datum
             logger.debug(f"Extracted lineages: {extracted_lineages} from references: {references}")
             if not ha_subtype or not na_subtype:
@@ -1153,8 +1150,8 @@ class ProcessingFunctions:
             errors=concat_result.errors,
         )
 
+    @staticmethod
     def resolve_host_taxon_id(
-        self,
         input_data: InputMetadata,
         output_field: str,
         input_fields: list[str],
@@ -1174,12 +1171,11 @@ class ProcessingFunctions:
         if not unvalidated_host:
             return RawProcessingResult()
 
-        return self.taxonomy_service.get_tax_id(
-            unvalidated_host, bool(args["is_insdc_ingest_group"])
-        )
+        taxonomy_service: TaxonomyService = args["taxonomy_service"]  # type: ignore
+        return taxonomy_service.get_tax_id(unvalidated_host, bool(args["is_insdc_ingest_group"]))
 
+    @staticmethod
     def scientific_name_from_id(
-        self,
         input_data: InputMetadata,
         output_field: str,
         input_fields: list[str],
@@ -1189,10 +1185,11 @@ class ProcessingFunctions:
         if not tax_id:
             return RawProcessingResult()
 
-        return self.taxonomy_service.get_scientific_name(tax_id)
+        taxonomy_service: TaxonomyService = args["taxonomy_service"]  # type: ignore
+        return taxonomy_service.get_scientific_name(tax_id)
 
+    @staticmethod
     def common_name_from_id(
-        self,
         input_data: InputMetadata,
         output_field: str,
         input_fields: list[str],
@@ -1202,7 +1199,8 @@ class ProcessingFunctions:
         if not tax_id:
             return RawProcessingResult()
 
-        return self.taxonomy_service.get_common_name(tax_id)
+        taxonomy_service: TaxonomyService = args["taxonomy_service"]  # type: ignore
+        return taxonomy_service.get_common_name(tax_id)
 
 
 def single_metadata_annotation(

--- a/preprocessing/nextclade/tests/host_processing_config.yaml
+++ b/preprocessing/nextclade/tests/host_processing_config.yaml
@@ -1,20 +1,18 @@
+taxonomy_service_url: "http://localhost:5000"
+
 processing_spec:
   hostNameScientific:
     function: scientific_name_from_id
     inputs:
       hostNameScientific: hostNameScientific
       hostTaxonId: processed.hostTaxonId
-    args: &preprocessingTaxonomyTestArgs
-      taxonomy_service_url: "http://localhost:5000"
   hostNameCommon:
     function: common_name_from_id
     inputs:
       hostTaxonId: processed.hostTaxonId
-    args: *preprocessingTaxonomyTestArgs
   hostTaxonId:
     function: resolve_host_taxon_id
     inputs:
       host: host
       hostNameScientific: hostNameScientific
       hostTaxonId: hostTaxonId
-    args: *preprocessingTaxonomyTestArgs

--- a/preprocessing/nextclade/tests/test_host_name_validation.py
+++ b/preprocessing/nextclade/tests/test_host_name_validation.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from loculus_preprocessing import processing_functions
+from loculus_preprocessing import external_services
 from loculus_preprocessing.config import get_config
 from loculus_preprocessing.datatypes import (
     UnprocessedData,
@@ -17,7 +17,7 @@ HOST_PROCESSING_CONFIG = "tests/host_processing_config.yaml"
 
 @pytest.fixture(autouse=True)
 def clear_taxonomy_caches():
-    processing_functions.taxonomy_cache.clear()
+    external_services.taxonomy_cache.clear()
 
 
 def make_response(status_code, json_data):
@@ -56,7 +56,7 @@ def taxonomy_service_mock(url: str, **kwargs):
     return make_response(404, {"detail": "not found"})
 
 
-@patch.object(processing_functions.taxonomy_cache, "session")
+@patch.object(external_services.taxonomy_cache, "session")
 def test_host_processing_tax_id(mock_session: MagicMock) -> None:
     mock_session.get.side_effect = taxonomy_service_mock
     config = get_config(HOST_PROCESSING_CONFIG, ignore_args=True)
@@ -82,7 +82,7 @@ def test_host_processing_tax_id(mock_session: MagicMock) -> None:
     assert mock_session.get.call_count == 2
 
 
-@patch.object(processing_functions.taxonomy_cache, "session")
+@patch.object(external_services.taxonomy_cache, "session")
 def test_host_processing_sci_name(mock_session: MagicMock) -> None:
     mock_session.get.side_effect = taxonomy_service_mock
     config = get_config(HOST_PROCESSING_CONFIG, ignore_args=True)
@@ -108,7 +108,7 @@ def test_host_processing_sci_name(mock_session: MagicMock) -> None:
     assert mock_session.get.call_count == 3
 
 
-@patch.object(processing_functions.taxonomy_cache, "session")
+@patch.object(external_services.taxonomy_cache, "session")
 def test_host_processing_legacy(mock_session: MagicMock) -> None:
     """Preprocessing used to use the hostTaxonId and hostNameScientific
     fields for host validation. We have since switched to using one
@@ -139,7 +139,7 @@ def test_host_processing_legacy(mock_session: MagicMock) -> None:
     assert mock_session.get.call_count == 0
 
 
-@patch.object(processing_functions.taxonomy_cache, "session")
+@patch.object(external_services.taxonomy_cache, "session")
 def test_host_processing_invalid_host_insdc(mock_session: MagicMock) -> None:
     """For an INSDC-ingested sequence with an invalid host, the derived host
     fields (hostTaxonId, hostNameScientific, hostNameCommon) should all be
@@ -166,7 +166,7 @@ def test_host_processing_invalid_host_insdc(mock_session: MagicMock) -> None:
     assert "Host validation for" in result[0].processed_entry.warnings[0].message
 
 
-@patch.object(processing_functions.taxonomy_cache, "session")
+@patch.object(external_services.taxonomy_cache, "session")
 def test_host_processing_invalid_host_direct(mock_session: MagicMock) -> None:
     """When a direct submitter provides an invalid host, the derived host
     fields (hostTaxonId, hostNameScientific, hostNameCommon) should all be

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -1490,7 +1490,7 @@ def test_call_function_converts_raw_errors_to_annotations() -> None:
         "is_insdc_ingest_group": False,
     }
 
-    result = ProcessingFunctions.call_function(
+    result = ProcessingFunctions(config=Config()).call_function(
         "process_options",
         args=args,
         input_data={"input": "NotAnOption"},

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -1490,7 +1490,7 @@ def test_call_function_converts_raw_errors_to_annotations() -> None:
         "is_insdc_ingest_group": False,
     }
 
-    result = ProcessingFunctions(config=Config()).call_function(
+    result = ProcessingFunctions.call_function(
         "process_options",
         args=args,
         input_data={"input": "NotAnOption"},


### PR DESCRIPTION
When working on https://github.com/loculus-project/loculus/pull/6916 I restructured the config and prepro a bit to have external services, like the taxonomy service and the new file processing (raw reads) service be structured the same way in the code. 

Generally I feel like this makes the code more readable and apart from the minimal config change basically just splits out the logic for calling the taxonomy service into a separate file. (I did clean up the logging a bit - every internal error is also logged in loculus logs not just sent to the user).

### BREAKING CHANGES
PPX PR: https://github.com/pathoplexus/pathoplexus/pull/1086

The `taxonomy_service_url` no longer needs to be supplied as an arg to every preprocessing function which uses it. Instead, it should be added to the already existing `taxonomyService` section of the values.yaml:
```
taxonomyService:
  dbVersion: "ncbi_taxonomy_2026-05-01"
  taxonomyDbPath: "/data/taxonomy.sqlite" # this is where the init container mounts the database
  taxonomy_service_url: *taxonomy_service_url
```
If `taxonomyService` is defined `taxonomy_service_url` will be supplied to the preprocessing pod via the helm template and prepro will use it in all preprocessing functions which rely on the service. 

Code changes should be covered by unit tests and integration tests

🚀 Preview: https://feat-taxonomy-service-con.loculus.org