### PR TITLE
fix(ingest): don't retry ingest jobs, submit in smaller batches, raise time limit

### DIFF
--- a/ingest/config/defaults.yaml
+++ b/ingest/config/defaults.yaml
@@ -70,7 +70,7 @@ subsample_fraction: 1.0
 db_username: postgres
 db_password: unsecure
 db_url: "jdbc:postgresql://127.0.0.1:5432/loculus"
-batch_chunk_size: 1000
+batch_chunk_size: 10000 # Batch size for submitting sequences to Loculus backend
 nextclade_dataset_server: https://data.clades.nextstrain.org/v3
 backend_request_timeout_seconds: 600
 match_previous_accession_versions: false

--- a/ingest/config/defaults.yaml
+++ b/ingest/config/defaults.yaml
@@ -70,7 +70,12 @@ subsample_fraction: 1.0
 db_username: postgres
 db_password: unsecure
 db_url: "jdbc:postgresql://127.0.0.1:5432/loculus"
-batch_chunk_size: 10000 # Batch size for submitting sequences to Loculus backend
+# Batch size for submitting sequences to Loculus backend.
+# Keep this small enough that one submit request completes well within
+# backend_request_timeout_seconds even for large-genome organisms: a client-side
+# timeout on a request the backend later completes successfully leaves the pipeline
+# believing the batch failed, while the rows are committed.
+batch_chunk_size: 1000
 nextclade_dataset_server: https://data.clades.nextstrain.org/v3
 backend_request_timeout_seconds: 600
 match_previous_accession_versions: false

--- a/ingest/config/defaults.yaml
+++ b/ingest/config/defaults.yaml
@@ -70,11 +70,6 @@ subsample_fraction: 1.0
 db_username: postgres
 db_password: unsecure
 db_url: "jdbc:postgresql://127.0.0.1:5432/loculus"
-# Batch size for submitting sequences to Loculus backend.
-# Keep this small enough that one submit request completes well within
-# backend_request_timeout_seconds even for large-genome organisms: a client-side
-# timeout on a request the backend later completes successfully leaves the pipeline
-# believing the batch failed, while the rows are committed.
 batch_chunk_size: 1000
 nextclade_dataset_server: https://data.clades.nextstrain.org/v3
 backend_request_timeout_seconds: 600

--- a/kubernetes/loculus/templates/ingest.yaml
+++ b/kubernetes/loculus/templates/ingest.yaml
@@ -103,14 +103,6 @@ spec:
   failedJobsHistoryLimit: 2
   jobTemplate:
     spec:
-      {{/*
-      No automatic retries. An ingest run is not idempotent across pods: if a submit
-      request times out client-side while the backend goes on to commit it, a replacement
-      pod re-reads previously-submitted state, cannot yet see the in-flight transaction,
-      and submits everything again - producing two Loculus accessions for one INSDC
-      accession, which then makes every later run fail in compare_hashes.
-      A failed run is simply picked up by the next scheduled run.
-      */}}
       backoffLimit: 0
       activeDeadlineSeconds: {{ $.Values.ingestLimitSeconds }}
       ttlSecondsAfterFinished: 86400

--- a/kubernetes/loculus/templates/ingest.yaml
+++ b/kubernetes/loculus/templates/ingest.yaml
@@ -103,6 +103,15 @@ spec:
   failedJobsHistoryLimit: 2
   jobTemplate:
     spec:
+      {{/*
+      No automatic retries. An ingest run is not idempotent across pods: if a submit
+      request times out client-side while the backend goes on to commit it, a replacement
+      pod re-reads previously-submitted state, cannot yet see the in-flight transaction,
+      and submits everything again - producing two Loculus accessions for one INSDC
+      accession, which then makes every later run fail in compare_hashes.
+      A failed run is simply picked up by the next scheduled run.
+      */}}
+      backoffLimit: 0
       activeDeadlineSeconds: {{ $.Values.ingestLimitSeconds }}
       ttlSecondsAfterFinished: 86400
       template:
