### PR TITLE
refactor(website): load secrets from Astro server environment

### DIFF
--- a/.github/workflows/website-playwright-dev-test.yml
+++ b/.github/workflows/website-playwright-dev-test.yml
@@ -55,3 +55,5 @@ jobs:
           npx playwright screenshot localhost:3000 test.png
         env:
           CONFIG_DIR: "tests/config"
+          BACKEND_KEYCLOAK_CLIENT_SECRET: "dummy"
+          OIDC_TRANSACTION_COOKIE_SECRET: "test-oidc-transaction-cookie-secret"

--- a/kubernetes/loculus/templates/_config-processor.tpl
+++ b/kubernetes/loculus/templates/_config-processor.tpl
@@ -42,18 +42,6 @@
         secretKeyRef:
           name: service-accounts
           key: backendUserPassword
-    - name: LOCULUSSUB_backendKeycloakClientSecret
-      valueFrom:
-        secretKeyRef:
-          name: backend-keycloak-client-secret
-          key: backendKeycloakClientSecret
-    {{- if eq .name "loculus-website-config" }}
-    - name: LOCULUSSUB_oidcTransactionCookieSecret
-      valueFrom:
-        secretKeyRef:
-          name: website-oidc-cookie-secret
-          key: oidcTransactionCookieSecret
-    {{- end }}
     - name: LOCULUSSUB_orcidSecret
       valueFrom:
         secretKeyRef:

--- a/kubernetes/loculus/templates/loculus-website-config.yaml
+++ b/kubernetes/loculus/templates/loculus-website-config.yaml
@@ -28,9 +28,7 @@ data:
         },
         "public": {
           {{- template "loculus.publicRuntimeConfig" . -}}
-        },
-        "backendKeycloakClientSecret" : "[[backendKeycloakClientSecret]]",
-        "oidcTransactionCookieSecret" : {{ if .Values.testconfig }}"test-oidc-transaction-cookie-secret"{{ else }}"[[oidcTransactionCookieSecret]]"{{ end }}
+        }
     }
 {{- range $key, $organismConfig := $organisms }}
 ---

--- a/kubernetes/loculus/templates/loculus-website.yaml
+++ b/kubernetes/loculus/templates/loculus-website.yaml
@@ -30,6 +30,17 @@ spec:
           image: "{{ $.Values.images.website.repository }}:{{ $.Values.images.website.tag | default $dockerTag }}"
           imagePullPolicy: "{{ $.Values.images.website.pullPolicy | default $.Values.imagePullPolicy }}"
           {{- include "loculus.resources" (list "website" .Values) | nindent 10 }}
+          env:
+            - name: BACKEND_KEYCLOAK_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: backend-keycloak-client-secret
+                  key: backendKeycloakClientSecret
+            - name: OIDC_TRANSACTION_COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: website-oidc-cookie-secret
+                  key: oidcTransactionCookieSecret
           ports:
             - containerPort: 3000
           volumeMounts:

--- a/website/.env.example
+++ b/website/.env.example
@@ -1,3 +1,5 @@
 CONFIG_DIR=./tests/config
 LOG_DIR=./log
 LOG_LEVEL=info
+BACKEND_KEYCLOAK_CLIENT_SECRET=dummy
+OIDC_TRANSACTION_COOKIE_SECRET=test-oidc-transaction-cookie-secret

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config';
+import { defineConfig, envField } from 'astro/config';
 import node from '@astrojs/node';
 import tailwindcss from '@tailwindcss/vite';
 import Icons from 'unplugin-icons/vite';
@@ -9,6 +9,20 @@ import flowbiteReact from 'flowbite-react/plugin/astro';
 // https://astro.build/config
 export default defineConfig({
     output: 'server',
+    env: {
+        schema: {
+            BACKEND_KEYCLOAK_CLIENT_SECRET: envField.string({
+                context: 'server',
+                access: 'secret',
+                min: 5,
+            }),
+            OIDC_TRANSACTION_COOKIE_SECRET: envField.string({
+                context: 'server',
+                access: 'secret',
+                min: 32,
+            }),
+        },
+    },
     integrations: [react(), mdx(), flowbiteReact()],
     security: {
         // Allow any forwarded host/proto (required for ingress-terminated deployments with dynamic hostnames).

--- a/website/src/middleware/authMiddleware.spec.ts
+++ b/website/src/middleware/authMiddleware.spec.ts
@@ -10,7 +10,6 @@ vi.mock('../config.ts', () => ({
     getConfiguredOrganisms: () => [],
     getRuntimeConfig: () => ({
         insecureCookies: false,
-        oidcTransactionCookieSecret: 'test-oidc-transaction-cookie-secret',
     }),
     getWebsiteConfig: () => ({ readOnlyMode: false }),
 }));

--- a/website/src/types/runtimeConfig.ts
+++ b/website/src/types/runtimeConfig.ts
@@ -19,8 +19,6 @@ export const serverConfig = serviceUrls.merge(
 export const runtimeConfig = z.object({
     public: serviceUrls,
     serverSide: serverConfig,
-    backendKeycloakClientSecret: z.string().min(5),
-    oidcTransactionCookieSecret: z.string().min(32),
     insecureCookies: z.boolean(),
 });
 

--- a/website/src/utils/authRequestCookies.spec.ts
+++ b/website/src/utils/authRequestCookies.spec.ts
@@ -11,7 +11,6 @@ import {
 vi.mock('../config.ts', () => ({
     getRuntimeConfig: () => ({
         insecureCookies: false,
-        oidcTransactionCookieSecret: 'test-oidc-transaction-cookie-secret',
     }),
 }));
 

--- a/website/src/utils/authRequestCookies.ts
+++ b/website/src/utils/authRequestCookies.ts
@@ -1,6 +1,7 @@
 import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
 
 import type { AstroCookies } from 'astro';
+import { OIDC_TRANSACTION_COOKIE_SECRET } from 'astro:env/server';
 
 import { getRuntimeConfig } from '../config.ts';
 
@@ -25,7 +26,7 @@ export type AuthRequest = {
 };
 
 function encryptionKey() {
-    return createHash('sha256').update(getRuntimeConfig().oidcTransactionCookieSecret).digest();
+    return createHash('sha256').update(OIDC_TRANSACTION_COOKIE_SECRET).digest();
 }
 
 function seal(store: AuthRequestStore): string {

--- a/website/src/utils/clientMetadata.ts
+++ b/website/src/utils/clientMetadata.ts
@@ -1,4 +1,4 @@
-import { getRuntimeConfig } from '../config';
+import { BACKEND_KEYCLOAK_CLIENT_SECRET } from 'astro:env/server';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 const clientMetadata = {
@@ -9,13 +9,8 @@ const clientMetadata = {
 /* eslint-enable @typescript-eslint/naming-convention */
 
 export const getClientMetadata = () => {
-    return { ...clientMetadata, client_secret: getClientSecret() }; // eslint-disable-line @typescript-eslint/naming-convention
-};
-
-const getClientSecret = () => {
-    const configDir = import.meta.env.CONFIG_DIR;
-    if (typeof configDir !== 'string' || configDir === '') {
-        return 'dummySecret';
-    }
-    return getRuntimeConfig().backendKeycloakClientSecret;
+    return {
+        ...clientMetadata,
+        client_secret: BACKEND_KEYCLOAK_CLIENT_SECRET, // eslint-disable-line @typescript-eslint/naming-convention
+    };
 };

--- a/website/vitest.config.ts
+++ b/website/vitest.config.ts
@@ -1,10 +1,19 @@
+import { fileURLToPath } from 'node:url';
+
 import react from '@vitejs/plugin-react';
 import Icons from 'unplugin-icons/vite';
 import { defineConfig as defineViteConfig, mergeConfig } from 'vite';
 import { defineConfig as defineVitestConfig } from 'vitest/config';
 
+const astroEnvServerModule = 'astro:env/server';
+
 const viteConfig = defineViteConfig({
     plugins: [react(), Icons({ compiler: 'jsx', jsx: 'react' })],
+    resolve: {
+        alias: {
+            [astroEnvServerModule]: fileURLToPath(new URL('./vitest.env.ts', import.meta.url)),
+        },
+    },
 });
 
 const vitestConfig = defineVitestConfig({

--- a/website/vitest.env.ts
+++ b/website/vitest.env.ts
@@ -1,0 +1,2 @@
+export const BACKEND_KEYCLOAK_CLIENT_SECRET = 'dummy';
+export const OIDC_TRANSACTION_COOKIE_SECRET = 'test-oidc-transaction-cookie-secret';

--- a/website/vitest.setup.ts
+++ b/website/vitest.setup.ts
@@ -43,8 +43,6 @@ export const testConfig = {
         keycloakUrl: 'http://authentication.dummy',
     },
     insecureCookies: true,
-    backendKeycloakClientSecret: 'dummy',
-    oidcTransactionCookieSecret: 'test-oidc-transaction-cookie-secret',
 } as RuntimeConfig;
 
 // Stubbing necessary since headlessui v2


### PR DESCRIPTION
## Summary

This is a stacked follow-up to #6994. It moves both secrets consumed by the website out of the processed `runtime_config.json` file and into Astro's typed server environment API.

The transaction-cookie encryption key and existing Keycloak client secret are now declared as server-only secret fields in `astro.config.mjs`. Kubernetes injects both values directly from their existing Secrets into the website container, and the website imports them from `astro:env/server` at runtime.

The config processor remains in place because website organism configuration still uses it to materialize remote reference URLs, but it no longer receives or substitutes either website secret. Non-secret deployment configuration continues to use `runtime_config.json`.

## Impact

- Website secrets are no longer written into the processed JSON configuration volume.
- Secret values remain runtime-only and are not embedded in the built server or browser bundles.
- All website replicas continue to receive the same Kubernetes-managed transaction-cookie key.
- Local development documents the two required environment variables in `.env.example`.
- Vitest uses a dedicated alias containing non-secret test values for Astro's virtual server-environment module.

## Verification

- `CI=1 npm run test -- --run` — 71 files and 722 tests passed.
- `npm run check-types` — Astro and TypeScript reported no errors, warnings, or hints.
- `npm run format` — passed.
- `npm run build` — production server build completed successfully.
- Confirmed the production build does not contain the test secret values.
- `helm lint kubernetes/loculus -f kubernetes/loculus/values.yaml` — passed.
- Rendered the Helm chart and confirmed both secret references appear on the website container and no longer appear in `runtime_config.json`.

Depends on #6994.

🚀 Preview: Add `preview` label to enable