### PR TITLE
feat!(helm): Allow full customization of urls and ingress, move network settings under networking

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -472,7 +472,7 @@ def generate_config(
     helm_template_cmd.extend(["--set", "disableBackend=true"])
     if from_live:
         helm_template_cmd.extend(["--set", "environment=server"])
-        helm_template_cmd.extend(["--set", f"host={live_host}"])
+        helm_template_cmd.extend(["--set", f"networking.host={live_host}"])
         helm_template_cmd.extend(["--set", "usePublicRuntimeConfigAsServerSide=true"])
     else:
         helm_template_cmd.extend(["--set", "environment=local"])

--- a/deploy.py
+++ b/deploy.py
@@ -536,7 +536,7 @@ def get_codespace_params(codespace_name):
     }
     return [
         "--set-json",
-        f"public={json.dumps(public_runtime_config)}",
+        f"networking.publicHosts={json.dumps(public_runtime_config)}",
     ]
 
 

--- a/docs/src/content/docs/for-administrators/setup-with-k3d-and-nginx.mdx
+++ b/docs/src/content/docs/for-administrators/setup-with-k3d-and-nginx.mdx
@@ -123,10 +123,11 @@ environment: local # Do not change this: this setup uses a "local" environment a
 runDevelopmentMainDatabase: true
 runDevelopmentKeycloakDatabase: true
 
-public:
-  backendUrl: 'https://api.<your domain>/backend'
-  lapisUrlTemplate: 'https://api.<your domain>/%organism%'
-  keycloakUrl: 'https://auth.<your domain>'
+networking:
+  publicHosts:
+    backendUrl: 'https://api.<your domain>/backend/'
+    lapisUrlTemplate: 'https://api.<your domain>/%organism%'
+    keycloakUrl: 'https://auth.<your domain>'
 
 auth:
   verifyEmail: false

--- a/docs/src/content/docs/for-administrators/setup-with-k3d-and-nginx.mdx
+++ b/docs/src/content/docs/for-administrators/setup-with-k3d-and-nginx.mdx
@@ -117,15 +117,15 @@ Create a file `my-values.yaml` with the following configuration for the instance
 
 ```yaml
 name: '<your instance name>'
-host: '<your domain>'
 environment: local # Do not change this: this setup uses a "local" environment as the public traffic is proxied through nginx.
 
 runDevelopmentMainDatabase: true
 runDevelopmentKeycloakDatabase: true
 
 networking:
+  host: '<your domain>'
   publicHosts:
-    backendUrl: 'https://api.<your domain>/backend/'
+    backendUrl: 'https://api.<your domain>/backend'
     lapisUrlTemplate: 'https://api.<your domain>/%organism%'
     keycloakUrl: 'https://auth.<your domain>'
 

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -623,7 +623,7 @@ fields:
 {{- else if $ingressHosts.lapis }}
   {{- $lapisUrlTemplate = printf "https://%s/%%organism%%" $ingressHosts.lapis }}
 {{- else if eq $.Values.environment "server" }}
-  {{- $lapisUrlTemplate = printf "https://lapis%s%s/%s" $.Values.networking.subdomainSeparator (.Values.host | default "") "%organism%" }}
+  {{- $lapisUrlTemplate = printf "https://lapis%s%s/%s" $.Values.networking.subdomainSeparator $.Values.host "%organism%" }}
 {{- else }}
   {{- $lapisUrlTemplate = printf "http://%s:8080/%%organism%%" $.Values.localHost }}
 {{- end }}

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -615,14 +615,15 @@ fields:
 {{- end}}
 
 {{- define "loculus.publicRuntimeConfig" }}
-{{- $publicRuntimeConfig := $.Values.networking.publicHosts }}
+{{- $publicRuntimeConfig := $.Values.networking.publicHosts | default dict }}
+{{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
 {{- $lapisUrlTemplate := "" }}
 {{- if $publicRuntimeConfig.lapisUrlTemplate }}
   {{- $lapisUrlTemplate = $publicRuntimeConfig.lapisUrlTemplate }}
-{{- else if $.Values.networking.ingressHosts.lapis }}
-  {{- $lapisUrlTemplate = printf "https://%s/%%organism%%" $.Values.networking.ingressHosts.lapis }}
+{{- else if $ingressHosts.lapis }}
+  {{- $lapisUrlTemplate = printf "https://%s/%%organism%%" $ingressHosts.lapis }}
 {{- else if eq $.Values.environment "server" }}
-  {{- $lapisUrlTemplate = printf "https://lapis%s%s/%s" $.Values.networking.subdomainSeparator $.Values.host "%organism%" }}
+  {{- $lapisUrlTemplate = printf "https://lapis%s%s/%s" $.Values.networking.subdomainSeparator (.Values.host | default "") "%organism%" }}
 {{- else }}
   {{- $lapisUrlTemplate = printf "http://%s:8080/%%organism%%" $.Values.localHost }}
 {{- end }}

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -615,14 +615,14 @@ fields:
 {{- end}}
 
 {{- define "loculus.publicRuntimeConfig" }}
-{{- $publicRuntimeConfig := $.Values.public }}
+{{- $publicRuntimeConfig := $.Values.networking.publicHosts }}
 {{- $lapisUrlTemplate := "" }}
 {{- if $publicRuntimeConfig.lapisUrlTemplate }}
   {{- $lapisUrlTemplate = $publicRuntimeConfig.lapisUrlTemplate }}
-{{- else if $.Values.ingress.hosts.lapis }}
-  {{- $lapisUrlTemplate = printf "https://%s/%%organism%%" $.Values.ingress.hosts.lapis }}
+{{- else if $.Values.networking.ingressHosts.lapis }}
+  {{- $lapisUrlTemplate = printf "https://%s/%%organism%%" $.Values.networking.ingressHosts.lapis }}
 {{- else if eq $.Values.environment "server" }}
-  {{- $lapisUrlTemplate = printf "https://lapis%s%s/%s" $.Values.subdomainSeparator $.Values.host "%organism%" }}
+  {{- $lapisUrlTemplate = printf "https://lapis%s%s/%s" $.Values.networking.subdomainSeparator $.Values.host "%organism%" }}
 {{- else }}
   {{- $lapisUrlTemplate = printf "http://%s:8080/%%organism%%" $.Values.localHost }}
 {{- end }}

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -619,6 +619,8 @@ fields:
 {{- $lapisUrlTemplate := "" }}
 {{- if $publicRuntimeConfig.lapisUrlTemplate }}
   {{- $lapisUrlTemplate = $publicRuntimeConfig.lapisUrlTemplate }}
+{{- else if $.Values.ingress.hosts.lapis }}
+  {{- $lapisUrlTemplate = printf "https://%s/%%organism%%" $.Values.ingress.hosts.lapis }}
 {{- else if eq $.Values.environment "server" }}
   {{- $lapisUrlTemplate = printf "https://lapis%s%s/%s" $.Values.subdomainSeparator $.Values.host "%organism%" }}
 {{- else }}

--- a/kubernetes/loculus/templates/_common-metadata.tpl
+++ b/kubernetes/loculus/templates/_common-metadata.tpl
@@ -615,18 +615,7 @@ fields:
 {{- end}}
 
 {{- define "loculus.publicRuntimeConfig" }}
-{{- $publicRuntimeConfig := $.Values.networking.publicHosts | default dict }}
-{{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
-{{- $lapisUrlTemplate := "" }}
-{{- if $publicRuntimeConfig.lapisUrlTemplate }}
-  {{- $lapisUrlTemplate = $publicRuntimeConfig.lapisUrlTemplate }}
-{{- else if $ingressHosts.lapis }}
-  {{- $lapisUrlTemplate = printf "https://%s/%%organism%%" $ingressHosts.lapis }}
-{{- else if eq $.Values.environment "server" }}
-  {{- $lapisUrlTemplate = printf "https://lapis%s%s/%s" $.Values.networking.subdomainSeparator $.Values.host "%organism%" }}
-{{- else }}
-  {{- $lapisUrlTemplate = printf "http://%s:8080/%%organism%%" $.Values.localHost }}
-{{- end }}
+{{- $lapisUrlTemplate := include "loculus.lapisUrlTemplate" . }}
 {{- $externalLapisUrlConfig := dict "lapisUrlTemplate" $lapisUrlTemplate "config" $.Values }}
             "backendUrl": "{{ include "loculus.backendUrl" . }}",
             "lapisUrls": {{- include "loculus.generateExternalLapisUrls" $externalLapisUrlConfig | fromYaml | toJson }},

--- a/kubernetes/loculus/templates/_urls.tpl
+++ b/kubernetes/loculus/templates/_urls.tpl
@@ -2,6 +2,8 @@
 {{- $publicRuntimeConfig := $.Values.public }}
   {{- if $publicRuntimeConfig.backendUrl }}
     {{- $publicRuntimeConfig.backendUrl -}}
+  {{- else if $.Values.ingress.hosts.backend -}}
+    {{- printf "https://%s" $.Values.ingress.hosts.backend -}}
   {{- else if eq $.Values.environment "server" -}}
     {{- (printf "https://backend%s%s" $.Values.subdomainSeparator $.Values.host) -}}
   {{- else -}}
@@ -13,6 +15,8 @@
 {{- $publicRuntimeConfig := $.Values.public }}
   {{- if $publicRuntimeConfig.websiteUrl }}
     {{- $publicRuntimeConfig.websiteUrl -}}
+  {{- else if $.Values.ingress.hosts.website -}}
+    {{- printf "https://%s" $.Values.ingress.hosts.website -}}
   {{- else if eq $.Values.environment "server" -}}
     {{- (printf "https://%s" $.Values.host) -}}
   {{- else -}}
@@ -22,7 +26,9 @@
 
 {{- define "loculus.s3Url" -}}
   {{- if $.Values.runDevelopmentS3 }}
-    {{- if eq $.Values.environment "server" -}}
+    {{- if $.Values.ingress.hosts.minio -}}
+        {{- printf "https://%s" $.Values.ingress.hosts.minio -}}
+    {{- else if eq $.Values.environment "server" -}}
         {{- (printf "https://s3%s%s" $.Values.subdomainSeparator $.Values.host) -}}
     {{- else -}}
         {{- printf "http://%s:8084" $.Values.localHost -}}
@@ -44,6 +50,8 @@
 {{- $publicRuntimeConfig := $.Values.public }}
   {{- if $publicRuntimeConfig.keycloakUrl }}
     {{- $publicRuntimeConfig.keycloakUrl -}}
+  {{- else if $.Values.ingress.hosts.keycloak -}}
+    {{- printf "https://%s" $.Values.ingress.hosts.keycloak -}}
   {{- else if eq $.Values.environment "server" -}}
     {{- (printf "https://authentication%s%s" $.Values.subdomainSeparator $.Values.host) -}}
   {{- else -}}

--- a/kubernetes/loculus/templates/_urls.tpl
+++ b/kubernetes/loculus/templates/_urls.tpl
@@ -1,24 +1,26 @@
 {{- define "loculus.backendUrl" -}}
-{{- $publicRuntimeConfig := $.Values.networking.publicHosts }}
+{{- $publicRuntimeConfig := $.Values.networking.publicHosts | default dict }}
+{{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
   {{- if $publicRuntimeConfig.backendUrl }}
     {{- $publicRuntimeConfig.backendUrl -}}
-  {{- else if $.Values.networking.ingressHosts.backend -}}
-    {{- printf "https://%s" $.Values.networking.ingressHosts.backend -}}
+  {{- else if $ingressHosts.backend -}}
+    {{- printf "https://%s" $ingressHosts.backend -}}
   {{- else if eq $.Values.environment "server" -}}
-    {{- (printf "https://backend%s%s" $.Values.networking.subdomainSeparator $.Values.host) -}}
+    {{- (printf "https://backend%s%s" $.Values.networking.subdomainSeparator (.Values.host | default "")) -}}
   {{- else -}}
     {{- printf "http://%s:8079" $.Values.localHost -}}
   {{- end -}}
 {{- end -}}
 
 {{- define "loculus.websiteUrl" -}}
-{{- $publicRuntimeConfig := $.Values.networking.publicHosts }}
+{{- $publicRuntimeConfig := $.Values.networking.publicHosts | default dict }}
+{{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
   {{- if $publicRuntimeConfig.websiteUrl }}
     {{- $publicRuntimeConfig.websiteUrl -}}
-  {{- else if $.Values.networking.ingressHosts.website -}}
-    {{- printf "https://%s" $.Values.networking.ingressHosts.website -}}
+  {{- else if $ingressHosts.website -}}
+    {{- printf "https://%s" $ingressHosts.website -}}
   {{- else if eq $.Values.environment "server" -}}
-    {{- (printf "https://%s" $.Values.host) -}}
+    {{- (printf "https://%s" (.Values.host | default "")) -}}
   {{- else -}}
     {{- printf "http://%s:3000" $.Values.localHost -}}
   {{- end -}}
@@ -26,10 +28,11 @@
 
 {{- define "loculus.s3Url" -}}
   {{- if $.Values.runDevelopmentS3 }}
-    {{- if $.Values.networking.ingressHosts.minio -}}
-        {{- printf "https://%s" $.Values.networking.ingressHosts.minio -}}
+    {{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
+    {{- if $ingressHosts.minio -}}
+        {{- printf "https://%s" $ingressHosts.minio -}}
     {{- else if eq $.Values.environment "server" -}}
-        {{- (printf "https://s3%s%s" $.Values.networking.subdomainSeparator $.Values.host) -}}
+        {{- (printf "https://s3%s%s" $.Values.networking.subdomainSeparator (.Values.host | default "")) -}}
     {{- else -}}
         {{- printf "http://%s:8084" $.Values.localHost -}}
     {{- end -}}
@@ -47,13 +50,14 @@
 {{- end -}}
 
 {{- define "loculus.keycloakUrl" -}}
-{{- $publicRuntimeConfig := $.Values.networking.publicHosts }}
+{{- $publicRuntimeConfig := $.Values.networking.publicHosts | default dict }}
+{{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
   {{- if $publicRuntimeConfig.keycloakUrl }}
     {{- $publicRuntimeConfig.keycloakUrl -}}
-  {{- else if $.Values.networking.ingressHosts.keycloak -}}
-    {{- printf "https://%s" $.Values.networking.ingressHosts.keycloak -}}
+  {{- else if $ingressHosts.keycloak -}}
+    {{- printf "https://%s" $ingressHosts.keycloak -}}
   {{- else if eq $.Values.environment "server" -}}
-    {{- (printf "https://authentication%s%s" $.Values.networking.subdomainSeparator $.Values.host) -}}
+    {{- (printf "https://authentication%s%s" $.Values.networking.subdomainSeparator (.Values.host | default "")) -}}
   {{- else -}}
     {{- printf "http://%s:8083" $.Values.localHost -}}
   {{- end -}}

--- a/kubernetes/loculus/templates/_urls.tpl
+++ b/kubernetes/loculus/templates/_urls.tpl
@@ -1,22 +1,22 @@
 {{- define "loculus.backendUrl" -}}
-{{- $publicRuntimeConfig := $.Values.public }}
+{{- $publicRuntimeConfig := $.Values.networking.publicHosts }}
   {{- if $publicRuntimeConfig.backendUrl }}
     {{- $publicRuntimeConfig.backendUrl -}}
-  {{- else if $.Values.ingress.hosts.backend -}}
-    {{- printf "https://%s" $.Values.ingress.hosts.backend -}}
+  {{- else if $.Values.networking.ingressHosts.backend -}}
+    {{- printf "https://%s" $.Values.networking.ingressHosts.backend -}}
   {{- else if eq $.Values.environment "server" -}}
-    {{- (printf "https://backend%s%s" $.Values.subdomainSeparator $.Values.host) -}}
+    {{- (printf "https://backend%s%s" $.Values.networking.subdomainSeparator $.Values.host) -}}
   {{- else -}}
     {{- printf "http://%s:8079" $.Values.localHost -}}
   {{- end -}}
 {{- end -}}
 
 {{- define "loculus.websiteUrl" -}}
-{{- $publicRuntimeConfig := $.Values.public }}
+{{- $publicRuntimeConfig := $.Values.networking.publicHosts }}
   {{- if $publicRuntimeConfig.websiteUrl }}
     {{- $publicRuntimeConfig.websiteUrl -}}
-  {{- else if $.Values.ingress.hosts.website -}}
-    {{- printf "https://%s" $.Values.ingress.hosts.website -}}
+  {{- else if $.Values.networking.ingressHosts.website -}}
+    {{- printf "https://%s" $.Values.networking.ingressHosts.website -}}
   {{- else if eq $.Values.environment "server" -}}
     {{- (printf "https://%s" $.Values.host) -}}
   {{- else -}}
@@ -26,10 +26,10 @@
 
 {{- define "loculus.s3Url" -}}
   {{- if $.Values.runDevelopmentS3 }}
-    {{- if $.Values.ingress.hosts.minio -}}
-        {{- printf "https://%s" $.Values.ingress.hosts.minio -}}
+    {{- if $.Values.networking.ingressHosts.minio -}}
+        {{- printf "https://%s" $.Values.networking.ingressHosts.minio -}}
     {{- else if eq $.Values.environment "server" -}}
-        {{- (printf "https://s3%s%s" $.Values.subdomainSeparator $.Values.host) -}}
+        {{- (printf "https://s3%s%s" $.Values.networking.subdomainSeparator $.Values.host) -}}
     {{- else -}}
         {{- printf "http://%s:8084" $.Values.localHost -}}
     {{- end -}}
@@ -47,13 +47,13 @@
 {{- end -}}
 
 {{- define "loculus.keycloakUrl" -}}
-{{- $publicRuntimeConfig := $.Values.public }}
+{{- $publicRuntimeConfig := $.Values.networking.publicHosts }}
   {{- if $publicRuntimeConfig.keycloakUrl }}
     {{- $publicRuntimeConfig.keycloakUrl -}}
-  {{- else if $.Values.ingress.hosts.keycloak -}}
-    {{- printf "https://%s" $.Values.ingress.hosts.keycloak -}}
+  {{- else if $.Values.networking.ingressHosts.keycloak -}}
+    {{- printf "https://%s" $.Values.networking.ingressHosts.keycloak -}}
   {{- else if eq $.Values.environment "server" -}}
-    {{- (printf "https://authentication%s%s" $.Values.subdomainSeparator $.Values.host) -}}
+    {{- (printf "https://authentication%s%s" $.Values.networking.subdomainSeparator $.Values.host) -}}
   {{- else -}}
     {{- printf "http://%s:8083" $.Values.localHost -}}
   {{- end -}}

--- a/kubernetes/loculus/templates/_urls.tpl
+++ b/kubernetes/loculus/templates/_urls.tpl
@@ -6,7 +6,7 @@
   {{- else if $ingressHosts.backend -}}
     {{- printf "https://%s" $ingressHosts.backend -}}
   {{- else if eq $.Values.environment "server" -}}
-    {{- (printf "https://backend%s%s" $.Values.networking.subdomainSeparator (.Values.host | default "")) -}}
+    {{- (printf "https://backend%s%s" $.Values.networking.subdomainSeparator $.Values.host) -}}
   {{- else -}}
     {{- printf "http://%s:8079" $.Values.localHost -}}
   {{- end -}}
@@ -20,7 +20,7 @@
   {{- else if $ingressHosts.website -}}
     {{- printf "https://%s" $ingressHosts.website -}}
   {{- else if eq $.Values.environment "server" -}}
-    {{- (printf "https://%s" (.Values.host | default "")) -}}
+    {{- (printf "https://%s" $.Values.host) -}}
   {{- else -}}
     {{- printf "http://%s:3000" $.Values.localHost -}}
   {{- end -}}
@@ -32,7 +32,7 @@
     {{- if $ingressHosts.minio -}}
         {{- printf "https://%s" $ingressHosts.minio -}}
     {{- else if eq $.Values.environment "server" -}}
-        {{- (printf "https://s3%s%s" $.Values.networking.subdomainSeparator (.Values.host | default "")) -}}
+        {{- (printf "https://s3%s%s" $.Values.networking.subdomainSeparator $.Values.host) -}}
     {{- else -}}
         {{- printf "http://%s:8084" $.Values.localHost -}}
     {{- end -}}
@@ -57,7 +57,7 @@
   {{- else if $ingressHosts.keycloak -}}
     {{- printf "https://%s" $ingressHosts.keycloak -}}
   {{- else if eq $.Values.environment "server" -}}
-    {{- (printf "https://authentication%s%s" $.Values.networking.subdomainSeparator (.Values.host | default "")) -}}
+    {{- (printf "https://authentication%s%s" $.Values.networking.subdomainSeparator $.Values.host) -}}
   {{- else -}}
     {{- printf "http://%s:8083" $.Values.localHost -}}
   {{- end -}}

--- a/kubernetes/loculus/templates/_urls.tpl
+++ b/kubernetes/loculus/templates/_urls.tpl
@@ -95,11 +95,17 @@
 {{- end -}}
 
 {{/* In the server environment the Ingress rules route a whole hostname at path /, so a public URL
-     that carries a path prefix cannot be served. Fail loudly instead of silently dropping the path. */}}
+     that carries a path prefix cannot be served. Fail loudly instead of silently dropping the path.
+     lapisUrlTemplate is the one exception: the LAPIS Ingress does route /%organism%/ and strips that
+     prefix (see lapis-ingress.yaml), so exactly that one trailing segment is allowed - for that key
+     only, and only as the whole path. */}}
 {{- define "loculus.assertPublicHostsRoutable" -}}
 {{- if eq $.Values.environment "server" -}}
   {{- range $key, $url := ($.Values.networking.publicHosts | default dict) -}}
-    {{- $rest := $url | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" | trimSuffix "/%organism%" -}}
+    {{- $rest := $url | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" -}}
+    {{- if eq $key "lapisUrlTemplate" -}}
+      {{- $rest = $rest | trimSuffix "/%organism%" -}}
+    {{- end -}}
     {{- if contains "/" $rest -}}
       {{- fail (printf "networking.publicHosts.%s = %q has a path prefix, which is not supported in the server environment: the Ingress routes the whole hostname at /. Use a URL without a path, or run environment=local behind your own reverse proxy." $key $url) -}}
     {{- end -}}

--- a/kubernetes/loculus/templates/_urls.tpl
+++ b/kubernetes/loculus/templates/_urls.tpl
@@ -1,10 +1,7 @@
 {{- define "loculus.backendUrl" -}}
 {{- $publicRuntimeConfig := $.Values.networking.publicHosts | default dict }}
-{{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
   {{- if $publicRuntimeConfig.backendUrl }}
     {{- $publicRuntimeConfig.backendUrl -}}
-  {{- else if $ingressHosts.backend -}}
-    {{- printf "https://%s" $ingressHosts.backend -}}
   {{- else if eq $.Values.environment "server" -}}
     {{- (printf "https://backend%s%s" $.Values.networking.subdomainSeparator $.Values.host) -}}
   {{- else -}}
@@ -14,11 +11,8 @@
 
 {{- define "loculus.websiteUrl" -}}
 {{- $publicRuntimeConfig := $.Values.networking.publicHosts | default dict }}
-{{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
   {{- if $publicRuntimeConfig.websiteUrl }}
     {{- $publicRuntimeConfig.websiteUrl -}}
-  {{- else if $ingressHosts.website -}}
-    {{- printf "https://%s" $ingressHosts.website -}}
   {{- else if eq $.Values.environment "server" -}}
     {{- (printf "https://%s" $.Values.host) -}}
   {{- else -}}
@@ -28,10 +22,7 @@
 
 {{- define "loculus.s3Url" -}}
   {{- if $.Values.runDevelopmentS3 }}
-    {{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
-    {{- if $ingressHosts.minio -}}
-        {{- printf "https://%s" $ingressHosts.minio -}}
-    {{- else if eq $.Values.environment "server" -}}
+    {{- if eq $.Values.environment "server" -}}
         {{- (printf "https://s3%s%s" $.Values.networking.subdomainSeparator $.Values.host) -}}
     {{- else -}}
         {{- printf "http://%s:8084" $.Values.localHost -}}
@@ -51,11 +42,8 @@
 
 {{- define "loculus.keycloakUrl" -}}
 {{- $publicRuntimeConfig := $.Values.networking.publicHosts | default dict }}
-{{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
   {{- if $publicRuntimeConfig.keycloakUrl }}
     {{- $publicRuntimeConfig.keycloakUrl -}}
-  {{- else if $ingressHosts.keycloak -}}
-    {{- printf "https://%s" $ingressHosts.keycloak -}}
   {{- else if eq $.Values.environment "server" -}}
     {{- (printf "https://authentication%s%s" $.Values.networking.subdomainSeparator $.Values.host) -}}
   {{- else -}}
@@ -85,3 +73,20 @@
 {{- define "loculus.lapisServiceName"}}
 {{- printf "loculus-lapis-service-%s" . }}
 {{- end }}
+
+{{/* Public URL template for LAPIS, with %organism% placeholder */}}
+{{- define "loculus.lapisUrlTemplate" -}}
+{{- $publicRuntimeConfig := $.Values.networking.publicHosts | default dict }}
+  {{- if $publicRuntimeConfig.lapisUrlTemplate -}}
+    {{- $publicRuntimeConfig.lapisUrlTemplate -}}
+  {{- else if eq $.Values.environment "server" -}}
+    {{- printf "https://lapis%s%s/%%organism%%" $.Values.networking.subdomainSeparator $.Values.host -}}
+  {{- else -}}
+    {{- printf "http://%s:8080/%%organism%%" $.Values.localHost -}}
+  {{- end -}}
+{{- end -}}
+
+{{/* Hostname of a public URL, for use in Ingress rules */}}
+{{- define "loculus.ingressHost" -}}
+{{- . | trimPrefix "https://" | trimPrefix "http://" | splitList "/" | first | splitList ":" | first -}}
+{{- end -}}

--- a/kubernetes/loculus/templates/_urls.tpl
+++ b/kubernetes/loculus/templates/_urls.tpl
@@ -78,6 +78,9 @@
 {{- define "loculus.lapisUrlTemplate" -}}
 {{- $publicRuntimeConfig := $.Values.networking.publicHosts | default dict }}
   {{- if $publicRuntimeConfig.lapisUrlTemplate -}}
+    {{- if not (contains "%organism%" $publicRuntimeConfig.lapisUrlTemplate) -}}
+      {{- fail (printf "networking.publicHosts.lapisUrlTemplate = %q must contain the %%organism%% placeholder, otherwise every organism is advertised at the same LAPIS URL." $publicRuntimeConfig.lapisUrlTemplate) -}}
+    {{- end -}}
     {{- $publicRuntimeConfig.lapisUrlTemplate -}}
   {{- else if eq $.Values.environment "server" -}}
     {{- printf "https://lapis%s%s/%%organism%%" $.Values.networking.subdomainSeparator $.Values.networking.host -}}

--- a/kubernetes/loculus/templates/_urls.tpl
+++ b/kubernetes/loculus/templates/_urls.tpl
@@ -3,7 +3,7 @@
   {{- if $publicRuntimeConfig.backendUrl }}
     {{- $publicRuntimeConfig.backendUrl -}}
   {{- else if eq $.Values.environment "server" -}}
-    {{- (printf "https://backend%s%s" $.Values.networking.subdomainSeparator $.Values.host) -}}
+    {{- (printf "https://backend%s%s" $.Values.networking.subdomainSeparator $.Values.networking.host) -}}
   {{- else -}}
     {{- printf "http://%s:8079" $.Values.localHost -}}
   {{- end -}}
@@ -14,7 +14,7 @@
   {{- if $publicRuntimeConfig.websiteUrl }}
     {{- $publicRuntimeConfig.websiteUrl -}}
   {{- else if eq $.Values.environment "server" -}}
-    {{- (printf "https://%s" $.Values.host) -}}
+    {{- (printf "https://%s" $.Values.networking.host) -}}
   {{- else -}}
     {{- printf "http://%s:3000" $.Values.localHost -}}
   {{- end -}}
@@ -23,7 +23,7 @@
 {{- define "loculus.s3Url" -}}
   {{- if $.Values.runDevelopmentS3 }}
     {{- if eq $.Values.environment "server" -}}
-        {{- (printf "https://s3%s%s" $.Values.networking.subdomainSeparator $.Values.host) -}}
+        {{- (printf "https://s3%s%s" $.Values.networking.subdomainSeparator $.Values.networking.host) -}}
     {{- else -}}
         {{- printf "http://%s:8084" $.Values.localHost -}}
     {{- end -}}
@@ -45,7 +45,7 @@
   {{- if $publicRuntimeConfig.keycloakUrl }}
     {{- $publicRuntimeConfig.keycloakUrl -}}
   {{- else if eq $.Values.environment "server" -}}
-    {{- (printf "https://authentication%s%s" $.Values.networking.subdomainSeparator $.Values.host) -}}
+    {{- (printf "https://authentication%s%s" $.Values.networking.subdomainSeparator $.Values.networking.host) -}}
   {{- else -}}
     {{- printf "http://%s:8083" $.Values.localHost -}}
   {{- end -}}
@@ -80,7 +80,7 @@
   {{- if $publicRuntimeConfig.lapisUrlTemplate -}}
     {{- $publicRuntimeConfig.lapisUrlTemplate -}}
   {{- else if eq $.Values.environment "server" -}}
-    {{- printf "https://lapis%s%s/%%organism%%" $.Values.networking.subdomainSeparator $.Values.host -}}
+    {{- printf "https://lapis%s%s/%%organism%%" $.Values.networking.subdomainSeparator $.Values.networking.host -}}
   {{- else -}}
     {{- printf "http://%s:8080/%%organism%%" $.Values.localHost -}}
   {{- end -}}
@@ -89,4 +89,17 @@
 {{/* Hostname of a public URL, for use in Ingress rules */}}
 {{- define "loculus.ingressHost" -}}
 {{- . | trimPrefix "https://" | trimPrefix "http://" | splitList "/" | first | splitList ":" | first -}}
+{{- end -}}
+
+{{/* In the server environment the Ingress rules route a whole hostname at path /, so a public URL
+     that carries a path prefix cannot be served. Fail loudly instead of silently dropping the path. */}}
+{{- define "loculus.assertPublicHostsRoutable" -}}
+{{- if eq $.Values.environment "server" -}}
+  {{- range $key, $url := ($.Values.networking.publicHosts | default dict) -}}
+    {{- $rest := $url | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" | trimSuffix "/%organism%" -}}
+    {{- if contains "/" $rest -}}
+      {{- fail (printf "networking.publicHosts.%s = %q has a path prefix, which is not supported in the server environment: the Ingress routes the whole hostname at /. Use a URL without a path, or run environment=local behind your own reverse proxy." $key $url) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
 {{- end -}}

--- a/kubernetes/loculus/templates/autoapprove-config.yaml
+++ b/kubernetes/loculus/templates/autoapprove-config.yaml
@@ -1,6 +1,6 @@
 {{- if not .Values.disableIngest }}
 {{- $testconfig := .Values.testconfig | default false }}
-{{- $backendHost := .Values.environment | eq "server" | ternary (printf "https://backend%s%s" .Values.subdomainSeparator $.Values.host) ($testconfig | ternary (printf "http://%s:8079" $.Values.localHost) "http://loculus-backend-service:8079") }}
+{{- $backendHost := .Values.environment | eq "server" | ternary (include "loculus.backendUrl" .) ($testconfig | ternary (printf "http://%s:8079" $.Values.localHost) "http://loculus-backend-service:8079") }}
 {{- $keycloakHost := $testconfig | ternary (printf "http://%s:8083" $.Values.localHost) "http://loculus-keycloak-service:8083" }}
 {{- $organismKeys := list }}
 {{- range $_, $item := (include "loculus.enabledOrganisms" . | fromJson).organisms }}

--- a/kubernetes/loculus/templates/docs-preview.yaml
+++ b/kubernetes/loculus/templates/docs-preview.yaml
@@ -1,6 +1,6 @@
 {{- $dockerTag := include "loculus.dockerTag" .Values }}
 {{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
-{{- $docsHost := $ingressHosts.docs | default (printf "docs%s%s" .Values.networking.subdomainSeparator (.Values.host | default "")) }}
+{{- $docsHost := $ingressHosts.docs | default (printf "docs%s%s" $.Values.networking.subdomainSeparator $.Values.host) }}
 {{- if .Values.previewDocs }}
 ---
 apiVersion: apps/v1

--- a/kubernetes/loculus/templates/docs-preview.yaml
+++ b/kubernetes/loculus/templates/docs-preview.yaml
@@ -1,5 +1,6 @@
 {{- $dockerTag := include "loculus.dockerTag" .Values }}
-{{- $docsHost := $.Values.networking.ingressHosts.docs | default (printf "docs%s%s" .Values.networking.subdomainSeparator .Values.host) }}
+{{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
+{{- $docsHost := $ingressHosts.docs | default (printf "docs%s%s" .Values.networking.subdomainSeparator (.Values.host | default "")) }}
 {{- if .Values.previewDocs }}
 ---
 apiVersion: apps/v1

--- a/kubernetes/loculus/templates/docs-preview.yaml
+++ b/kubernetes/loculus/templates/docs-preview.yaml
@@ -1,5 +1,5 @@
 {{- $dockerTag := include "loculus.dockerTag" .Values }}
-{{- $docsHost := $.Values.ingress.hosts.docs | default (printf "docs%s%s" .Values.subdomainSeparator .Values.host) }}
+{{- $docsHost := $.Values.networking.ingressHosts.docs | default (printf "docs%s%s" .Values.networking.subdomainSeparator .Values.host) }}
 {{- if .Values.previewDocs }}
 ---
 apiVersion: apps/v1

--- a/kubernetes/loculus/templates/docs-preview.yaml
+++ b/kubernetes/loculus/templates/docs-preview.yaml
@@ -1,5 +1,5 @@
 {{- $dockerTag := include "loculus.dockerTag" .Values }}
-{{- $docsHost := printf "docs%s%s" .Values.subdomainSeparator .Values.host }}
+{{- $docsHost := $.Values.ingress.hosts.docs | default (printf "docs%s%s" .Values.subdomainSeparator .Values.host) }}
 {{- if .Values.previewDocs }}
 ---
 apiVersion: apps/v1

--- a/kubernetes/loculus/templates/docs-preview.yaml
+++ b/kubernetes/loculus/templates/docs-preview.yaml
@@ -1,6 +1,5 @@
 {{- $dockerTag := include "loculus.dockerTag" .Values }}
-{{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
-{{- $docsHost := $ingressHosts.docs | default (printf "docs%s%s" $.Values.networking.subdomainSeparator $.Values.networking.host) }}
+{{- $docsHost := printf "docs%s%s" $.Values.networking.subdomainSeparator $.Values.networking.host }}
 {{- if .Values.previewDocs }}
 ---
 apiVersion: apps/v1

--- a/kubernetes/loculus/templates/docs-preview.yaml
+++ b/kubernetes/loculus/templates/docs-preview.yaml
@@ -1,6 +1,6 @@
 {{- $dockerTag := include "loculus.dockerTag" .Values }}
 {{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
-{{- $docsHost := $ingressHosts.docs | default (printf "docs%s%s" $.Values.networking.subdomainSeparator $.Values.host) }}
+{{- $docsHost := $ingressHosts.docs | default (printf "docs%s%s" $.Values.networking.subdomainSeparator $.Values.networking.host) }}
 {{- if .Values.previewDocs }}
 ---
 apiVersion: apps/v1

--- a/kubernetes/loculus/templates/docs-preview.yaml
+++ b/kubernetes/loculus/templates/docs-preview.yaml
@@ -1,5 +1,6 @@
 {{- $dockerTag := include "loculus.dockerTag" .Values }}
-{{- $docsHost := printf "docs%s%s" $.Values.networking.subdomainSeparator $.Values.host }}
+{{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
+{{- $docsHost := $ingressHosts.docs | default (printf "docs%s%s" $.Values.networking.subdomainSeparator $.Values.host) }}
 {{- if .Values.previewDocs }}
 ---
 apiVersion: apps/v1

--- a/kubernetes/loculus/templates/docs-preview.yaml
+++ b/kubernetes/loculus/templates/docs-preview.yaml
@@ -1,6 +1,5 @@
 {{- $dockerTag := include "loculus.dockerTag" .Values }}
-{{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
-{{- $docsHost := $ingressHosts.docs | default (printf "docs%s%s" $.Values.networking.subdomainSeparator $.Values.host) }}
+{{- $docsHost := printf "docs%s%s" $.Values.networking.subdomainSeparator $.Values.host }}
 {{- if .Values.previewDocs }}
 ---
 apiVersion: apps/v1

--- a/kubernetes/loculus/templates/ena-submission-config.yaml
+++ b/kubernetes/loculus/templates/ena-submission-config.yaml
@@ -1,7 +1,7 @@
 {{- if not .Values.disableEnaSubmission }}
 {{- $testconfig := .Values.testconfig | default false }}
 {{- $enaDepositionHost := $testconfig | ternary "127.0.0.1" "0.0.0.0" }}
-{{- $backendHost := .Values.environment | eq "server" | ternary (printf "https://backend%s%s" .Values.subdomainSeparator $.Values.host) ($testconfig | ternary (printf "http://%s:8079" $.Values.localHost) "http://loculus-backend-service:8079") }}
+{{- $backendHost := .Values.environment | eq "server" | ternary (include "loculus.backendUrl" .) ($testconfig | ternary (printf "http://%s:8079" $.Values.localHost) "http://loculus-backend-service:8079") }}
 {{- $keycloakHost := $testconfig | ternary (printf "http://%s:8083" $.Values.localHost) "http://loculus-keycloak-service:8083" }}
 {{- $submitToEnaProduction := .Values.enaDeposition.submitToEnaProduction | default false }}
 {{- $enaDbName := .Values.enaDeposition.enaDbName | default false }}

--- a/kubernetes/loculus/templates/ingest-config.yaml
+++ b/kubernetes/loculus/templates/ingest-config.yaml
@@ -1,6 +1,6 @@
 {{- $dockerTag := include "loculus.dockerTag" .Values }}
 {{- $testconfig := .Values.testconfig | default false }}
-{{- $backendHost := .Values.environment | eq "server" | ternary (printf "https://backend%s%s" .Values.subdomainSeparator $.Values.host) ($testconfig | ternary (printf "http://%s:8079" $.Values.localHost) "http://loculus-backend-service:8079") }}
+{{- $backendHost := .Values.environment | eq "server" | ternary (include "loculus.backendUrl" .) ($testconfig | ternary (printf "http://%s:8079" $.Values.localHost) "http://loculus-backend-service:8079") }}
 {{- $enaDepositionHost := $testconfig | ternary (printf "http://%s:5000" $.Values.localHost) "http://loculus-ena-submission-service:5000" }}
 {{- $keycloakHost := $testconfig | ternary (printf "http://%s:8083" $.Values.localHost) "http://loculus-keycloak-service:8083" }}
 {{- range $_, $item := (include "loculus.enabledOrganisms" . | fromJson).organisms }}

--- a/kubernetes/loculus/templates/ingressroute.yaml
+++ b/kubernetes/loculus/templates/ingressroute.yaml
@@ -1,4 +1,4 @@
-{{- $traefikApiVersion := ternary "traefik.io/v1alpha1" "traefik.containo.us/v1alpha1" (eq (int $.Values.traefikVersion) 3) -}}
+{{- $traefikApiVersion := ternary "traefik.io/v1alpha1" "traefik.containo.us/v1alpha1" (eq (int $.Values.networking.traefikVersion) 3) -}}
 apiVersion: {{ $traefikApiVersion }}
 kind: Middleware
 metadata:
@@ -47,12 +47,12 @@ spec:
     permanent: true
 ---
 {{- if eq $.Values.environment "server" }}
-{{- $websiteHost := $.Values.ingress.hosts.website | default $.Values.host }}
-{{- $backendHost := $.Values.ingress.hosts.backend | default (printf "backend%s%s" .Values.subdomainSeparator .Values.host) }}
-{{- $keycloakHost := $.Values.ingress.hosts.keycloak | default (printf "authentication%s%s" $.Values.subdomainSeparator $.Values.host) }}
-{{- $minioHost := $.Values.ingress.hosts.minio | default (printf "s3%s%s" $.Values.subdomainSeparator $.Values.host) }}
+{{- $websiteHost := $.Values.networking.ingressHosts.website | default $.Values.host }}
+{{- $backendHost := $.Values.networking.ingressHosts.backend | default (printf "backend%s%s" .Values.networking.subdomainSeparator .Values.host) }}
+{{- $keycloakHost := $.Values.networking.ingressHosts.keycloak | default (printf "authentication%s%s" $.Values.networking.subdomainSeparator $.Values.host) }}
+{{- $minioHost := $.Values.networking.ingressHosts.minio | default (printf "s3%s%s" $.Values.networking.subdomainSeparator $.Values.host) }}
 {{- $middlewareList := list (printf "%s-compression-middleware@kubernetescrd" $.Release.Namespace) }}
-{{- if $.Values.enforceHTTPS }}
+{{- if $.Values.networking.enforceHTTPS }}
 {{- $middlewareList = append $middlewareList (printf "%s-redirect-middleware@kubernetescrd" $.Release.Namespace) }}
 {{- end }}
 {{ if $.Values.robotsNoindexHeader }}

--- a/kubernetes/loculus/templates/ingressroute.yaml
+++ b/kubernetes/loculus/templates/ingressroute.yaml
@@ -47,7 +47,12 @@ spec:
     permanent: true
 ---
 {{- if eq $.Values.environment "server" }}
-{{- $websiteHost := $.Values.networking.ingressHosts.website | default $.Values.host }}
+{{- $websiteHostOverride := $.Values.networking.ingressHosts.website }}
+{{- $websiteHost := $websiteHostOverride | default $.Values.host }}
+{{- $wwwHost := "" }}
+{{- if and (not $websiteHostOverride) (not (hasPrefix "www." $websiteHost)) }}
+  {{- $wwwHost = printf "www.%s" $websiteHost }}
+{{- end }}
 {{- $backendHost := $.Values.networking.ingressHosts.backend | default (printf "backend%s%s" .Values.networking.subdomainSeparator .Values.host) }}
 {{- $keycloakHost := $.Values.networking.ingressHosts.keycloak | default (printf "authentication%s%s" $.Values.networking.subdomainSeparator $.Values.host) }}
 {{- $minioHost := $.Values.networking.ingressHosts.minio | default (printf "s3%s%s" $.Values.networking.subdomainSeparator $.Values.host) }}
@@ -87,7 +92,8 @@ spec:
                 name: loculus-website-service
                 port:
                   number: 3000
-    - host: "www.{{ $websiteHost }}"
+    {{- if $wwwHost }}
+    - host: "{{ $wwwHost }}"
       http:
         paths:
           - path: /
@@ -97,10 +103,13 @@ spec:
                 name: loculus-website-service
                 port:
                   number: 3000
+    {{- end }}
   tls:
   - hosts:
     - "{{ $websiteHost }}"
-    - "www.{{ $websiteHost }}"
+    {{- if $wwwHost }}
+    - "{{ $wwwHost }}"
+    {{- end }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/kubernetes/loculus/templates/ingressroute.yaml
+++ b/kubernetes/loculus/templates/ingressroute.yaml
@@ -47,9 +47,10 @@ spec:
     permanent: true
 ---
 {{- if eq $.Values.environment "server" }}
-{{- $backendHost := printf "backend%s%s" .Values.subdomainSeparator .Values.host }}
-{{- $keycloakHost := (printf "authentication%s%s" $.Values.subdomainSeparator $.Values.host) }}
-{{- $minioHost := (printf "s3%s%s" $.Values.subdomainSeparator $.Values.host) }}
+{{- $websiteHost := $.Values.ingress.hosts.website | default $.Values.host }}
+{{- $backendHost := $.Values.ingress.hosts.backend | default (printf "backend%s%s" .Values.subdomainSeparator .Values.host) }}
+{{- $keycloakHost := $.Values.ingress.hosts.keycloak | default (printf "authentication%s%s" $.Values.subdomainSeparator $.Values.host) }}
+{{- $minioHost := $.Values.ingress.hosts.minio | default (printf "s3%s%s" $.Values.subdomainSeparator $.Values.host) }}
 {{- $middlewareList := list (printf "%s-compression-middleware@kubernetescrd" $.Release.Namespace) }}
 {{- if $.Values.enforceHTTPS }}
 {{- $middlewareList = append $middlewareList (printf "%s-redirect-middleware@kubernetescrd" $.Release.Namespace) }}
@@ -76,7 +77,7 @@ metadata:
     traefik.ingress.kubernetes.io/router.middlewares: "{{ join "," $middlewareListForWebsite }}"
 spec:
   rules:
-    - host: "{{ .Values.host }}"
+    - host: "{{ $websiteHost }}"
       http:
         paths:
           - path: /
@@ -86,7 +87,7 @@ spec:
                 name: loculus-website-service
                 port:
                   number: 3000
-    - host: "www.{{ .Values.host }}"
+    - host: "www.{{ $websiteHost }}"
       http:
         paths:
           - path: /
@@ -98,8 +99,8 @@ spec:
                   number: 3000
   tls:
   - hosts:
-    - "{{ .Values.host }}"
-    - "www.{{ .Values.host }}"
+    - "{{ $websiteHost }}"
+    - "www.{{ $websiteHost }}"
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/kubernetes/loculus/templates/ingressroute.yaml
+++ b/kubernetes/loculus/templates/ingressroute.yaml
@@ -49,14 +49,14 @@ spec:
 {{- if eq $.Values.environment "server" }}
 {{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
 {{- $websiteHostOverride := $ingressHosts.website }}
-{{- $websiteHost := $websiteHostOverride | default (.Values.host | default "") }}
+{{- $websiteHost := $websiteHostOverride | default ($.Values.host | default "") }}
 {{- $wwwHost := "" }}
 {{- if and (not $websiteHostOverride) (not (hasPrefix "www." $websiteHost)) }}
   {{- $wwwHost = printf "www.%s" $websiteHost }}
 {{- end }}
-{{- $backendHost := $ingressHosts.backend | default (printf "backend%s%s" .Values.networking.subdomainSeparator (.Values.host | default "")) }}
-{{- $keycloakHost := $ingressHosts.keycloak | default (printf "authentication%s%s" $.Values.networking.subdomainSeparator (.Values.host | default "")) }}
-{{- $minioHost := $ingressHosts.minio | default (printf "s3%s%s" $.Values.networking.subdomainSeparator (.Values.host | default "")) }}
+{{- $backendHost := $ingressHosts.backend | default (printf "backend%s%s" $.Values.networking.subdomainSeparator $.Values.host) }}
+{{- $keycloakHost := $ingressHosts.keycloak | default (printf "authentication%s%s" $.Values.networking.subdomainSeparator $.Values.host) }}
+{{- $minioHost := $ingressHosts.minio | default (printf "s3%s%s" $.Values.networking.subdomainSeparator $.Values.host) }}
 {{- $middlewareList := list (printf "%s-compression-middleware@kubernetescrd" $.Release.Namespace) }}
 {{- if $.Values.networking.enforceHTTPS }}
 {{- $middlewareList = append $middlewareList (printf "%s-redirect-middleware@kubernetescrd" $.Release.Namespace) }}

--- a/kubernetes/loculus/templates/ingressroute.yaml
+++ b/kubernetes/loculus/templates/ingressroute.yaml
@@ -47,15 +47,16 @@ spec:
     permanent: true
 ---
 {{- if eq $.Values.environment "server" }}
-{{- $websiteHostOverride := $.Values.networking.ingressHosts.website }}
-{{- $websiteHost := $websiteHostOverride | default $.Values.host }}
+{{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
+{{- $websiteHostOverride := $ingressHosts.website }}
+{{- $websiteHost := $websiteHostOverride | default (.Values.host | default "") }}
 {{- $wwwHost := "" }}
 {{- if and (not $websiteHostOverride) (not (hasPrefix "www." $websiteHost)) }}
   {{- $wwwHost = printf "www.%s" $websiteHost }}
 {{- end }}
-{{- $backendHost := $.Values.networking.ingressHosts.backend | default (printf "backend%s%s" .Values.networking.subdomainSeparator .Values.host) }}
-{{- $keycloakHost := $.Values.networking.ingressHosts.keycloak | default (printf "authentication%s%s" $.Values.networking.subdomainSeparator $.Values.host) }}
-{{- $minioHost := $.Values.networking.ingressHosts.minio | default (printf "s3%s%s" $.Values.networking.subdomainSeparator $.Values.host) }}
+{{- $backendHost := $ingressHosts.backend | default (printf "backend%s%s" .Values.networking.subdomainSeparator (.Values.host | default "")) }}
+{{- $keycloakHost := $ingressHosts.keycloak | default (printf "authentication%s%s" $.Values.networking.subdomainSeparator (.Values.host | default "")) }}
+{{- $minioHost := $ingressHosts.minio | default (printf "s3%s%s" $.Values.networking.subdomainSeparator (.Values.host | default "")) }}
 {{- $middlewareList := list (printf "%s-compression-middleware@kubernetescrd" $.Release.Namespace) }}
 {{- if $.Values.networking.enforceHTTPS }}
 {{- $middlewareList = append $middlewareList (printf "%s-redirect-middleware@kubernetescrd" $.Release.Namespace) }}

--- a/kubernetes/loculus/templates/ingressroute.yaml
+++ b/kubernetes/loculus/templates/ingressroute.yaml
@@ -49,7 +49,8 @@ spec:
 {{- if eq $.Values.environment "server" }}
 {{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
 {{- $websiteHost := $ingressHosts.website | default (include "loculus.ingressHost" (include "loculus.websiteUrl" .)) }}
-{{- $wwwHost := ternary (printf "www.%s" $websiteHost) "" (eq $websiteHost $.Values.host) }}
+{{- /* only serve the www. alias for the plain default host: a cert for www.<override> would likely have no DNS */}}
+{{- $wwwHost := ternary (printf "www.%s" $websiteHost) "" (and (eq $websiteHost $.Values.host) (not (hasPrefix "www." $websiteHost))) }}
 {{- $backendHost := $ingressHosts.backend | default (include "loculus.ingressHost" (include "loculus.backendUrl" .)) }}
 {{- $keycloakHost := $ingressHosts.keycloak | default (include "loculus.ingressHost" (include "loculus.keycloakUrl" .)) }}
 {{- $minioHost := $ingressHosts.minio | default (include "loculus.ingressHost" (include "loculus.s3Url" .)) }}

--- a/kubernetes/loculus/templates/ingressroute.yaml
+++ b/kubernetes/loculus/templates/ingressroute.yaml
@@ -1,3 +1,4 @@
+{{- include "loculus.assertPublicHostsRoutable" . -}}
 {{- $traefikApiVersion := ternary "traefik.io/v1alpha1" "traefik.containo.us/v1alpha1" (eq (int $.Values.networking.traefikVersion) 3) -}}
 apiVersion: {{ $traefikApiVersion }}
 kind: Middleware
@@ -50,7 +51,7 @@ spec:
 {{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
 {{- $websiteHost := $ingressHosts.website | default (include "loculus.ingressHost" (include "loculus.websiteUrl" .)) }}
 {{- /* only serve the www. alias for the plain default host: a cert for www.<override> would likely have no DNS */}}
-{{- $wwwHost := ternary (printf "www.%s" $websiteHost) "" (and (eq $websiteHost $.Values.host) (not (hasPrefix "www." $websiteHost))) }}
+{{- $wwwHost := ternary (printf "www.%s" $websiteHost) "" (and (eq $websiteHost $.Values.networking.host) (not (hasPrefix "www." $websiteHost))) }}
 {{- $backendHost := $ingressHosts.backend | default (include "loculus.ingressHost" (include "loculus.backendUrl" .)) }}
 {{- $keycloakHost := $ingressHosts.keycloak | default (include "loculus.ingressHost" (include "loculus.keycloakUrl" .)) }}
 {{- $minioHost := $ingressHosts.minio | default (include "loculus.ingressHost" (include "loculus.s3Url" .)) }}

--- a/kubernetes/loculus/templates/ingressroute.yaml
+++ b/kubernetes/loculus/templates/ingressroute.yaml
@@ -54,7 +54,7 @@ spec:
 {{- $wwwHost := ternary (printf "www.%s" $websiteHost) "" (and (eq $websiteHost $.Values.networking.host) (not (hasPrefix "www." $websiteHost))) }}
 {{- $backendHost := $ingressHosts.backend | default (include "loculus.ingressHost" (include "loculus.backendUrl" .)) }}
 {{- $keycloakHost := $ingressHosts.keycloak | default (include "loculus.ingressHost" (include "loculus.keycloakUrl" .)) }}
-{{- $minioHost := $ingressHosts.minio | default (include "loculus.ingressHost" (include "loculus.s3Url" .)) }}
+{{- $minioHost := include "loculus.ingressHost" (include "loculus.s3Url" .) }}
 {{- $middlewareList := list (printf "%s-compression-middleware@kubernetescrd" $.Release.Namespace) }}
 {{- if $.Values.networking.enforceHTTPS }}
 {{- $middlewareList = append $middlewareList (printf "%s-redirect-middleware@kubernetescrd" $.Release.Namespace) }}
@@ -71,7 +71,9 @@ spec:
 {{ $middlewareListForKeycloak = append $middlewareListForKeycloak (printf "%s-basic-auth@kubernetescrd" $.Release.Namespace) }}
 {{ end }}
 
+{{ if $wwwHost }}
 {{ $middlewareListForWebsite = append $middlewareListForWebsite (printf "%s-redirect-www-middleware@kubernetescrd" $.Release.Namespace) }}
+{{ end }}
 
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/kubernetes/loculus/templates/ingressroute.yaml
+++ b/kubernetes/loculus/templates/ingressroute.yaml
@@ -47,16 +47,11 @@ spec:
     permanent: true
 ---
 {{- if eq $.Values.environment "server" }}
-{{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
-{{- $websiteHostOverride := $ingressHosts.website }}
-{{- $websiteHost := $websiteHostOverride | default ($.Values.host | default "") }}
-{{- $wwwHost := "" }}
-{{- if and (not $websiteHostOverride) (not (hasPrefix "www." $websiteHost)) }}
-  {{- $wwwHost = printf "www.%s" $websiteHost }}
-{{- end }}
-{{- $backendHost := $ingressHosts.backend | default (printf "backend%s%s" $.Values.networking.subdomainSeparator $.Values.host) }}
-{{- $keycloakHost := $ingressHosts.keycloak | default (printf "authentication%s%s" $.Values.networking.subdomainSeparator $.Values.host) }}
-{{- $minioHost := $ingressHosts.minio | default (printf "s3%s%s" $.Values.networking.subdomainSeparator $.Values.host) }}
+{{- $websiteHost := include "loculus.ingressHost" (include "loculus.websiteUrl" .) }}
+{{- $wwwHost := ternary (printf "www.%s" $websiteHost) "" (eq $websiteHost $.Values.host) }}
+{{- $backendHost := include "loculus.ingressHost" (include "loculus.backendUrl" .) }}
+{{- $keycloakHost := include "loculus.ingressHost" (include "loculus.keycloakUrl" .) }}
+{{- $minioHost := include "loculus.ingressHost" (include "loculus.s3Url" .) }}
 {{- $middlewareList := list (printf "%s-compression-middleware@kubernetescrd" $.Release.Namespace) }}
 {{- if $.Values.networking.enforceHTTPS }}
 {{- $middlewareList = append $middlewareList (printf "%s-redirect-middleware@kubernetescrd" $.Release.Namespace) }}

--- a/kubernetes/loculus/templates/ingressroute.yaml
+++ b/kubernetes/loculus/templates/ingressroute.yaml
@@ -47,11 +47,12 @@ spec:
     permanent: true
 ---
 {{- if eq $.Values.environment "server" }}
-{{- $websiteHost := include "loculus.ingressHost" (include "loculus.websiteUrl" .) }}
+{{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
+{{- $websiteHost := $ingressHosts.website | default (include "loculus.ingressHost" (include "loculus.websiteUrl" .)) }}
 {{- $wwwHost := ternary (printf "www.%s" $websiteHost) "" (eq $websiteHost $.Values.host) }}
-{{- $backendHost := include "loculus.ingressHost" (include "loculus.backendUrl" .) }}
-{{- $keycloakHost := include "loculus.ingressHost" (include "loculus.keycloakUrl" .) }}
-{{- $minioHost := include "loculus.ingressHost" (include "loculus.s3Url" .) }}
+{{- $backendHost := $ingressHosts.backend | default (include "loculus.ingressHost" (include "loculus.backendUrl" .)) }}
+{{- $keycloakHost := $ingressHosts.keycloak | default (include "loculus.ingressHost" (include "loculus.keycloakUrl" .)) }}
+{{- $minioHost := $ingressHosts.minio | default (include "loculus.ingressHost" (include "loculus.s3Url" .)) }}
 {{- $middlewareList := list (printf "%s-compression-middleware@kubernetescrd" $.Release.Namespace) }}
 {{- if $.Values.networking.enforceHTTPS }}
 {{- $middlewareList = append $middlewareList (printf "%s-redirect-middleware@kubernetescrd" $.Release.Namespace) }}

--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -1,4 +1,4 @@
-{{- $keycloakHost := (printf "authentication%s%s" $.Values.subdomainSeparator $.Values.host) }}
+{{- $keycloakHost := $.Values.ingress.hosts.keycloak | default (printf "authentication%s%s" $.Values.subdomainSeparator $.Values.host) }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -257,8 +257,8 @@ data:
           "publicClient": true,
           "directAccessGrantsEnabled": true,
           "redirectUris": [
-            "https://{{$.Values.host}}/*",
-            "http://{{$.Values.host}}/*",
+            "https://{{ $.Values.ingress.hosts.website | default $.Values.host }}/*",
+            "http://{{ $.Values.ingress.hosts.website | default $.Values.host }}/*",
             "http://localhost:3000/*"
           ]
         },

--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -1,4 +1,5 @@
-{{- $keycloakHost := $.Values.networking.ingressHosts.keycloak | default (printf "authentication%s%s" $.Values.networking.subdomainSeparator $.Values.host) }}
+{{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
+{{- $keycloakHost := $ingressHosts.keycloak | default (printf "authentication%s%s" $.Values.networking.subdomainSeparator (.Values.host | default "")) }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -257,8 +258,8 @@ data:
           "publicClient": true,
           "directAccessGrantsEnabled": true,
           "redirectUris": [
-            "https://{{ $.Values.networking.ingressHosts.website | default $.Values.host }}/*",
-            "http://{{ $.Values.networking.ingressHosts.website | default $.Values.host }}/*",
+            "https://{{ $ingressHosts.website | default (.Values.host | default "") }}/*",
+            "http://{{ $ingressHosts.website | default (.Values.host | default "") }}/*",
             "http://localhost:3000/*"
           ]
         },

--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -1,4 +1,4 @@
-{{- $keycloakHost := $.Values.ingress.hosts.keycloak | default (printf "authentication%s%s" $.Values.subdomainSeparator $.Values.host) }}
+{{- $keycloakHost := $.Values.networking.ingressHosts.keycloak | default (printf "authentication%s%s" $.Values.networking.subdomainSeparator $.Values.host) }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -257,8 +257,8 @@ data:
           "publicClient": true,
           "directAccessGrantsEnabled": true,
           "redirectUris": [
-            "https://{{ $.Values.ingress.hosts.website | default $.Values.host }}/*",
-            "http://{{ $.Values.ingress.hosts.website | default $.Values.host }}/*",
+            "https://{{ $.Values.networking.ingressHosts.website | default $.Values.host }}/*",
+            "http://{{ $.Values.networking.ingressHosts.website | default $.Values.host }}/*",
             "http://localhost:3000/*"
           ]
         },

--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -1,5 +1,3 @@
-{{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
-{{- $keycloakHost := $ingressHosts.keycloak | default (printf "authentication%s%s" $.Values.networking.subdomainSeparator (.Values.host | default "")) }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -258,8 +256,7 @@ data:
           "publicClient": true,
           "directAccessGrantsEnabled": true,
           "redirectUris": [
-            "https://{{ $ingressHosts.website | default (.Values.host | default "") }}/*",
-            "http://{{ $ingressHosts.website | default (.Values.host | default "") }}/*",
+            "{{ include "loculus.websiteUrl" . }}/*",
             "http://localhost:3000/*"
           ]
         },

--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -255,10 +255,9 @@ data:
           "enabled": true,
           "publicClient": true,
           "directAccessGrantsEnabled": true,
-          "redirectUris": [
-            "{{ include "loculus.websiteUrl" . }}/*",
-            "http://localhost:3000/*"
-          ]
+          {{- /* both schemes, so a deployment with enforceHTTPS=false keeps working */}}
+          {{- $website := include "loculus.websiteUrl" . | trimPrefix "https://" | trimPrefix "http://" }}
+          "redirectUris": {{ list (printf "https://%s/*" $website) (printf "http://%s/*" $website) "http://localhost:3000/*" | uniq | toJson }}
         },
         {
           "clientId" : "account-console2",

--- a/kubernetes/loculus/templates/keycloak-config-map.yaml
+++ b/kubernetes/loculus/templates/keycloak-config-map.yaml
@@ -255,9 +255,14 @@ data:
           "enabled": true,
           "publicClient": true,
           "directAccessGrantsEnabled": true,
-          {{- /* both schemes, so a deployment with enforceHTTPS=false keeps working */}}
-          {{- $website := include "loculus.websiteUrl" . | trimPrefix "https://" | trimPrefix "http://" }}
-          "redirectUris": {{ list (printf "https://%s/*" $website) (printf "http://%s/*" $website) "http://localhost:3000/*" | uniq | toJson }}
+          {{- $websiteUrl := include "loculus.websiteUrl" . }}
+          {{- $redirectUris := list (printf "%s/*" $websiteUrl) }}
+          {{- /* only accept a plaintext redirect where the deployment actually serves plain HTTP:
+                 with HTTPS enforced, an http:// redirect URI is a machine-in-the-middle handle on the auth code */}}
+          {{- if not $.Values.networking.enforceHTTPS }}
+            {{- $redirectUris = append $redirectUris (printf "http://%s/*" ($websiteUrl | trimPrefix "https://" | trimPrefix "http://")) }}
+          {{- end }}
+          "redirectUris": {{ append $redirectUris "http://localhost:3000/*" | uniq | toJson }}
         },
         {
           "clientId" : "account-console2",

--- a/kubernetes/loculus/templates/lapis-ingress.yaml
+++ b/kubernetes/loculus/templates/lapis-ingress.yaml
@@ -1,4 +1,5 @@
-{{- $lapisHost := $.Values.networking.ingressHosts.lapis | default (printf "lapis%s%s" .Values.networking.subdomainSeparator .Values.host) }}
+{{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
+{{- $lapisHost := $ingressHosts.lapis | default (printf "lapis%s%s" .Values.networking.subdomainSeparator (.Values.host | default "")) }}
 {{- $traefikApiVersion := ternary "traefik.io/v1alpha1" "traefik.containo.us/v1alpha1" (eq (int $.Values.networking.traefikVersion) 3) -}}
 {{- $enabledOrganismsResult := (include "loculus.enabledOrganisms" . | fromJson) }}
 {{- $enabledOrganismsList := $enabledOrganismsResult.organisms }}

--- a/kubernetes/loculus/templates/lapis-ingress.yaml
+++ b/kubernetes/loculus/templates/lapis-ingress.yaml
@@ -1,5 +1,5 @@
-{{- $lapisHost := $.Values.ingress.hosts.lapis | default (printf "lapis%s%s" .Values.subdomainSeparator .Values.host) }}
-{{- $traefikApiVersion := ternary "traefik.io/v1alpha1" "traefik.containo.us/v1alpha1" (eq (int $.Values.traefikVersion) 3) -}}
+{{- $lapisHost := $.Values.networking.ingressHosts.lapis | default (printf "lapis%s%s" .Values.networking.subdomainSeparator .Values.host) }}
+{{- $traefikApiVersion := ternary "traefik.io/v1alpha1" "traefik.containo.us/v1alpha1" (eq (int $.Values.networking.traefikVersion) 3) -}}
 {{- $enabledOrganismsResult := (include "loculus.enabledOrganisms" . | fromJson) }}
 {{- $enabledOrganismsList := $enabledOrganismsResult.organisms }}
 {{- $organismKeys := list -}}
@@ -74,7 +74,7 @@ spec:
 # This ingress is only used to redirect from $LAPIS_URL/$ORGANISM_NAME to $LAPIS_URL/$ORGANISM_NAME/
 # We need to do this so we can strip the /$ORGANISM_NAME/ prefix in the main lapis ingress (see #3360)
 {{- $redirectMiddlewareList := list -}}
-{{- if $.Values.enforceHTTPS -}}
+{{- if $.Values.networking.enforceHTTPS -}}
   {{- $redirectMiddlewareList = append $redirectMiddlewareList (printf "%s-redirect-middleware@kubernetescrd" $.Release.Namespace) }}
 {{- end }}
 {{- $redirectMiddlewareList = append $redirectMiddlewareList (printf "%s-redirect-slash@kubernetescrd" $.Release.Namespace) }}

--- a/kubernetes/loculus/templates/lapis-ingress.yaml
+++ b/kubernetes/loculus/templates/lapis-ingress.yaml
@@ -1,4 +1,4 @@
-{{- $lapisHost := printf "lapis%s%s" .Values.subdomainSeparator .Values.host }}
+{{- $lapisHost := $.Values.ingress.hosts.lapis | default (printf "lapis%s%s" .Values.subdomainSeparator .Values.host) }}
 {{- $traefikApiVersion := ternary "traefik.io/v1alpha1" "traefik.containo.us/v1alpha1" (eq (int $.Values.traefikVersion) 3) -}}
 {{- $enabledOrganismsResult := (include "loculus.enabledOrganisms" . | fromJson) }}
 {{- $enabledOrganismsList := $enabledOrganismsResult.organisms }}

--- a/kubernetes/loculus/templates/lapis-ingress.yaml
+++ b/kubernetes/loculus/templates/lapis-ingress.yaml
@@ -1,5 +1,5 @@
 {{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
-{{- $lapisHost := $ingressHosts.lapis | default (printf "lapis%s%s" .Values.networking.subdomainSeparator (.Values.host | default "")) }}
+{{- $lapisHost := $ingressHosts.lapis | default (printf "lapis%s%s" $.Values.networking.subdomainSeparator $.Values.host) }}
 {{- $traefikApiVersion := ternary "traefik.io/v1alpha1" "traefik.containo.us/v1alpha1" (eq (int $.Values.networking.traefikVersion) 3) -}}
 {{- $enabledOrganismsResult := (include "loculus.enabledOrganisms" . | fromJson) }}
 {{- $enabledOrganismsList := $enabledOrganismsResult.organisms }}

--- a/kubernetes/loculus/templates/lapis-ingress.yaml
+++ b/kubernetes/loculus/templates/lapis-ingress.yaml
@@ -1,5 +1,4 @@
-{{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
-{{- $lapisHost := $ingressHosts.lapis | default (printf "lapis%s%s" $.Values.networking.subdomainSeparator $.Values.host) }}
+{{- $lapisHost := include "loculus.ingressHost" (include "loculus.lapisUrlTemplate" .) }}
 {{- $traefikApiVersion := ternary "traefik.io/v1alpha1" "traefik.containo.us/v1alpha1" (eq (int $.Values.networking.traefikVersion) 3) -}}
 {{- $enabledOrganismsResult := (include "loculus.enabledOrganisms" . | fromJson) }}
 {{- $enabledOrganismsList := $enabledOrganismsResult.organisms }}

--- a/kubernetes/loculus/templates/lapis-ingress.yaml
+++ b/kubernetes/loculus/templates/lapis-ingress.yaml
@@ -1,4 +1,5 @@
-{{- $lapisHost := include "loculus.ingressHost" (include "loculus.lapisUrlTemplate" .) }}
+{{- $ingressHosts := $.Values.networking.ingressHosts | default dict }}
+{{- $lapisHost := $ingressHosts.lapis | default (include "loculus.ingressHost" (include "loculus.lapisUrlTemplate" .)) }}
 {{- $traefikApiVersion := ternary "traefik.io/v1alpha1" "traefik.containo.us/v1alpha1" (eq (int $.Values.networking.traefikVersion) 3) -}}
 {{- $enabledOrganismsResult := (include "loculus.enabledOrganisms" . | fromJson) }}
 {{- $enabledOrganismsList := $enabledOrganismsResult.organisms }}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -259,60 +259,90 @@
         },
         {
           "if": {
-            "properties": { "generateIndex": { "const": true } },
+            "properties": {
+              "generateIndex": {
+                "const": true
+              }
+            },
             "required": ["generateIndex"]
           },
           "then": {
             "properties": {
-              "type": { "enum": ["string", "authors"] }
+              "type": {
+                "enum": ["string", "authors"]
+              }
             },
             "errorMessage": "When generateIndex is true, type must be 'string' or 'authors'"
           }
         },
         {
           "if": {
-            "properties": { "autocomplete": { "const": true } },
+            "properties": {
+              "autocomplete": {
+                "const": true
+              }
+            },
             "required": ["autocomplete"]
           },
           "then": {
             "properties": {
-              "type": { "enum": ["string", "authors", "int", "float", "number", "boolean"] }
+              "type": {
+                "enum": ["string", "authors", "int", "float", "number", "boolean"]
+              }
             },
             "errorMessage": "When autocomplete is true, type must be 'string', 'authors', 'int', 'float', 'number', or 'boolean'"
           }
         },
         {
           "if": {
-            "properties": { "enableSubstringSearch": { "const": true } },
+            "properties": {
+              "enableSubstringSearch": {
+                "const": true
+              }
+            },
             "required": ["enableSubstringSearch"]
           },
           "then": {
             "properties": {
-              "type": { "enum": ["string", "authors"] }
+              "type": {
+                "enum": ["string", "authors"]
+              }
             },
             "errorMessage": "When enableSubstringSearch is true, type must be 'string' or 'authors'"
           }
         },
         {
           "if": {
-            "properties": { "lineageSystem": { "type": "string" } },
+            "properties": {
+              "lineageSystem": {
+                "type": "string"
+              }
+            },
             "required": ["lineageSystem"]
           },
           "then": {
             "properties": {
-              "type": { "enum": ["string", "authors"] }
+              "type": {
+                "enum": ["string", "authors"]
+              }
             },
             "errorMessage": "When lineageSystem is set, type must be 'string' or 'authors'"
           }
         },
         {
           "if": {
-            "properties": { "hierarchicalFilter": { "type": "string" } },
+            "properties": {
+              "hierarchicalFilter": {
+                "type": "string"
+              }
+            },
             "required": ["hierarchicalFilter"]
           },
           "then": {
             "properties": {
-              "type": { "enum": ["string", "authors"] }
+              "type": {
+                "enum": ["string", "authors"]
+              }
             },
             "errorMessage": "When hierarchicalFilter is set, type must be 'string' or 'authors'"
           }
@@ -325,35 +355,53 @@
         },
         {
           "if": {
-            "properties": { "rangeSearch": { "const": true } },
+            "properties": {
+              "rangeSearch": {
+                "const": true
+              }
+            },
             "required": ["rangeSearch"]
           },
           "then": {
             "properties": {
-              "type": { "enum": ["int", "float", "number", "date"] }
+              "type": {
+                "enum": ["int", "float", "number", "date"]
+              }
             },
             "errorMessage": "When rangeSearch is true, type must be numeric or date ('int', 'float', 'number', or 'date')"
           }
         },
         {
           "if": {
-            "properties": { "rangeOverlapSearch": { "type": "object" } },
+            "properties": {
+              "rangeOverlapSearch": {
+                "type": "object"
+              }
+            },
             "required": ["rangeOverlapSearch"]
           },
           "then": {
             "properties": {
-              "type": { "enum": ["int", "float", "number", "date"] }
+              "type": {
+                "enum": ["int", "float", "number", "date"]
+              }
             },
             "errorMessage": "When rangeOverlapSearch is set, type must be numeric or date ('int', 'float', 'number', or 'date')"
           }
         },
         {
           "if": {
-            "properties": { "required": { "const": true } },
+            "properties": {
+              "required": {
+                "const": true
+              }
+            },
             "required": ["required"]
           },
           "then": {
-            "not": { "required": ["requiredWhen"] },
+            "not": {
+              "required": ["requiredWhen"]
+            },
             "errorMessage": "A field with 'required: true' cannot also set 'requiredWhen' (it is already always required)."
           }
         }
@@ -481,14 +529,18 @@
               "docsIncludePrefix": false,
               "type": "array",
               "description": "Array of [Metadata fields (type)](#metadata-type) associated with the organism.",
-              "items": { "$ref": "#/definitions/metadata" }
+              "items": {
+                "$ref": "#/definitions/metadata"
+              }
             },
             "metadataAdd": {
               "groups": ["schema"],
               "docsIncludePrefix": false,
               "type": "array",
               "description": "Array of [Metadata fields (type)](#metadata-type) associated with the organism, in addtion to the fields in `metadata`.",
-              "items": { "$ref": "#/definitions/metadata" }
+              "items": {
+                "$ref": "#/definitions/metadata"
+              }
             },
             "metadataTemplate": {
               "groups": ["schema"],
@@ -544,7 +596,9 @@
                   },
                   "onlyForReferences": {
                     "type": "object",
-                    "additionalProperties": { "type": "string" },
+                    "additionalProperties": {
+                      "type": "string"
+                    },
                     "description": "Optional filter: maps segment name to reference name. When specified, this linkOut is only shown in the tool dropdown when the user has selected a matching reference (or no reference) for each listed segment. Use this to avoid showing reference-specific Nextclade datasets for the wrong reference in multi-reference organisms. Example: {main: CV-A16} or {M: MH396653}."
                   },
                   "category": {
@@ -1043,15 +1097,23 @@
         "requests": {
           "type": "object",
           "properties": {
-            "memory": { "type": "string" },
-            "cpu": { "type": "string" }
+            "memory": {
+              "type": "string"
+            },
+            "cpu": {
+              "type": "string"
+            }
           }
         },
         "limits": {
           "type": "object",
           "properties": {
-            "memory": { "type": "string" },
-            "cpu": { "type": "string" }
+            "memory": {
+              "type": "string"
+            },
+            "cpu": {
+              "type": "string"
+            }
           }
         }
       }
@@ -1170,7 +1232,9 @@
           "type": "object",
           "description": "Kubernetes nodeSelector for scheduling pods on specific nodes. Labels must match node labels. Example: { 'workload-type': 'loculuspool' }",
           "default": {},
-          "additionalProperties": { "type": "string" }
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "tolerations": {
           "type": "array",
@@ -1198,11 +1262,6 @@
       "type": "string",
       "default": "localhost",
       "description": "Host string used for local development"
-    },
-    "host": {
-      "groups": ["general"],
-      "type": "string",
-      "description": "Hostname where Loculus will be accessible"
     },
     "bannerMessage": {
       "groups": ["general"],
@@ -1398,84 +1457,89 @@
     "networking": {
       "groups": ["general"],
       "type": "object",
-      "description": "Network configuration. publicHosts sets the URLs advertised by the applications (redirects, callbacks, ...) and their hostnames are used in the Ingress rules; ingressHosts can override individual Ingress hostnames.",
+      "description": "Network configuration, in three layers. (1) host and subdomainSeparator define the naming convention every public URL is derived from. (2) networking.publicHosts overrides the public URL of an individual service; these URLs are what the applications advertise (website links, OAuth redirects, LAPIS URLs handed to clients). (3) The hostname of each public URL is also the hostname of that service's Ingress rule; networking.ingressHosts overrides that hostname alone, for the rare case where cluster routing must differ from the public URL. Inheritance only ever runs convention -> publicHosts -> ingressHosts: setting ingressHosts never changes an advertised URL. All of this applies to environment=server; in a local environment the URLs default to localHost with per-service ports and no Ingress hostnames are rendered.",
       "additionalProperties": false,
       "properties": {
+        "host": {
+          "groups": ["general"],
+          "type": "string",
+          "description": "Base domain of the deployment (server environment only). It is the website's hostname, and the base from which every other service's default URL is derived as https://<service><subdomainSeparator><host> \u2014 e.g. backend-myhost.com, authentication-myhost.com, lapis-myhost.com. Set this and nothing else for the standard layout. A www. alias for the website is added automatically when the website still sits on this host."
+        },
+        "subdomainSeparator": {
+          "groups": ["general"],
+          "type": "string",
+          "default": "-",
+          "description": "Separator between the service prefix and host when deriving default hostnames. Common values are '-' (backend-myhost.com) or '.' (backend.myhost.com)."
+        },
         "publicHosts": {
           "groups": ["general"],
           "type": "object",
-          "description": "Public URLs advertised by the application for redirects and callbacks. Overrides the default computed URLs. If not set, the URLs are computed from .Values.host and .Values.networking.subdomainSeparator. These URLs also determine the hostnames used in the Ingress rules, unless overridden per service via networking.ingressHosts.",
+          "description": "Per-service overrides for the public URLs the applications advertise. Leave a key unset to use the derived default https://<service><subdomainSeparator><host>. A URL set here also becomes the hostname of that service's Ingress rule (unless networking.ingressHosts overrides it), so overriding a URL alone is enough for a working deployment. In the server environment the URL must not contain a path \u2014 the Ingress routes a whole hostname at / \u2014 and rendering fails if it does.",
           "additionalProperties": false,
           "properties": {
             "backendUrl": {
               "groups": ["general"],
               "type": "string",
               "default": "",
-              "description": "Override the URL where the Loculus backend is publicly available. Example: https://api.loculus.x.y.com"
+              "description": "Public URL of the Loculus backend. Defaults to https://backend<subdomainSeparator><host>. Example: https://api.loculus.x.y.com"
             },
             "websiteUrl": {
               "groups": ["general"],
               "type": "string",
               "default": "",
-              "description": "Override the URL where the website is publicly available. Example: https://loculus.x.y.com"
+              "description": "Public URL of the website; also the base for the Keycloak redirect URIs. Defaults to https://<host>, so only set it when the website is not simply https://<host> \u2014 a non-HTTPS deployment, a non-default port, or a website domain unrelated to the other services. Setting it suppresses the automatic www. alias. Example: https://loculus.x.y.com"
             },
             "keycloakUrl": {
               "groups": ["general"],
               "type": "string",
               "default": "",
-              "description": "Override the URL where Keycloak is publicly available. Example: https://auth.loculus.x.y.com"
+              "description": "Public URL of Keycloak. Defaults to https://authentication<subdomainSeparator><host>. Example: https://auth.loculus.x.y.com"
             },
             "lapisUrlTemplate": {
               "groups": ["general"],
               "type": "string",
               "default": "",
-              "description": "Override the URL template for LAPIS instances. Must contain `%organism%` as a placeholder. Example: https://pathogen-api.loculus.x.y.com/%organism%"
+              "description": "Public URL template for the LAPIS instances; must contain `%organism%` as a placeholder, and in the server environment `/%organism%` must be the only path segment. Defaults to https://lapis<subdomainSeparator><host>/%organism%. Example: https://pathogen-api.loculus.x.y.com/%organism%"
             }
           }
         },
         "ingressHosts": {
           "groups": ["general"],
           "type": "object",
-          "description": "Escape hatch to override the hostname used in an individual service's Ingress rule, for the rare case where the hostname routed inside the cluster differs from the public URL (e.g. a CDN or reverse proxy in front). Each key defaults to the hostname of the corresponding networking.publicHosts URL.",
+          "description": "Per-service overrides for the hostname in a service's Ingress rule. Each key defaults to the hostname of the corresponding networking.publicHosts URL, which is almost always what you want; override only when the hostname routed inside the cluster must differ from the public URL, e.g. behind a CDN or an external reverse proxy that terminates the public name. An override here changes routing only \u2014 the URLs the applications advertise are unaffected.",
           "additionalProperties": false,
           "properties": {
             "website": {
               "type": "string",
-              "description": "Override hostname for the website Ingress. Defaults to the hostname of publicHosts.websiteUrl."
+              "description": "Hostname for the website Ingress rule. Defaults to the hostname of networking.publicHosts.websiteUrl."
             },
             "backend": {
               "type": "string",
-              "description": "Override hostname for the backend Ingress. Defaults to the hostname of publicHosts.backendUrl."
+              "description": "Hostname for the backend Ingress rule. Defaults to the hostname of networking.publicHosts.backendUrl."
             },
             "keycloak": {
               "type": "string",
-              "description": "Override hostname for the Keycloak Ingress. Defaults to the hostname of publicHosts.keycloakUrl."
+              "description": "Hostname for the keycloak Ingress rule. Defaults to the hostname of networking.publicHosts.keycloakUrl."
             },
             "lapis": {
               "type": "string",
-              "description": "Override hostname for the LAPIS Ingress. Defaults to the hostname of publicHosts.lapisUrlTemplate."
+              "description": "Hostname for the lapis Ingress rule. Defaults to the hostname of networking.publicHosts.lapisUrlTemplate."
             },
             "minio": {
               "type": "string",
-              "description": "Override hostname for the development MinIO Ingress. Defaults to s3<subdomainSeparator><host>."
+              "description": "Hostname for the Ingress rule of the development MinIO (only rendered with runDevelopmentS3). Defaults to s3<subdomainSeparator><host>."
             },
             "docs": {
               "type": "string",
-              "description": "Override hostname for the docs preview Ingress. Defaults to docs<subdomainSeparator><host>."
+              "description": "Hostname for the docs preview Ingress rule (only rendered with previewDocs). Defaults to docs<subdomainSeparator><host>."
             }
           }
-        },
-        "subdomainSeparator": {
-          "groups": ["general"],
-          "type": "string",
-          "default": "-",
-          "description": "Separator inserted between the subdomain prefix and the host when constructing default ingress hostnames. Used with .Values.host to form hostnames like backend<separator>myhost.com. Common values are '-' (for backend-myhost.com) or '.' (for backend.myhost.com)."
         },
         "enforceHTTPS": {
           "groups": ["general"],
           "type": "boolean",
           "default": true,
-          "description": "If true, adds a redirect middleware that redirects HTTP to HTTPS on all ingresses."
+          "description": "If true, attaches a middleware redirecting HTTP to HTTPS on all Ingress rules. When false, Keycloak additionally accepts the plaintext http:// variant of the website URL as a redirect URI."
         },
         "traefikVersion": {
           "groups": ["general"],
@@ -1710,7 +1774,9 @@
       "type": "object",
       "description": "An object where the keys are the organism IDs and values are an [Organism (type)](#organism-type)",
       "patternProperties": {
-        "^[a-z0-9-]+$": { "$ref": "#/definitions/organism" }
+        "^[a-z0-9-]+$": {
+          "$ref": "#/definitions/organism"
+        }
       }
     },
     "defaultOrganismConfig": {
@@ -1719,7 +1785,9 @@
     "defaultOrganisms": {
       "type": "object",
       "patternProperties": {
-        "^[a-z0-9-]+$": { "$ref": "#/definitions/organism" }
+        "^[a-z0-9-]+$": {
+          "$ref": "#/definitions/organism"
+        }
       }
     },
     "lineageSystemDefinitions": {
@@ -1863,12 +1931,16 @@
           "oneOf": [
             {
               "properties": {
-                "enabled": { "const": false }
+                "enabled": {
+                  "const": false
+                }
               }
             },
             {
               "properties": {
-                "enabled": { "const": true }
+                "enabled": {
+                  "const": true
+                }
               },
               "required": ["bucket"]
             }
@@ -1980,11 +2052,21 @@
       "type": "object",
       "description": "Which docker images to use. You can specify an [image spec (type)](#image-spec-type) for `lapis`, `lapisSilo`, `loculusSilo`, `website` and `backend`.",
       "properties": {
-        "lapis": { "$ref": "#/definitions/imageSpec" },
-        "lapisSilo": { "$ref": "#/definitions/imageSpec" },
-        "loculusSilo": { "$ref": "#/definitions/imageSpec" },
-        "website": { "$ref": "#/definitions/imageSpec" },
-        "backend": { "$ref": "#/definitions/imageSpec" }
+        "lapis": {
+          "$ref": "#/definitions/imageSpec"
+        },
+        "lapisSilo": {
+          "$ref": "#/definitions/imageSpec"
+        },
+        "loculusSilo": {
+          "$ref": "#/definitions/imageSpec"
+        },
+        "website": {
+          "$ref": "#/definitions/imageSpec"
+        },
+        "backend": {
+          "$ref": "#/definitions/imageSpec"
+        }
       },
       "additionalProperties": false
     },
@@ -2049,16 +2131,24 @@
         "requests": {
           "type": "object",
           "properties": {
-            "memory": { "type": "string" },
-            "cpu": { "type": "string" }
+            "memory": {
+              "type": "string"
+            },
+            "cpu": {
+              "type": "string"
+            }
           },
           "additionalProperties": false
         },
         "limits": {
           "type": "object",
           "properties": {
-            "memory": { "type": "string" },
-            "cpu": { "type": "string" }
+            "memory": {
+              "type": "string"
+            },
+            "cpu": {
+              "type": "string"
+            }
           },
           "additionalProperties": false
         }
@@ -2068,35 +2158,75 @@
     "resources": {
       "type": "object",
       "properties": {
-        "website": { "$ref": "#/definitions/resourceSpec" },
-        "docs": { "$ref": "#/definitions/resourceSpec" },
-        "ena-submission": { "$ref": "#/definitions/resourceSpec" },
-        "ena-submission-list-cronjob": { "$ref": "#/definitions/resourceSpec" },
-        "ingest": { "$ref": "#/definitions/resourceSpec" },
-        "keycloak": { "$ref": "#/definitions/resourceSpec" },
-        "silo": { "$ref": "#/definitions/resourceSpec" },
-        "lapis": { "$ref": "#/definitions/resourceSpec" },
-        "silo-importer": { "$ref": "#/definitions/resourceSpec" },
-        "backend": { "$ref": "#/definitions/resourceSpec" },
-        "preprocessing": { "$ref": "#/definitions/resourceSpec" },
+        "website": {
+          "$ref": "#/definitions/resourceSpec"
+        },
+        "docs": {
+          "$ref": "#/definitions/resourceSpec"
+        },
+        "ena-submission": {
+          "$ref": "#/definitions/resourceSpec"
+        },
+        "ena-submission-list-cronjob": {
+          "$ref": "#/definitions/resourceSpec"
+        },
+        "ingest": {
+          "$ref": "#/definitions/resourceSpec"
+        },
+        "keycloak": {
+          "$ref": "#/definitions/resourceSpec"
+        },
+        "silo": {
+          "$ref": "#/definitions/resourceSpec"
+        },
+        "lapis": {
+          "$ref": "#/definitions/resourceSpec"
+        },
+        "silo-importer": {
+          "$ref": "#/definitions/resourceSpec"
+        },
+        "backend": {
+          "$ref": "#/definitions/resourceSpec"
+        },
+        "preprocessing": {
+          "$ref": "#/definitions/resourceSpec"
+        },
         "organismSpecific": {
           "type": "object",
           "patternProperties": {
             ".*": {
               "type": "object",
               "properties": {
-                "website": { "$ref": "#/definitions/resourceSpec" },
-                "ena-submission": { "$ref": "#/definitions/resourceSpec" },
+                "website": {
+                  "$ref": "#/definitions/resourceSpec"
+                },
+                "ena-submission": {
+                  "$ref": "#/definitions/resourceSpec"
+                },
                 "ena-submission-list-cronjob": {
                   "$ref": "#/definitions/resourceSpec"
                 },
-                "ingest": { "$ref": "#/definitions/resourceSpec" },
-                "keycloak": { "$ref": "#/definitions/resourceSpec" },
-                "silo": { "$ref": "#/definitions/resourceSpec" },
-                "lapis": { "$ref": "#/definitions/resourceSpec" },
-                "silo-importer": { "$ref": "#/definitions/resourceSpec" },
-                "backend": { "$ref": "#/definitions/resourceSpec" },
-                "preprocessing": { "$ref": "#/definitions/resourceSpec" }
+                "ingest": {
+                  "$ref": "#/definitions/resourceSpec"
+                },
+                "keycloak": {
+                  "$ref": "#/definitions/resourceSpec"
+                },
+                "silo": {
+                  "$ref": "#/definitions/resourceSpec"
+                },
+                "lapis": {
+                  "$ref": "#/definitions/resourceSpec"
+                },
+                "silo-importer": {
+                  "$ref": "#/definitions/resourceSpec"
+                },
+                "backend": {
+                  "$ref": "#/definitions/resourceSpec"
+                },
+                "preprocessing": {
+                  "$ref": "#/definitions/resourceSpec"
+                }
               },
               "additionalProperties": false
             }

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1435,6 +1435,7 @@
               "groups": ["general"],
               "type": "string",
               "default": "",
+              "pattern": "^$|%organism%",
               "description": "Public URL template for the LAPIS instances; must contain `%organism%` as a placeholder, and in the server environment `/%organism%` must be the only path segment. Defaults to https://lapis<subdomainSeparator><host>/%organism%. Example: https://pathogen-api.loculus.x.y.com/%organism%"
             }
           }
@@ -1442,7 +1443,7 @@
         "ingressHosts": {
           "groups": ["general"],
           "type": "object",
-          "description": "Per-service overrides for the hostname in a service's Ingress rule. Each key defaults to the hostname of the corresponding networking.publicHosts URL, which is almost always what you want; override only when the hostname routed inside the cluster must differ from the public URL, e.g. behind a CDN or an external reverse proxy that terminates the public name. An override here changes routing only - the URLs the applications advertise are unaffected. Only services with a networking.publicHosts URL can be overridden here; the development MinIO and docs-preview Ingress hostnames are always s3/docs<subdomainSeparator><host>.",
+          "description": "Per-service overrides for the hostname in a service's Ingress rule. Each key defaults to the hostname of that service's public URL - whether that URL comes from networking.publicHosts or from the host/subdomainSeparator convention - which is almost always what you want; override only when the hostname routed inside the cluster must differ from the public URL, e.g. behind a CDN or an external reverse proxy that terminates the public name. An override here changes routing only: the URLs the applications advertise are unaffected, and setting networking.publicHosts is not a prerequisite. Overrides exist for the four services listed below; the development MinIO and docs-preview Ingress hostnames are always s3/docs<subdomainSeparator><host>.",
           "additionalProperties": false,
           "properties": {
             "website": {

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1399,7 +1399,7 @@
         "host": {
           "groups": ["general"],
           "type": "string",
-          "description": "Base domain of the deployment (server environment only). It is the website's hostname, and the base from which every other service's default URL is derived as https://<service><subdomainSeparator><host> \u2014 e.g. backend-myhost.com, authentication-myhost.com, lapis-myhost.com. Set this and nothing else for the standard layout. A www. alias for the website is added automatically when the website still sits on this host."
+          "description": "Base domain of the deployment (server environment only). It is the website's hostname, and the base from which every other service's default URL is derived as https://<service><subdomainSeparator><host> - e.g. backend-myhost.com, authentication-myhost.com, lapis-myhost.com. Set this and nothing else for the standard layout. A www. alias for the website is added automatically when the website still sits on this host."
         },
         "subdomainSeparator": {
           "groups": ["general"],
@@ -1410,7 +1410,7 @@
         "publicHosts": {
           "groups": ["general"],
           "type": "object",
-          "description": "Per-service overrides for the public URLs the applications advertise. Leave a key unset to use the derived default https://<service><subdomainSeparator><host>. A URL set here also becomes the hostname of that service's Ingress rule (unless networking.ingressHosts overrides it), so overriding a URL alone is enough for a working deployment. In the server environment the URL must not contain a path \u2014 the Ingress routes a whole hostname at / \u2014 and rendering fails if it does.",
+          "description": "Per-service overrides for the public URLs the applications advertise. Leave a key unset to use the derived default https://<service><subdomainSeparator><host>. A URL set here also becomes the hostname of that service's Ingress rule (unless networking.ingressHosts overrides it), so overriding a URL alone is enough for a working deployment. In the server environment the URL must not contain a path - the Ingress routes a whole hostname at / - and rendering fails if it does.",
           "additionalProperties": false,
           "properties": {
             "backendUrl": {
@@ -1423,7 +1423,7 @@
               "groups": ["general"],
               "type": "string",
               "default": "",
-              "description": "Public URL of the website; also the base for the Keycloak redirect URIs. Defaults to https://<host>, so only set it when the website is not simply https://<host> \u2014 a non-HTTPS deployment, a non-default port, or a website domain unrelated to the other services. Setting it suppresses the automatic www. alias. Example: https://loculus.x.y.com"
+              "description": "Public URL of the website; also the base for the Keycloak redirect URIs. Defaults to https://<host>, so only set it when the website is not simply https://<host> - a non-HTTPS deployment, a non-default port, or a website domain unrelated to the other services. Setting it suppresses the automatic www. alias. Example: https://loculus.x.y.com"
             },
             "keycloakUrl": {
               "groups": ["general"],
@@ -1442,22 +1442,26 @@
         "ingressHosts": {
           "groups": ["general"],
           "type": "object",
-          "description": "Per-service overrides for the hostname in a service's Ingress rule. Each key defaults to the hostname of the corresponding networking.publicHosts URL, which is almost always what you want; override only when the hostname routed inside the cluster must differ from the public URL, e.g. behind a CDN or an external reverse proxy that terminates the public name. An override here changes routing only \u2014 the URLs the applications advertise are unaffected. Only services with a networking.publicHosts URL can be overridden here; the development MinIO and docs-preview Ingress hostnames are always s3/docs<subdomainSeparator><host>.",
+          "description": "Per-service overrides for the hostname in a service's Ingress rule. Each key defaults to the hostname of the corresponding networking.publicHosts URL, which is almost always what you want; override only when the hostname routed inside the cluster must differ from the public URL, e.g. behind a CDN or an external reverse proxy that terminates the public name. An override here changes routing only - the URLs the applications advertise are unaffected. Only services with a networking.publicHosts URL can be overridden here; the development MinIO and docs-preview Ingress hostnames are always s3/docs<subdomainSeparator><host>.",
           "additionalProperties": false,
           "properties": {
             "website": {
+              "groups": ["general"],
               "type": "string",
               "description": "Hostname for the website Ingress rule. Defaults to the hostname of networking.publicHosts.websiteUrl."
             },
             "backend": {
+              "groups": ["general"],
               "type": "string",
               "description": "Hostname for the backend Ingress rule. Defaults to the hostname of networking.publicHosts.backendUrl."
             },
             "keycloak": {
+              "groups": ["general"],
               "type": "string",
               "description": "Hostname for the keycloak Ingress rule. Defaults to the hostname of networking.publicHosts.keycloakUrl."
             },
             "lapis": {
+              "groups": ["general"],
               "type": "string",
               "description": "Hostname for the lapis Ingress rule. Defaults to the hostname of networking.publicHosts.lapisUrlTemplate."
             }

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1393,24 +1393,24 @@
     "networking": {
       "groups": ["general"],
       "type": "object",
-      "description": "Network configuration, in three layers. (1) host and subdomainSeparator define the naming convention every public URL is derived from. (2) networking.publicHosts overrides the public URL of an individual service; these URLs are what the applications advertise (website links, OAuth redirects, LAPIS URLs handed to clients). (3) The hostname of each public URL is also the hostname of that service's Ingress rule; networking.ingressHosts overrides that hostname alone, for the rare case where cluster routing must differ from the public URL. Inheritance only ever runs convention -> publicHosts -> ingressHosts: setting ingressHosts never changes an advertised URL. All of this applies to environment=server; in a local environment the URLs default to localHost with per-service ports and no Ingress hostnames are rendered.",
+      "description": "Network configuration, in three layers. (1) host and subdomainSeparator define the naming convention every public URL is derived from. (2) networking.publicHosts overrides the public URL of an individual service; these URLs are what the applications advertise (website links, OAuth redirects, LAPIS URLs handed to clients). (3) The hostname of the website, backend, Keycloak and LAPIS public URLs is also the hostname of that service's Ingress rule; networking.ingressHosts overrides that hostname alone, for the rare case where cluster routing must differ from the public URL. Inheritance only ever runs convention -> publicHosts -> ingressHosts: setting ingressHosts never changes an advertised URL. The convention and the Ingress hostnames apply to environment=server; in a local environment the public URLs default to localHost with per-service ports instead, and the website, backend, Keycloak and MinIO Ingress rules are not rendered at all.",
       "additionalProperties": false,
       "properties": {
         "host": {
           "groups": ["general"],
           "type": "string",
-          "description": "Base domain of the deployment (server environment only). It is the website's hostname, and the base from which every other service's default URL is derived as https://<service><subdomainSeparator><host> - e.g. backend-myhost.com, authentication-myhost.com, lapis-myhost.com. Set this and nothing else for the standard layout. A www. alias for the website is added automatically when the website still sits on this host."
+          "description": "Base domain of the deployment. In the server environment it is the website's hostname and the base from which every other service's default URL is derived as https://<service><subdomainSeparator><host> - e.g. backend-myhost.com, authentication-myhost.com, lapis-myhost.com; it is also used for the docs-preview hostname in any environment. Set this and nothing else for the standard layout. A www. alias for the website is added automatically, unless the website has been moved off this host or this host already starts with www."
         },
         "subdomainSeparator": {
           "groups": ["general"],
           "type": "string",
           "default": "-",
-          "description": "Separator between the service prefix and host when deriving default hostnames. Common values are '-' (backend-myhost.com) or '.' (backend.myhost.com)."
+          "description": "Separator between the service prefix and networking.host when deriving default hostnames in the server environment. Common values are '-' (backend-myhost.com) or '.' (backend.myhost.com)."
         },
         "publicHosts": {
           "groups": ["general"],
           "type": "object",
-          "description": "Per-service overrides for the public URLs the applications advertise. Leave a key unset to use the derived default https://<service><subdomainSeparator><host>. A URL set here also becomes the hostname of that service's Ingress rule (unless networking.ingressHosts overrides it), so overriding a URL alone is enough for a working deployment. In the server environment the URL must not contain a path - the Ingress routes a whole hostname at / - and rendering fails if it does.",
+          "description": "Per-service overrides for the public URLs the applications advertise. Leave a key unset to use the derived default: https://<host> for the website and https://<service><subdomainSeparator><host> for the others in the server environment, or http://<localHost>:<port> in a local environment. A URL set here also becomes the hostname of that service's Ingress rule (unless networking.ingressHosts overrides it), so overriding a URL alone is enough for a working deployment. In the server environment the URL must not contain a path, because the Ingress routes a whole hostname at / - rendering fails if it does. The only exception is lapisUrlTemplate, whose trailing /%organism% segment the LAPIS Ingress does route.",
           "additionalProperties": false,
           "properties": {
             "backendUrl": {
@@ -1423,7 +1423,7 @@
               "groups": ["general"],
               "type": "string",
               "default": "",
-              "description": "Public URL of the website; also the base for the Keycloak redirect URIs. Defaults to https://<host>, so only set it when the website is not simply https://<host> - a non-HTTPS deployment, a non-default port, or a website domain unrelated to the other services. Setting it suppresses the automatic www. alias. Example: https://loculus.x.y.com"
+              "description": "Public URL of the website; also the base for the Keycloak redirect URIs. Defaults to https://<host>, so only set it when the website is not simply that - a non-HTTPS deployment, or a website domain unrelated to the other services. Setting it suppresses the automatic www. alias, since a certificate for www.<override> would usually have no DNS record. Example: https://loculus.x.y.com"
             },
             "keycloakUrl": {
               "groups": ["general"],
@@ -1449,22 +1449,22 @@
             "website": {
               "groups": ["general"],
               "type": "string",
-              "description": "Hostname for the website Ingress rule. Defaults to the hostname of networking.publicHosts.websiteUrl."
+              "description": "Hostname for the website Ingress rule. Defaults to the hostname of the resolved website URL - networking.publicHosts.websiteUrl if set, otherwise the convention-derived default."
             },
             "backend": {
               "groups": ["general"],
               "type": "string",
-              "description": "Hostname for the backend Ingress rule. Defaults to the hostname of networking.publicHosts.backendUrl."
+              "description": "Hostname for the backend Ingress rule. Defaults to the hostname of the resolved backend URL - networking.publicHosts.backendUrl if set, otherwise the convention-derived default."
             },
             "keycloak": {
               "groups": ["general"],
               "type": "string",
-              "description": "Hostname for the keycloak Ingress rule. Defaults to the hostname of networking.publicHosts.keycloakUrl."
+              "description": "Hostname for the Keycloak Ingress rule. Defaults to the hostname of the resolved Keycloak URL - networking.publicHosts.keycloakUrl if set, otherwise the convention-derived default."
             },
             "lapis": {
               "groups": ["general"],
               "type": "string",
-              "description": "Hostname for the lapis Ingress rule. Defaults to the hostname of networking.publicHosts.lapisUrlTemplate."
+              "description": "Hostname for the LAPIS Ingress rule. Defaults to the hostname of the resolved LAPIS URL - networking.publicHosts.lapisUrlTemplate if set, otherwise the convention-derived default."
             }
           }
         },
@@ -1472,7 +1472,7 @@
           "groups": ["general"],
           "type": "boolean",
           "default": true,
-          "description": "If true, attaches a middleware redirecting HTTP to HTTPS on all Ingress rules. When false, Keycloak additionally accepts the plaintext http:// variant of the website URL as a redirect URI."
+          "description": "If true, attaches an HTTP-to-HTTPS redirect middleware to the website, backend, Keycloak and development MinIO Ingress rules, and to the LAPIS trailing-slash redirect Ingress; note that the main LAPIS Ingress does not get it, so plain-HTTP LAPIS requests are served rather than redirected. When false, Keycloak additionally accepts the plaintext http:// variant of the website URL as a redirect URI."
         },
         "traefikVersion": {
           "groups": ["general"],

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1399,13 +1399,13 @@
     "networking": {
       "groups": ["general"],
       "type": "object",
-      "description": "Network configuration: public-facing URLs and ingress hostnames. publicHosts sets the URLs advertised by applications (for redirects, callbacks, etc.). ingressHosts sets the hostnames used in Ingress rules (for cluster routing).",
+      "description": "Network configuration. publicHosts sets the URLs advertised by the applications (redirects, callbacks, ...); their hostnames are also used in the Ingress rules.",
       "additionalProperties": false,
       "properties": {
         "publicHosts": {
           "groups": ["general"],
           "type": "object",
-          "description": "Public URLs advertised by the application for redirects and callbacks. Overrides the default computed URLs. If not set, the URLs fall back to the computed defaults from .Values.host and .Values.networking.subdomainSeparator, or from ingressHosts if those are set.",
+          "description": "Public URLs advertised by the application for redirects and callbacks. Overrides the default computed URLs. If not set, the URLs are computed from .Values.host and .Values.networking.subdomainSeparator. These URLs also determine the hostnames used in the Ingress rules.",
           "additionalProperties": false,
           "properties": {
             "backendUrl": {
@@ -1431,44 +1431,6 @@
               "type": "string",
               "default": "",
               "description": "Override the URL template for LAPIS instances. Must contain `%organism%` as a placeholder. Example: https://pathogen-api.loculus.x.y.com/%organism%"
-            }
-          }
-        },
-        "ingressHosts": {
-          "groups": ["general"],
-          "type": "object",
-          "description": "Override hostnames for each service's Ingress rule. Leave empty to use the default computed hostname from .Values.host and .Values.networking.subdomainSeparator.",
-          "additionalProperties": false,
-          "properties": {
-            "website": {
-              "type": "string",
-              "default": "",
-              "description": "Override hostname for the website Ingress. Defaults to .Values.host."
-            },
-            "backend": {
-              "type": "string",
-              "default": "",
-              "description": "Override hostname for the backend Ingress. Defaults to backend<subdomainSeparator><host>."
-            },
-            "keycloak": {
-              "type": "string",
-              "default": "",
-              "description": "Override hostname for the keycloak Ingress. Defaults to authentication<subdomainSeparator><host>."
-            },
-            "lapis": {
-              "type": "string",
-              "default": "",
-              "description": "Override hostname for the LAPIS Ingress. Defaults to lapis<subdomainSeparator><host>."
-            },
-            "minio": {
-              "type": "string",
-              "default": "",
-              "description": "Override hostname for the MinIO Ingress. Defaults to s3<subdomainSeparator><host>."
-            },
-            "docs": {
-              "type": "string",
-              "default": "",
-              "description": "Override hostname for the docs Ingress. Defaults to docs<subdomainSeparator><host>."
             }
           }
         },

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1399,13 +1399,13 @@
     "networking": {
       "groups": ["general"],
       "type": "object",
-      "description": "Network configuration. publicHosts sets the URLs advertised by the applications (redirects, callbacks, ...); their hostnames are also used in the Ingress rules.",
+      "description": "Network configuration. publicHosts sets the URLs advertised by the applications (redirects, callbacks, ...) and their hostnames are used in the Ingress rules; ingressHosts can override individual Ingress hostnames.",
       "additionalProperties": false,
       "properties": {
         "publicHosts": {
           "groups": ["general"],
           "type": "object",
-          "description": "Public URLs advertised by the application for redirects and callbacks. Overrides the default computed URLs. If not set, the URLs are computed from .Values.host and .Values.networking.subdomainSeparator. These URLs also determine the hostnames used in the Ingress rules.",
+          "description": "Public URLs advertised by the application for redirects and callbacks. Overrides the default computed URLs. If not set, the URLs are computed from .Values.host and .Values.networking.subdomainSeparator. These URLs also determine the hostnames used in the Ingress rules, unless overridden per service via networking.ingressHosts.",
           "additionalProperties": false,
           "properties": {
             "backendUrl": {
@@ -1431,6 +1431,38 @@
               "type": "string",
               "default": "",
               "description": "Override the URL template for LAPIS instances. Must contain `%organism%` as a placeholder. Example: https://pathogen-api.loculus.x.y.com/%organism%"
+            }
+          }
+        },
+        "ingressHosts": {
+          "groups": ["general"],
+          "type": "object",
+          "description": "Escape hatch to override the hostname used in an individual service's Ingress rule, for the rare case where the hostname routed inside the cluster differs from the public URL (e.g. a CDN or reverse proxy in front). Each key defaults to the hostname of the corresponding networking.publicHosts URL.",
+          "additionalProperties": false,
+          "properties": {
+            "website": {
+              "type": "string",
+              "description": "Override hostname for the website Ingress. Defaults to the hostname of publicHosts.websiteUrl."
+            },
+            "backend": {
+              "type": "string",
+              "description": "Override hostname for the backend Ingress. Defaults to the hostname of publicHosts.backendUrl."
+            },
+            "keycloak": {
+              "type": "string",
+              "description": "Override hostname for the Keycloak Ingress. Defaults to the hostname of publicHosts.keycloakUrl."
+            },
+            "lapis": {
+              "type": "string",
+              "description": "Override hostname for the LAPIS Ingress. Defaults to the hostname of publicHosts.lapisUrlTemplate."
+            },
+            "minio": {
+              "type": "string",
+              "description": "Override hostname for the development MinIO Ingress. Defaults to s3<subdomainSeparator><host>."
+            },
+            "docs": {
+              "type": "string",
+              "description": "Override hostname for the docs preview Ingress. Defaults to docs<subdomainSeparator><host>."
             }
           }
         },

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1506,7 +1506,7 @@
         "ingressHosts": {
           "groups": ["general"],
           "type": "object",
-          "description": "Per-service overrides for the hostname in a service's Ingress rule. Each key defaults to the hostname of the corresponding networking.publicHosts URL, which is almost always what you want; override only when the hostname routed inside the cluster must differ from the public URL, e.g. behind a CDN or an external reverse proxy that terminates the public name. An override here changes routing only \u2014 the URLs the applications advertise are unaffected.",
+          "description": "Per-service overrides for the hostname in a service's Ingress rule. Each key defaults to the hostname of the corresponding networking.publicHosts URL, which is almost always what you want; override only when the hostname routed inside the cluster must differ from the public URL, e.g. behind a CDN or an external reverse proxy that terminates the public name. An override here changes routing only \u2014 the URLs the applications advertise are unaffected. Only services with a networking.publicHosts URL can be overridden here; the development MinIO and docs-preview Ingress hostnames are always s3/docs<subdomainSeparator><host>.",
           "additionalProperties": false,
           "properties": {
             "website": {
@@ -1524,14 +1524,6 @@
             "lapis": {
               "type": "string",
               "description": "Hostname for the lapis Ingress rule. Defaults to the hostname of networking.publicHosts.lapisUrlTemplate."
-            },
-            "minio": {
-              "type": "string",
-              "description": "Hostname for the Ingress rule of the development MinIO (only rendered with runDevelopmentS3). Defaults to s3<subdomainSeparator><host>."
-            },
-            "docs": {
-              "type": "string",
-              "description": "Hostname for the docs preview Ingress rule (only rendered with previewDocs). Defaults to docs<subdomainSeparator><host>."
             }
           }
         },

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1202,6 +1202,7 @@
     "host": {
       "groups": ["general"],
       "type": "string",
+      "default": "loculus.example.org",
       "description": "Hostname where Loculus will be accessible"
     },
     "bannerMessage": {

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1202,7 +1202,6 @@
     "host": {
       "groups": ["general"],
       "type": "string",
-      "default": "loculus.example.org",
       "description": "Hostname where Loculus will be accessible"
     },
     "bannerMessage": {

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1404,7 +1404,7 @@
         "publicHosts": {
           "groups": ["general"],
           "type": "object",
-          "description": "Public URLs advertised by the application for redirects and callbacks. Overrides the default computed URLs. If not set, the URLs fall back to the computed defaults from .Values.host and .Values.subdomainSeparator, or from ingressHosts if those are set.",
+          "description": "Public URLs advertised by the application for redirects and callbacks. Overrides the default computed URLs. If not set, the URLs fall back to the computed defaults from .Values.host and .Values.networking.subdomainSeparator, or from ingressHosts if those are set.",
           "additionalProperties": false,
           "properties": {
             "backendUrl": {

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1827,6 +1827,51 @@
       },
       "additionalProperties": false
     },
+    "ingress": {
+      "groups": ["general"],
+      "type": "object",
+      "description": "Configure ingress hostnames independently from public URLs. By default, ingress hostnames are automatically constructed from .host and .subdomainSeparator. Set hosts to override the hostname used in the Ingress rules, e.g. when routing through a gateway/reverse proxy with different external hostnames than the internal ones.",
+      "additionalProperties": false,
+      "properties": {
+        "hosts": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Override hostnames for each service's Ingress rule. Leave empty to use the default computed hostname.",
+          "properties": {
+            "website": {
+              "type": "string",
+              "default": "",
+              "description": "Override hostname for the website Ingress. Defaults to .Values.host."
+            },
+            "backend": {
+              "type": "string",
+              "default": "",
+              "description": "Override hostname for the backend Ingress. Defaults to backend<subdomainSeparator><host>."
+            },
+            "keycloak": {
+              "type": "string",
+              "default": "",
+              "description": "Override hostname for the keycloak Ingress. Defaults to authentication<subdomainSeparator><host>."
+            },
+            "lapis": {
+              "type": "string",
+              "default": "",
+              "description": "Override hostname for the LAPIS Ingress. Defaults to lapis<subdomainSeparator><host>."
+            },
+            "minio": {
+              "type": "string",
+              "default": "",
+              "description": "Override hostname for the MinIO Ingress. Defaults to s3<subdomainSeparator><host>."
+            },
+            "docs": {
+              "type": "string",
+              "default": "",
+              "description": "Override hostname for the docs Ingress. Defaults to docs<subdomainSeparator><host>."
+            }
+          }
+        }
+      }
+    },
     "subdomainSeparator": {
       "type": "string",
       "default": "-"

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -259,90 +259,60 @@
         },
         {
           "if": {
-            "properties": {
-              "generateIndex": {
-                "const": true
-              }
-            },
+            "properties": { "generateIndex": { "const": true } },
             "required": ["generateIndex"]
           },
           "then": {
             "properties": {
-              "type": {
-                "enum": ["string", "authors"]
-              }
+              "type": { "enum": ["string", "authors"] }
             },
             "errorMessage": "When generateIndex is true, type must be 'string' or 'authors'"
           }
         },
         {
           "if": {
-            "properties": {
-              "autocomplete": {
-                "const": true
-              }
-            },
+            "properties": { "autocomplete": { "const": true } },
             "required": ["autocomplete"]
           },
           "then": {
             "properties": {
-              "type": {
-                "enum": ["string", "authors", "int", "float", "number", "boolean"]
-              }
+              "type": { "enum": ["string", "authors", "int", "float", "number", "boolean"] }
             },
             "errorMessage": "When autocomplete is true, type must be 'string', 'authors', 'int', 'float', 'number', or 'boolean'"
           }
         },
         {
           "if": {
-            "properties": {
-              "enableSubstringSearch": {
-                "const": true
-              }
-            },
+            "properties": { "enableSubstringSearch": { "const": true } },
             "required": ["enableSubstringSearch"]
           },
           "then": {
             "properties": {
-              "type": {
-                "enum": ["string", "authors"]
-              }
+              "type": { "enum": ["string", "authors"] }
             },
             "errorMessage": "When enableSubstringSearch is true, type must be 'string' or 'authors'"
           }
         },
         {
           "if": {
-            "properties": {
-              "lineageSystem": {
-                "type": "string"
-              }
-            },
+            "properties": { "lineageSystem": { "type": "string" } },
             "required": ["lineageSystem"]
           },
           "then": {
             "properties": {
-              "type": {
-                "enum": ["string", "authors"]
-              }
+              "type": { "enum": ["string", "authors"] }
             },
             "errorMessage": "When lineageSystem is set, type must be 'string' or 'authors'"
           }
         },
         {
           "if": {
-            "properties": {
-              "hierarchicalFilter": {
-                "type": "string"
-              }
-            },
+            "properties": { "hierarchicalFilter": { "type": "string" } },
             "required": ["hierarchicalFilter"]
           },
           "then": {
             "properties": {
-              "type": {
-                "enum": ["string", "authors"]
-              }
+              "type": { "enum": ["string", "authors"] }
             },
             "errorMessage": "When hierarchicalFilter is set, type must be 'string' or 'authors'"
           }
@@ -355,53 +325,35 @@
         },
         {
           "if": {
-            "properties": {
-              "rangeSearch": {
-                "const": true
-              }
-            },
+            "properties": { "rangeSearch": { "const": true } },
             "required": ["rangeSearch"]
           },
           "then": {
             "properties": {
-              "type": {
-                "enum": ["int", "float", "number", "date"]
-              }
+              "type": { "enum": ["int", "float", "number", "date"] }
             },
             "errorMessage": "When rangeSearch is true, type must be numeric or date ('int', 'float', 'number', or 'date')"
           }
         },
         {
           "if": {
-            "properties": {
-              "rangeOverlapSearch": {
-                "type": "object"
-              }
-            },
+            "properties": { "rangeOverlapSearch": { "type": "object" } },
             "required": ["rangeOverlapSearch"]
           },
           "then": {
             "properties": {
-              "type": {
-                "enum": ["int", "float", "number", "date"]
-              }
+              "type": { "enum": ["int", "float", "number", "date"] }
             },
             "errorMessage": "When rangeOverlapSearch is set, type must be numeric or date ('int', 'float', 'number', or 'date')"
           }
         },
         {
           "if": {
-            "properties": {
-              "required": {
-                "const": true
-              }
-            },
+            "properties": { "required": { "const": true } },
             "required": ["required"]
           },
           "then": {
-            "not": {
-              "required": ["requiredWhen"]
-            },
+            "not": { "required": ["requiredWhen"] },
             "errorMessage": "A field with 'required: true' cannot also set 'requiredWhen' (it is already always required)."
           }
         }
@@ -529,18 +481,14 @@
               "docsIncludePrefix": false,
               "type": "array",
               "description": "Array of [Metadata fields (type)](#metadata-type) associated with the organism.",
-              "items": {
-                "$ref": "#/definitions/metadata"
-              }
+              "items": { "$ref": "#/definitions/metadata" }
             },
             "metadataAdd": {
               "groups": ["schema"],
               "docsIncludePrefix": false,
               "type": "array",
               "description": "Array of [Metadata fields (type)](#metadata-type) associated with the organism, in addtion to the fields in `metadata`.",
-              "items": {
-                "$ref": "#/definitions/metadata"
-              }
+              "items": { "$ref": "#/definitions/metadata" }
             },
             "metadataTemplate": {
               "groups": ["schema"],
@@ -596,9 +544,7 @@
                   },
                   "onlyForReferences": {
                     "type": "object",
-                    "additionalProperties": {
-                      "type": "string"
-                    },
+                    "additionalProperties": { "type": "string" },
                     "description": "Optional filter: maps segment name to reference name. When specified, this linkOut is only shown in the tool dropdown when the user has selected a matching reference (or no reference) for each listed segment. Use this to avoid showing reference-specific Nextclade datasets for the wrong reference in multi-reference organisms. Example: {main: CV-A16} or {M: MH396653}."
                   },
                   "category": {
@@ -1097,23 +1043,15 @@
         "requests": {
           "type": "object",
           "properties": {
-            "memory": {
-              "type": "string"
-            },
-            "cpu": {
-              "type": "string"
-            }
+            "memory": { "type": "string" },
+            "cpu": { "type": "string" }
           }
         },
         "limits": {
           "type": "object",
           "properties": {
-            "memory": {
-              "type": "string"
-            },
-            "cpu": {
-              "type": "string"
-            }
+            "memory": { "type": "string" },
+            "cpu": { "type": "string" }
           }
         }
       }
@@ -1232,9 +1170,7 @@
           "type": "object",
           "description": "Kubernetes nodeSelector for scheduling pods on specific nodes. Labels must match node labels. Example: { 'workload-type': 'loculuspool' }",
           "default": {},
-          "additionalProperties": {
-            "type": "string"
-          }
+          "additionalProperties": { "type": "string" }
         },
         "tolerations": {
           "type": "array",
@@ -1766,9 +1702,7 @@
       "type": "object",
       "description": "An object where the keys are the organism IDs and values are an [Organism (type)](#organism-type)",
       "patternProperties": {
-        "^[a-z0-9-]+$": {
-          "$ref": "#/definitions/organism"
-        }
+        "^[a-z0-9-]+$": { "$ref": "#/definitions/organism" }
       }
     },
     "defaultOrganismConfig": {
@@ -1777,9 +1711,7 @@
     "defaultOrganisms": {
       "type": "object",
       "patternProperties": {
-        "^[a-z0-9-]+$": {
-          "$ref": "#/definitions/organism"
-        }
+        "^[a-z0-9-]+$": { "$ref": "#/definitions/organism" }
       }
     },
     "lineageSystemDefinitions": {
@@ -1923,16 +1855,12 @@
           "oneOf": [
             {
               "properties": {
-                "enabled": {
-                  "const": false
-                }
+                "enabled": { "const": false }
               }
             },
             {
               "properties": {
-                "enabled": {
-                  "const": true
-                }
+                "enabled": { "const": true }
               },
               "required": ["bucket"]
             }
@@ -2044,21 +1972,11 @@
       "type": "object",
       "description": "Which docker images to use. You can specify an [image spec (type)](#image-spec-type) for `lapis`, `lapisSilo`, `loculusSilo`, `website` and `backend`.",
       "properties": {
-        "lapis": {
-          "$ref": "#/definitions/imageSpec"
-        },
-        "lapisSilo": {
-          "$ref": "#/definitions/imageSpec"
-        },
-        "loculusSilo": {
-          "$ref": "#/definitions/imageSpec"
-        },
-        "website": {
-          "$ref": "#/definitions/imageSpec"
-        },
-        "backend": {
-          "$ref": "#/definitions/imageSpec"
-        }
+        "lapis": { "$ref": "#/definitions/imageSpec" },
+        "lapisSilo": { "$ref": "#/definitions/imageSpec" },
+        "loculusSilo": { "$ref": "#/definitions/imageSpec" },
+        "website": { "$ref": "#/definitions/imageSpec" },
+        "backend": { "$ref": "#/definitions/imageSpec" }
       },
       "additionalProperties": false
     },
@@ -2123,24 +2041,16 @@
         "requests": {
           "type": "object",
           "properties": {
-            "memory": {
-              "type": "string"
-            },
-            "cpu": {
-              "type": "string"
-            }
+            "memory": { "type": "string" },
+            "cpu": { "type": "string" }
           },
           "additionalProperties": false
         },
         "limits": {
           "type": "object",
           "properties": {
-            "memory": {
-              "type": "string"
-            },
-            "cpu": {
-              "type": "string"
-            }
+            "memory": { "type": "string" },
+            "cpu": { "type": "string" }
           },
           "additionalProperties": false
         }
@@ -2150,75 +2060,35 @@
     "resources": {
       "type": "object",
       "properties": {
-        "website": {
-          "$ref": "#/definitions/resourceSpec"
-        },
-        "docs": {
-          "$ref": "#/definitions/resourceSpec"
-        },
-        "ena-submission": {
-          "$ref": "#/definitions/resourceSpec"
-        },
-        "ena-submission-list-cronjob": {
-          "$ref": "#/definitions/resourceSpec"
-        },
-        "ingest": {
-          "$ref": "#/definitions/resourceSpec"
-        },
-        "keycloak": {
-          "$ref": "#/definitions/resourceSpec"
-        },
-        "silo": {
-          "$ref": "#/definitions/resourceSpec"
-        },
-        "lapis": {
-          "$ref": "#/definitions/resourceSpec"
-        },
-        "silo-importer": {
-          "$ref": "#/definitions/resourceSpec"
-        },
-        "backend": {
-          "$ref": "#/definitions/resourceSpec"
-        },
-        "preprocessing": {
-          "$ref": "#/definitions/resourceSpec"
-        },
+        "website": { "$ref": "#/definitions/resourceSpec" },
+        "docs": { "$ref": "#/definitions/resourceSpec" },
+        "ena-submission": { "$ref": "#/definitions/resourceSpec" },
+        "ena-submission-list-cronjob": { "$ref": "#/definitions/resourceSpec" },
+        "ingest": { "$ref": "#/definitions/resourceSpec" },
+        "keycloak": { "$ref": "#/definitions/resourceSpec" },
+        "silo": { "$ref": "#/definitions/resourceSpec" },
+        "lapis": { "$ref": "#/definitions/resourceSpec" },
+        "silo-importer": { "$ref": "#/definitions/resourceSpec" },
+        "backend": { "$ref": "#/definitions/resourceSpec" },
+        "preprocessing": { "$ref": "#/definitions/resourceSpec" },
         "organismSpecific": {
           "type": "object",
           "patternProperties": {
             ".*": {
               "type": "object",
               "properties": {
-                "website": {
-                  "$ref": "#/definitions/resourceSpec"
-                },
-                "ena-submission": {
-                  "$ref": "#/definitions/resourceSpec"
-                },
+                "website": { "$ref": "#/definitions/resourceSpec" },
+                "ena-submission": { "$ref": "#/definitions/resourceSpec" },
                 "ena-submission-list-cronjob": {
                   "$ref": "#/definitions/resourceSpec"
                 },
-                "ingest": {
-                  "$ref": "#/definitions/resourceSpec"
-                },
-                "keycloak": {
-                  "$ref": "#/definitions/resourceSpec"
-                },
-                "silo": {
-                  "$ref": "#/definitions/resourceSpec"
-                },
-                "lapis": {
-                  "$ref": "#/definitions/resourceSpec"
-                },
-                "silo-importer": {
-                  "$ref": "#/definitions/resourceSpec"
-                },
-                "backend": {
-                  "$ref": "#/definitions/resourceSpec"
-                },
-                "preprocessing": {
-                  "$ref": "#/definitions/resourceSpec"
-                }
+                "ingest": { "$ref": "#/definitions/resourceSpec" },
+                "keycloak": { "$ref": "#/definitions/resourceSpec" },
+                "silo": { "$ref": "#/definitions/resourceSpec" },
+                "lapis": { "$ref": "#/definitions/resourceSpec" },
+                "silo-importer": { "$ref": "#/definitions/resourceSpec" },
+                "backend": { "$ref": "#/definitions/resourceSpec" },
+                "preprocessing": { "$ref": "#/definitions/resourceSpec" }
               },
               "additionalProperties": false
             }

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1395,32 +1395,100 @@
       "required": ["github"],
       "additionalProperties": false
     },
-    "public": {
-      "group": ["website"],
+    "networking": {
+      "groups": ["general"],
       "type": "object",
-      "description": "TODO",
+      "description": "Network configuration: public-facing URLs and ingress hostnames. publicHosts sets the URLs advertised by applications (for redirects, callbacks, etc.). ingressHosts sets the hostnames used in Ingress rules (for cluster routing).",
+      "additionalProperties": false,
       "properties": {
-        "properties": {
-          "backendUrl": {
-            "groups": ["website"],
-            "type": "string",
-            "description": "Overwrite the URL where the Loculus backend is publicly available."
-          },
-          "websiteUrl": {
-            "groups": ["website"],
-            "type": "string",
-            "description": "Overwrite the URL where the website is publicly available."
-          },
-          "keycloakUrl": {
-            "groups": ["website"],
-            "type": "string",
-            "description": "Overwrite the URL where Keycloak is publicly available."
-          },
-          "lapisUrlTemplate": {
-            "groups": ["website"],
-            "type": "string",
-            "description": "Overwrite the URLs where the LAPIS instances are publicly available. Must contain `%organism%` as a placeholder."
+        "publicHosts": {
+          "groups": ["general"],
+          "type": "object",
+          "description": "Public URLs advertised by the application for redirects and callbacks. Overrides the default computed URLs. If not set, the URLs fall back to the computed defaults from .Values.host and .Values.subdomainSeparator, or from ingressHosts if those are set.",
+          "additionalProperties": false,
+          "properties": {
+            "backendUrl": {
+              "groups": ["general"],
+              "type": "string",
+              "default": "",
+              "description": "Override the URL where the Loculus backend is publicly available. Example: https://api.loculus.x.y.com"
+            },
+            "websiteUrl": {
+              "groups": ["general"],
+              "type": "string",
+              "default": "",
+              "description": "Override the URL where the website is publicly available. Example: https://loculus.x.y.com"
+            },
+            "keycloakUrl": {
+              "groups": ["general"],
+              "type": "string",
+              "default": "",
+              "description": "Override the URL where Keycloak is publicly available. Example: https://auth.loculus.x.y.com"
+            },
+            "lapisUrlTemplate": {
+              "groups": ["general"],
+              "type": "string",
+              "default": "",
+              "description": "Override the URL template for LAPIS instances. Must contain `%organism%` as a placeholder. Example: https://pathogen-api.loculus.x.y.com/%organism%"
+            }
           }
+        },
+        "ingressHosts": {
+          "groups": ["general"],
+          "type": "object",
+          "description": "Override hostnames for each service's Ingress rule. Leave empty to use the default computed hostname from .Values.host and .Values.networking.subdomainSeparator.",
+          "additionalProperties": false,
+          "properties": {
+            "website": {
+              "type": "string",
+              "default": "",
+              "description": "Override hostname for the website Ingress. Defaults to .Values.host."
+            },
+            "backend": {
+              "type": "string",
+              "default": "",
+              "description": "Override hostname for the backend Ingress. Defaults to backend<subdomainSeparator><host>."
+            },
+            "keycloak": {
+              "type": "string",
+              "default": "",
+              "description": "Override hostname for the keycloak Ingress. Defaults to authentication<subdomainSeparator><host>."
+            },
+            "lapis": {
+              "type": "string",
+              "default": "",
+              "description": "Override hostname for the LAPIS Ingress. Defaults to lapis<subdomainSeparator><host>."
+            },
+            "minio": {
+              "type": "string",
+              "default": "",
+              "description": "Override hostname for the MinIO Ingress. Defaults to s3<subdomainSeparator><host>."
+            },
+            "docs": {
+              "type": "string",
+              "default": "",
+              "description": "Override hostname for the docs Ingress. Defaults to docs<subdomainSeparator><host>."
+            }
+          }
+        },
+        "subdomainSeparator": {
+          "groups": ["general"],
+          "type": "string",
+          "default": "-",
+          "description": "Separator inserted between the subdomain prefix and the host when constructing default ingress hostnames. Used with .Values.host to form hostnames like backend<separator>myhost.com. Common values are '-' (for backend-myhost.com) or '.' (for backend.myhost.com)."
+        },
+        "enforceHTTPS": {
+          "groups": ["general"],
+          "type": "boolean",
+          "default": true,
+          "description": "If true, adds a redirect middleware that redirects HTTP to HTTPS on all ingresses."
+        },
+        "traefikVersion": {
+          "groups": ["general"],
+          "type": "integer",
+          "enum": [2, 3],
+          "default": 3,
+          "description": "Traefik major version for CRD API group. Use 2 for traefik.containo.us/v1alpha1 (Traefik v2) or 3 for traefik.io/v1alpha1 (Traefik v3)."
         }
       }
     },
@@ -1462,7 +1530,7 @@
             "public": {
               "groups": ["website"],
               "type": "object",
-              "description": "Settings for the `public` section of the `runtime_config.json`",
+              "description": "Settings for the `public` section of the `runtime_config.json`. This mirrors networking.publicHosts at runtime and is populated automatically.",
               "properties": {}
             }
           }
@@ -1684,18 +1752,6 @@
         }
       }
     },
-    "enforceHTTPS": {
-      "type": "boolean",
-      "default": true,
-      "description": "TODO"
-    },
-    "traefikVersion": {
-      "groups": ["general"],
-      "type": "integer",
-      "enum": [2, 3],
-      "default": 3,
-      "description": "Traefik major version for CRD API group. Use 2 for traefik.containo.us/v1alpha1 (Traefik v2) or 3 for traefik.io/v1alpha1 (Traefik v3)."
-    },
     "ingestLimitSeconds": {
       "type": "integer",
       "default": 1800,
@@ -1826,55 +1882,6 @@
         }
       },
       "additionalProperties": false
-    },
-    "ingress": {
-      "groups": ["general"],
-      "type": "object",
-      "description": "Configure ingress hostnames independently from public URLs. By default, ingress hostnames are automatically constructed from .host and .subdomainSeparator. Set hosts to override the hostname used in the Ingress rules, e.g. when routing through a gateway/reverse proxy with different external hostnames than the internal ones.",
-      "additionalProperties": false,
-      "properties": {
-        "hosts": {
-          "type": "object",
-          "additionalProperties": false,
-          "description": "Override hostnames for each service's Ingress rule. Leave empty to use the default computed hostname.",
-          "properties": {
-            "website": {
-              "type": "string",
-              "default": "",
-              "description": "Override hostname for the website Ingress. Defaults to .Values.host."
-            },
-            "backend": {
-              "type": "string",
-              "default": "",
-              "description": "Override hostname for the backend Ingress. Defaults to backend<subdomainSeparator><host>."
-            },
-            "keycloak": {
-              "type": "string",
-              "default": "",
-              "description": "Override hostname for the keycloak Ingress. Defaults to authentication<subdomainSeparator><host>."
-            },
-            "lapis": {
-              "type": "string",
-              "default": "",
-              "description": "Override hostname for the LAPIS Ingress. Defaults to lapis<subdomainSeparator><host>."
-            },
-            "minio": {
-              "type": "string",
-              "default": "",
-              "description": "Override hostname for the MinIO Ingress. Defaults to s3<subdomainSeparator><host>."
-            },
-            "docs": {
-              "type": "string",
-              "default": "",
-              "description": "Override hostname for the docs Ingress. Defaults to docs<subdomainSeparator><host>."
-            }
-          }
-        }
-      }
-    },
-    "subdomainSeparator": {
-      "type": "string",
-      "default": "-"
     },
     "getSubmissionListLimitSeconds": {
       "type": "integer",

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2694,8 +2694,6 @@ runDevelopmentKeycloakDatabase: true
 runDevelopmentMainDatabase: true
 runDevelopmentS3: true
 developmentDatabasePersistence: false
-enforceHTTPS: true
-traefikVersion: 3
 registrationTermsMessage: >
   You must agree to the <a href="http://main.loculus.org/terms">terms of use</a>.
 
@@ -2707,35 +2705,45 @@ enaDeposition:
   enaSuppressedListTestUrl: "https://loculus-project.github.io/ena-submission/suppressed/ppx-accessions-suppression-list.txt"
 rawReadsProcessingService:
   raw_reads_processing_service_url: http://loculus-raw-reads-processing:5000
-# Configure ingress hostnames independently from public URLs.
+# Configure networking: public-facing URLs (what apps advertise) and ingress hostnames
+# (what the Kubernetes Ingress routes on) independently.
 # By default, ingress hostnames are automatically constructed from .host and .subdomainSeparator
 # (e.g. backend.myhost.com, authentication.myhost.com, lapis.myhost.com).
-# Set these to override the hostname used in the Ingress rules, e.g. when routing
+# The publicHosts values set the URLs advertised by applications (for redirects, callbacks, etc.).
+# The ingressHosts values set the hostnames used in Ingress rules (for cluster routing).
+# Set ingressHosts to override the hostname used in the Ingress rules, e.g. when routing
 # through a gateway/reverse proxy with different external hostnames than the internal ones.
-# The public.*Url values in the app runtime config will remain independent of these.
 # Example:
-# ingress:
-#   hosts:
+# networking:
+#   publicHosts:
+#     websiteUrl: "https://loculus.x.y.com"
+#     backendUrl: "https://api.loculus.x.y.com"
+#     keycloakUrl: "https://auth.loculus.x.y.com"
+#     lapisUrlTemplate: "https://pathogen-api.loculus.x.y.com/%organism%"
+#   ingressHosts:
 #     website: "loculus.x.y.com"
 #     backend: "api.loculus.x.y.com"
 #     keycloak: "auth.loculus.x.y.com"
 #     lapis: "pathogen-api.loculus.x.y.com"
 #     minio: "s3.loculus.x.y.com"
 #     docs: "docs.loculus.x.y.com"
-ingress:
-  hosts:
+networking:
+  publicHosts:
+    backendUrl: ""
+    websiteUrl: ""
+    keycloakUrl: "auth.loculus.org"
+    lapisUrlTemplate: ""
+  ingressHosts:
     website: ""
-    backend: ""
+    backend: "backend-main.loculus.org"
     keycloak: ""
     lapis: ""
     minio: ""
     docs: ""
+  subdomainSeparator: "."
+  enforceHTTPS: true
+  traefikVersion: 3
 
-public:
-  backendUrl: ""
-  lapisUrlTemplate: ""
-
-subdomainSeparator: "."
 enableServiceMonitor: false
 replicas:
   website: 1

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2707,9 +2707,36 @@ enaDeposition:
   enaSuppressedListTestUrl: "https://loculus-project.github.io/ena-submission/suppressed/ppx-accessions-suppression-list.txt"
 rawReadsProcessingService:
   raw_reads_processing_service_url: http://loculus-raw-reads-processing:5000
-subdomainSeparator: "-"
-enableServiceMonitor: false
+# Configure ingress hostnames independently from public URLs.
+# By default, ingress hostnames are automatically constructed from .host and .subdomainSeparator
+# (e.g. backend.myhost.com, authentication.myhost.com, lapis.myhost.com).
+# Set these to override the hostname used in the Ingress rules, e.g. when routing
+# through a gateway/reverse proxy with different external hostnames than the internal ones.
+# The public.*Url values in the app runtime config will remain independent of these.
+# Example:
+# ingress:
+#   hosts:
+#     website: "loculus.x.y.com"
+#     backend: "api.loculus.x.y.com"
+#     keycloak: "auth.loculus.x.y.com"
+#     lapis: "pathogen-api.loculus.x.y.com"
+#     minio: "s3.loculus.x.y.com"
+#     docs: "docs.loculus.x.y.com"
+ingress:
+  hosts:
+    website: ""
+    backend: ""
+    keycloak: ""
+    lapis: ""
+    minio: ""
+    docs: ""
 
+public:
+  backendUrl: ""
+  lapisUrlTemplate: ""
+
+subdomainSeparator: "."
+enableServiceMonitor: false
 replicas:
   website: 1
   backend: 1

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2695,6 +2695,7 @@ runDevelopmentMainDatabase: true
 runDevelopmentS3: true
 developmentDatabasePersistence: false
 networking:
+  host: "helm-url-flex-simplified.loculus.org" # TODO: REVERT before merge
   subdomainSeparator: "-"
   enforceHTTPS: true
   traefikVersion: 3

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2694,6 +2694,10 @@ runDevelopmentKeycloakDatabase: true
 runDevelopmentMainDatabase: true
 runDevelopmentS3: true
 developmentDatabasePersistence: false
+networking:
+  subdomainSeparator: "-"
+  enforceHTTPS: true
+  traefikVersion: 3
 registrationTermsMessage: >
   You must agree to the <a href="http://main.loculus.org/terms">terms of use</a>.
 
@@ -2705,13 +2709,8 @@ enaDeposition:
   enaSuppressedListTestUrl: "https://loculus-project.github.io/ena-submission/suppressed/ppx-accessions-suppression-list.txt"
 rawReadsProcessingService:
   raw_reads_processing_service_url: http://loculus-raw-reads-processing:5000
-
-networking:
-  subdomainSeparator: "-"
-  enforceHTTPS: true
-  traefikVersion: 3
-
 enableServiceMonitor: false
+
 replicas:
   website: 1
   backend: 1

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2705,42 +2705,9 @@ enaDeposition:
   enaSuppressedListTestUrl: "https://loculus-project.github.io/ena-submission/suppressed/ppx-accessions-suppression-list.txt"
 rawReadsProcessingService:
   raw_reads_processing_service_url: http://loculus-raw-reads-processing:5000
-# Configure networking: public-facing URLs (what apps advertise) and ingress hostnames
-# (what the Kubernetes Ingress routes on) independently.
-# By default, ingress hostnames are automatically constructed from .host and .subdomainSeparator
-# (e.g. backend.myhost.com, authentication.myhost.com, lapis.myhost.com).
-# The publicHosts values set the URLs advertised by applications (for redirects, callbacks, etc.).
-# The ingressHosts values set the hostnames used in Ingress rules (for cluster routing).
-# Set ingressHosts to override the hostname used in the Ingress rules, e.g. when routing
-# through a gateway/reverse proxy with different external hostnames than the internal ones.
-# Example:
-# networking:
-#   publicHosts:
-#     websiteUrl: "https://loculus.x.y.com"
-#     backendUrl: "https://api.loculus.x.y.com"
-#     keycloakUrl: "https://auth.loculus.x.y.com"
-#     lapisUrlTemplate: "https://pathogen-api.loculus.x.y.com/%organism%"
-#   ingressHosts:
-#     website: "loculus.x.y.com"
-#     backend: "api.loculus.x.y.com"
-#     keycloak: "auth.loculus.x.y.com"
-#     lapis: "pathogen-api.loculus.x.y.com"
-#     minio: "s3.loculus.x.y.com"
-#     docs: "docs.loculus.x.y.com"
+
 networking:
-  publicHosts:
-    backendUrl: ""
-    websiteUrl: ""
-    keycloakUrl: "auth.loculus.org"
-    lapisUrlTemplate: ""
-  ingressHosts:
-    website: ""
-    backend: "backend-main.loculus.org"
-    keycloak: ""
-    lapis: ""
-    minio: ""
-    docs: ""
-  subdomainSeparator: "."
+  subdomainSeparator: "-"
   enforceHTTPS: true
   traefikVersion: 3
 

--- a/kubernetes/loculus/values_e2e_and_dev.yaml
+++ b/kubernetes/loculus/values_e2e_and_dev.yaml
@@ -13,7 +13,8 @@ disableRawReadsProcessingService: false
 disableEnaSubmission: true
 auth:
   verifyEmail: false
-host: localhost:3000
+networking:
+  host: localhost:3000
 siloImport:
   pollIntervalSeconds: 5
 defaultOrganisms:


### PR DESCRIPTION
# feat!(deployment): group networking values under `networking` and derive Ingress hostnames from the public URLs

Feature requested by @florianzwagemaker who also did initial implementation in #6699. This PR builds on his work there.

## ⚠️ BREAKING CHANGES

Rename in your values files:

| before (root)             | after                                                                               |
| ------------------------- | ----------------------------------------------------------------------------------- |
| `public.backendUrl`       | `networking.publicHosts.backendUrl`                                                 |
| `public.websiteUrl`       | `networking.publicHosts.websiteUrl`                                                 |
| `public.keycloakUrl`      | `networking.publicHosts.keycloakUrl`                                                |
| `public.lapisUrlTemplate` | `networking.publicHosts.lapisUrlTemplate`, append `/%organism%` path if not present |
| `host`                    | `networking.host`                                                                   |
| `subdomainSeparator`      | `networking.subdomainSeparator`                                                     |
| `enforceHTTPS`            | `networking.enforceHTTPS`                                                           |
| `traefikVersion`          | `networking.traefikVersion`                                                         |

## Why

- Configuring Loculus for anything other than the `<service>-<host>` subdomain layout was limited and partially broken.
- Networking-related values were scattered across the root of `values.yaml` — `host`,
  `subdomainSeparator`, `enforceHTTPS`, `traefikVersion`, `public` — with no indication that they
  belong together.
- Ingress hostnames were hardcoded to `<prefix><subdomainSeparator><host>` in five different
  templates. A deployment whose services do not live on sibling subdomains of one base domain (e.g.
  `loculus.x.y.com` + `api.loculus.x.y.com` + `auth.loculus.x.y.com`) could not be expressed at all.
- `public.backendUrl` / `websiteUrl` / `keycloakUrl` / `lapisUrlTemplate` changed only what
  the applications _advertise_, never what the Ingress _routes_. Setting them produced a deployment
  that hands out URLs no Ingress rule answers — with no error.
- `ingest`, `ena-submission` and `autoapprove` each re-derived the backend URL as
  `https://backend<sep><host>` rather than using the shared helper, so `public.backendUrl` never
  reached those configs.

## What this changes

All networking configuration now lives in one block with an explicit three-layer model, documented
in the schema:

```yaml
networking:
  host: myhost.com # (1) convention: base domain of the deployment
  subdomainSeparator: "-" # (1) convention: backend-myhost.com, lapis-myhost.com, ...
  publicHosts: {} # (2) override the public URL of an individual service
  ingressHosts: {} # (3) override the Ingress hostname of an individual service
  enforceHTTPS: true
  traefikVersion: 3
```

Inheritance runs in exactly one direction:

```
host + subdomainSeparator  →  publicHosts.<service>Url  →  ingressHosts.<service>
   (the convention)            (what apps advertise)        (what the cluster routes)
```

- Set nothing but `networking.host` and you get today's behaviour, unchanged.
- Set a `publicHosts` URL and **both** the advertised URL and that service's Ingress rule (and its
  TLS SAN) follow it.
- Set an `ingressHosts` entry only for the rare case where cluster routing must differ from the
  public URL — a CDN or external reverse proxy that terminates the public name. This changes routing
  only; advertised URLs are untouched.

Overrideable: `website`, `backend`, `keycloak`, `lapis`.

## Further behaviour changes beyond the renames

1. **Keycloak `redirectUris` are built from the website URL** instead of `https://<host>` +
   `http://<host>`, so they are correct when the website is not at `https://<host>`. The plaintext
   `http://` variant of the public host is now emitted **only when `networking.enforceHTTPS` is
   false**.
1. **The `www.` website rule is now conditional.** It is emitted only when the website is still on
   `networking.host` and that host does not already start with `www.`; the `redirect-www-middleware`
   is attached only when the rule exists. Previously `www.<host>` was emitted unconditionally, so
   `host: www.example.org` produced an unvalidatable `www.www.example.org` TLS SAN — and with a
   custom website hostname, a `www.` SAN with no DNS record would fail the ACME order and take the
   whole TLS secret, including the working host, down with it.

## Verification (by Claude)

- **No output change at default values.** Rendering `ingressroute`, `lapis-ingress`,
  `keycloak-config-map`, `loculus-website-config`, `docs-preview`, `ingest-config`,
  `autoapprove-config` and `ena-submission-config` for both `environment=server` and
  `environment=local` is byte-identical to `main`, apart from the intended `redirectUris` change.
- Scenario matrix rendered and checked:
  - `publicHosts` only → website / backend / keycloak / lapis Ingress hostnames and TLS SANs all
    follow; `www.` rule correctly suppressed; Keycloak `frontendUrl` and `redirectUris` follow.
  - `publicHosts` + `ingressHosts` → Ingress routes the internal hostnames while the advertised URLs
    and `redirectUris` keep the public ones.
  - `host: www.example.org` → no `www.www.` rule or SAN.
  - path in a `publicHosts` URL → fails in server environment, renders fine in local.
  - `runDevelopmentS3=false` (external S3 endpoint) → no failure from the MinIO hostname derivation.
  - stale top-level `host` / `subdomainSeparator`, and removed `ingressHosts.docs` → rejected by the
    schema.
- `values_e2e_and_dev.yaml` renders the same service URLs as before on the path `deploy.py --for-e2e`
  actually builds.

## Manual testing

- [ ] Loculus preview works
- [ ] Pathoplexus preview works (after required values.yaml migration)

🚀 Preview: Add `preview` label to enable