### PR TITLE
chore(backend): silence JNA restricted-method warning in tests

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -123,6 +123,11 @@ tasks.named('test') {
         dependsOn checkDocker
     }
     useJUnitPlatform()
+    // Testcontainers uses JNA to talk to the Docker daemon, which calls the restricted
+    // System::load. Without this, every test run prints "WARNING: A restricted method in
+    // java.lang.System has been called"; from a future JDK the call would be blocked outright.
+    // See JEP 472: https://openjdk.org/jeps/472
+    jvmArgs '--enable-native-access=ALL-UNNAMED'
     testLogging {
         events TestLogEvent.FAILED, TestLogEvent.STANDARD_ERROR
         exceptionFormat = TestExceptionFormat.FULL

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -123,10 +123,6 @@ tasks.named('test') {
         dependsOn checkDocker
     }
     useJUnitPlatform()
-    // Testcontainers uses JNA to talk to the Docker daemon, which calls the restricted
-    // System::load. Without this, every test run prints "WARNING: A restricted method in
-    // java.lang.System has been called"; from a future JDK the call would be blocked outright.
-    // See JEP 472: https://openjdk.org/jeps/472
     jvmArgs '--enable-native-access=ALL-UNNAMED'
     testLogging {
         events TestLogEvent.FAILED, TestLogEvent.STANDARD_ERROR


### PR DESCRIPTION
## Problem

Every backend test run on CI prints:

```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by com.sun.jna.Native in an unnamed module (file:.../jna-5.18.1.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```

Testcontainers talks to the Docker daemon via docker-java, which uses JNA, which calls the restricted `java.lang.System::load`. Under [JEP 472](https://openjdk.org/jeps/472) this is a warning on JDK 25 and will become a hard error in a future JDK unless native access is granted explicitly.

## Fix

Pass `--enable-native-access=ALL-UNNAMED` to the test JVM in `backend/build.gradle`.

We've already done the same thing for the backend image:
- https://github.com/loculus-project/loculus/pull/6462


🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable