### PR TITLE
fix(backend): display preprint servers in citations

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/crossref/CrossRefService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/crossref/CrossRefService.kt
@@ -167,6 +167,8 @@ class CrossRefService(
                 }
             }
             val journal = citationElement.selectFirst("journal_title")?.text()?.takeIf { it.isNotBlank() }
+                ?: citationElement.takeIf { it.tagName() == "postedcontent_cite" }
+                    ?.selectFirst("institution_name")?.text()?.takeIf { it.isNotBlank() }
 
             SeqSetCitationSource(
                 source = CitationSource(

--- a/backend/src/main/kotlin/org/loculus/backend/service/crossref/CrossRefService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/crossref/CrossRefService.kt
@@ -1,5 +1,6 @@
 package org.loculus.backend.service.crossref
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import mu.KotlinLogging
 import org.jsoup.Jsoup
 import org.jsoup.parser.Parser
@@ -25,6 +26,10 @@ import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 private val log = KotlinLogging.logger { }
+
+private val objectMapper = ObjectMapper()
+
+private const val CROSSREF_REST_API_ENDPOINT = "https://api.crossref.org"
 
 @ConfigurationProperties(prefix = "crossref")
 data class CrossRefServiceProperties(
@@ -84,7 +89,17 @@ class CrossRefService(
         }
     }
 
-    fun parseCrossRefCitedByXML(citedByXML: String): CrossRefCitedByResult {
+    /**
+     * Parses a CrossRef Cited-by forward links response.
+     *
+     * [postedContentServerResolver] is called with the DOI of each `postedcontent_cite` citation and should return the
+     * name of the preprint server hosting it (or null if unknown). The forward links schema carries no field for this,
+     * so it has to be looked up elsewhere; see [fetchPostedContentServer].
+     */
+    fun parseCrossRefCitedByXML(
+        citedByXML: String,
+        postedContentServerResolver: (String) -> String? = { null },
+    ): CrossRefCitedByResult {
         val parser = Parser.xmlParser().setTrackErrors(1)
         val doc = Jsoup.parse(citedByXML, "", parser)
 
@@ -166,9 +181,11 @@ class CrossRefService(
                     CitationContributor(givenName, surname)
                 }
             }
+            // postedcontent_cite only carries title, contributors, year and doi, so the preprint server
+            // (bioRxiv, medRxiv, ...) has to be resolved separately from the DOI.
             val journal = citationElement.selectFirst("journal_title")?.text()?.takeIf { it.isNotBlank() }
                 ?: citationElement.takeIf { it.tagName() == "postedcontent_cite" }
-                    ?.selectFirst("institution_name")?.text()?.takeIf { it.isNotBlank() }
+                    ?.let { postedContentServerResolver(sourceDOI) }?.takeIf { it.isNotBlank() }
 
             SeqSetCitationSource(
                 source = CitationSource(
@@ -213,10 +230,58 @@ class CrossRefService(
             connection.disconnect()
         }
 
+        // The same preprint can cite several SeqSets, so cache lookups for the duration of this request
+        val postedContentServers = mutableMapOf<String, String?>()
+
         return try {
-            parseCrossRefCitedByXML(response)
+            parseCrossRefCitedByXML(response) { sourceDOI ->
+                postedContentServers.getOrPut(sourceDOI) { fetchPostedContentServer(sourceDOI) }
+            }
         } catch (e: Exception) {
             throw RuntimeException("Failed to parse CrossRef citedBy response for DOI $doiPrefix", e)
+        }
+    }
+
+    /**
+     * Looks up the preprint server hosting a posted content DOI, e.g. "bioRxiv" for a 10.1101 preprint.
+     *
+     * The Cited-by forward links schema has no field for this (see crossref_query_output3.0.xsd), so we ask the
+     * public CrossRef REST API, which exposes the hosting service as `message.institution[].name`.
+     * Failures are logged and treated as "unknown" so that a single bad lookup doesn't fail the whole citation update.
+     */
+    fun fetchPostedContentServer(doi: String): String? {
+        val encodedDOI = URLEncoder.encode(doi, "UTF-8")
+        val mailtoParameter = properties.email
+            ?.takeIf { it.isNotBlank() }
+            ?.let { "?mailto=${URLEncoder.encode(it, "UTF-8")}" }
+            .orEmpty()
+        val connection = URI("$CROSSREF_REST_API_ENDPOINT/works/$encodedDOI$mailtoParameter")
+            .toURL()
+            .openConnection() as HttpURLConnection
+        connection.connectTimeout = 10_000
+        connection.readTimeout = 30_000
+        connection.requestMethod = "GET"
+
+        return try {
+            val responseCode = connection.responseCode
+            if (responseCode != HttpURLConnection.HTTP_OK) {
+                log.warn { "CrossRef REST request for posted content $doi returned $responseCode" }
+                return null
+            }
+            val body = connection.inputStream.use { String(it.readAllBytes()) }
+            objectMapper.readTree(body)
+                .path("message")
+                .path("institution")
+                .firstOrNull()
+                ?.path("name")
+                ?.takeIf { it.isTextual }
+                ?.asText()
+                ?.takeIf { it.isNotBlank() }
+        } catch (e: Exception) {
+            log.warn(e) { "Failed to look up the posted content server for $doi" }
+            null
+        } finally {
+            connection.disconnect()
         }
     }
 

--- a/backend/src/test/kotlin/org/loculus/backend/service/crossref/CrossRefServiceTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/crossref/CrossRefServiceTest.kt
@@ -198,6 +198,35 @@ class CrossRefServiceTest(
     }
 
     @Test
+    fun `parseCrossRefCitedByXML uses the hosting institution as journal for preprints`() {
+        val xml = """
+            <crossref_result>
+                <forward_link doi="10.1234/seqset-1">
+                    <postedcontent_cite>
+                        <title>A bioRxiv preprint</title>
+                        <institution_name>bioRxiv</institution_name>
+                        <year>2024</year>
+                        <doi>10.1101/2024.01.01.123456</doi>
+                    </postedcontent_cite>
+                </forward_link>
+                <forward_link doi="10.1234/seqset-2">
+                    <postedcontent_cite>
+                        <title>A medRxiv preprint</title>
+                        <institution_name>medRxiv</institution_name>
+                        <year>2025</year>
+                        <doi>10.1101/2025.01.01.123456</doi>
+                    </postedcontent_cite>
+                </forward_link>
+            </crossref_result>
+        """.trimIndent()
+
+        val result = crossRefService.parseCrossRefCitedByXML(xml)
+
+        assertEquals(listOf("bioRxiv", "medRxiv"), result.sources.map { it.source.journal })
+        assertTrue(result.validationErrors.isEmpty())
+    }
+
+    @Test
     fun `parseCrossRefCitedByXML returns valid sources and records errors for invalid ones in a mixed batch`() {
         val xml = """
           <crossref_result>

--- a/backend/src/test/kotlin/org/loculus/backend/service/crossref/CrossRefServiceTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/crossref/CrossRefServiceTest.kt
@@ -197,33 +197,70 @@ class CrossRefServiceTest(
         )
     }
 
-    @Test
-    fun `parseCrossRefCitedByXML uses the hosting institution as journal for preprints`() {
-        val xml = """
-            <crossref_result>
-                <forward_link doi="10.1234/seqset-1">
-                    <postedcontent_cite>
-                        <title>A bioRxiv preprint</title>
-                        <institution_name>bioRxiv</institution_name>
-                        <year>2024</year>
-                        <doi>10.1101/2024.01.01.123456</doi>
-                    </postedcontent_cite>
-                </forward_link>
-                <forward_link doi="10.1234/seqset-2">
-                    <postedcontent_cite>
-                        <title>A medRxiv preprint</title>
-                        <institution_name>medRxiv</institution_name>
-                        <year>2025</year>
-                        <doi>10.1101/2025.01.01.123456</doi>
-                    </postedcontent_cite>
-                </forward_link>
-            </crossref_result>
-        """.trimIndent()
+    private val postedContentXML = """
+        <crossref_result>
+            <forward_link doi="10.1234/seqset-1">
+                <postedcontent_cite>
+                    <title>A bioRxiv preprint</title>
+                    <year>2024</year>
+                    <doi>10.1101/2024.01.01.123456</doi>
+                </postedcontent_cite>
+            </forward_link>
+            <forward_link doi="10.1234/seqset-2">
+                <postedcontent_cite>
+                    <title>A medRxiv preprint</title>
+                    <year>2025</year>
+                    <doi>10.1101/2025.01.01.123456</doi>
+                </postedcontent_cite>
+            </forward_link>
+        </crossref_result>
+    """.trimIndent()
 
-        val result = crossRefService.parseCrossRefCitedByXML(xml)
+    @Test
+    fun `parseCrossRefCitedByXML uses the resolved preprint server as journal for posted content`() {
+        val servers = mapOf(
+            "10.1101/2024.01.01.123456" to "bioRxiv",
+            "10.1101/2025.01.01.123456" to "medRxiv",
+        )
+
+        val result = crossRefService.parseCrossRefCitedByXML(postedContentXML) { doi -> servers[doi] }
 
         assertEquals(listOf("bioRxiv", "medRxiv"), result.sources.map { it.source.journal })
         assertTrue(result.validationErrors.isEmpty())
+    }
+
+    @Test
+    fun `parseCrossRefCitedByXML keeps posted content citations when the preprint server is unknown`() {
+        val result = crossRefService.parseCrossRefCitedByXML(postedContentXML) { null }
+
+        assertEquals(listOf(null, null), result.sources.map { it.source.journal })
+        assertEquals(listOf("A bioRxiv preprint", "A medRxiv preprint"), result.sources.map { it.source.title })
+        assertTrue(result.validationErrors.isEmpty())
+    }
+
+    @Test
+    fun `parseCrossRefCitedByXML only resolves preprint servers for posted content citations`() {
+        val xml = """
+            <crossref_result>
+                <forward_link doi="10.1234/seqset-1">
+                    <journal_cite>
+                        <journal_title>Journal of Citations</journal_title>
+                        <article_title>A citing paper</article_title>
+                        <year>2024</year>
+                        <doi>10.5678/paper-1</doi>
+                    </journal_cite>
+                </forward_link>
+            </crossref_result>
+        """.trimIndent()
+        val resolvedDOIs = mutableListOf<String>()
+
+        val result = crossRefService.parseCrossRefCitedByXML(xml) { doi ->
+            resolvedDOIs.add(doi)
+            "should not be used"
+        }
+
+        assertEquals(listOf("Journal of Citations"), result.sources.map { it.source.journal })
+        assertTrue(resolvedDOIs.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Summary

Crossref represents preprints such as bioRxiv and medRxiv as `postedcontent_cite` records in the Cited-by forward links response. Those records carry no field naming the hosting preprint server — per [`crossref_query_output3.0.xsd`](https://doi.crossref.org/schemas/crossref_query_output3.0.xsd), `postedcontent_cite` is only `title?`, `contributors?`, `year?`, `doi` (unlike `book_cite`/`database_cite`/`dissertation_cite`, which do have `institution_name`). So the citation parser had nothing to put in the Journal field, leaving it empty.

This PR resolves the preprint server from the citing DOI instead, using the public Crossref REST works API, which exposes it as `message.institution[].name` (e.g. `10.1101/2020.05.01.20087403` → `medRxiv`).

- `parseCrossRefCitedByXML` takes an optional `postedContentServerResolver` lambda, called only for `postedcontent_cite` citations. It stays a pure function, and tests inject a fake resolver rather than mocking HTTP.
- `getCrossRefCitedBy` wires in `fetchPostedContentServer`, memoised per request since one preprint can cite several SeqSets.
- Lookup failures (non-200, network errors, missing `institution`) are logged and treated as "server unknown": the citation is still recorded, just without a journal, so one bad lookup can't fail the whole six-hourly citation update.

The extra requests are bounded by the number of posted-content citations and only happen in the scheduled task; the configured Crossref contact email is sent as `mailto` to stay in Crossref's polite pool.

## Validation

- `./gradlew test --tests org.loculus.backend.service.crossref.CrossRefServiceTest --console=plain`
- `./gradlew ktlintFormat --console=plain`
- Verified `fetchPostedContentServer` against the live API with a throwaway test (not committed): medRxiv and bioRxiv DOIs resolve correctly, and an unknown DOI returns null rather than throwing.
- Unit tests cover the resolved case, the unknown-server case, and that non-posted-content citations never trigger a lookup.

Closes #6971

🚀 Preview: Add `preview` label to enable