### PR TITLE
fix(website): report unreadable metadata files instead of hanging on "still being processed"

### DIFF
--- a/website/src/components/Submission/FormOrUploadWrapper.spec.tsx
+++ b/website/src/components/Submission/FormOrUploadWrapper.spec.tsx
@@ -1,10 +1,12 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { Result } from 'neverthrow';
 import { useState } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 
 import { FormOrUploadWrapper, type FileFactory, type InputError, type SequenceData } from './FormOrUploadWrapper';
 import { SUBMISSION_ID_INPUT_FIELD } from '../../settings';
+import type { SubmissionFileMapping } from './FileUpload/fileMapping';
 import type { InputField } from '../../types/config';
 import { Button } from '../common/Button';
 
@@ -206,6 +208,43 @@ describe('FormOrUploadWrapper', () => {
             expect(tsvRows.length).toBe(2);
             expect(tsvRows[0]).toBe('id\tcollectionCountry');
             expect(tsvRows[1]).toBe('foo\t"Foo\tBar"');
+        });
+    });
+
+    describe('Bulk upload', () => {
+        test('reports an error when the metadata file cannot be read', async () => {
+            const setSubmissionFileMapping = vi.fn();
+            const onError = vi.fn();
+
+            render(
+                <FormOrUploadWrapper
+                    inputMode='bulk'
+                    action='submit'
+                    organism='foo'
+                    setFileFactory={vi.fn()}
+                    metadataTemplateFields={DUMMY_METADATA_TEMPLATE_FIELDS}
+                    submissionDataTypes={{
+                        consensusSequences: false,
+                        maxSequencesPerEntry: 1,
+                        files: { enabled: true, categories: [{ name: 'rawReads' }] },
+                    }}
+                    setSubmissionFileMapping={setSubmissionFileMapping}
+                    onError={onError}
+                />,
+            );
+
+            // Not a valid gzip stream - decompression throws when the file is read.
+            const corruptGzip = new File([new Uint8Array([1, 2, 3, 4, 5])], 'metadata.tsv.gz');
+            await userEvent.upload(screen.getByTestId('metadata_file'), corruptGzip);
+
+            await waitFor(() => expect(onError).toHaveBeenCalled());
+            expect(onError.mock.calls.at(-1)![0]).toContain('Failed to read metadata file metadata.tsv.gz');
+
+            // The mapping must not stay `undefined`, otherwise submitting only ever reports
+            // 'Cannot submit: metadata file is still being processed.'
+            const lastMapping = setSubmissionFileMapping.mock.calls.at(-1)![0] as Result<SubmissionFileMapping, Error>;
+            expect(lastMapping).toBeDefined();
+            expect(lastMapping.isErr()).toBe(true);
         });
     });
 });

--- a/website/src/components/Submission/FormOrUploadWrapper.tsx
+++ b/website/src/components/Submission/FormOrUploadWrapper.tsx
@@ -1,4 +1,4 @@
-import type { Result } from 'neverthrow';
+import { err, type Result } from 'neverthrow';
 import { useEffect, useState, type Dispatch, type FC, type SetStateAction } from 'react';
 
 import type { UploadAction } from './DataUploadForm';
@@ -87,18 +87,30 @@ export const FormOrUploadWrapper: FC<FormOrUploadWrapperProps> = ({
                 setSubmissionFileMapping(undefined);
                 return;
             }
-            const text = columnMapping
-                ? await (await columnMapping.applyTo(metadataFile)).text()
-                : await metadataFile.text();
+            try {
+                const text = columnMapping
+                    ? await (await columnMapping.applyTo(metadataFile)).text()
+                    : await metadataFile.text();
 
-            if (state.cancelled) return;
+                if (state.cancelled) return;
 
-            const submissionFileMapping = parseSubmissionFileMapping(
-                text,
-                submissionDataTypes.files?.categories?.map((category) => category.name) ?? [],
-            );
-            setSubmissionFileMapping(submissionFileMapping);
-            if (submissionFileMapping.isErr()) onError(submissionFileMapping.error.message);
+                const submissionFileMapping = parseSubmissionFileMapping(
+                    text,
+                    submissionDataTypes.files?.categories?.map((category) => category.name) ?? [],
+                );
+                setSubmissionFileMapping(submissionFileMapping);
+                if (submissionFileMapping.isErr()) onError(submissionFileMapping.error.message);
+            } catch (error) {
+                // Reading the file can throw, e.g. when a compressed metadata file is corrupt and
+                // cannot be decompressed. Surface this instead of leaving the mapping undefined
+                // forever, which would only show 'metadata file is still being processed' on submit.
+                if (state.cancelled) return;
+                const message = `Failed to read metadata file ${metadataFile.handle().name}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`;
+                setSubmissionFileMapping(err(new Error(message)));
+                onError(message);
+            }
         })();
         return () => {
             state.cancelled = true;


### PR DESCRIPTION
Fixes #7105

## Root cause

Uploading a corrupt `metadata.tsv.gz` in bulk mode never reported that the file was broken; submitting only ever said `Cannot submit: metadata file is still being processed.`

The mechanism:

1. `FileUpload/fileProcessing.ts` — for a `.gz` metadata file, `CompressedFile.text()` calls `fflate.decompressSync(...)`, which **throws** (`Error: unexpected EOF`) on corrupt data.
2. `FormOrUploadWrapper.tsx` — the `useEffect` that derives the submission file mapping ran an async IIFE containing `await metadataFile.text()` with **no try/catch**. The throw became an unhandled promise rejection, so `setSubmissionFileMapping(...)` was never called and the state stayed `undefined`.
3. `DataUploadForm.tsx` — in bulk mode `submissionFileMapping === undefined` produces the misleading "still being processed" message, forever.

The request never reaches the backend, so this is unrelated to #7103 / #7104 (which change how backend errors are *displayed*).

Note the whole block is gated on `extraFilesEnabled`, so this only manifests for organisms with extra files enabled.

## Fix

Wrap the async body in `try/catch`. On failure set the state to an `Err` (matching the existing `Result<SubmissionFileMapping, Error>` type) with a message naming the file and the underlying cause, and call `onError(...)` so the user is told as soon as the file is selected. The `state.cancelled` guard is re-checked inside the `catch` (the throw happens after an `await`, so a superseded run can land there) — cancelled runs stay silent, as before.

The name comes from `metadataFile.handle().name` rather than `.inner().name`, because `ExcelFile.inner()` itself throws when uninitialised.

## Test

New regression test in `FormOrUploadWrapper.spec.tsx` renders the component in bulk mode with extra files enabled and uploads a genuinely corrupt `metadata.tsv.gz` (`new Uint8Array([1,2,3,4,5])`), exercising the real `CompressedFile.text()` → `fflate` path. It asserts both that `onError` fires and that the last `setSubmissionFileMapping` value is an `Err` rather than `undefined`.

**Verified red without the source fix.** With `FormOrUploadWrapper.tsx` stashed and only the spec applied:

```
 Test Files  1 failed (1)
      Tests  1 failed | 11 passed (12)
     Errors  1 error

 FAIL  src/components/Submission/FormOrUploadWrapper.spec.tsx > ... > reports an error when the metadata file cannot be read
    240|             await waitFor(() => expect(onError).toHaveBeenCalled());
       |                                                 ^

⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
Error: unexpected EOF
 ❯ Module.decompressSync node_modules/fflate/esm/index.mjs:1660:15
 ❯ decompress src/components/Submission/FileUpload/fileProcessing.ts:193:27
```

i.e. both halves of the mechanism are observable: the `waitFor` assertion times out because no error is reported, and the throw shows up as an unhandled rejection.

## Checks

`npm run check-types` (0 errors), `npm run test` (68 files / 743 tests passed), eslint and prettier clean on the changed files.

## Out of scope / follow-ups

- `FileUpload/FileUploadComponent.tsx:69-70` has the same unguarded `await ...text()` shape, but it only runs on the `initialValue !== undefined` edit/revision path — a different trigger that needs its own test. Left for a follow-up rather than widening this diff.
- `FileUpload/ColumnMappingModal.tsx:167` already wraps its `text()` call in try/catch — checked, no change needed.
- `FileUpload/fileMapping.ts:476` (`applyFileMappings`) takes a raw `File` (never a compressed `ProcessedFile`) and its `Result` is checked by the caller — not the same class of bug.

🚀 Preview: Add `preview` label to enable