### PR TITLE
feat!(config): Add options for sequencingInstrument and sequencingAssayType

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1073,7 +1073,7 @@ defaultOrganismConfig: &defaultOrganismConfig
           # ena-webin-cli -context reads -fields
           # ena-webin-cli=9.0.3
           # Last checked: 09.06.2026
-          # Fields listed in INSTRUMENT
+          # Fields listed in INSTRUMENT (excluding `unspecified`)
           - name: "454 GS"
           - name: "454 GS 20"
           - name: "454 GS FLX"

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1056,7 +1056,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         orderOnDetailsPage: 2060
       - name: sequencingInstrument
         ontology_id: GENEPIO:0001452
-        definition: The model of the sequencing instrument used.
+        definition: The model of the sequencing instrument used. (required when raw reads file are provided)
         guidance: Select the sequencing instrument from the pick list.
         example: MinION
         displayName: Sequencing instrument
@@ -1175,13 +1175,15 @@ defaultOrganismConfig: &defaultOrganismConfig
         orderOnDetailsPage: 2100
       - name: sequencingAssayType
         ontology_id: GENEPIO:0100997
-        definition: The overarching sequencing technique that was used to determine the sequence of a biomaterial, also called library strategy in the INSDC.
-        guidance: 'Example Guidance: Provide the name of the DNA or RNA sequencing technology used in your study. If unsure refer to the protocol documentation, or provide a null value.'
+        definition: The overarching sequencing technique that was used to determine the sequence of a biomaterial, also called library strategy in the INSDC. (required when raw reads file are provided)
+        guidance: Select the sequencing technology from the pick list.
         desired: true
         example: WGS
         displayName: Sequencing assay type
         header: Sequencing
         orderOnDetailsPage: 2130
+        requiredWhen:
+          - files.rawReads
         preprocessing:
           function: process_options
           inputs:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1146,7 +1146,6 @@ defaultOrganismConfig: &defaultOrganismConfig
           - name: "Sequel"
           - name: "Sequel II"
           - name: "Sequel IIe"
-          - name: "Tapestri"
           - name: "UG 100"
           # Fields listed in PLATFORM
           - name: "ILLUMINA"

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1058,13 +1058,112 @@ defaultOrganismConfig: &defaultOrganismConfig
         ontology_id: GENEPIO:0001452
         definition: The model of the sequencing instrument used.
         guidance: Select the sequencing instrument from the pick list.
-        example: Oxford Nanopore MinION [GENEPIO:0100142]
+        example: MinION
         displayName: Sequencing instrument
         header: Sequencing
         desired: true
         orderOnDetailsPage: 2080
         requiredWhen:
           - files.rawReads
+        preprocessing:
+          function: process_options
+          inputs:
+            input: sequencingInstrument
+        options:
+          # ena-webin-cli -context reads -fields
+          # ena-webin-cli=9.0.3
+          # Last checked: 09.06.2026
+          # Fields listed in INSTRUMENT
+          - name: "454 GS"
+          - name: "454 GS 20"
+          - name: "454 GS FLX"
+          - name: "454 GS FLX Titanium"
+          - name: "454 GS FLX+"
+          - name: "454 GS Junior"
+          - name: "AB 310 Genetic Analyzer"
+          - name: "AB 3130 Genetic Analyzer"
+          - name: "AB 3130xL Genetic Analyzer"
+          - name: "AB 3500 Genetic Analyzer"
+          - name: "AB 3500xL Genetic Analyzer"
+          - name: "AB 3730 Genetic Analyzer"
+          - name: "AB 3730xL Genetic Analyzer"
+          - name: "AB 5500 Genetic Analyzer"
+          - name: "AB 5500xl Genetic Analyzer"
+          - name: "AB 5500xl-W Genetic Analysis System"
+          - name: "BGISEQ-50"
+          - name: "BGISEQ-500"
+          - name: "DNBSEQ-G400"
+          - name: "DNBSEQ-G400 FAST"
+          - name: "DNBSEQ-G50"
+          - name: "DNBSEQ-T7"
+          - name: "Element AVITI"
+          - name: "FASTASeq 300"
+          - name: "GENIUS"
+          - name: "GS111"
+          - name: "Genapsys Sequencer"
+          - name: "GenoCare 1600"
+          - name: "GenoLab M"
+          - name: "GridION"
+          - name: "Helicos HeliScope"
+          - name: "HiSeq X Five"
+          - name: "HiSeq X Ten"
+          - name: "Illumina Genome Analyzer"
+          - name: "Illumina Genome Analyzer II"
+          - name: "Illumina Genome Analyzer IIx"
+          - name: "Illumina HiScanSQ"
+          - name: "Illumina HiSeq 1000"
+          - name: "Illumina HiSeq 1500"
+          - name: "Illumina HiSeq 2000"
+          - name: "Illumina HiSeq 2500"
+          - name: "Illumina HiSeq 3000"
+          - name: "Illumina HiSeq 4000"
+          - name: "Illumina HiSeq X"
+          - name: "Illumina MiSeq"
+          - name: "Illumina MiniSeq"
+          - name: "Illumina NovaSeq 6000"
+          - name: "Illumina NovaSeq X"
+          - name: "Illumina iSeq 100"
+          - name: "Ion GeneStudio S5"
+          - name: "Ion GeneStudio S5 Plus"
+          - name: "Ion GeneStudio S5 Prime"
+          - name: "Ion Torrent Genexus"
+          - name: "Ion Torrent PGM"
+          - name: "Ion Torrent Proton"
+          - name: "Ion Torrent S5"
+          - name: "Ion Torrent S5 XL"
+          - name: "MGISEQ-2000RS"
+          - name: "MinION"
+          - name: "NextSeq 1000"
+          - name: "NextSeq 2000"
+          - name: "NextSeq 500"
+          - name: "NextSeq 550"
+          - name: "Onso"
+          - name: "PacBio RS"
+          - name: "PacBio RS II"
+          - name: "PromethION"
+          - name: "Revio"
+          - name: "Sentosa SQ301"
+          - name: "Sequel"
+          - name: "Sequel II"
+          - name: "Sequel IIe"
+          - name: "Tapestri"
+          - name: "UG 100"
+          # Fields listed in PLATFORM
+          - name: "ILLUMINA"
+          - name: "PACBIO_SMRT"
+          - name: "OXFORD_NANOPORE"
+          - name: "BGISEQ"
+          - name: "LS454"
+          - name: "ION_TORRENT"
+          - name: "CAPILLARY"
+          - name: "DNBSEQ"
+          - name: "ELEMENT"
+          - name: "ULTIMA"
+          - name: "VELA_DIAGNOSTICS"
+          - name: "GENAPSYS"
+          - name: "GENEMIND"
+          - name: "TAPESTRI"
+          - name: "AVITI"
       - name: sequencingProtocol
         ontology_id: GENEPIO:0001454
         definition: The protocol used to generate the sequence.
@@ -1076,12 +1175,63 @@ defaultOrganismConfig: &defaultOrganismConfig
         orderOnDetailsPage: 2100
       - name: sequencingAssayType
         ontology_id: GENEPIO:0100997
-        definition: The overarching sequencing methodology that was used to determine the sequence of a biomaterial.
+        definition: The overarching sequencing technique that was used to determine the sequence of a biomaterial, also called library strategy in the INSDC.
         guidance: 'Example Guidance: Provide the name of the DNA or RNA sequencing technology used in your study. If unsure refer to the protocol documentation, or provide a null value.'
-        example: whole genome sequencing assay [OBI:0002117]
+        desired: true
+        example: WGS
         displayName: Sequencing assay type
         header: Sequencing
-        orderOnDetailsPage: 2120
+        orderOnDetailsPage: 2130
+        preprocessing:
+          function: process_options
+          inputs:
+            input: sequencingAssayType
+        options:
+          # ena-webin-cli -context reads -fields
+          # ena-webin-cli=9.0.3
+          # Last checked: 09.06.2026
+          # Fields listed in LIBRARY_STRATEGY
+          - name: "WGS"
+          - name: "WGA"
+          - name: "WXS"
+          - name: "RNA-Seq"
+          - name: "ssRNA-seq"
+          - name: "snRNA-seq"
+          - name: "miRNA-Seq"
+          - name: "ncRNA-Seq"
+          - name: "FL-cDNA"
+          - name: "EST"
+          - name: "Hi-C"
+          - name: "ATAC-seq"
+          - name: "WCS"
+          - name: "RAD-Seq"
+          - name: "CLONE"
+          - name: "POOLCLONE"
+          - name: "AMPLICON"
+          - name: "CLONEEND"
+          - name: "FINISHING"
+          - name: "ChIP-Seq"
+          - name: "MNase-Seq"
+          - name: "DNase-Hypersensitivity"
+          - name: "Bisulfite-Seq"
+          - name: "CTS"
+          - name: "MRE-Seq"
+          - name: "MeDIP-Seq"
+          - name: "MBD-Seq"
+          - name: "Tn-Seq"
+          - name: "VALIDATION"
+          - name: "FAIRE-seq"
+          - name: "SELEX"
+          - name: "RIP-Seq"
+          - name: "ChIA-PET"
+          - name: "Synthetic-Long-Read"
+          - name: "Targeted-Capture"
+          - name: "Tethered Chromatin Conformation Capture"
+          - name: "NOMe-seq"
+          - name: "ChM-Seq"
+          - name: "GBS"
+          - name: "Ribo-seq"
+          - name: "OTHER"
       - name: sequencedByOrganization
         ontology_id: GENEPIO:0100416
         definition: The name of the agency, organization or institution responsible for sequencing the isolate's genome.

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1056,7 +1056,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         orderOnDetailsPage: 2060
       - name: sequencingInstrument
         ontology_id: GENEPIO:0001452
-        definition: The model of the sequencing instrument used. (required when raw reads files are provided)
+        definition: The model of the sequencing instrument used. (required when raw read files are provided)
         guidance: Select the sequencing instrument from the pick list.
         example: MinION
         displayName: Sequencing instrument
@@ -1175,7 +1175,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         orderOnDetailsPage: 2100
       - name: sequencingAssayType
         ontology_id: GENEPIO:0100997
-        definition: The overarching sequencing technique that was used to determine the sequence of a biomaterial, also called library strategy in the INSDC. (required when raw reads files are provided)
+        definition: The overarching sequencing technique that was used to determine the sequence of a biomaterial, also called library strategy in the INSDC. (required when raw read files are provided)
         guidance: Select the sequencing technology from the pick list.
         desired: true
         example: WGS

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1182,8 +1182,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Sequencing assay type
         header: Sequencing
         orderOnDetailsPage: 2130
-        requiredWhen:
-          - files.rawReads
         preprocessing:
           function: process_options
           inputs:

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1056,7 +1056,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         orderOnDetailsPage: 2060
       - name: sequencingInstrument
         ontology_id: GENEPIO:0001452
-        definition: The model of the sequencing instrument used. (required when raw reads file are provided)
+        definition: The model of the sequencing instrument used. (required when raw reads files are provided)
         guidance: Select the sequencing instrument from the pick list.
         example: MinION
         displayName: Sequencing instrument
@@ -1175,7 +1175,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         orderOnDetailsPage: 2100
       - name: sequencingAssayType
         ontology_id: GENEPIO:0100997
-        definition: The overarching sequencing technique that was used to determine the sequence of a biomaterial, also called library strategy in the INSDC. (required when raw reads file are provided)
+        definition: The overarching sequencing technique that was used to determine the sequence of a biomaterial, also called library strategy in the INSDC. (required when raw reads files are provided)
         guidance: Select the sequencing technology from the pick list.
         desired: true
         example: WGS

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1063,6 +1063,8 @@ defaultOrganismConfig: &defaultOrganismConfig
         header: Sequencing
         desired: true
         orderOnDetailsPage: 2080
+        autocomplete: true
+        initiallyVisible: true
         requiredWhen:
           - files.rawReads
         preprocessing:
@@ -1181,6 +1183,8 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Sequencing assay type
         header: Sequencing
         orderOnDetailsPage: 2130
+        autocomplete: true
+        initiallyVisible: true
         preprocessing:
           function: process_options
           inputs:


### PR DESCRIPTION
Based on https://github.com/loculus-project/loculus/pull/6634, but only adds options for `sequencingInstrument` and `sequencingAssayType` metadata fields.

Related to https://github.com/loculus-project/loculus/issues/6842.

The options lists are taken from the allowed values listed here: https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#metadata-validation. Note that we exclude the `unspecified` value; ENA makes the PLATFORM field required if INSTRUMENT is `unspecified`, and since we're merging the INSTRUMENT and PLATFORM fields into one field on our side we can't support that.

### Screenshot
#### Options appear in the submission form:

<img width="947" height="296" alt="grafik" src="https://github.com/user-attachments/assets/07a1f570-af45-4002-894a-5d2668d80666" />

#### Incorrect values are rejected. 
Although note that there is an error because of the incorrect value and then also an error because `sequencingInstrument` is required when raw reads are provided (this is checked on the output field). Not strictly wrong just a bit noisy

<img width="1449" height="327" alt="grafik" src="https://github.com/user-attachments/assets/326665ac-1545-4ec1-bc24-e9f1f233343e" />

## BREAKING CHANGES
The values.yaml has already been updated on PPX and the db surgery performed, for other users switching from a string to a list of defined options a db surgery should be performed in advance, see https://github.com/pathoplexus/pathoplexus/pull/1091 for an example.

### PR Checklist
- [x] All necessary documentation has been adapted.
~- [ ] The implemented feature is covered by appropriate, automated tests.~
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://seq-metadata-options.loculus.org