### PR TITLE
fix(backend): Reapply date-based etag for get-released-data, with test compile fix

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -335,7 +335,7 @@ open class SubmissionController(
             ),
             Header(
                 name = "eTag",
-                description = "Last database write Etag",
+                description = "Last database write Etag, combined with the current date",
                 schema = Schema(type = "integer"),
             ),
         ],
@@ -343,8 +343,8 @@ open class SubmissionController(
     @ApiResponse(
         responseCode = "304",
         description =
-        "No database changes since last request " +
-            "(Etag in HttpHeaders.IF_NONE_MATCH matches lastDatabaseWriteETag)",
+        "No database changes since last request, and the date has not changed " +
+            "(Etag in HttpHeaders.IF_NONE_MATCH matches lastDatabaseWriteETagWithDate)",
     )
     @GetMapping("/get-released-data", produces = [MediaType.APPLICATION_NDJSON_VALUE])
     fun getReleasedData(
@@ -355,11 +355,11 @@ open class SubmissionController(
         ) @RequestHeader(value = HttpHeaders.IF_NONE_MATCH, required = false) ifNoneMatch: String?,
     ): ResponseEntity<StreamingResponseBody> {
         val requestStartNanos = System.nanoTime()
-        val lastDatabaseWriteETag = releasedDataModel.getLastDatabaseWriteETag(
+        val lastDatabaseWriteETagWithDate = releasedDataModel.getLastDatabaseWriteETagWithDate(
             tableNames = RELEASED_DATA_RELATED_TABLES,
             organism = organism,
         )
-        if (ifNoneMatch == lastDatabaseWriteETag) {
+        if (ifNoneMatch == lastDatabaseWriteETagWithDate) {
             submissionMetrics.recordPollingRequest(
                 GET_RELEASED_DATA_ENDPOINT,
                 organism.name,
@@ -370,7 +370,7 @@ open class SubmissionController(
         }
 
         val headers = HttpHeaders()
-        headers.eTag = lastDatabaseWriteETag
+        headers.eTag = lastDatabaseWriteETagWithDate
         headers.contentType = MediaType.APPLICATION_NDJSON
         compression?.let { headers.add(HttpHeaders.CONTENT_ENCODING, it.compressionName) }
 

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -336,7 +336,7 @@ open class SubmissionController(
             Header(
                 name = "eTag",
                 description = "Last database write Etag, combined with the current date",
-                schema = Schema(type = "integer"),
+                schema = Schema(type = "string"),
             ),
         ],
     )

--- a/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/ReleasedDataModel.kt
@@ -95,18 +95,17 @@ open class ReleasedDataModel(
     }
 
     /**
-     * Returns the ETag for the last relevant database write, as the most recent
-     * `last_time_updated` in the update tracker.
+     * Returns the timestamp of the last relevant database write, for use in ETags, taken from the
+     * most recent `last_time_updated` in the update tracker.
      *
-     * When [organism] and/or [pipelineVersion] are given, the lookup is scoped to
-     * the rows that affect that organism's released data at that pipeline version:
+     * When [organism] is given, the lookup is scoped to the rows that affect that organism's
+     * released data at its current pipeline version:
      * table-wide writes (tagged with NULL organism / pipeline_version) are always
      * included, plus the organism- and pipeline-specific preprocessed-data rows.
      * This means preprocessing of one organism (or of a not-yet-current pipeline
      * version) no longer invalidates the ETag of other organisms.
      */
-    @Transactional(readOnly = true)
-    open fun getLastDatabaseWriteETag(tableNames: List<String>? = null, organism: Organism? = null): String {
+    private fun getLastDatabaseWrite(tableNames: List<String>? = null, organism: Organism? = null): String {
         val pipelineVersion = organism?.let {
             submissionDatabaseService.getCurrentProcessingPipelineVersion(it)
         }
@@ -129,8 +128,23 @@ open class ReleasedDataModel(
             // Replace not strictly necessary but does no harm and a) shows UTC, b) simplifies silo import script logic
             ?.replace(" ", "Z")
             ?: ""
-        return "\"$lastUpdateTime\"" // ETag must be enclosed in double quotes
+        return lastUpdateTime
     }
+
+    /** ETag for the last relevant database write. */
+    @Transactional(readOnly = true)
+    open fun getLastDatabaseWriteETag(tableNames: List<String>? = null, organism: Organism? = null): String =
+        "\"${getLastDatabaseWrite(tableNames, organism)}\"" // ETag must be enclosed in double quotes
+
+    /**
+     * Same as [getLastDatabaseWriteETag], but also includes the current date.
+     * Useful because RESTRICTED entries can lapse to OPEN with no database write, so an ETag based on write
+     * timestamps alone would keep serving 304s past the `restrictedUntil` date.
+     */
+    @Transactional(readOnly = true)
+    open fun getLastDatabaseWriteETagWithDate(tableNames: List<String>? = null, organism: Organism? = null): String =
+        // ETag must be enclosed in double quotes
+        "\"${getLastDatabaseWrite(tableNames, organism)}|${dateProvider.getCurrentDate()}\""
 
     private fun conditionalMetadata(condition: Boolean, values: () -> MetadataMap): MetadataMap =
         if (condition) values() else emptyMap()

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
@@ -665,7 +665,7 @@ class GetReleasedDataEndpointWithDataUseTermsUrlTest(
         assertAccessionVersionIsRestrictedUntil(accessionVersion, threeMonthsFromNow)
 
         val etagWhileRestricted = submissionControllerClient.getReleasedData()
-            .andReturn().response.getHeader(ETAG)
+            .andReturn().response.getHeader(ETAG)!!
         submissionControllerClient.getReleasedData(ifNoneMatch = etagWhileRestricted)
             .andExpect(status().isNotModified)
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
@@ -652,7 +652,7 @@ class GetReleasedDataEndpointWithDataUseTermsUrlTest(
     }
 
     @Test
-    fun `GIVEN sequence entry with expired restricted data use terms THEN returns open data use terms`() {
+    fun `GIVEN sequence entry with expired restricted data use terms THEN returns open terms and new etag`() {
         every { dateProvider.getCurrentInstant() } answers { callOriginal() }
 
         val threeMonthsFromNow = dateMonthsFromNow(3)
@@ -664,11 +664,21 @@ class GetReleasedDataEndpointWithDataUseTermsUrlTest(
 
         assertAccessionVersionIsRestrictedUntil(accessionVersion, threeMonthsFromNow)
 
+        val etagWhileRestricted = submissionControllerClient.getReleasedData()
+            .andReturn().response.getHeader(ETAG)
+        submissionControllerClient.getReleasedData(ifNoneMatch = etagWhileRestricted)
+            .andExpect(status().isNotModified)
+
         val threeMonthsAndADayFromNow = LocalDateTime(
             date = dateMonthsFromNow(3).plus(1, DateTimeUnit.DAY),
             time = LocalTime.fromSecondOfDay(0),
         ).toInstant(DateProvider.timeZone)
         every { dateProvider.getCurrentInstant() } answers { threeMonthsAndADayFromNow }
+
+        // The restriction lapsing is not a database write, so the etag has to change on the date alone.
+        submissionControllerClient.getReleasedData(ifNoneMatch = etagWhileRestricted)
+            .andExpect(status().isOk)
+            .andExpect(header().string(ETAG, greaterThan(etagWhileRestricted)))
 
         assertAccessionVersionIsOpen(accessionVersion)
     }


### PR DESCRIPTION
Reapplies #7015 (reverted in #7086), original change by @maverbiest, plus one commit fixing what made main red.

#7015 didn't fail on its own merits: its `backend-tests` check last ran 2026-07-31 and never re-ran before merging. In between, #6974 upgraded spring-boot 3.5 → 4.1, i.e. Spring Framework 7, which annotates its API with JSpecify. `MockHttpServletResponse.getHeader()` therefore returns `String?` rather than the platform type `String!`, and Hamcrest's `greaterThan` needs a non-null `T` — so `compileTestKotlin` failed on the assertion the PR added. Verified against the jars: the 6.2.12 method carries no annotations, the 7.0.8 one carries `METHOD_RETURN org.jspecify.annotations.Nullable`.

Fix is `!!` on the header read. Locally: `compileTestKotlin` and `ktlintCheck` pass, and the full backend suite is green (74 classes, 567 tests, 0 failures) — including the reapplied `GIVEN sequence entry with expired restricted data use terms THEN returns open terms and new etag`.

Note #7013 is still closed: it was auto-closed by the #7015 merge and the revert didn't reopen it.

🚀 Preview: Add `preview` label to enable