### PR TITLE
chore(ci): make GitHub workflow job names unique and informative

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -12,7 +12,7 @@ concurrency:
   group: ci-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}-backend-tests
   cancel-in-progress: true
 jobs:
-  test:
+  backend-test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -36,7 +36,7 @@ jobs:
         run: ./gradlew test
         working-directory: ./backend
 
-  lint:
+  backend-lint:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -12,8 +12,7 @@ concurrency:
   group: ci-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}-cli-tests
   cancel-in-progress: true
 jobs:
-  unitTests:
-    name: Unit Tests
+  cli-unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -30,8 +29,7 @@ jobs:
       # - name: Run tests
       #   run: uv run pytest
       #   working-directory: cli
-  check-format:
-    name: Check formatting
+  cli-check-format:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -51,8 +49,7 @@ jobs:
       - name: Check ruff linting
         run: uv run ruff check .
         working-directory: cli
-  check-types:
-    name: Check types
+  cli-check-types:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,8 +7,8 @@ on:
   schedule:
     - cron: '26 9 * * 2' # Run on Tuesday mornings, in addition to PRs
 jobs:
-  analyze:
-    name: Analyze (${{ matrix.language }})
+  codeql-analyze:
+    name: CodeQL Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources

--- a/.github/workflows/datasets-assembly-mirror.yml
+++ b/.github/workflows/datasets-assembly-mirror.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '12 2 * * *' # Runs daily at 02:12 UTC
 jobs:
-  download-and-upload:
+  datasets-assembly-download-and-upload:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -71,8 +71,8 @@ jobs:
           for file in ${{ matrix.taxon_id }}-assembly-refseq.tar.zst ${{ matrix.taxon_id }}-assembly-genbank.tar.zst ; do
             s3cmd put "${file}" s3://loculus-public/mirror/"${file}"
           done
-  notify_on_failure:  # Runs only if 'build' job fails
-    needs: download-and-upload
+  datasets-assembly-notify-on-failure:  # Runs only if the download-and-upload job fails
+    needs: datasets-assembly-download-and-upload
     runs-on: ubuntu-latest
     if: failure()
     steps:

--- a/.github/workflows/datasets-mirror-priority-1.yml
+++ b/.github/workflows/datasets-mirror-priority-1.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '12 */2 * * *' # Runs every two hours at 12 minutes past the hour
 jobs:
-  mirror:
+  datasets-mirror-priority-1:
     strategy:
       matrix:
         taxon_id:

--- a/.github/workflows/datasets-mirror-priority-2.yml
+++ b/.github/workflows/datasets-mirror-priority-2.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '12 3 * * *' # Runs daily at 03:12 UTC
 jobs:
-  mirror:
+  datasets-mirror-priority-2:
     strategy:
       matrix:
         taxon_id:

--- a/.github/workflows/datasets-mirror.yml
+++ b/.github/workflows/datasets-mirror.yml
@@ -16,7 +16,7 @@ on:
         required: true
         type: number
 jobs:
-  download-and-upload:
+  datasets-mirror-download-and-upload:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -50,8 +50,8 @@ jobs:
           for file in ${{ inputs.taxon_id }}.zip ${{ inputs.taxon_id }}.tar.zst ; do
             s3cmd put "${file}" s3://loculus-public/mirror/"${file}"
           done
-  notify_on_failure:
-    needs: download-and-upload
+  datasets-mirror-notify-on-failure:
+    needs: datasets-mirror-download-and-upload
     runs-on: ubuntu-latest
     if: failure()
     steps:

--- a/.github/workflows/deacon-index.yml
+++ b/.github/workflows/deacon-index.yml
@@ -7,7 +7,7 @@ env:
   DEACON_INDEX_IMAGE: ghcr.io/loculus-project/deacon-index
 
 jobs:
-  build-and-upload:
+  deacon-index-build-and-upload:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -96,8 +96,8 @@ jobs:
           s3cmd cp s3://loculus-public/deacon-index/"${INDEX_VERSIONED}" \
             s3://loculus-public/deacon-index/"${INDEX_LATEST}"
 
-  notify_on_success:
-    needs: build-and-upload
+  deacon-index-notify-on-success:
+    needs: deacon-index-build-and-upload
     runs-on: ubuntu-latest
     if: success()
     steps:
@@ -106,11 +106,11 @@ jobs:
           SLACK_HOOK: ${{ secrets.SLACK_HOOK }}
         run: |
           curl -X POST -H 'Content-type: application/json' --data '{
-            "text": "✅ Successfully built and uploaded Deacon index ${{ needs.build-and-upload.outputs.index }} (also published as ghcr.io/loculus-project/deacon-index:${{ needs.build-and-upload.outputs.oci_tag }} / :latest): ${{ github.repository }}\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Details>"
+            "text": "✅ Successfully built and uploaded Deacon index ${{ needs.deacon-index-build-and-upload.outputs.index }} (also published as ghcr.io/loculus-project/deacon-index:${{ needs.deacon-index-build-and-upload.outputs.oci_tag }} / :latest): ${{ github.repository }}\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Details>"
           }' $SLACK_HOOK
 
-  notify_on_failure:
-    needs: build-and-upload
+  deacon-index-notify-on-failure:
+    needs: deacon-index-build-and-upload
     runs-on: ubuntu-latest
     if: failure()
     steps:

--- a/.github/workflows/ena-submission-unit-tests.yaml
+++ b/.github/workflows/ena-submission-unit-tests.yaml
@@ -18,8 +18,7 @@ defaults:
     shell: micromamba-shell {0}
     working-directory: ena-submission
 jobs:
-  checkFormat:
-    name: Check formatting
+  ena-check-format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -31,8 +30,7 @@ jobs:
           cache-environment: true
       - name: Run ruff format check
         run: ruff format --diff .
-  lint:
-    name: Lint code
+  ena-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -44,8 +42,7 @@ jobs:
           cache-environment: true
       - name: Run ruff check
         run: ruff check .
-  unitTests:
-    name: Unit Tests
+  ena-unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/format-backend-on-request.yml
+++ b/.github/workflows/format-backend-on-request.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - "backend/**"
 jobs:
-  format:
+  backend-format:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'format_me'))
     permissions:
       contents: write

--- a/.github/workflows/format-ena-deposition-on-dispatch.yml
+++ b/.github/workflows/format-ena-deposition-on-dispatch.yml
@@ -8,7 +8,7 @@ on:
       - ".github/workflows/format-ena-deposition-on-dispatch.yml"
       - "ruff.toml"
 jobs:
-  format:
+  deposition-format:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'format_me'))
     permissions:
       contents: write

--- a/.github/workflows/format-integration-tests.yml
+++ b/.github/workflows/format-integration-tests.yml
@@ -9,7 +9,7 @@ on:
       - 'integration-tests/**'
 
 jobs:
-  format:
+  integration-format:
     runs-on: ubuntu-latest
     
     defaults:

--- a/.github/workflows/format-website-on-dispatch.yml
+++ b/.github/workflows/format-website-on-dispatch.yml
@@ -7,7 +7,7 @@ on:
       - "website/**"
       - ".github/workflows/format-website-on-dispatch.yml"
 jobs:
-  format:
+  website-format:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'format_me'))
     permissions:
       contents: write

--- a/.github/workflows/helm-schema-lint.yaml
+++ b/.github/workflows/helm-schema-lint.yaml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint:
+  helm-lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/ingest-tests.yaml
+++ b/.github/workflows/ingest-tests.yaml
@@ -29,8 +29,7 @@ jobs:
           pytest tests/
         shell: micromamba-shell {0}
         working-directory: ingest
-  check-format:
-    name: Check formatting
+  ingest-check-format:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/ingest-tests.yaml
+++ b/.github/workflows/ingest-tests.yaml
@@ -13,8 +13,7 @@ concurrency:
   group: ci-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}-ingest-tests
   cancel-in-progress: true
 jobs:
-  unitTests:
-    name: Unit Tests
+  ingest-unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/loculus-silo-tests.yml
+++ b/.github/workflows/loculus-silo-tests.yml
@@ -9,7 +9,7 @@ defaults:
   run:
     working-directory: ./loculus-silo
 jobs:
-  tests:
+  silo-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -31,8 +31,7 @@ jobs:
       - name: Run tests
         run: |
           python -m pytest
-  typeCheck:
-    name: Type Checking
+  silo-type-check:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -47,8 +46,7 @@ jobs:
           uv pip install --system '.[test]'
       - name: Run mypy (checks type hints)
         run: mypy . --config-file .mypy.ini --non-interactive --install-types
-  lint:
-    name: Lint code
+  silo-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ncbi-taxonomy-db-unit-tests.yaml
+++ b/.github/workflows/ncbi-taxonomy-db-unit-tests.yaml
@@ -17,8 +17,7 @@ defaults:
     shell: micromamba-shell {0}
     working-directory: taxonomy/ncbi_tax_download
 jobs:
