### PR TITLE
feat(prepro): Pass files through nextclade pipeline

### DIFF
--- a/backend/docs/organismWithSuborganisms.md
+++ b/backend/docs/organismWithSuborganisms.md
@@ -271,7 +271,7 @@ Once the suborganism is assigned, it runs Nextclade with the correct Nextclade d
       "matchingSuborganism-gene2": [...]
     },
     "files": {
-      "raw_reads": [],
+      "rawReads": [],
       "sequencing_logs": []
     }
   },

--- a/backend/docs/organismWithSuborganisms.md
+++ b/backend/docs/organismWithSuborganisms.md
@@ -272,7 +272,7 @@ Once the suborganism is assigned, it runs Nextclade with the correct Nextclade d
     },
     "files": {
       "rawReads": [],
-      "sequencing_logs": []
+      "sequenceLogs": []
     }
   },
   "errors": [...],

--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -199,7 +199,7 @@ data class ProcessedData<SequenceType>(
     )
     val sequenceNameToFastaId: Map<SegmentName, String> = emptyMap(),
     @Schema(
-        example = """{"raw_reads": [{"fileId": "s0m3-uUiDd", "name": "data.fastaq"}], "sequencing_logs": []}""",
+        example = """{"rawReads": [{"fileId": "s0m3-uUiDd", "name": "data.fastaq"}], "sequencing_logs": []}""",
         description = "The key is the file category name, the value is a list of files, with ID and name.",
     )
     val files: FileCategoryFilesMap?,
@@ -336,7 +336,7 @@ data class SubmittedContentInternal<SequenceType, FilesType>(
     )
     val unalignedNucleotideSequences: Map<FastaId, SequenceType?>,
     @Schema(
-        example = """{"raw_reads": [{"fileId": "f1le-uuId-asdf", "name": "myfile.fastaq"]}""",
+        example = """{"rawReads": [{"fileId": "f1le-uuId-asdf", "name": "myfile.fastaq"]}""",
         description = "A map from file categories, to lists of files. The files can also have URLs.",
     )
     val files: Map<String, List<FilesType>>? = null,
@@ -451,7 +451,7 @@ fun SubmissionIdFilesMap.getAllFileIds(): Set<FileId> = this.values.flatMap {
 }.toSet()
 
 /**
- * A file category like 'raw_reads' or 'logs'.
+ * A file category like 'rawReads' or 'logs'.
  */
 typealias FileCategory = String
 

--- a/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SubmissionTypes.kt
@@ -199,7 +199,7 @@ data class ProcessedData<SequenceType>(
     )
     val sequenceNameToFastaId: Map<SegmentName, String> = emptyMap(),
     @Schema(
-        example = """{"rawReads": [{"fileId": "s0m3-uUiDd", "name": "data.fastaq"}], "sequencing_logs": []}""",
+        example = """{"rawReads": [{"fileId": "s0m3-uUiDd", "name": "data.fastaq"}], "sequenceLogs": []}""",
         description = "The key is the file category name, the value is a list of files, with ID and name.",
     )
     val files: FileCategoryFilesMap?,

