### PR TITLE
fix(website): stop rendering "undefined" when a problem detail has no `detail`

### DIFF
--- a/website/src/utils/stringifyMaybeAxiosError.spec.ts
+++ b/website/src/utils/stringifyMaybeAxiosError.spec.ts
@@ -1,0 +1,72 @@
+import { AxiosError, AxiosHeaders, type AxiosResponse } from 'axios';
+import { describe, expect, test } from 'vitest';
+
+import { stringifyMaybeAxiosError } from './stringifyMaybeAxiosError.ts';
+
+const axiosErrorWithResponseData = (data: unknown, status = 500): AxiosError => {
+    const config = { headers: new AxiosHeaders() };
+    const response = {
+        data,
+        status,
+        statusText: '',
+        headers: new AxiosHeaders(),
+        config,
+    } as AxiosResponse;
+    return new AxiosError(
+        `Request failed with status code ${status}`,
+        AxiosError.ERR_BAD_RESPONSE,
+        config,
+        {},
+        response,
+    );
+};
+
+describe('stringifyMaybeAxiosError', () => {
+    test('returns the detail of a complete problem detail', () => {
+        const error = axiosErrorWithResponseData({
+            type: 'about:blank',
+            title: 'Unprocessable Entity',
+            status: 422,
+            detail: "Invalid accession version format 'LOC_SS_1'",
+            instance: '/west-nile/get-data-to-edit/LOC_SS_1/1',
+        });
+
+        expect(stringifyMaybeAxiosError(error)).toBe("Invalid accession version format 'LOC_SS_1'");
+    });
+
+    test('falls back to title and status when the problem detail has no detail member', () => {
+        // Observed live: the backend omits `detail` when the underlying exception message is null.
+        const error = axiosErrorWithResponseData({
+            title: 'Internal Server Error',
+            status: 500,
+            instance: '/west-nile/get-data-to-edit/LOC_0001TLY/1',
+        });
+
+        const result = stringifyMaybeAxiosError(error);
+
+        expect(result).not.toContain('undefined');
+        expect(result).toBe('Internal Server Error (status 500)');
+    });
+
+    test('falls back to the error message when the response body carries nothing useful', () => {
+        const error = axiosErrorWithResponseData({});
+
+        const result = stringifyMaybeAxiosError(error);
+
+        expect(result).not.toContain('undefined');
+        expect(result).toBe('Request failed with status code 500');
+    });
+
+    test('reports when no response was received', () => {
+        const error = new AxiosError('Network Error', AxiosError.ERR_NETWORK, undefined, {});
+
+        expect(stringifyMaybeAxiosError(error)).toBe('Network Error; no response received');
+    });
+
+    test('returns the message of a plain error without surrounding quotes', () => {
+        const result = stringifyMaybeAxiosError(new Error('something went wrong'));
+
+        expect(result).toBe('something went wrong');
+        expect(result).not.toContain('"');
+    });
+});

--- a/website/src/utils/stringifyMaybeAxiosError.spec.ts
+++ b/website/src/utils/stringifyMaybeAxiosError.spec.ts
@@ -63,6 +63,11 @@ describe('stringifyMaybeAxiosError', () => {
         expect(stringifyMaybeAxiosError(error)).toBe('Network Error; no response received');
     });
 
