### PR TITLE
feat(website): show SeqSet citation formats on the page instead of in a modal

### DIFF
--- a/integration-tests/tests/pages/seqset.page.ts
+++ b/integration-tests/tests/pages/seqset.page.ts
@@ -78,7 +78,18 @@ export class SeqSetPage {
         await expect(this.page.getByText('Version', { exact: true })).toBeVisible();
         await expect(this.page.getByText('Size', { exact: true })).toBeVisible();
         await expect(this.page.getByText('Accession', { exact: true })).toBeVisible();
+        await this.expectCitationFormatsOnPage(name);
         await this.expectCreatorDetailsInModal();
+    }
+
+    /** The citation formats live directly on the page, not behind the export modal. */
+    async expectCitationFormatsOnPage(name: string) {
+        await expect(this.page.getByRole('heading', { name: 'How to cite' })).toBeVisible();
+        const citationText = this.page.getByTestId('citation-text');
+        await expect(citationText).toContainText(`SeqSet: ${name}`);
+        await this.page.getByRole('tab', { name: 'BibTeX' }).click();
+        await expect(citationText).toContainText('@dataset{');
+        await this.page.getByRole('tab', { name: 'APA' }).click();
     }
 
     async expectCreatorDetailsInModal() {

--- a/website/src/components/SeqSetCitations/CiteSeqSet.tsx
+++ b/website/src/components/SeqSetCitations/CiteSeqSet.tsx
@@ -1,0 +1,54 @@
+import { type FC, useState } from 'react';
+import { toast } from 'react-toastify';
+
+import { type CitationFormat, citationFormats, getCitation } from './citationFormats';
+import type { SeqSet } from '../../types/seqSetCitation';
+import { BoxWithTabsBox, BoxWithTabsTab, BoxWithTabsTabBar } from '../common/BoxWithTabs';
+import { Button } from '../common/Button';
+
+type CiteSeqSetProps = {
+    seqSet: SeqSet;
+    databaseName: string;
+    /** Absolute URL of this SeqSet page, used when the SeqSet has no DOI yet. */
+    seqSetUrl: string;
+};
+
+export const CiteSeqSet: FC<CiteSeqSetProps> = ({ seqSet, databaseName, seqSetUrl }) => {
+    const [selectedFormat, setSelectedFormat] = useState<CitationFormat>('apa');
+
+    const citation = getCitation(selectedFormat, { seqSet, databaseName, seqSetUrl });
+
+    const copyToClipboard = async () => {
+        await navigator.clipboard.writeText(citation);
+        toast.success('Copied to clipboard', {
+            position: 'bottom-center',
+            autoClose: 2000,
+        });
+    };
+
+    return (
+        <div>
+            <BoxWithTabsTabBar>
+                {citationFormats.map(({ id, label }) => (
+                    <BoxWithTabsTab
+                        key={id}
+                        label={label}
+                        isActive={selectedFormat === id}
+                        onClick={() => setSelectedFormat(id)}
+                    />
+                ))}
+            </BoxWithTabsTabBar>
+            <BoxWithTabsBox>
+                <pre
+                    data-testid='citation-text'
+                    className='whitespace-pre-wrap break-words font-mono text-sm text-gray-900'
+                >
+                    {citation}
+                </pre>
+                <Button variant='outline' className='mt-4' onClick={() => void copyToClipboard()}>
+                    Copy to clipboard
+                </Button>
+            </BoxWithTabsBox>
+        </div>
+    );
+};

--- a/website/src/components/SeqSetCitations/ExportSeqSet.tsx
+++ b/website/src/components/SeqSetCitations/ExportSeqSet.tsx
@@ -1,5 +1,4 @@
 import { type FC, useState } from 'react';
-import { toast } from 'react-toastify';
 
 import type { SeqSet, SeqSetRecord } from '../../types/seqSetCitation';
 import { serializeSeqSetRecords } from '../../utils/parseAccessionInput';
@@ -8,24 +7,11 @@ import { Button } from '../common/Button';
 type ExportSeqSetProps = {
     seqSet: SeqSet;
     seqSetRecords: SeqSetRecord[];
-    databaseName: string;
 };
 
-export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, databaseName }) => {
+export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords }) => {
     const [isDownloading, setIsDownloading] = useState(false);
     const [selectedDownload, setSelectedDownload] = useState(0);
-    const [selectedCitation, setSelectedCitation] = useState(0);
-
-    const formatYear = (date: string) => {
-        const dateObj = new Date(date);
-        return dateObj.getFullYear();
-    };
-
-    const getSeqSetURL = () => {
-        return seqSet.seqSetDOI === null || seqSet.seqSetDOI === undefined
-            ? window.location.href
-            : `https://doi.org/${seqSet.seqSetDOI}`;
-    };
 
     const downloadJSONSeqSet = () => {
         const exportData = {
@@ -65,161 +51,49 @@ export const ExportSeqSet: FC<ExportSeqSetProps> = ({ seqSet, seqSetRecords, dat
         setIsDownloading(false);
     };
 
-    const getBibtex = () => {
-        const citationKey = (seqSet.seqSetDOI ?? `${seqSet.seqSetId}.${seqSet.seqSetVersion}`).replace(/[^\w]/g, '_');
-        const fields = [
-            `title = {SeqSet: ${seqSet.name}}`,
-            `journal = {${databaseName}}`,
-            `year = {${formatYear(seqSet.createdAt)}}`,
-            `url = {${getSeqSetURL()}}`,
-        ];
-
-        if (seqSet.seqSetDOI !== null && seqSet.seqSetDOI !== undefined) {
-            fields.push(`doi = {${seqSet.seqSetDOI}}`);
-        }
-
-        return `@dataset{${citationKey},\n\t${fields.join(',\n\t')}\n}`;
-    };
-
-    const getMLACitation = () => {
-        return `SeqSet: ${seqSet.name}. ${databaseName}, ${formatYear(seqSet.createdAt)}. ${getSeqSetURL()}`;
-    };
-
-    const getAPACitation = () => {
-        return `SeqSet: ${seqSet.name}. (${formatYear(seqSet.createdAt)}). ${databaseName}. ${getSeqSetURL()}`;
-    };
-
-    const getSelectedCitationText = () => {
-        if (selectedCitation === 0) {
-            return getBibtex();
-        }
-        if (selectedCitation === 1) {
-            return getMLACitation();
-        }
-        return getAPACitation();
-    };
-
-    const copyToClipboard = async () => {
-        const citationText = getSelectedCitationText();
-        await navigator.clipboard.writeText(citationText);
-        toast.success('Copied to clipboard', {
-            position: 'bottom-center',
-            autoClose: 2000,
-        });
-    };
-
     return (
         <div className='flex flex-col items-center w-full'>
             <div className='flex justify-start items-center py-5'>
-                <h1 className='text-xl font-semibold py-4'>Export / Cite SeqSet</h1>
+                <h1 className='text-xl font-semibold py-4'>Export SeqSet</h1>
             </div>
             <div className='flex flex-col justify-around max-w-lg'>
-                <div>
-                    <div className='flex'>
-                        <div className='flex items-center me-4'>
-                            <input
-                                id='json-radio'
-                                data-testid='json-radio'
-                                checked={selectedDownload === 0}
-                                type='radio'
-                                className='h-4 w-4 p-2 text-primary-600 border-gray-300 checked:border-primary-600 focus:ring-primary-600 inline-block'
-                                onChange={() => setSelectedDownload(0)}
-                            />
-                            <label
-                                htmlFor='json-radio'
-                                className='ms-2 text-sm font-medium text-gray-900 dark:text-gray-300'
-                            >
-                                JSON
-                            </label>
-                        </div>
-                        <div className='flex items-center me-4'>
-                            <input
-                                id='tsv-radio'
-                                data-testid='tsv-radio'
-                                type='radio'
-                                checked={selectedDownload === 1}
-                                className='h-4 w-4 p-2 text-primary-600 border-gray-300 checked:border-primary-600 focus:ring-primary-600 inline-block'
-                                onChange={() => setSelectedDownload(1)}
-                            />
-                            <label
-                                htmlFor='tsv-radio'
-                                className='ms-2 text-sm font-medium text-gray-900 dark:text-gray-300'
-                            >
-                                TSV
-                            </label>
-                        </div>
-                    </div>
-                    <div className='pb-8 pt-4'>
-                        <Button variant='primary' onClick={downloadSeqSet} disabled={isDownloading}>
-                            Download
-                        </Button>
-                    </div>
-                </div>
-                <hr className='mb-8' />
                 <div className='flex'>
                     <div className='flex items-center me-4'>
                         <input
-                            id='bibtex-radio'
-                            checked={selectedCitation === 0}
+                            id='json-radio'
+                            data-testid='json-radio'
+                            checked={selectedDownload === 0}
                             type='radio'
-                            name='inline-radio-group'
                             className='h-4 w-4 p-2 text-primary-600 border-gray-300 checked:border-primary-600 focus:ring-primary-600 inline-block'
-                            onChange={() => setSelectedCitation(0)}
+                            onChange={() => setSelectedDownload(0)}
                         />
                         <label
-                            htmlFor='bibtex-radio'
+                            htmlFor='json-radio'
                             className='ms-2 text-sm font-medium text-gray-900 dark:text-gray-300'
                         >
-                            BibTeX
+                            JSON
                         </label>
                     </div>
                     <div className='flex items-center me-4'>
                         <input
-                            id='mla-radio'
+                            id='tsv-radio'
+                            data-testid='tsv-radio'
                             type='radio'
-                            checked={selectedCitation === 1}
-                            name='inline-radio-group'
+                            checked={selectedDownload === 1}
                             className='h-4 w-4 p-2 text-primary-600 border-gray-300 checked:border-primary-600 focus:ring-primary-600 inline-block'
-                            onChange={() => setSelectedCitation(1)}
+                            onChange={() => setSelectedDownload(1)}
                         />
                         <label
-                            htmlFor='mla-radio'
+                            htmlFor='tsv-radio'
                             className='ms-2 text-sm font-medium text-gray-900 dark:text-gray-300'
                         >
-                            MLA
-                        </label>
-                    </div>
-                    <div className='flex items-center me-4'>
-                        <input
-                            id='apa-radio'
-                            type='radio'
-                            checked={selectedCitation === 2}
-                            name='inline-radio-group'
-                            className='h-4 w-4 p-2 text-primary-600 border-gray-300 checked:border-primary-600 focus:ring-primary-600 inline-block'
-                            onChange={() => setSelectedCitation(2)}
-                        />
-                        <label
-                            htmlFor='apa-radio'
-                            className='ms-2 text-sm font-medium text-gray-900 dark:text-gray-300'
-                        >
-                            APA
+                            TSV
                         </label>
                     </div>
                 </div>
-
-                <div className='py-4 w-full'>
-                    <textarea
-                        id='citation-text'
-                        className='block w-full p-4 text-gray-900 border border-gray-300 rounded-lg bg-gray-50 text-base focus:ring-primary-500 focus:border-primary-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500'
-                        rows={5}
-                        cols={40}
-                        value={getSelectedCitationText()}
-                        readOnly
-                    />
-                </div>
-                <div className='pb-8'>
-                    <Button variant='primary' onClick={() => void copyToClipboard()} disabled={isDownloading}>
-                        Copy to clipboard
+                <div className='pb-8 pt-4'>
+                    <Button variant='primary' onClick={downloadSeqSet} disabled={isDownloading}>
+                        Download
                     </Button>
                 </div>
             </div>

--- a/website/src/components/SeqSetCitations/SeqSetItem.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItem.tsx
@@ -4,6 +4,7 @@ import { type FC, useState } from 'react';
 import { toast } from 'react-toastify';
 
 import CitationList from './CitationList.tsx';
+import { CiteSeqSet } from './CiteSeqSet.tsx';
 import { DatePlot, CategoryPlot } from './SeqSetPlots.tsx';
 import { SeqSetRecordsTableWithMetadata } from './SeqSetRecordsTableWithMetadata';
 import type { AggregateRow } from './getSeqSetStatistics.ts';
@@ -56,6 +57,9 @@ type SeqSetItemProps = {
     seqSetCitations: SeqSetCitation[];
     seqSetGraphs: SeqSetGraph[];
     seqSetGraphsData: Record<string, AggregateRow[]>;
+    /** Absolute URL of this SeqSet page, used in citations when the SeqSet has no DOI yet. */
+    seqSetUrl: string;
+    databaseName: string;
     isAdminView?: boolean;
     fieldsToDisplay?: { field: string; displayName: string }[];
     organismDisplayNames?: Record<string, string>;
@@ -70,6 +74,8 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
     seqSetCitations,
     seqSetGraphs,
     seqSetGraphsData,
+    seqSetUrl,
+    databaseName,
     isAdminView = false,
     fieldsToDisplay,
     organismDisplayNames,
@@ -171,6 +177,12 @@ const SeqSetItemInner: FC<SeqSetItemProps> = ({
                     />
                 </SeqSetSection>
             </div>
+            <SeqSetSectionSeparator />
+            <SeqSetSection title='How to cite'>
+                <div className='max-w-3xl'>
+                    <CiteSeqSet seqSet={seqSet} databaseName={databaseName} seqSetUrl={seqSetUrl} />
+                </div>
+            </SeqSetSection>
             <SeqSetSectionSeparator />
             <SeqSetSection
                 title='Statistics'

--- a/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
+++ b/website/src/components/SeqSetCitations/SeqSetItemActions.tsx
@@ -94,7 +94,7 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
                         onClick={() => setExportModalVisible(true)}
                     >
                         <MdiDownload className='w-4 h-4' />
-                        <span className='hidden sm:block'>Export / Cite</span>
+                        <span className='hidden sm:block'>Export</span>
                     </Button>
                     <Button
                         variant='outline'
@@ -154,7 +154,7 @@ const SeqSetItemActionsInner: FC<SeqSetItemActionsProps> = ({
                 className='min-h-[60vh]'
             >
                 <div className='min-w-[1000px]'></div>
-                <ExportSeqSet seqSet={seqSet} seqSetRecords={seqSetRecords} databaseName={databaseName} />
+                <ExportSeqSet seqSet={seqSet} seqSetRecords={seqSetRecords} />
             </BaseDialog>
             <BaseDialog
                 title='Creator details'

--- a/website/src/components/SeqSetCitations/citationFormats.spec.ts
+++ b/website/src/components/SeqSetCitations/citationFormats.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'vitest';
+
+import { getCitation } from './citationFormats';
+import type { SeqSet } from '../../types/seqSetCitation';
+
+const seqSetWithoutDoi: SeqSet = {
+    seqSetId: 'PP_SS_1915',
+    seqSetVersion: 1,
+    name: 'My SeqSet',
+    description: 'A test SeqSet',
+    // Midday UTC so the year does not depend on the local timezone.
+    createdAt: '2024-06-15T12:00:00Z',
+    createdBy: 'testuser',
+};
+
+const seqSetWithDoi: SeqSet = { ...seqSetWithoutDoi, seqSetDOI: '10.62599/PP_SS_1915.1' };
+
+const input = { databaseName: 'Pathoplexus', seqSetUrl: 'https://pathoplexus.org/seqsets/PP_SS_1915.1' };
+
+describe('getCitation', () => {
+    test('uses the SeqSet page URL when there is no DOI', () => {
+        expect(getCitation('apa', { seqSet: seqSetWithoutDoi, ...input })).toBe(
+            'SeqSet: My SeqSet. (2024). Pathoplexus. https://pathoplexus.org/seqsets/PP_SS_1915.1',
+        );
+        expect(getCitation('mla', { seqSet: seqSetWithoutDoi, ...input })).toBe(
+            'SeqSet: My SeqSet. Pathoplexus, 2024. https://pathoplexus.org/seqsets/PP_SS_1915.1',
+        );
+    });
+
+    test('prefers the DOI over the page URL', () => {
+        expect(getCitation('apa', { seqSet: seqSetWithDoi, ...input })).toBe(
+            'SeqSet: My SeqSet. (2024). Pathoplexus. https://doi.org/10.62599/PP_SS_1915.1',
+        );
+        expect(getCitation('mla', { seqSet: seqSetWithDoi, ...input })).toBe(
+            'SeqSet: My SeqSet. Pathoplexus, 2024. https://doi.org/10.62599/PP_SS_1915.1',
+        );
+    });
+
+    test('builds a BibTeX entry keyed on the accession version when there is no DOI', () => {
+        expect(getCitation('bibtex', { seqSet: seqSetWithoutDoi, ...input })).toBe(
+            [
+                '@dataset{PP_SS_1915_1,',
+                '\ttitle = {SeqSet: My SeqSet},',
+                '\tjournal = {Pathoplexus},',
+                '\tyear = {2024},',
+                '\turl = {https://pathoplexus.org/seqsets/PP_SS_1915.1}',
+                '}',
+            ].join('\n'),
+        );
+    });
+
+    test('adds a doi field and keys on the DOI when one exists', () => {
+        expect(getCitation('bibtex', { seqSet: seqSetWithDoi, ...input })).toBe(
+            [
+                '@dataset{10_62599_PP_SS_1915_1,',
+                '\ttitle = {SeqSet: My SeqSet},',
+                '\tjournal = {Pathoplexus},',
+                '\tyear = {2024},',
+                '\turl = {https://doi.org/10.62599/PP_SS_1915.1},',
+                '\tdoi = {10.62599/PP_SS_1915.1}',
+                '}',
+            ].join('\n'),
+        );
+    });
+});

--- a/website/src/components/SeqSetCitations/citationFormats.ts
+++ b/website/src/components/SeqSetCitations/citationFormats.ts
@@ -1,0 +1,59 @@
+import type { SeqSet } from '../../types/seqSetCitation';
+
+export type CitationFormat = 'apa' | 'mla' | 'bibtex';
+
+export const citationFormats: { id: CitationFormat; label: string }[] = [
+    { id: 'apa', label: 'APA' },
+    { id: 'mla', label: 'MLA' },
+    { id: 'bibtex', label: 'BibTeX' },
+];
+
+type CitationInput = {
+    seqSet: SeqSet;
+    databaseName: string;
+    /** Absolute URL of the SeqSet page, used when the SeqSet has no DOI yet. */
+    seqSetUrl: string;
+};
+
+const formatYear = (date: string) => new Date(date).getFullYear();
+
+const getCitationUrl = ({ seqSet, seqSetUrl }: CitationInput) =>
+    seqSet.seqSetDOI === null || seqSet.seqSetDOI === undefined ? seqSetUrl : `https://doi.org/${seqSet.seqSetDOI}`;
+
+const getBibtexCitation = (input: CitationInput) => {
+    const { seqSet, databaseName } = input;
+    const citationKey = (seqSet.seqSetDOI ?? `${seqSet.seqSetId}.${seqSet.seqSetVersion}`).replace(/[^\w]/g, '_');
+    const fields = [
+        `title = {SeqSet: ${seqSet.name}}`,
+        `journal = {${databaseName}}`,
+        `year = {${formatYear(seqSet.createdAt)}}`,
+        `url = {${getCitationUrl(input)}}`,
+    ];
+
+    if (seqSet.seqSetDOI !== null && seqSet.seqSetDOI !== undefined) {
+        fields.push(`doi = {${seqSet.seqSetDOI}}`);
+    }
+
+    return `@dataset{${citationKey},\n\t${fields.join(',\n\t')}\n}`;
+};
+
+const getMlaCitation = (input: CitationInput) => {
+    const { seqSet, databaseName } = input;
+    return `SeqSet: ${seqSet.name}. ${databaseName}, ${formatYear(seqSet.createdAt)}. ${getCitationUrl(input)}`;
+};
+
+const getApaCitation = (input: CitationInput) => {
+    const { seqSet, databaseName } = input;
+    return `SeqSet: ${seqSet.name}. (${formatYear(seqSet.createdAt)}). ${databaseName}. ${getCitationUrl(input)}`;
+};
+
+export const getCitation = (format: CitationFormat, input: CitationInput): string => {
+    switch (format) {
+        case 'bibtex':
+            return getBibtexCitation(input);
+        case 'mla':
+            return getMlaCitation(input);
+        case 'apa':
+            return getApaCitation(input);
+    }
+};

--- a/website/src/pages/seqsets/[seqSetId].[version].astro
+++ b/website/src/pages/seqsets/[seqSetId].[version].astro
@@ -21,6 +21,8 @@ const seqSetId = Astro.params.seqSetId!;
 const version = Astro.params.version!;
 const username = session?.user?.username;
 const seqSetAccessionVersion = `${seqSetId}.${version}`;
+// Canonical absolute URL of this SeqSet version, used in citations when there is no DOI yet.
+const seqSetUrl = new URL(routes.seqSetPage(seqSetAccessionVersion), Astro.url).href;
 
 // Create organism key to display name mapping
 const organismDisplayNames = Object.fromEntries(
@@ -125,6 +127,8 @@ const secondaryErrors = (
                     seqSetCitations={seqSetCitations}
                     seqSetGraphs={seqSetGraphs}
                     seqSetGraphsData={seqSetGraphsData}
+                    seqSetUrl={seqSetUrl}
+                    databaseName={websiteConfig.name}
                     isAdminView={seqSetResponse.value.createdBy === username}
                     fieldsToDisplay={websiteConfig.seqSetsFieldsToDisplay}
                     organismDisplayNames={organismDisplayNames}


### PR DESCRIPTION
Claude-generated PR - not much thought has gone into this but it's a quick proof of concept to see if we like this direction.

### Screenshots

<img width="1592" height="858" alt="Google Chrome 2026-08-05 17 49 42" src="https://github.com/user-attachments/assets/a2e9b2a6-d4c4-4302-bc8b-534d3598922c" />

---

The APA / MLA / BibTeX citations for a SeqSet were only reachable by opening
the "Export / Cite" modal, so a visitor landing on e.g.
/seqsets/PP_SS_1915.1 had no way to see how to cite the SeqSet without
knowing to click Export first.

Move the citation formats out of the modal and onto the SeqSet page as a
"How to cite" section with one tab per format (APA by default, then MLA and
BibTeX), placed directly under the Details / Citations grid and above
Statistics. The existing "Citations" section means *cited by*, so the two
are kept visually distinct. The modal keeps the JSON/TSV download only and
its heading and trigger button are renamed from "Export / Cite" to
"Export".

Implementation notes:

- The citation string building is extracted from ExportSeqSet into a pure
  citationFormats.ts module with unit tests, mirroring the existing
  formatCitationContributors.ts / .spec.ts pattern in this directory.
- The no-DOI fallback URL previously came from window.location.href. That
  was only safe because Headless UI does not render closed-dialog children;
  an always-rendered citation box would hit `window` during the SSR pass of
  the client:load island. The canonical absolute URL is now computed in
  [seqSetId].[version].astro and passed in as a prop, which also means the
  citation always points at the versioned page even when the visitor
  arrived via the unversioned redirect.
- Tabs reuse the existing BoxWithTabs components, whose Button is already
  gated on hydration, so no new Playwright race is introduced.
- The seqset page object asserts the citation formats are visible on the
  page and that switching to the BibTeX tab works. Its existing
  `getByRole('button', { name: 'Export' })` lookups still match the renamed
  button, and no on-page control uses "Download" or "Export" in its
  accessible name, so `closeModal()`'s hidden-Download assertion is
  unaffected.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable