### PR TITLE
ci: migrate setup-java from deprecated 'adopt' to 'temurin'

### DIFF
--- a/.github/workflows/backend-image.yml
+++ b/.github/workflows/backend-image.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: "21"
-          distribution: "adopt"
+          distribution: "temurin"
       - name: Setup Gradle
         if: env.CACHE_HIT == 'false'
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: "21"
-          distribution: "adopt"
+          distribution: "temurin"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Run tests
@@ -44,7 +44,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: "21"
-          distribution: "adopt"
+          distribution: "temurin"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Check Format And Lint

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: "21"
-          distribution: "adopt"
+          distribution: "temurin"
       - if: matrix.language == 'java-kotlin' && matrix.build-mode == 'manual'
         name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/format-backend-on-request.yml
+++ b/.github/workflows/format-backend-on-request.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: "21"
-          distribution: "adopt"
+          distribution: "temurin"
       
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6


### PR DESCRIPTION
`actions/setup-java@v5` warns that the legacy `adopt` distribution is deprecated and will be removed in v6:

> Warning: The 'adopt' legacy AdoptOpenJDK distribution is deprecated and will be removed in setup-java v6. Please migrate to the 'temurin' distribution.

Switching to `temurin` also makes the step faster and less flaky. Temurin 21 is pre-installed on the `ubuntu-latest` runners, so setup-java gets a toolcache hit instead of resolving and downloading a JDK from a remote API. That remote lookup is what occasionally fails, e.g. [this run](https://github.com/loculus-project/loculus/actions/runs/32382027328/job/96467315728):

```
Trying to resolve the latest version from remote
Error: Java setup failed due to network or configuration error(s)
Error: connect ETIMEDOUT 104.17.75.81:443
```

Same vendor and Java version as before — Temurin is the continuation of AdoptOpenJDK — so no change to what the build actually runs on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable