### PR TITLE
feat!(deposition): split and move out functions to be reused in raw reads, improve manifest creation code, fix bug in assembly revision code

### DIFF
--- a/ena-submission/ENA_submission.md
+++ b/ena-submission/ENA_submission.md
@@ -519,7 +519,7 @@ Revisions to a study or sample should be submitted the same way as original sequ
 
 ## 2. [Revising Assemblies](https://ena-docs.readthedocs.io/en/latest/update/assembly.html)
 
-It appears that all fields that were explicitly set via the manifest must be updated via an email. This includes changes to any field that is in the `manifest_fields_mapping` field of the default.yaml. Additionally, study and sample reference must stay the same and chromosome names cannot be changed (but new ones can be added).
+It appears that all fields that were explicitly set via the manifest must be updated via an email. This includes changes to any field that is in the `assembly_manifest_fields_mapping` field of the default.yaml. Additionally, study and sample reference must stay the same and chromosome names cannot be changed (but new ones can be added).
 However, unlike the alias a NEW `ASSEMBLYNAME` is required (cannot be the same as the assemblyname of the previous version).
 
 Currently we automate revision of studies and assemblies, if a manifest update is required the pipeline will not update the assembly but set the state of assembly submission to `HAS_ERRORS` and document the reason for the errors in the database. We will then receive a slack notification and will have to manually send an email to ENA to update the manifest.

--- a/ena-submission/ENA_submission.md
+++ b/ena-submission/ENA_submission.md
@@ -519,7 +519,7 @@ Revisions to a study or sample should be submitted the same way as original sequ
 
 ## 2. [Revising Assemblies](https://ena-docs.readthedocs.io/en/latest/update/assembly.html)
 
-It appears that all fields that were explicitly set via the manifest must be updated via an email. This includes changes to any field that is in the `assembly_manifest_fields_mapping` field of the default.yaml. Additionally, study and sample reference must stay the same and chromosome names cannot be changed (but new ones can be added).
+Study and sample accessions must stay the same in a revision and chromosome names cannot be changed (but new ones can be added). In the past, all metadata fields that were set via the manifest had to be revised via an email. ENA has now informed us we can revise these fields in a normal automated revision but we have had issues with it, so we have a `allow_revision_with_manifest_changes` flag which can enable/disable automated manifest revisions.
 However, unlike the alias a NEW `ASSEMBLYNAME` is required (cannot be the same as the assemblyname of the previous version).
 
 Currently we automate revision of studies and assemblies, if a manifest update is required the pipeline will not update the assembly but set the state of assembly submission to `HAS_ERRORS` and document the reason for the errors in the database. We will then receive a slack notification and will have to manually send an email to ENA to update the manifest.

--- a/ena-submission/config/defaults.yaml
+++ b/ena-submission/config/defaults.yaml
@@ -29,7 +29,7 @@ min_between_publicness_checks: 720
 log_level: DEBUG
 metadata_fallback_fields:
   specimenCollectorSampleId: submissionId
-manifest_fields_mapping:
+assembly_manifest_fields_mapping:
   authors:
     loculus_fields: [authors]
     function: reformat_authors
@@ -41,8 +41,7 @@ manifest_fields_mapping:
     default: "Unknown"
   coverage:
     loculus_fields: [depthOfCoverage]
-    type: int
-    default: 1
+    default: "1"
   run_ref:
     loculus_fields: [insdcRawReadsAccession]
 #ena_checklist: ERC000033 - do not use until all fields are mapped to ENA accepted options

--- a/ena-submission/src/ena_deposition/call_loculus.py
+++ b/ena-submission/src/ena_deposition/call_loculus.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import traceback
 import uuid
 from collections.abc import Iterator
 from http import HTTPMethod
@@ -148,6 +149,25 @@ def get_group_info(config: Config, group_id: int) -> Group:
         raise requests.exceptions.HTTPError from err
     # response.json() returns python dict
     return GroupDetails.model_validate(response.json()).group
+
+
+def get_address(config: Config, center_name: str, group_id: int) -> str | None:
+    try:
+        group_details = get_group_info(config, group_id)
+    except Exception as e:
+        logger.error(f"Failed to fetch group info for groupId={group_id}\n{traceback.format_exc()}")
+        msg = f"Failed to fetch group info from Loculus for group: {group_id}, {e}"
+        raise RuntimeError(msg) from e
+    address = group_details.address
+    address_list = [
+        center_name,  # corresponds to Loculus' "Institution" group field
+        address.city,
+        address.state,
+        address.country,
+    ]
+    address_string = ", ".join([x for x in address_list if x])
+    logger.debug("Created address from group_info")
+    return address_string
 
 
 def fetch_released_entries(config: Config, organism: str) -> Iterator[dict[str, Any]]:

--- a/ena-submission/src/ena_deposition/config.py
+++ b/ena-submission/src/ena_deposition/config.py
@@ -28,8 +28,7 @@ class MetadataMapping(BaseModel):
 class ManifestFieldDetails(BaseModel):
     loculus_fields: list[str] = field(default_factory=list)
     function: str | None = None
-    type: str | None = None
-    default: str | int | None = None
+    default: str | None = None
 
 
 class ExternalMetadataField(BaseModel):
@@ -106,7 +105,7 @@ class Config(BaseModel):
     unique_project_suffix: str
     metadata_mapping: dict[str, MetadataMapping]
     metadata_fallback_fields: dict[str, str]
-    manifest_fields_mapping: dict[str, ManifestFieldDetails]
+    assembly_manifest_fields_mapping: dict[str, ManifestFieldDetails]
     ingest_pipeline_submission_group: int
     ena_checklist: str | None = None
     set_alias_suffix: str | None = None  # Add to test revisions in dev

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -373,11 +373,12 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
     return not manifest_fields_changed(config, db_engine, submission_row, last_version_entry)
 
 
-def is_flatfile_data_changed(
+def has_assembly_data_changed(
     config: Config, db_engine: Engine, submission_row: SubmissionTableEntry
 ) -> bool:
     """
-    Check if change in sequence or flatfile metadata has occurred since last version.
+    Check if there have been changes in the: sequence, flatfile or manifest
+    (if config.allow_revision_with_manifest_changes is true) metadata since last version.
     """
     last_entry = get_last_entry(db_engine, submission_row.pkey)
 
@@ -486,7 +487,8 @@ def assembly_table_create(db_engine: Engine, config: Config):
             logger.debug(f"Entry {row.accession} is a revision, checking if it can be revised")
             if not can_be_revised(config, db_engine, submission_row):
                 continue
-            if not is_flatfile_data_changed(config, db_engine, submission_row):
+            if not has_assembly_data_changed(config, db_engine, submission_row):
+                # Do not revise assembly if there are no changes
                 update_assembly_results_with_latest_version(db_engine, seq_key)
                 continue
 

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -377,8 +377,10 @@ def has_assembly_data_changed(
     config: Config, db_engine: Engine, submission_row: SubmissionTableEntry
 ) -> bool:
     """
-    Check if there have been changes in the: sequence, flatfile or manifest
-    (if config.allow_revision_with_manifest_changes is true) metadata since last version.
+    Check if there have been changes since last version in: 
+    - sequence
+    - flatfile
+    - manifest metadata (iff config.allow_revision_with_manifest_changes==True)
     """
     last_entry = get_last_entry(db_engine, submission_row.pkey)
 

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -41,8 +41,6 @@ from .notifications import SlackConfig, send_slack_notification, slack_conn_init
 from .submission_db_helper import (
     AccessionVersion,
     AssemblyTableEntry,
-    ProjectTableEntry,
-    SampleTableEntry,
     Status,
     StatusAll,
     SubmissionTableEntry,

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -377,7 +377,7 @@ def has_assembly_data_changed(
     config: Config, db_engine: Engine, submission_row: SubmissionTableEntry
 ) -> bool:
     """
-    Check if there have been changes since last version in: 
+    Check if there have been changes since last version in:
     - sequence
     - flatfile
     - manifest metadata (iff config.allow_revision_with_manifest_changes==True)

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -21,9 +21,12 @@ from .ena_submission_helper import (
     create_ena_assembly,
     create_flatfile,
     create_manifest,
-    get_authors,
     get_description,
     get_ena_analysis_process,
+    linked_accession_diff,
+    manifest_fields_diff,
+    resolve_manifest_field,
+    resolve_required_manifest_field,
     retry_failed_submissions_for_matching_errors,
     set_accession_does_not_exist_error,
 )
@@ -48,6 +51,7 @@ from .submission_db_helper import (
     find_conditions_in_db,
     find_errors_or_stuck_in_db,
     find_waiting_in_db,
+    get_last_entry,
     is_latest_revision,
     is_revision,
     previous_version,
@@ -103,66 +107,6 @@ def get_segment_order(unaligned_sequences: dict[str, str | None]) -> list[str]:
     return sorted(segment_order)
 
 
-def get_address(config: Config, submission_row: SubmissionTableEntry) -> str | None:
-    if not config.is_broker:
-        return None
-    try:
-        group_details = call_loculus.get_group_info(config, submission_row.seq_metadata["groupId"])
-    except Exception as e:
-        logger.error(
-            f"Failed to fetch group info for groupId={submission_row.seq_metadata['groupId']}\n"
-            f"{traceback.format_exc()}"
-        )
-        msg = (
-            "Failed to fetch group info from Loculus for group: "
-            f"{submission_row.seq_metadata['groupId']}, {e}"
-        )
-        raise RuntimeError(msg) from e
-    address = group_details.address
-    address_list = [
-        submission_row.center_name,  # corresponds to Loculus' "Institution" group field
-        address.city,
-        address.state,
-        address.country,
-    ]
-    address_string = ", ".join([x for x in address_list if x])
-    logger.debug("Created address from group_info")
-    return address_string
-
-
-def get_assembly_values_in_metadata(config: Config, metadata: dict[str, str]) -> dict[str, str]:
-    assembly_values = {}
-    for key in config.manifest_fields_mapping:
-        default = config.manifest_fields_mapping[key].default
-        loculus_fields = config.manifest_fields_mapping[key].loculus_fields
-        type = config.manifest_fields_mapping[key].type
-        function = config.manifest_fields_mapping[key].function
-        if type == "int":
-            if len(loculus_fields) != 1:
-                msg = (
-                    "Only one loculus field allowed for int type but found: len(loculus_fields): "
-                    f"{len(loculus_fields)} for key: {key}. Fields: {loculus_fields}."
-                )
-                raise ValueError(msg)
-            try:
-                value = str(int(metadata.get(loculus_fields[0])))  # type: ignore
-            except TypeError:
-                value = default  # type: ignore
-        else:
-            values = [
-                metadata.get(loculus_field)
-                for loculus_field in loculus_fields
-                if metadata.get(loculus_field)
-            ]
-            value = default or None if not values else ", ".join(values)  # type: ignore
-        if function == "reformat_authors":
-            value = get_authors(str(value))
-        if not config.is_broker and key == "authors":
-            continue
-        assembly_values[key] = value
-    return assembly_values
-
-
 def make_assembly_name(accession: str, version: int) -> str:
     """
     Create a unique assembly name based on accession, version and timestamp.
@@ -210,7 +154,7 @@ def create_manifest_object(
 
     flat_file = create_flatfile(config, metadata, ena_organism, unaligned_nucleotide_sequences, dir)
 
-    assembly_values = get_assembly_values_in_metadata(config, metadata)
+    assembly_manifest_fields_mapping = config.assembly_manifest_fields_mapping
 
     try:
         manifest = AssemblyManifest(
@@ -221,8 +165,26 @@ def create_manifest_object(
             chromosome_list=chromosome_list_file,
             description=get_description(config, metadata),
             moleculetype=ena_organism.molecule_type,
-            **assembly_values,  # type: ignore
-            address=get_address(config, submission_row),
+            platform=resolve_required_manifest_field(
+                assembly_manifest_fields_mapping["platform"], metadata
+            ),
+            program=resolve_required_manifest_field(
+                assembly_manifest_fields_mapping["program"], metadata
+            ),
+            coverage=resolve_required_manifest_field(
+                assembly_manifest_fields_mapping["coverage"], metadata
+            ),
+            authors=resolve_manifest_field(assembly_manifest_fields_mapping["authors"], metadata)
+            if config.is_broker
+            else None,
+            run_ref=resolve_manifest_field(assembly_manifest_fields_mapping["run_ref"], metadata),
+            address=call_loculus.get_address(
+                config,
+                submission_row.center_name,  # type: ignore
+                submission_row.seq_metadata["groupId"],
+            )
+            if config.is_broker
+            else None,
         )
     except Exception as e:
         # log traceback for better debugging
@@ -351,27 +313,9 @@ def manifest_fields_changed(
     submission_row: SubmissionTableEntry,
     last_version_entry: SubmissionTableEntry,
 ) -> bool:
-    differing_fields = {}
-    for mapping in config.manifest_fields_mapping.values():
-        loculus_field_names = mapping.loculus_fields
-        for loculus_field_name in loculus_field_names:
-            last_entry = last_version_entry.seq_metadata.get(loculus_field_name)
-            new_entry = submission_row.seq_metadata.get(loculus_field_name)
-            if loculus_field_name == "authors":
-                try:
-                    last_entry = get_authors(last_entry) if last_entry else last_entry
-                    new_entry = get_authors(new_entry) if new_entry else new_entry
-                except Exception as e:
-                    logger.error(
-                        f"Error formatting authors field for comparison: {e}. "
-                        f"Traceback: {traceback.format_exc()}"
-                    )
-                    differing_fields[loculus_field_name] = (
-                        f"Last: {last_entry}, New: {new_entry}, Error reformatting: {e}"
-                    )
-                    continue
-            if last_entry != new_entry:
-                differing_fields[loculus_field_name] = f"Last: {last_entry}, New: {new_entry}, "
+    differing_fields = manifest_fields_diff(
+        config.assembly_manifest_fields_mapping, submission_row, last_version_entry
+    )
     if differing_fields:
         error = (
             "Assembly cannot be revised because metadata fields in manifest would change from "
@@ -400,17 +344,7 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
     seq_key = submission_row.pkey
     if not is_latest_revision(db_engine, seq_key):
         return False
-    version_to_revise = previous_version(db_engine, seq_key)
-    last_version_rows = find_conditions_in_db(
-        db_engine,
-        SubmissionTableEntry,
-        conditions={"accession": submission_row.accession, "version": version_to_revise},
-    )
-    if len(last_version_rows) == 0:
-        error_msg = f"Last version {version_to_revise} not found in submission_table"
-        raise RuntimeError(error_msg)
-
-    last_version_entry = last_version_rows[0]
+    last_version_entry = get_last_entry(db_engine, seq_key)
 
     previous_sample_accession, previous_study_accession = get_project_and_sample_results(
         db_engine, last_version_entry
@@ -419,36 +353,19 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
         f"Previous sample accession: {previous_sample_accession}, "
         f"previous study accession: {previous_study_accession}"
     )
-    if submission_row.seq_metadata.get("biosampleAccession"):
-        new_sample_accession = submission_row.seq_metadata["biosampleAccession"]
-        if previous_sample_accession != new_sample_accession:
-            error = (
-                "Assembly cannot be revised because biosampleAccession in new version: "
-                f"{new_sample_accession} differs from last version: {previous_sample_accession}"
-            )
-            logger.error(error)
-            update_assembly_error(
-                db_engine,
-                [error],
-                seq_key=asdict(submission_row.pkey),
-                update_type="revision",
-            )
-            return False
-    if submission_row.seq_metadata.get("bioprojectAccession"):
-        new_project_accession = submission_row.seq_metadata["bioprojectAccession"]
-        if new_project_accession != previous_study_accession:
-            error = (
-                "Assembly cannot be revised because bioprojectAccession in new version: "
-                f"{new_project_accession} differs from last version: {previous_study_accession}"
-            )
-            logger.error(error)
-            update_assembly_error(
-                db_engine,
-                [error],
-                seq_key=asdict(submission_row.pkey),
-                update_type="revision",
-            )
-            return False
+    linked_accession_mismatches = linked_accession_diff(
+        submission_row, previous_sample_accession, previous_study_accession
+    )
+    if linked_accession_mismatches:
+        error = (
+            "Assembly cannot be revised because linked accessions in new version differ from "
+            f"last version: {json.dumps(linked_accession_mismatches)}"
+        )
+        logger.error(error)
+        update_assembly_error(
+            db_engine, [error], seq_key=asdict(submission_row.pkey), update_type="revision"
+        )
+        return False
     if config.allow_revision_with_manifest_changes:
         logger.debug(
             "allow_revision_with_manifest_changes=True, skipping manifest field comparison"
@@ -457,27 +374,18 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
     return not manifest_fields_changed(config, db_engine, submission_row, last_version_entry)
 
 
-def is_flatfile_data_changed(db_engine: Engine, submission_row: SubmissionTableEntry) -> bool:
+def is_flatfile_data_changed(
+    config: Config, db_engine: Engine, submission_row: SubmissionTableEntry
+) -> bool:
     """
     Check if change in sequence or flatfile metadata has occurred since last version.
     """
-    seq_key = submission_row.pkey
-    version_to_revise = previous_version(db_engine, seq_key)
-    last_version_rows = find_conditions_in_db(
-        db_engine,
-        SubmissionTableEntry,
-        conditions={"accession": seq_key.accession, "version": version_to_revise},
-    )
-    if len(last_version_rows) == 0:
-        error_msg = f"Last version {version_to_revise} not found in submission_table"
-        raise RuntimeError(error_msg)
-
-    last_entry = last_version_rows[0]
+    last_entry = get_last_entry(db_engine, submission_row.pkey)
 
     if submission_row.unaligned_nucleotide_sequences != last_entry.unaligned_nucleotide_sequences:
         logger.debug(
-            f"Unaligned nucleotide sequences have changed for {seq_key.accession}, "
-            f"from {version_to_revise} to {seq_key.version} - should be revised"
+            f"Unaligned nucleotide sequences have changed for {submission_row.accession}, "
+            f"from {last_entry.version} to {submission_row.version} - should be revised"
             "(Metadata maybe also changed.)"
         )
         return True
@@ -497,8 +405,16 @@ def is_flatfile_data_changed(db_engine: Engine, submission_row: SubmissionTableE
                 f"for {submission_row.accession}. (Maybe other fields changed as well)"
             )
             return True
+    if config.allow_revision_with_manifest_changes and manifest_fields_diff(
+        config.assembly_manifest_fields_mapping, submission_row, last_entry
+    ):
+        logger.debug(
+            f"Manifest fields have changed for {submission_row.accession}, "
+            f"from {last_entry.version} to {submission_row.version} - should be revised"
+        )
+        return True
     logger.debug(
-        f"No changes detected for {submission_row.accession} from version {version_to_revise} "
+        f"No changes detected for {submission_row.accession} from version {last_entry.version} "
         f"to {submission_row.version}"
     )
     return False
@@ -604,7 +520,7 @@ def assembly_table_create(db_engine: Engine, config: Config):
             logger.debug(f"Entry {row.accession} is a revision, checking if it can be revised")
             if not can_be_revised(config, db_engine, submission_row):
                 continue
-            if not is_flatfile_data_changed(db_engine, submission_row):
+            if not is_flatfile_data_changed(config, db_engine, submission_row):
                 update_assembly_results_with_latest_version(db_engine, seq_key)
                 continue
 

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -501,7 +501,14 @@ def assembly_table_create(db_engine: Engine, config: Config):
             )
             manifest_file = create_manifest(manifest_object, is_broker=config.is_broker)
         except Exception as e:
-            logger.error(f"Manifest creation failed for accession {row.accession} with error {e}")
+            error_msg = f"Manifest creation failed for accession {row.accession} with error {e}"
+            logger.error(error_msg)
+            update_assembly_error(
+                db_engine,
+                [error_msg],
+                seq_key=asdict(row.pkey),
+                update_type="creation",
+            )
             continue
 
         update_values: dict[str, Any] = {"status": Status.SUBMITTING}

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -52,6 +52,7 @@ from .submission_db_helper import (
     find_errors_or_stuck_in_db,
     find_waiting_in_db,
     get_last_entry,
+    get_project_and_sample_results,
     is_latest_revision,
     is_revision,
     previous_version,
@@ -448,39 +449,6 @@ def update_assembly_results_with_latest_version(db_engine: Engine, seq_key: Acce
         model_class=AssemblyTableEntry,
         reraise=False,
     )
-
-
-def get_project_and_sample_results(
-    db_engine: Engine, submission_row: SubmissionTableEntry
-) -> tuple[str, str]:
-    seq_key = {"accession": submission_row.accession, "version": submission_row.version}
-
-    sample_rows = find_conditions_in_db(db_engine, SampleTableEntry, conditions=seq_key)
-    if len(sample_rows) == 0:
-        error_msg = f"Entry {submission_row.accession} not found in sample_table"
-        raise RuntimeError(error_msg)
-
-    project_rows = find_conditions_in_db(
-        db_engine,
-        ProjectTableEntry,
-        conditions={"project_id": submission_row.project_id},
-    )
-    if len(project_rows) == 0:
-        error_msg = f"Entry {submission_row.accession} not found in project_table"
-        raise RuntimeError(error_msg)
-    sample_accession = (
-        sample_rows[0].result.get("ena_sample_accession") if sample_rows[0].result else None
-    )
-    study_accession = (
-        project_rows[0].result.get("bioproject_accession") if project_rows[0].result else None
-    )
-    if not sample_accession or not study_accession:
-        error_msg = (
-            f"Missing sample_accession or study_accession for accession {submission_row.accession} "
-            "cannot create manifest"
-        )
-        raise RuntimeError(error_msg)
-    return cast(str, sample_accession), cast(str, study_accession)
 
 
 def assembly_table_create(db_engine: Engine, config: Config):

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -8,9 +8,10 @@ import re
 import string
 import subprocess  # noqa: S404
 import tempfile
+import traceback
 from collections import defaultdict
 from collections.abc import Iterable, Sequence
-from dataclasses import Field, asdict, dataclass, is_dataclass
+from dataclasses import Field, asdict, dataclass, fields, is_dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, ClassVar, Final, Literal, Protocol
@@ -34,7 +35,7 @@ from tenacity import (
 )
 from unidecode import unidecode
 
-from ena_deposition.config import Config, EnaOrganismDetails
+from ena_deposition.config import Config, EnaOrganismDetails, ManifestFieldDetails
 
 from .ena_types import (
     DEFAULT_EMBL_PROPERTY_FIELDS,
@@ -55,6 +56,7 @@ from .submission_db_helper import (
     ProjectTableEntry,
     SampleTableEntry,
     Status,
+    SubmissionTableEntry,
     add_to_assembly_table,
     update_db_where_conditions,
     update_with_retry,
@@ -519,50 +521,106 @@ def create_manifest(
     Creates a temp manifest file:
     https://ena-docs.readthedocs.io/en/latest/submit/assembly/genome.html#manifest-files
     """
+    if not manifest.fasta and not manifest.flatfile:
+        msg = "Either fasta or flatfile must be provided"
+        raise ValueError(msg)
+
     if dir:
         os.makedirs(dir, exist_ok=True)
         filename = os.path.join(dir, "manifest.tsv")
     else:
         with tempfile.NamedTemporaryFile(delete=False, suffix=".tsv") as temp:
             filename = temp.name
-    if not manifest.fasta and not manifest.flatfile:
-        msg = "Either fasta or flatfile must be provided"
-        raise ValueError(msg)
+
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(f"STUDY\t{manifest.study}\n")
-        f.write(f"SAMPLE\t{manifest.sample}\n")
-        f.write(
-            f"ASSEMBLYNAME\t{manifest.assemblyname}\n"
-        )  # This is the alias that needs to be unique
-        f.write(f"ASSEMBLY_TYPE\t{manifest.assembly_type!s}\n")
-        f.write(f"COVERAGE\t{manifest.coverage}\n")
-        f.write(f"PROGRAM\t{manifest.program}\n")
-        f.write(f"PLATFORM\t{manifest.platform}\n")
-        if manifest.flatfile:
-            f.write(f"FLATFILE\t{manifest.flatfile}\n")
-        if manifest.fasta:
-            f.write(f"FASTA\t{manifest.fasta}\n")
-        f.write(f"CHROMOSOME_LIST\t{manifest.chromosome_list}\n")
-        if manifest.description:
-            f.write(f"DESCRIPTION\t{manifest.description}\n")
-        if manifest.moleculetype:
-            f.write(f"MOLECULETYPE\t{manifest.moleculetype!s}\n")
-        if manifest.run_ref:
-            f.write(f"RUN_REF\t{manifest.run_ref}\n")
-        if manifest.authors:
-            if not is_broker:
-                logger.error("Cannot set authors field for non broker")
-                msg = "Cannot set authors field for non broker"
+        for field in fields(manifest):
+            value = getattr(manifest, field.name)
+            if value is None:
+                continue
+            if isinstance(value, list):
+                f.writelines(f"{field.name.upper()}\t{val}\n" for val in value)
+                continue
+            if field.name in {"authors", "address"} and not is_broker:
+                msg = f"Cannot set {field.name} field for non broker"
+                logger.error(msg)
                 raise ValueError(msg)
-            f.write(f"AUTHORS\t{manifest.authors}\n")
-        if manifest.address:
-            if not is_broker:
-                logger.error("Cannot set address field for non broker")
-                msg = "Cannot set address field for non broker"
-                raise ValueError(msg)
-            f.write(f"ADDRESS\t{manifest.address}\n")
+            f.write(f"{field.name.upper()}\t{value}\n")
 
     return filename
+
+
+def resolve_manifest_field(
+    field_details: ManifestFieldDetails, metadata: dict[str, Any]
+) -> str | None:
+    """Resolve an assembly manifest field's value from Loculus metadata per
+    config.assembly_manifest_fields_mapping, falling back to field_details.default if the
+    mapped Loculus fields are absent or empty."""
+    values = [metadata.get(loculus_field) for loculus_field in field_details.loculus_fields]
+
+    if field_details.function == "reformat_authors":
+        value = get_authors(values[0] or "")
+    else:
+        value = ", ".join(str(v) for v in values if v is not None) or None
+
+    if value is not None:
+        return value
+    return field_details.default
+
+
+def resolve_required_manifest_field(
+    field_details: ManifestFieldDetails, metadata: dict[str, Any]
+) -> str:
+    """Like resolve_manifest_field, but for required fields."""
+    value = resolve_manifest_field(field_details, metadata)
+    if value is None:
+        msg = (
+            "Manifest field resolved to None despite being required: "
+            f"loculus_fields={field_details.loculus_fields}, no default configured."
+        )
+        raise ValueError(msg)
+    return value
+
+
+def manifest_fields_diff(
+    assembly_manifest_fields_mapping: dict[str, ManifestFieldDetails],
+    submission_row: SubmissionTableEntry,
+    last_version_entry: SubmissionTableEntry,
+) -> dict[str, str]:
+    differing_fields = {}
+    for field, mapping in assembly_manifest_fields_mapping.items():
+        try:
+            last_value = resolve_manifest_field(mapping, last_version_entry.seq_metadata)
+            new_value = resolve_manifest_field(mapping, submission_row.seq_metadata)
+        except Exception as e:
+            logger.error(
+                f"Error resolving manifest field {field} for comparison: {e}. "
+                f"Traceback: {traceback.format_exc()}"
+            )
+            differing_fields[field] = f"Error resolving field: {e}"
+            continue
+        if last_value != new_value:
+            differing_fields[field] = f"Last: {last_value}, New: {new_value}, "
+    return differing_fields
+
+
+def linked_accession_diff(
+    submission_row: SubmissionTableEntry,
+    previous_sample_accession: str,
+    previous_study_accession: str,
+) -> dict[str, str]:
+    """If the submitter provided a biosampleAccession/bioprojectAccession (e.g. because reads
+    are linked to an already-existing sample/project), check it still matches the accession
+    used for the previous version."""
+    previous_accessions = {
+        "biosampleAccession": previous_sample_accession,
+        "bioprojectAccession": previous_study_accession,
+    }
+    differing_fields = {}
+    for field, previous_accession in previous_accessions.items():
+        new_accession = submission_row.seq_metadata.get(field)
+        if new_accession and new_accession != previous_accession:
+            differing_fields[field] = f"Last: {previous_accession}, New: {new_accession}"
+    return differing_fields
 
 
 def post_webin_cli(

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -196,7 +196,7 @@ def authors_to_ascii(authors: str) -> str:
     return "; ".join(formatted_author_list)
 
 
-def reformat_authors_from_loculus_to_embl_style(authors: str) -> str:
+def reformat_authors_from_loculus_to_embl_style(authors: str) -> str | None:
     """This function reformats the Loculus authors string to the format expected by ENA
     Loculus format: `Doe, John A.; Roe, Jane Britt C.`
     EMBL expected: `Doe J.A., Roe J.B.C.;`
@@ -214,7 +214,10 @@ def reformat_authors_from_loculus_to_embl_style(authors: str) -> str:
         last_names, first_names = author.split(",")[0].strip(), author.split(",")[1].strip()
         initials = "".join([name[0] + "." for name in first_names.split() if name])
         ena_authors.append(f"{last_names} {initials}".strip())
-    return authors_to_ascii(", ".join(ena_authors)) + ";"
+    ascii_authors = authors_to_ascii(", ".join(ena_authors))
+    if not ascii_authors:
+        return None
+    return ascii_authors + ";"
 
 
 def create_ena_project(config: Config, project_set: ProjectSet) -> CreationResult:
@@ -414,15 +417,15 @@ def get_description(config: Config, metadata: dict[str, str]) -> str:
     )
 
 
-def get_authors(authors: str) -> str:
+def get_authors(authors: str) -> str | None:
     try:
-        authors = reformat_authors_from_loculus_to_embl_style(authors)
+        formatted_authors = reformat_authors_from_loculus_to_embl_style(authors)
         logger.debug("Reformatted authors")
     except Exception as err:
         msg = f"Was unable to format authors: {authors} as ENA expects"
         logger.error(msg)
         raise ValueError(msg) from err
-    return authors
+    return formatted_authors
 
 
 def get_country(metadata: dict[str, str]) -> str:

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -560,7 +560,7 @@ def resolve_manifest_field(
     if field_details.function == "reformat_authors":
         value = get_authors(values[0] or "")
     else:
-        value = ", ".join(str(v) for v in values if v is not None) or None
+        value = ", ".join(str(v) for v in values if v) or None
 
     if value is not None:
         return value

--- a/ena-submission/src/ena_deposition/notifications.py
+++ b/ena-submission/src/ena_deposition/notifications.py
@@ -44,8 +44,12 @@ def slack_conn_init(
 
 def notify(config: SlackConfig, text: str):
     """Send slack notification using slack hook"""
-    if config.slack_hook:
+    if not config.slack_hook:
+        return
+    try:
         requests.post(config.slack_hook, data=json.dumps({"text": text}), timeout=10)
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Error sending slack notification: {e}")
 
 
 def upload_file_with_comment(

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -3,10 +3,10 @@ import os
 import re
 import typing
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
 from enum import StrEnum
-from typing import Any, Final
+from typing import Any, Final, cast
 
 import pytz
 from sqlalchemy import Engine, Enum, create_engine, delete, func, make_url, or_, select, update
@@ -562,3 +562,50 @@ def previous_version(engine: Engine, seq_key: AccessionVersion) -> int | None:
     )
     all_versions = sorted(row.version for row in rows)
     return all_versions[-2]
+
+
+def get_last_entry(db_engine: Engine, accession_version: AccessionVersion) -> SubmissionTableEntry:
+    version_to_revise = previous_version(db_engine, accession_version)
+    last_version_rows = find_conditions_in_db(
+        db_engine,
+        SubmissionTableEntry,
+        conditions={"accession": accession_version.accession, "version": version_to_revise},
+    )
+    if len(last_version_rows) == 0:
+        error_msg = f"Last version {version_to_revise} not found in submission_table"
+        raise RuntimeError(error_msg)
+
+    return last_version_rows[0]
+
+
+def get_project_and_sample_results(
+    db_engine: Engine, submission_row: SubmissionTableEntry
+) -> tuple[str, str]:
+    sample_rows = find_conditions_in_db(
+        db_engine, SampleTableEntry, conditions=asdict(submission_row.pkey)
+    )
+    if len(sample_rows) == 0:
+        error_msg = f"Entry {submission_row.accession} not found in sample_table"
+        raise RuntimeError(error_msg)
+
+    project_rows = find_conditions_in_db(
+        db_engine,
+        ProjectTableEntry,
+        conditions={"project_id": submission_row.project_id},
+    )
+    if len(project_rows) == 0:
+        error_msg = f"Entry {submission_row.accession} not found in project_table"
+        raise RuntimeError(error_msg)
+    sample_accession = (
+        sample_rows[0].result.get("ena_sample_accession") if sample_rows[0].result else None
+    )
+    study_accession = (
+        project_rows[0].result.get("bioproject_accession") if project_rows[0].result else None
+    )
+    if not sample_accession or not study_accession:
+        error_msg = (
+            f"Missing sample_accession or study_accession for accession {submission_row.accession} "
+            "cannot create manifest"
+        )
+        raise RuntimeError(error_msg)
+    return cast(str, sample_accession), cast(str, study_accession)

--- a/ena-submission/test/test_ena_submission.py
+++ b/ena-submission/test/test_ena_submission.py
@@ -29,6 +29,7 @@ from ena_deposition.ena_submission_helper import (
     get_chromsome_accessions,
     get_ena_analysis_process,
     get_sample_xml,
+    manifest_fields_diff,
     reformat_authors_from_loculus_to_embl_style,
 )
 from ena_deposition.ena_types import (
@@ -469,6 +470,52 @@ class AssemblyCreationTests(unittest.TestCase):
             "segment_order": ["main"],
         }
         self.assertEqual(response.result, desired_response)
+
+
+class ManifestFieldsDiffTests(unittest.TestCase):
+    def test_no_diff_for_identical_entries(self):
+        entry = sample_data_in_submission_table()
+
+        differing_fields = manifest_fields_diff(
+            MOCK_CONFIG.assembly_manifest_fields_mapping, entry, entry
+        )
+
+        self.assertEqual(differing_fields, {})
+
+    def test_diff_detected_when_mapped_field_changes(self):
+        # Neither entry has a usable "depthOfCoverage" value (missing vs. empty string), so
+        # "coverage" falls back to its configured default ("1") on both sides.
+        last_version_entry = sample_data_in_submission_table()
+        submission_row = sample_data_in_submission_table()
+        submission_row.seq_metadata = {
+            **submission_row.seq_metadata,
+            "sequencingInstrument": "Nanopore",
+            "depthOfCoverage": ""
+        }
+
+        differing_fields = manifest_fields_diff(
+            MOCK_CONFIG.assembly_manifest_fields_mapping, submission_row, last_version_entry
+        )
+
+        self.assertEqual(set(differing_fields), {"platform"})
+        self.assertIn("Illumina", differing_fields["platform"])
+        self.assertIn("Nanopore", differing_fields["platform"])
+        self.assertNotIn("coverage", differing_fields)
+
+    def test_diff_records_error_when_field_resolution_fails(self):
+        last_version_entry = sample_data_in_submission_table()
+        submission_row = sample_data_in_submission_table()
+        submission_row.seq_metadata = {
+            **submission_row.seq_metadata,
+            "authors": "Doe, John 中文",  # non-Latin characters are rejected
+        }
+
+        differing_fields = manifest_fields_diff(
+            MOCK_CONFIG.assembly_manifest_fields_mapping, submission_row, last_version_entry
+        )
+
+        self.assertIn("authors", differing_fields)
+        self.assertIn("Error resolving field", differing_fields["authors"])
 
 
 if __name__ == "__main__":

--- a/ena-submission/test/test_ena_submission.py
+++ b/ena-submission/test/test_ena_submission.py
@@ -490,7 +490,7 @@ class ManifestFieldsDiffTests(unittest.TestCase):
         submission_row.seq_metadata = {
             **submission_row.seq_metadata,
             "sequencingInstrument": "Nanopore",
-            "depthOfCoverage": ""
+            "depthOfCoverage": "",
         }
 
         differing_fields = manifest_fields_diff(

--- a/ena-submission/test/test_ena_submission.py
+++ b/ena-submission/test/test_ena_submission.py
@@ -83,9 +83,9 @@ def mock_config():
     config.metadata_mapping = {
         key: MetadataMapping(**item) for key, item in defaults["metadata_mapping"].items()
     }
-    config.manifest_fields_mapping = {
+    config.assembly_manifest_fields_mapping = {
         key: ManifestFieldDetails(**item)
-        for key, item in defaults["manifest_fields_mapping"].items()
+        for key, item in defaults["assembly_manifest_fields_mapping"].items()
     }
     config.ena_checklist = "ERC000033"
     config.set_alias_suffix = None

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -1078,12 +1078,26 @@ class TestKnownBioprojectAndIncorrectBioSample(TestSubmission):
 
 
 class TestRevisionAssemblyModificationTests(TestSubmission):
+    @pytest.mark.parametrize(
+        ("modify_assembly", "modify_manifest"),
+        [
+            pytest.param(True, False, id="assembly_field_changed"),
+            pytest.param(False, True, id="manifest_only_changed"),
+        ],
+    )
     @patch(
         "ena_deposition.upload_external_metadata_to_loculus.submit_external_metadata", autospec=True
     )
     @patch("ena_deposition.call_loculus.get_group_info", autospec=True)
-    def test_revise(self, mock_get_group_info: Mock, mock_submit_external_metadata: Mock) -> None:
+    def test_revise(
+        self,
+        mock_get_group_info: Mock,
+        mock_submit_external_metadata: Mock,
+        modify_assembly: bool,
+        modify_manifest: bool,
+    ) -> None:
         self.config.set_alias_suffix = "revision" + str(uuid.uuid4())
+        self.config.allow_revision_with_manifest_changes = True
         multi_segment_submission(
             self.db_engine, self.config, mock_get_group_info, mock_submit_external_metadata
         )
@@ -1091,7 +1105,9 @@ class TestRevisionAssemblyModificationTests(TestSubmission):
         # get data
         mock_get_group_info.return_value = TEST_GROUP
         mock_submit_external_metadata.return_value = mock_requests_post()
-        sequences_to_upload = get_revisions()
+        sequences_to_upload = get_revisions(
+            modify_assembly=modify_assembly, modify_manifest=modify_manifest
+        )
 
         # upload sequences
         upload_sequences(self.db_engine, sequences_to_upload)

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -466,7 +466,7 @@ def get_revisions(modify_manifest: bool = False, modify_assembly: bool = True) -
             else:
                 new_value["metadata"]["hostAge"] = "revised host age"
             if modify_manifest:
-                new_value["metadata"]["authors"] = "Author, Revised;"
+                new_value["metadata"]["sequencingInstrument"] = "Helicos HeliScope"
             revised_sequences[accession_version] = new_value
         return revised_sequences
 


### PR DESCRIPTION
refactor in preparation of https://github.com/loculus-project/loculus/pull/6816

- splits and moves some functions out of the assembly file into generic helper files so that functions can be reused in raw reads
- improves manifest creation code (raw reads also require a manifest with slightly different fields)
- fix bug in assembly revision code: if `allow_revision_with_manifest_changes` is true we also want the pipeline to revise assemblies automatically (instead of sending us a slack notification) if the manifest metadata changed. I added this to the ena workflow tests.

## Breaking Change
Technically `manifest_fields_mapping` has been renamed `assembly_manifest_fields_mapping` - however as Pathoplexus is the only user of the ENA code and we havent configured it there no changes are required.

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
I added additional unit tests for the manifest generation and manifest field diff code and additionally I added a new ena workflow test that covers the bug case (workflow tests talk to ENA dev directly, sadly ENA dev does not process assemblies so part of the full process can only be covered in production code but the workflow tests document this)

🚀 Preview: Add `preview` label to enable