### PR TITLE
chore(backend): run tests with compact object headers, as production does

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -130,10 +130,9 @@ tasks.named('test') {
     // java.lang.System has been called"; from a future JDK the call would be blocked outright.
     // See JEP 472: https://openjdk.org/jeps/472
     jvmArgs '--enable-native-access=ALL-UNNAMED'
+    
     // Run tests with the same object layout as production
     jvmArgs '-XX:+UseCompactObjectHeaders'
-    
-    jvmArgs '--enable-native-access=ALL-UNNAMED'
 
     testLogging {
         events TestLogEvent.FAILED, TestLogEvent.STANDARD_ERROR

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -128,12 +128,7 @@ tasks.named('test') {
     // java.lang.System has been called"; from a future JDK the call would be blocked outright.
     // See JEP 472: https://openjdk.org/jeps/472
     jvmArgs '--enable-native-access=ALL-UNNAMED'
-    // Run tests with the same object layout as production, so that layout-sensitive
-    // breakage (libraries reading field offsets via Unsafe/VarHandle) shows up in CI
-    // rather than in a pod. Keep in sync with JVM_OPTS in
-    // kubernetes/loculus/templates/loculus-backend.yaml.
-    // Only semantics-affecting flags belong here; the heap-sizing flags set in
-    // production tune footprint for long-lived pods and would only slow tests down.
+    // Run tests with the same object layout as production
     jvmArgs '-XX:+UseCompactObjectHeaders'
     testLogging {
         events TestLogEvent.FAILED, TestLogEvent.STANDARD_ERROR

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -123,6 +123,11 @@ tasks.named('test') {
         dependsOn checkDocker
     }
     useJUnitPlatform()
+    // Testcontainers uses JNA to talk to the Docker daemon, which calls the restricted
+    // System::load. Without this, every test run prints "WARNING: A restricted method in
+    // java.lang.System has been called"; from a future JDK the call would be blocked outright.
+    // See JEP 472: https://openjdk.org/jeps/472
+    jvmArgs '--enable-native-access=ALL-UNNAMED'
     testLogging {
         events TestLogEvent.FAILED, TestLogEvent.STANDARD_ERROR
         exceptionFormat = TestExceptionFormat.FULL

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -128,6 +128,13 @@ tasks.named('test') {
     // java.lang.System has been called"; from a future JDK the call would be blocked outright.
     // See JEP 472: https://openjdk.org/jeps/472
     jvmArgs '--enable-native-access=ALL-UNNAMED'
+    // Run tests with the same object layout as production, so that layout-sensitive
+    // breakage (libraries reading field offsets via Unsafe/VarHandle) shows up in CI
+    // rather than in a pod. Keep in sync with JVM_OPTS in
+    // kubernetes/loculus/templates/loculus-backend.yaml.
+    // Only semantics-affecting flags belong here; the heap-sizing flags set in
+    // production tune footprint for long-lived pods and would only slow tests down.
+    jvmArgs '-XX:+UseCompactObjectHeaders'
     testLogging {
         events TestLogEvent.FAILED, TestLogEvent.STANDARD_ERROR
         exceptionFormat = TestExceptionFormat.FULL

--- a/kubernetes/loculus/templates/loculus-backend.yaml
+++ b/kubernetes/loculus/templates/loculus-backend.yaml
@@ -97,9 +97,8 @@ spec:
               {{- .Values.backendExtraArgs | toYaml | nindent 12 }}
             {{- end }}
           env:
-            # If a flag here changes object layout or other observable JVM semantics,
-            # mirror it in the test task in backend/build.gradle so CI exercises the
-            # same layout. Pure heap/GC tuning does not need mirroring.
+            # If a flag in JVM_OPTS below changes object layout or other observable JVM
+            # semantics, mirror it in the test task in backend/build.gradle
             - name: JVM_OPTS
               value: -XX:+UseContainerSupport -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxHeapFreeRatio=5 -XX:MinHeapFreeRatio=2
           {{- if $.Values.seqSets.crossRef }}

--- a/kubernetes/loculus/templates/loculus-backend.yaml
+++ b/kubernetes/loculus/templates/loculus-backend.yaml
@@ -97,6 +97,9 @@ spec:
               {{- .Values.backendExtraArgs | toYaml | nindent 12 }}
             {{- end }}
           env:
+            # If a flag here changes object layout or other observable JVM semantics,
+            # mirror it in the test task in backend/build.gradle so CI exercises the
+            # same layout. Pure heap/GC tuning does not need mirroring.
             - name: JVM_OPTS
               value: -XX:+UseContainerSupport -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxHeapFreeRatio=5 -XX:MinHeapFreeRatio=2
           {{- if $.Values.seqSets.crossRef }}


### PR DESCRIPTION
Production runs the backend with `-XX:+UseCompactObjectHeaders` ([`kubernetes/loculus/templates/loculus-backend.yaml`](../blob/main/kubernetes/loculus/templates/loculus-backend.yaml), `JVM_OPTS`):

```
-XX:+UseContainerSupport -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxHeapFreeRatio=5 -XX:MinHeapFreeRatio=2
```

Compact object headers shrink the object header from 12 to 8 bytes, which changes field offsets and object layout. It's a product (no longer experimental) flag in JDK 25 and defaults to off.

The test JVM did not set it, so tests ran against a memory layout production never uses, and production ran a layout CI never tested. Layout-sensitive breakage — a library reading field offsets via `Unsafe`/`VarHandle` — would surface in a pod rather than in CI.

🚀 Preview: Add `preview` label to enable