### PR TITLE
fix!(website): Restrict upload of xz compressed metadata TSVs in the website

### DIFF
--- a/docs/src/content/docs/for-users/submit-sequences.md
+++ b/docs/src/content/docs/for-users/submit-sequences.md
@@ -87,4 +87,4 @@ As with the website, data will now be processed, and you will have to approve yo
 
 ### Compressing files
 
-For both sequence and metadata files, compression is supported. The supported formats are: `zip`, `gz` (gzip), `zst` (ZStandard) and `xz` (LZMA). (Note that Excel file uploads with `xz` compression are currently not supported.)
+For both sequence and metadata files, compression is supported. The supported formats are: `zip`, `gz` (gzip) and `zst` (ZStandard). `xz` (LZMA) is additionally supported for sequence files. Metadata files with `xz` compression are currently not supported when submitting through the website.

--- a/docs/src/content/docs/for-users/submit-sequences.md
+++ b/docs/src/content/docs/for-users/submit-sequences.md
@@ -87,4 +87,4 @@ As with the website, data will now be processed, and you will have to approve yo
 
 ### Compressing files
 
-For both sequence and metadata files, compression is supported. The supported formats are: `zip`, `gz` (gzip) and `zst` (ZStandard). `xz` (LZMA) is additionally supported for sequence files. Metadata files with `xz` compression are currently not supported when submitting through the website.
+For both sequence and metadata files, compression is supported. The supported formats are: `zip`, `gz` (gzip) and `zst` (ZStandard). `xz` (LZMA) is additionally supported for sequence files. Metadata files with `xz` compression are not supported when submitting through the website, but can be submitted through the API.

--- a/website/src/components/Submission/FileUpload/fileProcessing.spec.ts
+++ b/website/src/components/Submission/FileUpload/fileProcessing.spec.ts
@@ -66,6 +66,14 @@ describe('fileProcessing', () => {
         10000,
     );
 
+    test('LZMA compressed TSV file cannot be processed', async () => {
+        const file = new File(['dummy'], 'testfile.tsv.xz');
+        const processingResult = await METADATA_FILE_KIND.processRawFile(file);
+
+        expect(processingResult.isErr()).toBeTruthy();
+        expect(processingResult._unsafeUnwrapErr().message).toContain('LZMA compression');
+    });
+
     test('LZMA compressed excel file cannot be processed', async () => {
         const file = await loadTestFile('testfile_different_formats.xlsx.xz');
         const processingResult = await METADATA_FILE_KIND.processRawFile(file);

--- a/website/src/components/Submission/FileUpload/fileProcessing.ts
+++ b/website/src/components/Submission/FileUpload/fileProcessing.ts
@@ -31,7 +31,17 @@ export const METADATA_FILE_KIND: FileKind<ProcessedFile> = {
         const dataExtension = isCompressed ? fileNameParts[fileNameParts.length - 2] : extension;
         const compressionExtension = isCompressed ? extension : null;
         if (dataExtension === 'tsv' && !isCompressed) return ok(new RawFile(file));
-        if (dataExtension === 'tsv' && isCompressed) return ok(new CompressedFile(file));
+        if (dataExtension === 'tsv' && isCompressed) {
+            if (compressionExtension === 'xz') {
+                return err(
+                    new Error(
+                        'LZMA compression (.xz files) is not supported with TSV files yet. ' +
+                            'Please use a different compression format for TSV files.',
+                    ),
+                );
+            }
+            return ok(new CompressedFile(file));
+        }
         if (dataExtension === 'xlsx' || dataExtension === 'xls') {
             if (isCompressed && compressionExtension === 'xz') {
                 return err(

--- a/website/src/components/Submission/FileUpload/fileProcessing.ts
+++ b/website/src/components/Submission/FileUpload/fileProcessing.ts
@@ -30,27 +30,22 @@ export const METADATA_FILE_KIND: FileKind<ProcessedFile> = {
         const isCompressed = COMPRESSION_EXTENSIONS.includes(extension);
         const dataExtension = isCompressed ? fileNameParts[fileNameParts.length - 2] : extension;
         const compressionExtension = isCompressed ? extension : null;
-        if (dataExtension === 'tsv' && !isCompressed) return ok(new RawFile(file));
-        if (dataExtension === 'tsv' && isCompressed) {
-            if (compressionExtension === 'xz') {
-                return err(
-                    new Error(
-                        'LZMA compression (.xz files) is not supported with TSV files yet. ' +
-                            'Please use a different compression format for TSV files.',
-                    ),
-                );
-            }
+
+        if (METADATA_FILE_KIND.supportedExtensions.includes(dataExtension) && compressionExtension === 'xz') {
+            return err(
+                new Error(
+                    'LZMA compression (.xz files) is not supported for metadata files. ' +
+                        'Please use a different compression format or leave it uncompressed.',
+                ),
+            );
+        }
+
+        if (dataExtension === 'tsv') {
+            if (!isCompressed) return ok(new RawFile(file));
             return ok(new CompressedFile(file));
         }
+
         if (dataExtension === 'xlsx' || dataExtension === 'xls') {
-            if (isCompressed && compressionExtension === 'xz') {
-                return err(
-                    new Error(
-                        'LZMA compression (.xz files) is not supported with Excel files yet. ' +
-                            'Please use a different compression format for Excel files.',
-                    ),
-                );
-            }
             const compression = isCompressed ? (compressionExtension as SupportedInBrowserCompressionKind) : null;
             const excelFile = new ExcelFile(file, compression);
             try {
@@ -60,6 +55,7 @@ export const METADATA_FILE_KIND: FileKind<ProcessedFile> = {
             }
             return ok(excelFile);
         }
+
         return err(
             new Error(
                 `Unsupported file extension for metadata upload. Please use one of: ${METADATA_FILE_KIND.supportedExtensions.join(


### PR DESCRIPTION
resolves #7121 

### Breaking changes

- **This PR prevents xz-compressed metadata files of any form (not just excel) from being submitted via the website**. Users must either use a supported compression format for metadata, submit uncompressed metadata, or they can still submit xz-compressed metadata via the API. Sequence files can still be xz-compressed. 


### Summary

- The website currently allows xz-compressed metadata TSVs, as long as the user doesn't do any actions that involve reading the metadata file within the website (such as column mapping). For this reason, excel metadata files do not support xz compression as they require parsing by the website.
- However, with the updates to bulk submission with extra files brought in by #6922 , when extra files are enabled then the metadata TSV is _always_ parsed - to check for and display file linkage. Even if the user doesn't add any extra files, it still parses to display any reuse of file IDs.
- This means currently if a user uploads an xz-compressed metadata file with file sharing enabled for the organism, they get a 'xz files cannot be opened for editing' message. This message could be more informative, but IMO it would still be confusing that some organisms without file sharing support xz and others with file sharing do not.
- Therefore, this PR also restricts providing xz-compressed metadata TSVs, in line with the existing behaviour for metadata xlsx files. 

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable