### PR TITLE
Revert "fix(backend): Add current date to etag that's used in get-released-data"

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -335,7 +335,7 @@ open class SubmissionController(
             ),
             Header(
                 name = "eTag",
-                description = "Last database write Etag, combined with the current date",
+                description = "Last database write Etag",
                 schema = Schema(type = "integer"),
             ),
         ],
@@ -343,8 +343,8 @@ open class SubmissionController(
     @ApiResponse(
         responseCode = "304",
         description =
-        "No database changes since last request, and the date has not changed " +
-            "(Etag in HttpHeaders.IF_NONE_MATCH matches lastDatabaseWriteETagWithDate)",
+        "No database changes since last request " +
+            "(Etag in HttpHeaders.IF_NONE_MATCH matches lastDatabaseWriteETag)",
     )
     @GetMapping("/get-released-data", produces = [MediaType.APPLICATION_NDJSON_VALUE])
     fun getReleasedData(
@@ -355,11 +355,11 @@ open class SubmissionController(
         ) @RequestHeader(value = HttpHeaders.IF_NONE_MATCH, required = false) ifNoneMatch: String?,
     ): ResponseEntity<StreamingResponseBody> {
         val requestStartNanos = System.nanoTime()
-        val lastDatabaseWriteETagWithDate = releasedDataModel.getLastDatabaseWriteETagWithDate(
+        val lastDatabaseWriteETag = releasedDataModel.getLastDatabaseWriteETag(
             tableNames = RELEASED_DATA_RELATED_TABLES,
             organism = organism,
         )
-        if (ifNoneMatch == lastDatabaseWriteETagWithDate) {
+        if (ifNoneMatch == lastDatabaseWriteETag) {
             submissionMetrics.recordPollingRequest(
                 GET_RELEASED_DATA_ENDPOINT,
                 organism.name,
@@ -370,7 +370,7 @@ open class SubmissionController(
         }
 
         val headers = HttpHeaders()
-        headers.eTag = lastDatabaseWriteETagWithDate
+        headers.eTag = lastDatabaseWriteETag
         headers.contentType = MediaType.APPLICATION_NDJSON
         compression?.let { headers.add(HttpHeaders.CONTENT_ENCODING, it.compressionName) }
 

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -95,17 +95,18 @@ open class ReleasedDataModel(
     }
 
     /**
-     * Returns the timestamp of the last relevant database write, for use in ETags, taken from the
-     * most recent `last_time_updated` in the update tracker.
+     * Returns the ETag for the last relevant database write, as the most recent
+     * `last_time_updated` in the update tracker.
      *
-     * When [organism] is given, the lookup is scoped to the rows that affect that organism's
-     * released data at its current pipeline version:
+     * When [organism] and/or [pipelineVersion] are given, the lookup is scoped to
+     * the rows that affect that organism's released data at that pipeline version:
      * table-wide writes (tagged with NULL organism / pipeline_version) are always
      * included, plus the organism- and pipeline-specific preprocessed-data rows.
      * This means preprocessing of one organism (or of a not-yet-current pipeline
      * version) no longer invalidates the ETag of other organisms.
      */
-    private fun getLastDatabaseWrite(tableNames: List<String>? = null, organism: Organism? = null): String {
+    @Transactional(readOnly = true)
+    open fun getLastDatabaseWriteETag(tableNames: List<String>? = null, organism: Organism? = null): String {
         val pipelineVersion = organism?.let {
             submissionDatabaseService.getCurrentProcessingPipelineVersion(it)
         }
@@ -128,23 +129,8 @@ open class ReleasedDataModel(
             // Replace not strictly necessary but does no harm and a) shows UTC, b) simplifies silo import script logic
             ?.replace(" ", "Z")
             ?: ""
-        return lastUpdateTime
+        return "\"$lastUpdateTime\"" // ETag must be enclosed in double quotes
     }
-
-    /** ETag for the last relevant database write. */
-    @Transactional(readOnly = true)
-    open fun getLastDatabaseWriteETag(tableNames: List<String>? = null, organism: Organism? = null): String =
-        "\"${getLastDatabaseWrite(tableNames, organism)}\"" // ETag must be enclosed in double quotes
-
-    /**
-     * Same as [getLastDatabaseWriteETag], but also includes the current date.
-     * Useful because RESTRICTED entries can lapse to OPEN with no database write, so an ETag based on write
-     * timestamps alone would keep serving 304s past the `restrictedUntil` date.
-     */
-    @Transactional(readOnly = true)
-    open fun getLastDatabaseWriteETagWithDate(tableNames: List<String>? = null, organism: Organism? = null): String =
-        // ETag must be enclosed in double quotes
-        "\"${getLastDatabaseWrite(tableNames, organism)}|${dateProvider.getCurrentDate()}\""
 
     private fun conditionalMetadata(condition: Boolean, values: () -> MetadataMap): MetadataMap =
         if (condition) values() else emptyMap()

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
@@ -652,7 +652,7 @@ class GetReleasedDataEndpointWithDataUseTermsUrlTest(
     }
 
     @Test
-    fun `GIVEN sequence entry with expired restricted data use terms THEN returns open terms and new etag`() {
+    fun `GIVEN sequence entry with expired restricted data use terms THEN returns open data use terms`() {
         every { dateProvider.getCurrentInstant() } answers { callOriginal() }
 
         val threeMonthsFromNow = dateMonthsFromNow(3)
@@ -664,21 +664,11 @@ class GetReleasedDataEndpointWithDataUseTermsUrlTest(
 
         assertAccessionVersionIsRestrictedUntil(accessionVersion, threeMonthsFromNow)
 
-        val etagWhileRestricted = submissionControllerClient.getReleasedData()
-            .andReturn().response.getHeader(ETAG)
-        submissionControllerClient.getReleasedData(ifNoneMatch = etagWhileRestricted)
-            .andExpect(status().isNotModified)
-
         val threeMonthsAndADayFromNow = LocalDateTime(
             date = dateMonthsFromNow(3).plus(1, DateTimeUnit.DAY),
             time = LocalTime.fromSecondOfDay(0),
         ).toInstant(DateProvider.timeZone)
         every { dateProvider.getCurrentInstant() } answers { threeMonthsAndADayFromNow }
-
-        // The restriction lapsing is not a database write, so the etag has to change on the date alone.
-        submissionControllerClient.getReleasedData(ifNoneMatch = etagWhileRestricted)
-            .andExpect(status().isOk)
-            .andExpect(header().string(ETAG, greaterThan(etagWhileRestricted)))
 
         assertAccessionVersionIsOpen(accessionVersion)
     }


### PR DESCRIPTION
Reverts loculus-project/loculus#7015

🚀 Preview: Add `preview` label to enable