### PR TITLE
fix(website): parse backend error responses so users see the real message

### DIFF
--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -15,6 +15,7 @@ import { getLatestAccessionVersionForRevision, type SequenceEntryHistory } from 
 import type { ClientConfig } from '../../types/runtimeConfig.ts';
 import { createAuthorizationHeader } from '../../utils/createAuthorizationHeader.ts';
 import { getAccessionVersionString, parseAccessionVersionFromString } from '../../utils/extractAccessionVersion.ts';
+import { stringifyMaybeAxiosError } from '../../utils/stringifyMaybeAxiosError.ts';
 import { displayConfirmationDialog } from '../ConfirmationDialog.tsx';
 import { SequenceEntryHistoryMenu } from '../SequenceDetailsPage/SequenceEntryHistoryMenu.tsx';
 import { ExtraFilesUpload } from '../Submission/DataUploadForm.tsx';
@@ -36,7 +37,11 @@ type EditPageProps = {
 const logger = getClientLogger('EditPage');
 
 /**
- * Extracts the detail field from a backend error response
+ * Extracts the detail field from a backend error response.
+ *
+ * The fallback must not be `JSON.stringify(error)`: AxiosError has a custom `toJSON()` that
+ * strips `response`, so stringifying it dumps the request config at the user instead of the
+ * backend's message (see issue #7103).
  */
 function getErrorDetail(error: unknown): string {
     if (
@@ -45,7 +50,7 @@ function getErrorDetail(error: unknown): string {
     ) {
         return error.response.data.detail;
     }
-    return JSON.stringify(error);
+    return stringifyMaybeAxiosError(error);
 }
 
 const InnerEditPage: FC<EditPageProps> = ({

--- a/website/src/services/backendApi.spec.ts
+++ b/website/src/services/backendApi.spec.ts
@@ -49,6 +49,26 @@ describe('problemDetail', () => {
 });
 
 describe('backendApi error declarations', () => {
+    // zodios matches an error response against the endpoint's declared `errors` by status code.
+    // An endpoint with no `status: 'default'` entry silently fails to match anything it did not
+    // enumerate, so `isErrorFromAlias` returns false and the caller loses the backend's message —
+    // regardless of the schema. `submitReviewedSequence` declared 401 only and hit exactly that.
+    test('every endpoint declares a catch-all error response', () => {
+        // Deliberately typed loosely: zodios' types claim `alias` and `errors` are always present,
+        // but this test exists to catch an endpoint added without them.
+        const endpoints = backendApi as readonly {
+            alias?: string;
+            path: string;
+            errors?: readonly { status: number | 'default' }[];
+        }[];
+
+        const missing = endpoints
+            .filter((endpoint) => !(endpoint.errors ?? []).some((error) => error.status === 'default'))
+            .map((endpoint) => endpoint.alias ?? endpoint.path);
+
+        expect(missing).toEqual([]);
+    });
+
     test('recognises a backend error from revise', () => {
         expect(isErrorFromAlias(backendApi, 'revise', axiosErrorForUrl('/west-nile/revise'))).toBe(true);
     });

--- a/website/src/services/backendApi.spec.ts
+++ b/website/src/services/backendApi.spec.ts
@@ -1,0 +1,51 @@
+import { isErrorFromAlias } from '@zodios/core';
+import { AxiosError, AxiosHeaders } from 'axios';
+import { describe, expect, test } from 'vitest';
+
+import { backendApi } from './backendApi.ts';
+import { problemDetail } from '../types/backend.ts';
+
+/**
+ * The exact shape the backend serialises for an error, as observed live against
+ * backend-main.loculus.org. Spring's Jackson mixin omits `type` (it never leaves its
+ * `about:blank` default) — see ExceptionHandler.responseEntity in the backend.
+ *
+ * Regression test for #7103: the website used to require `type`, so no backend error ever
+ * validated and users were shown a raw AxiosError dump instead of the message.
+ */
+const backendErrorBody = {
+    title: 'Unprocessable Entity',
+    status: 422,
+    detail: 'Accession version LOC_001DSEM.1 is not in state APPROVED_FOR_RELEASE',
+    instance: '/west-nile/revise',
+};
+
+const axiosErrorForUrl = (url: string, status = 422) => {
+    const config = { url, method: 'post', headers: new AxiosHeaders() };
+    return new AxiosError(`Request failed with status code ${status}`, 'ERR_BAD_REQUEST', config, {}, {
+        data: backendErrorBody,
+        status,
+        statusText: '',
+        headers: {},
+        config,
+    } as never);
+};
+
+describe('problemDetail', () => {
+    test('parses a backend error response that omits type', () => {
+        const result = problemDetail.safeParse(backendErrorBody);
+        expect(result.success).toBe(true);
+    });
+});
+
+describe('backendApi error declarations', () => {
+    test('recognises a backend error from revise', () => {
+        expect(isErrorFromAlias(backendApi, 'revise', axiosErrorForUrl('/west-nile/revise'))).toBe(true);
+    });
+
+    test('recognises a backend error from submitReviewedSequence', () => {
+        expect(
+            isErrorFromAlias(backendApi, 'submitReviewedSequence', axiosErrorForUrl('/west-nile/submit-edited-data')),
+        ).toBe(true);
+    });
+});

--- a/website/src/services/backendApi.spec.ts
+++ b/website/src/services/backendApi.spec.ts
@@ -8,7 +8,8 @@ import { problemDetail } from '../types/backend.ts';
 /**
  * The exact shape the backend serialises for an error, as observed live against
  * backend-main.loculus.org. Spring's Jackson mixin omits `type` (it never leaves its
- * `about:blank` default) — see ExceptionHandler.responseEntity in the backend.
+ * `about:blank` default) — see ExceptionHandler.responseEntity in the backend. RFC 9457
+ * section 3.1.1 makes that omission correct: an absent `type` means `about:blank`.
  *
  * Regression test for #7103: the website used to require `type`, so no backend error ever
  * validated and users were shown a raw AxiosError dump instead of the message.
@@ -32,9 +33,18 @@ const axiosErrorForUrl = (url: string, status = 422) => {
 };
 
 describe('problemDetail', () => {
-    test('parses a backend error response that omits type', () => {
+    test('parses a backend error response that omits type, defaulting it per RFC 9457', () => {
         const result = problemDetail.safeParse(backendErrorBody);
+
         expect(result.success).toBe(true);
+        expect(result.data?.type).toBe('about:blank');
+        expect(result.data?.detail).toBe(backendErrorBody.detail);
+    });
+
+    test('keeps an explicit type', () => {
+        const result = problemDetail.safeParse({ ...backendErrorBody, type: 'https://example.org/errors/foo' });
+
+        expect(result.data?.type).toBe('https://example.org/errors/foo');
     });
 });
 

--- a/website/src/services/backendApi.ts
+++ b/website/src/services/backendApi.ts
@@ -75,7 +75,7 @@ const getDataToEditEndpoint = makeEndpoint({
     alias: 'getDataToEdit',
     parameters: [authorizationHeader],
     response: sequenceEntryToEdit,
-    errors: [notAuthorizedError],
+    errors: [{ status: 'default', schema: problemDetail }, notAuthorizedError],
 });
 
 const revokeSequencesEndpoint = makeEndpoint({
@@ -148,7 +148,7 @@ const getSequencesEndpoint = makeEndpoint({
         },
     ],
     response: getSequencesResponse,
-    errors: [notAuthorizedError, { status: 404, schema: problemDetail }],
+    errors: [{ status: 'default', schema: problemDetail }, notAuthorizedError, { status: 404, schema: problemDetail }],
 });
 
 const approveProcessedDataEndpoint = makeEndpoint({
@@ -201,7 +201,7 @@ const extractUnprocessedDataEndpoint = makeEndpoint({
         },
     ],
     response: z.union([z.string(), unprocessedData]),
-    errors: [notAuthorizedError],
+    errors: [{ status: 'default', schema: problemDetail }, notAuthorizedError],
 });
 
 const submitProcessedDataEndpoint = makeEndpoint({

--- a/website/src/services/backendApi.ts
+++ b/website/src/services/backendApi.ts
@@ -107,7 +107,12 @@ const submitReviewedSequenceEndpoint = makeEndpoint({
         },
     ],
     response: z.never(),
-    errors: [notAuthorizedError],
+    errors: [
+        { status: 'default', schema: problemDetail },
+        { status: 400, schema: problemDetail },
+        { status: 422, schema: problemDetail },
+        notAuthorizedError,
+    ],
 });
 
 const getSequencesEndpoint = makeEndpoint({

--- a/website/src/types/backend.ts
+++ b/website/src/types/backend.ts
@@ -279,11 +279,12 @@ export const submitFiles = uploadFiles.merge(
     }),
 );
 
-// Mirrors Spring's ProblemDetail as the backend actually serializes it: Jackson omits
-// `type` (it stays at the default `about:blank`) and omits `instance` when it is not set,
-// so both must be optional or every backend error fails to parse.
+// Mirrors RFC 9457 (Problem Details for HTTP APIs), which the backend follows: every member
+// is optional, and an absent `type` "is assumed to be `about:blank`" (RFC 9457 section 3.1.1).
+// Spring omits `type` for exactly that reason, and omits `instance` when it is not set, so
+// requiring either of them makes every backend error fail to parse.
 export const problemDetail = z.object({
-    type: z.string().optional(),
+    type: z.string().default('about:blank'),
     title: z.string(),
     status: z.number(),
     detail: z.string(),

--- a/website/src/types/backend.ts
+++ b/website/src/types/backend.ts
@@ -279,8 +279,11 @@ export const submitFiles = uploadFiles.merge(
     }),
 );
 
+// Mirrors Spring's ProblemDetail as the backend actually serializes it: Jackson omits
+// `type` (it stays at the default `about:blank`) and omits `instance` when it is not set,
+// so both must be optional or every backend error fails to parse.
 export const problemDetail = z.object({
-    type: z.string(),
+    type: z.string().optional(),
     title: z.string(),
     status: z.number(),
     detail: z.string(),


### PR DESCRIPTION
Fixes #7103.

This PR fixes bugs that limited the helpfulness/precision of error messages.

### Examples

Before:
<img width="1279" height="191" alt="Google Chrome 2026-08-19 18 41 07" src="https://github.com/user-attachments/assets/72261d22-8139-4348-a90e-dcda468294e2" />

After:
<img width="1335" height="176" alt="Google Chrome 2026-08-19 18 41 14" src="https://github.com/user-attachments/assets/27716ef9-5aa2-4089-a7c5-dcca7e4c13a8" />

---

Before:
<img width="521" height="244" alt="Google Chrome 2026-08-19 18 46 38" src="https://github.com/user-attachments/assets/5bde2d29-8beb-42f2-9afb-ad1b22fcbd28" />

After:
<img width="327" height="127" alt="Google Chrome 2026-08-19 18 45 41" src="https://github.com/user-attachments/assets/7972eaa1-3386-48ba-ba9b-ff3d4007fa29" />

---

Before:
<img width="566" height="206" alt="Google Chrome 2026-08-19 18 49 02" src="https://github.com/user-attachments/assets/3de56fc0-7dec-4811-9228-0cb3391de36a" />

After:
<img width="527" height="214" alt="Google Chrome 2026-08-19 18 48 21" src="https://github.com/user-attachments/assets/a6877c70-997e-4ba3-8118-d4579b7facd5" />

---

## Root cause

Not what the earlier analysis on the issue concluded. The backend does **not** serialise `"instance": null` — it omits **`type`**.

Probed live against `backend-main.loculus.org`:

```
GET /nonexistent-organism/get-released-data
{"title":"Bad Request","status":400,"detail":"…","instance":"/nonexistent-organism/get-released-data"}

GET /get-seqset?seqSetId=doesnotexist&version=1
{"title":"Not Found","status":404,"detail":"…","instance":"/get-seqset"}
```

`instance` is present as a non-null string, so it can't be the field that fails validation. `type` is absent: `ProblemDetail.forStatus()` leaves it at its `about:blank` default and Spring's `ProblemDetailJacksonMixin` is `@JsonInclude(NON_EMPTY)`, so Jackson drops it. Both probes go through the same private `responseEntity()` helper in `ExceptionHandler.kt` that `handleUnprocessableEntityException` uses, so the 422 in the issue has the same shape.

The website's `problemDetail` schema declared `type: z.string()` (required). Running `safeParse` on the observed body names the failing field exactly:

```
[{"code":"invalid_type","expected":"string","received":"undefined","path":["type"],"message":"Required"}]
```

`isErrorFromAlias` only returns true when a declared error schema `safeParse`s the response body, so it returned `false` for every backend error. `EditPage.getErrorDetail` then fell back to `JSON.stringify(error)` — and because `AxiosError` has a custom `toJSON()` that strips `response`, that dumps the request config at the user instead of the backend's message. That's the screenshot in the issue.

## Second, independent bug (and an audit of the whole class)

`submitReviewedSequenceEndpoint` declared `errors: [notAuthorizedError]` — 401 only. zodios matches errors by status (or a `status: 'default'` entry), so `isErrorFromAlias(backendApi, 'submitReviewedSequence', …)` could never match a 400/422 regardless of the schema. Fixing only the schema would have left the "Submit edits" path in `EditPage` broken.

I then audited every endpoint in every zodios API definition the website has, by synthesising a problem-detail error at statuses 400/403/404/409/422/500 and checking whether `isErrorFromPath` matches it. Three more `backendApi` endpoints had the same gap:

| Endpoint | Declared | Unmatched before |
| --- | --- | --- |
| `getDataToEdit` | 401 | 400, 403, 404, 409, 422, 500 |
| `getSequences` | 401, 404 | 400, 403, 409, 422, 500 |
| `extractUnprocessedData` | 401 | 400, 403, 404, 409, 422, 500 |

`getSequences` is the live one — `useSubmissionOperations.ts:130` calls `isErrorFromAlias` on it. All three now declare `status: 'default'`, and a test asserts the invariant across every `backendApi` endpoint so it can't recur (verified: it fails listing all three before the fix).

`groupManagementApi`, `seqSetCitationApi` and `lapisApi` have the same gap on ~30 endpoints, but **none of them is ever passed to `isErrorFrom*`** (checked — only `backendApi` is; they go through `ZodiosWrapperClient`, which parses `response.data` directly). Those gaps are latent, not live, so I've left them alone rather than churn 30 declarations for no behaviour change.

## Changes

- `website/src/types/backend.ts` — `type: z.string().default('about:blank')`. RFC 9457 §3.1.1: *"When this member is not present, its value is assumed to be `about:blank`."* So the backend is compliant here and the website was not — a zod default states the spec's semantics rather than merely tolerating the omission, and keeps `ProblemDetail.type` a required `string` for consumers.
- `website/src/services/backendApi.ts` — declare `default`/400/422 problem-detail errors on `submitReviewedSequence`, and a `default` on `getDataToEdit`, `getSequences` and `extractUnprocessedData`.
- `website/src/components/Edit/EditPage.tsx` — fall back to `stringifyMaybeAxiosError` (used consistently elsewhere in the codebase) instead of `JSON.stringify(error)`.
- `website/src/services/backendApi.spec.ts` — regression test built from the literal live-observed body.

## Blast radius

`type` being required broke strict problem-detail parsing well beyond `EditPage`: `DataUploadForm.tsx:483`, `useSubmissionOperations.ts:116/123/130`, `backendClient.ts:195`, and `zodiosWrapperClient.ts:74` for its backend-facing subclasses (`GroupManagementClient` and `SeqSetCitationClient` both pass `(axiosError) => axiosError.data` with no normalisation, and that site uses `.parse`, so it throws and degrades to "Unknown error from backend"). The `/get-seqset` 404 probed above is literally a `SeqSetCitationClient` endpoint. Making `type` optional repairs all of them.

`serviceHooks.ts:72` and the LAPIS subclass of `ZodiosWrapperClient` were **not** affected: LAPIS does send `type` (`{"error":{"type":"about:blank","title":"Bad Request","status":400,…}}`, probed live against `lapis-main.loculus.org`). This is a backend-only bug.

Related but **not** claimed fixed: #6976. `zodiosWrapperClient.createProblemDetail`'s fallback sets `title: error.message`, while the now-working path sets `title: "Unprocessable Entity"` — so this change may be what *surfaces* #6976 rather than what fixes it. Worth a look separately.

## Why not require `type` from the backend instead?

RFC 9457 makes every member optional, and `type` specifically defaults to `about:blank` when absent — which is exactly why Spring omits it (it never leaves that default). The spec's general posture is that consumers degrade around missing members: §3.1 says a member whose value type doesn't match "MUST be ignored — i.e., processing will continue as if the member had not been present." Rejecting a whole problem document over one absent optional member is the opposite of that.

Note `type` is *not* the media type. That's the `Content-Type: application/problem+json` header, which the backend already sends correctly on every error.

Strictly, `title`/`status`/`detail` are optional per the RFC too. I deliberately kept them required: the UI needs `detail`, and a body without one is better off failing validation and hitting the (now readable) fallback than rendering an empty toast.

## Verification

- The new assertions **fail on `main` and pass with this change** (checked by stashing the source fixes).
- `npm run check-types` — 0 errors (370 files).
- `npm run test` — 714 passed.
- eslint + prettier clean.

Not manually exercised in a running website; the regression test drives the exact code path with the literal live response body.

## Latent issues found, left out of scope

- `isErrorFromAlias` matches `endpoint.path` against `config.url` with an anchored regex, so it returns `false` for any absolute `config.url`. Not in play here (the issue's dump has a relative URL), but a real second failure mode.
- `stringifyMaybeAxiosError` returns `data.detail` unchecked; a non-ProblemDetail object body yields the literal string `"undefined"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable