### PR TITLE
perf(backend): batch accession updates

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
@@ -352,14 +352,47 @@ class UploadDatabaseService(
             "Generated ${submissionIdToAccessionMap.size} new accessions for original upload with UploadId $uploadId:"
         }
 
-        submissionIdToAccessionMap.forEach { (submissionId, accession) ->
-            MetadataUploadAuxTable.update(
-                where = {
-                    (submissionIdColumn eq submissionId) and (uploadIdColumn eq uploadId)
-                },
-            ) {
-                it[accessionColumn] = accession
-                it[versionColumn] = 1
+        transaction {
+            submissionIdToAccessionMap.processInDatabaseSafeChunks { chunk ->
+                val values = chunk.joinToString(", ") { "(?, ?)" }
+                val updateSql = """
+                    UPDATE metadata_upload_aux_table AS metadata
+                    SET
+                        accession = generated.accession,
+                        version = 1
+                    FROM (VALUES $values) AS generated(submission_id, accession)
+                    WHERE
+                        metadata.upload_id = ?
+                        AND metadata.submission_id = generated.submission_id
+                    RETURNING metadata.submission_id
+                """.trimIndent()
+                val stringColumnType = VarCharColumnType()
+                val arguments = chunk.flatMap { (submissionId, accession) ->
+                    listOf(
+                        Pair(stringColumnType, submissionId),
+                        Pair(stringColumnType, accession),
+                    )
+                } + Pair(stringColumnType, uploadId)
+
+                val updatedSubmissionIds = exec(
+                    updateSql,
+                    arguments,
+                    explicitStatementType = StatementType.SELECT,
+                ) { resultSet ->
+                    val result = mutableSetOf<SubmissionId>()
+                    while (resultSet.next()) {
+                        result += resultSet.getString("submission_id")
+                    }
+                    result
+                } ?: emptySet()
+                val expectedSubmissionIds = chunk.mapTo(mutableSetOf()) { it.first }
+
+                if (updatedSubmissionIds != expectedSubmissionIds) {
+                    throw IllegalStateException(
+                        "Expected to assign ${expectedSubmissionIds.size} accessions for upload $uploadId, " +
+                            "but updated ${updatedSubmissionIds.size}.",
+                    )
+                }
             }
         }
     }

--- a/backend/src/test/kotlin/org/loculus/backend/service/submission/UploadDatabaseServiceTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/submission/UploadDatabaseServiceTest.kt
@@ -1,0 +1,90 @@
+package org.loculus.backend.service.submission
+
+import io.mockk.every
+import io.mockk.mockk
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.select
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.loculus.backend.api.Organism
+import org.loculus.backend.auth.AuthenticatedUser
+import org.loculus.backend.controller.DEFAULT_ORGANISM
+import org.loculus.backend.controller.EndpointTest
+import org.loculus.backend.service.GenerateAccessionFromNumberService
+import org.loculus.backend.utils.DateProvider
+import org.loculus.backend.utils.MetadataEntry
+import org.springframework.beans.factory.annotation.Autowired
+
+private const val NUMBER_OF_ACCESSIONS_ACROSS_TWO_CHUNKS = 10_001
+
+@EndpointTest
+class UploadDatabaseServiceTest(
+    @Autowired private val uploadDatabaseService: UploadDatabaseService,
+    @Autowired private val generateAccessionFromNumberService: GenerateAccessionFromNumberService,
+    @Autowired private val dateProvider: DateProvider,
+) {
+    @Test
+    fun `WHEN generating accessions for an original upload THEN assigns every row in set-based chunks`() {
+        val targetUploadId = "target-upload"
+        val otherUploadId = "other-upload"
+        val authenticatedUser = mockk<AuthenticatedUser>()
+        every { authenticatedUser.username } returns "test-user"
+        val expectedSubmissionIds = (1..NUMBER_OF_ACCESSIONS_ACROSS_TWO_CHUNKS).map {
+            "submission-$it"
+        }
+
+        insertMetadata(targetUploadId, expectedSubmissionIds, authenticatedUser)
+        insertMetadata(otherUploadId, listOf("other-submission"), authenticatedUser)
+
+        uploadDatabaseService.generateNewAccessionsForOriginalUpload(targetUploadId)
+
+        val targetRows = getAuxRows(targetUploadId)
+        assertEquals(NUMBER_OF_ACCESSIONS_ACROSS_TWO_CHUNKS, targetRows.size)
+        assertEquals(expectedSubmissionIds.toSet(), targetRows.map { it.submissionId }.toSet())
+        assertTrue(targetRows.all { it.version == 1L })
+
+        val accessions = targetRows.map { it.accession }
+        assertTrue(accessions.all { it != null && generateAccessionFromNumberService.validateAccession(it) })
+        assertEquals(NUMBER_OF_ACCESSIONS_ACROSS_TWO_CHUNKS, accessions.toSet().size)
+
+        val otherRow = getAuxRows(otherUploadId).single()
+        assertNull(otherRow.accession)
+        assertNull(otherRow.version)
+    }
+
+    private fun insertMetadata(uploadId: String, submissionIds: List<String>, authenticatedUser: AuthenticatedUser) {
+        uploadDatabaseService.batchInsertMetadataInAuxTable(
+            uploadId = uploadId,
+            authenticatedUser = authenticatedUser,
+            groupId = 1,
+            submittedOrganism = Organism(DEFAULT_ORGANISM),
+            uploadedMetadataBatch = submissionIds.map {
+                MetadataEntry(it, mapOf("field" to "value"))
+            },
+            uploadedAt = dateProvider.getCurrentDateTime(),
+            files = null,
+        )
+    }
+
+    private fun getAuxRows(uploadId: String): List<AuxRow> = transaction {
+        MetadataUploadAuxTable
+            .select(
+                MetadataUploadAuxTable.submissionIdColumn,
+                MetadataUploadAuxTable.accessionColumn,
+                MetadataUploadAuxTable.versionColumn,
+            )
+            .where { MetadataUploadAuxTable.uploadIdColumn eq uploadId }
+            .map {
+                AuxRow(
+                    submissionId = it[MetadataUploadAuxTable.submissionIdColumn],
+                    accession = it[MetadataUploadAuxTable.accessionColumn],
+                    version = it[MetadataUploadAuxTable.versionColumn],
+                )
+            }
+    }
+
+    private data class AuxRow(val submissionId: String, val accession: String?, val version: Long?)
+}


### PR DESCRIPTION
### What

During submission the backend assigned accessions with one UPDATE statement
per sequence, so 500k single-row statements per upload. This PR assigns them
in batches instead.

### Result (500k sequences)

| Stage | Before | After |
|---|---|---|
| Upload | 4351s | **2269s** (−48%) |
| Preprocessing (drain) | 2228s | 2217s |
| Approval | 246s | 237s |
| LAPIS/SILO | 782s | 742s |
| **Total workload** | **7642s** | **5508s** |

### PR Checklist
- ~~All necessary documentation has been adapted.~~
  - internal change
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
  - 500k benchmark run on the perf cluster, numbers above

🚀 Preview: Add `preview` label to enable