### PR TITLE
feat(deposition): use foreign key constraints and use ORM with transactions and joins in more places

### DIFF
--- a/ena-submission/flyway/sql/V1.7__sample_assembly_foreign_keys.sql
+++ b/ena-submission/flyway/sql/V1.7__sample_assembly_foreign_keys.sql
@@ -1,0 +1,13 @@
+-- sample_table and assembly_table rows share the (accession, version) of the
+-- submission_table row they were derived from. Add explicit foreign keys so
+-- this relationship is enforced by the DB and can be used for joins.
+
+ALTER TABLE sample_table
+ADD CONSTRAINT fk_sample_submission
+FOREIGN KEY (accession, version)
+REFERENCES submission_table(accession, version);
+
+ALTER TABLE assembly_table
+ADD CONSTRAINT fk_assembly_submission
+FOREIGN KEY (accession, version)
+REFERENCES submission_table(accession, version);

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -358,7 +358,7 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
             ProjectTableEntry.result,
         )
         .join(SampleTableEntry.submission)
-        .join(ProjectTableEntry.submission)
+        .join(SubmissionTableEntry.project)
         .where(
             SampleTableEntry.accession == submission_row.accession,
             SampleTableEntry.version == version_to_revise,

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -234,54 +234,44 @@ def create_manifest_object(
     return manifest
 
 
-def submission_table_start(db_engine: Engine, config: Config) -> None:
+def submission_table_start(db_engine: Engine) -> None:
     """
-    1. Find all entries in submission_table in state SUBMITTED_SAMPLE
-    2. If entry has insdcRawReadsAccession, check it exists in ENA, if not set error and continue
-    3. If (exists an entry in the assembly_table for (accession, version)):
-    a.      If (in state SUBMITTED) update state in submission_table to SUBMITTED_ALL
-    b.      Else update state to SUBMITTING_ASSEMBLY
-    4. Else create corresponding entry in assembly_table
+    1. Find all entries in submission_table in state SUBMITTED_SAMPLE,
+       create corresponding entry in assembly_table,
+       set status to SUBMITTING_ASSEMBLY in submission_table
     """
-    conditions = {"status_all": StatusAll.SUBMITTED_SAMPLE}
-    ready_to_submit = find_conditions_in_db(db_engine, SubmissionTableEntry, conditions=conditions)
-    logger.debug(
-        f"Found {len(ready_to_submit)} entries in submission_table in status SUBMITTED_SAMPLE"
+    stmt = (
+        select(SubmissionTableEntry)
+        .outerjoin(SubmissionTableEntry.sample)
+        .where(
+            SubmissionTableEntry.status_all == StatusAll.SUBMITTED_SAMPLE,
+            AssemblyTableEntry.accession.is_(None),
+        )
     )
-    for row in ready_to_submit:
-        seq_key = asdict(row.pkey)
+    with Session(db_engine) as session:
+        submissions = session.scalars(stmt).all()
+        logger.debug(
+            f"Found {len(submissions)} entries in submission_table without corresponding assembly_table entry"  # noqa: E501
+        )
 
-        run_ref = row.seq_metadata.get("insdcRawReadsAccession")
-        if run_ref and not accession_exists(run_ref, config):
-            set_accession_does_not_exist_error(
-                conditions=seq_key,
-                accession=run_ref,
-                accession_type="RUN_REF",
-                db_engine=db_engine,
+        created = []
+        for submission in submissions:
+            assembly = AssemblyTableEntry(
+                accession=submission.accession,
+                version=submission.version,
+                started_at=datetime.now(tz=pytz.utc),
             )
-            continue
+            submission.sample = assembly
+            submission.status_all = StatusAll.SUBMITTING_ASSEMBLY
+            created.append(assembly)
 
-        # 1. check if there exists an entry in the assembly_table for seq_key
-        corresponding_assembly = find_conditions_in_db(
-            db_engine, AssemblyTableEntry, conditions=seq_key
-        )
-        status_all = None
-        if len(corresponding_assembly) == 1:
-            if corresponding_assembly[0].status == Status.SUBMITTED:
-                status_all = StatusAll.SUBMITTED_ALL
-            else:
-                status_all = StatusAll.SUBMITTING_ASSEMBLY
-        else:
-            # If not: create assembly_entry, change status to SUBMITTING_ASSEMBLY
-            if not add_to_assembly_table(db_engine, AssemblyTableEntry(**seq_key)):
-                continue
-            status_all = StatusAll.SUBMITTING_ASSEMBLY
-        update_db_where_conditions(
-            db_engine,
-            model_class=SubmissionTableEntry,
-            conditions=seq_key,
-            update_values={"status_all": status_all},
-        )
+        try:
+            session.add_all(created)
+            session.commit()
+        except Exception:
+            logger.exception("Error while syncing assembly_table with submission_table")
+            session.rollback()
+            raise
 
 
 def update_assembly_error(
@@ -548,6 +538,16 @@ def assembly_table_create(db_engine: Engine, config: Config):
             sample_result, project_result, seq_key
         )
 
+        run_ref = submission.seq_metadata.get("insdcRawReadsAccession")
+        if run_ref and not accession_exists(run_ref, config):
+            set_accession_does_not_exist_error(
+                conditions=seq_key,
+                accession=run_ref,
+                accession_type="RUN_REF",
+                db_engine=db_engine,
+            )
+            continue
+
         if is_revision(db_engine, seq_key):
             logger.debug(f"Entry {seq_key.accession} is a revision, checking if it can be revised")
             if not can_be_revised(config, db_engine, submission):
@@ -785,7 +785,7 @@ def create_assembly(config: Config, stop_event: threading.Event):
             logger.warning("create_assembly stopped due to exception in another task")
             return
         logger.debug("Checking for assemblies to create")
-        submission_table_start(db_engine, config)
+        submission_table_start(db_engine)
 
         assembly_table_create(db_engine, config)
         assembly_table_update(db_engine, config, time_threshold=config.min_between_ena_checks)

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -9,7 +9,8 @@ from datetime import datetime, timedelta
 from typing import Any, Literal, cast
 
 import pytz
-from sqlalchemy import Engine
+from sqlalchemy import Engine, select
+from sqlalchemy.orm import Session
 
 from ena_deposition import call_loculus
 
@@ -283,51 +284,11 @@ def submission_table_start(db_engine: Engine, config: Config) -> None:
         )
 
 
-def submission_table_update(db_engine: Engine) -> None:
-    """
-    1. Find all entries in submission_table in state SUBMITTING_ASSEMBLY
-    2. If (exists an entry in the assembly_table for (accession, version)):
-    a.      If (in state SUBMITTED) update state in submission_table to SUBMITTED_ALL
-    3. Else throw Error
-    """
-    conditions = {"status_all": StatusAll.SUBMITTING_ASSEMBLY}
-    submitting_assembly = find_conditions_in_db(
-        db_engine, SubmissionTableEntry, conditions=conditions
-    )
-    if len(submitting_assembly) > 0:
-        logger.debug(
-            f"Found {len(submitting_assembly)} entries in submission_table "
-            f"in status SUBMITTING_ASSEMBLY"
-        )
-    for row in submitting_assembly:
-        seq_key = asdict(row.pkey)
-
-        corresponding_assembly = find_conditions_in_db(
-            db_engine, AssemblyTableEntry, conditions=seq_key
-        )
-        if len(corresponding_assembly) == 1 and corresponding_assembly[0].status == str(
-            Status.SUBMITTED
-        ):
-            update_values = {"status_all": StatusAll.SUBMITTED_ALL}
-            update_db_where_conditions(
-                db_engine,
-                model_class=SubmissionTableEntry,
-                conditions=seq_key,
-                update_values=update_values,
-            )
-        if len(corresponding_assembly) == 0:
-            error_msg = (
-                "Entry in submission_table in status SUBMITTING_ASSEMBLY",
-                " with no corresponding assembly",
-            )
-            raise RuntimeError(error_msg)
-
-
 def update_assembly_error(
     db_engine: Engine,
     error: list[str],
     seq_key: dict[str, Any],
-    update_type: Literal["revision"] | Literal["creation"],
+    update_type: Literal["revision", "creation"],
 ) -> None:
     logger.error(
         f"Assembly {update_type} failed for accession {seq_key['accession']} "
@@ -401,23 +362,25 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
     if not is_latest_revision(db_engine, seq_key):
         return False
     version_to_revise = previous_version(db_engine, seq_key)
-    last_version_rows = find_conditions_in_db(
-        db_engine,
-        SubmissionTableEntry,
-        conditions={"accession": submission_row.accession, "version": version_to_revise},
+    stmt = (
+        select(
+            SubmissionTableEntry,
+            SampleTableEntry.result,
+            ProjectTableEntry.result,
+        )
+        .join(SampleTableEntry.submission)
+        .join(ProjectTableEntry.submission)
+        .where(
+            SampleTableEntry.accession == submission_row.accession,
+            SampleTableEntry.version == version_to_revise,
+        )
     )
-    if len(last_version_rows) == 0:
-        error_msg = f"Last version {version_to_revise} not found in submission_table"
-        raise RuntimeError(error_msg)
 
-    last_version_entry = last_version_rows[0]
+    with Session(db_engine) as session:
+        last_version_entry, previous_sample, previous_study = session.execute(stmt).all()
 
     previous_sample_accession, previous_study_accession = get_project_and_sample_results(
-        db_engine, last_version_entry
-    )
-    logger.debug(
-        f"Previous sample accession: {previous_sample_accession}, "
-        f"previous study accession: {previous_study_accession}"
+        previous_sample, previous_study, seq_key
     )
     if submission_row.seq_metadata.get("biosampleAccession"):
         new_sample_accession = submission_row.seq_metadata["biosampleAccession"]
@@ -535,36 +498,20 @@ def update_assembly_results_with_latest_version(db_engine: Engine, seq_key: Acce
 
 
 def get_project_and_sample_results(
-    db_engine: Engine, submission_row: SubmissionTableEntry
+    sample_result: dict[str, Any] | None,
+    project_result: dict[str, Any] | None,
+    seq_key: AccessionVersion,
 ) -> tuple[str, str]:
-    seq_key = {"accession": submission_row.accession, "version": submission_row.version}
+    sample_accession = sample_result.get("ena_sample_accession") if sample_result else None
+    study_accession = project_result.get("bioproject_accession") if project_result else None
 
-    sample_rows = find_conditions_in_db(db_engine, SampleTableEntry, conditions=seq_key)
-    if len(sample_rows) == 0:
-        error_msg = f"Entry {submission_row.accession} not found in sample_table"
-        raise RuntimeError(error_msg)
-
-    project_rows = find_conditions_in_db(
-        db_engine,
-        ProjectTableEntry,
-        conditions={"project_id": submission_row.project_id},
-    )
-    if len(project_rows) == 0:
-        error_msg = f"Entry {submission_row.accession} not found in project_table"
-        raise RuntimeError(error_msg)
-    sample_accession = (
-        sample_rows[0].result.get("ena_sample_accession") if sample_rows[0].result else None
-    )
-    study_accession = (
-        project_rows[0].result.get("bioproject_accession") if project_rows[0].result else None
-    )
     if not sample_accession or not study_accession:
         error_msg = (
-            f"Missing sample_accession or study_accession for accession {submission_row.accession} "
-            "cannot create manifest"
+            f"Missing sample_accession or study_accession for accession {seq_key.accession} "
+            "cannot create assembly manifest"
         )
         raise RuntimeError(error_msg)
-    return cast(str, sample_accession), cast(str, study_accession)
+    return sample_accession, study_accession
 
 
 def assembly_table_create(db_engine: Engine, config: Config):
@@ -572,39 +519,40 @@ def assembly_table_create(db_engine: Engine, config: Config):
     1. Find all entries in assembly_table in state READY
     2. Create temporary files: chromosome_list_file, embl_file, manifest_file
     3. Update assembly_table to state SUBMITTING (only proceed if update succeeds)
-    4. If (create_ena_assembly succeeds): update state to SUBMITTED with results
+    4. If (create_ena_assembly succeeds): update state to WAITING with results
     3. Else update state to HAS_ERRORS with error messages
 
     If config.test=True: use the test ENA webin-cli endpoint for submission.
     """
-    conditions = {"status": Status.READY}
-    ready_to_submit_assembly = find_conditions_in_db(
-        db_engine, AssemblyTableEntry, conditions=conditions
+    stmt = (
+        select(
+            AssemblyTableEntry,
+            SubmissionTableEntry,
+            SampleTableEntry.result,
+            ProjectTableEntry.result,
+        )
+        .join(SampleTableEntry.submission)
+        .join(ProjectTableEntry.submission)
+        .join(AssemblyTableEntry.submission)
+        .where(AssemblyTableEntry.status == Status.READY)
     )
-    if len(ready_to_submit_assembly) > 0:
-        logger.debug(
-            f"Found {len(ready_to_submit_assembly)} entries in assembly_table in status READY"
-        )
-    for row in ready_to_submit_assembly:
-        seq_key = row.pkey
-        submission_rows = find_conditions_in_db(
-            db_engine, SubmissionTableEntry, conditions=asdict(seq_key)
-        )
-        if len(submission_rows) == 0:
-            error_msg = f"Entry {row.accession} not found in submitting_table"
-            raise RuntimeError(error_msg)
-        submission_row = submission_rows[0]
-        center_name = submission_row.center_name
 
+    with Session(db_engine) as session:
+        ready_to_submit_assembly = session.execute(stmt).all()
+    logger.debug(f"Found {len(ready_to_submit_assembly)} entries in assembly_table in status READY")
+
+    for assembly, submission, sample_result, project_result in ready_to_submit_assembly:
+        seq_key = assembly.pkey
+        center_name = submission.center_name
         sample_accession, study_accession = get_project_and_sample_results(
-            db_engine, submission_row
+            sample_result, project_result, seq_key
         )
 
         if is_revision(db_engine, seq_key):
-            logger.debug(f"Entry {row.accession} is a revision, checking if it can be revised")
-            if not can_be_revised(config, db_engine, submission_row):
+            logger.debug(f"Entry {seq_key.accession} is a revision, checking if it can be revised")
+            if not can_be_revised(config, db_engine, submission):
                 continue
-            if not is_flatfile_data_changed(db_engine, submission_row):
+            if not is_flatfile_data_changed(db_engine, submission):
                 update_assembly_results_with_latest_version(db_engine, seq_key)
                 continue
 
@@ -613,11 +561,13 @@ def assembly_table_create(db_engine: Engine, config: Config):
                 config,
                 sample_accession,
                 study_accession,
-                submission_row,
+                submission,
             )
             manifest_file = create_manifest(manifest_object, is_broker=config.is_broker)
         except Exception as e:
-            logger.error(f"Manifest creation failed for accession {row.accession} with error {e}")
+            logger.error(
+                f"Manifest creation failed for accession {seq_key.accession} with error {e}"
+            )
             continue
 
         update_values: dict[str, Any] = {"status": Status.SUBMITTING}
@@ -634,8 +584,8 @@ def assembly_table_create(db_engine: Engine, config: Config):
                 "not starting submission."
             )
             continue
-        logger.info(f"Starting assembly creation for accession {row.accession}")
-        segment_order = get_segment_order(submission_row.unaligned_nucleotide_sequences)
+        logger.info(f"Starting assembly creation for accession {seq_key.accession}")
+        segment_order = get_segment_order(submission.unaligned_nucleotide_sequences)
 
         # Actual webin-cli command is run here
         assembly_creation_results: CreationResult = create_ena_assembly(
@@ -662,7 +612,7 @@ def assembly_table_create(db_engine: Engine, config: Config):
             update_assembly_error(
                 db_engine,
                 assembly_creation_results.errors,
-                seq_key=asdict(row.pkey),
+                seq_key=asdict(seq_key),
                 update_type="creation",
             )
 
@@ -720,27 +670,42 @@ def assembly_table_update(db_engine: Engine, config: Config, time_threshold: int
             if not (result_contains_gca_accession and result_contains_insdc_accession):
                 if row.result == new_result.result:
                     continue
-                status = Status.WAITING
+                update_db_where_conditions(
+                    db_engine,
+                    model_class=AssemblyTableEntry,
+                    conditions=asdict(seq_key),
+                    update_values={
+                        "result": new_result.result,
+                        "status": Status.WAITING,
+                        "finished_at": datetime.now(tz=pytz.utc),
+                    },
+                )
                 logger.info(
                     f"Assembly partially accessioned by ENA for {seq_key.accession} "
                     f"version {seq_key.version}"
                 )
             else:
-                status = Status.SUBMITTED
                 logger.info(
                     f"Assembly accessioned by ENA for {seq_key.accession} version {seq_key.version}"
                 )
-            update_with_retry(
-                db_engine=db_engine,
-                conditions=asdict(seq_key),
-                update_values={
-                    "status": status,
-                    "result": new_result.result,
-                    "finished_at": datetime.now(tz=pytz.utc),
-                },
-                model_class=AssemblyTableEntry,
-                reraise=False,
-            )
+                with Session(db_engine) as session:
+                    try:
+                        submission_ = session.get(
+                            SubmissionTableEntry,
+                            asdict(seq_key),
+                        )
+
+                        submission_.assembly.status = Status.SUBMITTED
+                        submission_.assembly.finished_at = datetime.now(tz=pytz.utc)
+                        submission_.assembly.result = new_result.result
+                        submission_.status_all = StatusAll.SUBMITTED_ALL
+
+                        session.commit()
+                    except Exception:
+                        logger.exception(
+                            f"Error while updating submission_table for {seq_key} after successful assembly creation"  # noqa: E501
+                        )
+                        session.rollback()
 
 
 def assembly_table_handle_errors(
@@ -821,7 +786,6 @@ def create_assembly(config: Config, stop_event: threading.Event):
             return
         logger.debug("Checking for assemblies to create")
         submission_table_start(db_engine, config)
-        submission_table_update(db_engine)
 
         assembly_table_create(db_engine, config)
         assembly_table_update(db_engine, config, time_threshold=config.min_between_ena_checks)

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -515,10 +515,13 @@ def get_project_and_sample_results(
 def assembly_table_create(db_engine: Engine, config: Config):
     """
     1. Find all entries in assembly_table in state READY
-    2. Create temporary files: chromosome_list_file, embl_file, manifest_file
-    3. Update assembly_table to state SUBMITTING (only proceed if update succeeds)
-    4. If (create_ena_assembly succeeds): update state to WAITING with results
-    3. Else update state to HAS_ERRORS with error messages
+    2. If revision: check if can be revised, if not continue
+    3. If insdcRawReadsAccession was provided: check accession exists in ENA,
+        if not update to HAS_ERRORS and continue
+    4. Create temporary files: chromosome_list_file, embl_file, manifest_file
+    5. Update assembly_table to state SUBMITTING (only proceed if update succeeds)
+    6. If (create_ena_assembly succeeds): update state to WAITING with results
+       Else update state to HAS_ERRORS with error messages
 
     If config.test=True: use the test ENA webin-cli endpoint for submission.
     """

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -520,9 +520,9 @@ def assembly_table_create(db_engine: Engine, config: Config):
             SampleTableEntry.result,
             ProjectTableEntry.result,
         )
-        .join(SampleTableEntry.submission)
-        .join(SubmissionTableEntry.project)
         .join(AssemblyTableEntry.submission)
+        .join(SubmissionTableEntry.sample)
+        .join(SubmissionTableEntry.project)
         .where(AssemblyTableEntry.status == Status.READY)
     )
 

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -44,7 +44,6 @@ from .submission_db_helper import (
     Status,
     StatusAll,
     SubmissionTableEntry,
-    add_to_assembly_table,
     db_init,
     find_conditions_in_db,
     find_errors_or_stuck_in_db,

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -366,7 +366,7 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
     )
 
     with Session(db_engine) as session:
-        last_version_entry, previous_sample, previous_study = session.execute(stmt).all()
+        last_version_entry, previous_sample, previous_study = session.execute(stmt).one()
 
     previous_sample_accession, previous_study_accession = get_project_and_sample_results(
         previous_sample, previous_study, seq_key

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -241,7 +241,7 @@ def submission_table_start(db_engine: Engine) -> None:
     """
     stmt = (
         select(SubmissionTableEntry)
-        .outerjoin(SubmissionTableEntry.sample)
+        .outerjoin(SubmissionTableEntry.assembly)
         .where(
             SubmissionTableEntry.status_all == StatusAll.SUBMITTED_SAMPLE,
             AssemblyTableEntry.accession.is_(None),
@@ -260,7 +260,7 @@ def submission_table_start(db_engine: Engine) -> None:
                 version=submission.version,
                 started_at=datetime.now(tz=pytz.utc),
             )
-            submission.sample = assembly
+            submission.assembly = assembly
             submission.status_all = StatusAll.SUBMITTING_ASSEMBLY
             created.append(assembly)
 

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -48,9 +48,7 @@ from .submission_db_helper import (
     find_conditions_in_db,
     find_errors_or_stuck_in_db,
     find_waiting_in_db,
-    is_latest_revision,
-    is_revision,
-    previous_version,
+    get_revision_status,
     update_db_where_conditions,
     update_with_retry,
 )
@@ -348,9 +346,10 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
        requires manual revision
     """
     seq_key = submission_row.pkey
-    if not is_latest_revision(db_engine, seq_key):
+    revision_status = get_revision_status(db_engine, seq_key)
+    if not revision_status.is_latest_revision:
         return False
-    version_to_revise = previous_version(db_engine, seq_key)
+    version_to_revise = revision_status.previous_version
     stmt = (
         select(
             SubmissionTableEntry,
@@ -414,7 +413,8 @@ def is_flatfile_data_changed(db_engine: Engine, submission_row: SubmissionTableE
     Check if change in sequence or flatfile metadata has occurred since last version.
     """
     seq_key = submission_row.pkey
-    version_to_revise = previous_version(db_engine, seq_key)
+    revision_status = get_revision_status(db_engine, seq_key)
+    version_to_revise = revision_status.previous_version
     last_version_rows = find_conditions_in_db(
         db_engine,
         SubmissionTableEntry,
@@ -457,7 +457,8 @@ def is_flatfile_data_changed(db_engine: Engine, submission_row: SubmissionTableE
 
 
 def update_assembly_results_with_latest_version(db_engine: Engine, seq_key: AccessionVersion):
-    version_to_revise = previous_version(db_engine, seq_key)
+    revision_status = get_revision_status(db_engine, seq_key)
+    version_to_revise = revision_status.previous_version
     last_version_rows = find_conditions_in_db(
         db_engine,
         AssemblyTableEntry,
@@ -474,16 +475,24 @@ def update_assembly_results_with_latest_version(db_engine: Engine, seq_key: Acce
         f"{seq_key.version} using results from version {version_to_revise} as there was no"
         "change in flatfile data."
     )
-    update_with_retry(
-        db_engine=db_engine,
-        conditions=asdict(seq_key),
-        update_values={
-            "status": Status.SUBMITTED,
-            "result": last_version_rows[0].result,
-        },
-        model_class=AssemblyTableEntry,
-        reraise=False,
-    )
+    with Session(db_engine) as session:
+        try:
+            submission_ = session.get(
+                SubmissionTableEntry,
+                asdict(seq_key),
+            )
+
+            submission_.assembly.status = Status.SUBMITTED
+            submission_.assembly.finished_at = datetime.now(tz=pytz.utc)
+            submission_.assembly.result = last_version_rows[0].result
+            submission_.status_all = StatusAll.SUBMITTED_ALL
+
+            session.commit()
+        except Exception:
+            logger.exception(
+                f"Error while updating submission_table for {seq_key} after successful assembly creation"  # noqa: E501
+            )
+            session.rollback()
 
 
 def get_project_and_sample_results(
@@ -547,7 +556,8 @@ def assembly_table_create(db_engine: Engine, config: Config):
             )
             continue
 
-        if is_revision(db_engine, seq_key):
+        revision_status = get_revision_status(db_engine, seq_key)
+        if revision_status.is_revision:
             logger.debug(f"Entry {seq_key.accession} is a revision, checking if it can be revised")
             if not can_be_revised(config, db_engine, submission):
                 continue

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -521,7 +521,7 @@ def assembly_table_create(db_engine: Engine, config: Config):
             ProjectTableEntry.result,
         )
         .join(SampleTableEntry.submission)
-        .join(ProjectTableEntry.submission)
+        .join(SubmissionTableEntry.project)
         .join(AssemblyTableEntry.submission)
         .where(AssemblyTableEntry.status == Status.READY)
     )

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -30,6 +30,7 @@ from .ena_types import (
 )
 from .notifications import SlackConfig, send_slack_notification, slack_conn_init
 from .submission_db_helper import (
+    AccessionVersion,
     SampleTableEntry,
     Status,
     StatusAll,
@@ -171,10 +172,9 @@ def update_with_existing_biosample(db_engine: Engine, row: SubmissionTableEntry,
     biosample = row.seq_metadata["biosampleAccession"]
 
     logger.info("Checking if biosample actually exists and is public")
-    seq_key = asdict(row.pkey)
     if not accession_exists(biosample, config):
         set_accession_does_not_exist_error(
-            conditions=seq_key,
+            conditions=asdict(row.pkey),
             accession=biosample,
             accession_type="BIOSAMPLE",
             db_engine=db_engine,
@@ -182,7 +182,7 @@ def update_with_existing_biosample(db_engine: Engine, row: SubmissionTableEntry,
         return
 
     logger.info("Updating entry with biosampleAccession to state SUBMITTED")
-    update_successful_submission_status(
+    update_successful_sample_submission(
         db_engine,
         row.pkey,
         CreationResult(
@@ -234,9 +234,11 @@ def sync_state_with_submission_table(db_engine: Engine):
             raise
 
 
-def update_successful_submission_status(
-    db_engine: Engine, seq_key, sample_creation_results: CreationResult
+def update_successful_sample_submission(
+    db_engine: Engine, seq_key: AccessionVersion, sample_creation_results: CreationResult
 ):
+    """Update entry in sample_table to state SUBMITTED with results after successful sample creation
+    and update corresponding entry in submission_table to state SUBMITTED_SAMPLE"""
     with Session(db_engine) as session:
         try:
             submission_ = session.get(
@@ -263,7 +265,7 @@ def sample_table_create(db_engine: Engine, config: Config):
     2. Create sample_set_object: use metadata, center_name, organism, and ingest fields
     from submission_table
     3. Update sample_table to state SUBMITTING (only proceed if update succeeds)
-    4. If (create_ena_sample succeeds): update state to SUBMITTED with results
+    4. If (create_ena_sample succeeds): update_successful_sample_submission
     3. Else update state to HAS_ERRORS with error messages
 
     If config.random_alias=True add a timestamp to the alias suffix to allow for multiple
@@ -318,7 +320,7 @@ def sample_table_create(db_engine: Engine, config: Config):
             logger.info(
                 f"Sample creation succeeded for {seq_key.accession} version {seq_key.version}"
             )
-            update_successful_submission_status(db_engine, seq_key, sample_creation_results)
+            update_successful_sample_submission(db_engine, seq_key, sample_creation_results)
         else:
             logger.error(
                 f"Sample creation failed for {seq_key.accession} version {seq_key.version}"

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -5,7 +5,8 @@ from dataclasses import asdict
 from datetime import datetime
 
 import pytz
-from sqlalchemy import Engine
+from sqlalchemy import Engine, select
+from sqlalchemy.orm import Session
 
 from .config import Config, MetadataMapping
 from .ena_submission_helper import (
@@ -33,9 +34,7 @@ from .submission_db_helper import (
     Status,
     StatusAll,
     SubmissionTableEntry,
-    add_to_sample_table,
     db_init,
-    find_conditions_in_db,
     find_errors_or_stuck_in_db,
     is_latest_revision,
     is_revision,
@@ -200,56 +199,42 @@ def update_with_existing_biosample(db_engine: Engine, row: SubmissionTableEntry,
 def sync_state_with_submission_table(db_engine: Engine):
     """
     1. Find all entries in submission_table in state SUBMITTED_PROJECT
-    2. If (exists an entry in the sample_table for (accession, version)):
-    a.      If (in state SUBMITTED) update state in submission_table to SUBMITTED_SAMPLE
-    3. If (exists "biosampleAccession" in "metadata"):
-        create entry in sample_table, update state to SUBMITTED_SAMPLE
-    4. Else create corresponding entry in sample_table
+    where no corresponding entry exists in sample_table (by accession and version)
+    2. If (exists "biosampleAccession" in "metadata") add to result in new sample_table entry
     """
-    # Check submission_table for newly added sequences
-    conditions = {"status_all": StatusAll.SUBMITTED_PROJECT}
-    ready_to_submit = find_conditions_in_db(db_engine, SubmissionTableEntry, conditions=conditions)
-    logger.debug(
-        f"Found {len(ready_to_submit)} entries in submission_table in status SUBMITTED_PROJECT"
+    stmt = (
+        select(SubmissionTableEntry)
+        .outerjoin(SubmissionTableEntry.sample)
+        .where(
+            SubmissionTableEntry.status_all == StatusAll.SUBMITTED_PROJECT,
+            SampleTableEntry.accession.is_(None),
+        )
     )
-    for row in ready_to_submit:
-        seq_key = asdict(row.pkey)
+    with Session(db_engine) as session:
+        submissions = session.scalars(stmt).all()
 
-        # 1. check if there exists an entry in the sample table for seq_key
-        corresponding_sample = find_conditions_in_db(
-            db_engine, SampleTableEntry, conditions=seq_key
-        )
-        if len(corresponding_sample) == 1 and corresponding_sample[0].status == str(
-            Status.SUBMITTED
-        ):
-            update_db_where_conditions(
-                db_engine,
-                model_class=SubmissionTableEntry,
-                conditions=seq_key,
-                update_values={"status_all": StatusAll.SUBMITTED_SAMPLE},
+        created = []
+        for submission in submissions:
+            sample = SampleTableEntry(
+                accession=submission.accession,
+                version=submission.version,
+                started_at=datetime.now(tz=pytz.utc),
+                result=(
+                    {"biosample_accession": biosample}
+                    if (biosample := submission.seq_metadata.get("biosampleAccession"))
+                    else None
+                ),
             )
-            continue
-        if len(corresponding_sample) == 1:
-            logger.debug(
-                f"Entry for {seq_key} already exists in sample_table with status "
-                f"{corresponding_sample[0].status}, not updating submission_table status."
-            )
-            continue
-        if len(corresponding_sample) > 1:
-            logger.error(
-                f"Multiple entries found in sample_table for {seq_key}, not updating "
-                "submission_table status or adding to sample_table."
-            )
-            continue
-        biosample = None
-        if row and row.seq_metadata.get("biosampleAccession"):
-            biosample = row.seq_metadata["biosampleAccession"]
-        add_to_sample_table(
-            db_engine,
-            SampleTableEntry(
-                **seq_key, result={"biosample_accession": biosample} if biosample else None
-            ),
-        )
+            submission.sample = sample
+            created.append(sample)
+
+        try:
+            session.add_all(created)
+            session.commit()
+        except Exception:
+            logger.exception("Error while syncing sample_table with submission_table")
+            session.rollback()
+            raise
 
 
 def sample_table_create(db_engine: Engine, config: Config):
@@ -264,30 +249,30 @@ def sample_table_create(db_engine: Engine, config: Config):
     If config.random_alias=True add a timestamp to the alias suffix to allow for multiple
     submissions of the same sample for testing.
     """
-    conditions = {"status": Status.READY}
-    ready_to_submit_sample = find_conditions_in_db(
-        db_engine, SampleTableEntry, conditions=conditions
+    stmt = (
+        select(SampleTableEntry, SubmissionTableEntry)
+        .join(SampleTableEntry.submission)
+        .where(SampleTableEntry.status == Status.READY)
     )
+
+    with Session(db_engine) as session:
+        ready_to_submit_sample = session.execute(stmt).all()
+
     logger.debug(f"Found {len(ready_to_submit_sample)} entries in sample_table in status READY")
-    for row in ready_to_submit_sample:
-        seq_key = row.pkey
+    for sample, submission in ready_to_submit_sample:
+        seq_key = sample.pkey
         is_rev = is_revision(db_engine, seq_key)
         if is_rev and not is_latest_revision(db_engine, seq_key):
             logger.warning(f"Skipping submission for {seq_key} as it is not the latest version.")
             continue
 
         logger.info(f"Processing sample_table entry for {seq_key}")
-        sample_data_in_submission_table = find_conditions_in_db(
-            db_engine, SubmissionTableEntry, conditions=asdict(seq_key)
-        )
 
-        if row.result and row.result.get("biosample_accession"):
-            update_with_existing_biosample(db_engine, sample_data_in_submission_table[0], config)
+        if sample.result and sample.result.get("biosample_accession"):
+            update_with_existing_biosample(db_engine, submission, config)
             continue
 
-        sample_set = construct_sample_set_object(
-            config, sample_data_in_submission_table[0], row, config.random_alias
-        )
+        sample_set = construct_sample_set_object(config, submission, sample, config.random_alias)
         update_values = {
             "status": Status.SUBMITTING,
             "started_at": datetime.now(tz=pytz.utc),
@@ -305,34 +290,46 @@ def sample_table_create(db_engine: Engine, config: Config):
                 "- not starting submission."
             )
             continue
-        logger.info(f"Starting sample creation for accession {row.accession}")
+        logger.info(f"Starting sample creation for accession {sample.accession}")
         sample_creation_results: CreationResult = create_ena_sample(
             config, sample_set, revision=is_rev
         )
         if sample_creation_results.result:
-            update_values = {
-                "status": Status.SUBMITTED,
-                "result": sample_creation_results.result,
-                "finished_at": datetime.now(tz=pytz.utc),
-            }
             logger.info(
                 f"Sample creation succeeded for {seq_key.accession} version {seq_key.version}"
             )
+            with Session(db_engine) as session:
+                try:
+                    submission_ = session.get(
+                        SubmissionTableEntry,
+                        asdict(seq_key),
+                    )
+
+                    submission_.sample.status = Status.SUBMITTED
+                    submission_.sample.finished_at = datetime.now(tz=pytz.utc)
+                    submission_.sample.result = sample_creation_results.result
+                    submission_.status_all = StatusAll.SUBMITTED_SAMPLE
+
+                    session.commit()
+                except Exception:
+                    logger.exception(
+                        f"Error while updating submission_table for {seq_key} after successful sample creation"  # noqa: E501
+                    )
+                    session.rollback()
         else:
-            update_values = {
-                "status": Status.HAS_ERRORS,
-                "errors": sample_creation_results.errors,
-                "started_at": datetime.now(tz=pytz.utc),
-            }
             logger.error(
                 f"Sample creation failed for {seq_key.accession} version {seq_key.version}"
             )
-        update_with_retry(
-            db_engine=db_engine,
-            conditions=asdict(seq_key),
-            update_values=update_values,
-            model_class=SampleTableEntry,
-        )
+            update_with_retry(
+                db_engine=db_engine,
+                conditions=asdict(seq_key),
+                update_values={
+                    "status": Status.HAS_ERRORS,
+                    "errors": sample_creation_results.errors,
+                    "started_at": datetime.now(tz=pytz.utc),
+                },
+                model_class=SampleTableEntry,
+            )
 
 
 def sample_table_handle_errors(
@@ -391,7 +388,6 @@ def create_sample(config: Config, stop_event: threading.Event):
         sync_state_with_submission_table(db_engine)
 
         sample_table_create(db_engine, config)
-        sync_state_with_submission_table(db_engine)  # update submission_table state after creation
         last_retry_time = sample_table_handle_errors(
             db_engine, config, slack_config, last_retry_time
         )

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -184,7 +184,7 @@ def update_with_existing_biosample(db_engine: Engine, row: SubmissionTableEntry,
     logger.info("Updating entry with biosampleAccession to state SUBMITTED")
     update_successful_submission_status(
         db_engine,
-        seq_key,
+        row.pkey,
         CreationResult(
             errors=[],
             warnings=[],

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -36,8 +36,7 @@ from .submission_db_helper import (
     SubmissionTableEntry,
     db_init,
     find_errors_or_stuck_in_db,
-    is_latest_revision,
-    is_revision,
+    get_revision_status,
     update_db_where_conditions,
     update_with_retry,
 )
@@ -183,16 +182,14 @@ def update_with_existing_biosample(db_engine: Engine, row: SubmissionTableEntry,
         return
 
     logger.info("Updating entry with biosampleAccession to state SUBMITTED")
-    update_db_where_conditions(
+    update_successful_submission_status(
         db_engine,
-        model_class=SampleTableEntry,
-        conditions=seq_key,
-        update_values={
-            "accession": row.accession,
-            "version": row.version,
-            "result": {"ena_sample_accession": biosample, "biosample_accession": biosample},
-            "status": Status.SUBMITTED,
-        },
+        seq_key,
+        CreationResult(
+            errors=[],
+            warnings=[],
+            result={"ena_sample_accession": biosample, "biosample_accession": biosample},
+        ),
     )
 
 
@@ -237,6 +234,29 @@ def sync_state_with_submission_table(db_engine: Engine):
             raise
 
 
+def update_successful_submission_status(
+    db_engine: Engine, seq_key, sample_creation_results: CreationResult
+):
+    with Session(db_engine) as session:
+        try:
+            submission_ = session.get(
+                SubmissionTableEntry,
+                asdict(seq_key),
+            )
+
+            submission_.sample.status = Status.SUBMITTED
+            submission_.sample.finished_at = datetime.now(tz=pytz.utc)
+            submission_.sample.result = sample_creation_results.result
+            submission_.status_all = StatusAll.SUBMITTED_SAMPLE
+
+            session.commit()
+        except Exception:
+            logger.exception(
+                f"Error while updating submission_table for {seq_key} after successful sample creation"  # noqa: E501
+            )
+            session.rollback()
+
+
 def sample_table_create(db_engine: Engine, config: Config):
     """
     1. Find all entries in sample_table in state READY
@@ -261,8 +281,8 @@ def sample_table_create(db_engine: Engine, config: Config):
     logger.debug(f"Found {len(ready_to_submit_sample)} entries in sample_table in status READY")
     for sample, submission in ready_to_submit_sample:
         seq_key = sample.pkey
-        is_rev = is_revision(db_engine, seq_key)
-        if is_rev and not is_latest_revision(db_engine, seq_key):
+        revision_status = get_revision_status(db_engine, seq_key)
+        if revision_status.is_revision and not revision_status.is_latest_revision:
             logger.warning(f"Skipping submission for {seq_key} as it is not the latest version.")
             continue
 
@@ -292,30 +312,13 @@ def sample_table_create(db_engine: Engine, config: Config):
             continue
         logger.info(f"Starting sample creation for accession {sample.accession}")
         sample_creation_results: CreationResult = create_ena_sample(
-            config, sample_set, revision=is_rev
+            config, sample_set, revision=revision_status.is_revision
         )
         if sample_creation_results.result:
             logger.info(
                 f"Sample creation succeeded for {seq_key.accession} version {seq_key.version}"
             )
-            with Session(db_engine) as session:
-                try:
-                    submission_ = session.get(
-                        SubmissionTableEntry,
-                        asdict(seq_key),
-                    )
-
-                    submission_.sample.status = Status.SUBMITTED
-                    submission_.sample.finished_at = datetime.now(tz=pytz.utc)
-                    submission_.sample.result = sample_creation_results.result
-                    submission_.status_all = StatusAll.SUBMITTED_SAMPLE
-
-                    session.commit()
-                except Exception:
-                    logger.exception(
-                        f"Error while updating submission_table for {seq_key} after successful sample creation"  # noqa: E501
-                    )
-                    session.rollback()
+            update_successful_submission_status(db_engine, seq_key, sample_creation_results)
         else:
             logger.error(
                 f"Sample creation failed for {seq_key.accession} version {seq_key.version}"

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -870,13 +870,16 @@ def set_accession_does_not_exist_error(
                 },
             )
         case "RUN_REF":
-            assembly_table_entry = AssemblyTableEntry(
-                **conditions,  # type: ignore
-                status=Status.HAS_ERRORS,
-                errors=[error_text],
-                result={},  # type: ignore
+            succeeded = update_db_where_conditions(
+                db_engine,
+                AssemblyTableEntry,
+                conditions,
+                {
+                    "status": Status.HAS_ERRORS,
+                    "errors": [error_text],
+                    "result": {"run_ref": accession},
+                },
             )
-            succeeded = add_to_assembly_table(db_engine, assembly_table_entry)
 
     if not succeeded:
         logger.warning(f"{accession_type} creation failed and DB update failed.")

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -55,7 +55,6 @@ from .submission_db_helper import (
     ProjectTableEntry,
     SampleTableEntry,
     Status,
-    add_to_assembly_table,
     update_db_where_conditions,
     update_with_retry,
 )
@@ -839,7 +838,7 @@ def accession_exists(
 def set_accession_does_not_exist_error(
     conditions: dict[str, Any],
     accession: str,
-    accession_type: Literal["BIOPROJECT"] | Literal["BIOSAMPLE"] | Literal["RUN_REF"],
+    accession_type: Literal["BIOPROJECT", "BIOSAMPLE", "RUN_REF"],
     db_engine: Engine,
 ):
     error_text = f"Accession {accession} of type {accession_type} does not exist in ENA."

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -9,7 +9,19 @@ from enum import StrEnum
 from typing import Any, Final
 
 import pytz
-from sqlalchemy import Engine, Enum, create_engine, delete, func, make_url, or_, select, update
+from sqlalchemy import (
+    Engine,
+    Enum,
+    ForeignKey,
+    ForeignKeyConstraint,
+    create_engine,
+    delete,
+    func,
+    make_url,
+    or_,
+    select,
+    update,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import (
     DeclarativeBase,
@@ -17,6 +29,7 @@ from sqlalchemy.orm import (
     MappedAsDataclass,
     Session,
     mapped_column,
+    relationship,
 )
 from tenacity import (
     Retrying,
@@ -144,7 +157,7 @@ class SubmissionTableEntry(Base):
     seq_metadata: Mapped[dict[str, Any]] = mapped_column("metadata", JSONB, default_factory=dict)
     errors: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
     warnings: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
-    status_all: Mapped[Status] = mapped_column(
+    status_all: Mapped[StatusAll] = mapped_column(
         Enum(StatusAll, native_enum=False),  # Store enum as string in DB table.
         default=StatusAll.READY_TO_SUBMIT,
     )
@@ -157,7 +170,32 @@ class SubmissionTableEntry(Base):
     external_metadata: Mapped[dict[str, str | Sequence[str]] | None] = mapped_column(
         JSONB, default=None
     )
-    project_id: Mapped[int | None] = mapped_column(default=None)
+    project_id: Mapped[int | None] = mapped_column(
+        ForeignKey("ena_deposition_schema.project_table.project_id"), default=None
+    )
+
+    # Relationships (not part of the dataclass constructor; populated by the ORM).
+    project: Mapped["ProjectTableEntry | None"] = relationship(
+        back_populates="submissions",
+        default=None,
+        init=False,
+        repr=False,
+        uselist=False,
+    )
+    sample: Mapped["SampleTableEntry | None"] = relationship(
+        back_populates="submission",
+        default=None,
+        init=False,
+        repr=False,
+        uselist=False,
+    )
+    assembly: Mapped["AssemblyTableEntry | None"] = relationship(
+        back_populates="submission",
+        default=None,
+        init=False,
+        repr=False,
+        uselist=False,
+    )
 
     @property
     def pkey(self) -> AccessionVersion:
@@ -189,6 +227,12 @@ class ProjectTableEntry(Base):
     ena_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
     ncbi_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
 
+    # One project can have many submission_table rows pointing at it
+    # (group_id, organism) -> project_id, one row per accession/version.
+    submissions: Mapped[list["SubmissionTableEntry"]] = relationship(
+        back_populates="project", default_factory=list, init=False, repr=False
+    )
+
     @property
     def pkey(self) -> ProjectId:
         return ProjectId(project_id=self.project_id)
@@ -198,7 +242,16 @@ class SampleTableEntry(Base):
     """Maps to sample_table. Primary key: (accession, version)."""
 
     __tablename__ = "sample_table"
-    __table_args__: typing.ClassVar[dict[str, Any]] = {"schema": "ena_deposition_schema"}
+    __table_args__: typing.ClassVar[tuple[ForeignKeyConstraint, dict[str, Any]]] = (
+        ForeignKeyConstraint(
+            ["accession", "version"],
+            [
+                "ena_deposition_schema.submission_table.accession",
+                "ena_deposition_schema.submission_table.version",
+            ],
+        ),
+        {"schema": "ena_deposition_schema"},
+    )
 
     accession: Mapped[str] = mapped_column(primary_key=True)
     version: Mapped[int] = mapped_column(primary_key=True)
@@ -214,6 +267,11 @@ class SampleTableEntry(Base):
     ena_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
     ncbi_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
 
+    # Same (accession, version) as the submission_table row it was derived from.
+    submission: Mapped["SubmissionTableEntry"] = relationship(
+        back_populates="sample", default=None, init=False, repr=False
+    )
+
     @property
     def pkey(self) -> AccessionVersion:
         return AccessionVersion(accession=self.accession, version=self.version)
@@ -223,7 +281,16 @@ class AssemblyTableEntry(Base):
     """Maps to assembly_table. Primary key: (accession, version)."""
 
     __tablename__ = "assembly_table"
-    __table_args__: typing.ClassVar[dict[str, Any]] = {"schema": "ena_deposition_schema"}
+    __table_args__: typing.ClassVar[tuple[ForeignKeyConstraint, dict[str, Any]]] = (
+        ForeignKeyConstraint(
+            ["accession", "version"],
+            [
+                "ena_deposition_schema.submission_table.accession",
+                "ena_deposition_schema.submission_table.version",
+            ],
+        ),
+        {"schema": "ena_deposition_schema"},
+    )
 
     accession: Mapped[str] = mapped_column(primary_key=True)
     version: Mapped[int] = mapped_column(primary_key=True)
@@ -240,6 +307,11 @@ class AssemblyTableEntry(Base):
     ncbi_nucleotide_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
     ena_gca_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
     ncbi_gca_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
+
+    # Same (accession, version) as the submission_table row it was derived from.
+    submission: Mapped["SubmissionTableEntry"] = relationship(
+        back_populates="assembly", default=None, init=False, repr=False
+    )
 
     @property
     def pkey(self) -> AccessionVersion:

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -595,42 +595,26 @@ def add_to_submission_table(engine: Engine, entry: SubmissionTableEntry) -> bool
         return False
 
 
-def is_latest_revision(engine: Engine, seq_key: AccessionVersion) -> bool:
-    """Return True if *seq_key* is the latest of multiple versions for its accession."""
-    if seq_key.version == 1:
-        return False
+@dataclass(frozen=True)
+class RevisionStatus:
+    is_revision: bool
+    is_latest_revision: bool
+    previous_version: int | None
+
+
+def get_revision_status(engine: Engine, seq_key: AccessionVersion) -> RevisionStatus:
+    """Return a RevisionStatus object for *seq_key*."""
     rows = find_conditions_in_db(
         engine,
         SubmissionTableEntry,
         {"accession": seq_key.accession},
     )
     all_versions = sorted(row.version for row in rows)
-    return len(all_versions) > 1 and seq_key.version == all_versions[-1]
-
-
-def is_revision(engine: Engine, seq_key: AccessionVersion) -> bool:
-    """Return True if *seq_key* is a revision of an accession submitted to ENA.
-    Note: a sequence with version > 1 is not necessarily a revision as the first version
-    might not have been submitted to ENA yet."""
-    if seq_key.version == 1:
-        return False
-    rows = find_conditions_in_db(
-        engine,
-        SubmissionTableEntry,
-        {"accession": seq_key.accession},
+    is_rev = len(all_versions) > 1
+    is_latest_rev = len(all_versions) > 1 and seq_key.version == all_versions[-1]
+    prev_version = all_versions[-2] if len(all_versions) > 1 else None
+    return RevisionStatus(
+        is_revision=is_rev,
+        is_latest_revision=is_latest_rev,
+        previous_version=prev_version,
     )
-    all_versions = sorted(row.version for row in rows)
-    return len(all_versions) > 1
-
-
-def previous_version(engine: Engine, seq_key: AccessionVersion) -> int | None:
-    """Return the previous version number for *seq_key*, or None if not a revision."""
-    if not is_revision(engine, seq_key):
-        return None
-    rows = find_conditions_in_db(
-        engine,
-        SubmissionTableEntry,
-        {"accession": seq_key.accession},
-    )
-    all_versions = sorted(row.version for row in rows)
-    return all_versions[-2]

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -604,7 +604,7 @@ class RevisionStatus:
 
     is_revision: True if *seq_key* is a revision of an accession submitted to ENA.
     is_latest_revision: True if *seq_key* is the latest of multiple versions for its accession
-    previous_version: The version number of the previous version, or None if there is no previous version.
+    previous_version: The previous version number for *seq_key*, or None if not a revision
     """
 
     is_revision: bool

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -269,7 +269,7 @@ class SampleTableEntry(Base):
 
     # Same (accession, version) as the submission_table row it was derived from.
     submission: Mapped["SubmissionTableEntry"] = relationship(
-        back_populates="sample", default=None, init=False, repr=False
+        back_populates="sample", init=False, repr=False
     )
 
     @property
@@ -310,7 +310,7 @@ class AssemblyTableEntry(Base):
 
     # Same (accession, version) as the submission_table row it was derived from.
     submission: Mapped["SubmissionTableEntry"] = relationship(
-        back_populates="assembly", default=None, init=False, repr=False
+        back_populates="assembly", init=False, repr=False
     )
 
     @property

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -597,6 +597,16 @@ def add_to_submission_table(engine: Engine, entry: SubmissionTableEntry) -> bool
 
 @dataclass(frozen=True)
 class RevisionStatus:
+    """
+    Represents the revision status of a sequence in submission_table.
+    Note: a sequence with version > 1 is not necessarily a revision
+    as the first version might not have been submitted to ENA yet.
+
+    is_revision: True if *seq_key* is a revision of an accession submitted to ENA.
+    is_latest_revision: True if *seq_key* is the latest of multiple versions for its accession
+    previous_version: The version number of the previous version, or None if there is no previous version.
+    """
+
     is_revision: bool
     is_latest_revision: bool
     previous_version: int | None

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -107,11 +107,12 @@ def assert_bioproject_accession(
 
 def delete_all_records(db_engine: Engine) -> None:
     logger.debug("Deleting all records from all deposition tables except flyway")
+    # Delete child rows before parents: sample_table/assembly_table -> submission_table -> project_table
     for model_class in [
-        ProjectTableEntry,
         SampleTableEntry,
         AssemblyTableEntry,
         SubmissionTableEntry,
+        ProjectTableEntry,
     ]:
         delete_records_in_db(db_engine, model_class, {})
 

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -62,6 +62,7 @@ from ena_deposition.submission_db_helper import (
     add_to_assembly_table,
     add_to_project_table,
     add_to_sample_table,
+    add_to_submission_table,
     db_init,
     delete_records_in_db,
     find_conditions_in_db,
@@ -678,8 +679,20 @@ class TestFirstPublicUpdate(TestSubmission):
         entry_data = {**test_data["base_entry"], "result": test_data["invalid_result"]}
         entry = config.entry_class(**entry_data)
 
-        # Insert into the database
+        # sample_table/assembly_table rows require a matching submission_table row (FK constraint)
         add_function = test_data["add_function"]
+        if add_function is not add_to_project_table:
+            add_to_submission_table(
+                self.db_engine,
+                SubmissionTableEntry(
+                    accession=entry_data["accession"],
+                    version=entry_data["version"],
+                    organism="test_organism",
+                    group_id=1,
+                ),
+            )
+
+        # Insert into the database
         entity_id = add_function(self.db_engine, entry)
         if entity_id is None:
             msg = f"Failed to add {entity_type.value} entry to the database."

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -36,9 +36,6 @@ from ena_deposition.create_assembly import (
 from ena_deposition.create_assembly import (
     submission_table_start as create_assembly_submission_table_start,
 )
-from ena_deposition.create_assembly import (
-    submission_table_update as create_assembly_submission_table_update,
-)
 from ena_deposition.create_project import (
     project_table_create,
     project_table_handle_errors,
@@ -377,7 +374,6 @@ def _test_successful_assembly_submission(
     # So we can test the rest of the pipeline
     set_db_to_known_erz_accession(db_engine, sequences_to_upload, single_segment=single_segment)
     assembly_table_update(db_engine, config, time_threshold=0)
-    create_assembly_submission_table_update(db_engine)
     if single_segment:
         check_assembly_submission_with_nuc_without_gca(db_engine, sequences_to_upload)
     else:
@@ -392,7 +388,6 @@ def _test_successful_assembly_submission_no_wait(
 
     assert config.test, "Not submitting to dev - stopping"
     assembly_table_create(db_engine, config)
-    create_assembly_submission_table_update(db_engine)
     check_assembly_submission_submitted(db_engine, sequences_to_upload)
 
 
@@ -430,7 +425,6 @@ def _test_successful_sample_submission(
     check_sample_submission_started(db_engine, sequences_to_upload)
 
     sample_table_create(db_engine, config)
-    create_sample_sync_state_with_submission_table(db_engine)
     check_sample_submission_submitted(db_engine, sequences_to_upload)
 
 
@@ -1009,7 +1003,6 @@ class TestKnownBioprojectAndBioSample(TestSubmission):
         check_sample_submission_started(self.db_engine, sequences_to_upload)
         create_sample_sync_state_with_submission_table(self.db_engine)
         sample_table_create(self.db_engine, self.config)
-        create_sample_sync_state_with_submission_table(self.db_engine)
         check_sample_submission_submitted(self.db_engine, sequences_to_upload)
         _test_successful_assembly_submission(self.db_engine, self.config, sequences_to_upload)
 

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -108,10 +108,10 @@ def assert_bioproject_accession(
 def delete_all_records(db_engine: Engine) -> None:
     logger.debug("Deleting all records from all deposition tables except flyway")
     for model_class in [
-        SubmissionTableEntry,
         ProjectTableEntry,
         SampleTableEntry,
         AssemblyTableEntry,
+        SubmissionTableEntry,
     ]:
         delete_records_in_db(db_engine, model_class, {})
 
@@ -363,7 +363,7 @@ def _test_successful_assembly_submission(
     sequences_to_upload: dict[str, Any],
     single_segment: bool = False,
 ) -> None:
-    create_assembly_submission_table_start(db_engine, config)
+    create_assembly_submission_table_start(db_engine)
     check_assembly_submission_started(db_engine, sequences_to_upload)
 
     assert config.test, "Not submitting to dev - stopping"
@@ -383,7 +383,7 @@ def _test_successful_assembly_submission(
 def _test_successful_assembly_submission_no_wait(
     db_engine: Engine, config: Config, sequences_to_upload: dict[str, Any]
 ) -> None:
-    create_assembly_submission_table_start(db_engine, config)
+    create_assembly_submission_table_start(db_engine)
     check_assembly_submission_started(db_engine, sequences_to_upload)
 
     assert config.test, "Not submitting to dev - stopping"
@@ -398,7 +398,7 @@ def _test_assembly_submission_errored(
     sequences_to_upload: dict[str, Any],
     mock_notify: Mock,
 ) -> None:
-    create_assembly_submission_table_start(db_engine, config)
+    create_assembly_submission_table_start(db_engine)
     check_assembly_submission_started(db_engine, sequences_to_upload)
 
     assert config.test, "Not submitting to dev - stopping"

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -107,7 +107,8 @@ def assert_bioproject_accession(
 
 def delete_all_records(db_engine: Engine) -> None:
     logger.debug("Deleting all records from all deposition tables except flyway")
-    # Delete child rows before parents: sample_table/assembly_table -> submission_table -> project_table
+    # Delete child rows before parents:
+    # sample_table/assembly_table -> submission_table -> project_table
     for model_class in [
         SampleTableEntry,
         AssemblyTableEntry,


### PR DESCRIPTION
1. add proper foreign key annotations for all tables!
2. Reduce number of database calls: 
- do status updates in batches where possible
- use transactions for syncing state across databases (no more splitting up updates SubmissionTable.StatusAll=SUBMITTED_SAMPLE and SampleTable.Status=SUBMITTED into 2 db calls)
- use table joins for getting sequence metadata from the SubmissionTable for submissions

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable