### PR TITLE
fix(backend): don't leak Postgres internals in duplicate submissionId error

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
@@ -360,9 +360,8 @@ class SubmitModel(
             }
         } catch (e: ExposedSQLException) {
             if (e.sqlState == UNIQUE_CONSTRAINT_VIOLATION_SQL_STATE) {
-                throw DuplicateKeyException(
-                    "Metadata file contains at least one duplicate submissionId: ${e.cause?.cause}",
-                )
+                log.warn(e) { "Duplicate submissionId in metadata file for uploadId $uploadId" }
+                throw DuplicateKeyException("Metadata file contains at least one duplicate submissionId")
             }
             throw e
         }
@@ -381,9 +380,8 @@ class SubmitModel(
                 )
             } catch (e: ExposedSQLException) {
                 if (e.sqlState == UNIQUE_CONSTRAINT_VIOLATION_SQL_STATE) {
-                    throw DuplicateKeyException(
-                        "Sequence file contains at least one duplicate submissionId: ${e.cause?.cause}",
-                    )
+                    log.warn(e) { "Duplicate submissionId in sequence file for uploadId $uploadId" }
+                    throw DuplicateKeyException("Sequence file contains at least one duplicate submissionId")
                 }
                 throw e
             }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
@@ -8,6 +8,7 @@ import kotlinx.datetime.toLocalDateTime
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.hasEntry
+import org.hamcrest.Matchers.not
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -210,6 +211,47 @@ class SubmitEndpointTest(
             .andExpect(expectedStatus)
             .andExpect(jsonPath("\$.title").value(expectedTitle))
             .andExpect(jsonPath("\$.detail", containsString(expectedMessage)))
+    }
+
+    @Test
+    fun `GIVEN duplicate submissionId in metadata THEN error detail contains no database internals`() {
+        submissionControllerClient.submit(
+            metadataFile = SubmitFiles.metadataFileWith(
+                content = """
+                    id	firstColumn
+                    sameHeader	someValue
+                    sameHeader	someValue2
+                """.trimIndent(),
+            ),
+            sequencesFile = DefaultFiles.sequencesFile,
+            groupId = groupId,
+        )
+            .andExpect(status().isUnprocessableEntity)
+            .andExpect(jsonPath("\$.detail").value("Metadata file contains at least one duplicate submissionId"))
+            .andExpect(jsonPath("\$.detail", not(containsString("PSQLException"))))
+            .andExpect(jsonPath("\$.detail", not(containsString("constraint"))))
+            .andExpect(jsonPath("\$.detail", not(containsString("metadata_upload_aux_table"))))
+    }
+
+    @Test
+    fun `GIVEN duplicate submissionId in sequences THEN error detail contains no database internals`() {
+        submissionControllerClient.submit(
+            metadataFile = DefaultFiles.metadataFile,
+            sequencesFile = SubmitFiles.sequenceFileWith(
+                content = """
+                    >sameHeader_main
+                    AC
+                    >sameHeader_main
+                    AC
+                """.trimIndent(),
+            ),
+            groupId = groupId,
+        )
+            .andExpect(status().isUnprocessableEntity)
+            .andExpect(jsonPath("\$.detail").value("Sequence file contains at least one duplicate submissionId"))
+            .andExpect(jsonPath("\$.detail", not(containsString("PSQLException"))))
+            .andExpect(jsonPath("\$.detail", not(containsString("constraint"))))
+            .andExpect(jsonPath("\$.detail", not(containsString("sequence_upload_aux_table"))))
     }
 
     @Test


### PR DESCRIPTION
Fixes #7106

## Problem

Submitting a metadata file (or FASTA) with a duplicate `submissionId` returned a 422 whose user-facing `detail` embedded the raw `ExposedSQLException` cause — Postgres error text, the internal aux table and constraint name, and the internal upload UUID:

```
Metadata file contains at least one duplicate submissionId: org.postgresql.util.PSQLException:
ERROR: duplicate key value violates unique constraint "metadata_upload_aux_table_pkey"
  Detail: Key (upload_id, submission_id)=(308f5438-…, SAMPLE_C) already exists.
```

## The two leak sites

Both in `backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt`, both interpolating `${e.cause?.cause}` into a `DuplicateKeyException` message inside a `catch (e: ExposedSQLException)` guarded on `UNIQUE_CONSTRAINT_VIOLATION_SQL_STATE`:

- `uploadMetadata` (~L363) — "Metadata file contains at least one duplicate submissionId", constraint `metadata_upload_aux_table_pkey`
- `uploadSequences` (~L384) — "Sequence file contains at least one duplicate submissionId", constraint `sequence_upload_aux_table_pkey` (fires on duplicate FASTA ids)

`ExceptionHandler.handleUnprocessableEntityException` only uses `e.message`, so these two interpolations were the sole source of the leak — no handler change needed.

## The fix

Drop the interpolation at both sites; log the exception server-side instead with `log.error(e) { "… for uploadId $uploadId" }` (exception passed as argument, so the stack trace is preserved for operators). The surviving user-facing message text is unchanged.

## Tests

Two new tests in `SubmitEndpointTest` assert the response `detail` is exactly the clean message and contains none of `PSQLException`, `constraint`, or the aux table name — one per leak site.

**Existing assertions checked, not edited.** `SubmitEndpointTest.kt:401`/`:418` and `ReviseEndpointTest.kt:606` all go through `jsonPath("$.detail", containsString(expectedMessage))` with prefix-only expected strings, so they pass unchanged. None asserted the raw Postgres text.

**Red-without-fix evidence.** With the new tests in place and the `SubmitModel.kt` change stashed (`git stash push -- <path>`), both fail:

```
SubmitEndpointTest > GIVEN duplicate submissionId in metadata THEN error detail contains no database internals() FAILED
  java.lang.AssertionError: JSON path "$.detail" expected:<Metadata file contains at least one duplicate submissionId>
  but was:<Metadata file contains at least one duplicate submissionId: org.postgresql.util.PSQLException: ERROR:
  duplicate key value violates unique constraint "metadata_upload_aux_table_pkey"
    Detail: Key (upload_id, submission_id)=(db754461-187c-48eb-b7e1-13eef88cc95e, sameHeader) already exists.>

SubmitEndpointTest > GIVEN duplicate submissionId in sequences THEN error detail contains no database internals() FAILED
  java.lang.AssertionError: JSON path "$.detail" expected:<Sequence file contains at least one duplicate submissionId>
  but was:<Sequence file contains at least one duplicate submissionId: org.postgresql.util.PSQLException: ERROR:
  duplicate key value violates unique constraint "sequence_upload_aux_table_pkey"
    Detail: Key (upload_id, fasta_id)=(9d6d1efb-2bf2-42b5-b80e-31043dc4ad75, sameHeader_main) already exists.>

39 tests completed, 2 failed
```

**What was run (locally, no Docker, `USE_NONDOCKER_INFRA=true`):**
- `./gradlew test --tests '*SubmitEndpointTest*' --tests '*ReviseEndpointTest*'` → 68 tests, 0 failures
- full `./gradlew test` → **583 tests, 74 classes, 0 failures** (~75s)
- `./gradlew ktlintCheck` → clean

## Deliberately out of scope

- **Naming the offending duplicate id in the message** would be a real UX win, but it cannot be done safely here: extracting it means parsing the Postgres error string, which is not a stable API. It requires application-level duplicate detection before insert (e.g. tracking seen ids per batch/upload) — worth a follow-up issue.
- **#6795** ("Null byte in submission id causes 504 at database insertion") is related — same aux table — but distinct: that is *missing validation* producing an unhandled failure, whereas this is a *handled* 422 whose message was assembled from the raw exception. Not fixed here.

🚀 Preview: Add `preview` label to enable