### PR TITLE
perf(backend): insert initial data use terms in one statement

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/datauseterms/DataUseTermsDatabaseService.kt
@@ -1,7 +1,12 @@
 package org.loculus.backend.service.datauseterms
 
+import org.jetbrains.exposed.v1.core.QueryParameter
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.stringParam
+import org.jetbrains.exposed.v1.datetime.dateTimeParam
 import org.jetbrains.exposed.v1.jdbc.batchInsert
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.loculus.backend.api.DataUseTerms
 import org.loculus.backend.api.DataUseTermsHistoryEntry
@@ -10,6 +15,7 @@ import org.loculus.backend.auth.AuthenticatedUser
 import org.loculus.backend.controller.NotFoundException
 import org.loculus.backend.log.AuditLogger
 import org.loculus.backend.service.submission.AccessionPreconditionValidator
+import org.loculus.backend.service.submission.MetadataUploadAuxTable
 import org.loculus.backend.utils.Accession
 import org.loculus.backend.utils.DateProvider
 import org.loculus.backend.utils.processInDatabaseSafeChunks
@@ -24,6 +30,47 @@ class DataUseTermsDatabaseService(
     private val auditLogger: AuditLogger,
     private val dateProvider: DateProvider,
 ) {
+
+    fun setInitialDataUseTerms(
+        authenticatedUser: AuthenticatedUser,
+        uploadId: String,
+        expectedCount: Int,
+        newDataUseTerms: DataUseTerms,
+    ) {
+        dataUseTermsPreconditionValidator.checkThatRestrictedUntilDateValid(newDataUseTerms)
+        val restrictedUntil = (newDataUseTerms as? DataUseTerms.Restricted)?.restrictedUntil
+
+        val insertedCount = DataUseTermsTable.insert(
+            MetadataUploadAuxTable
+                .select(
+                    MetadataUploadAuxTable.accessionColumn,
+                    dateTimeParam(dateProvider.getCurrentDateTime()),
+                    stringParam(newDataUseTerms.type.toString()),
+                    QueryParameter(restrictedUntil, DataUseTermsTable.restrictedUntilColumn.columnType),
+                    stringParam(authenticatedUser.username),
+                )
+                .where { MetadataUploadAuxTable.uploadIdColumn eq uploadId },
+            columns = listOf(
+                DataUseTermsTable.accessionColumn,
+                DataUseTermsTable.changeDateColumn,
+                DataUseTermsTable.dataUseTermsTypeColumn,
+                DataUseTermsTable.restrictedUntilColumn,
+                DataUseTermsTable.userNameColumn,
+            ),
+        ) ?: 0
+
+        if (insertedCount != expectedCount) {
+            throw IllegalStateException(
+                "Expected to set initial data use terms for $expectedCount accessions in upload $uploadId, " +
+                    "but inserted $insertedCount.",
+            )
+        }
+
+        auditLogger.log(
+            username = authenticatedUser.username,
+            description = "Set data use terms to $newDataUseTerms for $insertedCount accessions in upload $uploadId",
+        )
+    }
 
     fun setNewDataUseTerms(
         authenticatedUser: AuthenticatedUser,

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
@@ -25,6 +25,7 @@ import org.loculus.backend.model.SubmissionId
 import org.loculus.backend.model.SubmissionParams
 import org.loculus.backend.service.GenerateAccessionFromNumberService
 import org.loculus.backend.service.datauseterms.DataUseTermsDatabaseService
+import org.loculus.backend.service.groupmanagement.GroupManagementPreconditionValidator
 import org.loculus.backend.service.submission.MetadataUploadAuxTable.accessionColumn
 import org.loculus.backend.service.submission.MetadataUploadAuxTable.fastaIdsColumn
 import org.loculus.backend.service.submission.MetadataUploadAuxTable.filesColumn
@@ -61,6 +62,7 @@ class UploadDatabaseService(
     private val compressor: CompressionService,
     private val accessionPreconditionValidator: AccessionPreconditionValidator,
     private val dataUseTermsDatabaseService: DataUseTermsDatabaseService,
+    private val groupManagementPreconditionValidator: GroupManagementPreconditionValidator,
     private val generateAccessionFromNumberService: GenerateAccessionFromNumberService,
     private val auditLogger: AuditLogger,
 ) {
@@ -258,11 +260,18 @@ class UploadDatabaseService(
 
         if (submissionParams is SubmissionParams.OriginalSubmissionParams) {
             log.debug { "Setting data use terms for submission $uploadId to ${submissionParams.dataUseTerms}" }
-            val accessions = insertionResult.map { it.accession }
-            dataUseTermsDatabaseService.setNewDataUseTerms(
+            // setNewDataUseTerms authorized the groups of the affected entries in chunks, which
+            // the set based insert cannot do. rows of an original upload all carry the submitted
+            // group, so the group is authorized once for the whole upload instead.
+            groupManagementPreconditionValidator.validateUserIsAllowedToModifyGroup(
+                submissionParams.groupId,
                 submissionParams.authenticatedUser,
-                accessions,
-                submissionParams.dataUseTerms,
+            )
+            dataUseTermsDatabaseService.setInitialDataUseTerms(
+                authenticatedUser = submissionParams.authenticatedUser,
+                uploadId = uploadId,
+                expectedCount = insertionResult.size,
+                newDataUseTerms = submissionParams.dataUseTerms,
             )
         }
 

--- a/backend/src/test/kotlin/org/loculus/backend/service/submission/UploadDatabaseServiceTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/submission/UploadDatabaseServiceTest.kt
@@ -1,0 +1,184 @@
+package org.loculus.backend.service.submission
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.datetime.LocalDate
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.select
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.loculus.backend.api.DataUseTerms
+import org.loculus.backend.api.DataUseTermsType
+import org.loculus.backend.api.Organism
+import org.loculus.backend.auth.AuthenticatedUser
+import org.loculus.backend.controller.DEFAULT_GROUP
+import org.loculus.backend.controller.DEFAULT_ORGANISM
+import org.loculus.backend.controller.EndpointTest
+import org.loculus.backend.controller.dateMonthsFromNow
+import org.loculus.backend.model.SubmissionParams
+import org.loculus.backend.service.datauseterms.DATA_USE_TERMS_TABLE_NAME
+import org.loculus.backend.service.datauseterms.DataUseTermsDatabaseService
+import org.loculus.backend.service.datauseterms.DataUseTermsTable
+import org.loculus.backend.service.groupmanagement.GroupManagementDatabaseService
+import org.loculus.backend.utils.DateProvider
+import org.loculus.backend.utils.MetadataEntry
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.mock.web.MockMultipartFile
+
+@EndpointTest
+class UploadDatabaseServiceTest(
+    @Autowired private val uploadDatabaseService: UploadDatabaseService,
+    @Autowired private val dataUseTermsDatabaseService: DataUseTermsDatabaseService,
+    @Autowired private val groupManagementDatabaseService: GroupManagementDatabaseService,
+    @Autowired private val dateProvider: DateProvider,
+) {
+    @Test
+    fun `WHEN mapping an original upload THEN inserts its initial data use terms in one set`() {
+        val authenticatedUser = testUser()
+        val groupId = groupManagementDatabaseService.createNewGroup(DEFAULT_GROUP, authenticatedUser).groupId
+        val targetUploadId = "target-terms-upload"
+        val otherUploadId = "other-terms-upload"
+        val restrictedUntil = dateMonthsFromNow(6)
+
+        insertMetadata(targetUploadId, listOf("target-1", "target-2"), authenticatedUser, groupId)
+        insertMetadata(otherUploadId, listOf("other-1"), authenticatedUser, groupId)
+        uploadDatabaseService.generateNewAccessionsForOriginalUpload(targetUploadId)
+        uploadDatabaseService.generateNewAccessionsForOriginalUpload(otherUploadId)
+
+        val mappings = uploadDatabaseService.mapAndCopy(
+            targetUploadId,
+            originalSubmissionParams(authenticatedUser, groupId, DataUseTerms.Restricted(restrictedUntil)),
+        )
+
+        val rows = getDataUseTermsRows()
+        assertEquals(mappings.size, rows.size)
+        assertEquals(mappings.map { it.accession }.toSet(), rows.map { it.accession }.toSet())
+        assertTrue(rows.all { it.type == DataUseTermsType.RESTRICTED.toString() })
+        assertTrue(rows.all { it.restrictedUntil == restrictedUntil })
+        assertTrue(rows.all { it.username == TEST_USERNAME })
+        assertEquals(1, rows.map { it.changeDate }.toSet().size)
+
+        val trackerRows = getDataUseTermsTrackerRows()
+        assertEquals(1, trackerRows.size)
+        assertEquals(DEFAULT_ORGANISM, trackerRows.single().organism)
+        assertNull(trackerRows.single().pipelineVersion)
+    }
+
+    @Test
+    fun `WHEN initial data use terms count does not match THEN rolls back terms and tracker`() {
+        val authenticatedUser = testUser()
+        val groupId = groupManagementDatabaseService.createNewGroup(DEFAULT_GROUP, authenticatedUser).groupId
+        val uploadId = "mismatched-terms-upload"
+
+        insertMetadata(uploadId, listOf("target-1", "target-2"), authenticatedUser, groupId)
+        uploadDatabaseService.generateNewAccessionsForOriginalUpload(uploadId)
+        uploadDatabaseService.mapAndCopy(uploadId, revisionSubmissionParams(authenticatedUser))
+
+        val exception = assertThrows<IllegalStateException> {
+            dataUseTermsDatabaseService.setInitialDataUseTerms(
+                authenticatedUser = authenticatedUser,
+                uploadId = uploadId,
+                expectedCount = 3,
+                newDataUseTerms = DataUseTerms.Open,
+            )
+        }
+
+        assertTrue(exception.message!!.contains("but inserted 2"))
+        assertTrue(getDataUseTermsRows().isEmpty())
+        assertTrue(getDataUseTermsTrackerRows().isEmpty())
+    }
+
+    private fun insertMetadata(
+        uploadId: String,
+        submissionIds: List<String>,
+        authenticatedUser: AuthenticatedUser,
+        groupId: Int = 1,
+    ) {
+        uploadDatabaseService.batchInsertMetadataInAuxTable(
+            uploadId = uploadId,
+            authenticatedUser = authenticatedUser,
+            groupId = groupId,
+            submittedOrganism = Organism(DEFAULT_ORGANISM),
+            uploadedMetadataBatch = submissionIds.map {
+                MetadataEntry(it, mapOf("field" to "value"))
+            },
+            uploadedAt = dateProvider.getCurrentDateTime(),
+        )
+    }
+
+    private fun getDataUseTermsRows(): List<DataUseTermsRow> = transaction {
+        DataUseTermsTable.selectAll().map {
+            DataUseTermsRow(
+                accession = it[DataUseTermsTable.accessionColumn],
+                changeDate = it[DataUseTermsTable.changeDateColumn].toString(),
+                type = it[DataUseTermsTable.dataUseTermsTypeColumn],
+                restrictedUntil = it[DataUseTermsTable.restrictedUntilColumn],
+                username = it[DataUseTermsTable.userNameColumn],
+            )
+        }
+    }
+
+    private fun getDataUseTermsTrackerRows(): List<TrackerRow> = transaction {
+        UpdateTrackerTable
+            .selectAll()
+            .where { UpdateTrackerTable.tableNameColumn eq DATA_USE_TERMS_TABLE_NAME }
+            .map {
+                TrackerRow(
+                    organism = it[UpdateTrackerTable.organismColumn],
+                    pipelineVersion = it[UpdateTrackerTable.pipelineVersionColumn],
+                )
+            }
+    }
+
+    private fun testUser(): AuthenticatedUser = mockk<AuthenticatedUser>().also {
+        every { it.username } returns TEST_USERNAME
+        every { it.isSuperUser } returns false
+    }
+
+    private fun originalSubmissionParams(
+        authenticatedUser: AuthenticatedUser,
+        groupId: Int,
+        dataUseTerms: DataUseTerms,
+    ) = SubmissionParams.OriginalSubmissionParams(
+        organism = Organism(DEFAULT_ORGANISM),
+        authenticatedUser = authenticatedUser,
+        metadataFile = emptyMetadataFile(),
+        sequenceFile = null,
+        groupId = groupId,
+        dataUseTerms = dataUseTerms,
+    )
+
+    private fun revisionSubmissionParams(authenticatedUser: AuthenticatedUser) =
+        SubmissionParams.RevisionSubmissionParams(
+            organism = Organism(DEFAULT_ORGANISM),
+            authenticatedUser = authenticatedUser,
+            metadataFile = emptyMetadataFile(),
+            sequenceFile = null,
+        )
+
+    private fun emptyMetadataFile() = MockMultipartFile(
+        "metadataFile",
+        "metadata.tsv",
+        "text/tab-separated-values",
+        byteArrayOf(),
+    )
+
+    private data class DataUseTermsRow(
+        val accession: String,
+        val changeDate: String,
+        val type: String,
+        val restrictedUntil: LocalDate?,
+        val username: String,
+    )
+
+    private data class TrackerRow(val organism: String?, val pipelineVersion: Long?)
+
+    private companion object {
+        const val TEST_USERNAME = "initial-terms-test-user"
+    }
+}


### PR DESCRIPTION
### what

setting the initial data use terms for an upload was one insert per accession, so a
500k submission ran 500,000 single row inserts. the upload is one request served by
one backend thread, so database time there is close to wall time.

the rows are now inserted with one `INSERT ... SELECT` straight from
`metadata_upload_aux_table`, which is where the accessions already are. exposed
reports how many rows the statement wrote, so the count is checked against the
number of mapped rows and a mismatch aborts the transaction.

### numbers

two 500k runs in the same configuration, 32 preprocessing replicas and 4 nextclade
jobs:

| | before | after |
|---|---:|---:|
| inserting the terms | 500,000 statements, 1,927,529 ms | 1 statement, 3,011 ms |
| upload stage | 2352 s | 350 s |

both are single runs, and the measured code issued the same statement through a raw
prepared statement rather than through exposed, so read these as evidence for the
set based approach rather than for this exact commit.

### notes

`setNewDataUseTerms` authorized the groups of the affected entries in chunks, which
the set based insert cannot do. rows of an original upload all carry the submitted
group, so the group is authorized once for the whole upload instead.

the audit entry now records the upload id and the row count instead of every
accession, and the aux rows are deleted afterwards, so the accessions are no longer
recoverable from the audit log alone. that is a deliberate trade, happy to change it
if you would rather keep the list.

this pr was rebased. it used to sit on the branch of #7074, which was closed in
favour of #7096, so it now holds only the data use terms change against main. the
benchmark result files that were in it are gone, and the raw prepared statement was
replaced by exposed's own insert from select.

### PR Checklist
- [x] All necessary documentation has been adapted.
  - no user facing or api change
- [x] The implemented feature is covered by appropriate, automated tests.
  - `UploadDatabaseServiceTest`, one test for the happy path and one for the count mismatch rollback
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
  - the two benchmark runs above, plus the backend suite locally
