### PR TITLE
fix(website): stop reporting a replaced file as uploaded while it's requesting upload url

### DIFF
--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.spec.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.spec.tsx
@@ -421,6 +421,33 @@ describe('FolderUploadComponent', () => {
             );
         });
 
+        it('stops reporting a replaced file as uploaded as soon as the replacement is confirmed', async () => {
+            let deliverUploadUrls = () => {};
+            mockRequestMultipartUpload.mockReturnValue(
+                new Promise((resolve) => {
+                    deliverUploadUrls = () =>
+                        resolve(ok([{ fileId: 'replacement-id', urls: ['http://test.com/url1'] }]));
+                }),
+            );
+
+            render(<FolderUploadComponentWithState {...defaultPropsWithFiles} />);
+
+            const file = new File(['content'], 'file-a.txt', { type: 'text/plain' });
+            Object.defineProperty(file, 'webkitRelativePath', { value: '', writable: false });
+            await userEvent.upload(screen.getByTestId('add_extraFiles'), file);
+            await waitFor(() => expect(screen.getByText(/already exist and will be replaced/)).toBeInTheDocument());
+            await userEvent.click(screen.getByRole('button', { name: 'Replace' }));
+
+            // The request for upload urls is still in flight, so nothing has been uploaded yet: the
+            // replaced entry must stop claiming the previous upload it is about to replace, while
+            // the untouched entry keeps its own.
+            await waitFor(() => expect(screen.getByTestId('status_extraFiles_file-a.txt')).not.toHaveTextContent('✓'));
+            expect(screen.getByTestId('status_extraFiles_file-b.txt')).toHaveTextContent('✓');
+
+            deliverUploadUrls();
+            await waitFor(() => expect(screen.getByTestId('status_extraFiles_file-a.txt')).toHaveTextContent('✓'));
+        });
+
         it('leaves the existing files alone when the overwrite is cancelled', async () => {
             mockRequestMultipartUpload.mockReturnValue(
                 ok([{ fileId: 'replacement-id', urls: ['http://test.com/url1'] }]),

--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
@@ -324,9 +324,6 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
             // Updates the state of file uploads and triggers the upload of the new files
             const addFiles = async () => {
                 const existingFiles = fileUploadState.files.filter((file) => !filePaths.has(file.path));
-                // Show the newly selected files straight away. Without this, a file being replaced
-                // keeps rendering its previous upload -- complete with tick -- for as long as the
-                // request for upload urls takes, claiming an upload that has not happened yet.
                 setFileUploadState({ type: 'uploadInProgress', files: [...existingFiles, ...awaiting] });
                 const pendingFiles = await requestFileUploads(awaiting);
                 setFileUploadState({

--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
@@ -173,7 +173,7 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
     async function requestFileUploads(filesAwaitingUrls: Awaiting[]): Promise<Pending[]> {
         const pendingFiles: Pending[] = [];
         for (const file of filesAwaitingUrls) {
-            const { partCount, partSize } = calculatePartSizeAndCount(file.file.size);
+            const { partCount, partSize } = calculatePartSizeAndCount(file.size);
             const result = await backendClient.requestMultipartUpload(accessToken, groupId, 1, partCount);
             result.match(
                 (data) => {
@@ -181,7 +181,7 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
                         type: 'pending',
                         file: file.file,
                         path: file.path,
-                        size: file.file.size,
+                        size: file.size,
                         fileId: data[0].fileId,
                         urls: data[0].urls,
                         uploadedParts: 0,
@@ -262,6 +262,7 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
                     file: f,
                     // Assign the path without the parent folder
                     path: f.webkitRelativePath.split('/').slice(1).join('/'),
+                    size: f.size,
                 })),
             });
         }
@@ -300,6 +301,7 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
                 type: 'awaiting',
                 file: f,
                 path: f.name,
+                size: f.size,
             }));
 
             // If the state is undefined, set it to the new awaiting files
@@ -480,7 +482,7 @@ const FileListItem: FC<FileListeItemProps> = ({ file, fileCategory }) => {
             <div className='flex-1 min-w-0 flex items-center'>
                 <FilePath file={file} />
                 <span className='text-xs text-gray-400 ml-2 whitespace-nowrap'>
-                    ({file.type === 'previousUpload' ? 'uploaded' : formatFileSize(fileSizeOf(file))})
+                    ({file.type === 'previousUpload' ? 'uploaded' : formatFileSize(file.size)})
                 </span>
                 <span className='text-xs text-blue-500 ml-2 w-9 shrink-0 text-right whitespace-nowrap'>
                     {showProgress ? `${percentage}%` : ''}
@@ -492,9 +494,6 @@ const FileListItem: FC<FileListeItemProps> = ({ file, fileCategory }) => {
         </div>
     );
 };
-
-const fileSizeOf = (file: Exclude<SingleFileUpload, PreviousUpload>) =>
-    file.type === 'awaiting' ? file.file.size : file.size;
 
 const FilePath: FC<{ file: SingleFileUpload }> = ({ file }) => {
     const folderPath = file.path.split('/').slice(0, -1);

--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
@@ -324,6 +324,10 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
             // Updates the state of file uploads and triggers the upload of the new files
             const addFiles = async () => {
                 const existingFiles = fileUploadState.files.filter((file) => !filePaths.has(file.path));
+                // Show the newly selected files straight away. Without this, a file being replaced
+                // keeps rendering its previous upload -- complete with tick -- for as long as the
+                // request for upload urls takes, claiming an upload that has not happened yet.
+                setFileUploadState({ type: 'uploadInProgress', files: [...existingFiles, ...awaiting] });
                 const pendingFiles = await requestFileUploads(awaiting);
                 setFileUploadState({
                     type: 'uploadInProgress',
@@ -479,7 +483,7 @@ const FileListItem: FC<FileListeItemProps> = ({ file, fileCategory }) => {
             <div className='flex-1 min-w-0 flex items-center'>
                 <FilePath file={file} />
                 <span className='text-xs text-gray-400 ml-2 whitespace-nowrap'>
-                    ({file.type === 'previousUpload' ? 'uploaded' : formatFileSize(file.size)})
+                    ({file.type === 'previousUpload' ? 'uploaded' : formatFileSize(fileSizeOf(file))})
                 </span>
                 <span className='text-xs text-blue-500 ml-2 w-9 shrink-0 text-right whitespace-nowrap'>
                     {showProgress ? `${percentage}%` : ''}
@@ -491,6 +495,9 @@ const FileListItem: FC<FileListeItemProps> = ({ file, fileCategory }) => {
         </div>
     );
 };
+
+const fileSizeOf = (file: Exclude<SingleFileUpload, PreviousUpload>) =>
+    file.type === 'awaiting' ? file.file.size : file.size;
 
 const FilePath: FC<{ file: SingleFileUpload }> = ({ file }) => {
     const folderPath = file.path.split('/').slice(0, -1);
@@ -518,6 +525,7 @@ const formatFileSize = (bytes: number): string => {
 // Determine status icon for file upload
 const getStatusIcon = (status: UploadStatus) => {
     switch (status) {
+        case 'awaiting':
         case 'pending':
             return <LucideLoader className='animate-spin h-3 w-3 text-blue-500' />;
         case 'previousUpload':

--- a/website/src/components/Submission/FileUpload/fileUpload.ts
+++ b/website/src/components/Submission/FileUpload/fileUpload.ts
@@ -46,7 +46,7 @@ type FileError = {
 
 export type SingleFileUpload = Awaiting | Pending | Uploaded | PreviousUpload | FileError;
 
-export type UploadStatus = 'awaiting' | 'pending' | 'uploaded' | 'previousUpload' | 'error';
+export type UploadStatus = SingleFileUpload['type'];
 
 /**
  * The state that the component is in, right after the user dropped the files.

--- a/website/src/components/Submission/FileUpload/fileUpload.ts
+++ b/website/src/components/Submission/FileUpload/fileUpload.ts
@@ -44,9 +44,9 @@ type FileError = {
     msg: string;
 };
 
-export type SingleFileUpload = Pending | Uploaded | PreviousUpload | FileError;
+export type SingleFileUpload = Awaiting | Pending | Uploaded | PreviousUpload | FileError;
 
-export type UploadStatus = 'pending' | 'uploaded' | 'previousUpload' | 'error';
+export type UploadStatus = 'awaiting' | 'pending' | 'uploaded' | 'previousUpload' | 'error';
 
 /**
  * The state that the component is in, right after the user dropped the files.

--- a/website/src/components/Submission/FileUpload/fileUpload.ts
+++ b/website/src/components/Submission/FileUpload/fileUpload.ts
@@ -6,6 +6,7 @@ export type Awaiting = {
     type: 'awaiting';
     file: File;
     path: string;
+    size: number;
 };
 
 export type Pending = {


### PR DESCRIPTION
Followup to #7050 which blocked submission while upload to s3 is in process but missed the (small) window between file drop and upload url being returned from backend.

While a replaced file is uploading, the UI keeps showing the *previous* file's upload as complete — green tick and `(uploaded)` label — for as long as the request for upload urls takes. This causes e2e test flakiness as we use the tick mark as proof that upload completed, eg [this run](https://github.com/loculus-project/loculus/actions/runs/32494192105).

<details>

`addFiles` does not touch the upload state until the round trip returns:

```js
const addFiles = async () => {
    const existingFiles = fileUploadState.files.filter((file) => !filePaths.has(file.path));
    const pendingFiles = await requestFileUploads(awaiting);   // ← nothing reflects the user's choice yet
    setFileUploadState({ type: 'uploadInProgress', files: [...existingFiles, ...pendingFiles] });
```

Between confirming **Replace** and the urls arriving, the category is still `uploadCompleted` and the row for the replaced path still holds its `previousUpload` entry. Consequences:

- The user is told the replacement is uploaded when it is not. Navigate away in that window and the old file is silently kept.
- Anything deriving "is this category settled?" from the state — including the submission checks added in #7050 — sees `uploadCompleted` and will let a submission through against a stale `fileId`.

## Changes

11 lines of production code across two files, five of them comment:

- `fileUpload.ts` — admit `Awaiting` into `SingleFileUpload`, and `'awaiting'` into `UploadStatus`.
- `FolderUploadComponent.tsx` — set `uploadInProgress` with the awaiting files as soon as the user confirms, before requesting urls; render `'awaiting'` with the spinner already used for `pending`; small `fileSizeOf` helper, since `Awaiting` carries `file: File` rather than a `size` field.

## Also fixes an integration-test flake

`expectExtraFileUploaded` asserts on the tick:

```ts
await expect(this.page.getByTestId(`status_${fileCategory}_${fileName}`)).toHaveText('✓');
```

and `getStatusIcon` renders the same `✓` for `previousUpload` as for `uploaded`. So for a file being *replaced*, that assertion is satisfied by the carried-over previous upload and returns immediately — **14 ms** after clicking Replace in one recent firefox run, long before the replacement had a url. The test then submitted mid-upload, #7050's `validateFileUploadStates` correctly refused, and the confirmation dialog never appeared.

</details>

## Testing

- New unit test in `FolderUploadComponent.spec.tsx` holds `requestMultipartUpload` pending and asserts only the untouched file is ticked mid-replacement, then that both are ticked once the urls arrive. Verified red without the fix (`Unable to find an element with the text: (7 B)`) and green with it.

🚀 Preview: Add `preview` label to enable