### PR TITLE
fix(backend): repair main compile break from the scope-etag merge race

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -366,7 +366,7 @@ open class SubmissionController(
                 HttpStatus.NOT_MODIFIED,
                 requestStartNanos,
             )
-            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).eTag(lastDatabaseWriteETag).build()
+            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).eTag(lastDatabaseWriteETagWithDate).build()
         }
 
         val headers = HttpHeaders()


### PR DESCRIPTION
Alternative to #7093 (revert of #7082) — fixes the breakage instead of dropping the feature.

### What broke

#7082 added `.eTag(lastDatabaseWriteETag)` to the 304 path of `getReleasedData`, but #7087 had meanwhile renamed that local to `lastDatabaseWriteETagWithDate`. Both merged without a rebase, so main no longer compiles:

```
e: SubmissionController.kt:369:72 Unresolved reference 'lastDatabaseWriteETag'.
```

All five failing jobs on `main` at d8820008 (`backend-tests`, `backend-image`, `CodeQL Advanced`, `Integration tests`, `Update argocd_metadata`) trace back to this single compile error.

### Fix

One line — use the renamed local. That is also the value #7082's own test expects, since it is exactly the etag that matched `If-None-Match`:

```kotlin
.andExpect(header().string(ETAG, initialEtag!!))
```

### Verified locally

- `compileKotlin`, `compileTestKotlin`, `ktlintCheck` clean
- Full backend suite: 74 classes, 568 tests, 0 failures, 1 skipped

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable