### PR TITLE
feat(ingest): enrich mirrored GenBank metadata

### DIFF
--- a/.github/workflows/datasets-mirror.yml
+++ b/.github/workflows/datasets-mirror.yml
@@ -44,10 +44,40 @@ jobs:
           host_bucket = %(bucket)s.hel1.your-objectstorage.com
           verbosity = WARNING
           EOF
+      - name: Enrich mirrored accessions from GenBank
+        env:
+          ENTREZ_API_KEY: ${{ secrets.NCBI_API_KEY }}
+          ENTREZ_EMAIL: ${{ vars.ENTREZ_EMAIL }}
+        shell: bash -l {0}
+        run: |
+          set -Eeuo pipefail
+
+          if [[ -z "${ENTREZ_EMAIL}" ]]; then
+            echo "Repository variable ENTREZ_EMAIL must be configured for Entrez enrichment." >&2
+            exit 1
+          fi
+
+          taxon_id="${{ inputs.taxon_id }}"
+          previous="${taxon_id}.entrez.previous.jsonl"
+          enriched="${taxon_id}.entrez.jsonl"
+
+          args=(
+            "${taxon_id}.zip"
+            --email "${ENTREZ_EMAIL}"
+            --output "${enriched}"
+          )
+          if s3cmd info "s3://loculus-public/mirror/${enriched}" >/dev/null 2>&1; then
+            s3cmd get "s3://loculus-public/mirror/${enriched}" "${previous}"
+            args+=(--previous-enrichment "${previous}")
+          fi
+          if [[ -n "${ENTREZ_API_KEY}" ]]; then
+            args+=(--api-key "${ENTREZ_API_KEY}")
+          fi
+          python mirroring/enrich_genbank.py "${args[@]}"
       - name: Upload to Object Storage
         shell: bash -l {0}
         run: |
-          for file in ${{ inputs.taxon_id }}.zip ${{ inputs.taxon_id }}.tar.zst ; do
+          for file in ${{ inputs.taxon_id }}.zip ${{ inputs.taxon_id }}.tar.zst ${{ inputs.taxon_id }}.entrez.jsonl ; do
             s3cmd put "${file}" s3://loculus-public/mirror/"${file}"
           done
   notify_on_failure:

--- a/.github/workflows/datasets-mirror.yml
+++ b/.github/workflows/datasets-mirror.yml
@@ -44,6 +44,12 @@ jobs:
           host_bucket = %(bucket)s.hel1.your-objectstorage.com
           verbosity = WARNING
           EOF
+      - name: Upload dataset to Object Storage
+        shell: bash -l {0}
+        run: |
+          for file in ${{ inputs.taxon_id }}.zip ${{ inputs.taxon_id }}.tar.zst ; do
+            s3cmd put "${file}" s3://loculus-public/mirror/"${file}"
+          done
       - name: Enrich mirrored accessions from GenBank
         env:
           ENTREZ_API_KEY: ${{ secrets.NCBI_API_KEY }}
@@ -74,12 +80,11 @@ jobs:
             args+=(--api-key "${ENTREZ_API_KEY}")
           fi
           python mirroring/enrich_genbank.py "${args[@]}"
-      - name: Upload to Object Storage
+      - name: Upload enrichment to Object Storage
         shell: bash -l {0}
         run: |
-          for file in ${{ inputs.taxon_id }}.zip ${{ inputs.taxon_id }}.tar.zst ${{ inputs.taxon_id }}.entrez.jsonl ; do
-            s3cmd put "${file}" s3://loculus-public/mirror/"${file}"
-          done
+          file=${{ inputs.taxon_id }}.entrez.jsonl
+          s3cmd put "${file}" s3://loculus-public/mirror/"${file}"
   notify_on_failure:
     needs: download-and-upload
     runs-on: ubuntu-latest

--- a/mirroring/enrich_genbank.py
+++ b/mirroring/enrich_genbank.py
@@ -227,7 +227,7 @@ def main():
     )
     parser.add_argument("--output", default="-", help="JSON Lines output path (default: stdout)")
     parser.add_argument("--refresh", action="store_true", help="Ignore records in --previous-enrichment")
-    parser.add_argument("--batch-size", type=int, default=100, help="Accessions per EFetch request")
+    parser.add_argument("--batch-size", type=int, default=20, help="Accessions per EFetch request")
     args = parser.parse_args()
 
     if not 1 <= args.batch_size <= 200:

--- a/mirroring/enrich_genbank.py
+++ b/mirroring/enrich_genbank.py
@@ -9,8 +9,10 @@ nuccore and writes fields that Datasets/NCBI Virus may omit.
 from __future__ import print_function
 
 import argparse
+import email.utils
 import io
 import json
+import random
 import re
 import sys
 import time
@@ -23,6 +25,8 @@ import zipfile
 
 EUTILS_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
 ACCESSION_RE = re.compile(r"\b([A-Za-z]{1,6}_?\d+(?:\.\d+)?)\b")
+MAX_429_RETRIES = 5
+MAX_RETRY_DELAY_SECONDS = 60
 
 
 def accessions_from_fasta(lines):
@@ -152,6 +156,20 @@ def parse_record(node):
     }
 
 
+def retry_after_seconds(error):
+    """Return the delay requested by an HTTP Retry-After header, if present."""
+    value = error.headers.get("Retry-After")
+    if not value:
+        return None
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        retry_at = email.utils.parsedate_to_datetime(value)
+        if retry_at is None:
+            return None
+        return max(0.0, retry_at.timestamp() - time.time())
+
+
 def fetch_batch(accessions, email, api_key):
     query = {
         "db": "nuccore",
@@ -164,8 +182,26 @@ def fetch_batch(accessions, email, api_key):
     if api_key:
         query["api_key"] = api_key
     url = EUTILS_URL + "?" + urllib.parse.urlencode(query)
-    with urllib.request.urlopen(url, timeout=90) as response:
-        root = ET.parse(response).getroot()
+    for retry in range(MAX_429_RETRIES + 1):
+        try:
+            with urllib.request.urlopen(url, timeout=90) as response:
+                root = ET.parse(response).getroot()
+            break
+        except urllib.error.HTTPError as error:
+            if error.code != 429 or retry == MAX_429_RETRIES:
+                raise
+            requested_delay = retry_after_seconds(error)
+            exponential_delay = min(2 ** retry, MAX_RETRY_DELAY_SECONDS)
+            delay = max(requested_delay or 0, exponential_delay)
+            # Jitter reduces the chance that parallel mirror jobs retry together.
+            delay = min(delay + random.uniform(0, 1), MAX_RETRY_DELAY_SECONDS)
+            print(
+                "Entrez returned HTTP 429; retrying in {:.1f}s ({}/{})".format(
+                    delay, retry + 1, MAX_429_RETRIES
+                ),
+                file=sys.stderr,
+            )
+            time.sleep(delay)
     records = {}
     for sequence in root.findall("INSDSeq") + root.findall("GBSeq"):
         record = parse_record(sequence)

--- a/mirroring/enrich_genbank.py
+++ b/mirroring/enrich_genbank.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Enrich NCBI Datasets mirror accessions from NCBI Entrez/GenBank.
+
+The Datasets download remains the source of sequence data. This program is a
+downstream metadata sidecar: it obtains the corresponding INSDC record from
+nuccore and writes fields that Datasets/NCBI Virus may omit.
+"""
+
+from __future__ import print_function
+
+import argparse
+import io
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+import zipfile
+
+
+EUTILS_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+ACCESSION_RE = re.compile(r"\b([A-Za-z]{1,6}_?\d+(?:\.\d+)?)\b")
+
+
+def accessions_from_fasta(lines):
+    """Yield the first accession-looking identifier from each FASTA header."""
+    for line in lines:
+        if line.startswith(">"):
+            match = ACCESSION_RE.search(line)
+            if match:
+                yield match.group(1)
+
+
+def accessions_from_input(path):
+    if path.endswith(".zip"):
+        with zipfile.ZipFile(path) as archive:
+            names = [name for name in archive.namelist()
+                     if name.endswith("ncbi_dataset/data/genomic.fna")]
+            if not names:
+                raise ValueError("zip does not contain ncbi_dataset/data/genomic.fna")
+            with archive.open(names[0]) as fasta:
+                return set(accessions_from_fasta(io.TextIOWrapper(fasta, encoding="utf-8")))
+
+    with open(path, "r", encoding="utf-8") as handle:
+        first = handle.read(1)
+        handle.seek(0)
+        if first == ">":
+            return set(accessions_from_fasta(handle))
+        return set(line.strip() for line in handle if line.strip() and not line.startswith("#"))
+
+
+def load_previous_enrichment(path):
+    """Read a previous JSONL output into an accession-version keyed mapping."""
+    if not path:
+        return {}
+
+    records = {}
+    with open(path, "r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            accession = record.get("requested_accession")
+            if not accession:
+                raise ValueError(
+                    "{}:{} does not contain requested_accession".format(path, line_number)
+                )
+            records[accession] = record
+    return records
+
+
+def children_text(node, path):
+    return [child.text for child in node.findall(path) if child.text]
+
+
+def parse_record(node):
+    qualifiers = {}
+    for feature in node.findall("./INSDSeq_feature-table/INSDFeature"):
+        if feature.findtext("INSDFeature_key") != "source":
+            continue
+        for item in feature.findall("./INSDFeature_quals/INSDQualifier"):
+            key = item.findtext("INSDQualifier_name")
+            value = item.findtext("INSDQualifier_value")
+            if key and value:
+                qualifiers.setdefault(key, []).append(value)
+
+    authors = []
+    for reference in node.findall("./INSDSeq_references/INSDReference"):
+        authors.extend(children_text(reference, "./INSDReference_authors/INSDReference_author"))
+
+    return {
+        "accession_version": node.findtext("INSDSeq_accession-version"),
+        "accession_base": node.findtext("INSDSeq_primary-accession"),
+        "definition": node.findtext("INSDSeq_definition"),
+        "organism": node.findtext("INSDSeq_organism"),
+        "taxonomy": node.findtext("INSDSeq_taxonomy"),
+        "division": node.findtext("INSDSeq_division"),
+        "length": node.findtext("INSDSeq_length"),
+        "update_date": node.findtext("INSDSeq_update-date"),
+        "create_date": node.findtext("INSDSeq_create-date"),
+        "strain": qualifiers.get("strain", []),
+        "isolate": qualifiers.get("isolate", []),
+        "host": qualifiers.get("host", []),
+        "host_age": qualifiers.get("host_age", []),
+        "authors": authors,
+        "source_qualifiers": qualifiers,
+    }
+
+
+def fetch_batch(accessions, email, api_key):
+    query = {
+        "db": "nuccore",
+        "id": ",".join(accessions),
+        "rettype": "gbwithparts",
+        "retmode": "xml",
+        "tool": "loc-mirror-insdc",
+        "email": email,
+    }
+    if api_key:
+        query["api_key"] = api_key
+    url = EUTILS_URL + "?" + urllib.parse.urlencode(query)
+    with urllib.request.urlopen(url, timeout=90) as response:
+        root = ET.parse(response).getroot()
+    records = {}
+    for sequence in root.findall("INSDSeq"):
+        record = parse_record(sequence)
+        for key in (record["accession_version"], record["accession_base"]):
+            if key:
+                records[key] = record
+    return records
+
+
+def chunks(items, size):
+    for start in range(0, len(items), size):
+        yield items[start:start + size]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", help="Datasets .zip, FASTA, or one-accession-per-line file")
+    parser.add_argument("--email", required=True, help="Contact email required by NCBI E-utilities")
+    parser.add_argument("--api-key", help="Optional NCBI API key (also raises request allowance)")
+    parser.add_argument(
+        "--previous-enrichment",
+        help="Previous enrichment JSONL; records in it are reused by requested accession version",
+    )
+    parser.add_argument("--output", default="-", help="JSON Lines output path (default: stdout)")
+    parser.add_argument("--refresh", action="store_true", help="Ignore records in --previous-enrichment")
+    parser.add_argument("--batch-size", type=int, default=100, help="Accessions per EFetch request")
+    args = parser.parse_args()
+
+    if not 1 <= args.batch_size <= 200:
+        parser.error("--batch-size must be between 1 and 200")
+    accessions = sorted(accessions_from_input(args.input))
+    if not accessions:
+        parser.error("no accessions found")
+
+    previous = {} if args.refresh else load_previous_enrichment(args.previous_enrichment)
+    records = []
+    missing = []
+    for accession in accessions:
+        record = previous.get(accession)
+        if record:
+            records.append(record)
+        else:
+            missing.append(accession)
+
+    # NCBI allows three requests/second without a key, ten with one. Leave a
+    # margin; reuse of the previous enrichment makes repeat runs cheap.
+    pause = 0.12 if args.api_key else 0.35
+    for batch in chunks(missing, args.batch_size):
+        try:
+            fetched = fetch_batch(batch, args.email, args.api_key)
+        except (urllib.error.URLError, ET.ParseError) as error:
+            raise RuntimeError("Entrez request failed for {}: {}".format(
+                ",".join(batch), error))
+        for requested in batch:
+            record = fetched.get(requested)
+            if record is None:
+                record = fetched.get(requested.split(".", 1)[0])
+            if record is None:
+                record = {"requested_accession": requested, "not_found": True}
+            else:
+                record = dict(record, requested_accession=requested)
+            records.append(record)
+        time.sleep(pause)
+
+    output = sys.stdout if args.output == "-" else open(args.output, "w", encoding="utf-8")
+    try:
+        for record in sorted(records, key=lambda item: item["requested_accession"]):
+            output.write(json.dumps(record, sort_keys=True) + "\n")
+    finally:
+        if output is not sys.stdout:
+            output.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/mirroring/enrich_genbank.py
+++ b/mirroring/enrich_genbank.py
@@ -76,7 +76,49 @@ def children_text(node, path):
     return [child.text for child in node.findall(path) if child.text]
 
 
+def parse_gbseq(node):
+    """Parse the GBSeq XML schema returned by nuccore EFetch."""
+    qualifiers = {}
+    for feature in node.findall("./GBSeq_feature-table/GBFeature"):
+        if feature.findtext("GBFeature_key") != "source":
+            continue
+        for item in feature.findall("./GBFeature_quals/GBQualifier"):
+            key = item.findtext("GBQualifier_name")
+            value = item.findtext("GBQualifier_value")
+            if key and value:
+                qualifiers.setdefault(key, []).append(value)
+
+    direct_submission_authors = []
+    authors = []
+    for reference in node.findall("./GBSeq_references/GBReference"):
+        reference_authors = children_text(reference, "./GBReference_authors/GBAuthor")
+        authors.extend(reference_authors)
+        if reference.findtext("GBReference_title") == "Direct Submission":
+            direct_submission_authors.extend(reference_authors)
+
+    return {
+        "accession_version": node.findtext("GBSeq_accession-version"),
+        "accession_base": node.findtext("GBSeq_primary-accession"),
+        "definition": node.findtext("GBSeq_definition"),
+        "organism": node.findtext("GBSeq_organism"),
+        "taxonomy": node.findtext("GBSeq_taxonomy"),
+        "division": node.findtext("GBSeq_division"),
+        "length": node.findtext("GBSeq_length"),
+        "update_date": node.findtext("GBSeq_update-date"),
+        "create_date": node.findtext("GBSeq_create-date"),
+        "strain": qualifiers.get("strain", []),
+        "isolate": qualifiers.get("isolate", []),
+        "host": qualifiers.get("host", []),
+        "host_age": qualifiers.get("host_age", []),
+        "authors": direct_submission_authors or authors,
+        "source_qualifiers": qualifiers,
+    }
+
+
 def parse_record(node):
+    if node.tag == "GBSeq":
+        return parse_gbseq(node)
+
     qualifiers = {}
     for feature in node.findall("./INSDSeq_feature-table/INSDFeature"):
         if feature.findtext("INSDFeature_key") != "source":
@@ -125,7 +167,7 @@ def fetch_batch(accessions, email, api_key):
     with urllib.request.urlopen(url, timeout=90) as response:
         root = ET.parse(response).getroot()
     records = {}
-    for sequence in root.findall("INSDSeq"):
+    for sequence in root.findall("INSDSeq") + root.findall("GBSeq"):
         record = parse_record(sequence)
         for key in (record["accession_version"], record["accession_base"]):
             if key:

--- a/mirroring/enrich_genbank.py
+++ b/mirroring/enrich_genbank.py
@@ -240,7 +240,7 @@ def main():
     )
     parser.add_argument("--output", default="-", help="JSON Lines output path (default: stdout)")
     parser.add_argument("--refresh", action="store_true", help="Ignore records in --previous-enrichment")
-    parser.add_argument("--batch-size", type=int, default=20, help="Accessions per EFetch request")
+    parser.add_argument("--batch-size", type=int, default=100, help="Accessions per EFetch request")
     args = parser.parse_args()
 
     if not 1 <= args.batch_size <= 200:

--- a/mirroring/enrich_genbank.py
+++ b/mirroring/enrich_genbank.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 
 import argparse
 import email.utils
+import http.client
 import io
 import json
 import random
@@ -198,6 +199,18 @@ def fetch_batch(accessions, email, api_key):
             print(
                 "Entrez returned HTTP 429; retrying in {:.1f}s ({}/{})".format(
                     delay, retry + 1, MAX_429_RETRIES
+                ),
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+        except http.client.IncompleteRead as error:
+            if retry == MAX_429_RETRIES:
+                raise
+            delay = min(2 ** retry + random.uniform(0, 1), MAX_RETRY_DELAY_SECONDS)
+            print(
+                "Entrez response was truncated after {} bytes; "
+                "retrying in {:.1f}s ({}/{})".format(
+                    len(error.partial), delay, retry + 1, MAX_429_RETRIES
                 ),
                 file=sys.stderr,
             )

--- a/mirroring/enrich_genbank.py
+++ b/mirroring/enrich_genbank.py
@@ -25,7 +25,7 @@ import zipfile
 
 EUTILS_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
 ACCESSION_RE = re.compile(r"\b([A-Za-z]{1,6}_?\d+(?:\.\d+)?)\b")
-MAX_429_RETRIES = 5
+MAX_429_RETRIES = 10
 MAX_RETRY_DELAY_SECONDS = 60
 
 

--- a/mirroring/enrich_genbank.py
+++ b/mirroring/enrich_genbank.py
@@ -205,7 +205,9 @@ def main():
     missing = []
     for accession in accessions:
         record = previous.get(accession)
-        if record:
+        # Retry an earlier miss: it may have been caused by a transient Entrez
+        # response or, as in a schema migration, an older parser.
+        if record and not record.get("not_found"):
             records.append(record)
         else:
             missing.append(accession)

--- a/mirroring/test_enrich_genbank.py
+++ b/mirroring/test_enrich_genbank.py
@@ -1,4 +1,5 @@
 import io
+import http.client
 import unittest
 import urllib.error
 from unittest import mock
@@ -46,6 +47,19 @@ class FetchBatchRetryTest(unittest.TestCase):
 
         enrich_genbank.fetch_batch(["AB123.1"], "me@example.test", "api-key")
         sleep.assert_called_once_with(12)
+
+    @mock.patch.object(enrich_genbank.random, "uniform", return_value=0)
+    @mock.patch.object(enrich_genbank.time, "sleep")
+    @mock.patch.object(enrich_genbank.urllib.request, "urlopen")
+    def test_retries_truncated_response(self, urlopen, sleep, _uniform):
+        truncated = mock.MagicMock()
+        truncated.__enter__.return_value.read.side_effect = http.client.IncompleteRead(
+            b"<GBSet>"
+        )
+        urlopen.side_effect = [truncated, io.BytesIO(EMPTY_RESPONSE)]
+
+        self.assertEqual(enrich_genbank.fetch_batch(["AB123.1"], "me@example.test", None), {})
+        sleep.assert_called_once_with(1)
 
     @mock.patch.object(enrich_genbank.time, "sleep")
     @mock.patch.object(enrich_genbank.urllib.request, "urlopen")

--- a/mirroring/test_enrich_genbank.py
+++ b/mirroring/test_enrich_genbank.py
@@ -1,0 +1,66 @@
+import io
+import unittest
+import urllib.error
+from unittest import mock
+
+import enrich_genbank
+
+
+EMPTY_RESPONSE = b"<GBSet />"
+
+
+class FetchBatchRetryTest(unittest.TestCase):
+    @mock.patch.object(enrich_genbank.random, "uniform", return_value=0)
+    @mock.patch.object(enrich_genbank.time, "sleep")
+    @mock.patch.object(enrich_genbank.urllib.request, "urlopen")
+    def test_retries_429_with_exponential_backoff(
+        self, urlopen, sleep, _uniform
+    ):
+        urlopen.side_effect = [
+            urllib.error.HTTPError(
+                "https://example.test", 429, "Too Many Requests", {}, None
+            ),
+            urllib.error.HTTPError(
+                "https://example.test", 429, "Too Many Requests", {}, None
+            ),
+            io.BytesIO(EMPTY_RESPONSE),
+        ]
+
+        self.assertEqual(enrich_genbank.fetch_batch(["AB123.1"], "me@example.test", None), {})
+        self.assertEqual([call.args[0] for call in sleep.call_args_list], [1, 2])
+
+    @mock.patch.object(enrich_genbank.random, "uniform", return_value=0)
+    @mock.patch.object(enrich_genbank.time, "sleep")
+    @mock.patch.object(enrich_genbank.urllib.request, "urlopen")
+    def test_honors_retry_after_header(self, urlopen, sleep, _uniform):
+        urlopen.side_effect = [
+            urllib.error.HTTPError(
+                "https://example.test",
+                429,
+                "Too Many Requests",
+                {"Retry-After": "12"},
+                None,
+            ),
+            io.BytesIO(EMPTY_RESPONSE),
+        ]
+
+        enrich_genbank.fetch_batch(["AB123.1"], "me@example.test", "api-key")
+        sleep.assert_called_once_with(12)
+
+    @mock.patch.object(enrich_genbank.time, "sleep")
+    @mock.patch.object(enrich_genbank.urllib.request, "urlopen")
+    def test_does_not_retry_other_http_errors(self, urlopen, sleep):
+        error = urllib.error.HTTPError(
+            "https://example.test", 400, "Bad Request", {}, None
+        )
+        urlopen.side_effect = error
+
+        with self.assertRaises(urllib.error.HTTPError) as raised:
+            enrich_genbank.fetch_batch(["AB123.1"], "me@example.test", None)
+
+        self.assertIs(raised.exception, error)
+        sleep.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This adds a GenBank/Entrez metadata sidecar to the NCBI Datasets mirror. The existing NCBI Datasets ZIP and compressed archive remain the source of sequence data, while `mirroring/enrich_genbank.py` fetches the corresponding nuccore records and writes a taxon-specific `.entrez.jsonl` file containing metadata that may be absent from NCBI Virus/Datasets.

The enrichment parser supports both INSDSeq and GBSeq XML responses and records accession identifiers, definition, organism, taxonomy, division, dates, source qualifiers, and authors. Existing enrichment output is downloaded from object storage and reused by accession version, while prior misses are retried so transient failures and parser improvements can fill them later.

## Reliability

Entrez requests now:

- respect NCBI's API-key and non-key request-rate guidance;
- retry HTTP 429 responses with capped exponential backoff, jitter, and `Retry-After` support;
- retry truncated chunked HTTP responses (`IncompleteRead`);
- use batches of 100 accessions to keep large taxa within the GitHub Actions job limit.

The workflow uploads the base dataset ZIP and tar archive before starting enrichment. This ensures the ordinary mirror is updated even if enrichment later fails or exceeds the Actions time limit. The enrichment JSONL is uploaded separately after it completes.

## Validation

- `python -m unittest discover -s mirroring -p 'test_*.py' -v` — 4 tests pass.
- Python compilation and YAML parsing checks pass.
- A local batch-size-100 run for taxon `3048148` produced 15,800 records in 8m37s and recovered from a deliberately observed truncated upstream response.
- The matching GitHub Actions run for `3048148` completed successfully end-to-end.
- A large Influenza A (`197911`) mirror completed successfully with batch size 100, where batch size 20 had previously exceeded the six-hour job limit.

## Impact

Consumers can join the new JSONL sidecar to mirrored accessions for richer INSDC/GenBank metadata. Existing ZIP and tar artifact names and locations are unchanged, and their upload no longer depends on enrichment succeeding.

🚀 Preview: Add `preview` label to enable