### PR TITLE
chore(backend): silence Byte Buddy agent and Unsafe warnings in tests

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -123,6 +123,16 @@ tasks.named('test') {
         dependsOn checkDocker
     }
     useJUnitPlatform()
+    // https://github.com/mockk/mockk/pull/1550
+    doFirst {
+        def agentJar = configurations.testRuntimeClasspath.find { it.name.startsWith('byte-buddy-agent-') }
+        if (agentJar == null) {
+            throw new GradleException("byte-buddy-agent jar not found on testRuntimeClasspath")
+        }
+        jvmArgs "-javaagent:$agentJar"
+    }
+    // https://github.com/raphw/byte-buddy/issues/1922
+    jvmArgs '--sun-misc-unsafe-memory-access=allow'
     testLogging {
         events TestLogEvent.FAILED, TestLogEvent.STANDARD_ERROR
         exceptionFormat = TestExceptionFormat.FULL

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -136,6 +136,9 @@ tasks.named('test') {
     if (JavaVersion.current().isCompatibleWith(JavaVersion.toVersion(24))) {
         jvmArgs '--sun-misc-unsafe-memory-access=allow'
     }
+    // Same reason as org.gradle.jvmargs in gradle.properties, but for the forked test JVM:
+    // https://github.com/gradle/gradle/issues/19989
+    jvmArgs '-Xshare:off'
     testLogging {
         events TestLogEvent.FAILED, TestLogEvent.STANDARD_ERROR
         exceptionFormat = TestExceptionFormat.FULL

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -125,11 +125,12 @@ tasks.named('test') {
     useJUnitPlatform()
     // https://github.com/mockk/mockk/pull/1550
     doFirst {
-        def agentJar = configurations.testRuntimeClasspath.find { it.name.startsWith('byte-buddy-agent-') }
-        if (agentJar == null) {
-            throw new GradleException("byte-buddy-agent jar not found on testRuntimeClasspath")
+        def agentJar = configurations.testRuntimeClasspath.files.find { it.name.startsWith('byte-buddy-agent-') }
+        if (agentJar != null) {
+            jvmArgs "-javaagent:${agentJar.absolutePath}"
+        } else {
+            logger.warn("byte-buddy-agent jar not found on testRuntimeClasspath; running tests without -javaagent")
         }
-        jvmArgs "-javaagent:$agentJar"
     }
     // https://github.com/raphw/byte-buddy/issues/1922
     jvmArgs '--sun-misc-unsafe-memory-access=allow'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -138,7 +138,7 @@ tasks.named('test') {
     // https://github.com/raphw/byte-buddy/issues/1922
     if (JavaVersion.current().isCompatibleWith(JavaVersion.toVersion(24))) {
         jvmArgs '--sun-misc-unsafe-memory-access=allow'
-    }
+    jvmArgs '--sun-misc-unsafe-memory-access=allow'
     
     // Same reason as org.gradle.jvmargs in gradle.properties, but for the forked test JVM:
     // https://github.com/gradle/gradle/issues/19989

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -136,8 +136,6 @@ tasks.named('test') {
     }
     
     // https://github.com/raphw/byte-buddy/issues/1922
-    if (JavaVersion.current().isCompatibleWith(JavaVersion.toVersion(24))) {
-        jvmArgs '--sun-misc-unsafe-memory-access=allow'
     jvmArgs '--sun-misc-unsafe-memory-access=allow'
     
     // Same reason as org.gradle.jvmargs in gradle.properties, but for the forked test JVM:

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -133,7 +133,9 @@ tasks.named('test') {
         }
     }
     // https://github.com/raphw/byte-buddy/issues/1922
-    jvmArgs '--sun-misc-unsafe-memory-access=allow'
+    if (JavaVersion.current().isCompatibleWith(JavaVersion.toVersion(24))) {
+        jvmArgs '--sun-misc-unsafe-memory-access=allow'
+    }
     testLogging {
         events TestLogEvent.FAILED, TestLogEvent.STANDARD_ERROR
         exceptionFormat = TestExceptionFormat.FULL


### PR DESCRIPTION
Fixes the following `./gradlew test` JVM warnings the way the libraries that cause the warnings recommend:

```
BackendApplicationTest STANDARD_ERROR
    WARNING: A Java agent has been loaded dynamically (/home/runner/.gradle/caches/modules-2/files-2.1/net.bytebuddy/byte-buddy-agent/1.18.10/9426d28828bdcdf42666bb7a68c468279ea78f59/byte-buddy-agent-1.18.10.jar)
    WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
    WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
    WARNING: Dynamic loading of agents will be disallowed by default in a future release

OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by net.bytebuddy.dynamic.loading.ClassInjector$UsingUnsafe$Dispatcher$CreationAction (file:/home/runner/.gradle/caches/modules-2/files-2.1/net.bytebuddy/byte-buddy/1.18.10/5b34812ced047973a6d42654d50c3b69124ce587/byte-buddy-1.18.10.jar)
WARNING: Please consider reporting this to the maintainers of class net.bytebuddy.dynamic.loading.ClassInjector$UsingUnsafe$Dispatcher$CreationAction
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
```


Dynamic agent load: Fixed the way MockK now documents ([mockk/mockk#1550](https://github.com/mockk/mockk/pull/1550))

`sun.misc.Unsafe::objectFieldOffset`: Byte Buddy's `ClassInjector$UsingUnsafe` eagerly probes for `Unsafe` in a static initialiser. Upstream will not change this — raphw closed [byte-buddy#1922](https://github.com/raphw/byte-buddy/issues/1922) with *"this warning disappears as of Java 26 where the resolve is disabled by default"*. Muted with `--sun-misc-unsafe-memory-access=allow`.

🚀 Preview: Add `preview` label to enable