-  checkFormat:
-    name: Check formatting
+  taxonomydb-check-format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -30,8 +29,7 @@ jobs:
           cache-environment: true
       - name: Run ruff format check
         run: ruff check . --fix --diff
-  lint:
-    name: Lint code
+  taxonomydb-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -43,8 +41,7 @@ jobs:
           cache-environment: true
       - name: Run ruff check
         run: ruff check .
-  unitTests:
-    name: Unit Tests
+  taxonomydb-unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/ncbi-taxonomy-db.yml
+++ b/.github/workflows/ncbi-taxonomy-db.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 3 1 * *" # First of every month, 03:00 UTC
 
 jobs:
-  build-and-upload:
+  taxonomydb-build-and-upload:
     runs-on: ubuntu-latest
     outputs:
       db_zipped: ${{ steps.set-filenames.outputs.db_zipped }}
@@ -64,8 +64,8 @@ jobs:
           s3cmd cp s3://loculus-public/taxonomy/"${DB_ZIPPED}" \
             s3://loculus-public/taxonomy/"${DB_LATEST}"
 
-  notify_on_success:
-    needs: build-and-upload
+  taxonomydb-notify-on-success:
+    needs: taxonomydb-build-and-upload
     runs-on: ubuntu-latest
     if: success()
     steps:
@@ -74,11 +74,11 @@ jobs:
           SLACK_HOOK: ${{ secrets.SLACK_HOOK }}
         run: |
           curl -X POST -H 'Content-type: application/json' --data '{
-            "text": "✅ Successfully built and uploaded NCBI taxonomy DB ${{ needs.build-and-upload.outputs.db_zipped }}: ${{ github.repository }}\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Details>"
+            "text": "✅ Successfully built and uploaded NCBI taxonomy DB ${{ needs.taxonomydb-build-and-upload.outputs.db_zipped }}: ${{ github.repository }}\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Details>"
           }' $SLACK_HOOK
 
-  notify_on_failure:
-    needs: build-and-upload
+  taxonomydb-notify-on-failure:
+    needs: taxonomydb-build-and-upload
     runs-on: ubuntu-latest
     if: failure()
     steps:

--- a/.github/workflows/preprocessing-tests.yaml
+++ b/.github/workflows/preprocessing-tests.yaml
@@ -16,8 +16,7 @@ defaults:
     shell: micromamba-shell {0}
     working-directory: preprocessing/nextclade/
 jobs:
-  unitTests:
-    name: Unit Tests
+  prepro-unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -35,8 +34,7 @@ jobs:
       - name: Run tests
         run: |
           pytest
-  typeCheck:
-    name: Type Checking
+  prepro-type-check:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -53,8 +51,7 @@ jobs:
           uv pip install --system '.[test]'
       - name: Run mypy (checks type hints)
         run: mypy . --config-file .mypy.ini --non-interactive --install-types
-  formatCheck:
-    name: Code Format Checking
+  prepro-format-check:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/raw-reads-processing-unit-tests.yaml
+++ b/.github/workflows/raw-reads-processing-unit-tests.yaml
@@ -18,8 +18,7 @@ defaults:
     shell: micromamba-shell {0}
     working-directory: raw-reads-processing
 jobs:
-  checkFormat:
-    name: Check formatting
+  rawreads-check-format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -31,8 +30,7 @@ jobs:
           cache-environment: true
       - name: Run ruff format check
         run: ruff format --diff .
-  lint:
-    name: Lint code
+  raw-reads-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -44,8 +42,7 @@ jobs:
           cache-environment: true
       - name: Run ruff check
         run: ruff check .
-  unitTests:
-    name: Unit Tests
+  rawreads-unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:

--- a/.github/workflows/taxonomy-service-unit-tests.yaml
+++ b/.github/workflows/taxonomy-service-unit-tests.yaml
@@ -18,8 +18,7 @@ defaults:
     shell: micromamba-shell {0}
     working-directory: taxonomy/taxonomy_service
 jobs:
-  checkFormat:
-    name: Check formatting
+  taxonomy-check-format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -31,8 +30,7 @@ jobs:
           cache-environment: true
       - name: Run ruff format check
         run: ruff check . --fix --diff
-  lint:
-    name: Lint code
+  taxonomy-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -44,8 +42,7 @@ jobs:
           cache-environment: true
       - name: Run ruff check
         run: ruff check .