--- a/integration-tests/tests/pages/submission.page.ts
+++ b/integration-tests/tests/pages/submission.page.ts
@@ -60,7 +60,7 @@ class SubmissionPage {
         void this.page
             .getByRole('button', { name: 'Continue under Open terms' })
             .click({ timeout: 3_000 })
-            .catch(() => { });
+            .catch(() => {});
 
         await this.page.waitForURL('**/review', { timeout: 15_000 });
         return new ReviewPage(this.page);

--- a/integration-tests/tests/pages/submission.page.ts
+++ b/integration-tests/tests/pages/submission.page.ts
@@ -32,8 +32,8 @@ class SubmissionPage {
         await this.page.getByRole('link', { name: 'Submit Upload new sequences.' }).click();
     }
 
-    async discardRawReadsFiles() {
-        await this.page.getByTestId('discard_rawReads').click();
+    async discardFiles(fileCategory: string) {
+        await this.page.getByTestId(`discard_${fileCategory}`).click();
         // Confirmation modal appears and the discard button must be clicked
         await this.page.getByRole('button', { name: 'Discard', exact: true }).click();
     }

--- a/integration-tests/tests/pages/submission.page.ts
+++ b/integration-tests/tests/pages/submission.page.ts
@@ -33,7 +33,7 @@ class SubmissionPage {
     }
 
     async discardRawReadsFiles() {
-        await this.page.getByTestId('discard_raw_reads').click();
+        await this.page.getByTestId('discard_rawReads').click();
         // Confirmation modal appears and the discard button must be clicked
         await this.page.getByRole('button', { name: 'Discard', exact: true }).click();
     }
@@ -60,7 +60,7 @@ class SubmissionPage {
         void this.page
             .getByRole('button', { name: 'Continue under Open terms' })
             .click({ timeout: 3_000 })
-            .catch(() => {});
+            .catch(() => { });
 
         await this.page.waitForURL('**/review', { timeout: 15_000 });
         return new ReviewPage(this.page);

--- a/integration-tests/tests/specs/features/file-sharing.spec.ts
+++ b/integration-tests/tests/specs/features/file-sharing.spec.ts
@@ -66,7 +66,7 @@ test('bulk submit 1 seq: discarding and readding a file', async ({ page, groupId
     await submissionPage.navigateToSubmissionPage(ORGANISM_NAME);
     await submissionPage.uploadMetadataFile(METADATA_HEADERS, [[ID_1, COUNTRY_1, '2023-01-01']]);
     await submissionPage.uploadExternalFiles(RAW_READS, { [ID_1]: FILES_SINGLE }, tmpDir);
-    await submissionPage.discardRawReadsFiles();
+    await submissionPage.discardFiles(RAW_READS);
     await submissionPage.uploadExternalFiles(RAW_READS, { [ID_1]: FILES_DOUBLE }, tmpDir);
     const reviewPage = await submissionPage.submitAndWaitForProcessingDone();
     await reviewPage.checkFilesInReviewDialog(FILES_DOUBLE, Object.keys(FILES_SINGLE));

--- a/integration-tests/tests/specs/features/file-sharing.spec.ts
+++ b/integration-tests/tests/specs/features/file-sharing.spec.ts
@@ -8,7 +8,7 @@ import { BulkSubmissionPage, SingleSequenceSubmissionPage } from '../../pages/su
 
 const ORGANISM_NAME = 'Test organism (with files)';
 const ORGANISM_URL_NAME = 'dummy-organism-with-files';
-const RAW_READS = 'raw_reads';
+const RAW_READS = 'rawReads';
 const METADATA_HEADERS = ['submissionId', 'country', 'date'];
 const COUNTRY_1 = 'Norway';
 const COUNTRY_2 = 'Uganda';

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -416,7 +416,7 @@
                           "name": {
                             "groups": ["schema"],
                             "type": "string",
-                            "description": "The name of the file category, e.g. 'raw_reads'."
+                            "description": "The name of the file category, e.g. 'rawReads'."
                           },
                           "displayName": {
                             "groups": ["schema"],

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -97,6 +97,8 @@ defaultOrganismConfig: &defaultOrganismConfig
     files:
       - name: annotations
         displayName: Annotations
+      - name: raw_reads
+        displayName: Raw reads
     ### Field list
     ## General fields
     # name: Key used across app to refer to this field (required)

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -90,9 +90,9 @@ defaultOrganismConfig: &defaultOrganismConfig
       maxSequencesPerEntry: 1
       # files:  # uncomment to enable submission of raw reads files
       #   enabled: true
-        # categories:
-        #   - name: rawReads
-        #     displayName: Raw reads
+      #   categories:
+      #    - name: rawReads
+      #      displayName: Raw reads
     loadSequencesAutomatically: true
     earliestReleaseDate:
       enabled: true
@@ -102,8 +102,8 @@ defaultOrganismConfig: &defaultOrganismConfig
     files:
       - name: annotations
         displayName: Annotations
-      # - name: rawReads  # uncomment to enable submission of raw reads files
-      #   displayName: Raw reads
+        # - name: rawReads  # uncomment to enable submission of raw reads files
+        #   displayName: Raw reads
     ### Field list
     ## General fields
     # name: Key used across app to refer to this field (required)

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -88,22 +88,22 @@ defaultOrganismConfig: &defaultOrganismConfig
     submissionDataTypes: &defaultSubmissionDataTypes
       consensusSequences: true
       maxSequencesPerEntry: 1
-      files:
-        enabled: false
-        categories: &defaultSubmissionFileCategories
-          - name: rawReads
-            displayName: Raw reads
+      # files:  # uncomment to enable submission of raw reads files
+      #   enabled: true
+        # categories:
+        #   - name: rawReads
+        #     displayName: Raw reads
     loadSequencesAutomatically: true
     earliestReleaseDate:
       enabled: true
       externalFields:
         - ncbiReleaseDate
     richFastaHeaderFields: ["displayName"]
-    files: &defaultOutputFileCategories
+    files:
       - name: annotations
         displayName: Annotations
-      - name: rawReads
-        displayName: Raw reads
+      # - name: rawReads  # uncomment to enable submission of raw reads files
+      #   displayName: Raw reads
     ### Field list
     ## General fields
     # name: Key used across app to refer to this field (required)
@@ -1912,8 +1912,12 @@ defaultOrganisms:
         consensusSequences: false
         files:
           enabled: true
-          categories: *defaultSubmissionFileCategories
-      files: *defaultOutputFileCategories
+          categories:
+            - name: rawReads
+              displayName: Raw reads
+      files:
+        - name: rawReads
+          displayName: Raw reads
       metadata: *dummyMetadata
       website:
         tableColumns:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -88,6 +88,11 @@ defaultOrganismConfig: &defaultOrganismConfig
     submissionDataTypes: &defaultSubmissionDataTypes
       consensusSequences: true
       maxSequencesPerEntry: 1
+      files:
+        enabled: false
+        categories:
+          - name: rawReads
+            displayName: Raw reads
     loadSequencesAutomatically: true
     earliestReleaseDate:
       enabled: true
@@ -97,7 +102,7 @@ defaultOrganismConfig: &defaultOrganismConfig
     files:
       - name: annotations
         displayName: Annotations
-      - name: raw_reads
+      - name: rawReads
         displayName: Raw reads
     ### Field list
     ## General fields
@@ -1907,12 +1912,6 @@ defaultOrganisms:
         consensusSequences: false
         files:
           enabled: true
-          categories:
-            - name: raw_reads
-              displayName: Raw reads
-      files:
-        - name: raw_reads
-          displayName: Raw reads
       metadata: *dummyMetadata
       website:
         tableColumns:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -88,11 +88,6 @@ defaultOrganismConfig: &defaultOrganismConfig
     submissionDataTypes: &defaultSubmissionDataTypes
       consensusSequences: true
       maxSequencesPerEntry: 1
-      # files:  # uncomment to enable submission of raw reads files
-      #   enabled: true
-      #   categories:
-      #    - name: rawReads
-      #      displayName: Raw reads
     loadSequencesAutomatically: true
     earliestReleaseDate:
       enabled: true
@@ -102,8 +97,6 @@ defaultOrganismConfig: &defaultOrganismConfig
     files:
       - name: annotations
         displayName: Annotations
-        # - name: rawReads  # uncomment to enable submission of raw reads files
-        #   displayName: Raw reads
     ### Field list
     ## General fields
     # name: Key used across app to refer to this field (required)

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -90,7 +90,7 @@ defaultOrganismConfig: &defaultOrganismConfig
       maxSequencesPerEntry: 1
       files:
         enabled: false
-        categories:
+        categories: &defaultSubmissionFileCategories
           - name: rawReads
             displayName: Raw reads
     loadSequencesAutomatically: true
@@ -99,7 +99,7 @@ defaultOrganismConfig: &defaultOrganismConfig
       externalFields:
         - ncbiReleaseDate
     richFastaHeaderFields: ["displayName"]
-    files:
+    files: &defaultOutputFileCategories
       - name: annotations
         displayName: Annotations
       - name: rawReads
@@ -1912,6 +1912,8 @@ defaultOrganisms:
         consensusSequences: false
         files:
           enabled: true
+          categories: *defaultSubmissionFileCategories
+      files: *defaultOutputFileCategories
       metadata: *dummyMetadata
       website:
         tableColumns:

--- a/kubernetes/loculus/values_preview_server.yaml
+++ b/kubernetes/loculus/values_preview_server.yaml
@@ -156,3 +156,23 @@ defaultResources:
   limits:
     memory: "1Gi"
     cpu: "20m"
+defaultOrganisms:
+  ebola-sudan: &fileSharingOrganismDefaults
+    schema:
+      submissionDataTypes:
+        files:
+          enabled: true
+          categories:
+            - name: rawReads
+              displayName: Raw reads
+      files:
+        - name: annotations
+          displayName: Annotations
+        - name: rawReads
+          displayName: Raw reads
+  west-nile: *fileSharingOrganismDefaults
+  dummy-organism: *fileSharingOrganismDefaults
+  not-aligned-organism: *fileSharingOrganismDefaults
+  cchf: *fileSharingOrganismDefaults
+  cchf-multi-ref: *fileSharingOrganismDefaults
+  enteroviruses: *fileSharingOrganismDefaults

--- a/preprocessing/nextclade/src/loculus_preprocessing/backend.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/backend.py
@@ -17,6 +17,7 @@ import requests
 
 from .config import Config
 from .datatypes import (
+    FileIdAndName,
     FileUploadInfo,
     ProcessedEntry,
     UnprocessedData,
@@ -93,6 +94,15 @@ def parse_ndjson(ndjson_data: str) -> Sequence[UnprocessedEntry]:
             key: trim_ns(value) if value else None
             for key, value in unaligned_nucleotide_sequences.items()
         }
+        submitted_files = json_object["data"].get("files")
+        file_mapping = (
+            {
+                category: [FileIdAndName(fileId=f["fileId"], name=f["name"]) for f in files]
+                for category, files in submitted_files.items()
+            }
+            if submitted_files
+            else None
+        )
         unprocessed_data = UnprocessedData(
             submitter=json_object["submitter"],
             group_id=json_object["groupId"],
@@ -102,6 +112,7 @@ def parse_ndjson(ndjson_data: str) -> Sequence[UnprocessedEntry]:
             unalignedNucleotideSequences=trimmed_unaligned_nucleotide_sequences
             if unaligned_nucleotide_sequences
             else {},
+            files=file_mapping,
         )
         entry = UnprocessedEntry(
             accessionVersion=f"{json_object['accession']}.{json_object['version']}",

--- a/preprocessing/nextclade/src/loculus_preprocessing/backend.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/backend.py
@@ -17,6 +17,7 @@ import requests
 
 from .config import Config
 from .datatypes import (
+    FileCategory,
     FileIdAndName,
     FileUploadInfo,
     ProcessedEntry,
@@ -97,7 +98,9 @@ def parse_ndjson(ndjson_data: str) -> Sequence[UnprocessedEntry]:
         submitted_files = json_object["data"].get("files")
         file_mapping = (
             {
-                category: [FileIdAndName(fileId=f["fileId"], name=f["name"]) for f in files]
+                FileCategory(category): [
+                    FileIdAndName(fileId=f["fileId"], name=f["name"]) for f in files
+                ]
                 for category, files in submitted_files.items()
             }
             if submitted_files

--- a/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
@@ -23,6 +23,7 @@ ProcessedMetadata = dict[str, ProcessedMetadataValue]
 InputMetadataValue = str | None
 InputMetadata = dict[str, InputMetadataValue]
 FastaId = str
+FileCategory = str
 
 ProcessingAnnotationAlignment: Final = "alignment"
 
@@ -75,6 +76,12 @@ class ProcessingAnnotation:
 
 
 @dataclass
+class FileIdAndName:
+    fileId: str  # noqa: N815
+    name: str
+
+
+@dataclass
 class UnprocessedData:
     submitter: str
     group_id: int
@@ -82,6 +89,7 @@ class UnprocessedData:
     submissionId: str  # noqa: N815
     metadata: InputMetadata
     unalignedNucleotideSequences: dict[SequenceName, NucleotideSequence | None]  # noqa: N815
+    files: dict[FileCategory, list[FileIdAndName]] | None
 
 
 @dataclass
@@ -97,6 +105,7 @@ FunctionArgs = dict[ArgName, ArgValue]
 @dataclass
 class UnprocessedAfterNextclade:
     inputMetadata: InputMetadata  # noqa: N815
+    files: dict[FileCategory, list[FileIdAndName]] | None
     # Derived metadata produced by Nextclade
     nextcladeMetadata: dict[SequenceName, Any] | None  # noqa: N815
     unalignedNucleotideSequences: dict[SequenceName, NucleotideSequence | None]  # noqa: N815
@@ -110,21 +119,15 @@ class UnprocessedAfterNextclade:
 
 
 @dataclass
-class FileIdAndName:
-    fileId: str  # noqa: N815
-    name: str
-
-
-@dataclass
 class ProcessedData:
     metadata: ProcessedMetadata
+    files: dict[FileCategory, list[FileIdAndName]] | None
     unalignedNucleotideSequences: dict[SequenceName, Any]  # noqa: N815
     alignedNucleotideSequences: dict[SequenceName, Any]  # noqa: N815
     nucleotideInsertions: dict[SequenceName, Any]  # noqa: N815
     alignedAminoAcidSequences: dict[GeneName, Any]  # noqa: N815
     aminoAcidInsertions: dict[GeneName, Any]  # noqa: N815
     sequenceNameToFastaId: dict[SequenceName, FastaId]  # noqa: N815
-    files: dict[str, list[FileIdAndName]] | None = None
 
 
 @dataclass

--- a/preprocessing/nextclade/src/loculus_preprocessing/nextclade.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/nextclade.py
@@ -26,6 +26,8 @@ from .datatypes import (
     AminoAcidSequence,
     AnnotationSourceType,
     FastaId,
+    FileCategory,
+    FileIdAndName,
     GeneName,
     GenericSequence,
     NucleotideInsertion,
@@ -801,6 +803,9 @@ def enrich_with_nextclade(  # noqa: PLR0914
         }
         for entry in unprocessed
     }
+    input_files: dict[AccessionVersion, dict[FileCategory, list[FileIdAndName]] | None] = {
+        entry.accessionVersion: entry.data.files for entry in unprocessed
+    }
 
     batch = assign_segment_for_alignment(unprocessed, config=config, dataset_dir=dataset_dir)
     unaligned_nucleotide_sequences = batch.unalignedNucleotideSequences
@@ -893,6 +898,7 @@ def enrich_with_nextclade(  # noqa: PLR0914
     return {
         id: UnprocessedAfterNextclade(
             inputMetadata=input_metadata[id],
+            files=input_files[id],
             nextcladeMetadata=nextclade_metadata[id],
             unalignedNucleotideSequences=unaligned_nucleotide_sequences[id],
             alignedNucleotideSequences=aligned_nucleotide_sequences[id],

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -297,6 +297,7 @@ def processed_entry_no_alignment(  # noqa: PLR0913, PLR0917
             version=version_from_str(accession_version),
             data=ProcessedData(
                 metadata=output_metadata,
+                files=unprocessed.files,
                 unalignedNucleotideSequences=unprocessed.unalignedNucleotideSequences,
                 alignedNucleotideSequences=aligned_nucleotide_sequences,
                 nucleotideInsertions=nucleotide_insertions,
@@ -538,6 +539,7 @@ def process_single(
         version=version_from_str(accession_version),
         data=ProcessedData(
             metadata=output_metadata,
+            files=unprocessed.files,
             unalignedNucleotideSequences=unprocessed.unalignedNucleotideSequences,
             alignedNucleotideSequences=unprocessed.alignedNucleotideSequences,
             nucleotideInsertions=unprocessed.nucleotideInsertions,
@@ -599,6 +601,7 @@ def processed_entry_with_errors(id) -> SubmissionData:
             version=version_from_str(id),
             data=ProcessedData(
                 metadata=dict[str, ProcessedMetadataValue](),
+                files=None,
                 unalignedNucleotideSequences=defaultdict(dict[str, Any]),
                 alignedNucleotideSequences=defaultdict(dict[str, Any]),
                 nucleotideInsertions=defaultdict(dict[str, Any]),
@@ -662,10 +665,13 @@ def upload_flatfiles(processed: Sequence[SubmissionData], config: Config) -> Non
             file_name = f"{accession}.{version}.embl"
             upload_info = request_upload(submission_data.group_id, 1, config)[0]
             file_id = upload_info.fileId
-            upload_embl_file_to_presigned_url(file_content, upload_info.url, upload_info.headers)
-            submission_data.processed_entry.data.files = {
-                "annotations": [FileIdAndName(fileId=file_id, name=file_name)]
-            }
+            url = upload_info.url
+            upload_embl_file_to_presigned_url(file_content, url)
+            processed_files = submission_data.processed_entry.data.files or {}
+            processed_files.setdefault("annotations", []).append(
+                FileIdAndName(fileId=file_id, name=file_name)
+            )
+            submission_data.processed_entry.data.files = processed_files
         except Exception as e:
             logger.error("Error creating or uploading EMBL file: %s", e)
             submission_data.processed_entry.errors.append(

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -665,8 +665,7 @@ def upload_flatfiles(processed: Sequence[SubmissionData], config: Config) -> Non
             file_name = f"{accession}.{version}.embl"
             upload_info = request_upload(submission_data.group_id, 1, config)[0]
             file_id = upload_info.fileId
-            url = upload_info.url
-            upload_embl_file_to_presigned_url(file_content, url)
+            upload_embl_file_to_presigned_url(file_content, upload_info.url, upload_info.headers)
             processed_files = submission_data.processed_entry.data.files or {}
             processed_files.setdefault("annotations", []).append(
                 FileIdAndName(fileId=file_id, name=file_name)

--- a/preprocessing/nextclade/tests/factory_methods.py
+++ b/preprocessing/nextclade/tests/factory_methods.py
@@ -9,6 +9,8 @@ import pytz
 from loculus_preprocessing.datatypes import (
     AnnotationSource,
     AnnotationSourceType,
+    FileCategory,
+    FileIdAndName,
     NucleotideSequence,
     ProcessedData,
     ProcessedEntry,
@@ -77,6 +79,7 @@ class UnprocessedEntryFactory:
         accession_id: str,
         sequences: dict[SegmentName, NucleotideSequence | None],
         group_id: int = 2,
+        files: dict[FileCategory, list[FileIdAndName]] | None = None,
     ) -> UnprocessedEntry:
         return UnprocessedEntry(
             accessionVersion=f"LOC_{accession_id}.1",
@@ -89,6 +92,7 @@ class UnprocessedEntryFactory:
                 group_id=group_id,
                 metadata=metadata_dict,
                 unalignedNucleotideSequences=sequences,
+                files=files,
             ),
         )
 
@@ -130,6 +134,7 @@ class ProcessedEntryFactory:
         errors: list[ProcessingAnnotation] | None = None,
         warnings: list[ProcessingAnnotation] | None = None,
         processed_alignment: ProcessedAlignment | None = None,
+        files: dict[FileCategory, list[FileIdAndName]] | None = None,
     ) -> ProcessedEntry:
         if errors is None:
             errors = []
@@ -147,6 +152,7 @@ class ProcessedEntryFactory:
             version=1,
             data=ProcessedData(
                 metadata=base_metadata_dict,
+                files=files,
                 unalignedNucleotideSequences=processed_alignment.unalignedNucleotideSequences,
                 alignedNucleotideSequences=processed_alignment.alignedNucleotideSequences,
                 nucleotideInsertions=processed_alignment.nucleotideInsertions,
@@ -163,9 +169,11 @@ class ProcessedEntryFactory:
 class Case:
     name: str
     input_metadata: dict[str, str | None] = field(default_factory=dict)
+    input_files: dict[FileCategory, list[FileIdAndName]] | None = None
     input_sequence: dict[str, str | None] = field(default_factory=lambda: {"main": None})
     accession_id: str = "000999"
     expected_metadata: dict[str, ProcessedMetadataValue] = field(default_factory=dict)
+    expected_files: dict[FileCategory, list[FileIdAndName]] | None = None
     expected_errors: list[ProcessingAnnotation] | None = None
     expected_warnings: list[ProcessingAnnotation] | None = None
     expected_processed_alignment: ProcessedAlignment | None = None
@@ -179,6 +187,7 @@ class Case:
             accession_id=self.accession_id,
             sequences=self.input_sequence,
             group_id=self.group_id,
+            files=self.input_files,
         )
         expected_output = factory_custom.create_processed_entry(
             metadata_dict=self.expected_metadata,
@@ -186,6 +195,7 @@ class Case:
             errors=self.expected_errors or [],
             warnings=self.expected_warnings or [],
             processed_alignment=self.expected_processed_alignment,
+            files=self.expected_files,
         )
         return ProcessingTestCase(
             name=self.name, input=unprocessed_entry, expected_output=expected_output
@@ -264,4 +274,9 @@ def verify_processed_entry(
     assert actual.sequenceNameToFastaId == expected.sequenceNameToFastaId, (
         f"{test_name}: sequence name to fasta header map '{actual.sequenceNameToFastaId}' do not "
         f"match expectation '{expected.sequenceNameToFastaId}'."
+    )
+
+    # Check files
+    assert actual.files == expected.files, (
+        f"{test_name}: files '{actual.files}' do not match expectation '{expected.files}'."
     )

--- a/preprocessing/nextclade/tests/test_host_name_validation.py
+++ b/preprocessing/nextclade/tests/test_host_name_validation.py
@@ -37,6 +37,7 @@ def make_entry(metadata: dict, group_id: int) -> UnprocessedEntry:
             group_id=group_id,
             metadata=metadata,
             unalignedNucleotideSequences={},
+            files=None,
         ),
     )
 

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -830,6 +830,7 @@ def test_preprocessing_without_consensus_sequences(config: Config) -> None:
                 "name_required": sequence_name,
             },
             unalignedNucleotideSequences={},
+            files=None,
         ),
     )
 

--- a/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
+++ b/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
@@ -26,6 +26,7 @@ from loculus_preprocessing.config import (
 )
 from loculus_preprocessing.datatypes import (
     AnnotationSourceType,
+    FileIdAndName,
     SegmentClassificationMethod,
     SubmissionData,
     UnprocessedData,
@@ -279,6 +280,46 @@ single_segment_case_definitions = [
                 "VP35EbolaSudan": ebola_sudan_aa(
                     sequence_with_deletion("single", aligned=True), "VP35"
                 ),
+            },
+            aminoAcidInsertions={},
+            sequenceNameToFastaId={"main": "fastaHeader"},
+        ),
+    ),
+    Case(
+        name="with file",
+        input_metadata={},
+        input_files={
+            "raw_reads": [
+                FileIdAndName(fileId="file-id-0001", name="reads_R1.fastq"),
+                FileIdAndName(fileId="file-id-0002", name="reads_R2.fastq"),
+            ]
+        },
+        input_sequence={"fastaHeader": sequence_with_mutation("single")},
+        accession_id="1",
+        expected_metadata={
+            "completeness": 1.0,
+            "totalInsertedNucs": 0,
+            "totalSnps": 1,
+            "totalDeletedNucs": 0,
+            "length": len(consensus_sequence("single")),
+            "nonExistentField": "None",
+            "variant": True,
+        },
+        expected_files={
+            "raw_reads": [
+                FileIdAndName(fileId="file-id-0001", name="reads_R1.fastq"),
+                FileIdAndName(fileId="file-id-0002", name="reads_R2.fastq"),
+            ]
+        },
+        expected_errors=[],
+        expected_warnings=[],
+        expected_processed_alignment=ProcessedAlignment(
+            unalignedNucleotideSequences={"main": sequence_with_mutation("single")},
+            alignedNucleotideSequences={"main": sequence_with_mutation("single")},
+            nucleotideInsertions={},
+            alignedAminoAcidSequences={
+                "NPEbolaSudan": ebola_sudan_aa(sequence_with_mutation("single"), "NP"),
+                "VP35EbolaSudan": ebola_sudan_aa(sequence_with_mutation("single"), "VP35"),
             },
             aminoAcidInsertions={},
             sequenceNameToFastaId={"main": "fastaHeader"},
@@ -1285,6 +1326,7 @@ def test_max_sequences_per_entry_batch_isolation() -> None:
                 "ebola-sudan": sequence_with_mutation("ebola-sudan"),
                 "ebola-zaire": sequence_with_mutation("ebola-zaire"),
             },
+            files=None,
         ),
     )
 
@@ -1299,6 +1341,7 @@ def test_max_sequences_per_entry_batch_isolation() -> None:
             unalignedNucleotideSequences={
                 "ebola-sudan": sequence_with_mutation("ebola-sudan"),
             },
+            files=None,
         ),
     )
 
@@ -1332,6 +1375,7 @@ def test_preprocessing_without_metadata() -> None:
                 "ebola-sudan": sequence_with_mutation("ebola-sudan"),
                 "ebola-zaire": sequence_with_mutation("ebola-zaire"),
             },
+            files=None,
         ),
     )
 
@@ -1458,6 +1502,7 @@ def test_create_flatfile():
                 "authors": "Smith, Doe A;",
             },
             unalignedNucleotideSequences={"main": sequence_with_mutation("single")},
+            files=None,
         ),
     )
 

--- a/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
+++ b/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
@@ -289,7 +289,7 @@ single_segment_case_definitions = [
         name="with file",
         input_metadata={},
         input_files={
-            "raw_reads": [
+            "rawReads": [
                 FileIdAndName(fileId="file-id-0001", name="reads_R1.fastq"),
                 FileIdAndName(fileId="file-id-0002", name="reads_R2.fastq"),
             ]
@@ -306,7 +306,7 @@ single_segment_case_definitions = [
             "variant": True,
         },
         expected_files={
-            "raw_reads": [
+            "rawReads": [
                 FileIdAndName(fileId="file-id-0001", name="reads_R1.fastq"),
                 FileIdAndName(fileId="file-id-0002", name="reads_R2.fastq"),
             ]


### PR DESCRIPTION
Related to https://github.com/loculus-project/loculus/issues/6758

resolves https://github.com/loculus-project/loculus/issues/6986

Essentially the same as https://github.com/loculus-project/loculus/pull/6731, but now merging onto main.

There are some minor differences to address comments:
- Refactor of `raw_reads` -> `rawReads` (this is why the PR now touches a bunch more files than the original PR)
- Config for files is now all under `defaultOrganismConfig` in `values.yaml` (where it is disabled), `dummy-organism-with-files` now only does `files.enabled: true`
- Minor typing tweak in `backend.py`

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://just-passing-through.loculus.org