### PR TITLE
feat(deposition): add tests that ensure sqlAlchemy db table models do…

### DIFF
--- a/.github/workflows/ena-submission-unit-tests.yaml
+++ b/.github/workflows/ena-submission-unit-tests.yaml
@@ -65,5 +65,5 @@ jobs:
           # They require postgres to be running
             pytest \
             --ignore=./test/test_ena_submission_integration.py \
-            --ignore=./test/test_api.py
+            --ignore=./test/test_api.py \
             --ignore=./test/test_schema_matches_models.py

--- a/.github/workflows/ena-submission-unit-tests.yaml
+++ b/.github/workflows/ena-submission-unit-tests.yaml
@@ -66,3 +66,4 @@ jobs:
             pytest \
             --ignore=./test/test_ena_submission_integration.py \
             --ignore=./test/test_api.py
+            --ignore=./test/test_schema_matches_models.py

--- a/.github/workflows/ena-submission-workflow-tests.yml
+++ b/.github/workflows/ena-submission-workflow-tests.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
             # The unit tests are run in ena-submission-unit-tests.yaml
             pytest \
-              --ignore=./test/test_ena_submission.py
+              --ignore=./test/test_ena_submission.py \
               --ignore=./test/test_get_ena_submission_list.py
         shell: micromamba-shell {0}
         working-directory: ena-submission

--- a/.github/workflows/ena-submission-workflow-tests.yml
+++ b/.github/workflows/ena-submission-workflow-tests.yml
@@ -66,5 +66,6 @@ jobs:
             # The unit tests are run in ena-submission-unit-tests.yaml
             pytest \
               --ignore=./test/test_ena_submission.py
+              --ignore=./test/test_get_ena_submission_list.py
         shell: micromamba-shell {0}
         working-directory: ena-submission

--- a/ena-submission/flyway/sql/V1.7__set_fields_not_null.sql
+++ b/ena-submission/flyway/sql/V1.7__set_fields_not_null.sql
@@ -1,0 +1,5 @@
+UPDATE submission_table SET unaligned_nucleotide_sequences = '{}'::jsonb WHERE unaligned_nucleotide_sequences IS NULL;
+UPDATE submission_table SET metadata = '{}'::jsonb WHERE metadata IS NULL;
+
+ALTER TABLE submission_table ALTER COLUMN unaligned_nucleotide_sequences SET NOT NULL;
+ALTER TABLE submission_table ALTER COLUMN metadata SET NOT NULL;

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -154,9 +154,7 @@ class SubmissionTableEntry(Base):
 
     # Optional fields with defaults.
     # 'seq_metadata' maps to the DB column "metadata".
-    seq_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "metadata", JSONB, nullable=True, default_factory=dict
-    )
+    seq_metadata: Mapped[dict[str, Any]] = mapped_column("metadata", JSONB, default_factory=dict)
     errors: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
     warnings: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
     status_all: Mapped[Status] = mapped_column(
@@ -166,7 +164,7 @@ class SubmissionTableEntry(Base):
     started_at: Mapped[datetime] = mapped_column(default_factory=lambda: datetime.now(tz=pytz.utc))
     finished_at: Mapped[datetime | None] = mapped_column(default=None)
     unaligned_nucleotide_sequences: Mapped[dict[str, str | None]] = mapped_column(
-        JSONB, nullable=True, default_factory=dict
+        JSONB, default_factory=dict
     )
     center_name: Mapped[str | None] = mapped_column(default=None)
     external_metadata: Mapped[dict[str, str | Sequence[str]] | None] = mapped_column(

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -9,7 +9,20 @@ from enum import StrEnum
 from typing import Any, Final, cast
 
 import pytz
-from sqlalchemy import Engine, Enum, create_engine, delete, func, make_url, or_, select, update
+from sqlalchemy import (
+    DateTime,
+    Engine,
+    Enum,
+    ForeignKey,
+    Index,
+    create_engine,
+    delete,
+    func,
+    make_url,
+    or_,
+    select,
+    update,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import (
     DeclarativeBase,
@@ -141,23 +154,27 @@ class SubmissionTableEntry(Base):
 
     # Optional fields with defaults.
     # 'seq_metadata' maps to the DB column "metadata".
-    seq_metadata: Mapped[dict[str, Any]] = mapped_column("metadata", JSONB, default_factory=dict)
+    seq_metadata: Mapped[dict[str, Any]] = mapped_column(
+        "metadata", JSONB, nullable=True, default_factory=dict
+    )
     errors: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
     warnings: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
     status_all: Mapped[Status] = mapped_column(
         Enum(StatusAll, native_enum=False),  # Store enum as string in DB table.
         default=StatusAll.READY_TO_SUBMIT,
     )
-    started_at: Mapped[datetime | None] = mapped_column(default=None)
+    started_at: Mapped[datetime | None] = mapped_column(nullable=False, default=None)
     finished_at: Mapped[datetime | None] = mapped_column(default=None)
     unaligned_nucleotide_sequences: Mapped[dict[str, str | None]] = mapped_column(
-        JSONB, default_factory=dict
+        JSONB, nullable=True, default_factory=dict
     )
     center_name: Mapped[str | None] = mapped_column(default=None)
     external_metadata: Mapped[dict[str, str | Sequence[str]] | None] = mapped_column(
         JSONB, default=None
     )
-    project_id: Mapped[int | None] = mapped_column(default=None)
+    project_id: Mapped[int | None] = mapped_column(
+        ForeignKey("ena_deposition_schema.project_table.project_id"), default=None
+    )
 
     @property
     def pkey(self) -> AccessionVersion:
@@ -168,7 +185,11 @@ class ProjectTableEntry(Base):
     """Maps to project_table. Primary key: project_id (BIGSERIAL)."""
 
     __tablename__ = "project_table"
-    __table_args__: typing.ClassVar[dict[str, Any]] = {"schema": "ena_deposition_schema"}
+    __table_args__: typing.ClassVar[tuple[Any, ...]] = (
+        Index("idx_project_table_group_id", "group_id"),
+        Index("idx_project_table_organism", "organism"),
+        {"schema": "ena_deposition_schema"},
+    )
 
     # BIGSERIAL primary key — server-generated, excluded from __init__.
     project_id: Mapped[int | None] = mapped_column(
@@ -182,12 +203,16 @@ class ProjectTableEntry(Base):
         Enum(Status, native_enum=False),
         default=Status.READY,
     )
-    started_at: Mapped[datetime | None] = mapped_column(default=None)
+    started_at: Mapped[datetime | None] = mapped_column(nullable=False, default=None)
     finished_at: Mapped[datetime | None] = mapped_column(default=None)
     center_name: Mapped[str | None] = mapped_column(default=None)
     result: Mapped[dict[str, str | Sequence[str]] | None] = mapped_column(JSONB, default=None)
-    ena_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
-    ncbi_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
+    ena_first_publicly_visible: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), default=None
+    )
+    ncbi_first_publicly_visible: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), default=None
+    )
 
     @property
     def pkey(self) -> ProjectId:
@@ -208,11 +233,15 @@ class SampleTableEntry(Base):
         Enum(Status, native_enum=False),
         default=Status.READY,
     )
-    started_at: Mapped[datetime | None] = mapped_column(default=None)
+    started_at: Mapped[datetime | None] = mapped_column(nullable=False, default=None)
     finished_at: Mapped[datetime | None] = mapped_column(default=None)
     result: Mapped[dict[str, str | Sequence[str]] | None] = mapped_column(JSONB, default=None)
-    ena_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
-    ncbi_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
+    ena_first_publicly_visible: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), default=None
+    )
+    ncbi_first_publicly_visible: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), default=None
+    )
 
     @property
     def pkey(self) -> AccessionVersion:
@@ -233,13 +262,21 @@ class AssemblyTableEntry(Base):
         Enum(Status, native_enum=False),
         default=Status.READY,
     )
-    started_at: Mapped[datetime | None] = mapped_column(default=None)
+    started_at: Mapped[datetime | None] = mapped_column(nullable=False, default=None)
     finished_at: Mapped[datetime | None] = mapped_column(default=None)
     result: Mapped[dict[str, str | Sequence[str]] | None] = mapped_column(JSONB, default=None)
-    ena_nucleotide_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
-    ncbi_nucleotide_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
-    ena_gca_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
-    ncbi_gca_first_publicly_visible: Mapped[datetime | None] = mapped_column(default=None)
+    ena_nucleotide_first_publicly_visible: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), default=None
+    )
+    ncbi_nucleotide_first_publicly_visible: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), default=None
+    )
+    ena_gca_first_publicly_visible: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), default=None
+    )
+    ncbi_gca_first_publicly_visible: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), default=None
+    )
 
     @property
     def pkey(self) -> AccessionVersion:

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -163,7 +163,7 @@ class SubmissionTableEntry(Base):
         Enum(StatusAll, native_enum=False),  # Store enum as string in DB table.
         default=StatusAll.READY_TO_SUBMIT,
     )
-    started_at: Mapped[datetime | None] = mapped_column(nullable=False, default=None)
+    started_at: Mapped[datetime] = mapped_column(default_factory=lambda: datetime.now(tz=pytz.utc))
     finished_at: Mapped[datetime | None] = mapped_column(default=None)
     unaligned_nucleotide_sequences: Mapped[dict[str, str | None]] = mapped_column(
         JSONB, nullable=True, default_factory=dict
@@ -203,7 +203,7 @@ class ProjectTableEntry(Base):
         Enum(Status, native_enum=False),
         default=Status.READY,
     )
-    started_at: Mapped[datetime | None] = mapped_column(nullable=False, default=None)
+    started_at: Mapped[datetime] = mapped_column(default_factory=lambda: datetime.now(tz=pytz.utc))
     finished_at: Mapped[datetime | None] = mapped_column(default=None)
     center_name: Mapped[str | None] = mapped_column(default=None)
     result: Mapped[dict[str, str | Sequence[str]] | None] = mapped_column(JSONB, default=None)
@@ -233,7 +233,7 @@ class SampleTableEntry(Base):
         Enum(Status, native_enum=False),
         default=Status.READY,
     )
-    started_at: Mapped[datetime | None] = mapped_column(nullable=False, default=None)
+    started_at: Mapped[datetime] = mapped_column(default_factory=lambda: datetime.now(tz=pytz.utc))
     finished_at: Mapped[datetime | None] = mapped_column(default=None)
     result: Mapped[dict[str, str | Sequence[str]] | None] = mapped_column(JSONB, default=None)
     ena_first_publicly_visible: Mapped[datetime | None] = mapped_column(
@@ -262,7 +262,7 @@ class AssemblyTableEntry(Base):
         Enum(Status, native_enum=False),
         default=Status.READY,
     )
-    started_at: Mapped[datetime | None] = mapped_column(nullable=False, default=None)
+    started_at: Mapped[datetime] = mapped_column(default_factory=lambda: datetime.now(tz=pytz.utc))
     finished_at: Mapped[datetime | None] = mapped_column(default=None)
     result: Mapped[dict[str, str | Sequence[str]] | None] = mapped_column(JSONB, default=None)
     ena_nucleotide_first_publicly_visible: Mapped[datetime | None] = mapped_column(

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -157,7 +157,7 @@ class SubmissionTableEntry(Base):
     seq_metadata: Mapped[dict[str, Any]] = mapped_column("metadata", JSONB, default_factory=dict)
     errors: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
     warnings: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
-    status_all: Mapped[Status] = mapped_column(
+    status_all: Mapped[StatusAll] = mapped_column(
         Enum(StatusAll, native_enum=False),  # Store enum as string in DB table.
         default=StatusAll.READY_TO_SUBMIT,
     )

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -497,7 +497,6 @@ def update_with_retry[T: TableEntry](
 
 def add_to_project_table(engine: Engine, entry: ProjectTableEntry) -> int | None:
     """Insert *entry* into project_table and return the generated project_id."""
-    entry.started_at = datetime.now(tz=pytz.utc)
     try:
         with Session(engine) as session:
             session.add(entry)
@@ -512,7 +511,6 @@ def add_to_project_table(engine: Engine, entry: ProjectTableEntry) -> int | None
 
 def add_to_sample_table(engine: Engine, entry: SampleTableEntry) -> bool:
     """Insert *entry* into sample_table. Returns True on success."""
-    entry.started_at = datetime.now(tz=pytz.utc)
     try:
         with Session(engine, expire_on_commit=False) as session:
             session.add(entry)
@@ -525,7 +523,6 @@ def add_to_sample_table(engine: Engine, entry: SampleTableEntry) -> bool:
 
 def add_to_assembly_table(engine: Engine, entry: AssemblyTableEntry) -> bool:
     """Insert *entry* into assembly_table. Returns True on success."""
-    entry.started_at = datetime.now(tz=pytz.utc)
     try:
         with Session(engine, expire_on_commit=False) as session:
             session.add(entry)
@@ -547,7 +544,6 @@ def in_submission_table(engine: Engine, conditions: dict[str, Any]) -> bool:
 
 def add_to_submission_table(engine: Engine, entry: SubmissionTableEntry) -> bool:
     """Insert *entry* into submission_table. Returns True on success."""
-    entry.started_at = datetime.now(tz=pytz.utc)
     try:
         with Session(engine, expire_on_commit=False) as session:
             session.add(entry)

--- a/ena-submission/test/test_schema_matches_models.py
+++ b/ena-submission/test/test_schema_matches_models.py
@@ -120,7 +120,13 @@ def test_orm_models_match_flyway_schema() -> None:
     db_metadata.reflect(bind=engine, schema=SCHEMA)
 
     failures: dict[str, list[str]] = {}
-    for orm_table in Base.metadata.tables.values():
+    orm_tables = {t.name: t for t in Base.metadata.tables.values()}
+    db_table_names = {key.split(".", 1)[1] for key in db_metadata.tables} - {
+        "flyway_schema_history"
+    }
+    for extra in sorted(db_table_names - orm_tables.keys()):
+        failures[extra] = [f"table '{extra}' exists in DB {SCHEMA} but is not defined in the ORM"]
+    for orm_table in orm_tables.values():
         table_name = orm_table.name
         db_table_key = f"{SCHEMA}.{table_name}"
         if db_table_key not in db_metadata.tables:

--- a/ena-submission/test/test_schema_matches_models.py
+++ b/ena-submission/test/test_schema_matches_models.py
@@ -13,11 +13,13 @@ flyway -url=jdbc:postgresql://localhost:5432/loculus -schemas=ena_deposition_sch
 
 # ruff: noqa: S101 (allow asserts in tests)
 
+from collections.abc import Iterator
 from typing import Any
 
+import pytest
 from ena_deposition.config import get_config
 from ena_deposition.submission_db_helper import Base, db_init
-from sqlalchemy import MetaData, Table
+from sqlalchemy import Engine, MetaData, Table
 from sqlalchemy.types import JSON, Boolean, DateTime, Integer, String, TypeEngine
 
 CONFIG_FILE = "./test/test_config.yaml"
@@ -108,13 +110,19 @@ def _compare_table(orm_table: Table, db_table: Table) -> list[str]:
     return mismatches
 
 
-def test_orm_models_match_flyway_schema() -> None:
+@pytest.fixture(name="engine")
+def engine_fixture() -> Iterator[Engine]:
+    config = get_config(CONFIG_FILE)
+    engine = db_init(config.db_password, config.db_username, config.db_url)
+    yield engine
+    engine.dispose()
+
+
+def test_orm_models_match_flyway_schema(engine: Engine) -> None:
     """The ORM models in submission_db_helper.py are hand-maintained rather than
     generated from the flyway migrations, so nothing stops them from drifting
     apart. This reflects the actual (migrated) DB schema and diffs it against
     `Base.metadata` to catch that drift."""
-    config = get_config(CONFIG_FILE)
-    engine = db_init(config.db_password, config.db_username, config.db_url)
 
     db_metadata = MetaData()
     db_metadata.reflect(bind=engine, schema=SCHEMA)
@@ -135,8 +143,6 @@ def test_orm_models_match_flyway_schema() -> None:
         mismatches = _compare_table(orm_table, db_metadata.tables[db_table_key])
         if mismatches:
             failures[table_name] = mismatches
-
-    engine.dispose()
 
     assert not failures, "\n".join(
         f"{table}:\n  " + "\n  ".join(issues) for table, issues in failures.items()

--- a/ena-submission/test/test_schema_matches_models.py
+++ b/ena-submission/test/test_schema_matches_models.py
@@ -1,0 +1,135 @@
+"""
+Verifies that the SQLAlchemy ORM models in submission_db_helper.py match the
+actual database schema produced by the flyway migrations in flyway/sql/.
+
+Requires a running Postgres instance with the ena-submission schema migrated,
+see test_ena_submission_integration.py for how to set one up:
+
+docker run --name test-postgres -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=unsecure \
+    -e POSTGRES_DB=loculus -p 5432:5432 -d postgres
+flyway -url=jdbc:postgresql://localhost:5432/loculus -schemas=ena_deposition_schema \
+    -user=postgres -password=unsecure -locations=filesystem:./flyway/sql migrate
+"""
+
+# ruff: noqa: S101 (allow asserts in tests)
+
+from typing import Any
+
+from ena_deposition.config import get_config
+from ena_deposition.submission_db_helper import Base, db_init
+from sqlalchemy import MetaData, Table
+from sqlalchemy.types import JSON, Boolean, DateTime, Integer, String, TypeEngine
+
+CONFIG_FILE = "./test/test_config.yaml"
+SCHEMA = "ena_deposition_schema"
+
+
+# Broad base classes rather than exact types
+# e.g. flyway's TEXT and SQLAlchemy's default VARCHAR (used for
+# Enum(native_enum=False)) count as equivalent.
+_TYPE_CATEGORIES: tuple[tuple[type[TypeEngine[Any]], str], ...] = (
+    (JSON, "json"),
+    (Boolean, "boolean"),
+    (DateTime, "datetime"),
+    (Integer, "integer"),
+    (String, "string"),
+)
+
+
+def _type_category(type_: TypeEngine[Any]) -> str:
+    return next(
+        (name for base, name in _TYPE_CATEGORIES if isinstance(type_, base)),
+        type_.__class__.__name__.lower(),
+    )
+
+
+def _compare_table(orm_table: Table, db_table: Table) -> list[str]:
+    mismatches: list[str] = []
+
+    orm_columns = {c.name: c for c in orm_table.columns}
+    db_columns = {c.name: c for c in db_table.columns}
+
+    missing_in_db = orm_columns.keys() - db_columns.keys()
+    if missing_in_db:
+        mismatches.append(f"columns defined in ORM but missing in DB: {sorted(missing_in_db)}")
+    extra_in_db = db_columns.keys() - orm_columns.keys()
+    if extra_in_db:
+        mismatches.append(f"columns in DB but not defined in ORM: {sorted(extra_in_db)}")
+
+    for name in sorted(orm_columns.keys() & db_columns.keys()):
+        orm_col = orm_columns[name]
+        db_col = db_columns[name]
+
+        orm_category = _type_category(orm_col.type)
+        db_category = _type_category(db_col.type)
+        if orm_category != db_category:
+            mismatches.append(
+                f"column '{name}': type category mismatch "
+                f"(ORM: {orm_col.type} -> {orm_category}, DB: {db_col.type} -> {db_category})"
+            )
+        elif orm_category == "datetime":
+            orm_tz = bool(getattr(orm_col.type, "timezone", False))
+            db_tz = bool(getattr(db_col.type, "timezone", False))
+            if orm_tz != db_tz:
+                mismatches.append(
+                    f"column '{name}': timezone-awareness mismatch "
+                    f"(ORM timezone={orm_tz}, DB timezone={db_tz})"
+                )
+
+        # Server-generated (autoincrement) primary keys are declared
+        # nullable=True on the ORM side (the value isn't known until
+        # insert) even though the DB enforces NOT NULL.
+        is_autoincrement_pk = orm_col.primary_key and orm_col.autoincrement is True
+        if not is_autoincrement_pk and orm_col.nullable != db_col.nullable:
+            mismatches.append(
+                f"column '{name}': nullable mismatch "
+                f"(ORM nullable={orm_col.nullable}, DB nullable={db_col.nullable})"
+            )
+
+    orm_pk = {c.name for c in orm_table.primary_key.columns}
+    db_pk = {c.name for c in db_table.primary_key.columns}
+    if orm_pk != db_pk:
+        mismatches.append(f"primary key mismatch (ORM: {sorted(orm_pk)}, DB: {sorted(db_pk)})")
+
+    orm_fks = {
+        (fk.parent.name, fk.column.table.name, fk.column.name) for fk in orm_table.foreign_keys
+    }
+    db_fks = {
+        (fk.parent.name, fk.column.table.name, fk.column.name) for fk in db_table.foreign_keys
+    }
+    if orm_fks != db_fks:
+        mismatches.append(f"foreign key mismatch (ORM: {orm_fks}, DB: {db_fks})")
+
+    orm_indexes = {(ix.name, tuple(sorted(c.name for c in ix.columns))) for ix in orm_table.indexes}
+    db_indexes = {(ix.name, tuple(sorted(c.name for c in ix.columns))) for ix in db_table.indexes}
+    if orm_indexes != db_indexes:
+        mismatches.append(f"index mismatch (ORM: {orm_indexes}, DB: {db_indexes})")
+
+    return mismatches
+
+
+def test_orm_models_match_flyway_schema() -> None:
+    """The ORM models in submission_db_helper.py are hand-maintained rather than
+    generated from the flyway migrations, so nothing stops them from drifting
+    apart. This reflects the actual (migrated) DB schema and diffs it against
+    `Base.metadata` to catch that drift."""
+    config = get_config(CONFIG_FILE)
+    engine = db_init(config.db_password, config.db_username, config.db_url)
+
+    db_metadata = MetaData()
+    db_metadata.reflect(bind=engine, schema=SCHEMA)
+
+    failures: dict[str, list[str]] = {}
+    for orm_table in Base.metadata.tables.values():
+        table_name = orm_table.name
+        db_table_key = f"{SCHEMA}.{table_name}"
+        if db_table_key not in db_metadata.tables:
+            failures[table_name] = [f"table '{table_name}' defined in ORM but missing in DB"]
+            continue
+        mismatches = _compare_table(orm_table, db_metadata.tables[db_table_key])
+        if mismatches:
+            failures[table_name] = mismatches
+
+    assert not failures, "\n".join(
+        f"{table}:\n  " + "\n  ".join(issues) for table, issues in failures.items()
+    )

--- a/ena-submission/test/test_schema_matches_models.py
+++ b/ena-submission/test/test_schema_matches_models.py
@@ -136,6 +136,8 @@ def test_orm_models_match_flyway_schema() -> None:
         if mismatches:
             failures[table_name] = mismatches
 
+    engine.dispose()
+
     assert not failures, "\n".join(
         f"{table}:\n  " + "\n  ".join(issues) for table, issues in failures.items()
     )


### PR DESCRIPTION
… not get out of sync with flyway migration code

Uses https://docs.sqlalchemy.org/en/21/core/reflection.html `db_metadata.reflect(bind=engine, schema=SCHEMA)` to read the existing DB tables into a sqlAlchemy table object. Then it compares the table objects: flagging missing columns, type, nullability and constraint issues (i.e. indices, FK and PK constraints).

Additionally, this PR adds a couple of nullability and constraints in the code that were missing.

- The `started_at` columns are always not null - this is now reflected in the code
- The code always assumed `unaligned_nucleotide_sequences` and `metadata` exist in the data to submit to the ENA and set the default to an empty JSONB `{}`, hence these fields are never null. Add a migration to the db to also enforce this.

### Screenshot

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
Example test failure on nullability mismatch:
```
================================================== FAILURES ===================================================
_____________________________________ test_orm_models_match_flyway_schema _____________________________________
test/test_schema_matches_models.py:141: in test_orm_models_match_flyway_schema
    assert not failures, "\n".join(
E   AssertionError: submission_table:
E       column 'unaligned_nucleotide_sequences': nullable mismatch (ORM nullable=True, DB nullable=False)
E   assert not {'submission_table': ["column 'unaligned_nucleotide_sequences': nullable mismatch (ORM nullable=True, DB nullable=False)"]}
```
Test failure on column name mismatch:
```
================================================== FAILURES ===================================================
_____________________________________ test_orm_models_match_flyway_schema _____________________________________
test/test_schema_matches_models.py:141: in test_orm_models_match_flyway_schema
    assert not failures, "\n".join(
E   AssertionError: submission_table:
E       columns defined in ORM but missing in DB: ['unaligned_nucleotide_sequence']
E       columns in DB but not defined in ORM: ['unaligned_nucleotide_sequences']
E   assert not {'submission_table': ["columns defined in ORM but missing in DB: ['unaligned_nucleotide_sequence']", "columns in DB but not defined in ORM: ['unaligned_nucleotide_sequences']"]}
```
Table name mismatch:
```
================================================== FAILURES ===================================================
_____________________________________ test_orm_models_match_flyway_schema _____________________________________
test/test_schema_matches_models.py:141: in test_orm_models_match_flyway_schema
    assert not failures, "\n".join(
E   AssertionError: submission_table:
E       table 'submission_table' exists in DB ena_deposition_schema but is not defined in the ORM
E     submission_tables:
E       table 'submission_tables' defined in ORM but missing in DB
E   assert not {'submission_table': ["table 'submission_table' exists in DB ena_deposition_schema but is not defined in the ORM"], 'submission_tables': ["table 'submission_tables' defined in ORM but missing in DB"]}
```
Primary key mismatch:
```
================================================== FAILURES ===================================================
_____________________________________ test_orm_models_match_flyway_schema _____________________________________
test/test_schema_matches_models.py:141: in test_orm_models_match_flyway_schema
    assert not failures, "\n".join(
E   AssertionError: submission_table:
E       primary key mismatch (ORM: ['accession'], DB: ['accession', 'version'])
E   assert not {'submission_table': ["primary key mismatch (ORM: ['accession'], DB: ['accession', 'version'])"]}
```

🚀 Preview: Add `preview` label to enable