### PR TITLE
chore(deployment): use opus tier alias for @claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,4 +46,6 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          # Tier alias: always resolves to the current Opus model
+          claude_args: |
+            --model opus


### PR DESCRIPTION
## Summary

`claude-code-review.yml` was switched to the `opus` tier alias in #7088, but `claude.yml` — the workflow that runs when someone `@claude`-mentions on an issue or PR — was left with no `model` setting at all. That means it runs on whatever `anthropics/claude-code-action@v1` defaults to, which is not guaranteed to be an Opus-tier model and can change under us without any signal in this repo.

This sets it explicitly, via the same mechanism and the same alias the review workflow now uses:

```yaml
claude_args: |
  --model opus
```

## Why the alias rather than a pinned ID

`--model opus` resolves to the current Opus model at run time (today, Opus 5). Pinning a dated ID like the old `claude-opus-4-5-20251101` would be reproducible, but it goes stale silently at every Opus release and needs a follow-up PR each time — which is exactly the drift #7088 cleaned up on the review workflow. The alias still guarantees the capability tier, which the unset default does not, so this is the setting that needs no maintenance while keeping `@claude` responses on Opus.

The replaced line was the commented-out `# claude_args: '--allowed-tools Bash(gh pr:*)'` example from the action's template. It was never active, and dropping it changes no tool permissions — this workflow intentionally leaves tools unrestricted, unlike the review workflow's explicit `--allowedTools` allowlist.

## Testing

- `yaml.safe_load` parses the file and `jobs.claude.steps[1].with.claude_args` reads back as `--model opus`.
- Behavioural verification needs a live run: `@claude` on any issue or PR after merge should execute on Opus. There's no way to exercise this from a branch, since the mention trigger uses the workflow definition on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable