### PR TITLE
fix(backend): Use percent encoding for spaces in filenames in `get-released-data`

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -40,7 +40,7 @@ import org.loculus.backend.utils.toTimestamp
 import org.loculus.backend.utils.toUtcDateString
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.net.URLEncoder
+import org.springframework.web.util.UriUtils.encodePathSegment
 import java.nio.charset.StandardCharsets
 
 private val log = KotlinLogging.logger { }
@@ -232,7 +232,7 @@ open class ReleasedDataModel(
         filesMap: FileCategoryFilesMap,
     ): Map<FileCategory, List<FileIdAndNameAndReadUrl>> = filesMap.mapValues { (category, fileIdandName) ->
         fileIdandName.map { (fileId, name) ->
-            val encoded = URLEncoder.encode(name, StandardCharsets.UTF_8)
+            val encoded = encodePathSegment(name, StandardCharsets.UTF_8)
             val url = when (backendConfig.fileSharing.outputFileUrlType) {
                 FileUrlType.WEBSITE -> "${backendConfig.websiteUrl}/seq/$accession.$version/$category/$encoded"
                 FileUrlType.BACKEND -> "${backendConfig.backendUrl}/files/get/$accession/$version/$category/$encoded"

--- a/integration-tests/tests/specs/features/file-sharing.spec.ts
+++ b/integration-tests/tests/specs/features/file-sharing.spec.ts
@@ -28,8 +28,8 @@ const ID_1 = 'sub1';
 const ID_2 = 'sub2';
 const FILES_SINGLE = { 'testfile.fastq': EBOLA_SUDAN_SMALL_FASTQ(1) };
 const FILES_DOUBLE = {
-    'file1.fastq': EBOLA_SUDAN_SMALL_FASTQ(1),
-    'file2.fastq': EBOLA_SUDAN_SMALL_FASTQ(2),
+    'file 1.fastq': EBOLA_SUDAN_SMALL_FASTQ(1),
+    'file 2.fastq': EBOLA_SUDAN_SMALL_FASTQ(2),
 };
 
 test('submit single seq w/ 2 FASTQ files thru single seq submission form', async ({


### PR DESCRIPTION
resolves #6765

### Summary

The `java.net.URLEncoder` function, used to build the file URLs in `get-released-data`, converts spaces ` ` into `+`, but the backend decodes file names using encoding `%20` for spaces.

Filenames with spaces worked on the _review_ page, because the files dialog on this page builds the call from the file name, and uses the correct encoding. However, the file URLs on released data pages would return 404s, because these rely on the file URL provided by `get-released-data` which had the encoding issue.

This PR updates `get-released-data` to use Spring's `encodePathSegment` which does the correct encoding for spaces.

### Screenshot

#### Before

Filenames with spaces worked on the review page, as the `FilesDialog` on the website constructs the URL from the filename, with correct percent encoding for spaces:

<img width="859" height="367" alt="image" src="https://github.com/user-attachments/assets/bc81c12b-5f9d-4319-b060-7126b0b136b2" />


However they resulted in 404s once released, as the incorrectly-encoded URLs from `get-released-data` are used:

<img width="1000" height="706" alt="image" src="https://github.com/user-attachments/assets/1febbe54-76ef-4027-b972-980d90b3a603" />

#### After

Files can still be downloaded on the review page, and also from pages using file URLs from `get-released-data`, as they are now correctly encoded:

<img width="994" height="792" alt="image" src="https://github.com/user-attachments/assets/b0d4a1dc-55a5-4924-901d-747b80da1737" />

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable