### PR TITLE
fix(website): keep Tools drop-down inside the viewport on mobile

### DIFF
--- a/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
@@ -215,7 +215,15 @@ export const LinkOutMenu: FC<LinkOutMenuProps> = ({
                     <IwwaArrowDown className='ml-2 h-5 w-5' aria-hidden='true' />
                 </MenuButton>
 
-                <MenuItems className='absolute right-0 mt-2 w-64  origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-hidden'>
+                {/*
+                 * `anchor` positions the panel with floating-ui, which keeps it inside the viewport:
+                 * it prefers right-alignment under the button, but shifts/flips and caps its size when
+                 * there isn't enough room - without it the panel hangs off-screen on narrow viewports.
+                 */}
+                <MenuItems
+                    anchor={{ to: 'bottom end', gap: 8, padding: 8 }}
+                    className='z-50 w-64 rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-hidden'
+                >
                     <div className='py-1'>
                         <div className='px-4 py-2 text-sm text-gray-500'>
                             Analyze {sequenceCount !== undefined ? formatNumberWithDefaultLocale(sequenceCount) : '...'}{' '}

--- a/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
+++ b/website/src/components/SearchPage/DownloadDialog/LinkOutMenu.tsx
@@ -219,6 +219,7 @@ export const LinkOutMenu: FC<LinkOutMenuProps> = ({
                  * `anchor` positions the panel with floating-ui, which keeps it inside the viewport:
                  * it prefers right-alignment under the button, but shifts/flips and caps its size when
                  * there isn't enough room - without it the panel hangs off-screen on narrow viewports.
+                 * Prevents: https://github.com/loculus-project/loculus/issues/6988
                  */}
                 <MenuItems
                     anchor={{ to: 'bottom end', gap: 8, padding: 8 }}


### PR DESCRIPTION
Claude-created PR to fix #6988:

The Tools drop-down panel was positioned with plain CSS (`absolute right-0 w-64`), so its right edge was pinned to the right edge of the Tools button. On narrow viewports the button wraps onto its own line at the left of the toolbar, which put most of the 256px-wide panel off the left edge of the screen - and because the overflow is to the left of the document origin, it cannot be scrolled into view.

Switch the panel to Headless UI's `anchor` prop, which positions it with floating-ui. It still prefers right-alignment under the button (`bottom end`, 8px gap), but now shifts and flips to stay inside the viewport and caps its width/height to the available space, scrolling internally instead of running past the fold.

Measured in Chromium with the surrounding toolbar reproduced at a 360px mobile viewport:

  before  x=-131.9  right=124.1  bottom=908  (viewport 360x560)
  after   x=8.0     right=264.0  bottom=552, panel scrolls internally

Desktop positioning is unchanged (identical box at 768px). Also adds `z-50`, matching the other menus in the codebase.

Fixes #6988

### Screenshot

Correct positioining now on mobile:
<img width="231" height="269" alt="Google Chrome 2026-08-05 15 57 32" src="https://github.com/user-attachments/assets/8b8f4c2c-c94b-4e3e-b190-fab74170ad8a" />

And still fine on desktop:
<img width="445" height="131" alt="Google Chrome 2026-08-05 15 57 42" src="https://github.com/user-attachments/assets/34e4e9b5-123d-43ea-a7c2-4cab2e1f7116" />

🚀 Preview: https://fix-tools-dropdown-mobile.loculus.org