### PR TITLE
chore(backend): migrate HTTP 422 title from UNPROCESSABLE_ENTITY to UNPROCESSABLE CONTENT (per RFC 9110)

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/controller/ExceptionHandler.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/ExceptionHandler.kt
@@ -63,12 +63,12 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
         ProcessingValidationException::class,
         DuplicateKeyException::class,
     )
-    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_CONTENT)
     fun handleUnprocessableEntityException(e: Exception): ResponseEntity<ProblemDetail> {
         log.info { "Caught unprocessable entity exception: ${e.message}" }
 
         return responseEntity(
-            HttpStatus.UNPROCESSABLE_ENTITY,
+            HttpStatus.UNPROCESSABLE_CONTENT,
             e.message,
         )
     }

--- a/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/SubmissionController.kt
@@ -205,7 +205,7 @@ open class SubmissionController(
             submissionMetrics.recordPollingRequest(
                 EXTRACT_UNPROCESSED_DATA_ENDPOINT,
                 organism.name,
-                HttpStatus.UNPROCESSABLE_ENTITY,
+                HttpStatus.UNPROCESSABLE_CONTENT,
                 requestStartNanos,
             )
             throw UnprocessableEntityException(

--- a/backend/src/test/kotlin/org/loculus/backend/controller/ExceptionHandlerTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/ExceptionHandlerTest.kt
@@ -75,7 +75,7 @@ class ExceptionHandlerTest(@Autowired val mockMvc: MockMvc) {
     }
 
     @Test
-    fun `GIVEN InvalidSequenceFileException is thrown THEN returns Unprocessable Content (422)`() {
+    fun `GIVEN UnprocessableEntityException is thrown THEN returns Unprocessable Content (422)`() {
         every { validControllerCall() } throws UnprocessableEntityException("SomeMessage")
 
         mockMvc.perform(validRequest)
@@ -86,7 +86,7 @@ class ExceptionHandlerTest(@Autowired val mockMvc: MockMvc) {
     }
 
     @Test
-    fun `GIVEN ProcessingException is thrown THEN returns Unprocessable Content (422)`() {
+    fun `GIVEN ProcessingValidationException is thrown THEN returns Unprocessable Content (422)`() {
         every { validControllerCall() } throws ProcessingValidationException("SomeMessage")
 
         mockMvc.perform(validRequest)

--- a/backend/src/test/kotlin/org/loculus/backend/controller/ExceptionHandlerTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/ExceptionHandlerTest.kt
@@ -75,24 +75,24 @@ class ExceptionHandlerTest(@Autowired val mockMvc: MockMvc) {
     }
 
     @Test
-    fun `GIVEN InvalidSequenceFileException is thrown THEN returns Unprocessable Entity (422)`() {
+    fun `GIVEN InvalidSequenceFileException is thrown THEN returns Unprocessable Content (422)`() {
         every { validControllerCall() } throws UnprocessableEntityException("SomeMessage")
 
         mockMvc.perform(validRequest)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
-            .andExpect(jsonPath("$.title").value("Unprocessable Entity"))
+            .andExpect(jsonPath("$.title").value("Unprocessable Content"))
             .andExpect(jsonPath("$.detail").value("SomeMessage"))
     }
 
     @Test
-    fun `GIVEN ProcessingException is thrown THEN returns Unprocessable Entity (422)`() {
+    fun `GIVEN ProcessingException is thrown THEN returns Unprocessable Content (422)`() {
         every { validControllerCall() } throws ProcessingValidationException("SomeMessage")
 
         mockMvc.perform(validRequest)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
-            .andExpect(jsonPath("$.title").value("Unprocessable Entity"))
+            .andExpect(jsonPath("$.title").value("Unprocessable Content"))
             .andExpect(jsonPath("$.detail").value("SomeMessage"))
     }
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/datauseterms/DataUseTermsControllerTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/datauseterms/DataUseTermsControllerTest.kt
@@ -94,7 +94,7 @@ class DataUseTermsControllerTest(
     @Test
     fun `GIVEN non-existing accessions WHEN setting new data use terms THEN return unprocessable entity`() {
         client.changeDataUseTerms(DEFAULT_DATA_USE_CHANGE_REQUEST)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail", containsString("Accessions 1, 2 do not exist")),
@@ -199,7 +199,7 @@ class DataUseTermsControllerTest(
             DataUseTermsTestCase(
                 setupDataUseTerms = DataUseTerms.Open,
                 newDataUseTerms = DataUseTerms.Open,
-                expectedStatus = status().isUnprocessableEntity,
+                expectedStatus = status().isUnprocessableContent,
                 expectedContentType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
                 expectedDetailContains = "The data use terms have already been set to 'Open'",
             ),
@@ -213,7 +213,7 @@ class DataUseTermsControllerTest(
             DataUseTermsTestCase(
                 setupDataUseTerms = DataUseTerms.Open,
                 newDataUseTerms = DataUseTerms.Restricted(dateMonthsFromNow(6)),
-                expectedStatus = status().isUnprocessableEntity,
+                expectedStatus = status().isUnprocessableContent,
                 expectedContentType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
                 expectedDetailContains = "Cannot change data use terms from OPEN to RESTRICTED.",
             ),
@@ -228,7 +228,7 @@ class DataUseTermsControllerTest(
             DataUseTermsTestCase(
                 setupDataUseTerms = DataUseTerms.Restricted(dateMonthsFromNow(6)),
                 newDataUseTerms = DataUseTerms.Restricted(dateMonthsFromNow(7)),
-                expectedStatus = status().isUnprocessableEntity,
+                expectedStatus = status().isUnprocessableContent,
                 expectedContentType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
                 expectedDetailContains = "Cannot extend restricted data use period. " +
                     "Please choose a date before ${dateMonthsFromNow(6)}.",

--- a/backend/src/test/kotlin/org/loculus/backend/controller/debug/DeleteAllSequenceDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/debug/DeleteAllSequenceDataEndpointTest.kt
@@ -135,7 +135,7 @@ class DeleteAllSequenceDataEndpointTest(
 
         useNewerProcessingPipelineVersionTask.task()
         submissionControllerClient.extractUnprocessedData(numberOfSequenceEntries = 1, pipelineVersion = 1)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
 
         deleteAllSequences(jwtForSuperUser)
             .andExpect(status().isNoContent)

--- a/backend/src/test/kotlin/org/loculus/backend/controller/files/CompleteMultipartUploadEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/files/CompleteMultipartUploadEndpointTest.kt
@@ -60,7 +60,7 @@ class CompleteMultipartUploadEndpointTest(
             .andGetFileIdsAndMultipartUrls()[0]
 
         filesClient.completeMultipartUploads(listOf(FileIdAndEtags(fileIdAndUrls.fileId, emptyList())))
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().string(containsString("No etags provided")))
     }
 
@@ -75,7 +75,7 @@ class CompleteMultipartUploadEndpointTest(
         val wrongEtag2 = (if (etag2[0] != 'a') 'a' else 'b') + etag2.substring(1)
 
         filesClient.completeMultipartUploads(listOf(FileIdAndEtags(fileIdAndUrls.fileId, listOf(etag1, wrongEtag2))))
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().string(containsString("InvalidPart")))
     }
 
@@ -89,7 +89,7 @@ class CompleteMultipartUploadEndpointTest(
             .headers().map()["etag"]!![0]
 
         filesClient.completeMultipartUploads(listOf(FileIdAndEtags(fileIdAndUrls.fileId, listOf(etag1, etag2))))
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().string(containsString("EntityTooSmall")))
     }
 }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/CitationEndpointsTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/CitationEndpointsTest.kt
@@ -128,7 +128,7 @@ class CitationEndpointsTest(
             )
 
         client.deleteSeqSet(seqSetId, seqSetVersion)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -342,7 +342,7 @@ class CitationEndpointsTest(
             sourceDOI = "10.5678/crossref-paper",
             seqSetAccessionVersions = listOf("$seqSetId.$seqSetVersion"),
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
 
         // The citation must still be reported as CrossRef-origin, untouched by the rejected request.
         client.getAllSeqSetCitations()
@@ -410,7 +410,7 @@ class CitationEndpointsTest(
         seqSetCrossRefCitationsTask.task()
 
         client.deleteSeqSetCitation(sourceDOI = "10.5678/crossref-paper")
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
     }
 
     @Test

--- a/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/SeqSetEndpointsTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/SeqSetEndpointsTest.kt
@@ -200,7 +200,7 @@ class SeqSetEndpointsTest(@Autowired private val client: SeqSetCitationsControll
             .andExpect(status().isOk)
 
         client.deleteSeqSet(seqSetId, 1)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(

--- a/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/SeqSetValidationEndpointsTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/seqsetcitations/SeqSetValidationEndpointsTest.kt
@@ -40,7 +40,7 @@ class SeqSetValidationEndpointsTest(
     fun `WHEN calling validate seqSet records with non-existing accessions THEN returns unprocessable entity`() {
         val accessionJson = """[{"accession": "ABCD", "type": "loculus"}]"""
         client.validateSeqSetRecords(seqSetRecords = accessionJson)
-            .andExpect(status().isUnprocessableEntity())
+            .andExpect(status().isUnprocessableContent())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -51,7 +51,7 @@ class SeqSetValidationEndpointsTest(
 
         val accessionVersionJson = """[{"accession": "ABCD.1", "type": "loculus"}]"""
         client.validateSeqSetRecords(seqSetRecords = accessionVersionJson)
-            .andExpect(status().isUnprocessableEntity())
+            .andExpect(status().isUnprocessableContent())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -65,7 +65,7 @@ class SeqSetValidationEndpointsTest(
     fun `WHEN calling validate seqSet records with invalid status accessions THEN returns unprocessable entity`() {
         val accessionJson = """[{"accession": "ABCD.EF", "type": "loculus"}]"""
         client.validateSeqSetRecords(seqSetRecords = accessionJson)
-            .andExpect(status().isUnprocessableEntity())
+            .andExpect(status().isUnprocessableContent())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -84,7 +84,7 @@ class SeqSetValidationEndpointsTest(
         val accessionJson = """[{"accession": "$invalidAccession", "type": "loculus"}]"""
 
         client.validateSeqSetRecords(seqSetRecords = accessionJson)
-            .andExpect(status().isUnprocessableEntity())
+            .andExpect(status().isUnprocessableContent())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -105,7 +105,7 @@ class SeqSetValidationEndpointsTest(
             {"accession": "$validAccession", "type": "loculus"}
         ]"""
         client.validateSeqSetRecords(seqSetRecords = accessionJson)
-            .andExpect(status().isUnprocessableEntity())
+            .andExpect(status().isUnprocessableContent())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -127,7 +127,7 @@ class SeqSetValidationEndpointsTest(
     @Test
     fun `WHEN writing seqSet with missing name THEN returns unprocessable entity`() {
         client.createSeqSet(seqSetName = "")
-            .andExpect(status().isUnprocessableEntity())
+            .andExpect(status().isUnprocessableContent())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -136,7 +136,7 @@ class SeqSetValidationEndpointsTest(
                 ),
             )
         client.updateSeqSet(seqSetName = "")
-            .andExpect(status().isUnprocessableEntity())
+            .andExpect(status().isUnprocessableContent())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -157,7 +157,7 @@ class SeqSetValidationEndpointsTest(
         val seqSetId = JsonPath.read<String>(seqSetResult.response.contentAsString, "$.seqSetId")
 
         client.updateSeqSet(seqSetId = seqSetId, seqSetRecords = accessionJson)
-            .andExpect(status().isUnprocessableEntity())
+            .andExpect(status().isUnprocessableContent())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -170,7 +170,7 @@ class SeqSetValidationEndpointsTest(
     @Test
     fun `WHEN writing seqSet with missing records THEN returns unprocessable entity`() {
         client.createSeqSet(seqSetRecords = "[]")
-            .andExpect(status().isUnprocessableEntity())
+            .andExpect(status().isUnprocessableContent())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -179,7 +179,7 @@ class SeqSetValidationEndpointsTest(
                 ),
             )
         client.updateSeqSet(seqSetRecords = "[]")
-            .andExpect(status().isUnprocessableEntity())
+            .andExpect(status().isUnprocessableContent())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -207,7 +207,7 @@ class SeqSetValidationEndpointsTest(
             createSeqSetWithDOI(accessionJson)
         }
         createSeqSetWithDOI(accessionJson)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ApproveProcessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ApproveProcessedDataEndpointTest.kt
@@ -138,7 +138,7 @@ class ApproveProcessedDataEndpointTest(
                 AccessionVersion(nonExistentAccession, 1),
             ),
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(jsonPath("$.detail", containsString("Accession versions $nonExistentAccession.1 do not exist")))
 
@@ -158,7 +158,7 @@ class ApproveProcessedDataEndpointTest(
                 nonExistingVersion,
             ),
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -188,7 +188,7 @@ class ApproveProcessedDataEndpointTest(
             scope = ALL,
             accessionVersionsInCorrectState + accessionVersionNotInCorrectState,
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -219,7 +219,7 @@ class ApproveProcessedDataEndpointTest(
             defaultOrganismData.getAccessionVersions() + otherOrganismData.getAccessionVersions(),
             organism = OTHER_ORGANISM,
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("$.detail")
@@ -349,7 +349,7 @@ class ApproveProcessedDataEndpointTest(
             scope = WITHOUT_WARNINGS,
             accessionVersionsFilter = listOf(AccessionVersion(accessionOfDataWithErrors, 1)),
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/DeleteSequencesEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/DeleteSequencesEndpointTest.kt
@@ -110,7 +110,7 @@ class DeleteSequencesEndpointTest(
             accessionVersionsToDelete.sortedWith(AccessionVersionComparator).joinToString(", ") {
                 "${it.accession}.${it.version} - ${it.status}"
             }
-        deletionResult.andExpect(status().isUnprocessableEntity)
+        deletionResult.andExpect(status().isUnprocessableContent)
             .andExpect(
                 content().contentType(MediaType.APPLICATION_PROBLEM_JSON),
             )
@@ -136,7 +136,7 @@ class DeleteSequencesEndpointTest(
             scope = ALL,
             accessionVersionsFilter = listOf(nonExistingAccession, nonExistingVersion),
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -257,7 +257,7 @@ class DeleteSequencesEndpointTest(
             accessionVersionsFilter = listOf(accessionVersion.toAccessionVersion()),
             organism = OTHER_ORGANISM,
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail", containsString("accession versions are not of organism $OTHER_ORGANISM:")),

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetDataToEditEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetDataToEditEndpointTest.kt
@@ -62,7 +62,7 @@ class GetDataToEditEndpointTest(
         val nonExistentAccession = "DefinitelyNotExisting"
 
         client.getSequenceEntryToEdit(nonExistentAccession, 1)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
@@ -82,7 +82,7 @@ class GetDataToEditEndpointTest(
         client.getSequenceEntryToEdit(firstAccession, 1, organism = DEFAULT_ORGANISM)
             .andExpect(status().isOk)
         client.getSequenceEntryToEdit(firstAccession, 1, organism = OTHER_ORGANISM)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
@@ -100,7 +100,7 @@ class GetDataToEditEndpointTest(
         convenienceClient.prepareDataTo(Status.PROCESSED, errors = true)
 
         client.getSequenceEntryToEdit("1", nonExistentAccessionVersion)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
@@ -151,7 +151,7 @@ class GetDataToEditEndpointTest(
             .first()
 
         client.getSequenceEntryToEdit(accessionVersion.accession, accessionVersion.version)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(jsonPath("\$.detail", containsString("is a revocation")))
     }
 }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetSubmittedMetadataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetSubmittedMetadataEndpointTest.kt
@@ -209,7 +209,7 @@ class GetSubmittedMetadataEndpointTest(
     fun `WHEN I filter by accessionVersions with invalid format THEN returns 422`() {
         submissionControllerClient.getSubmittedMetadata(
             accessionVersionsFilter = listOf("not-a-valid-accession-version"),
-        ).andExpect(status().isUnprocessableEntity)
+        ).andExpect(status().isUnprocessableContent)
     }
 
     // Regression test for https://github.com/loculus-project/loculus/issues/4036

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ReviseEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ReviseEndpointTest.kt
@@ -181,7 +181,7 @@ class ReviseEndpointTest(
                 """.trimIndent(),
             ),
             SubmitFiles.sequenceFileWith(),
-        ).andExpect(status().isUnprocessableEntity)
+        ).andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
@@ -206,7 +206,7 @@ class ReviseEndpointTest(
                 """.trimIndent(),
             ),
             SubmitFiles.sequenceFileWith(),
-        ).andExpect(status().isUnprocessableEntity)
+        ).andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
@@ -226,7 +226,7 @@ class ReviseEndpointTest(
             DefaultFiles.sequencesFileMultiSegmented,
             organism = OTHER_ORGANISM,
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
@@ -263,7 +263,7 @@ class ReviseEndpointTest(
             DefaultFiles.getRevisedMetadataFile(accessions),
             DefaultFiles.sequencesFile,
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -386,7 +386,7 @@ class ReviseEndpointTest(
             ),
             DefaultFiles.sequencesFile,
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -419,7 +419,7 @@ class ReviseEndpointTest(
             ),
             DefaultFiles.sequencesFile,
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -456,7 +456,7 @@ class ReviseEndpointTest(
             ),
             DefaultFiles.sequencesFile,
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -567,8 +567,8 @@ class ReviseEndpointTest(
                     """.trimIndent(),
                 ),
                 SubmitFiles.sequenceFileWith(),
-                status().isUnprocessableEntity,
-                "Unprocessable Entity",
+                status().isUnprocessableContent,
+                "Unprocessable Content",
                 "contains no value for 'id'",
             ),
             Arguments.of(
@@ -580,8 +580,8 @@ class ReviseEndpointTest(
                     """.trimIndent(),
                 ),
                 SubmitFiles.sequenceFileWith(),
-                status().isUnprocessableEntity,
-                "Unprocessable Entity",
+                status().isUnprocessableContent,
+                "Unprocessable Content",
                 "The metadata file does not contain either header 'id' or 'submissionId'",
             ),
             Arguments.of(
@@ -594,8 +594,8 @@ class ReviseEndpointTest(
                     """.trimIndent(),
                 ),
                 SubmitFiles.sequenceFileWith(),
-                status().isUnprocessableEntity,
-                "Unprocessable Entity",
+                status().isUnprocessableContent,
+                "Unprocessable Content",
                 "Duplicate submission_id found in metadata file: sameHeader",
             ),
             Arguments.of(
@@ -609,8 +609,8 @@ class ReviseEndpointTest(
                             AC
                     """.trimIndent(),
                 ),
-                status().isUnprocessableEntity,
-                "Unprocessable Entity",
+                status().isUnprocessableContent,
+                "Unprocessable Content",
                 "Sequence file contains at least one duplicate submissionId",
             ),
             Arguments.of(
@@ -631,8 +631,8 @@ class ReviseEndpointTest(
                             AC
                     """.trimIndent(),
                 ),
-                status().isUnprocessableEntity,
-                "Unprocessable Entity",
+                status().isUnprocessableContent,
+                "Unprocessable Content",
                 "Sequence file contains 2 FASTA ids that are not present in the metadata file: 'notInMetadata', 'notInMetadata2'",
             ),
             Arguments.of(
@@ -650,8 +650,8 @@ class ReviseEndpointTest(
                             AC
                     """.trimIndent(),
                 ),
-                status().isUnprocessableEntity,
-                "Unprocessable Entity",
+                status().isUnprocessableContent,
+                "Unprocessable Content",
                 "Metadata file contains 1 FASTA ids that are not present in the sequence file: 'notInSequences'",
             ),
             Arguments.of(
@@ -664,8 +664,8 @@ class ReviseEndpointTest(
                     """.trimIndent(),
                 ),
                 SubmitFiles.sequenceFileWith(),
-                status().isUnprocessableEntity,
-                "Unprocessable Entity",
+                status().isUnprocessableContent,
+                "Unprocessable Content",
                 "The revised metadata file does not contain the header 'accession'",
             ),
             Arguments.of(
@@ -678,8 +678,8 @@ class ReviseEndpointTest(
                     """.trimIndent(),
                 ),
                 SubmitFiles.sequenceFileWith(),
-                status().isUnprocessableEntity,
-                "Unprocessable Entity",
+                status().isUnprocessableContent,
+                "Unprocessable Content",
                 "contains no value for 'accession'",
             ),
         )

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/RevokeEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/RevokeEndpointTest.kt
@@ -67,7 +67,7 @@ class RevokeEndpointTest(
 
         val nonExistingAccession = "123"
         client.revokeSequenceEntries(listOf(nonExistingAccession))
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
@@ -82,7 +82,7 @@ class RevokeEndpointTest(
             .prepareDefaultSequenceEntriesToApprovedForRelease(organism = DEFAULT_ORGANISM).map { it.accession }
 
         client.revokeSequenceEntries(listOf(accessions.first()), organism = OTHER_ORGANISM)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
@@ -132,7 +132,7 @@ class RevokeEndpointTest(
         val accessions = convenienceClient.prepareDefaultSequenceEntriesToHasErrors().map { it.accession }
 
         client.revokeSequenceEntries(accessions)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEditedSequenceEntryVersionEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEditedSequenceEntryVersionEndpointTest.kt
@@ -117,7 +117,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
         val sequenceString = editedDataWithNonExistingVersion.displayAccessionVersion()
 
         client.submitEditedSequenceEntryVersion(editedDataWithNonExistingVersion)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(
                 jsonPath("\$.detail")
                     .value("Accession versions $sequenceString do not exist"),
@@ -137,7 +137,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
         val editedDataWithNonExistingAccession = generateEditedData(nonExistingAccession)
 
         client.submitEditedSequenceEntryVersion(editedDataWithNonExistingAccession)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(
                 jsonPath("\$.detail").value(
                     "Accession versions $nonExistingAccession.1 do not exist",
@@ -160,7 +160,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
         val editedData = generateEditedData(accessions.first())
 
         client.submitEditedSequenceEntryVersion(editedData, organism = OTHER_ORGANISM)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -230,7 +230,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
         )
 
         client.submitEditedSequenceEntryVersion(editedData)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(
                 jsonPath("\$.detail", containsString("duplicate file names")),
             )
@@ -256,7 +256,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
         )
 
         client.submitEditedSequenceEntryVersion(editedData)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -286,7 +286,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
         )
 
         client.submitEditedSequenceEntryVersion(editedData)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(
                 jsonPath(
                     "\$.detail",
@@ -320,7 +320,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
         )
 
         client.submitEditedSequenceEntryVersion(editedData)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(
                 jsonPath("\$.detail", containsString("No file uploaded for file ID")),
             )
@@ -383,7 +383,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
         )
 
         client.submitEditedSequenceEntryVersion(editedData)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(
                 jsonPath(
                     "\$.detail",

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
@@ -77,7 +77,7 @@ class SubmitEndpointFileSharingTest(
             organism = DEFAULT_ORGANISM,
             groupId = groupId,
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -136,7 +136,7 @@ class SubmitEndpointFileSharingTest(
             organism = DEFAULT_ORGANISM,
             groupId = groupId,
         )
-            .andExpect(status().isUnprocessableEntity())
+            .andExpect(status().isUnprocessableContent())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -160,7 +160,7 @@ class SubmitEndpointFileSharingTest(
             organism = DEFAULT_ORGANISM,
             groupId = groupId,
         )
-            .andExpect(status().isUnprocessableEntity())
+            .andExpect(status().isUnprocessableContent())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(
@@ -185,7 +185,7 @@ class SubmitEndpointFileSharingTest(
             organism = DEFAULT_ORGANISM,
             groupId = groupId,
         )
-            .andExpect(status().isUnprocessableEntity())
+            .andExpect(status().isUnprocessableContent())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath(

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
@@ -366,8 +366,8 @@ class SubmitEndpointTest(
                         """.trimIndent(),
                     ),
                     DefaultFiles.sequencesFile,
-                    status().isUnprocessableEntity,
-                    "Unprocessable Entity",
+                    status().isUnprocessableContent,
+                    "Unprocessable Content",
                     "contains no value for 'id'",
                     DEFAULT_ORGANISM,
                     DataUseTerms.Open,
@@ -381,8 +381,8 @@ class SubmitEndpointTest(
                         """.trimIndent(),
                     ),
                     DefaultFiles.sequencesFile,
-                    status().isUnprocessableEntity,
-                    "Unprocessable Entity",
+                    status().isUnprocessableContent,
+                    "Unprocessable Content",
                     "The metadata file does not contain either header 'id' or 'submissionId'",
                     DEFAULT_ORGANISM,
                     DataUseTerms.Open,
@@ -397,8 +397,8 @@ class SubmitEndpointTest(
                         """.trimIndent(),
                     ),
                     DefaultFiles.sequencesFile,
-                    status().isUnprocessableEntity,
-                    "Unprocessable Entity",
+                    status().isUnprocessableContent,
+                    "Unprocessable Content",
                     "Metadata file contains at least one duplicate submissionId",
                     DEFAULT_ORGANISM,
                     DataUseTerms.Open,
@@ -414,8 +414,8 @@ class SubmitEndpointTest(
                             AC
                         """.trimIndent(),
                     ),
-                    status().isUnprocessableEntity,
-                    "Unprocessable Entity",
+                    status().isUnprocessableContent,
+                    "Unprocessable Content",
                     "Sequence file contains at least one duplicate submissionId",
                     DEFAULT_ORGANISM,
                     DataUseTerms.Open,
@@ -436,8 +436,8 @@ class SubmitEndpointTest(
                             AC
                         """.trimIndent(),
                     ),
-                    status().isUnprocessableEntity,
-                    "Unprocessable Entity",
+                    status().isUnprocessableContent,
+                    "Unprocessable Content",
                     "Sequence file contains 1 FASTA ids that are not present in the metadata file: 'notInMetadata'",
                     DEFAULT_ORGANISM,
                     DataUseTerms.Open,
@@ -457,8 +457,8 @@ class SubmitEndpointTest(
                             AC
                         """.trimIndent(),
                     ),
-                    status().isUnprocessableEntity,
-                    "Unprocessable Entity",
+                    status().isUnprocessableContent,
+                    "Unprocessable Content",
                     "Metadata file contains 1 FASTA ids that are not present in the sequence file: 'notInSequences'",
                     DEFAULT_ORGANISM,
                     DataUseTerms.Open,
@@ -540,7 +540,7 @@ class SubmitEndpointTest(
             sequencesFile,
             groupId = groupId,
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitExternalMetadataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitExternalMetadataEndpointTest.kt
@@ -104,7 +104,7 @@ class SubmitExternalMetadataEndpointTest(
                 PreparedExternalMetadata.successfullySubmitted(accession = accession),
                 externalMetadataUpdater = "other_db",
             )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail")
@@ -124,7 +124,7 @@ class SubmitExternalMetadataEndpointTest(
             .submitExternalMetadata(
                 PreparedExternalMetadata.successfullySubmitted(accession = accession),
             )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail")
@@ -147,7 +147,7 @@ class SubmitExternalMetadataEndpointTest(
             .submitExternalMetadata(
                 PreparedExternalMetadata.successfullySubmitted(accession = accession),
             )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail")

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
@@ -247,7 +247,7 @@ class SubmitProcessedDataEndpointTest(
         submissionControllerClient.submitProcessedData(
             invalidDataScenario.processedDataThatNeedsAValidAccession.copy(accession = accessions.first()),
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(jsonPath("\$.detail").value(invalidDataScenario.expectedErrorMessage))
 
@@ -268,7 +268,7 @@ class SubmitProcessedDataEndpointTest(
             PreparedProcessedData.successfullyProcessed(accession = accessions.first()),
             PreparedProcessedData.successfullyProcessed(accession = nonExistentAccession),
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail")
@@ -294,7 +294,7 @@ class SubmitProcessedDataEndpointTest(
             PreparedProcessedData.successfullyProcessed(accession = accessions.first())
                 .copy(version = nonExistentVersion),
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
@@ -319,7 +319,7 @@ class SubmitProcessedDataEndpointTest(
             PreparedProcessedData.successfullyProcessed(accession = accessionsInProcessing.first()),
             PreparedProcessedData.successfullyProcessed(accession = accessionsNotInProcessing.first()),
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
@@ -366,7 +366,7 @@ class SubmitProcessedDataEndpointTest(
             PreparedProcessedData.successfullyProcessed(accession = accession),
             organism = DEFAULT_ORGANISM,
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail")
@@ -387,7 +387,7 @@ class SubmitProcessedDataEndpointTest(
             PreparedProcessedData.successfullyProcessedOtherOrganismData(accession = defaultOrganismAccession),
             organism = DEFAULT_ORGANISM,
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(
                 jsonPath("\$.detail").value("Unknown fields in metadata: specialOtherField."),
             )
@@ -468,7 +468,7 @@ class SubmitProcessedDataEndpointTest(
                 ),
             ),
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(
                 jsonPath(
                     "$.detail",
@@ -500,7 +500,7 @@ class SubmitProcessedDataEndpointTest(
                 ),
             ),
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
     }
 
     @Test
@@ -521,7 +521,7 @@ class SubmitProcessedDataEndpointTest(
                 ),
             ),
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(jsonPath("$.detail", containsString("not part of the configured output categories")))
     }
 
@@ -544,7 +544,7 @@ class SubmitProcessedDataEndpointTest(
                 ),
             ),
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(jsonPath("$.detail", containsString("duplicate file names")))
     }
 
@@ -566,7 +566,7 @@ class SubmitProcessedDataEndpointTest(
                 ),
             ),
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(
                 jsonPath(
                     "$.detail",
@@ -599,7 +599,7 @@ class SubmitProcessedDataEndpointTest(
                 ),
             ),
         )
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
             .andExpect(
                 jsonPath(
                     "$.detail",

--- a/backend/src/test/kotlin/org/loculus/backend/service/submission/UseNewerProcessingPipelineVersionTaskTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/submission/UseNewerProcessingPipelineVersionTaskTest.kt
@@ -61,7 +61,7 @@ class UseNewerProcessingPipelineVersionTaskTest(
         assertThat(submissionDatabaseService.getCurrentProcessingPipelineVersion(Organism(DEFAULT_ORGANISM)), `is`(3L))
 
         submissionControllerClient.extractUnprocessedData(numberOfSequenceEntries = 10, pipelineVersion = 2)
-            .andExpect(status().isUnprocessableEntity)
+            .andExpect(status().isUnprocessableContent)
     }
 
     @Suppress("ktlint:standard:max-line-length")

--- a/website/src/services/backendClient.spec.ts
+++ b/website/src/services/backendClient.spec.ts
@@ -22,7 +22,7 @@ describe('BackendClient', () => {
     test('returns a ProblemDetail received from the backend', async () => {
         const problemDetail: ProblemDetail = {
             type: 'about:blank',
-            title: 'Unprocessable Entity',
+            title: 'Unprocessable Content',
             status: 422,
             detail: "Invalid accession version format 'LOC_SS_1'",
         };


### PR DESCRIPTION
Fix backend warnings `'val isUnprocessableEntity: ResultMatcher' is deprecated. Deprecated in Java.`

Spring Framework 7 (Boot 4.1.0) follows [RFC 9110 §15.5.21](https://www.rfc-editor.org/rfc/rfc9110#name-422-unprocessable-content) in renaming HTTP 422 from *Unprocessable Entity* to *Unprocessable Content*.

⚠️ Note: the 422 response `title` changes, in line with RFC 9110

```diff
 {
   "type": "about:blank",
-  "title": "Unprocessable Entity",
+  "title": "Unprocessable Content",
   "status": 422,
   "detail": "..."
 }
```

🚀 Preview: https://chore-spring7-unprocessab.loculus.org