### PR TITLE
feat(backend): scope the `extract-unprocessed-data` etag by organism

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -232,7 +232,7 @@ open class SubmissionController(
                 HttpStatus.NOT_MODIFIED,
                 requestStartNanos,
             )
-            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build()
+            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).eTag(lastDatabaseWriteETag).build()
         }
 
         val headers = HttpHeaders()
@@ -366,7 +366,7 @@ open class SubmissionController(
                 HttpStatus.NOT_MODIFIED,
                 requestStartNanos,
             )
-            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build()
+            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).eTag(lastDatabaseWriteETag).build()
         }
 
         val headers = HttpHeaders()

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -224,7 +224,7 @@ open class SubmissionController(
             )
         }
 
-        val lastDatabaseWriteETag = releasedDataModel.getLastDatabaseWriteETag(organism=organism)
+        val lastDatabaseWriteETag = releasedDataModel.getLastDatabaseWriteETag(organism = organism)
         if (ifNoneMatch == lastDatabaseWriteETag) {
             submissionMetrics.recordPollingRequest(
                 EXTRACT_UNPROCESSED_DATA_ENDPOINT,

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -224,7 +224,7 @@ open class SubmissionController(
             )
         }
 
-        val lastDatabaseWriteETag = releasedDataModel.getLastDatabaseWriteETag()
+        val lastDatabaseWriteETag = releasedDataModel.getLastDatabaseWriteETag(organism=organism)
         if (ifNoneMatch == lastDatabaseWriteETag) {
             submissionMetrics.recordPollingRequest(
                 EXTRACT_UNPROCESSED_DATA_ENDPOINT,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ExtractUnprocessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ExtractUnprocessedDataEndpointTest.kt
@@ -14,6 +14,7 @@ import org.hamcrest.Matchers.hasEntry
 import org.hamcrest.Matchers.hasProperty
 import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.matchesRegex
+import org.hamcrest.Matchers.not
 import org.hamcrest.Matchers.notNullValue
 import org.junit.jupiter.api.Test
 import org.loculus.backend.api.FileIdAndNameAndReadUrl
@@ -113,7 +114,40 @@ class ExtractUnprocessedDataEndpointTest(
         )
 
         responseNoNewData.andExpect(status().isNotModified)
-            .andExpect(header().doesNotExist(ETAG))
+            .andExpect(header().string(ETAG, secondEtag!!))
+    }
+
+    @Test
+    fun `GIVEN preprocessed data submitted for one organism THEN the etag for another organism is unaffected`() {
+        val defaultOrganismEntries = convenienceClient.prepareDefaultSequenceEntriesToInProcessing(
+            organism = DEFAULT_ORGANISM,
+        )
+        convenienceClient.prepareDefaultSequenceEntriesToInProcessing(organism = OTHER_ORGANISM)
+
+        val otherOrganismEtagBefore = client.extractUnprocessedData(0, organism = OTHER_ORGANISM)
+            .andReturn().response.getHeader(ETAG)
+
+        // Submitting processed data for DEFAULT_ORGANISM only must not change OTHER_ORGANISM's etag.
+        convenienceClient.submitProcessedData(
+            defaultOrganismEntries.map { PreparedProcessedData.withErrors(accession = it.accession) },
+            organism = DEFAULT_ORGANISM,
+        )
+
+        val otherOrganismEtagAfter = client.extractUnprocessedData(0, organism = OTHER_ORGANISM)
+            .andReturn().response.getHeader(ETAG)
+        assertThat(otherOrganismEtagAfter, `is`(otherOrganismEtagBefore))
+
+        client.extractUnprocessedData(
+            DefaultFiles.NUMBER_OF_SEQUENCES,
+            organism = OTHER_ORGANISM,
+            ifNoneMatch = otherOrganismEtagBefore,
+        ).andExpect(status().isNotModified)
+            .andExpect(header().string(ETAG, otherOrganismEtagBefore!!))
+
+        // Meanwhile DEFAULT_ORGANISM's etag did change, since it received the preprocessed data write.
+        val defaultOrganismEtagAfter = client.extractUnprocessedData(0, organism = DEFAULT_ORGANISM)
+            .andReturn().response.getHeader(ETAG)
+        assertThat(defaultOrganismEtagAfter, `is`(not(otherOrganismEtagBefore)))
     }
 
     @Test

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ExtractUnprocessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ExtractUnprocessedDataEndpointTest.kt
@@ -137,13 +137,6 @@ class ExtractUnprocessedDataEndpointTest(
             .andReturn().response.getHeader(ETAG)
         assertThat(otherOrganismEtagAfter, `is`(otherOrganismEtagBefore))
 
-        client.extractUnprocessedData(
-            DefaultFiles.NUMBER_OF_SEQUENCES,
-            organism = OTHER_ORGANISM,
-            ifNoneMatch = otherOrganismEtagBefore,
-        ).andExpect(status().isNotModified)
-            .andExpect(header().string(ETAG, otherOrganismEtagBefore!!))
-
         // Meanwhile DEFAULT_ORGANISM's etag did change, since it received the preprocessed data write.
         val defaultOrganismEtagAfter = client.extractUnprocessedData(0, organism = DEFAULT_ORGANISM)
             .andReturn().response.getHeader(ETAG)

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
@@ -213,7 +213,7 @@ class GetReleasedDataEndpointTest(
             ifNoneMatch = initialEtag,
         )
         responseNoNewData.andExpect(status().isNotModified)
-            .andExpect(header().doesNotExist(ETAG))
+            .andExpect(header().string(ETAG, initialEtag!!))
 
         prepareRevokedAndRevocationAndRevisedVersions()
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
@@ -223,7 +223,7 @@ class GetReleasedDataEndpointTest(
 
         responseAfterMoreDataAdded.andExpect(status().isOk)
             .andExpect(header().string(ETAG, notNullValue()))
-            .andExpect(header().string(ETAG, greaterThan(initialEtag!!)))
+            .andExpect(header().string(ETAG, greaterThan(initialEtag)))
 
         val responseBodyMoreData = responseAfterMoreDataAdded
             .expectNdjsonAndGetContent<ReleasedData>()


### PR DESCRIPTION
resolves #

The `extract-unprocessed-data` endpoint is always called on an organism-level and this should be reflected in the etag. 

Additionally, when adding tests I noticed we do return the etag if the response is 304. I asked claude and this is apparently against convention, see https://datatracker.ietf.org/doc/html/rfc7232 (we worked around this by reusing the etag we used in the call):
```
    The server generating a 304 response MUST generate any of the
   following header fields that would have been sent in a 200 (OK)
   response to the same request: Cache-Control, Content-Location, Date,
   ETag, Expires, and Vary.
```

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable