### PR TITLE
chore(deployment): collect traefik logs in integration tests

### DIFF
--- a/.github/scripts/collect_kubernetes_logs.sh
+++ b/.github/scripts/collect_kubernetes_logs.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+mkdir -p kubernetes_logs
+
+# Traefik is in kube-system; --tail=-1 because a selector defaults to 10 lines
+kubectl logs -n kube-system -l app.kubernetes.io/name=traefik --tail=-1 \
+  > kubernetes_logs/traefik.txt 2>/dev/null || true
+
 pods=$(kubectl get pods -l app=loculus -o jsonpath='{.items[*].metadata.name}' || true)
 
 echo "Collecting logs from pods: $pods"

--- a/deploy.py
+++ b/deploy.py
@@ -173,6 +173,7 @@ def main():
 
 
 # Enable traefik access log and raise log level to DEBUG to get more insights into failures in CI
+# This resource is how k3s/k3d-bundled traefik is configured 
 TRAEFIK_LOGGING_CONFIG = """
 apiVersion: helm.cattle.io/v1
 kind: HelmChartConfig

--- a/deploy.py
+++ b/deploy.py
@@ -172,6 +172,26 @@ def main():
         )
 
 
+# Traefik proxies LAPIS and logs why it failed a request (e.g. a 502) at DEBUG only,
+# with its access log off, so by default CI artifacts hold no record of such failures.
+# Keys are for traefik chart 40.1.x as shipped by k3s; chart 41+ renamed them to
+# log/accessLog. Applies to the local k3d cluster only, never to server deployments.
+TRAEFIK_LOGGING_CONFIG = """
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: traefik
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    logs:
+      general:
+        level: DEBUG
+      access:
+        enabled: true
+"""
+
+
 def handle_cluster():
     if args.delete:
         print(f"Deleting cluster '{CLUSTER_NAME}'.")
@@ -194,6 +214,8 @@ def handle_cluster():
             command += f" --image {args.k3s_image}"
 
         run_command([command], shell=True)
+
+    run_command(["kubectl", "apply", "-f", "-"], input=TRAEFIK_LOGGING_CONFIG, text=True)
 
     install_secret_generator()
     while not is_traefik_running():

--- a/deploy.py
+++ b/deploy.py
@@ -172,7 +172,7 @@ def main():
         )
 
 
-# Enable access log and raise log level to DEBUG to get more insights into failures in CI
+# Enable traefik access log and raise log level to DEBUG to get more insights into failures in CI
 TRAEFIK_LOGGING_CONFIG = """
 apiVersion: helm.cattle.io/v1
 kind: HelmChartConfig

--- a/deploy.py
+++ b/deploy.py
@@ -172,10 +172,7 @@ def main():
         )
 
 
-# Traefik proxies LAPIS and logs why it failed a request (e.g. a 502) at DEBUG only,
-# with its access log off, so by default CI artifacts hold no record of such failures.
-# Keys are for traefik chart 40.1.x as shipped by k3s; chart 41+ renamed them to
-# log/accessLog. Applies to the local k3d cluster only, never to server deployments.
+# Enable access log and raise log level to DEBUG to get more insights into failures in CI
 TRAEFIK_LOGGING_CONFIG = """
 apiVersion: helm.cattle.io/v1
 kind: HelmChartConfig


### PR DESCRIPTION
Resolves #5478

## Problem

Integration tests occasionally fail on a console error that the CI artifacts contain no record of:

```
Error: Unexpected console error: Failed to load resource: the server responded with a status of 502 (Bad Gateway)
```

Two independent gaps cause this, and fixing either one alone still leaves an empty artifact:

1. **Traefik's log is never collected.** `collect_kubernetes_logs.sh` selects `-l app=loculus`, which
   never matches traefik in `kube-system`. Traefik proxies LAPIS in the k3d cluster
   (`-p 8080:80@loadbalancer`), so it is the only component that can produce a proxy-level 502 — and
   when it does, the request never reaches LAPIS, so no loculus pod logs anything at all.
2. **Even when collected, the log is silent at default settings.** Traefik logs the *reason* an
   upstream request failed at DEBUG level only, and ships with its access log disabled:

   ```go
   // pkg/proxy/httputil/proxy.go, traefik v3.7.8 (the version k3s ships)
   logger.Debug().Err(err).Msgf("%d %s", statusCode, statusText(statusCode))
   ```

## Change

- `.github/scripts/collect_kubernetes_logs.sh`: also collect the traefik log from `kube-system`.
  `--tail=-1` is required — with a label selector `kubectl logs` defaults to the last **10 lines**,
  which would produce a file that looks collected but is useless.
- `deploy.py`: apply a `HelmChartConfig` raising traefik's log level and enabling its access log,
  during cluster creation.

## Why this is in the cluster-setup step and not the chart

It was worth asking whether this belongs in the loculus chart behind a value. It does not, and not
just as a matter of taste:

- Traefik is **cluster-wide infrastructure** in `kube-system`, installed by k3s's helm-controller.
  The loculus chart is installed **once per namespace** — which is precisely why the middleware
  names it renders are already namespace-prefixed (`{{ $.Release.Namespace }}-cors-all-origins@...`).
- A `kube-system` object templated by the chart would be **owned by whichever release installed it
  first**. Every later release on a shared cluster would then fail to install with *"rendered
  manifests contain a resource that already exists ... owned by another release"*. A value gate
  defaulting to `false` would not remove that landmine, just hide it behind a flag.
- Turning it on for a server deployment would reconfigure logging for **every other namespace's**
  traffic on that cluster, which is not something an application release should do.

Keeping it in `deploy.py cluster` confines it to the local k3d cluster, where it is also useful for
local debugging. It is **inlined** rather than kept as a file under `kubernetes/` so its scope stays
obvious — a manifest sitting next to the chart reads as something the chart deploys.

## Why these values keys

k3s installs traefik from **chart 40.1.4** (`manifests/traefik.yaml`, traefik image 3.7.8), whose
keys are `logs.general.level` (default `INFO`) and `logs.access.enabled` (default `false`). This
flips exactly those two. Note for future readers: chart **41+** renamed them to `log:` / `accessLog:`,
so following today's upstream chart docs would silently have no effect here.

## What this buys us

On the next occurrence, the 502 appears as an access-log line naming the router, upstream address and
duration, plus a DEBUG line giving the cause. That cause is what distinguishes the hypotheses that
otherwise have to be separated by inference:

| Cause | Status | Log signature |
|---|---|---|
| Pooled upstream connection died | 502 | `connection reset by peer` / `EOF` / `broken pipe` |
| No healthy endpoints for the service | 503 | `no available server` |
| Upstream too slow | 504 | `context deadline exceeded` |

## Cost

Roughly 330 bytes per proxied request (measured: 4110 log lines for 2000 requests), so a few MB per
run, and highly compressible in the uploaded artifact.

## Testing

Verified: the inlined YAML parses and reaches `kubectl` correctly over stdin, `bash -n` and
`py_compile` pass, `./deploy.py --dry-run --verbose cluster` shows the apply in the right place, and
the two values keys were checked against chart 40.1.0's own `values.yaml` rather than assumed.

Not verified locally: that traefik actually restarts with DEBUG and the access log on, which needs a
running k3d cluster. The first CI run on this branch confirms it — if `kubernetes-logs-*/traefik.txt`
contains access-log lines, it works.

This is diagnostics only; no application behaviour and no test expectations change.

🚀 Preview: Add `preview` label to enable