### PR TITLE
fix(deployment): fix schema docs annotations and guard them in CI

### DIFF
--- a/.github/workflows/helm-schema-lint.yaml
+++ b/.github/workflows/helm-schema-lint.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "kubernetes/**"
+      - "docs/src/content/docs/reference/helm-chart-config.mdx"
       - ".github/workflows/helm-schema-lint.yaml"
   push:
     branches:
@@ -21,6 +22,9 @@ jobs:
         uses: azure/setup-helm@v5
         with:
           version: v3.18.3
+
+      - name: Check schema annotations
+        run: python3 kubernetes/utils/check_schema_annotations.py
 
       - name: Run Helm lint on values files
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,12 @@ repos:
         entry: npx prettier@3.6.2 --write
         language: system
         files: ^kubernetes/loculus/values\.schema\.json$
+      - id: check-schema-annotations
+        name: check values.schema.json annotations
+        entry: python3 kubernetes/utils/check_schema_annotations.py
+        language: system
+        pass_filenames: false
+        files: ^(kubernetes/loculus/values.schema.json|docs/src/content/docs/reference/helm-chart-config.mdx)$
       - id: helm-lint
         name: helm lint
         entry: bash

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -955,13 +955,13 @@
             "additionalProperties": false,
             "properties": {
               "name": {
-                "groups": ["referenceGenomes"],
+                "groups": ["reference-genome"],
                 "docsIncludePrefix": false,
                 "type": "string",
                 "description": "Name of the segment (e.g., 'S', 'M', 'L', or 'main' for single-segmented organisms)"
               },
               "displayName": {
-                "groups": ["referenceGenomes"],
+                "groups": ["reference-genome"],
                 "docsIncludePrefix": false,
                 "type": "string",
                 "description": "Display name of the segment used on the website (e.g., 'S', 'M', 'L', or 'main' for single-segmented organisms)"
@@ -1028,8 +1028,7 @@
                   },
                   "required": ["name", "sequence"]
                 }
-              },
-              "additionalProperties": false
+              }
             }
           }
         }
@@ -1116,21 +1115,18 @@
     },
     "accessionPrefix": {
       "groups": ["general"],
-      "group": "general",
       "type": "string",
       "default": "LOC_",
       "description": "Prefix used for accession numbers"
     },
     "dateFieldForGroupGraph": {
       "groups": ["general"],
-      "group": "general",
       "type": ["string", "null"],
       "default": null,
       "description": "The metadata field used to plot cumulative submissions over time on the group page (typically 'earliestReleaseDate' or another date field). Set to null to disable the chart. If the specified field does not exist for an organism, the chart will show no data for that organism."
     },
     "zstdCompressionLevel": {
       "groups": ["general"],
-      "group": "general",
       "type": "integer",
       "default": 10,
       "minimum": -7,
@@ -1139,7 +1135,6 @@
     },
     "pipelineVersionUpgradeCheckIntervalSeconds": {
       "groups": ["general"],
-      "group": "general",
       "type": "integer",
       "default": 10,
       "minimum": 1,
@@ -1373,17 +1368,17 @@
           "type": "object",
           "properties": {
             "organization": {
-              "group": ["general"],
+              "groups": ["general"],
               "type": "string",
               "description": "A github organization or username."
             },
             "repository": {
-              "group": ["general"],
+              "groups": ["general"],
               "type": "string",
               "description": "A github repository belonging to the given organization."
             },
             "issueTemplate": {
-              "group": ["general"],
+              "groups": ["general"],
               "type": "string",
               "description": "An optional issuetemplate to use."
             }
@@ -1396,31 +1391,29 @@
       "additionalProperties": false
     },
     "public": {
-      "group": ["website"],
+      "groups": ["website"],
       "type": "object",
-      "description": "TODO",
+      "description": "Overrides for the public URLs at which the services are reachable.",
       "properties": {
-        "properties": {
-          "backendUrl": {
-            "groups": ["website"],
-            "type": "string",
-            "description": "Overwrite the URL where the Loculus backend is publicly available."
-          },
-          "websiteUrl": {
-            "groups": ["website"],
-            "type": "string",
-            "description": "Overwrite the URL where the website is publicly available."
-          },
-          "keycloakUrl": {
-            "groups": ["website"],
-            "type": "string",
-            "description": "Overwrite the URL where Keycloak is publicly available."
-          },
-          "lapisUrlTemplate": {
-            "groups": ["website"],
-            "type": "string",
-            "description": "Overwrite the URLs where the LAPIS instances are publicly available. Must contain `%organism%` as a placeholder."
-          }
+        "backendUrl": {
+          "groups": ["website"],
+          "type": "string",
+          "description": "Overwrite the URL where the Loculus backend is publicly available."
+        },
+        "websiteUrl": {
+          "groups": ["website"],
+          "type": "string",
+          "description": "Overwrite the URL where the website is publicly available."
+        },
+        "keycloakUrl": {
+          "groups": ["website"],
+          "type": "string",
+          "description": "Overwrite the URL where Keycloak is publicly available."
+        },
+        "lapisUrlTemplate": {
+          "groups": ["website"],
+          "type": "string",
+          "description": "Overwrite the URLs where the LAPIS instances are publicly available. Must contain `%organism%` as a placeholder."
         }
       }
     },

--- a/kubernetes/utils/check_schema_annotations.py
+++ b/kubernetes/utils/check_schema_annotations.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Lint values.schema.json for misspelled keywords and broken docs annotations.
+
+values.schema.json carries custom annotations on top of JSON Schema:
+
+    groups             which sections of the Helm chart config reference a value appears in
+    docsIncludePrefix  set to false to reset the dotted path shown in the reference
+    placeholder        render <placeholder> instead of the literal key
+
+They are read only by docs/src/components/SchemaDocs.astro, which renders
+docs/src/content/docs/reference/helm-chart-config.mdx. JSON Schema treats unknown keywords as
+annotations and ignores them, so "group" instead of "groups", or "groups": ["referenceGenomes"]
+when the page renders group='reference-genome', is silently accepted by helm and by every
+validator - the only symptom is a value quietly missing from the published reference. This
+script turns those mistakes into errors.
+
+It also catches structural slips that are valid JSON Schema but almost certainly unintended,
+such as a "properties" or "additionalProperties" key nested *inside* a properties map.
+
+Usage: python3 kubernetes/utils/check_schema_annotations.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA = REPO_ROOT / "kubernetes/loculus/values.schema.json"
+DOCS_PAGE = REPO_ROOT / "docs/src/content/docs/reference/helm-chart-config.mdx"
+
+# Custom annotations consumed by SchemaDocs.astro, plus errorMessage (ajv-errors).
+CUSTOM_KEYWORDS = {"groups", "docsIncludePrefix", "placeholder", "errorMessage"}
+
+# JSON Schema keywords in use in this file.
+SCHEMA_KEYWORDS = {
+    "$schema", "$id", "$ref", "$comment", "$defs", "definitions",
+    "title", "description", "default", "examples", "deprecated",
+    "type", "enum", "const", "format",
+    "properties", "patternProperties", "additionalProperties", "propertyNames",
+    "required", "minProperties", "maxProperties", "dependencies",
+    "items", "prefixItems", "additionalItems", "contains", "minItems", "maxItems", "uniqueItems",
+    "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf",
+    "minLength", "maxLength", "pattern",
+    "allOf", "anyOf", "oneOf", "not", "if", "then", "else",
+}
+KNOWN_KEYWORDS = SCHEMA_KEYWORDS | CUSTOM_KEYWORDS
+
+# Structural keywords that are implausible as the name of an actual config value: finding one of
+# these as a key inside a properties map means a nesting level was lost. Keywords that make
+# perfectly good value names (required, type, default, description, pattern, ...) are excluded.
+STRUCTURAL_KEYWORDS = {
+    "properties", "patternProperties", "additionalProperties", "propertyNames",
+    "allOf", "anyOf", "oneOf", "$ref", "$defs", "definitions", "prefixItems",
+}
+
+SINGLE_SCHEMA = {"not", "if", "then", "else", "items", "contains", "propertyNames",
+                 "additionalProperties", "additionalItems"}
+SCHEMA_LIST = {"allOf", "anyOf", "oneOf", "prefixItems"}
+NAMED_SCHEMAS = {"properties", "patternProperties", "definitions", "$defs", "dependencies"}
+
+
+def docs_groups() -> set[str]:
+    """The group names the reference page renders a section for."""
+    return set(re.findall(r"group='([^']+)'", DOCS_PAGE.read_text()))
+
+
+def check(node: object, path: str, errors: list[str], used: dict[str, list[str]]) -> None:
+    if not isinstance(node, dict):
+        return
+
+    for key in node:
+        if key not in KNOWN_KEYWORDS:
+            hint = " (did you mean 'groups'? only the plural is read)" if key == "group" else ""
+            errors.append(f"{path}: unknown keyword {key!r}{hint}")
+
+    groups = node.get("groups")
+    if groups is not None:
+        if not isinstance(groups, list) or not all(isinstance(g, str) for g in groups):
+            errors.append(f"{path}.groups: must be a list of strings, got {groups!r}")
+        else:
+            for group in groups:
+                used.setdefault(group, []).append(path)
+
+    for keyword in NAMED_SCHEMAS:
+        for name, child in (node.get(keyword) or {}).items():
+            if name in STRUCTURAL_KEYWORDS:
+                errors.append(
+                    f"{path}.{keyword}.{name}: a config value named after the structural JSON "
+                    f"Schema keyword {name!r} - a lost nesting level?"
+                )
+            check(child, f"{path}.{keyword}.{name}", errors, used)
+
+    for keyword in SINGLE_SCHEMA:
+        if isinstance(node.get(keyword), dict):
+            check(node[keyword], f"{path}.{keyword}", errors, used)
+
+    for keyword in SCHEMA_LIST:
+        for index, child in enumerate(node.get(keyword) or []):
+            check(child, f"{path}.{keyword}[{index}]", errors, used)
+
+
+def main() -> int:
+    rendered = docs_groups()
+    if not rendered:
+        print(f"error: no group='...' sections found in {DOCS_PAGE}", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+    used: dict[str, list[str]] = {}
+    check(json.loads(SCHEMA.read_text()), "(root)", errors, used)
+
+    for group in sorted(set(used) - rendered):
+        errors.append(
+            f"group {group!r} is used by {len(used[group])} value(s) but no section of "
+            f"{DOCS_PAGE.relative_to(REPO_ROOT)} renders it, so they are undocumented "
+            f"(e.g. {used[group][0]})"
+        )
+    for group in sorted(rendered - set(used)):
+        errors.append(
+            f"{DOCS_PAGE.relative_to(REPO_ROOT)} renders a section for group {group!r} but no "
+            f"value is annotated with it, so the section is empty"
+        )
+
+    if errors:
+        print(f"{SCHEMA.relative_to(REPO_ROOT)}: {len(errors)} problem(s):", file=sys.stderr)
+        for error in errors:
+            print(f"  {error}", file=sys.stderr)
+        return 1
+
+    print(f"{SCHEMA.relative_to(REPO_ROOT)}: OK - {len(rendered)} documented groups, "
+          f"{sum(len(v) for v in used.values())} annotated values")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The values.schema.json annotations that drive the Helm chart config reference are
custom keywords, so JSON Schema silently ignores mistakes in them. Fixes eight
`group` typos (the docs only read `groups`), the `referenceGenomes` group name
that no docs section renders, the doubly-nested `public.properties.properties`
that meant its four URL keys were never validated, and a stray
`additionalProperties` inside a properties map. Adds
kubernetes/utils/check_schema_annotations.py, wired into helm-schema-lint and
pre-commit, which catches all of the above.

### Screenshot

Before:

Missing schema entries due to typos

<img width="820" height="160" alt="Google Chrome 2026-08-05 15 12 02" src="https://github.com/user-attachments/assets/8641bdc1-6be1-4b46-a787-5a32bd96f433" />

🚀 Preview: Add `preview` label to enable