### PR TITLE
feat(raw-reads-processing): update deacon index to mask high quality PPX consensus sequence k-mers

### DIFF
--- a/.github/workflows/deacon-index.yml
+++ b/.github/workflows/deacon-index.yml
@@ -42,8 +42,7 @@ jobs:
       - name: Create deacon index
         shell: bash -l {0}
         run: |
-          curl -fL https://objectstorage.uk-london-1.oraclecloud.com/n/lrbvkel2wjot/b/human-genome-bucket/o/deacon/misc/panhuman-1.k31w15c8.idx -o "${INDEX_VERSIONED}"
-          ls -lh "${INDEX_VERSIONED}"
+          python3 ./raw-reads-processing/build-index.py -o "${INDEX_VERSIONED}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/deacon-index.yml
+++ b/.github/workflows/deacon-index.yml
@@ -2,6 +2,9 @@ name: Create and Upload Custom Deacon Index
 
 on:
   workflow_dispatch: # Only manual trigger for now, since this is a rare operation
+  push:
+    branches:
+      - filter_low_qc
 
 env:
   DEACON_INDEX_IMAGE: ghcr.io/loculus-project/deacon-index
@@ -92,8 +95,8 @@ jobs:
         run: |
           s3cmd put "${INDEX_VERSIONED}" s3://loculus-public/deacon-index/"${INDEX_VERSIONED}"
 
-          s3cmd cp s3://loculus-public/deacon-index/"${INDEX_VERSIONED}" \
-            s3://loculus-public/deacon-index/"${INDEX_LATEST}"
+          # s3cmd cp s3://loculus-public/deacon-index/"${INDEX_VERSIONED}" \
+          #  s3://loculus-public/deacon-index/"${INDEX_LATEST}"
 
   notify_on_success:
     needs: build-and-upload

--- a/raw-reads-processing/README.md
+++ b/raw-reads-processing/README.md
@@ -88,6 +88,6 @@ DEACON_INDEX_PATH=./deacon.idx
 
 ## Deacon index
 
-We use a custom deacon index from https://objectstorage.uk-london-1.oraclecloud.com/n/lrbvkel2wjot/b/human-genome-bucket/o/deacon/misc/panhuman-1.k31w15c8.idx.
+We use a custom deacon index, generated during a manual build action in `loculus/raw-reads-processing/build-index.py`, based on https://objectstorage.uk-london-1.oraclecloud.com/n/lrbvkel2wjot/b/human-genome-bucket/o/deacon/misc/panhuman-1.k31w15c8.idx.
 
-It uses deacon's default panhuman-1.k31w15c8 index (which excludes k-mers occurring in refSeq virus sequences) with a complexity filter of kdust 0.8.
+It uses deacon's default panhuman-1.k31w15c8 index (which excludes k-mers occurring in refSeq virus sequences) with a complexity filter of kdust 0.8 and additionally filters out all k-mers that are found in high-quality consensus sequences on PPX to further avoid accidental flagging of viral genomes.

--- a/raw-reads-processing/build-index.py
+++ b/raw-reads-processing/build-index.py
@@ -17,7 +17,9 @@ from pathlib import Path
 
 import requests
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 PATHOPLEXUS_URL = "https://pathoplexus.org"
@@ -34,7 +36,9 @@ REQUEST_TIMEOUT_SECONDS = 300
 
 
 def fetch_loculus_info() -> dict:
-    response = requests.get(f"{PATHOPLEXUS_URL}/loculus-info", timeout=REQUEST_TIMEOUT_SECONDS)
+    response = requests.get(
+        f"{PATHOPLEXUS_URL}/loculus-info", timeout=REQUEST_TIMEOUT_SECONDS
+    )
     response.raise_for_status()
     return response.json()
 
@@ -65,7 +69,9 @@ def download_organism_fasta(organism: str, dest: Path, tmp_dir: Path) -> None:
 
 
 def download_base_index(dest: Path) -> None:
-    with requests.get(BASE_INDEX_URL, stream=True, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+    with requests.get(
+        BASE_INDEX_URL, stream=True, timeout=REQUEST_TIMEOUT_SECONDS
+    ) as response:
         response.raise_for_status()
         with dest.open("wb") as f:
             for chunk in response.iter_content(chunk_size=1024 * 1024):
@@ -79,7 +85,9 @@ def parse_dataset_params(url: str) -> tuple[str, str]:
     return dataset_name, dataset_server
 
 
-def run_nextclade(fasta_path: Path, dataset_name: str, dataset_server: str, out_dir: Path) -> None:
+def run_nextclade(
+    fasta_path: Path, dataset_name: str, dataset_server: str, out_dir: Path
+) -> None:
     args = [
         "nextclade",
         "run",
@@ -109,7 +117,9 @@ def good_sequence_indices(tsv_path: Path) -> set[str]:
         }
 
 
-def filter_fasta_by_index(fasta_path: Path, good_indices: set[str], combined_fasta: Path) -> None:
+def filter_fasta_by_index(
+    fasta_path: Path, good_indices: set[str], combined_fasta: Path
+) -> None:
     """Append only the FASTA records at `good_indices` to combined_fasta."""
     dropped = 0
     with fasta_path.open() as src, combined_fasta.open("a") as dst:
@@ -127,7 +137,9 @@ def filter_fasta_by_index(fasta_path: Path, good_indices: set[str], combined_fas
     logger.info("Dropped %d sequences from %s", dropped, fasta_path.name)
 
 
-def run_deacon_index_diff(temp_index: Path, combined_fasta: Path, output_path: Path) -> None:
+def run_deacon_index_diff(
+    temp_index: Path, combined_fasta: Path, output_path: Path
+) -> None:
     args = [
         "deacon",
         "index",
@@ -178,7 +190,9 @@ def build_index(output_path: Path) -> None:
 
                 logger.info("Filtering FASTA for good sequences...")
                 good_indices = good_sequence_indices(tmp_dir / "nextclade.tsv")
-                logger.info("Found %d good sequences for %s", len(good_indices), organism)
+                logger.info(
+                    "Found %d good sequences for %s", len(good_indices), organism
+                )
                 filter_fasta_by_index(organism_fasta, good_indices, combined_fasta)
 
         run_deacon_index_diff(temp_index, combined_fasta, output_path)

--- a/raw-reads-processing/build-index.py
+++ b/raw-reads-processing/build-index.py
@@ -31,7 +31,7 @@ BASE_INDEX_URL = (
     "https://objectstorage.uk-london-1.oraclecloud.com/n/lrbvkel2wjot/b/"
     "human-genome-bucket/o/deacon/misc/panhuman-1.k31w15c8.idx"
 )
-# mpox clade 1b sequence including commonly incorrectly flagged insertion 
+# mpox clade 1b sequence including commonly incorrectly flagged insertion
 # `ins_10453:TAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGAT`
 ADDITIONAL_SEQUENCES_FOR_MASK = {"PP_0014ESS.1"}
 

--- a/raw-reads-processing/build-index.py
+++ b/raw-reads-processing/build-index.py
@@ -197,6 +197,7 @@ def build_index(output_path: Path) -> None:
                     "Found %d good sequences for %s", len(good_indices), organism
                 )
                 filter_fasta_by_index(organism_fasta, good_indices, combined_fasta)
+            organism_fasta.unlink()
 
         run_deacon_index_diff(temp_index, combined_fasta, output_path)
 

--- a/raw-reads-processing/build-index.py
+++ b/raw-reads-processing/build-index.py
@@ -11,6 +11,7 @@ import argparse
 import csv
 import logging
 import subprocess  # noqa: S404
+import sys
 import tempfile
 import urllib.parse
 from pathlib import Path
@@ -21,6 +22,8 @@ logging.basicConfig(
     level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
 )
 logger = logging.getLogger(__name__)
+
+csv.field_size_limit(sys.maxsize)
 
 PATHOPLEXUS_URL = "https://pathoplexus.org"
 LAPIS_URL = "https://lapis.pathoplexus.org"

--- a/raw-reads-processing/build-index.py
+++ b/raw-reads-processing/build-index.py
@@ -31,6 +31,9 @@ BASE_INDEX_URL = (
     "https://objectstorage.uk-london-1.oraclecloud.com/n/lrbvkel2wjot/b/"
     "human-genome-bucket/o/deacon/misc/panhuman-1.k31w15c8.idx"
 )
+# mpox clade 1b sequence including commonly incorrectly flagged insertion 
+# `ins_10453:TAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGATTAGAT`
+ADDITIONAL_SEQUENCES_FOR_MASK = {"PP_0014ESS.1"}
 
 KMER_LEN = 31
 WINDOW_SIZE = 15
@@ -143,12 +146,26 @@ def append_good_seq(
 def run_deacon_index_diff(
     temp_index: Path, combined_fasta: Path, output_path: Path
 ) -> None:
+    # create deacon index of mask using W=1 to get all possible kmers
+    args_mask = [
+        "deacon",
+        "index",
+        "build",
+        str(combined_fasta),
+        "-k",
+        str(KMER_LEN),
+        "-w",
+        str(1),
+        "-o",
+        str(temp_index.with_suffix(".mask.idx")),
+    ]
+    subprocess.run(args_mask, check=True)  # noqa: S603, S607
     args = [
         "deacon",
         "index",
         "diff",
         str(temp_index),
-        str(combined_fasta),
+        str(temp_index.with_suffix(".mask.idx")),
         "-k",
         str(KMER_LEN),
         "-w",
@@ -193,6 +210,7 @@ def build_index(output_path: Path) -> None:
 
                 logger.info("Filtering FASTA for good sequences...")
                 good_seq_names = good_sequence_names(tmp_dir / "nextclade.tsv")
+                good_seq_names |= ADDITIONAL_SEQUENCES_FOR_MASK
                 logger.info(
                     "Found %d good sequences for %s", len(good_seq_names), organism
                 )

--- a/raw-reads-processing/build-index.py
+++ b/raw-reads-processing/build-index.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Build a deacon index from PPX consensus sequences that pass nextclade QC.
+
+For every organism configured on Pathoplexus, downloads the latest open,
+unrevoked consensus sequences, runs nextclade to identify sequences with
+qc.overallStatus == "good", and folds the good sequences into a deacon
+index diffed against a base human/kdust-filtered index.
+"""
+
+import argparse
+import csv
+import logging
+import subprocess  # noqa: S404
+import tempfile
+import urllib.parse
+from pathlib import Path
+
+import requests
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+PATHOPLEXUS_URL = "https://pathoplexus.org"
+LAPIS_URL = "https://lapis.pathoplexus.org"
+BASE_INDEX_URL = (
+    "https://objectstorage.uk-london-1.oraclecloud.com/n/lrbvkel2wjot/b/"
+    "human-genome-bucket/o/deacon/misc/panhuman-1.k31w15c8.idx"
+)
+
+KMER_LEN = 31
+WINDOW_SIZE = 15
+
+REQUEST_TIMEOUT_SECONDS = 300
+
+
+def fetch_loculus_info() -> dict:
+    response = requests.get(f"{PATHOPLEXUS_URL}/loculus-info", timeout=REQUEST_TIMEOUT_SECONDS)
+    response.raise_for_status()
+    return response.json()
+
+
+def nextclade_urls_for_organism(loculus_info: dict, organism: str) -> list[str]:
+    schema = loculus_info["organisms"][organism]["schema"]
+    return [
+        link_out["url"]
+        for link_out in schema.get("linkOuts") or []
+        if "nextclade" in link_out.get("name", "").lower()
+    ]
+
+
+def download_organism_fasta(organism: str, dest: Path, tmp_dir: Path) -> None:
+    url = (
+        f"{LAPIS_URL}/{organism}/sample/unalignedNucleotideSequences"
+        "?dataUseTerms=OPEN&dataFormat=fasta&versionStatus=LATEST_VERSION&isRevocation=false"
+    )
+    zst_path = tmp_dir / f"{organism}.fasta.zst"
+    with requests.get(url, stream=True, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+        response.raise_for_status()
+        with zst_path.open("wb") as f:
+            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                f.write(chunk)
+
+    with dest.open("wb") as f:
+        subprocess.run(["zstdcat", str(zst_path)], stdout=f, check=True)  # noqa: S603, S607
+
+
+def download_base_index(dest: Path) -> None:
+    with requests.get(BASE_INDEX_URL, stream=True, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+        response.raise_for_status()
+        with dest.open("wb") as f:
+            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                f.write(chunk)
+
+
+def parse_dataset_params(url: str) -> tuple[str, str]:
+    query = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+    dataset_name = query.get("dataset-name", [""])[0]
+    dataset_server = query.get("dataset-server", [""])[0]
+    return dataset_name, dataset_server
+
+
+def run_nextclade(fasta_path: Path, dataset_name: str, dataset_server: str, out_dir: Path) -> None:
+    args = [
+        "nextclade",
+        "run",
+        "--retry-reverse-complement=true",
+        "--verbosity=error",
+        "--output-all",
+        str(out_dir),
+        "--dataset-name",
+        dataset_name,
+        "--jobs",
+        "4",
+    ]
+    if dataset_server:
+        args += ["--server", dataset_server]
+    args += ["--", str(fasta_path)]
+
+    logger.info("Running nextclade for dataset '%s'", dataset_name)
+    subprocess.run(args, check=True)  # noqa: S603, S607
+
+
+def good_sequence_indices(tsv_path: Path) -> set[str]:
+    """FASTA headers with qc.overallStatus == "good"."""
+    with tsv_path.open(newline="") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        return {
+            row["seqName"] for row in reader if row.get("qc.overallStatus") == "good"
+        }
+
+
+def filter_fasta_by_index(fasta_path: Path, good_indices: set[str], combined_fasta: Path) -> None:
+    """Append only the FASTA records at `good_indices` to combined_fasta."""
+    dropped = 0
+    with fasta_path.open() as src, combined_fasta.open("a") as dst:
+        keep = False
+        for line in src:
+            if line.startswith(">"):
+                seq_name = line[1:].strip()
+                keep = seq_name in good_indices
+            if keep:
+                dst.write(line)
+            else:
+                dropped += 1
+        # Ensure records from separate files cannot run together.
+        dst.write("\n")
+    logger.info("Dropped %d sequences from %s", dropped, fasta_path.name)
+
+
+def run_deacon_index_diff(temp_index: Path, combined_fasta: Path, output_path: Path) -> None:
+    args = [
+        "deacon",
+        "index",
+        "diff",
+        str(temp_index),
+        str(combined_fasta),
+        "-k",
+        str(KMER_LEN),
+        "-w",
+        str(WINDOW_SIZE),
+        "-o",
+        str(output_path),
+    ]
+    subprocess.run(args, check=True)  # noqa: S603, S607
+
+
+def build_index(output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        temp_index = tmp_dir / "deacon_human_kdust_filtered.idx"
+        combined_fasta = tmp_dir / "combined.fasta"
+        combined_fasta.touch()
+
+        logger.info("Downloading base index from %s...", BASE_INDEX_URL)
+        download_base_index(temp_index)
+
+        loculus_info = fetch_loculus_info()
+        organisms = sorted(loculus_info["organisms"].keys())
+
+        for organism in organisms:
+            organism_fasta = tmp_dir / f"{organism}.fasta"
+            logger.info("Downloading %s...", organism)
+            download_organism_fasta(organism, organism_fasta, tmp_dir)
+
+            if organism_fasta.stat().st_size == 0:
+                logger.warning("Empty FASTA returned for %s; skipping.", organism)
+                continue
+
+            for url in nextclade_urls_for_organism(loculus_info, organism):
+                dataset_name, dataset_server = parse_dataset_params(url)
+                logger.info(
+                    "dataset_name=%s dataset_server=%s", dataset_name, dataset_server
+                )
+
+                run_nextclade(organism_fasta, dataset_name, dataset_server, tmp_dir)
+
+                logger.info("Filtering FASTA for good sequences...")
+                good_indices = good_sequence_indices(tmp_dir / "nextclade.tsv")
+                logger.info("Found %d good sequences for %s", len(good_indices), organism)
+                filter_fasta_by_index(organism_fasta, good_indices, combined_fasta)
+
+        run_deacon_index_diff(temp_index, combined_fasta, output_path)
+
+    logger.info("Output written to: %s", output_path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-o", "--output", required=True, help="Output index path")
+    args = parser.parse_args()
+
+    build_index(Path(args.output))
+
+
+if __name__ == "__main__":
+    main()

--- a/raw-reads-processing/build-index.py
+++ b/raw-reads-processing/build-index.py
@@ -111,7 +111,7 @@ def run_nextclade(
     subprocess.run(args, check=True)  # noqa: S603, S607
 
 
-def good_sequence_indices(tsv_path: Path) -> set[str]:
+def good_sequence_names(tsv_path: Path) -> set[str]:
     """FASTA headers with qc.overallStatus == "good"."""
     with tsv_path.open(newline="") as f:
         reader = csv.DictReader(f, delimiter="\t")
@@ -120,17 +120,17 @@ def good_sequence_indices(tsv_path: Path) -> set[str]:
         }
 
 
-def filter_fasta_by_index(
-    fasta_path: Path, good_indices: set[str], combined_fasta: Path
+def append_good_seq(
+    fasta_path: Path, good_seq_names: set[str], combined_fasta: Path
 ) -> None:
-    """Append only the FASTA records at `good_indices` to combined_fasta."""
+    """Append only the FASTA records at `good_seq_names` to combined_fasta."""
     dropped = 0
     with fasta_path.open() as src, combined_fasta.open("a") as dst:
         keep = False
         for line in src:
             if line.startswith(">"):
                 seq_name = line[1:].strip()
-                keep = seq_name in good_indices
+                keep = seq_name in good_seq_names
                 if not keep:
                     dropped += 1
             if keep:
@@ -192,11 +192,11 @@ def build_index(output_path: Path) -> None:
                 run_nextclade(organism_fasta, dataset_name, dataset_server, tmp_dir)
 
                 logger.info("Filtering FASTA for good sequences...")
-                good_indices = good_sequence_indices(tmp_dir / "nextclade.tsv")
+                good_seq_names = good_sequence_names(tmp_dir / "nextclade.tsv")
                 logger.info(
-                    "Found %d good sequences for %s", len(good_indices), organism
+                    "Found %d good sequences for %s", len(good_seq_names), organism
                 )
-                filter_fasta_by_index(organism_fasta, good_indices, combined_fasta)
+                append_good_seq(organism_fasta, good_seq_names, combined_fasta)
             organism_fasta.unlink()
 
         run_deacon_index_diff(temp_index, combined_fasta, output_path)

--- a/raw-reads-processing/build-index.py
+++ b/raw-reads-processing/build-index.py
@@ -58,7 +58,7 @@ def nextclade_urls_for_organism(loculus_info: dict, organism: str) -> list[str]:
 def download_organism_fasta(organism: str, dest: Path, tmp_dir: Path) -> None:
     url = (
         f"{LAPIS_URL}/{organism}/sample/unalignedNucleotideSequences"
-        "?dataUseTerms=OPEN&dataFormat=fasta&versionStatus=LATEST_VERSION&isRevocation=false"
+        "?dataUseTerms=OPEN&dataFormat=fasta&versionStatus=LATEST_VERSION&isRevocation=false&compression=zstd"
     )
     zst_path = tmp_dir / f"{organism}.fasta.zst"
     with requests.get(url, stream=True, timeout=REQUEST_TIMEOUT_SECONDS) as response:
@@ -96,8 +96,8 @@ def run_nextclade(
         "run",
         "--retry-reverse-complement=true",
         "--verbosity=error",
-        "--output-all",
-        str(out_dir),
+        "--output-tsv",
+        str(out_dir / "nextclade.tsv"),
         "--dataset-name",
         dataset_name,
         "--jobs",
@@ -131,10 +131,10 @@ def filter_fasta_by_index(
             if line.startswith(">"):
                 seq_name = line[1:].strip()
                 keep = seq_name in good_indices
+                if not keep:
+                    dropped += 1
             if keep:
                 dst.write(line)
-            else:
-                dropped += 1
         # Ensure records from separate files cannot run together.
         dst.write("\n")
     logger.info("Dropped %d sequences from %s", dropped, fasta_path.name)

--- a/raw-reads-processing/environment.yml
+++ b/raw-reads-processing/environment.yml
@@ -15,3 +15,4 @@ dependencies:
   - deacon=0.17.0
   - openjdk=21
   - nextclade=3.21.2
+  - zstd=1.5.7

--- a/raw-reads-processing/environment.yml
+++ b/raw-reads-processing/environment.yml
@@ -14,3 +14,4 @@ dependencies:
   - pyyaml=6.0.3
   - deacon=0.17.0
   - openjdk=21
+  - nextclade=3.21.2


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/6759

builds on work I did in https://github.com/loculus-project/loculus/pull/6916/changes/968e314e8f88e80477b6c53bfe6cf802596f89d6, but now also filters out high quality PPX k-mers - claude helped me convert this to a python script as the bash script got too complex when I added in running nextclade and filtering out poor QC sequences. Additionally (see comments in https://loculus.slack.com/archives/C0ALH6CB9NY/p1787513362831529 an mpox clade 1b is added as clade 1bs almost all include a commonly incorrectly insertion while nextclade annotates them as poor quality - probably as we use a very general dataset that works for all sequences)

### Screenshot

Plot of k-mers from PPX consensus sequences flagged with our current deacon index (a good approximate for how many reads we may accidentally flag as human although they are in fact viral):
<img width="2400" height="1560" alt="image" src="https://github.com/user-attachments/assets/4bbef992-bec9-4d63-b923-a9cf2ac2927d" />

Results with this index (note organisms without mapped kmers are dropped)

<img width="1830" height="908" alt="image" src="https://github.com/user-attachments/assets/b20cb87d-ab29-4929-88c4-c2ccbe872eb8" />



### PR Checklist
- [x] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable