### PR TITLE
Revert "feat(backend): scope the `extract-unprocessed-data` etag by organism"

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -224,7 +224,7 @@ open class SubmissionController(
             )
         }
 
-        val lastDatabaseWriteETag = releasedDataModel.getLastDatabaseWriteETag(organism = organism)
+        val lastDatabaseWriteETag = releasedDataModel.getLastDatabaseWriteETag()
         if (ifNoneMatch == lastDatabaseWriteETag) {
             submissionMetrics.recordPollingRequest(
                 EXTRACT_UNPROCESSED_DATA_ENDPOINT,
@@ -232,7 +232,7 @@ open class SubmissionController(
                 HttpStatus.NOT_MODIFIED,
                 requestStartNanos,
             )
-            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).eTag(lastDatabaseWriteETag).build()
+            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build()
         }
 
         val headers = HttpHeaders()
@@ -366,7 +366,7 @@ open class SubmissionController(
                 HttpStatus.NOT_MODIFIED,
                 requestStartNanos,
             )
-            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).eTag(lastDatabaseWriteETag).build()
+            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build()
         }
 
         val headers = HttpHeaders()

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ExtractUnprocessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ExtractUnprocessedDataEndpointTest.kt
@@ -14,7 +14,6 @@ import org.hamcrest.Matchers.hasEntry
 import org.hamcrest.Matchers.hasProperty
 import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.matchesRegex
-import org.hamcrest.Matchers.not
 import org.hamcrest.Matchers.notNullValue
 import org.junit.jupiter.api.Test
 import org.loculus.backend.api.FileIdAndNameAndReadUrl
@@ -114,33 +113,7 @@ class ExtractUnprocessedDataEndpointTest(
         )
 
         responseNoNewData.andExpect(status().isNotModified)
-            .andExpect(header().string(ETAG, secondEtag!!))
-    }
-
-    @Test
-    fun `GIVEN preprocessed data submitted for one organism THEN the etag for another organism is unaffected`() {
-        val defaultOrganismEntries = convenienceClient.prepareDefaultSequenceEntriesToInProcessing(
-            organism = DEFAULT_ORGANISM,
-        )
-        convenienceClient.prepareDefaultSequenceEntriesToInProcessing(organism = OTHER_ORGANISM)
-
-        val otherOrganismEtagBefore = client.extractUnprocessedData(0, organism = OTHER_ORGANISM)
-            .andReturn().response.getHeader(ETAG)
-
-        // Submitting processed data for DEFAULT_ORGANISM only must not change OTHER_ORGANISM's etag.
-        convenienceClient.submitProcessedData(
-            defaultOrganismEntries.map { PreparedProcessedData.withErrors(accession = it.accession) },
-            organism = DEFAULT_ORGANISM,
-        )
-
-        val otherOrganismEtagAfter = client.extractUnprocessedData(0, organism = OTHER_ORGANISM)
-            .andReturn().response.getHeader(ETAG)
-        assertThat(otherOrganismEtagAfter, `is`(otherOrganismEtagBefore))
-
-        // Meanwhile DEFAULT_ORGANISM's etag did change, since it received the preprocessed data write.
-        val defaultOrganismEtagAfter = client.extractUnprocessedData(0, organism = DEFAULT_ORGANISM)
-            .andReturn().response.getHeader(ETAG)
-        assertThat(defaultOrganismEtagAfter, `is`(not(otherOrganismEtagBefore)))
+            .andExpect(header().doesNotExist(ETAG))
     }
 
     @Test

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
@@ -213,7 +213,7 @@ class GetReleasedDataEndpointTest(
             ifNoneMatch = initialEtag,
         )
         responseNoNewData.andExpect(status().isNotModified)
-            .andExpect(header().string(ETAG, initialEtag!!))
+            .andExpect(header().doesNotExist(ETAG))
 
         prepareRevokedAndRevocationAndRevisedVersions()
 
@@ -223,7 +223,7 @@ class GetReleasedDataEndpointTest(
 
         responseAfterMoreDataAdded.andExpect(status().isOk)
             .andExpect(header().string(ETAG, notNullValue()))
-            .andExpect(header().string(ETAG, greaterThan(initialEtag)))
+            .andExpect(header().string(ETAG, greaterThan(initialEtag!!)))
 
         val responseBodyMoreData = responseAfterMoreDataAdded
             .expectNdjsonAndGetContent<ReleasedData>()


### PR DESCRIPTION
Reverts loculus-project/loculus#7082 - merge conflict breaking CI

🚀 Preview: Add `preview` label to enable