+    test('never renders "undefined" when the thrown value is not an error at all', () => {
+        expect(stringifyMaybeAxiosError(undefined)).toBe('An unknown error occurred');
+        expect(stringifyMaybeAxiosError(null)).toBe('An unknown error occurred');
+    });
+
     test('returns the message of a plain error without surrounding quotes', () => {
         const result = stringifyMaybeAxiosError(new Error('something went wrong'));
 

--- a/website/src/utils/stringifyMaybeAxiosError.ts
+++ b/website/src/utils/stringifyMaybeAxiosError.ts
@@ -7,7 +7,7 @@ export const stringifyMaybeAxiosError = (error: unknown): string => {
         return `${error.message}; no response received`;
     }
 
-    const data = (error as AxiosError).response?.data;
+    const data = (error as AxiosError | undefined)?.response?.data;
     if (typeof data === 'object' && data !== null) {
         // The backend omits members of the problem detail whose value is null,
         // so `detail` (and even `title`) may be absent.
@@ -21,5 +21,11 @@ export const stringifyMaybeAxiosError = (error: unknown): string => {
     }
 
     const message = (error as Error | undefined)?.message;
-    return typeof message === 'string' && message !== '' ? message : String(error);
+    if (typeof message === 'string' && message !== '') {
+        return message;
+    }
+    if (typeof error === 'string' && error !== '') {
+        return error;
+    }
+    return 'An unknown error occurred';
 };

--- a/website/src/utils/stringifyMaybeAxiosError.ts
+++ b/website/src/utils/stringifyMaybeAxiosError.ts
@@ -9,8 +9,17 @@ export const stringifyMaybeAxiosError = (error: unknown): string => {
 
     const data = (error as AxiosError).response?.data;
     if (typeof data === 'object' && data !== null) {
-        return (data as ProblemDetail).detail;
+        // The backend omits members of the problem detail whose value is null,
+        // so `detail` (and even `title`) may be absent.
+        const { detail, title, status } = data as Partial<ProblemDetail>;
+        if (typeof detail === 'string' && detail !== '') {
+            return detail;
+        }
+        if (typeof title === 'string' && title !== '') {
+            return typeof status === 'number' ? `${title} (status ${status})` : title;
+        }
     }
 
-    return JSON.stringify((error as Error).message);
+    const message = (error as Error | undefined)?.message;
+    return typeof message === 'string' && message !== '' ? message : String(error);
 };


### PR DESCRIPTION
## The defect

`website/src/utils/stringifyMaybeAxiosError.ts` read `.detail` off the response body without checking it exists:

```ts
const data = (error as AxiosError).response?.data;
if (typeof data === 'object' && data !== null) {
    return (data as ProblemDetail).detail;   // can be undefined
}
```

The signature promises `string`, but when the backend sends a problem detail with no `detail` member the helper returns `undefined`. Callers interpolate the result into user-facing text, so the user literally sees the word "undefined".

The backend omits `detail` whenever the underlying exception message is null: Spring's `ProblemDetailJacksonMixin` is `@JsonInclude(NON_EMPTY)`, so null members are dropped from the JSON entirely.

## Live evidence (not theoretical)

Observed against a real deployment, on a sequence in `RECEIVED` state:

```
GET /west-nile/get-data-to-edit/<accession>/1
→ HTTP 500  {"title":"Internal Server Error","status":500,"instance":"/west-nile/get-data-to-edit/..."}
```

No `detail` key at all. The helper is used by `DataUploadForm.tsx`, `useGroupOperations.ts`, `useSubmissionOperations.ts`, `RevokeButton.tsx`, `EditDataUseTermsToasts.ts` and `AutoCompleteOptions.ts`, so any of those call sites can render "undefined".

Separately, the final fallback was `JSON.stringify((error as Error).message)`, which wraps a plain string in quotes — a non-Axios error rendered as `"something went wrong"` with visible quote characters.

## The fix

A fallback ladder that returns something useful in every branch: `detail` (when it is a non-empty string) → `title` plus the HTTP status → the error's own `message` → the thrown value if it is itself a non-empty string → a generic `'An unknown error occurred'`. The existing `error.response === undefined && error.request !== undefined` branch, which returns `"<message>; no response received"`, is untouched.

No new `JSON.stringify` is introduced anywhere.

A second commit closes a neighbouring hole found while testing: `stringifyMaybeAxiosError(undefined)` threw a `TypeError` while reading `.response` (reachable from a promise rejected with no value), and the terminal fallback would otherwise have rendered the literal string `"undefined"` — the very thing this PR removes. The response is now read optionally and non-error throwables get the generic message.

## Tests

New `website/src/utils/stringifyMaybeAxiosError.spec.ts` covering a full problem detail, a problem detail missing `detail` (the bug — asserts the output contains no "undefined"), an object body with nothing useful in it, a network error with no response, a plain non-Axios `Error`, and `undefined`/`null` throwables.

### Red without the source fix

With the spec in place and the source change stashed (`git stash push -- src/utils/stringifyMaybeAxiosError.ts`), 3 of 5 tests fail:

```
 ❯ src/utils/stringifyMaybeAxiosError.spec.ts (5 tests | 3 failed)
   × falls back to title and status when the problem detail has no detail member
   × falls back to the error message when the response body carries nothing useful
   × returns the message of a plain error without surrounding quotes

AssertionError: the given combination of arguments (undefined and string) is invalid
for this assertion. You can use an array, a map, an object, a set, a string, or a
weakset instead of a string
 ❯ src/utils/stringifyMaybeAxiosError.spec.ts:47:28
     47|         expect(result).not.toContain('undefined');

AssertionError: expected '"something went wrong"' to be 'something went wrong'
Expected: "something went wrong"
Received: ""something went wrong""
```

The first failure is the bug itself: the helper returned `undefined`, so `toContain` could not even run against it.

## Checks

`npm run check-types` (0 errors), `npx eslint`, `npx prettier --check`, and the full `npm run test` suite (69 files, 748 tests, all passing). The green full suite is the primary evidence that no existing expectation depended on the old output; consistent with that, every spec that constructs a problem detail (`backendClient.spec.ts`, `getTableData.spec.ts`, `SubmissionForm.spec.tsx`) supplies a `detail`, so behaviour there is unchanged.

The Playwright suite under `integration-tests/` was not run locally (it needs a deployment). It contains no assertion on these error strings, so no impact is expected, but CI is the authority there.

## Out of scope

- `problemDetail` in `website/src/types/backend.ts` is deliberately untouched (being changed by #7104); the helper reads the body as a `Partial<ProblemDetail>` locally instead.
- A string (e.g. HTML) `response.data` body still falls through to `error.message` rather than being rendered, which is the existing and better behaviour.

Related to #5449 ("Make errors more user friendly by replacing JSON.stringify") — this addresses one instance of that class of defect, not the whole issue.

🚀 Preview: Add `preview` label to enable
