### PR TITLE
fix(deployment): move serversTransport annotation to Services

### DIFF
--- a/kubernetes/loculus/templates/_servers-transport.tpl
+++ b/kubernetes/loculus/templates/_servers-transport.tpl
@@ -1,5 +1,5 @@
-{{/* Reference to servers-transport.yaml, as traefik expects it in a
-`traefik.ingress.kubernetes.io/service.serverstransport` annotation. */}}
+{{/* Reference to servers-transport.yaml, for the Service annotation:
+https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress/#on-service */}}
 {{- define "loculus.serversTransportRef" -}}
 {{- printf "%s-short-idle-conn-timeout@kubernetescrd" .Release.Namespace -}}
 {{- end -}}

--- a/kubernetes/loculus/templates/ingressroute.yaml
+++ b/kubernetes/loculus/templates/ingressroute.yaml
@@ -74,7 +74,6 @@ metadata:
   name: loculus-website-ingress
   annotations:
     traefik.ingress.kubernetes.io/router.middlewares: "{{ join "," $middlewareListForWebsite }}"
-    traefik.ingress.kubernetes.io/service.serverstransport: "{{ include "loculus.serversTransportRef" $ }}"
 spec:
   rules:
     - host: "{{ .Values.host }}"
@@ -108,7 +107,6 @@ metadata:
   name: loculus-backend-ingress
   annotations:
     traefik.ingress.kubernetes.io/router.middlewares: "{{ join "," $middlewareList }}"
-    traefik.ingress.kubernetes.io/service.serverstransport: "{{ include "loculus.serversTransportRef" $ }}"
 spec:
   rules:
     - host: "{{ $backendHost }}"
@@ -131,7 +129,6 @@ metadata:
   name: loculus-keycloak-ingress
   annotations:
     traefik.ingress.kubernetes.io/router.middlewares: "{{ join "," $middlewareListForKeycloak }}"
-    traefik.ingress.kubernetes.io/service.serverstransport: "{{ include "loculus.serversTransportRef" $ }}"
 spec:
   rules:
     - host: "{{ $keycloakHost }}"
@@ -155,7 +152,6 @@ metadata:
   name: minio-ingress
   annotations:
     traefik.ingress.kubernetes.io/router.middlewares: "{{ join "," $middlewareList }}"
-    traefik.ingress.kubernetes.io/service.serverstransport: "{{ include "loculus.serversTransportRef" $ }}"
 spec:
   rules:
     - host: "{{ $minioHost }}"

--- a/kubernetes/loculus/templates/keycloak-service.yaml
+++ b/kubernetes/loculus/templates/keycloak-service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: loculus-keycloak-service
+  annotations:
+    traefik.ingress.kubernetes.io/service.serverstransport: "{{ include "loculus.serversTransportRef" . }}"
 spec:
   {{- template "loculus.serviceType" . }}
   selector:

--- a/kubernetes/loculus/templates/lapis-ingress.yaml
+++ b/kubernetes/loculus/templates/lapis-ingress.yaml
@@ -29,7 +29,6 @@ metadata:
   name: lapis-ingress
   annotations:
     traefik.ingress.kubernetes.io/router.middlewares: "{{ $.Release.Namespace }}-cors-all-origins@kubernetescrd,{{- $first := true }}{{- range $key := $organismKeys }}{{ if $first }}{{ $first = false }}{{ else }},{{ end }}{{ $.Release.Namespace }}-strip-{{ $key }}-prefix@kubernetescrd{{- end }}"
-    traefik.ingress.kubernetes.io/service.serverstransport: "{{ include "loculus.serversTransportRef" $ }}"
 spec:
   rules:
   - host: {{ if eq $.Values.environment "server" }}{{ $lapisHost }}{{ end }}

--- a/kubernetes/loculus/templates/lapis-service.yaml
+++ b/kubernetes/loculus/templates/lapis-service.yaml
@@ -5,6 +5,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "loculus.lapisServiceName" $key }}
+  annotations:
+    traefik.ingress.kubernetes.io/service.serverstransport: "{{ include "loculus.serversTransportRef" $ }}"
 spec:
   type: ClusterIP
   selector:

--- a/kubernetes/loculus/templates/loculus-backend-service.yaml
+++ b/kubernetes/loculus/templates/loculus-backend-service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: loculus-backend-service
+  annotations:
+    traefik.ingress.kubernetes.io/service.serverstransport: "{{ include "loculus.serversTransportRef" . }}"
   labels:
     app: loculus
     component: backend

--- a/kubernetes/loculus/templates/minio-service.yaml
+++ b/kubernetes/loculus/templates/minio-service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: loculus-minio-service
+  annotations:
+    traefik.ingress.kubernetes.io/service.serverstransport: "{{ include "loculus.serversTransportRef" . }}"
 spec:
   {{- template "loculus.serviceType" . }}
   selector:

--- a/kubernetes/loculus/templates/servers-transport.yaml
+++ b/kubernetes/loculus/templates/servers-transport.yaml
@@ -4,7 +4,7 @@ Traefik's default 90s idle keep-alive outlives our backends' (Tomcat 20s, Node/u
 reuses connections they are closing -> 502 Bad Gateway.
 https://github.com/loculus-project/loculus/pull/7092
 
-Beware: this replaces traefik's cluster-wide static serversTransport for these routers instead of
+Beware: this replaces traefik's cluster-wide static serversTransport for these services instead of
 merging with it, so changes made there won't apply and need mirroring here.
 */}}
 apiVersion: {{ $traefikApiVersion }}

--- a/kubernetes/loculus/templates/website-service.yaml
+++ b/kubernetes/loculus/templates/website-service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: loculus-website-service
+  annotations:
+    traefik.ingress.kubernetes.io/service.serverstransport: "{{ include "loculus.serversTransportRef" . }}"
 spec:
   {{- template "loculus.serviceType" .}}
   selector:


### PR DESCRIPTION
Follow-up to #7092, where I put the annotation on the wrong resource (it belongs on `Service` not `IngressRoute`. This was quite hidden in docs https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress/#on-service (all the 3 LLM reviews missed that!).

When the 502 that was supposed to have been fixed happened again ([#7123](https://github.com/loculus-project/loculus/actions/runs/32495589274/job/96813114087)) I investigated and realized the error.

## Change

Move the annotation from the four Ingresses onto the Services they route to. The [`ServersTransport`](https://github.com/loculus-project/loculus/blob/48bf3e5a22321be51b8f78ea8b6539a8677fb07e/kubernetes/loculus/templates/servers-transport.yaml) itself is unchanged:

| Service | Template |
|---|---|
| `loculus-lapis-service-<organism>` | `lapis-service.yaml` (inside the per-organism `range`) |
| `loculus-website-service` | `website-service.yaml` |
| `loculus-backend-service` | `loculus-backend-service.yaml` |
| `loculus-keycloak-service` | `keycloak-service.yaml` |
| `loculus-minio-service` | `minio-service.yaml` |

🚀 Preview: Add `preview` label to enable