### PR TITLE
fix(backend): drop stale compression_migration_checked_at declaration

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/dbtables/SequenceEntriesTable.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/dbtables/SequenceEntriesTable.kt
@@ -35,7 +35,6 @@ object SequenceEntriesTable : Table(SEQUENCE_ENTRIES_TABLE_NAME) {
     val submittedAtTimestampColumn = datetime("submitted_at")
     val releasedAtTimestampColumn = datetime("released_at").nullable()
     val isRevocationColumn = bool("is_revocation").default(false)
-    val compressionMigrationCheckedAtColumn = datetime("compression_migration_checked_at").nullable()
 
     override val primaryKey = PrimaryKey(accessionColumn, versionColumn)
 


### PR DESCRIPTION
Small fix removing a landminde: `compression_migration_checked_at` was added by `V1.20` and dropped again by `V1.21` (#5461), but the column was never removed from the Exposed declaration in `SequenceEntriesTable`

This would cause errors when using `SequenceEntriesTable.selectAll()` (that's how Claude noticed it).

I got Claude to audit all table declarations and this was the only table that was out of sync with `docs/db/schema.sql.`

🚀 Preview: Add `preview` label to enable