### PR TITLE
fix(backend): discard processed data whose sequence entry was edited

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -289,6 +289,7 @@ class SubmissionDatabaseService(
         log.info { "updating processed data" }
 
         val processedAccessionVersions = mutableListOf<String>()
+        val discardedAccessionVersions = mutableListOf<String>()
         val processedFiles = mutableMapOf<AccessionVersion, Set<FileId>>()
         val processingResultCounts = mutableMapOf<ProcessingResult, Int>()
         BufferedReader(InputStreamReader(inputStream)).use { reader ->
@@ -306,9 +307,12 @@ class SubmissionDatabaseService(
                 submittedProcessedDataBatch.forEach { submittedProcessedData ->
                     val processingResult = submittedProcessedData.processingResult()
 
-                    insertProcessedData(submittedProcessedData, organism, pipelineVersion)
-                    processedAccessionVersions.add(submittedProcessedData.displayAccessionVersion())
-                    processingResultCounts.merge(processingResult, 1, Int::plus)
+                    if (insertProcessedData(submittedProcessedData, organism, pipelineVersion)) {
+                        processedAccessionVersions.add(submittedProcessedData.displayAccessionVersion())
+                        processingResultCounts.merge(processingResult, 1, Int::plus)
+                    } else {
+                        discardedAccessionVersions.add(submittedProcessedData.displayAccessionVersion())
+                    }
                 }
             }
         }
@@ -327,7 +331,8 @@ class SubmissionDatabaseService(
         }
 
         log.info {
-            "Updated ${processedAccessionVersions.size} sequences to $PROCESSED. " +
+            "Updated ${processedAccessionVersions.size} sequences to $PROCESSED, " +
+                "discarded ${discardedAccessionVersions.size} results whose claim was revoked. " +
                 "Processing result counts: " +
                 processingResultCounts.entries.joinToString { "${it.key}=${it.value}" }
         }
@@ -459,11 +464,15 @@ class SubmissionDatabaseService(
         }
     }
 
+    /**
+     * Stores the result of one processing job. Returns false if the result was discarded because the
+     * pipeline's claim on the entry had been revoked while it was working on it.
+     */
     private fun insertProcessedData(
         submittedProcessedData: SubmittedProcessedData,
         organism: Organism,
         pipelineVersion: Long,
-    ) {
+    ): Boolean {
         val submittedErrors = submittedProcessedData.errors.orEmpty()
         val submittedWarnings = submittedProcessedData.warnings.orEmpty()
         val processedData = when {
@@ -489,8 +498,44 @@ class SubmissionDatabaseService(
             }
 
         if (numberInserted != 1) {
+            if (claimWasRevoked(submittedProcessedData, pipelineVersion)) {
+                log.warn {
+                    "Discarding processed data for ${submittedProcessedData.displayAccessionVersion()} " +
+                        "of pipeline version $pipelineVersion: the claim on this entry was revoked while it " +
+                        "was being processed. The entry will be handed out for processing again."
+                }
+                return false
+            }
             throwInsertFailedException(submittedProcessedData, pipelineVersion)
         }
+        return true
+    }
+
+    /**
+     * True if the sequence entry still exists but has no preprocessed data row for the given pipeline
+     * version, i.e. the claim was revoked while the pipeline was working on the entry: it was edited
+     * (which resets preprocessed data for all pipeline versions), the stale-in-processing cleanup ran,
+     * or outdated pipeline data was pruned. Results of a revoked claim are obsolete and can be dropped;
+     * the entry is picked up again by [fetchUnprocessedEntriesAndUpdateToInProcessing].
+     */
+    private fun claimWasRevoked(accessionVersion: AccessionVersionInterface, pipelineVersion: Long): Boolean {
+        val sepd = SequenceEntriesPreprocessedDataTable
+        val claimExists = sepd
+            .select(sepd.accessionColumn)
+            .where {
+                sepd.accessionVersionEquals(accessionVersion) and
+                    (sepd.pipelineVersionColumn eq pipelineVersion)
+            }
+            .limit(1)
+            .count() > 0
+        if (claimExists) {
+            return false
+        }
+        return SequenceEntriesTable
+            .select(SequenceEntriesTable.accessionColumn)
+            .where { SequenceEntriesTable.accessionVersionIsIn(listOf(accessionVersion)) }
+            .limit(1)
+            .count() > 0
     }
 
     /**

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -507,13 +507,6 @@ class SubmissionDatabaseService(
         return true
     }
 
-    /**
-     * True if the sequence entry still exists but has no preprocessed data row for the given pipeline
-     * version, i.e. the claim was revoked while the pipeline was working on the entry: it was edited
-     * (which resets preprocessed data for all pipeline versions), the stale-in-processing cleanup ran,
-     * or outdated pipeline data was pruned. Results of a revoked claim are obsolete and can be dropped;
-     * the entry is picked up again by [fetchUnprocessedEntriesAndUpdateToInProcessing].
-     */
     private fun claimWasRevoked(accessionVersion: AccessionVersionInterface, pipelineVersion: Long): Boolean {
         val sepd = SequenceEntriesPreprocessedDataTable
         val claimExists = sepd

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -312,6 +312,9 @@ class SubmissionDatabaseService(
                         processingResultCounts.merge(processingResult, 1, Int::plus)
                     } else {
                         discardedAccessionVersions.add(submittedProcessedData.displayAccessionVersion())
+                        processedFiles.remove(
+                            AccessionVersion(submittedProcessedData.accession, submittedProcessedData.version),
+                        )
                     }
                 }
             }

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/SubmissionDatabaseService.kt
@@ -464,10 +464,6 @@ class SubmissionDatabaseService(
         }
     }
 
-    /**
-     * Stores the result of one processing job. Returns false if the result was discarded because the
-     * pipeline's claim on the entry had been revoked while it was working on it.
-     */
     private fun insertProcessedData(
         submittedProcessedData: SubmittedProcessedData,
         organism: Organism,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
@@ -334,6 +334,25 @@ class SubmitProcessedDataEndpointTest(
             .assertStatusIs(Status.PROCESSED)
     }
 
+    // Same state as after a sequence edit, which removes the sepd rows of all pipeline versions
+    // (https://github.com/loculus-project/loculus/issues/7128).
+    @Test
+    fun `WHEN I submit data for an entry without a claim THEN discards it and stores the claimed entries`() {
+        val accessionsInProcessing = convenienceClient.prepareDataTo(Status.IN_PROCESSING).map { it.accession }
+        val accessionsWithoutClaim = convenienceClient.prepareDataTo(Status.RECEIVED).map { it.accession }
+
+        submissionControllerClient.submitProcessedData(
+            PreparedProcessedData.successfullyProcessed(accession = accessionsInProcessing.first()),
+            PreparedProcessedData.successfullyProcessed(accession = accessionsWithoutClaim.first()),
+        )
+            .andExpect(status().isNoContent)
+
+        convenienceClient.getSequenceEntry(accession = accessionsInProcessing.first(), version = 1)
+            .assertStatusIs(Status.PROCESSED)
+        convenienceClient.getSequenceEntry(accession = accessionsWithoutClaim.first(), version = 1)
+            .assertStatusIs(Status.RECEIVED)
+    }
+
     @Test
     fun `WHEN I submit a JSON entry with a missing field THEN returns bad request`() {
         val accession = prepareUnprocessedSequenceEntry()

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
@@ -43,6 +43,7 @@ import org.loculus.backend.controller.groupmanagement.GroupManagementControllerC
 import org.loculus.backend.controller.groupmanagement.andGetGroupId
 import org.loculus.backend.controller.jwtForDefaultUser
 import org.loculus.backend.service.files.FilesDatabaseService
+import org.loculus.backend.service.files.S3Service
 import org.loculus.backend.service.submission.AminoAcidSymbols
 import org.loculus.backend.service.submission.NucleotideSymbols
 import org.loculus.backend.service.submission.SubmissionDatabaseService
@@ -69,6 +70,7 @@ class SubmitProcessedDataEndpointTest(
     @Autowired val useNewerProcessingPipelineVersionTask: UseNewerProcessingPipelineVersionTask,
     @Autowired val submissionDatabaseService: SubmissionDatabaseService,
     @Autowired val filesDatabaseService: FilesDatabaseService,
+    @Autowired val s3Service: S3Service,
     @Autowired val objectMapper: ObjectMapper,
 ) {
 
@@ -351,6 +353,44 @@ class SubmitProcessedDataEndpointTest(
             .assertStatusIs(Status.PROCESSED)
         convenienceClient.getSequenceEntry(accession = accessionsWithoutClaim.first(), version = 1)
             .assertStatusIs(Status.RECEIVED)
+    }
+
+    // A discarded result must not publish its files, they end up referenced by nothing.
+    @Test
+    fun `WHEN a discarded result has files for a released entry THEN the files are not published`() {
+        val groupId = groupManagementClient
+            .createNewGroup(group = DEFAULT_GROUP, jwt = jwtForDefaultUser)
+            .andGetGroupId()
+        val accession = prepareUnprocessedSequenceEntry(DEFAULT_ORGANISM, groupId = groupId)
+
+        val fileV1 = filesClient.requestUploads(groupId = groupId, jwt = jwtForDefaultUser).andGetFileIdsAndUrls()[0]
+        convenienceClient.uploadFile(fileV1.presignedWriteUrl, "FileV1", fileV1.headers)
+        convenienceClient.extractUnprocessedData(pipelineVersion = 1)
+        submissionControllerClient.submitProcessedData(
+            PreparedProcessedData.withFiles(
+                accession,
+                mapOf("myFileCategory" to listOf(FileIdAndName(fileV1.fileId, "v1.txt"))),
+            ),
+            pipelineVersion = 1,
+        ).andExpect(status().isNoContent)
+        convenienceClient.approveProcessedSequenceEntries(listOf(AccessionVersion(accession, 1)))
+
+        // Pipeline version 2 submits a result for the released entry without holding a claim on it.
+        val fileV2 = filesClient.requestUploads(groupId = groupId, jwt = jwtForDefaultUser).andGetFileIdsAndUrls()[0]
+        convenienceClient.uploadFile(fileV2.presignedWriteUrl, "FileV2", fileV2.headers)
+        submissionControllerClient.submitProcessedData(
+            PreparedProcessedData.withFiles(
+                accession,
+                mapOf("myFileCategory" to listOf(FileIdAndName(fileV2.fileId, "v2.txt"))),
+            ),
+            pipelineVersion = 2,
+        ).andExpect(status().isNoContent)
+
+        val response = HttpClient.newHttpClient().send(
+            HttpRequest.newBuilder().uri(URI.create(s3Service.getPublicUrl(fileV2.fileId))).build(),
+            HttpResponse.BodyHandlers.ofString(),
+        )
+        assertThat(response.statusCode(), `is`(403))
     }
 
     @Test


### PR DESCRIPTION
Rethinking this PR I'm now not sure we need it - it only affects reprocessing where a 10min delay on a few sequences isn't a big deal.

Fixes #7128.

When a user edits a sequence entry (which is only allowed when the _current_ prepro version's entry is `PROCESSED`) we delet sequence_entries_preprocessed_data rows all pipeline versions of that accessionVersion. Preprocessing could already be underway for a a _higher_ prepro version than current, when that delete happens. When that pipeline then submits it would get a 422 for the whole batch which would only get reprocessed once the cleanup job clears them (10min for PPX).

This isn't so bad as it only happens during reprocessing - so not sure we need to make this change here.

### Changes

A result whose claim no longer exists is now discarded: WARN log, counted separately, and the summary line reads `Updated N sequences to PROCESSED, discarded M results whose claim was revoked`. The entry is handed out again and reprocessed, as it already was. Unknown accession versions and rows in an unexpected state still fail with 422.

`Updated 0, discarded 100` repeating would indicate a lease threshold set below batch duration.

Not addressed: the update has no fencing token, so two pods of the same pipeline version can still race an edit and land pre-edit data on a fresh claim. That needs a claim id in the protocol. However, this should be a very rare issue and it would resolve on the next reprocessing so it's not permanent.

### Alternatives considered

We could block editing a sequence when any entry greater or equal to current is `IN_PROCESSING` - however that would mean people could not edit while a reprocessing is in process which could be hours and is not a good user experience.

🚀 Preview: Add `preview` label to enable