@@ -170,6 +179,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      backoffLimit: 0
       activeDeadlineSeconds: {{ $.Values.ingestLimitSeconds }}
       template:
         {{- include "loculus.ingestPodSpec" (dict

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -48,7 +48,10 @@ siloImport:
   siloTimeoutSeconds: 3600
   hardRefreshIntervalSeconds: 3600
   pollIntervalSeconds: 30
-ingestLimitSeconds: 1800
+# Wall-clock cap for one ingest run. Must comfortably exceed a full from-empty
+# bootstrap of the largest organism: mpox is ~13k x ~190kb and submits at roughly
+# 100ms/record, so ~25min of submitting plus ~10min of download/hash/sort.
+ingestLimitSeconds: 3600
 getSubmissionListLimitSeconds: 600
 preprocessingTimeout: 600
 accessionPrefix: "LOC_"

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -48,9 +48,6 @@ siloImport:
   siloTimeoutSeconds: 3600
   hardRefreshIntervalSeconds: 3600
   pollIntervalSeconds: 30
-# Wall-clock cap for one ingest run. Must comfortably exceed a full from-empty
-# bootstrap of the largest organism: mpox is ~13k x ~190kb and submits at roughly
-# 100ms/record, so ~25min of submitting plus ~10min of download/hash/sort.
 ingestLimitSeconds: 3600
 getSubmissionListLimitSeconds: 600
 preprocessingTimeout: 600


### PR DESCRIPTION
## What happened

On 2026-08-19 the demo mpox ingest produced **two Loculus accessions for every one of 9,941 INSDC accessions** (19,882 entries where there should be ~13,300). Every mpox ingest run on demo has failed since, because `compare_hashes` raises on the duplicate:

```
ValueError: INSDC accession OP881936 has multiple loculus accessions: PPD_00QN62P and PPD_00QDHVA!
```

Production and staging were checked for the same condition across all 14 organisms and are clean.

## Root cause

Reconstructed from the demo pod and backend logs. It was **not** a concurrency race — the ingest lock behaved correctly throughout (an rsv-b cron pod waited 17 minutes for its bootstrap pod and only then proceeded). The two writers were **two pods of the same Job, running sequentially**, because the Job was retried:

```
12:24:37  pod A   "No conflicting ingest pods for mpox, proceeding."   (correct, DB empty)
12:27:30  pod A   get-submitted-metadata -> "Got 0 records as expected" (correct, DB empty)
12:34:01  pod A   Submitting batch 1 (9,999 records, ~1.9 GB)
12:44:38  pod A   ReadTimeoutError, read timeout=600   <- client gives up
12:44:40  pod A   Snakemake "Error in rule submit" -> pod fails
12:44:54  pod B   Job controller's retry starts
12:47:46  pod B   get-submitted-metadata -> 200 in 38ms -> "Got 0 records as expected"  <- the bug
12:47:49  pod B   Sequences to submit: 13288   <- resubmits everything
12:52:33  backend POST /mpox/submit - status 200 - took 1089661ms   <- pod A's request SUCCEEDS
12:54:12  pod B   Submitting batch 1 -> duplicate
```

Three things stacked up:

1. **A client timeout on a request that succeeded.** The backend took 1,089,661 ms (18m10s) and returned `200`, but `backend_request_timeout_seconds` is 600, so the client declared failure 8 minutes before the server declared success.
2. **`backoffLimit` defaulted to 6**, so the Job started a replacement pod. An ingest run is not idempotent across pods.
3. **The retry could not see the first pod's writes.** Its dedup query ran while the original insert transaction was still open, returning zero rows in 38 ms.

Each run then landed exactly one batch (9,999 = one chunk, since `record_counter` includes the TSV header) because `activeDeadlineSeconds: 1800` killed the second pod mid-POST: 2 x 9,999 = 19,998.

## Changes

- **`backoffLimit: 0`** on the ingest and revoke-and-regroup CronJob `jobTemplate`s. A failed run is never retried on stale state; the next scheduled run picks it up, reading committed data. The bootstrap Job created by the PostSync trigger inherits this, since `kubectl create job --from=cronjob/...` copies the jobTemplate — which matters, because this incident came through the bootstrap path.
- **`batch_chunk_size` 10000 -> 1000** moved out to #7183, so this PR is only about the retry and the deadline.
- **`ingestLimitSeconds` 1800 -> 3600.** A full from-empty bootstrap of mpox needs ~25 min of submitting plus ~10 min of download/hash/sort, so 30 min was not enough for the run to finish even when it works. Note this value is global rather than per-organism.

## Deliberately not included

- **Idempotency on `submissionId`.** A uniqueness constraint is the only change that makes duplication structurally impossible regardless of timeouts and transaction visibility — unique-index conflict detection *does* see uncommitted rows, so a second writer blocks and then fails cleanly rather than duplicating. It needs care to stay compatible with revoke-and-reingest, so it belongs in its own PR.
- **Cleanup of the existing demo duplicates**, which needs either a demo reset or revoking one accession from each of the 9,941 pairs (`compare_hashes` tolerates a `REVOKED` sibling).

🚀 Preview: Add `preview` label to enable
