### PR TITLE
feat(website): improve bulk submission docs and simplify fileMapping

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
@@ -108,8 +108,9 @@ class FilesController(
         description =
         "Requests S3 pre-signed URLs to upload files. The endpoint returns a list of file IDs and URLs. " +
             "The URLs should be used to upload the files via HTTP PUT, including all headers listed in the " +
-            "`headers` field of each response entry. Afterwards, the file IDs can be used in the " +
-            "`fileMapping` in the /submit endpoint. " +
+            "`headers` field of each response entry. Afterwards, the file IDs can be attached to the metadata " +
+            "in the `files.<fileCategory>` column, each entry should consist of a space-separated list of files" +
+            "associated with the entry, supplied as <fileName>:<fileId>. " +
             "Note: the presigned URL includes an `If-None-Match: *` condition to prevent accidental " +
             "overwrites. If the file ID has already been uploaded to, S3 will return HTTP 412 " +
             "(Precondition Failed) - this means the file already exists and cannot be overwritten.",
@@ -152,7 +153,7 @@ class FilesController(
         "Requests S3 pre-signed URLs to upload files using multipart upload. The endpoint returns a list of " +
             "file IDs and, for each file ID, a list of URLs. The URLs should be used to upload the parts " +
             "and the upload should then be completed using the /complete-multipart-upload endpoint. " +
-            "Afterwards, the file IDs can be used in the `fileMapping` in the /submit endpoint.",
+            "Afterwards, the file IDs can be attached to the metadata in the `files.<fileCategory>` column.",
     )
     @PostMapping("/request-multipart-upload")
     fun requestMultipartUploads(

--- a/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
@@ -109,7 +109,7 @@ class FilesController(
         "Requests S3 pre-signed URLs to upload files. The endpoint returns a list of file IDs and URLs. " +
             "The URLs should be used to upload the files via HTTP PUT, including all headers listed in the " +
             "`headers` field of each response entry. Afterwards, the file IDs can be attached to the metadata " +
-            "in the `files.<fileCategory>` column, each entry should consist of a space-separated list of files" +
+            "in the `files.<fileCategory>` column, each entry should consist of a space-separated list of files " +
             "associated with the entry, supplied as <fileName>:<fileId>. " +
             "Note: the presigned URL includes an `If-None-Match: *` condition to prevent accidental " +
             "overwrites. If the file ID has already been uploaded to, S3 will return HTTP 412 " +

--- a/docs/src/content/docs/for-users/submit-extra-files.md
+++ b/docs/src/content/docs/for-users/submit-extra-files.md
@@ -154,22 +154,20 @@ you can proceed to attach the file ID to your submission as described in the nex
 ### Attach file IDs to submission
 
 Now, you can follow the regular steps for [sequence submission](../submit-sequences/), calling the `/<organism>/submit` endpoint.
-But you add another parameter to the curl call:
+Files are attached by adding a `files.<fileCategory>` column to the metadata TSV file for each file category you want to submit files for.
 
-```bash
-  -F 'fileMapping=<mapping JSON>'
+The `fileCategory` needs to be a predefined category which is organism specific, e.g. a column named `files.rawReads`.
+
+The cell value for a given submission ID is a space-separated list of `fileName:fileId` pairs, e.g.:
+
+```
+files.rawReads
+reads_1.fq:8D8AC610-566D-4EF0-9C22-186B2A5ED793 reads_2.fq:2ea137d0-8773-4e0a-a9aa-5591de12ff23
 ```
 
-And the `mapping JSON` has this structure:
-
-```json
-{submissionID: {<fileCategory>: [{fileId: <fileId>, name: <fileName>}]}}
-```
-
-- The `submissionID` links the file mapping to the sequence.
-- The `fileCategory` needs to be a predefined category which is organism specific.
 - The `fileId` is the ID received in the previous step, which identifies the actual file.
 - The `fileName` can be chosen freely, but depending on configuration it might become an identifier for the file later on.
+- Cells may be left empty for submission IDs that don't have files in that category.
 
 ## Filename restrictions
 

--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -20,8 +20,8 @@ import { SequenceEntryHistoryMenu } from '../SequenceDetailsPage/SequenceEntryHi
 import { ExtraFilesUpload } from '../Submission/DataUploadForm.tsx';
 import {
     applyFileMappings,
+    toSingleSubmissionFileMapping,
     type FileMapping,
-    type ResolvedSubmissionFile,
 } from '../Submission/FileUpload/fileMapping.ts';
 import { Button } from '../common/Button';
 import ErrorBox from '../common/ErrorBox';
@@ -68,13 +68,13 @@ const InnerEditPage: FC<EditPageProps> = ({
     );
 
     const extraFilesEnabled = submissionDataTypes.files?.enabled ?? false;
-    const [fileMapping, setFileMapping] = useState<FileMapping<ResolvedSubmissionFile> | undefined>(() => {
+    const [fileMapping, setFileMapping] = useState<FileMapping | undefined>(() => {
         const previousFiles = dataToEdit.submittedData.files;
         if (!previousFiles) return undefined;
         return new Map(
             Object.entries(previousFiles).map(([category, files]) => [
                 category,
-                files.map((file) => ({ name: file.name, path: file.name, fileId: file.fileId })),
+                new Map(files.map((file) => [file.name, file.fileId])),
             ]),
         );
     });
@@ -113,7 +113,7 @@ const InnerEditPage: FC<EditPageProps> = ({
             let finalMetadataFile = metadataFile;
 
             if (extraFilesEnabled && fileMapping !== undefined) {
-                const finalSubmissionFileMapping = new Map([[dataToEdit.submissionId, fileMapping]]);
+                const finalSubmissionFileMapping = toSingleSubmissionFileMapping(dataToEdit.submissionId, fileMapping);
                 const finalMetadataFileResult = await applyFileMappings(metadataFile, finalSubmissionFileMapping);
                 if (finalMetadataFileResult.isErr()) {
                     toast.error(finalMetadataFileResult.error.message, { position: 'top-center', autoClose: false });
@@ -146,7 +146,7 @@ const InnerEditPage: FC<EditPageProps> = ({
                     ? Object.fromEntries(
                           [...fileMapping].map(([category, files]) => [
                               category,
-                              [...files.values()].map((file) => ({ fileId: file.fileId, name: file.name })),
+                              [...files.entries()].map(([path, fileId]) => ({ fileId, name: path })),
                           ]),
                       )
                     : null;

--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -74,7 +74,7 @@ const InnerEditPage: FC<EditPageProps> = ({
         return new Map(
             Object.entries(previousFiles).map(([category, files]) => [
                 category,
-                new Map(files.map((file) => [file.name, { name: file.name, path: file.name, fileId: file.fileId }])),
+                files.map((file) => ({ name: file.name, path: file.name, fileId: file.fileId })),
             ]),
         );
     });

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -32,12 +32,13 @@ import {
     applyFileMappings,
     resolveFileMappings,
     getLinkageErrors,
+    toSingleSubmissionFileMapping,
     type CategoryLinkage,
     type FileLinkage,
     type FileMapping,
-    type ResolvedSubmissionFile,
     type SubmissionFile,
     type SubmissionFileMapping,
+    type UploadedFile,
 } from './FileUpload/fileMapping.ts';
 
 export type UploadAction = 'submit' | 'revise';
@@ -77,7 +78,7 @@ const InnerDataUploadForm = ({
 
     const { submit, revise, isPending } = useSubmitFiles(accessToken, organism, clientConfig, onSuccess, onError);
     const [fileFactory, setFileFactory] = useState<FileFactory | undefined>(undefined);
-    const [fileMapping, setFileMapping] = useState<FileMapping<ResolvedSubmissionFile> | undefined>(undefined);
+    const [fileMapping, setFileMapping] = useState<FileMapping | undefined>(undefined);
     const [submissionFileMapping, setSubmissionFileMapping] = useState<
         Result<SubmissionFileMapping, Error> | undefined
     >(undefined);
@@ -130,7 +131,7 @@ const InnerDataUploadForm = ({
         if (extraFilesEnabled) {
             if (inputMode === 'form') {
                 if (fileMapping !== undefined) {
-                    const finalSubmissionFileMapping = new Map([[submissionId!, fileMapping]]);
+                    const finalSubmissionFileMapping = toSingleSubmissionFileMapping(submissionId!, fileMapping);
                     const finalMetadataFileResult = await applyFileMappings(metadataFile, finalSubmissionFileMapping);
                     if (finalMetadataFileResult.isErr()) {
                         onError(finalMetadataFileResult.error.message);
@@ -335,7 +336,13 @@ export const InputModeTabs = ({
 const CategoryLinkageStatus = ({ categoryLinkage }: { categoryLinkage: CategoryLinkage | undefined }) => {
     if (categoryLinkage === undefined) return null;
 
-    const statuses: { key: string; icon: string; color: string; files: SubmissionFile[]; message: string }[] = [
+    const statuses: {
+        key: string;
+        icon: string;
+        color: string;
+        files: (SubmissionFile | UploadedFile)[];
+        message: string;
+    }[] = [
         {
             key: 'linked',
             icon: '✓',
@@ -396,8 +403,8 @@ export const ExtraFilesUpload = ({
     inputMode: InputMode;
     groupId: number;
     fileCategories: FileCategory[];
-    fileMapping: FileMapping<ResolvedSubmissionFile> | undefined;
-    setFileMapping: Dispatch<SetStateAction<FileMapping<ResolvedSubmissionFile> | undefined>>;
+    fileMapping: FileMapping | undefined;
+    setFileMapping: Dispatch<SetStateAction<FileMapping | undefined>>;
     fileLinkage?: FileLinkage;
     onError: (message: string) => void;
 }) => {

--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.spec.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.spec.tsx
@@ -48,10 +48,10 @@ const defaultProps = {
     onError: mockOnError,
 };
 
-// The fileMapping is keyed by category, then by file path. Previous uploads have no upload path,
-// so (within a single entry, where names are unique) they are keyed by and carry a path of their name.
+// The fileMapping is keyed by category, then a list of files. Previous uploads have no upload path,
+// so (within a single entry, where names are unique) they carry a path equal to their name.
 const fileMappingOf = (files: { fileId: string; name: string }[]) =>
-    new Map([['extraFiles', new Map(files.map((f) => [f.name, { name: f.name, path: f.name, fileId: f.fileId }]))]]);
+    new Map([['extraFiles', files.map((f) => ({ name: f.name, path: f.name, fileId: f.fileId }))]]);
 
 const defaultPropsWithFiles = {
     ...defaultProps,
@@ -93,7 +93,7 @@ describe('FolderUploadComponent', () => {
                 <FolderUploadComponent
                     {...defaultProps}
                     inputMode='form'
-                    fileMapping={new Map([['extraFiles', new Map()]])}
+                    fileMapping={new Map([['extraFiles', []]])}
                 />,
             );
 

--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.spec.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.spec.tsx
@@ -48,10 +48,10 @@ const defaultProps = {
     onError: mockOnError,
 };
 
-// The fileMapping is keyed by category, then a list of files. Previous uploads have no upload path,
-// so (within a single entry, where names are unique) they carry a path equal to their name.
+// The fileMapping is keyed by category, then by file path, to its file ID. Previous uploads have no
+// upload path, so (within a single entry, where names are unique) they are keyed by their name.
 const fileMappingOf = (files: { fileId: string; name: string }[]) =>
-    new Map([['extraFiles', files.map((f) => ({ name: f.name, path: f.name, fileId: f.fileId }))]]);
+    new Map([['extraFiles', new Map(files.map((f) => [f.name, f.fileId]))]]);
 
 const defaultPropsWithFiles = {
     ...defaultProps,
@@ -93,7 +93,7 @@ describe('FolderUploadComponent', () => {
                 <FolderUploadComponent
                     {...defaultProps}
                     inputMode='form'
-                    fileMapping={new Map([['extraFiles', []]])}
+                    fileMapping={new Map([['extraFiles', new Map()]])}
                 />,
             );
 
@@ -257,9 +257,7 @@ describe('FolderUploadComponent', () => {
             expect(screen.getByText('file-b.txt')).toBeInTheDocument();
 
             const mapping = latestReportedMapping(defaultPropsWithFiles.fileMapping);
-            expect([...mapping!.get('extraFiles')!.values()]).toEqual([
-                { name: 'file-b.txt', path: 'file-b.txt', fileId: 'file-2' },
-            ]);
+            expect([...mapping!.get('extraFiles')!.entries()]).toEqual([['file-b.txt', 'file-2']]);
         });
 
         it('files are discarded by path, not by name', async () => {
@@ -282,8 +280,8 @@ describe('FolderUploadComponent', () => {
             await waitFor(() => expect(screen.getAllByText('a.txt')).toHaveLength(1));
             expect(screen.getByText('sub2 /')).toBeInTheDocument();
             expect(screen.queryByText('sub1 /')).not.toBeInTheDocument();
-            expect([...latestReportedMapping(undefined)!.get('extraFiles')!.values()]).toEqual([
-                { name: 'a.txt', path: 'sub2/a.txt', fileId: 'file-2' },
+            expect([...latestReportedMapping(undefined)!.get('extraFiles')!.entries()]).toEqual([
+                ['sub2/a.txt', 'file-2'],
             ]);
         });
 
@@ -358,9 +356,9 @@ describe('FolderUploadComponent', () => {
             expect(screen.getAllByText('(uploaded)')).toHaveLength(1);
 
             const categoryFiles = latestReportedMapping(defaultPropsWithFiles.fileMapping)!.get('extraFiles')!;
-            expect([...categoryFiles.values()]).toEqual([
-                { name: 'file-b.txt', path: 'file-b.txt', fileId: 'file-2' },
-                { name: 'file-a.txt', path: 'file-a.txt', fileId: 'replacement-id' },
+            expect([...categoryFiles.entries()]).toEqual([
+                ['file-b.txt', 'file-2'],
+                ['file-a.txt', 'replacement-id'],
             ]);
         });
 

--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
@@ -41,14 +41,12 @@ type UploadStatus = 'pending' | 'uploaded' | 'previousUpload' | 'error';
 type Awaiting = {
     type: 'awaiting';
     file: File;
-    name: string;
     path: string;
 };
 
 type Pending = {
     type: 'pending';
     file: File;
-    name: string;
     path: string;
     size: number;
     fileId: string;
@@ -62,7 +60,6 @@ type Pending = {
 type Uploaded = {
     type: 'uploaded';
     fileId: string;
-    name: string;
     path: string;
     size: number;
 };
@@ -70,13 +67,11 @@ type Uploaded = {
 type PreviousUpload = {
     type: 'previousUpload';
     fileId: string;
-    name: string;
     path: string;
 };
 
 type FileError = {
     type: 'error';
-    name: string;
     path: string;
     size: number;
     msg: string;
@@ -158,7 +153,6 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
         const files: PreviousUpload[] = [...categoryFiles.entries()].map(([path, fileId]) => ({
             type: 'previousUpload',
             fileId,
-            name: path.split('/').pop() ?? path,
             path,
         }));
         return { type: 'uploadCompleted', files };
@@ -189,11 +183,10 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
                     draft.files = draft.files.map((file) => {
                         if (file.type === 'pending' && file.fileId === fileId) {
                             if (newStatus === 'uploaded') {
-                                return { type: 'uploaded', fileId, name: file.name, path: file.path, size: file.size };
+                                return { type: 'uploaded', fileId, path: file.path, size: file.size };
                             } else {
                                 return {
                                     type: 'error',
-                                    name: file.name,
                                     path: file.path,
                                     size: file.size,
                                     msg: errorMsg!,
@@ -234,7 +227,7 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
                 await uploadMultipartFile(pending);
             } catch (err) {
                 onError(
-                    `Upload failed for file ${pending.fileId} ${pending.name}: ${err instanceof Error ? err.message : String(err)}`,
+                    `Upload failed for file ${pending.fileId} ${pending.path}: ${err instanceof Error ? err.message : String(err)}`,
                 );
                 return;
             }
@@ -251,7 +244,6 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
                     pendingFiles.push({
                         type: 'pending',
                         file: file.file,
-                        name: file.name,
                         path: file.path,
                         size: file.file.size,
                         fileId: data[0].fileId,
@@ -329,7 +321,6 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
                 files: filesArray.map((f) => ({
                     type: 'awaiting',
                     file: f,
-                    name: f.name,
                     // Assign the path without the parent folder
                     path: f.webkitRelativePath.split('/').slice(1).join('/'),
                 })),
@@ -358,7 +349,6 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
             const awaiting: Awaiting[] = Array.from(e.target.files).map((f) => ({
                 type: 'awaiting',
                 file: f,
-                name: f.name,
                 path: f.name,
             }));
 
@@ -400,7 +390,7 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
                 displayConfirmationDialog({
                     dialogText:
                         'The following file(s) already exist and will be replaced: ' +
-                        collisions.map((file) => file.name).join(', '),
+                        collisions.map((file) => file.path).join(', '),
                     confirmButtonText: 'Replace',
                     onConfirmation: addFiles,
                 });
@@ -557,12 +547,13 @@ const FileListItem: FC<FileListeItemProps> = ({ file, fileCategory }) => {
 
 const FilePath: FC<{ file: SingleFileUpload }> = ({ file }) => {
     const folderPath = file.path.split('/').slice(0, -1);
+    const fileName = file.path.split('/').slice(-1)[0];
     return (
         <span title={file.path} className='text-xs flex items-center min-w-0'>
             {folderPath.length > 0 && (
                 <span className='text-gray-400 truncate max-w-[140px] mr-1'>{folderPath.join(' / ') + ' / '}</span>
             )}
-            <span className='text-gray-700 truncate max-w-[140px]'>{file.name}</span>
+            <span className='text-gray-700 truncate max-w-[140px]'>{fileName}</span>
         </span>
     );
 };

--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
@@ -2,7 +2,7 @@ import { produce } from 'immer';
 import React, { useEffect, useState, type Dispatch, type FC, type SetStateAction } from 'react';
 import { toast } from 'react-toastify';
 
-import { type FileMapping, type ResolvedSubmissionFile } from './fileMapping';
+import { type FileMapping } from './fileMapping';
 import useClientFlag from '../../../hooks/isClient';
 import { BackendClient } from '../../../services/backendClient';
 import { type FileCategory } from '../../../types/config';
@@ -90,8 +90,8 @@ type FolderUploadComponentProps = {
     accessToken: string;
     clientConfig: ClientConfig;
     groupId: number;
-    fileMapping: FileMapping<ResolvedSubmissionFile> | undefined;
-    setFileMapping: Dispatch<SetStateAction<FileMapping<ResolvedSubmissionFile> | undefined>>;
+    fileMapping: FileMapping | undefined;
+    setFileMapping: Dispatch<SetStateAction<FileMapping | undefined>>;
     onError: (message: string) => void;
 };
 
@@ -153,13 +153,13 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
 }) => {
     const [fileUploadState, setFileUploadState] = useState<FileUploadState | undefined>(() => {
         const categoryFiles = fileMapping?.get(fileCategory.name);
-        if (categoryFiles === undefined || categoryFiles.length === 0) return undefined;
+        if (categoryFiles === undefined || categoryFiles.size === 0) return undefined;
 
-        const files: PreviousUpload[] = categoryFiles.map((file) => ({
+        const files: PreviousUpload[] = [...categoryFiles.entries()].map(([path, fileId]) => ({
             type: 'previousUpload',
-            fileId: file.fileId,
-            name: file.name,
-            path: file.path,
+            fileId,
+            name: path.split('/').pop() ?? path,
+            path,
         }));
         return { type: 'uploadCompleted', files };
     });
@@ -304,11 +304,7 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
                     const newMapping = new Map(currentMapping);
                     newMapping.set(
                         fileCategory.name,
-                        fileUploadState.files.map((file) => ({
-                            name: file.name,
-                            path: file.path,
-                            fileId: file.fileId,
-                        })),
+                        new Map(fileUploadState.files.map((file) => [file.path, file.fileId])),
                     );
                     return newMapping;
                 });

--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
@@ -155,7 +155,7 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
         const categoryFiles = fileMapping?.get(fileCategory.name);
         if (categoryFiles === undefined || categoryFiles.length === 0) return undefined;
 
-        const files: PreviousUpload[] = [...categoryFiles.values()].map((file) => ({
+        const files: PreviousUpload[] = categoryFiles.map((file) => ({
             type: 'previousUpload',
             fileId: file.fileId,
             name: file.name,

--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
@@ -153,7 +153,7 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
 }) => {
     const [fileUploadState, setFileUploadState] = useState<FileUploadState | undefined>(() => {
         const categoryFiles = fileMapping?.get(fileCategory.name);
-        if (categoryFiles === undefined || categoryFiles.size === 0) return undefined;
+        if (categoryFiles === undefined || categoryFiles.length === 0) return undefined;
 
         const files: PreviousUpload[] = [...categoryFiles.values()].map((file) => ({
             type: 'previousUpload',
@@ -304,16 +304,11 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
                     const newMapping = new Map(currentMapping);
                     newMapping.set(
                         fileCategory.name,
-                        new Map(
-                            fileUploadState.files.map((file) => [
-                                file.path,
-                                {
-                                    name: file.name,
-                                    path: file.path,
-                                    fileId: file.fileId,
-                                },
-                            ]),
-                        ),
+                        fileUploadState.files.map((file) => ({
+                            name: file.name,
+                            path: file.path,
+                            fileId: file.fileId,
+                        })),
                     );
                     return newMapping;
                 });

--- a/website/src/components/Submission/FileUpload/fileMapping.spec.ts
+++ b/website/src/components/Submission/FileUpload/fileMapping.spec.ts
@@ -11,6 +11,7 @@ import {
     type ResolvedSubmissionFile,
     type SubmissionFile,
     type SubmissionFileMapping,
+    type UploadedFile,
 } from './fileMapping';
 
 const tsv = (rows: string[][]) => rows.map((row) => row.join('\t')).join('\n');
@@ -30,13 +31,31 @@ const errorOf = (text: string, categories: string[] = knownCategories): string =
     return result.error.message;
 };
 
-const fileMappingOf = <T extends SubmissionFile>(categories: Record<string, T[]>): FileMapping<T> =>
-    new Map(Object.entries(categories));
+const mapOf = <T extends SubmissionFile>(files: T[], keyFn: (file: T) => string): Map<string, T> =>
+    new Map(files.map((file) => [keyFn(file), file]));
 
+// Folder-upload fixtures are keyed by path, mirroring what FolderUploadComponent produces; a path's
+// value is just its file ID, since a name is always derivable from the path itself.
+const fileMappingOf = (categories: Record<string, UploadedFile[]>): FileMapping =>
+    new Map(
+        Object.entries(categories).map(([category, files]) => [
+            category,
+            new Map(files.map((f) => [f.path, f.fileId])),
+        ]),
+    );
+
+// Metadata fixtures are keyed by name, since that's a file entry's declared identity.
 const submissionMappingOf = <T extends SubmissionFile>(
     submissions: Record<string, Record<string, T[]>>,
 ): SubmissionFileMapping<T> =>
-    new Map(Object.entries(submissions).map(([submissionId, categories]) => [submissionId, fileMappingOf(categories)]));
+    new Map(
+        Object.entries(submissions).map(([submissionId, categories]) => [
+            submissionId,
+            new Map(
+                Object.entries(categories).map(([category, files]) => [category, mapOf(files, (file) => file.name)]),
+            ),
+        ]),
+    );
 
 const resolvedFileIdOf = (
     submissionFileMapping: SubmissionFileMapping<ResolvedSubmissionFile>,
@@ -44,10 +63,8 @@ const resolvedFileIdOf = (
     category: string,
     path: string,
 ): string | undefined =>
-    submissionFileMapping
-        .get(submissionId)
-        ?.get(category)
-        ?.find((f) => f.path === path)?.fileId;
+    [...(submissionFileMapping.get(submissionId)?.get(category)?.values() ?? [])].find((file) => file.path === path)
+        ?.fileId;
 
 describe('parseSubmissionFileMapping', () => {
     it('parses every accepted file entry form', () => {
@@ -137,12 +154,15 @@ describe('parseSubmissionFileMapping', () => {
         expect(errorOf(text)).toContain('Found duplicate file names for entry e1 in the raw category: a.txt');
     });
 
-    it('rejects duplicate file paths within one entry', () => {
+    it('allows two different names to share the same explicit path', () => {
         const text = tsv([
             ['id', 'files.raw'],
             ['e1', 'a.txt::x b.txt::x'],
         ]);
-        expect(errorOf(text)).toContain('Found duplicate file paths for entry e1 in the raw category: x');
+        expect(entriesOf(text, 'e1', 'raw')).toEqual([
+            { name: 'a.txt', path: 'x', fileId: undefined },
+            { name: 'b.txt', path: 'x', fileId: undefined },
+        ]);
     });
 
     it('omits the category entirely for an empty cell', () => {
@@ -170,7 +190,7 @@ describe('parseSubmissionFileMapping', () => {
 describe('resolveFileMappings', () => {
     const metadataEntry: SubmissionFile = { name: 'a.txt', path: 'a.txt' };
     const metadataEntryWithFileId: SubmissionFile = { name: 'a.txt', path: 'a.txt', fileId: 'existing-id' };
-    const uploadEntry: ResolvedSubmissionFile = { name: 'a.txt', path: 'a.txt', fileId: 'uploaded-id' };
+    const uploadEntry: UploadedFile = { path: 'a.txt', fileId: 'uploaded-id' };
     const emptyDetails = { linked: [], reused: [], missing: [], orphaned: [], shadowed: [] };
 
     describe('linked', () => {
@@ -220,7 +240,7 @@ describe('resolveFileMappings', () => {
 
     describe('missing', () => {
         it('when a metadata entry has no file ID and no upload folder entry on its path', () => {
-            const otherUpload: ResolvedSubmissionFile = { name: 'b.txt', path: 'b.txt', fileId: 'uploaded-b' };
+            const otherUpload: UploadedFile = { path: 'b.txt', fileId: 'uploaded-b' };
             const { submissionFileMapping, fileLinkage } = resolveFileMappings(
                 submissionMappingOf({ e1: { raw: [metadataEntry] } }),
                 fileMappingOf({ raw: [otherUpload] }),
@@ -242,7 +262,7 @@ describe('resolveFileMappings', () => {
     });
 
     describe('shadowed', () => {
-        it('when every metadata entry on the path has its own file ID', () => {
+        it('when every metadata entry on the path has its own file ID, so none of them claim the upload', () => {
             const { submissionFileMapping, fileLinkage } = resolveFileMappings(
                 submissionMappingOf({ e1: { raw: [metadataEntryWithFileId] } }),
                 fileMappingOf({ raw: [uploadEntry] }),
@@ -272,9 +292,13 @@ describe('resolveFileMappings', () => {
 
 describe('getLinkageErrors', () => {
     const file = (path: string): SubmissionFile => ({ name: path, path });
+    const upload = (path: string): UploadedFile => ({ path, fileId: `id-${path}` });
     const detailsOf = (missing: string[], orphaned: string[]) =>
         new Map([
-            ['raw', { linked: [], reused: [], missing: missing.map(file), orphaned: orphaned.map(file), shadowed: [] }],
+            [
+                'raw',
+                { linked: [], reused: [], missing: missing.map(file), orphaned: orphaned.map(upload), shadowed: [] },
+            ],
         ]);
 
     it('returns undefined when nothing is missing or orphaned', () => {
@@ -301,8 +325,8 @@ describe('getLinkageErrors', () => {
                     linked: [],
                     reused: [file('a.txt')],
                     missing: [],
-                    orphaned: [file('stray.txt')],
-                    shadowed: [file('a.txt')],
+                    orphaned: [upload('stray.txt')],
+                    shadowed: [upload('a.txt')],
                 },
             ],
         ]);
@@ -311,10 +335,17 @@ describe('getLinkageErrors', () => {
         );
     });
 
+    it('ignores linked and reused files', () => {
+        const fileLinkage = new Map([
+            ['raw', { linked: [upload('a.txt')], reused: [file('b.txt')], missing: [], orphaned: [], shadowed: [] }],
+        ]);
+        expect(getLinkageErrors(fileLinkage)).toBeUndefined();
+    });
+
     it('joins problems across categories', () => {
         const fileLinkage = new Map([
             ['raw', { linked: [], reused: [], missing: [file('a.txt')], orphaned: [], shadowed: [] }],
-            ['processed', { linked: [], reused: [], missing: [], orphaned: [file('b.json')], shadowed: [] }],
+            ['processed', { linked: [], reused: [], missing: [], orphaned: [upload('b.json')], shadowed: [] }],
         ]);
         expect(getLinkageErrors(fileLinkage)).toBe(
             `${getLinkageErrorMessage(LinkageType.MISSING, 'raw', 'a.txt')} ${getLinkageErrorMessage(LinkageType.ORPHANED, 'processed', 'b.json')}`,

--- a/website/src/components/Submission/FileUpload/fileMapping.spec.ts
+++ b/website/src/components/Submission/FileUpload/fileMapping.spec.ts
@@ -8,7 +8,6 @@ import {
     LinkageType,
     parseSubmissionFileMapping,
     type FileMapping,
-    type ResolvedSubmissionFile,
     type SubmissionFile,
     type SubmissionFileMapping,
     type UploadedFile,
@@ -31,9 +30,6 @@ const errorOf = (text: string, categories: string[] = knownCategories): string =
     return result.error.message;
 };
 
-const mapOf = <T extends SubmissionFile>(files: T[], keyFn: (file: T) => string): Map<string, T> =>
-    new Map(files.map((file) => [keyFn(file), file]));
-
 // Folder-upload fixtures are keyed by path, mirroring what FolderUploadComponent produces; a path's
 // value is just its file ID, since a name is always derivable from the path itself.
 const fileMappingOf = (categories: Record<string, UploadedFile[]>): FileMapping =>
@@ -52,19 +48,13 @@ const submissionMappingOf = <T extends SubmissionFile>(
         Object.entries(submissions).map(([submissionId, categories]) => [
             submissionId,
             new Map(
-                Object.entries(categories).map(([category, files]) => [category, mapOf(files, (file) => file.name)]),
+                Object.entries(categories).map(([category, files]) => [
+                    category,
+                    new Map(files.map((file) => [file.name, file])),
+                ]),
             ),
         ]),
     );
-
-const resolvedFileIdOf = (
-    submissionFileMapping: SubmissionFileMapping<ResolvedSubmissionFile>,
-    submissionId: string,
-    category: string,
-    path: string,
-): string | undefined =>
-    [...(submissionFileMapping.get(submissionId)?.get(category)?.values() ?? [])].find((file) => file.path === path)
-        ?.fileId;
 
 describe('parseSubmissionFileMapping', () => {
     it('parses every accepted file entry form', () => {
@@ -200,7 +190,7 @@ describe('resolveFileMappings', () => {
                 fileMappingOf({ raw: [uploadEntry] }),
             );
             expect(fileLinkage.get('raw')).toEqual({ ...emptyDetails, linked: [uploadEntry] });
-            expect(resolvedFileIdOf(submissionFileMapping, 'e1', 'raw', 'a.txt')).toBe('uploaded-id');
+            expect(submissionFileMapping.get('e1')!.get('raw')!.get('a.txt')!.fileId).toBe('uploaded-id');
         });
 
         it('when several metadata entries reference the same upload folder entry', () => {
@@ -221,8 +211,8 @@ describe('resolveFileMappings', () => {
                 linked: [uploadEntry],
                 reused: [metadataEntryWithFileId],
             });
-            expect(resolvedFileIdOf(submissionFileMapping, 'e1', 'raw', 'a.txt')).toBe('existing-id');
-            expect(resolvedFileIdOf(submissionFileMapping, 'e2', 'raw', 'a.txt')).toBe('uploaded-id');
+            expect(submissionFileMapping.get('e1')!.get('raw')!.get('a.txt')!.fileId).toBe('existing-id');
+            expect(submissionFileMapping.get('e2')!.get('raw')!.get('a.txt')!.fileId).toBe('uploaded-id');
         });
     });
 
@@ -233,7 +223,7 @@ describe('resolveFileMappings', () => {
                 fileMappingOf({}),
             );
             expect(fileLinkage.get('raw')).toEqual({ ...emptyDetails, reused: [metadataEntryWithFileId] });
-            expect(resolvedFileIdOf(submissionFileMapping, 'e1', 'raw', 'a.txt')).toBe('existing-id');
+            expect(submissionFileMapping.get('e1')!.get('raw')!.get('a.txt')!.fileId).toBe('existing-id');
             expect(getLinkageErrors(fileLinkage)).toBeUndefined();
         });
     });
@@ -272,7 +262,7 @@ describe('resolveFileMappings', () => {
                 reused: [metadataEntryWithFileId],
                 shadowed: [uploadEntry],
             });
-            expect(resolvedFileIdOf(submissionFileMapping, 'e1', 'raw', 'a.txt')).toBe('existing-id');
+            expect(submissionFileMapping.get('e1')!.get('raw')!.get('a.txt')!.fileId).toBe('existing-id');
         });
     });
 

--- a/website/src/components/Submission/FileUpload/fileMapping.spec.ts
+++ b/website/src/components/Submission/FileUpload/fileMapping.spec.ts
@@ -30,8 +30,6 @@ const errorOf = (text: string, categories: string[] = knownCategories): string =
     return result.error.message;
 };
 
-// Folder-upload fixtures are keyed by path, mirroring what FolderUploadComponent produces; a path's
-// value is just its file ID, since a name is always derivable from the path itself.
 const fileMappingOf = (categories: Record<string, UploadedFile[]>): FileMapping =>
     new Map(
         Object.entries(categories).map(([category, files]) => [
@@ -40,7 +38,6 @@ const fileMappingOf = (categories: Record<string, UploadedFile[]>): FileMapping 
         ]),
     );
 
-// Metadata fixtures are keyed by name, since that's a file entry's declared identity.
 const submissionMappingOf = <T extends SubmissionFile>(
     submissions: Record<string, Record<string, T[]>>,
 ): SubmissionFileMapping<T> =>

--- a/website/src/components/Submission/FileUpload/fileMapping.spec.ts
+++ b/website/src/components/Submission/FileUpload/fileMapping.spec.ts
@@ -31,12 +31,23 @@ const errorOf = (text: string, categories: string[] = knownCategories): string =
 };
 
 const fileMappingOf = <T extends SubmissionFile>(categories: Record<string, T[]>): FileMapping<T> =>
-    new Map(Object.entries(categories).map(([category, files]) => [category, new Map(files.map((f) => [f.path, f]))]));
+    new Map(Object.entries(categories));
 
 const submissionMappingOf = <T extends SubmissionFile>(
     submissions: Record<string, Record<string, T[]>>,
 ): SubmissionFileMapping<T> =>
     new Map(Object.entries(submissions).map(([submissionId, categories]) => [submissionId, fileMappingOf(categories)]));
+
+const resolvedFileIdOf = (
+    submissionFileMapping: SubmissionFileMapping<ResolvedSubmissionFile>,
+    submissionId: string,
+    category: string,
+    path: string,
+): string | undefined =>
+    submissionFileMapping
+        .get(submissionId)
+        ?.get(category)
+        ?.find((f) => f.path === path)?.fileId;
 
 describe('parseSubmissionFileMapping', () => {
     it('parses every accepted file entry form', () => {
@@ -169,7 +180,7 @@ describe('resolveFileMappings', () => {
                 fileMappingOf({ raw: [uploadEntry] }),
             );
             expect(fileLinkage.get('raw')).toEqual({ ...emptyDetails, linked: [uploadEntry] });
-            expect(submissionFileMapping.get('e1')!.get('raw')!.get('a.txt')!.fileId).toBe('uploaded-id');
+            expect(resolvedFileIdOf(submissionFileMapping, 'e1', 'raw', 'a.txt')).toBe('uploaded-id');
         });
 
         it('when several metadata entries reference the same upload folder entry', () => {
@@ -190,8 +201,8 @@ describe('resolveFileMappings', () => {
                 linked: [uploadEntry],
                 reused: [metadataEntryWithFileId],
             });
-            expect(submissionFileMapping.get('e1')!.get('raw')!.get('a.txt')!.fileId).toBe('existing-id');
-            expect(submissionFileMapping.get('e2')!.get('raw')!.get('a.txt')!.fileId).toBe('uploaded-id');
+            expect(resolvedFileIdOf(submissionFileMapping, 'e1', 'raw', 'a.txt')).toBe('existing-id');
+            expect(resolvedFileIdOf(submissionFileMapping, 'e2', 'raw', 'a.txt')).toBe('uploaded-id');
         });
     });
 
@@ -202,7 +213,7 @@ describe('resolveFileMappings', () => {
                 fileMappingOf({}),
             );
             expect(fileLinkage.get('raw')).toEqual({ ...emptyDetails, reused: [metadataEntryWithFileId] });
-            expect(submissionFileMapping.get('e1')!.get('raw')!.get('a.txt')!.fileId).toBe('existing-id');
+            expect(resolvedFileIdOf(submissionFileMapping, 'e1', 'raw', 'a.txt')).toBe('existing-id');
             expect(getLinkageErrors(fileLinkage)).toBeUndefined();
         });
     });
@@ -241,7 +252,7 @@ describe('resolveFileMappings', () => {
                 reused: [metadataEntryWithFileId],
                 shadowed: [uploadEntry],
             });
-            expect(submissionFileMapping.get('e1')!.get('raw')!.get('a.txt')!.fileId).toBe('existing-id');
+            expect(resolvedFileIdOf(submissionFileMapping, 'e1', 'raw', 'a.txt')).toBe('existing-id');
         });
     });
 

--- a/website/src/components/Submission/FileUpload/fileMapping.ts
+++ b/website/src/components/Submission/FileUpload/fileMapping.ts
@@ -23,9 +23,33 @@ export type ResolvedSubmissionFile = SubmissionFile & {
 type SubmissionId = string;
 type FileCategory = string;
 type FilePath = string;
+type FileName = string;
+type FileId = string;
 
-export type FileMapping<T extends SubmissionFile = SubmissionFile> = Map<FileCategory, T[]>;
-export type SubmissionFileMapping<T extends SubmissionFile = SubmissionFile> = Map<SubmissionId, FileMapping<T>>;
+/**
+ * A file uploaded via the folder upload component, identified by its path.
+ */
+export type UploadedFile = {
+    path: FilePath;
+    fileId: FileId;
+};
+
+/**
+ * Files uploaded via the folder upload component, keyed by path. Paths are unique within an upload,
+ * since re-adding a file at the same path replaces the existing one. Every uploaded file already has
+ * a file ID, and doesn't need its own name stored alongside it: a name is only ever the last segment
+ * of its path.
+ */
+export type FileMapping = Map<FileCategory, Map<FilePath, FileId>>;
+
+/**
+ * Files declared per submission in the metadata, keyed by name. A name is the declared identity of a
+ * file entry; its path (defaulting to the name) is only used to look up a matching upload.
+ */
+export type SubmissionFileMapping<T extends SubmissionFile = SubmissionFile> = Map<
+    SubmissionId,
+    Map<FileCategory, Map<FileName, T>>
+>;
 
 /**
  * Types of file linkage between the files declared within the metadata and the uploaded files.
@@ -47,100 +71,12 @@ export enum LinkageType {
     SHADOWED = 'shadowed',
 }
 
-/**
- * A mapping of (file category, file path) to the metadata entries and uploaded files which reference them.
- */
-type LinkageMapping = Map<
-    FileCategory,
-    Map<
-        FilePath,
-        {
-            metadataEntries: { submissionId: SubmissionId; file: SubmissionFile }[];
-            uploadEntry?: ResolvedSubmissionFile;
-        }
-    >
->;
-
-/**
- * Returns a mapping of (file category, file path) to the metadata entries and uploaded files which reference them.
- * @param submissionFileMapping The mapping of submission IDs to file categories and paths, as declared in the metadata.
- * @param fileMapping The mapping of file categories and paths to uploaded files.
- * @returns A mapping of file categories and paths to the metadata entries and uploaded files which reference them.
- */
-function getLinkageMapping(
-    submissionFileMapping: SubmissionFileMapping,
-    fileMapping: FileMapping<ResolvedSubmissionFile> | undefined,
-): LinkageMapping {
-    const linkageMapping: LinkageMapping = new Map();
-
-    const getOrCreateLinkageEntry = (category: FileCategory, path: FilePath) => {
-        let pathMapping = linkageMapping.get(category);
-        if (pathMapping === undefined) {
-            pathMapping = new Map();
-            linkageMapping.set(category, pathMapping);
-        }
-        let linkageEntry = pathMapping.get(path);
-        if (linkageEntry === undefined) {
-            linkageEntry = { metadataEntries: [] };
-            pathMapping.set(path, linkageEntry);
-        }
-        return linkageEntry;
-    };
-
-    for (const [submissionId, categoryMapping] of submissionFileMapping) {
-        for (const [category, files] of categoryMapping) {
-            for (const file of files) {
-                getOrCreateLinkageEntry(category, file.path).metadataEntries.push({ submissionId, file });
-            }
-        }
-    }
-
-    if (fileMapping !== undefined) {
-        for (const [category, files] of fileMapping) {
-            for (const file of files) getOrCreateLinkageEntry(category, file.path).uploadEntry = file;
-        }
-    }
-
-    return linkageMapping;
-}
-
-/**
- * An entry containing the submission ID, file category, path, and resolved file.
- * Used to build a resolved submission file mapping, which contains the file IDs for all files which are linked or reused.
- */
-type ResolvedEntry = {
-    submissionId: SubmissionId;
-    category: FileCategory;
-    file: ResolvedSubmissionFile;
-};
-
-/**
- * Returns a mapping of submission IDs to file categories and paths, containing the resolved files which are linked or reused.
- * @param entries The entries containing the submission ID, file category, path, and resolved file.
- * @returns A mapping of submission IDs to file categories and paths, containing the resolved files which are linked or reused.
- */
-function getResolvedSubmissionFileMapping(entries: ResolvedEntry[]): SubmissionFileMapping<ResolvedSubmissionFile> {
-    const mapping: SubmissionFileMapping<ResolvedSubmissionFile> = new Map();
-
-    for (const { submissionId, category, file } of entries) {
-        const categoryMapping: Map<FileCategory, ResolvedSubmissionFile[]> = mapping.get(submissionId) ?? new Map();
-        const files: ResolvedSubmissionFile[] = categoryMapping.get(category) ?? [];
-
-        files.push(file);
-
-        categoryMapping.set(category, files);
-        mapping.set(submissionId, categoryMapping);
-    }
-
-    return mapping;
-}
-
 export type CategoryLinkage = {
-    [LinkageType.LINKED]: SubmissionFile[];
+    [LinkageType.LINKED]: UploadedFile[];
     [LinkageType.REUSED]: SubmissionFile[];
     [LinkageType.MISSING]: SubmissionFile[];
-    [LinkageType.ORPHANED]: SubmissionFile[];
-    [LinkageType.SHADOWED]: SubmissionFile[];
+    [LinkageType.ORPHANED]: UploadedFile[];
+    [LinkageType.SHADOWED]: UploadedFile[];
 };
 
 export function initializeCategoryLinkage(): CategoryLinkage {
@@ -159,55 +95,97 @@ export function initializeCategoryLinkage(): CategoryLinkage {
 export type FileLinkage = Map<FileCategory, CategoryLinkage>;
 
 /**
+ * An entry containing the submission ID, file category, and resolved file.
+ * Used to build a resolved submission file mapping, which contains the file IDs for all files which are linked or reused.
+ */
+type ResolvedEntry = {
+    submissionId: SubmissionId;
+    category: FileCategory;
+    file: ResolvedSubmissionFile;
+};
+
+/**
+ * Returns a mapping of submission IDs to file categories, containing the resolved files which are linked or reused.
+ * @param entries The entries containing the submission ID, file category, and resolved file.
+ * @returns A mapping of submission IDs to file categories, containing the resolved files which are linked or reused.
+ */
+function getResolvedSubmissionFileMapping(entries: ResolvedEntry[]): SubmissionFileMapping<ResolvedSubmissionFile> {
+    const mapping: SubmissionFileMapping<ResolvedSubmissionFile> = new Map();
+
+    for (const { submissionId, category, file } of entries) {
+        const categoryMapping: Map<FileCategory, Map<FileName, ResolvedSubmissionFile>> = mapping.get(submissionId) ??
+        new Map();
+        const files: Map<FileName, ResolvedSubmissionFile> = categoryMapping.get(category) ?? new Map();
+
+        files.set(file.name, file);
+
+        categoryMapping.set(category, files);
+        mapping.set(submissionId, categoryMapping);
+    }
+
+    return mapping;
+}
+
+/**
  * Determines how each declared and uploaded file is linked, and produces a resolved submission file mapping from the valid entries.
- * @param submissionFileMapping The mapping of submission IDs to file categories, names and paths, as declared in the metadata.
+ * @param submissionFileMapping The mapping of submission IDs to file categories and names, as declared in the metadata.
  * @param fileMapping The mapping of file categories and paths to uploaded files.
  * @returns The resolved submission file mapping, and the file linkage details for each file category.
  */
 export function resolveFileMappings(
     submissionFileMapping: SubmissionFileMapping,
-    fileMapping: FileMapping<ResolvedSubmissionFile> | undefined,
+    fileMapping: FileMapping | undefined,
 ): {
     submissionFileMapping: SubmissionFileMapping<ResolvedSubmissionFile>;
     fileLinkage: FileLinkage;
 } {
-    const linkageMapping = getLinkageMapping(submissionFileMapping, fileMapping);
     const fileLinkage: FileLinkage = new Map();
     const resolvedEntries: ResolvedEntry[] = [];
 
-    for (const [category, pathMapping] of linkageMapping) {
-        const categoryLinkage: CategoryLinkage = initializeCategoryLinkage();
+    // Every file category which appears on either side, so it gets linkage details even if only declared on one.
+    const categories = new Set<FileCategory>();
+    for (const categoryMapping of submissionFileMapping.values())
+        for (const category of categoryMapping.keys()) categories.add(category);
+    if (fileMapping !== undefined) for (const category of fileMapping.keys()) categories.add(category);
 
-        for (const linkageEntry of pathMapping.values()) {
-            for (const { submissionId, file } of linkageEntry.metadataEntries) {
+    for (const category of categories) {
+        const categoryLinkage = initializeCategoryLinkage();
+        const uploads = fileMapping?.get(category);
+        // Paths claimed by a metadata entry without its own file ID, so the upload is genuinely linked.
+        const claimedPaths = new Set<FilePath>();
+        // Paths referenced by a metadata entry which has its own file ID instead, so the upload is shadowed.
+        const shadowedPaths = new Set<FilePath>();
+
+        for (const [submissionId, categoryMapping] of submissionFileMapping) {
+            const files = categoryMapping.get(category);
+            if (files === undefined) continue;
+
+            for (const file of files.values()) {
                 if (file.fileId !== undefined) {
-                    // A metadata file entry with its own file ID is reusing a pre-existing file
+                    // A metadata file entry with its own file ID is reusing a pre-existing file,
+                    // and does not need to be linked against any upload.
                     categoryLinkage.reused.push(file);
-                } else if (linkageEntry.uploadEntry === undefined) {
-                    // If the metadata file entry does not have its own file ID, and there is no uploaded file,
-                    // then the file is missing
-                    categoryLinkage.missing.push(file);
+                    shadowedPaths.add(file.path);
+                    resolvedEntries.push({ submissionId, category, file: { ...file, fileId: file.fileId } });
+                    continue;
                 }
 
-                // A file ID in the metadata takes precedence over the one from the upload
-                const fileId = file.fileId ?? linkageEntry.uploadEntry?.fileId;
+                const fileId = uploads?.get(file.path);
+                if (fileId === undefined) {
+                    categoryLinkage.missing.push(file);
+                    continue;
+                }
 
-                // A file ID from either metadata or upload resolves the entry
-                // Shadowed uploads are reported separately and block submission
-                if (fileId !== undefined) resolvedEntries.push({ submissionId, category, file: { ...file, fileId } });
+                claimedPaths.add(file.path);
+                resolvedEntries.push({ submissionId, category, file: { ...file, fileId } });
             }
+        }
 
-            if (linkageEntry.uploadEntry === undefined) continue;
-
-            if (linkageEntry.metadataEntries.some(({ file }) => file.fileId === undefined)) {
-                // The uploaded file has (at least one) corresponding metadata entry, so is linked
-                categoryLinkage.linked.push(linkageEntry.uploadEntry);
-            } else if (linkageEntry.metadataEntries.length > 0) {
-                // The uploaded file has corresponding metadata entries, but they all have file IDs
-                categoryLinkage.shadowed.push(linkageEntry.uploadEntry);
-            } else {
-                // The uploaded file has no metadata entries
-                categoryLinkage.orphaned.push(linkageEntry.uploadEntry);
+        if (uploads !== undefined) {
+            for (const [path, fileId] of uploads) {
+                if (claimedPaths.has(path)) categoryLinkage.linked.push({ path, fileId });
+                else if (shadowedPaths.has(path)) categoryLinkage.shadowed.push({ path, fileId });
+                else categoryLinkage.orphaned.push({ path, fileId });
             }
         }
 
@@ -216,6 +194,32 @@ export function resolveFileMappings(
 
     const resolvedSubmissionFileMapping = getResolvedSubmissionFileMapping(resolvedEntries);
     return { submissionFileMapping: resolvedSubmissionFileMapping, fileLinkage };
+}
+
+/**
+ * Wraps a single submission's uploaded files into a resolved submission file mapping, for input modes
+ * where every uploaded file is used exactly as uploaded, with no metadata file-linkage step. A path is
+ * used as its own name, which is valid since these input modes never allow subdirectories, so a path is
+ * always already just a file name.
+ * @param submissionId The ID of the submission the uploaded files belong to.
+ * @param fileMapping The mapping of file categories and paths to uploaded files.
+ * @returns A resolved submission file mapping containing only the given submission.
+ */
+export function toSingleSubmissionFileMapping(
+    submissionId: SubmissionId,
+    fileMapping: FileMapping,
+): SubmissionFileMapping<ResolvedSubmissionFile> {
+    return new Map([
+        [
+            submissionId,
+            new Map(
+                [...fileMapping].map(([category, files]) => [
+                    category,
+                    new Map([...files].map(([path, fileId]) => [path, { name: path, path, fileId }])),
+                ]),
+            ),
+        ],
+    ]);
 }
 
 /**
@@ -247,7 +251,7 @@ export function getLinkageErrorMessage(
  */
 export function getLinkageErrors(fileLinkage: FileLinkage): string | undefined {
     const errors: string[] = [];
-    const getFilePaths = (files: SubmissionFile[]) => files.map((file) => file.path).join(', ');
+    const getFilePaths = (files: { path: FilePath }[]) => files.map((file) => file.path).join(', ');
 
     for (const [category, { missing, orphaned, shadowed }] of fileLinkage) {
         if (missing.length > 0)
@@ -297,9 +301,9 @@ const getIdColumn = (columns: { name: string; index: number }[]) =>
 
 /**
  * Reads the file entries declared in the file columns of a metadata file, validating that submission IDs are
- * unique and that each submission declares unique file names and paths per category.
+ * unique and that each submission declares unique file names per category.
  * @param text The contents of the uploaded metadata file.
- * @returns A mapping of submission IDs to file categories and paths, or the first validation error encountered.
+ * @returns A mapping of submission IDs to file categories and names, or the first validation error encountered.
  */
 export function parseSubmissionFileMapping(
     text: string,
@@ -337,7 +341,7 @@ export function parseSubmissionFileMapping(
     if (idColumn === undefined)
         return err(new Error('Missing id column. Please ensure this is included in the uploaded metadata file.'));
 
-    // Build a mapping of submission IDs to file categories and paths
+    // Build a mapping of submission IDs to file categories and names
     const submissionFileMapping: SubmissionFileMapping = new Map();
     for (const row of rows) {
         // Validate submission ID is present and unique
@@ -351,8 +355,8 @@ export function parseSubmissionFileMapping(
                 ),
             );
 
-        // Build a mapping of file categories to file paths and entries for the submission
-        const fileMapping: FileMapping = new Map();
+        // Build a mapping of file categories to file names and entries for the submission
+        const categoryMapping = new Map<FileCategory, Map<FileName, SubmissionFile>>();
         for (const { category, index } of fileColumns) {
             // Skip empty cells
             const cell = row[index] ?? '';
@@ -365,34 +369,23 @@ export function parseSubmissionFileMapping(
                 .filter((entry) => entry !== '')
                 .map((entry) => parseFileEntry(entry));
 
-            // Check for parsing errors in the file entries and
-            // validate the submission has unique file names and paths
-            const fileNames = new Set<string>();
-            const filePaths = new Set<string>();
-            const fileEntries: SubmissionFile[] = [];
+            // Check for parsing errors in the file entries and validate the submission has unique file names
+            const fileEntries = new Map<FileName, SubmissionFile>();
             for (const fileEntryResult of fileEntryResults) {
                 if (fileEntryResult.isErr()) return err(fileEntryResult.error);
                 const file = fileEntryResult.value;
 
-                if (fileNames.has(file.name))
+                if (fileEntries.has(file.name))
                     return err(
                         new Error(
                             `Found duplicate file names for entry ${submissionId} in the ${category} category: ${file.name}.`,
                         ),
                     );
-                if (filePaths.has(file.path))
-                    return err(
-                        new Error(
-                            `Found duplicate file paths for entry ${submissionId} in the ${category} category: ${file.path}.`,
-                        ),
-                    );
-                fileNames.add(file.name);
-                filePaths.add(file.path);
-                fileEntries.push(file);
+                fileEntries.set(file.name, file);
             }
-            fileMapping.set(category, fileEntries);
+            categoryMapping.set(category, fileEntries);
         }
-        submissionFileMapping.set(submissionId, fileMapping);
+        submissionFileMapping.set(submissionId, categoryMapping);
     }
 
     return ok(submissionFileMapping);
@@ -446,7 +439,7 @@ export async function applyFileMappings(
             const files = resolvedSubmissionFileMapping.get(submissionId)?.get(category);
             if (files === undefined) continue;
 
-            updatedRow[index] = files
+            updatedRow[index] = [...files.values()]
                 .map((file) => `${file.name}${FILE_NAME_ID_SEPARATOR}${file.fileId}`)
                 .join(FILES_SEPARATOR);
         }

--- a/website/src/components/Submission/FileUpload/fileMapping.ts
+++ b/website/src/components/Submission/FileUpload/fileMapping.ts
@@ -127,9 +127,7 @@ function getResolvedSubmissionFileMapping(entries: ResolvedEntry[]): SubmissionF
         const categoryMapping: Map<FileCategory, ResolvedSubmissionFile[]> = mapping.get(submissionId) ?? new Map();
         const files: ResolvedSubmissionFile[] = categoryMapping.get(category) ?? [];
 
-        files.push({
-            ...file,
-        });
+        files.push(file);
 
         categoryMapping.set(category, files);
         mapping.set(submissionId, categoryMapping);
@@ -450,7 +448,7 @@ export async function applyFileMappings(
             const files = resolvedSubmissionFileMapping.get(submissionId)?.get(category);
             if (files === undefined) continue;
 
-            updatedRow[index] = [...files.values()]
+            updatedRow[index] = files
                 .map((file) => `${file.name}${FILE_NAME_ID_SEPARATOR}${file.fileId}`)
                 .join(FILES_SEPARATOR);
         }

--- a/website/src/components/Submission/FileUpload/fileMapping.ts
+++ b/website/src/components/Submission/FileUpload/fileMapping.ts
@@ -35,16 +35,13 @@ export type UploadedFile = {
 };
 
 /**
- * Files uploaded via the folder upload component, keyed by path. Paths are unique within an upload,
- * since re-adding a file at the same path replaces the existing one. Every uploaded file already has
- * a file ID, and doesn't need its own name stored alongside it: a name is only ever the last segment
- * of its path.
+ * Files uploaded via the folder upload component, keyed by path. Paths are unique within an upload.
+ * Every uploaded file has a file ID.
  */
 export type FileMapping = Map<FileCategory, Map<FilePath, FileId>>;
 
 /**
- * Files declared per submission in the metadata, keyed by name. A name is the declared identity of a
- * file entry; its path (defaulting to the name) is only used to look up a matching upload.
+ * Files declared per submission in the metadata, keyed by name.
  */
 export type SubmissionFileMapping<T extends SubmissionFile = SubmissionFile> = Map<
     SubmissionId,

--- a/website/src/components/Submission/FileUpload/fileMapping.ts
+++ b/website/src/components/Submission/FileUpload/fileMapping.ts
@@ -24,7 +24,7 @@ type SubmissionId = string;
 type FileCategory = string;
 type FilePath = string;
 
-export type FileMapping<T extends SubmissionFile = SubmissionFile> = Map<FileCategory, Map<FilePath, T>>;
+export type FileMapping<T extends SubmissionFile = SubmissionFile> = Map<FileCategory, T[]>;
 export type SubmissionFileMapping<T extends SubmissionFile = SubmissionFile> = Map<SubmissionId, FileMapping<T>>;
 
 /**
@@ -88,15 +88,16 @@ function getLinkageMapping(
     };
 
     for (const [submissionId, categoryMapping] of submissionFileMapping) {
-        for (const [category, pathMapping] of categoryMapping) {
-            for (const [path, file] of pathMapping)
-                getOrCreateLinkageEntry(category, path).metadataEntries.push({ submissionId, file });
+        for (const [category, files] of categoryMapping) {
+            for (const file of files) {
+                getOrCreateLinkageEntry(category, file.path).metadataEntries.push({ submissionId, file });
+            }
         }
     }
 
     if (fileMapping !== undefined) {
-        for (const [category, pathMapping] of fileMapping) {
-            for (const [path, file] of pathMapping) getOrCreateLinkageEntry(category, path).uploadEntry = file;
+        for (const [category, files] of fileMapping) {
+            for (const file of files) getOrCreateLinkageEntry(category, file.path).uploadEntry = file;
         }
     }
 
@@ -120,29 +121,21 @@ type ResolvedEntry = {
  * @returns A mapping of submission IDs to file categories and paths, containing the resolved files which are linked or reused.
  */
 function getResolvedSubmissionFileMapping(entries: ResolvedEntry[]): SubmissionFileMapping<ResolvedSubmissionFile> {
-    const resolvedSubmissionFileMapping: SubmissionFileMapping<ResolvedSubmissionFile> = new Map();
+    const mapping: SubmissionFileMapping<ResolvedSubmissionFile> = new Map();
 
-    const getOrCreateMapping = (
-        submissionId: SubmissionId,
-        category: FileCategory,
-    ): Map<FilePath, ResolvedSubmissionFile> => {
-        let categoryMapping = resolvedSubmissionFileMapping.get(submissionId);
-        if (categoryMapping === undefined) {
-            categoryMapping = new Map();
-            resolvedSubmissionFileMapping.set(submissionId, categoryMapping);
-        }
-        let pathMapping = categoryMapping.get(category);
-        if (pathMapping === undefined) {
-            pathMapping = new Map();
-            categoryMapping.set(category, pathMapping);
-        }
-        return pathMapping;
-    };
+    for (const { submissionId, category, file } of entries) {
+        const categoryMapping: Map<FileCategory, ResolvedSubmissionFile[]> = mapping.get(submissionId) ?? new Map();
+        const files: ResolvedSubmissionFile[] = categoryMapping.get(category) ?? [];
 
-    for (const { submissionId, category, path, file } of entries)
-        getOrCreateMapping(submissionId, category).set(path, file);
+        files.push({
+            ...file,
+        });
 
-    return resolvedSubmissionFileMapping;
+        categoryMapping.set(category, files);
+        mapping.set(submissionId, categoryMapping);
+    }
+
+    return mapping;
 }
 
 export type CategoryLinkage = {
@@ -153,6 +146,16 @@ export type CategoryLinkage = {
     [LinkageType.SHADOWED]: SubmissionFile[];
 };
 
+export function initializeCategoryLinkage(): CategoryLinkage {
+    return {
+        [LinkageType.LINKED]: [],
+        [LinkageType.REUSED]: [],
+        [LinkageType.MISSING]: [],
+        [LinkageType.ORPHANED]: [],
+        [LinkageType.SHADOWED]: [],
+    };
+}
+
 /**
  * A mapping of file categories to the linkage details within that category.
  */
@@ -160,7 +163,7 @@ export type FileLinkage = Map<FileCategory, CategoryLinkage>;
 
 /**
  * Determines how each declared and uploaded file is linked, and produces a resolved submission file mapping from the valid entries.
- * @param submissionFileMapping The mapping of submission IDs to file categories and paths, as declared in the metadata.
+ * @param submissionFileMapping The mapping of submission IDs to file categories, names and paths, as declared in the metadata.
  * @param fileMapping The mapping of file categories and paths to uploaded files.
  * @returns The resolved submission file mapping, and the file linkage details for each file category.
  */
@@ -176,13 +179,7 @@ export function resolveFileMappings(
     const resolvedEntries: ResolvedEntry[] = [];
 
     for (const [category, pathMapping] of linkageMapping) {
-        const categoryLinkage: CategoryLinkage = {
-            linked: [],
-            reused: [],
-            missing: [],
-            orphaned: [],
-            shadowed: [],
-        };
+        const categoryLinkage: CategoryLinkage = initializeCategoryLinkage();
 
         for (const [path, linkageEntry] of pathMapping) {
             for (const { submissionId, file } of linkageEntry.metadataEntries) {
@@ -375,7 +372,8 @@ export function parseSubmissionFileMapping(
             // Check for parsing errors in the file entries and
             // validate the submission has unique file names and paths
             const fileNames = new Set<string>();
-            const fileEntries = new Map<FilePath, SubmissionFile>();
+            const filePaths = new Set<string>();
+            const fileEntries: SubmissionFile[] = [];
             for (const fileEntryResult of fileEntryResults) {
                 if (fileEntryResult.isErr()) return err(fileEntryResult.error);
                 const file = fileEntryResult.value;
@@ -386,14 +384,15 @@ export function parseSubmissionFileMapping(
                             `Found duplicate file names for entry ${submissionId} in the ${category} category: ${file.name}.`,
                         ),
                     );
-                if (fileEntries.has(file.path))
+                if (filePaths.has(file.path))
                     return err(
                         new Error(
                             `Found duplicate file paths for entry ${submissionId} in the ${category} category: ${file.path}.`,
                         ),
                     );
                 fileNames.add(file.name);
-                fileEntries.set(file.path, file);
+                filePaths.add(file.path);
+                fileEntries.push(file);
             }
             fileMapping.set(category, fileEntries);
         }

--- a/website/src/components/Submission/FileUpload/fileMapping.ts
+++ b/website/src/components/Submission/FileUpload/fileMapping.ts
@@ -111,7 +111,6 @@ function getLinkageMapping(
 type ResolvedEntry = {
     submissionId: SubmissionId;
     category: FileCategory;
-    path: FilePath;
     file: ResolvedSubmissionFile;
 };
 
@@ -179,7 +178,7 @@ export function resolveFileMappings(
     for (const [category, pathMapping] of linkageMapping) {
         const categoryLinkage: CategoryLinkage = initializeCategoryLinkage();
 
-        for (const [path, linkageEntry] of pathMapping) {
+        for (const linkageEntry of pathMapping.values()) {
             for (const { submissionId, file } of linkageEntry.metadataEntries) {
                 if (file.fileId !== undefined) {
                     // A metadata file entry with its own file ID is reusing a pre-existing file
@@ -195,8 +194,7 @@ export function resolveFileMappings(
 
                 // A file ID from either metadata or upload resolves the entry
                 // Shadowed uploads are reported separately and block submission
-                if (fileId !== undefined)
-                    resolvedEntries.push({ submissionId, category, path, file: { ...file, fileId } });
+                if (fileId !== undefined) resolvedEntries.push({ submissionId, category, file: { ...file, fileId } });
             }
 
             if (linkageEntry.uploadEntry === undefined) continue;


### PR DESCRIPTION
- the fileMapping produced by the folderComponent should be from filePath to fileID
- the fileMapping produced by the metadata is a map from the submissionID to another map from the fileName to the filePath OR the fileName to the fileID (if no filePath or fileID is provided filePath is set to fileName) - filePath doesnt actually have to be unique
- files with a fileID do not need to be mapped, files with a path must be joined to the filePaths in the folderComponent

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://bulk-file-anya.loculus.org