-  unitTests:
-    name: Unit Tests
+  taxonomy-unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/values-schema-prettier.yml
+++ b/.github/workflows/values-schema-prettier.yml
@@ -11,7 +11,7 @@ on:
       - '.github/workflows/values-schema-prettier.yml'
 
 jobs:
-  prettier:
+  values-schema-prettier:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/website-image.yml
+++ b/.github/workflows/website-image.yml
@@ -45,8 +45,8 @@ jobs:
           EXISTS=$(docker manifest inspect ${{ env.DOCKER_IMAGE_NAME }}:${{ steps.prepare.outputs.dir-hash }} > /dev/null 2>&1 && echo "true" || echo "false")
           echo "cache-hit=$EXISTS" >> $GITHUB_OUTPUT
 
-  build:
-    name: Build ${{ matrix.platform }}
+  website-build-image:
+    name: Build website image ${{ matrix.platform }}
     needs: check-cache
     if: needs.check-cache.outputs.cache-hit == 'false'
     runs-on: ${{ matrix.runner }}
@@ -108,7 +108,7 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  merge-or-retag:
+  website-merge-or-retag:
     name: Publish Website Docker Image
     needs: [check-cache, build]
     if: always() && needs.check-cache.result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped')

--- a/.github/workflows/website-image.yml
+++ b/.github/workflows/website-image.yml
@@ -110,8 +110,8 @@ jobs:
 
   website-merge-or-retag:
     name: Publish Website Docker Image
-    needs: [check-cache, build]
-    if: always() && needs.check-cache.result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped')
+    needs: [check-cache, website-build-image]
+    if: always() && needs.check-cache.result == 'success' && (needs.website-build-image.result == 'success' || needs.website-build-image.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/website-tests.yml
+++ b/.github/workflows/website-tests.yml
@@ -13,8 +13,7 @@ concurrency:
   group: ci-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}-website-tests
   cancel-in-progress: true
 jobs:
-  checks:
-    name: Check format and types
+  website-checks:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
@@ -33,8 +32,7 @@ jobs:
       - run: npm run check-format
       - run: npm run check-types
         if: always()
-  unitTests:
-    name: Unit Tests
+  website-unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:

--- a/.github/workflows/yamlfmt-lint.yml
+++ b/.github/workflows/yamlfmt-lint.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint:
+  yaml-lint:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/google/yamlfmt:0.21.0


### PR DESCRIPTION
## Summary

Every workflow job key is now unique across the repo and names its component, so PR check lists and branch-protection rules are unambiguous. Previously 6 groups of jobs shared a check name — `Check formatting` ×2, `notify_on_failure` ×4, `notify_on_success` ×2, `build-and-upload` ×2, `download-and-upload` ×2, `mirror` ×2 — and generic keys like `test`, `lint`, `unitTests` appeared in many files.

## Changes

- Prefixed job keys with their component: `backend-test`, `cli-check-types`, `silo-lint`, `prepro-type-check`, `taxonomy-unit-tests`, `taxonomydb-lint`, `website-checks`, `ena-lint`, `ingest-check-format`, `helm-lint`, `yaml-lint`, and so on.
- Dropped redundant `name:` overrides (`Unit Tests`, `Lint code`, `Check formatting`, `Type Checking`) now that the key itself is descriptive.
- Disambiguated the scheduled mirror/build workflows: `deacon-index-*`, `taxonomydb-*`, `datasets-mirror-*`, `datasets-assembly-*`, and the two reusable-workflow callers `datasets-mirror-priority-1` / `-2`.
- Normalised underscored keys (`notify_on_failure`) to kebab-case.
- Updated all `needs:` entries and `needs.<job>.outputs.*` expressions to match. Notably `website-image.yml`'s publish job still pointed at the old `build` id, which would have made GitHub reject the whole workflow.

## Notes for reviewers

- **Branch protection needs updating on merge.** Renaming job keys renames the check runs, so any required status checks referencing the old names (`test`, `lint`, `unitTests`, `Check formatting`, …) will sit permanently pending until the rules are repointed.
- The `check-name:` values consumed by `update-argocd-metadata.yml` all refer to Docker-image job `name:` fields, which are untouched.

## Verification

`actionlint` reports no new findings, `yamlfmt -lint` is clean, and a script checking every job's effective check name for repo-wide uniqueness and every `needs:` target for existence passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable