### PR TITLE
refactor/fix(website): Block submissions proceeding while files are still uploading

### DIFF
--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -23,6 +23,7 @@ import {
     getSingleSubmissionFileMapping,
     type FileMapping,
 } from '../Submission/FileUpload/fileMapping.ts';
+import { getPreviousFileUploadState, type FileUploadState } from '../Submission/FileUpload/fileUpload.ts';
 import { Button } from '../common/Button';
 import ErrorBox from '../common/ErrorBox';
 import { Spinner } from '../common/Spinner';
@@ -68,18 +69,10 @@ const InnerEditPage: FC<EditPageProps> = ({
     );
 
     const extraFilesEnabled = submissionDataTypes.files?.enabled ?? false;
-    const [fileMapping, setFileMapping] = useState<FileMapping | undefined>(() => {
-        const previousFiles = dataToEdit.submittedData.files;
-        if (!previousFiles) return undefined;
-        return new Map(
-            Object.entries(previousFiles).map(([category, files]) => [
-                category,
-                // Subfolders are not allowed for form submissions/revisions,
-                // so here file name and path are equivalent
-                new Map(files.map((file) => [file.name, file.fileId])),
-            ]),
-        );
-    });
+    const [fileUploadStates, setFileUploadStates] = useState<Map<string, FileUploadState>>(
+        dataToEdit.submittedData.files ? getPreviousFileUploadState(dataToEdit.submittedData.files) : new Map(),
+    );
+    const [fileMapping, setFileMapping] = useState<FileMapping | undefined>(undefined);
 
     const isCreatingRevision = dataToEdit.status === approvedForReleaseStatus;
 
@@ -164,6 +157,21 @@ const InnerEditPage: FC<EditPageProps> = ({
         }
     };
 
+    const handleSubmit = () => {
+        if (Array.from(fileUploadStates.values()).some((state) => state.type !== 'uploadCompleted')) {
+            toast.error('Please wait for all files to finish uploading before submitting.', {
+                position: 'top-center',
+                autoClose: false,
+            });
+            return;
+        }
+
+        displayConfirmationDialog({
+            dialogText: 'Do you really want to submit?',
+            onConfirmation: submitEditedDataForAccessionVersion,
+        });
+    };
+
     const isPending = isRevisionPending || isEditPending;
     const latestVersionForRevision = sequenceEntryHistory
         ? getLatestAccessionVersionForRevision(sequenceEntryHistory)?.version
@@ -236,23 +244,15 @@ const InnerEditPage: FC<EditPageProps> = ({
                         inputMode='form'
                         groupId={dataToEdit.groupId}
                         fileCategories={submissionDataTypes.files?.categories ?? []}
-                        fileMapping={fileMapping}
+                        fileUploadStates={fileUploadStates}
+                        setFileUploadStates={setFileUploadStates}
                         setFileMapping={setFileMapping}
                         onError={(msg) => toast.error(msg, { position: 'top-center', autoClose: false })}
                     />
                 </div>
             )}
             <div className={isCreatingRevision ? 'flex justify-end gap-x-6' : 'flex items-center gap-4 mt-4'}>
-                <Button
-                    variant='primary'
-                    onClick={() =>
-                        displayConfirmationDialog({
-                            dialogText: 'Do you really want to submit?',
-                            onConfirmation: submitEditedDataForAccessionVersion,
-                        })
-                    }
-                    disabled={isPending}
-                >
+                <Button variant='primary' onClick={handleSubmit} disabled={isPending}>
                     {isPending && <Spinner size='sm' className='mr-2' />}
                     {isCreatingRevision ? 'Upload and proceed to Approval' : 'Submit edits and proceed to Approval'}
                 </Button>

--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -23,7 +23,11 @@ import {
     getSingleSubmissionFileMapping,
     type FileMapping,
 } from '../Submission/FileUpload/fileMapping.ts';
-import { getPreviousFileUploadState, type FileUploadState } from '../Submission/FileUpload/fileUpload.ts';
+import {
+    getInitialFileUploadStates,
+    validateFileUploadStates,
+    type FileUploadState,
+} from '../Submission/FileUpload/fileUpload.ts';
 import { Button } from '../common/Button';
 import ErrorBox from '../common/ErrorBox';
 import { Spinner } from '../common/Spinner';
@@ -70,7 +74,7 @@ const InnerEditPage: FC<EditPageProps> = ({
 
     const extraFilesEnabled = submissionDataTypes.files?.enabled ?? false;
     const [fileUploadStates, setFileUploadStates] = useState<Map<string, FileUploadState>>(
-        dataToEdit.submittedData.files ? getPreviousFileUploadState(dataToEdit.submittedData.files) : new Map(),
+        dataToEdit.submittedData.files ? getInitialFileUploadStates(dataToEdit.submittedData.files) : new Map(),
     );
     const [fileMapping, setFileMapping] = useState<FileMapping | undefined>(undefined);
 
@@ -158,11 +162,9 @@ const InnerEditPage: FC<EditPageProps> = ({
     };
 
     const handleSubmit = () => {
-        if (Array.from(fileUploadStates.values()).some((state) => state.type !== 'uploadCompleted')) {
-            toast.error('Please wait for all files to finish uploading before submitting.', {
-                position: 'top-center',
-                autoClose: false,
-            });
+        const fileUploadStateResult = validateFileUploadStates(fileUploadStates);
+        if (fileUploadStateResult.isErr()) {
+            toast.error(fileUploadStateResult.error.message, { position: 'top-center', autoClose: false });
             return;
         }
 

--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -24,7 +24,7 @@ import {
     type FileMapping,
 } from '../Submission/FileUpload/fileMapping.ts';
 import {
-    getInitialFileUploadStates,
+    getPreviousFileUploadStates,
     validateFileUploadStates,
     type FileUploadState,
 } from '../Submission/FileUpload/fileUpload.ts';
@@ -74,7 +74,7 @@ const InnerEditPage: FC<EditPageProps> = ({
 
     const extraFilesEnabled = submissionDataTypes.files?.enabled ?? false;
     const [fileUploadStates, setFileUploadStates] = useState<Map<string, FileUploadState>>(() =>
-        dataToEdit.submittedData.files ? getInitialFileUploadStates(dataToEdit.submittedData.files) : new Map(),
+        dataToEdit.submittedData.files ? getPreviousFileUploadStates(dataToEdit.submittedData.files) : new Map(),
     );
     const [fileMapping, setFileMapping] = useState<FileMapping | undefined>(undefined);
 

--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -73,7 +73,7 @@ const InnerEditPage: FC<EditPageProps> = ({
     );
 
     const extraFilesEnabled = submissionDataTypes.files?.enabled ?? false;
-    const [fileUploadStates, setFileUploadStates] = useState<Map<string, FileUploadState>>(
+    const [fileUploadStates, setFileUploadStates] = useState<Map<string, FileUploadState>>(() =>
         dataToEdit.submittedData.files ? getInitialFileUploadStates(dataToEdit.submittedData.files) : new Map(),
     );
     const [fileMapping, setFileMapping] = useState<FileMapping | undefined>(undefined);

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -38,7 +38,7 @@ import {
     type FileMapping,
     type SubmissionFileMapping,
 } from './FileUpload/fileMapping.ts';
-import type { FileUploadState } from './FileUpload/fileUpload.ts';
+import { validateFileUploadStates, type FileUploadState } from './FileUpload/fileUpload.ts';
 
 export type UploadAction = 'submit' | 'revise';
 
@@ -126,8 +126,9 @@ const InnerDataUploadForm = ({
             return;
         }
 
-        if (Array.from(fileUploadStates.values()).some((state) => state.type !== 'uploadCompleted')) {
-            onError('Please wait for all files to finish uploading before submitting.');
+        const fileUploadStateResult = validateFileUploadStates(fileUploadStates);
+        if (fileUploadStateResult.isErr()) {
+            onError(fileUploadStateResult.error.message);
             return;
         }
 

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -420,7 +420,7 @@ export const ExtraFilesUpload = ({
     fileLinkage?: FileLinkage;
     onError: (message: string) => void;
 }) => {
-    const setStateForCategory =
+    const setCategoryFileUploadState =
         (category: string): Dispatch<SetStateAction<FileUploadState | undefined>> =>
         (update) =>
             setFileUploadStates((prev) => {
@@ -452,7 +452,7 @@ export const ExtraFilesUpload = ({
                             groupId={groupId}
                             onError={onError}
                             fileUploadState={fileUploadStates.get(fileCategory.name)}
-                            setFileUploadState={setStateForCategory(fileCategory.name)}
+                            setFileUploadState={setCategoryFileUploadState(fileCategory.name)}
                             setFileMapping={setFileMapping}
                         />
                         {inputMode === 'bulk' && (

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -38,6 +38,7 @@ import {
     type FileMapping,
     type SubmissionFileMapping,
 } from './FileUpload/fileMapping.ts';
+import type { FileUploadState } from './FileUpload/fileUpload.ts';
 
 export type UploadAction = 'submit' | 'revise';
 
@@ -76,6 +77,7 @@ const InnerDataUploadForm = ({
 
     const { submit, revise, isPending } = useSubmitFiles(accessToken, organism, clientConfig, onSuccess, onError);
     const [fileFactory, setFileFactory] = useState<FileFactory | undefined>(undefined);
+    const [fileUploadStates, setFileUploadStates] = useState<Map<string, FileUploadState>>(new Map());
     const [fileMapping, setFileMapping] = useState<FileMapping | undefined>(undefined);
     const [submissionFileMapping, setSubmissionFileMapping] = useState<
         Result<SubmissionFileMapping, Error> | undefined
@@ -121,6 +123,11 @@ const InnerDataUploadForm = ({
 
         if (dataUseTermsEnabled && !agreedToINSDCUploadTerms) {
             onError('Please tick the box to agree that you will not independently submit these sequences to INSDC');
+            return;
+        }
+
+        if (Array.from(fileUploadStates.values()).some((state) => state.type !== 'uploadCompleted')) {
+            onError('Please wait for all files to finish uploading before submitting.');
             return;
         }
 
@@ -234,7 +241,8 @@ const InnerDataUploadForm = ({
                             clientConfig={clientConfig}
                             groupId={group.groupId}
                             onError={onError}
-                            fileMapping={fileMapping}
+                            fileUploadStates={fileUploadStates}
+                            setFileUploadStates={setFileUploadStates}
                             setFileMapping={setFileMapping}
                             fileLinkage={fileLinkage}
                         />
@@ -394,7 +402,8 @@ export const ExtraFilesUpload = ({
     inputMode,
     groupId,
     fileCategories,
-    fileMapping,
+    fileUploadStates,
+    setFileUploadStates,
     setFileMapping,
     fileLinkage,
     onError,
@@ -404,11 +413,23 @@ export const ExtraFilesUpload = ({
     inputMode: InputMode;
     groupId: number;
     fileCategories: FileCategory[];
-    fileMapping: FileMapping | undefined;
+    fileUploadStates: Map<string, FileUploadState>;
+    setFileUploadStates: Dispatch<SetStateAction<Map<string, FileUploadState>>>;
     setFileMapping: Dispatch<SetStateAction<FileMapping | undefined>>;
     fileLinkage?: FileLinkage;
     onError: (message: string) => void;
 }) => {
+    const setStateForCategory =
+        (category: string): Dispatch<SetStateAction<FileUploadState | undefined>> =>
+        (update) =>
+            setFileUploadStates((prev) => {
+                const next = typeof update === 'function' ? update(prev.get(category)) : update;
+                const map = new Map(prev);
+                if (next === undefined) map.delete(category);
+                else map.set(category, next);
+                return map;
+            });
+
     return (
         <div className='grid sm:grid-cols-3 gap-x-16 gap-y-4'>
             <div>
@@ -429,7 +450,8 @@ export const ExtraFilesUpload = ({
                             clientConfig={clientConfig}
                             groupId={groupId}
                             onError={onError}
-                            fileMapping={fileMapping}
+                            fileUploadState={fileUploadStates.get(fileCategory.name)}
+                            setFileUploadState={setStateForCategory(fileCategory.name)}
                             setFileMapping={setFileMapping}
                         />
                         {inputMode === 'bulk' && (

--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.spec.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.spec.tsx
@@ -1,14 +1,17 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { err, ok } from 'neverthrow';
+import { useState, type ComponentProps } from 'react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import { FolderUploadComponent } from './FolderUploadComponent';
 import { type FileMapping } from './fileMapping';
+import { type FileUploadState } from './fileUpload';
 import * as multipartUpload from '../../../utils/multipartUpload';
 
 const mockRequestMultipartUpload = vi.fn();
 const mockCompleteMultipartUpload = vi.fn();
+const mockOnError = vi.fn();
 
 vi.mock('../../../services/backendClient', () => {
     return {
@@ -31,8 +34,28 @@ vi.mock('../../../utils/multipartUpload', async () => {
     };
 });
 
-const mockSetFileMapping = vi.fn();
-const mockOnError = vi.fn();
+let fileMapping: FileMapping | undefined;
+
+const FolderUploadComponentWithState = ({
+    initialState,
+    initialMapping,
+    ...props
+}: Omit<ComponentProps<typeof FolderUploadComponent>, 'fileUploadState' | 'setFileUploadState' | 'setFileMapping'> & {
+    initialState?: FileUploadState;
+    initialMapping?: FileMapping;
+}) => {
+    const [fileUploadState, setFileUploadState] = useState(initialState);
+    const [mapping, setMapping] = useState<FileMapping | undefined>(initialMapping);
+    fileMapping = mapping;
+    return (
+        <FolderUploadComponent
+            {...props}
+            fileUploadState={fileUploadState}
+            setFileUploadState={setFileUploadState}
+            setFileMapping={setMapping}
+        />
+    );
+};
 
 const defaultProps = {
     fileCategory: {
@@ -43,39 +66,32 @@ const defaultProps = {
     accessToken: 'test-token',
     clientConfig: { backendUrl: 'http://test-backend', lapisUrls: {} },
     groupId: 1,
-    fileMapping: undefined,
-    setFileMapping: mockSetFileMapping,
     onError: mockOnError,
 };
 
-// The fileMapping is keyed by category, then by file path, to its file ID. Previous uploads have no
-// upload path, so (within a single entry, where names are unique) they are keyed by their name.
-const fileMappingOf = (files: { fileId: string; path: string }[]) =>
-    new Map([['extraFiles', new Map(files.map((f) => [f.path, f.fileId]))]]);
+const previousUploadsState = (files: { fileId: string; path: string }[]): FileUploadState => ({
+    type: 'uploadCompleted',
+    files: files.map(({ fileId, path }) => ({ type: 'previousUpload', fileId, path })),
+});
+
+const previousUploads = [
+    { fileId: 'file-1', path: 'file-a.txt' },
+    { fileId: 'file-2', path: 'file-b.txt' },
+];
 
 const defaultPropsWithFiles = {
     ...defaultProps,
     inputMode: 'form' as const,
-    fileMapping: fileMappingOf([
-        { fileId: 'file-1', path: 'file-a.txt' },
-        { fileId: 'file-2', path: 'file-b.txt' },
-    ]),
+    initialState: previousUploadsState(previousUploads),
 };
 
-/**
- * The component reports its files by passing an updater to `setFileMapping`, so apply the most
- * recent updater to the mapping it was given to see the mapping the parent would end up with.
- */
-const latestReportedMapping = (currentMapping: FileMapping | undefined): FileMapping | undefined => {
-    const updater = mockSetFileMapping.mock.lastCall?.[0] as (
-        mapping: FileMapping | undefined,
-    ) => FileMapping | undefined;
-    return updater(currentMapping);
-};
+// The mapping is keyed by category, then by file path, to its file ID.
+const categoryFileEntries = () => [...fileMapping!.get('extraFiles')!.entries()];
 
 describe('FolderUploadComponent', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        fileMapping = undefined;
         mockRequestMultipartUpload.mockReturnValue(ok([]));
         mockCompleteMultipartUpload.mockReturnValue(ok(undefined));
         vi.mocked(multipartUpload.uploadPart).mockResolvedValue('"etag"');
@@ -83,19 +99,13 @@ describe('FolderUploadComponent', () => {
 
     describe('folder upload', () => {
         it('renders upload folder button', () => {
-            render(<FolderUploadComponent {...defaultProps} />);
+            render(<FolderUploadComponentWithState {...defaultProps} />);
             expect(screen.getByText('Upload folder')).toBeInTheDocument();
             expect(screen.getByTestId('folder-up-icon')).toBeInTheDocument();
         });
 
-        it('renders upload folder button when the mapping has no files for the category', () => {
-            render(
-                <FolderUploadComponent
-                    {...defaultProps}
-                    inputMode='form'
-                    fileMapping={new Map([['extraFiles', new Map()]])}
-                />,
-            );
+        it('renders upload folder button when there is no upload state for the category', () => {
+            render(<FolderUploadComponentWithState {...defaultProps} inputMode='form' />);
 
             expect(screen.getByText('Upload folder')).toBeInTheDocument();
             expect(screen.getByTestId('extraFiles')).toBeInTheDocument();
@@ -105,7 +115,7 @@ describe('FolderUploadComponent', () => {
         it('displays files after selection', async () => {
             mockRequestMultipartUpload.mockReturnValue(ok([{ fileId: 'file-1', urls: ['http://test.com/url1'] }]));
 
-            render(<FolderUploadComponent {...defaultProps} />);
+            render(<FolderUploadComponentWithState {...defaultProps} />);
 
             const input = screen.getByTestId('extraFiles');
             const file = new File(['content'], 'test.txt', { type: 'text/plain' });
@@ -136,7 +146,7 @@ describe('FolderUploadComponent', () => {
                 return '"etag"';
             });
 
-            render(<FolderUploadComponent {...defaultProps} />);
+            render(<FolderUploadComponentWithState {...defaultProps} />);
 
             const input = screen.getByTestId('extraFiles');
             const file = new File(['x'.repeat(20_000_000)], 'large.txt', { type: 'text/plain' });
@@ -160,7 +170,7 @@ describe('FolderUploadComponent', () => {
                 ]),
             );
 
-            render(<FolderUploadComponent {...defaultProps} />);
+            render(<FolderUploadComponentWithState {...defaultProps} />);
 
             const input = screen.getByTestId('extraFiles');
             const file = new File(['x'.repeat(30_000_000)], 'large.txt', { type: 'text/plain' });
@@ -180,7 +190,7 @@ describe('FolderUploadComponent', () => {
             );
             vi.mocked(multipartUpload.uploadPart).mockResolvedValueOnce('"etag1"').mockResolvedValueOnce('"etag2"');
 
-            render(<FolderUploadComponent {...defaultProps} />);
+            render(<FolderUploadComponentWithState {...defaultProps} />);
 
             const input = screen.getByTestId('extraFiles');
             const file = new File(['x'.repeat(20_000_000)], 'test.txt', { type: 'text/plain' });
@@ -200,7 +210,7 @@ describe('FolderUploadComponent', () => {
         it('shows success state after upload completes', async () => {
             mockRequestMultipartUpload.mockReturnValue(ok([{ fileId: 'file-1', urls: ['http://test.com/url1'] }]));
 
-            render(<FolderUploadComponent {...defaultProps} />);
+            render(<FolderUploadComponentWithState {...defaultProps} />);
 
             const input = screen.getByTestId('extraFiles');
             const file = new File(['content'], 'test.txt', { type: 'text/plain' });
@@ -216,7 +226,7 @@ describe('FolderUploadComponent', () => {
         it('filters out dot files', async () => {
             mockRequestMultipartUpload.mockReturnValue(ok([{ fileId: 'file-1', urls: ['http://test.com/url1'] }]));
 
-            render(<FolderUploadComponent {...defaultProps} />);
+            render(<FolderUploadComponentWithState {...defaultProps} />);
 
             const input = screen.getByTestId('extraFiles');
             const validFile = new File(['content'], 'test.txt', { type: 'text/plain' });
@@ -241,7 +251,7 @@ describe('FolderUploadComponent', () => {
 
     describe('rejects whitespace', () => {
         it('rejects a folder upload containing a file name with whitespace', async () => {
-            render(<FolderUploadComponent {...defaultProps} />);
+            render(<FolderUploadComponentWithState {...defaultProps} />);
 
             const file = new File(['content'], 'my reads.fastq', { type: 'text/plain' });
             Object.defineProperty(file, 'webkitRelativePath', {
@@ -256,7 +266,7 @@ describe('FolderUploadComponent', () => {
         });
 
         it('rejects a folder upload containing a folder name with whitespace', async () => {
-            render(<FolderUploadComponent {...defaultProps} />);
+            render(<FolderUploadComponentWithState {...defaultProps} />);
 
             const file = new File(['content'], 'reads.fastq', { type: 'text/plain' });
             Object.defineProperty(file, 'webkitRelativePath', {
@@ -271,7 +281,7 @@ describe('FolderUploadComponent', () => {
         });
 
         it('rejects individually selected files with whitespace in their names', async () => {
-            render(<FolderUploadComponent {...defaultProps} />);
+            render(<FolderUploadComponentWithState {...defaultProps} />);
 
             const file = new File(['content'], 'my reads.fastq', { type: 'text/plain' });
             Object.defineProperty(file, 'webkitRelativePath', { value: '', writable: false });
@@ -285,7 +295,7 @@ describe('FolderUploadComponent', () => {
 
     describe('previous uploads', () => {
         it('renders previous uploads with an "uploaded" label', () => {
-            render(<FolderUploadComponent {...defaultPropsWithFiles} />);
+            render(<FolderUploadComponentWithState {...defaultPropsWithFiles} />);
 
             expect(screen.getByText('file-a.txt')).toBeInTheDocument();
             expect(screen.getByText('file-b.txt')).toBeInTheDocument();
@@ -295,14 +305,13 @@ describe('FolderUploadComponent', () => {
 
     describe('discarding individual files', () => {
         it('files can be discarded and removed from the file mapping', async () => {
-            render(<FolderUploadComponent {...defaultPropsWithFiles} />);
+            render(<FolderUploadComponentWithState {...defaultPropsWithFiles} />);
 
             await userEvent.click(screen.getByTestId('discard_extraFiles_file-a.txt'));
             await waitFor(() => expect(screen.queryByText('file-a.txt')).not.toBeInTheDocument());
             expect(screen.getByText('file-b.txt')).toBeInTheDocument();
 
-            const mapping = latestReportedMapping(defaultPropsWithFiles.fileMapping);
-            expect([...mapping!.get('extraFiles')!.entries()]).toEqual([['file-b.txt', 'file-2']]);
+            expect(categoryFileEntries()).toEqual([['file-b.txt', 'file-2']]);
         });
 
         it('files are discarded by path, not by name', async () => {
@@ -310,7 +319,7 @@ describe('FolderUploadComponent', () => {
                 .mockReturnValueOnce(ok([{ fileId: 'file-1', urls: ['http://test.com/url1'] }]))
                 .mockReturnValueOnce(ok([{ fileId: 'file-2', urls: ['http://test.com/url2'] }]));
 
-            render(<FolderUploadComponent {...defaultProps} />);
+            render(<FolderUploadComponentWithState {...defaultProps} />);
 
             const firstFile = new File(['content'], 'a.txt', { type: 'text/plain' });
             Object.defineProperty(firstFile, 'webkitRelativePath', { value: 'folder/sub1/a.txt', writable: false });
@@ -325,22 +334,22 @@ describe('FolderUploadComponent', () => {
             await waitFor(() => expect(screen.getAllByText('a.txt')).toHaveLength(1));
             expect(screen.getByText('sub2 /')).toBeInTheDocument();
             expect(screen.queryByText('sub1 /')).not.toBeInTheDocument();
-            expect([...latestReportedMapping(undefined)!.get('extraFiles')!.entries()]).toEqual([
-                ['sub2/a.txt', 'file-2'],
-            ]);
+            expect(categoryFileEntries()).toEqual([['sub2/a.txt', 'file-2']]);
         });
 
         it('reverts to the upload folder prompt and clears the file mapping after discarding the last upload', async () => {
-            const singleFileProps = {
-                ...defaultPropsWithFiles,
-                fileMapping: fileMappingOf([{ fileId: 'file-1', path: 'file-a.txt' }]),
-            };
-            render(<FolderUploadComponent {...singleFileProps} />);
+            const singleFile = { fileId: 'file-1', path: 'file-a.txt' };
+            render(
+                <FolderUploadComponentWithState
+                    {...defaultPropsWithFiles}
+                    initialState={previousUploadsState([singleFile])}
+                />,
+            );
 
             await userEvent.click(screen.getByTestId('discard_extraFiles_file-a.txt'));
             await waitFor(() => expect(screen.getByText('Upload folder')).toBeInTheDocument());
             expect(screen.queryByText('file-a.txt')).not.toBeInTheDocument();
-            expect(latestReportedMapping(singleFileProps.fileMapping)).toBeUndefined();
+            expect(fileMapping).toBeUndefined();
         });
 
         it('disables the individual discard buttons while an upload is in progress', async () => {
@@ -348,7 +357,7 @@ describe('FolderUploadComponent', () => {
             // Keep the upload pending so the component stays in the uploadInProgress state.
             vi.mocked(multipartUpload.uploadPart).mockReturnValue(new Promise(() => {}));
 
-            render(<FolderUploadComponent {...defaultPropsWithFiles} />);
+            render(<FolderUploadComponentWithState {...defaultPropsWithFiles} />);
 
             const file = new File(['content'], 'added.txt', { type: 'text/plain' });
             Object.defineProperty(file, 'webkitRelativePath', { value: '', writable: false });
@@ -361,7 +370,7 @@ describe('FolderUploadComponent', () => {
         it('keeps existing files when adding additional ones', async () => {
             mockRequestMultipartUpload.mockReturnValue(ok([{ fileId: 'added-id', urls: ['http://test.com/url1'] }]));
 
-            render(<FolderUploadComponent {...defaultPropsWithFiles} />);
+            render(<FolderUploadComponentWithState {...defaultPropsWithFiles} />);
 
             const file = new File(['content'], 'added.txt', { type: 'text/plain' });
             Object.defineProperty(file, 'webkitRelativePath', { value: '', writable: false });
@@ -382,7 +391,7 @@ describe('FolderUploadComponent', () => {
                 ok([{ fileId: 'replacement-id', urls: ['http://test.com/url1'] }]),
             );
 
-            render(<FolderUploadComponent {...defaultPropsWithFiles} />);
+            render(<FolderUploadComponentWithState {...defaultPropsWithFiles} />);
 
             const file = new File(['content'], 'file-a.txt', { type: 'text/plain' });
             Object.defineProperty(file, 'webkitRelativePath', { value: '', writable: false });
@@ -400,8 +409,7 @@ describe('FolderUploadComponent', () => {
             expect(screen.getAllByText('file-a.txt')).toHaveLength(1);
             expect(screen.getAllByText('(uploaded)')).toHaveLength(1);
 
-            const categoryFiles = latestReportedMapping(defaultPropsWithFiles.fileMapping)!.get('extraFiles')!;
-            expect([...categoryFiles.entries()]).toEqual([
+            expect(categoryFileEntries()).toEqual([
                 ['file-b.txt', 'file-2'],
                 ['file-a.txt', 'replacement-id'],
             ]);
@@ -412,7 +420,7 @@ describe('FolderUploadComponent', () => {
                 ok([{ fileId: 'replacement-id', urls: ['http://test.com/url1'] }]),
             );
 
-            render(<FolderUploadComponent {...defaultPropsWithFiles} />);
+            render(<FolderUploadComponentWithState {...defaultPropsWithFiles} />);
 
             const file = new File(['content'], 'file-a.txt', { type: 'text/plain' });
             Object.defineProperty(file, 'webkitRelativePath', { value: '', writable: false });
@@ -434,7 +442,7 @@ describe('FolderUploadComponent', () => {
             // Keep the upload pending so the component stays in the uploadInProgress state.
             vi.mocked(multipartUpload.uploadPart).mockReturnValue(new Promise(() => {}));
 
-            render(<FolderUploadComponent {...defaultPropsWithFiles} />);
+            render(<FolderUploadComponentWithState {...defaultPropsWithFiles} />);
 
             const file = new File(['content'], 'added.txt', { type: 'text/plain' });
             Object.defineProperty(file, 'webkitRelativePath', { value: '', writable: false });
@@ -445,32 +453,35 @@ describe('FolderUploadComponent', () => {
 
     describe('discarding all files', () => {
         it('shows a dialog before discarding all files and discards after confirmation', async () => {
-            render(<FolderUploadComponent {...defaultPropsWithFiles} />);
+            render(<FolderUploadComponentWithState {...defaultPropsWithFiles} />);
 
             await userEvent.click(screen.getByTestId('discard_extraFiles'));
             await waitFor(() => expect(screen.getByText(/are you sure you want to discard/i)).toBeInTheDocument());
 
             await userEvent.click(screen.getByRole('button', { name: /^Discard$/ }));
             await waitFor(() => expect(screen.getByText('Upload folder')).toBeInTheDocument());
-            expect(latestReportedMapping(defaultPropsWithFiles.fileMapping)).toBeUndefined();
+            expect(fileMapping).toBeUndefined();
         });
 
         it('removes only its own category when the file mapping holds several', async () => {
             const otherCategoryFiles = new Map([['other-file.txt', 'file-3']]);
-            const fileMapping = new Map([...defaultPropsWithFiles.fileMapping, ['otherFiles', otherCategoryFiles]]);
-            render(<FolderUploadComponent {...defaultPropsWithFiles} fileMapping={fileMapping} />);
+            render(
+                <FolderUploadComponentWithState
+                    {...defaultPropsWithFiles}
+                    initialMapping={new Map([['otherFiles', otherCategoryFiles]])}
+                />,
+            );
 
             await userEvent.click(screen.getByTestId('discard_extraFiles'));
             await userEvent.click(screen.getByRole('button', { name: /^Discard$/ }));
             await waitFor(() => expect(screen.getByText('Upload folder')).toBeInTheDocument());
 
-            const mapping = latestReportedMapping(fileMapping);
-            expect(mapping!.has('extraFiles')).toBe(false);
-            expect(mapping!.get('otherFiles')).toBe(otherCategoryFiles);
+            expect(fileMapping!.has('extraFiles')).toBe(false);
+            expect(fileMapping!.get('otherFiles')).toBe(otherCategoryFiles);
         });
 
         it('keeps the files when discarding all files is cancelled', async () => {
-            render(<FolderUploadComponent {...defaultPropsWithFiles} />);
+            render(<FolderUploadComponentWithState {...defaultPropsWithFiles} />);
 
             await userEvent.click(screen.getByTestId('discard_extraFiles'));
             await waitFor(() => expect(screen.getByText(/are you sure you want to discard/i)).toBeInTheDocument());
@@ -487,7 +498,7 @@ describe('FolderUploadComponent', () => {
             mockRequestMultipartUpload.mockReturnValue(ok([{ fileId: 'failed-id', urls: ['http://test.com/url1'] }]));
             mockCompleteMultipartUpload.mockReturnValue(err({ detail: 'Could not complete upload' }));
 
-            render(<FolderUploadComponent {...defaultProps} />);
+            render(<FolderUploadComponentWithState {...defaultProps} />);
 
             const input = screen.getByTestId('extraFiles');
             const file = new File(['content'], 'test.txt', { type: 'text/plain' });
@@ -495,7 +506,7 @@ describe('FolderUploadComponent', () => {
 
             await userEvent.upload(input, file);
             await waitFor(() => expect(screen.getByText('✗')).toBeInTheDocument());
-            expect(mockOnError).toHaveBeenCalledWith(expect.stringContaining('Could not complete upload'));
+            expect(defaultProps.onError).toHaveBeenCalledWith(expect.stringContaining('Could not complete upload'));
 
             // A failed file never reaches 'uploaded', so the component stays in the in-progress state
             // and only the discard-all button remains usable.

--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.spec.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.spec.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { err, ok } from 'neverthrow';
-import { useState, type ComponentProps } from 'react';
+import { useEffect, useState, type ComponentProps } from 'react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import { FolderUploadComponent } from './FolderUploadComponent';
@@ -34,19 +34,19 @@ vi.mock('../../../utils/multipartUpload', async () => {
     };
 });
 
-let fileMapping: FileMapping | undefined;
-
 const FolderUploadComponentWithState = ({
     initialState,
     initialMapping,
+    onMapping,
     ...props
 }: Omit<ComponentProps<typeof FolderUploadComponent>, 'fileUploadState' | 'setFileUploadState' | 'setFileMapping'> & {
     initialState?: FileUploadState;
     initialMapping?: FileMapping;
+    onMapping?: (mapping: FileMapping | undefined) => void;
 }) => {
     const [fileUploadState, setFileUploadState] = useState(initialState);
     const [mapping, setMapping] = useState<FileMapping | undefined>(initialMapping);
-    fileMapping = mapping;
+    useEffect(() => onMapping?.(mapping), [mapping, onMapping]);
     return (
         <FolderUploadComponent
             {...props}
@@ -86,12 +86,11 @@ const defaultPropsWithFiles = {
 };
 
 // The mapping is keyed by category, then by file path, to its file ID.
-const categoryFileEntries = () => [...fileMapping!.get('extraFiles')!.entries()];
+const mappingOf = (files: [path: string, fileId: string][]) => new Map([['extraFiles', new Map(files)]]);
 
 describe('FolderUploadComponent', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        fileMapping = undefined;
         mockRequestMultipartUpload.mockReturnValue(ok([]));
         mockCompleteMultipartUpload.mockReturnValue(ok(undefined));
         vi.mocked(multipartUpload.uploadPart).mockResolvedValue('"etag"');
@@ -305,13 +304,14 @@ describe('FolderUploadComponent', () => {
 
     describe('discarding individual files', () => {
         it('files can be discarded and removed from the file mapping', async () => {
-            render(<FolderUploadComponentWithState {...defaultPropsWithFiles} />);
+            const onMapping = vi.fn();
+            render(<FolderUploadComponentWithState {...defaultPropsWithFiles} onMapping={onMapping} />);
 
             await userEvent.click(screen.getByTestId('discard_extraFiles_file-a.txt'));
             await waitFor(() => expect(screen.queryByText('file-a.txt')).not.toBeInTheDocument());
             expect(screen.getByText('file-b.txt')).toBeInTheDocument();
 
-            expect(categoryFileEntries()).toEqual([['file-b.txt', 'file-2']]);
+            expect(onMapping).toHaveBeenLastCalledWith(mappingOf([['file-b.txt', 'file-2']]));
         });
 
         it('files are discarded by path, not by name', async () => {
@@ -319,7 +319,8 @@ describe('FolderUploadComponent', () => {
                 .mockReturnValueOnce(ok([{ fileId: 'file-1', urls: ['http://test.com/url1'] }]))
                 .mockReturnValueOnce(ok([{ fileId: 'file-2', urls: ['http://test.com/url2'] }]));
 
-            render(<FolderUploadComponentWithState {...defaultProps} />);
+            const onMapping = vi.fn();
+            render(<FolderUploadComponentWithState {...defaultProps} onMapping={onMapping} />);
 
             const firstFile = new File(['content'], 'a.txt', { type: 'text/plain' });
             Object.defineProperty(firstFile, 'webkitRelativePath', { value: 'folder/sub1/a.txt', writable: false });
@@ -334,22 +335,24 @@ describe('FolderUploadComponent', () => {
             await waitFor(() => expect(screen.getAllByText('a.txt')).toHaveLength(1));
             expect(screen.getByText('sub2 /')).toBeInTheDocument();
             expect(screen.queryByText('sub1 /')).not.toBeInTheDocument();
-            expect(categoryFileEntries()).toEqual([['sub2/a.txt', 'file-2']]);
+            expect(onMapping).toHaveBeenLastCalledWith(mappingOf([['sub2/a.txt', 'file-2']]));
         });
 
         it('reverts to the upload folder prompt and clears the file mapping after discarding the last upload', async () => {
             const singleFile = { fileId: 'file-1', path: 'file-a.txt' };
+            const onMapping = vi.fn();
             render(
                 <FolderUploadComponentWithState
                     {...defaultPropsWithFiles}
                     initialState={previousUploadsState([singleFile])}
+                    onMapping={onMapping}
                 />,
             );
 
             await userEvent.click(screen.getByTestId('discard_extraFiles_file-a.txt'));
             await waitFor(() => expect(screen.getByText('Upload folder')).toBeInTheDocument());
             expect(screen.queryByText('file-a.txt')).not.toBeInTheDocument();
-            expect(fileMapping).toBeUndefined();
+            expect(onMapping).toHaveBeenLastCalledWith(undefined);
         });
 
         it('disables the individual discard buttons while an upload is in progress', async () => {
@@ -391,7 +394,8 @@ describe('FolderUploadComponent', () => {
                 ok([{ fileId: 'replacement-id', urls: ['http://test.com/url1'] }]),
             );
 
-            render(<FolderUploadComponentWithState {...defaultPropsWithFiles} />);
+            const onMapping = vi.fn();
+            render(<FolderUploadComponentWithState {...defaultPropsWithFiles} onMapping={onMapping} />);
 
             const file = new File(['content'], 'file-a.txt', { type: 'text/plain' });
             Object.defineProperty(file, 'webkitRelativePath', { value: '', writable: false });
@@ -409,10 +413,12 @@ describe('FolderUploadComponent', () => {
             expect(screen.getAllByText('file-a.txt')).toHaveLength(1);
             expect(screen.getAllByText('(uploaded)')).toHaveLength(1);
 
-            expect(categoryFileEntries()).toEqual([
-                ['file-b.txt', 'file-2'],
-                ['file-a.txt', 'replacement-id'],
-            ]);
+            expect(onMapping).toHaveBeenLastCalledWith(
+                mappingOf([
+                    ['file-b.txt', 'file-2'],
+                    ['file-a.txt', 'replacement-id'],
+                ]),
+            );
         });
 
         it('leaves the existing files alone when the overwrite is cancelled', async () => {
@@ -453,22 +459,25 @@ describe('FolderUploadComponent', () => {
 
     describe('discarding all files', () => {
         it('shows a dialog before discarding all files and discards after confirmation', async () => {
-            render(<FolderUploadComponentWithState {...defaultPropsWithFiles} />);
+            const onMapping = vi.fn();
+            render(<FolderUploadComponentWithState {...defaultPropsWithFiles} onMapping={onMapping} />);
 
             await userEvent.click(screen.getByTestId('discard_extraFiles'));
             await waitFor(() => expect(screen.getByText(/are you sure you want to discard/i)).toBeInTheDocument());
 
             await userEvent.click(screen.getByRole('button', { name: /^Discard$/ }));
             await waitFor(() => expect(screen.getByText('Upload folder')).toBeInTheDocument());
-            expect(fileMapping).toBeUndefined();
+            expect(onMapping).toHaveBeenLastCalledWith(undefined);
         });
 
         it('removes only its own category when the file mapping holds several', async () => {
             const otherCategoryFiles = new Map([['other-file.txt', 'file-3']]);
+            const onMapping = vi.fn();
             render(
                 <FolderUploadComponentWithState
                     {...defaultPropsWithFiles}
                     initialMapping={new Map([['otherFiles', otherCategoryFiles]])}
+                    onMapping={onMapping}
                 />,
             );
 
@@ -476,8 +485,7 @@ describe('FolderUploadComponent', () => {
             await userEvent.click(screen.getByRole('button', { name: /^Discard$/ }));
             await waitFor(() => expect(screen.getByText('Upload folder')).toBeInTheDocument());
 
-            expect(fileMapping!.has('extraFiles')).toBe(false);
-            expect(fileMapping!.get('otherFiles')).toBe(otherCategoryFiles);
+            expect(onMapping).toHaveBeenLastCalledWith(new Map([['otherFiles', otherCategoryFiles]]));
         });
 
         it('keeps the files when discarding all files is cancelled', async () => {

--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
@@ -3,6 +3,15 @@ import React, { useEffect, useState, type Dispatch, type FC, type SetStateAction
 import { toast } from 'react-toastify';
 
 import { type FileMapping } from './fileMapping';
+import type {
+    Awaiting,
+    FileUploadState,
+    Pending,
+    PreviousUpload,
+    SingleFileUpload,
+    Uploaded,
+    UploadStatus,
+} from './fileUpload';
 import useClientFlag from '../../../hooks/isClient';
 import { BackendClient } from '../../../services/backendClient';
 import { type FileCategory } from '../../../types/config';
@@ -15,77 +24,14 @@ import LucideFile from '~icons/lucide/file';
 import LucideFolderUp from '~icons/lucide/folder-up';
 import LucideLoader from '~icons/lucide/loader';
 
-/**
- * The state that the component is in, right after the user dropped the files.
- * We're awaiting the presigned upload URLs from the backend, to start uploading.
- */
-type AwaitingUrlState = {
-    type: 'awaitingUrls';
-    files: Awaiting[];
-};
-
-type UploadInProgressState = {
-    type: 'uploadInProgress';
-    files: SingleFileUpload[];
-};
-
-type UploadCompleted = {
-    type: 'uploadCompleted';
-    files: (Uploaded | PreviousUpload)[];
-};
-
-type FileUploadState = AwaitingUrlState | UploadInProgressState | UploadCompleted;
-
-type UploadStatus = 'pending' | 'uploaded' | 'previousUpload' | 'error';
-
-type Awaiting = {
-    type: 'awaiting';
-    file: File;
-    path: string;
-};
-
-type Pending = {
-    type: 'pending';
-    file: File;
-    path: string;
-    size: number;
-    fileId: string;
-    urls: string[];
-    uploadedParts: number;
-    totalParts: number;
-    partSize: number;
-    etags?: string[];
-};
-
-type Uploaded = {
-    type: 'uploaded';
-    fileId: string;
-    path: string;
-    size: number;
-};
-
-type PreviousUpload = {
-    type: 'previousUpload';
-    fileId: string;
-    path: string;
-};
-
-type FileError = {
-    type: 'error';
-    path: string;
-    size: number;
-    msg: string;
-};
-
-type SingleFileUpload = Pending | Uploaded | PreviousUpload | FileError;
-
 type FolderUploadComponentProps = {
     fileCategory: FileCategory;
     inputMode: InputMode;
     accessToken: string;
     clientConfig: ClientConfig;
     groupId: number;
-    fileMapping: FileMapping | undefined;
+    fileUploadState: FileUploadState | undefined;
+    setFileUploadState: Dispatch<SetStateAction<FileUploadState | undefined>>;
     setFileMapping: Dispatch<SetStateAction<FileMapping | undefined>>;
     onError: (message: string) => void;
 };
@@ -142,21 +88,11 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
     accessToken,
     clientConfig,
     groupId,
-    fileMapping,
+    fileUploadState,
+    setFileUploadState,
     setFileMapping,
     onError,
 }) => {
-    const [fileUploadState, setFileUploadState] = useState<FileUploadState | undefined>(() => {
-        const categoryFiles = fileMapping?.get(fileCategory.name);
-        if (categoryFiles === undefined || categoryFiles.size === 0) return undefined;
-
-        const files: PreviousUpload[] = [...categoryFiles.entries()].map(([path, fileId]) => ({
-            type: 'previousUpload',
-            fileId,
-            path,
-        }));
-        return { type: 'uploadCompleted', files };
-    });
     const [isDragging, setIsDragging] = useState(false);
 
     const backendClient = new BackendClient(clientConfig.backendUrl);

--- a/website/src/components/Submission/FileUpload/fileUpload.spec.ts
+++ b/website/src/components/Submission/FileUpload/fileUpload.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateFileUploadStates, type FileUploadState } from './fileUpload';
+
+const uploaded = { type: 'uploaded', fileId: 'file-1', path: 'a.txt', size: 7 } as const;
+const previousUpload = { type: 'previousUpload', fileId: 'file-2', path: 'b.txt' } as const;
+
+const statesOf = (...states: FileUploadState[]) => new Map(states.map((state, index) => [`category${index}`, state]));
+
+describe('validateFileUploadStates', () => {
+    it('accepts a submission without any file categories', () => {
+        expect(validateFileUploadStates(new Map()).isOk()).toBeTruthy();
+    });
+
+    it('accepts categories whose uploads have all completed', () => {
+        const result = validateFileUploadStates(
+            statesOf(
+                { type: 'uploadCompleted', files: [uploaded] },
+                { type: 'uploadCompleted', files: [previousUpload] },
+            ),
+        );
+
+        expect(result.isOk()).toBeTruthy();
+    });
+
+    it('rejects a category which is still awaiting upload urls', () => {
+        const result = validateFileUploadStates(statesOf({ type: 'awaitingUrls', files: [] }));
+
+        expect(result.isErr()).toBeTruthy();
+        expect(result._unsafeUnwrapErr().message).toContain('wait for all files to finish uploading');
+    });
+
+    it('rejects a category whose upload is still in progress', () => {
+        const result = validateFileUploadStates(
+            statesOf({ type: 'uploadCompleted', files: [uploaded] }, { type: 'uploadInProgress', files: [uploaded] }),
+        );
+
+        expect(result.isErr()).toBeTruthy();
+        expect(result._unsafeUnwrapErr().message).toContain('wait for all files to finish uploading');
+    });
+});

--- a/website/src/components/Submission/FileUpload/fileUpload.ts
+++ b/website/src/components/Submission/FileUpload/fileUpload.ts
@@ -64,7 +64,7 @@ type UploadCompleted = {
 
 export type FileUploadState = AwaitingUrlState | UploadInProgressState | UploadCompleted;
 
-export const getPreviousFileUploadState = (files: FilesByCategory) =>
+export const getInitialFileUploadStates = (files: FilesByCategory): Map<string, FileUploadState> =>
     new Map(
         Object.entries(files)
             .filter(([_, files]) => files.length > 0)
@@ -78,3 +78,10 @@ export const getPreviousFileUploadState = (files: FilesByCategory) =>
                 },
             ]),
     );
+
+export const validateFileUploadStates = (fileUploadStates: Map<string, FileUploadState>): Result<void, Error> => {
+    if (Array.from(fileUploadStates.values()).some((state) => state.type !== 'uploadCompleted'))
+        return err(new Error('Please wait for all files to finish uploading before submitting.'));
+
+    return ok();
+};

--- a/website/src/components/Submission/FileUpload/fileUpload.ts
+++ b/website/src/components/Submission/FileUpload/fileUpload.ts
@@ -31,6 +31,9 @@ export type Uploaded = {
 export type PreviousUpload = {
     type: 'previousUpload';
     fileId: string;
+    // Previous uploads only appear for form submissions/revisions
+    // where we have a single folder of uniquely named files.
+    // Therefore, name and path are equivalent
     path: string;
 };
 
@@ -66,7 +69,7 @@ type UploadCompleted = {
 
 export type FileUploadState = AwaitingUrlState | UploadInProgressState | UploadCompleted;
 
-export const getInitialFileUploadStates = (files: FilesByCategory): Map<string, FileUploadState> =>
+export const getPreviousFileUploadStates = (files: FilesByCategory): Map<string, FileUploadState> =>
     new Map(
         Object.entries(files)
             .filter(([_, files]) => files.length > 0)
@@ -74,8 +77,9 @@ export const getInitialFileUploadStates = (files: FilesByCategory): Map<string, 
                 category,
                 {
                     type: 'uploadCompleted',
-                    // Subfolders are not allowed for form submissions/revisions,
-                    // so here file name and path are equivalent
+                    // Previous uploads only appear for form submissions/revisions
+                    // where we have a single folder of uniquely named files.
+                    // Therefore, name and path are equivalent
                     files: files.map((f) => ({ type: 'previousUpload', fileId: f.fileId, path: f.name })),
                 },
             ]),

--- a/website/src/components/Submission/FileUpload/fileUpload.ts
+++ b/website/src/components/Submission/FileUpload/fileUpload.ts
@@ -43,7 +43,7 @@ type FileError = {
 
 export type SingleFileUpload = Pending | Uploaded | PreviousUpload | FileError;
 
-export type UploadStatus = 'awaiting' | 'pending' | 'uploaded' | 'previousUpload' | 'error';
+export type UploadStatus = 'pending' | 'uploaded' | 'previousUpload' | 'error';
 
 /**
  * The state that the component is in, right after the user dropped the files.

--- a/website/src/components/Submission/FileUpload/fileUpload.ts
+++ b/website/src/components/Submission/FileUpload/fileUpload.ts
@@ -1,3 +1,5 @@
+import { err, ok, Result } from 'neverthrow';
+
 import type { FilesByCategory } from '../../../types/backend';
 
 export type Awaiting = {

--- a/website/src/components/Submission/FileUpload/fileUpload.ts
+++ b/website/src/components/Submission/FileUpload/fileUpload.ts
@@ -1,0 +1,80 @@
+import type { FilesByCategory } from '../../../types/backend';
+
+export type Awaiting = {
+    type: 'awaiting';
+    file: File;
+    path: string;
+};
+
+export type Pending = {
+    type: 'pending';
+    file: File;
+    path: string;
+    size: number;
+    fileId: string;
+    urls: string[];
+    uploadedParts: number;
+    totalParts: number;
+    partSize: number;
+    etags?: string[];
+};
+
+export type Uploaded = {
+    type: 'uploaded';
+    fileId: string;
+    path: string;
+    size: number;
+};
+
+export type PreviousUpload = {
+    type: 'previousUpload';
+    fileId: string;
+    path: string;
+};
+
+type FileError = {
+    type: 'error';
+    path: string;
+    size: number;
+    msg: string;
+};
+
+export type SingleFileUpload = Pending | Uploaded | PreviousUpload | FileError;
+
+export type UploadStatus = 'awaiting' | 'pending' | 'uploaded' | 'previousUpload' | 'error';
+
+/**
+ * The state that the component is in, right after the user dropped the files.
+ * We're awaiting the presigned upload URLs from the backend, to start uploading.
+ */
+type AwaitingUrlState = {
+    type: 'awaitingUrls';
+    files: Awaiting[];
+};
+
+type UploadInProgressState = {
+    type: 'uploadInProgress';
+    files: SingleFileUpload[];
+};
+
+type UploadCompleted = {
+    type: 'uploadCompleted';
+    files: (Uploaded | PreviousUpload)[];
+};
+
+export type FileUploadState = AwaitingUrlState | UploadInProgressState | UploadCompleted;
+
+export const getPreviousFileUploadState = (files: FilesByCategory) =>
+    new Map(
+        Object.entries(files)
+            .filter(([_, files]) => files.length > 0)
+            .map(([category, files]) => [
+                category,
+                {
+                    type: 'uploadCompleted',
+                    // Subfolders are not allowed for form submissions/revisions,
+                    // so here file name and path are equivalent
+                    files: files.map((f) => ({ type: 'previousUpload', fileId: f.fileId, path: f.name })),
+                },
+            ]),
+    );


### PR DESCRIPTION
resolves #6766, replaces #6855

### Summary

- Lifts `FileUploadState` out of each `FolderUploadComponent` and into a single state of `Map<FileCategoryName, FileUploadState>` for the submission/revision/edit components.
- From here, adds validation for all file categories to be in state `uploadCompleted` before proceeding with submission.

### Screenshot

Attempting (multiple times) to submit while a file is still uploading:

<img width="375" height="382" alt="image" src="https://github.com/user-attachments/assets/588d8714-fb27-4f19-8fa9-3e6fed388cad" />
 
### PR Checklist
- [ ] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://upload-state-refactor.loculus.org