### PR TITLE
test(integration): ignore stochastic 502 console errors

### DIFF
--- a/integration-tests/tests/fixtures/console-warnings.fixture.ts
+++ b/integration-tests/tests/fixtures/console-warnings.fixture.ts
@@ -12,6 +12,9 @@ export const test = base.extend({
                     'ERR_INCOMPLETE_CHUNKED_ENCODING',
                     "Response to preflight request doesn't pass access control check", // LAPIS sometimes hangs up preflight requests for unknown reasons
                     'has been externalized for browser compatibility.',
+                    // LAPIS/SILO briefly 502s (via traefik) when SILO picks up new data
+                    // https://github.com/GenSpectrum/LAPIS/issues/1699
+                    'Failed to load resource: the server responded with a status of 502 (Bad Gateway)',
                 ];
 
                 const isHarmless = harmlessMessages.some((harmless) =>


### PR DESCRIPTION
We sometimes get `502 (Bad Gateway)` — probably via traefik, potentially when SILO/LAPIS gets new data (see https://github.com/GenSpectrum/LAPIS/issues/1699). Any Playwright test that happens to load a page in that window fails the console-error check in `console-warnings.fixture.ts`, so this shows up as stochastic CI flakiness unrelated to the change under test.

This adds the 502 message to the existing `harmlessMessages` filter list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable