### PR TITLE
Compress submission uploads with zstd in the browser

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12,6 +12,7 @@
                 "@astrojs/node": "^11.1.2",
                 "@emotion/react": "^11.14.0",
                 "@headlessui/react": "^2.2.10",
+                "@hpcc-js/wasm-zstd": "^1.15.0",
                 "@lokalise/xlsx": "^0.20.3",
                 "@mui/material": "~5.14.20",
                 "@svgr/core": "^8.1.0",
@@ -2068,6 +2069,12 @@
                 "react": "^18 || ^19 || ^19.0.0-rc",
                 "react-dom": "^18 || ^19 || ^19.0.0-rc"
             }
+        },
+        "node_modules/@hpcc-js/wasm-zstd": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/@hpcc-js/wasm-zstd/-/wasm-zstd-1.15.0.tgz",
+            "integrity": "sha512-WjcnbecP+iWNzg/njGoUmQ64DNyadGuEnpNy3a151xqasIHThzZMNuGO2xk3vMwyQ3iYbDU7Z29ntXj4aPolQg==",
+            "license": "Apache-2.0"
         },
         "node_modules/@humanfs/core": {
             "version": "0.19.1",

--- a/website/package.json
+++ b/website/package.json
@@ -22,6 +22,7 @@
         "@astrojs/node": "^11.1.2",
         "@emotion/react": "^11.14.0",
         "@headlessui/react": "^2.2.10",
+        "@hpcc-js/wasm-zstd": "^1.15.0",
         "@lokalise/xlsx": "^0.20.3",
         "@mui/material": "~5.14.20",
         "@svgr/core": "^8.1.0",

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -2,9 +2,9 @@ import { isErrorFromAlias } from '@zodios/core';
 import type { AxiosError } from 'axios';
 import { DateTime } from 'luxon';
 import type { Result } from 'neverthrow';
-import { type FormEvent, useState, type Dispatch, type SetStateAction, useMemo } from 'react';
+import { type FormEvent, useState, type Dispatch, type SetStateAction, useEffect, useMemo } from 'react';
 
-import { compressForUpload } from './FileUpload/compressForUpload.ts';
+import { compressForUpload, warmCompressor } from './FileUpload/compressForUpload.ts';
 import { type FileFactory, FormOrUploadWrapper, type InputMode } from './FormOrUploadWrapper.tsx';
 import { getClientLogger } from '../../clientLogger.ts';
 import { FolderUploadComponent } from './FileUpload/FolderUploadComponent.tsx';
@@ -90,6 +90,12 @@ const InnerDataUploadForm = ({
     const [agreedToINSDCUploadTerms, setAgreedToINSDCUploadTerms] = useState(false);
 
     const [confirmedNoPII, setConfirmedNoPII] = useState(false);
+
+    const [isCompressing, setIsCompressing] = useState(false);
+
+    useEffect(() => {
+        void warmCompressor();
+    }, []);
 
     const fileLinkage = useMemo(
         () =>
@@ -177,10 +183,15 @@ const InnerDataUploadForm = ({
         }
 
         const submitSequenceData = async () => {
-            const [metadataToUpload, sequenceToUpload] = await Promise.all([
-                compressForUpload(finalMetadataFile),
-                sequenceFile === undefined ? Promise.resolve(undefined) : compressForUpload(sequenceFile),
-            ]);
+            setIsCompressing(true);
+            let metadataToUpload;
+            let sequenceToUpload;
+            try {
+                metadataToUpload = await compressForUpload(finalMetadataFile);
+                sequenceToUpload = sequenceFile === undefined ? undefined : await compressForUpload(sequenceFile);
+            } finally {
+                setIsCompressing(false);
+            }
             switch (action) {
                 case 'submit': {
                     const groupId = group.groupId;
@@ -211,10 +222,11 @@ const InnerDataUploadForm = ({
                     'You have selected the Open Data Use Terms. Once released under the Open Data Use Terms sequences will be deposited to INSDC and cannot be changed to the Restricted-Use Data Use Terms.',
                 confirmButtonText: 'Continue under Open terms',
                 closeButtonText: 'Cancel',
-                onConfirmation: () => void submitSequenceData(),
+                onConfirmation: () =>
+                    void submitSequenceData().catch((error: unknown) => onError(stringifyMaybeAxiosError(error))),
             });
         } else {
-            await submitSequenceData();
+            await submitSequenceData().catch((error: unknown) => onError(stringifyMaybeAxiosError(error)));
         }
     };
 
@@ -286,9 +298,11 @@ const InnerDataUploadForm = ({
                         type='submit'
                         className='rounded-md py-2 text-sm font-semibold shadow-xs focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 bg-primary-600 text-white hover:bg-primary-500'
                         onClick={(e) => void handleSubmit(e)}
-                        alsoDisabledIf={isPending}
+                        alsoDisabledIf={isPending || isCompressing}
                     >
-                        <div className={`absolute ml-1.5 inline-flex ${isPending ? 'visible' : 'invisible'}`}>
+                        <div
+                            className={`absolute ml-1.5 inline-flex ${isPending || isCompressing ? 'visible' : 'invisible'}`}
+                        >
                             <Spinner size='sm' />
                         </div>
                         <span className='flex-1 text-center mx-8'>Upload and proceed to Approval</span>

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -4,6 +4,7 @@ import { DateTime } from 'luxon';
 import type { Result } from 'neverthrow';
 import { type FormEvent, useState, type Dispatch, type SetStateAction, useMemo } from 'react';
 
+import { compressForUpload } from './FileUpload/compressForUpload.ts';
 import { type FileFactory, FormOrUploadWrapper, type InputMode } from './FormOrUploadWrapper.tsx';
 import { getClientLogger } from '../../clientLogger.ts';
 import { FolderUploadComponent } from './FileUpload/FolderUploadComponent.tsx';
@@ -175,13 +176,17 @@ const InnerDataUploadForm = ({
             }
         }
 
-        const submitSequenceData = () => {
+        const submitSequenceData = async () => {
+            const [metadataToUpload, sequenceToUpload] = await Promise.all([
+                compressForUpload(finalMetadataFile),
+                sequenceFile === undefined ? Promise.resolve(undefined) : compressForUpload(sequenceFile),
+            ]);
             switch (action) {
                 case 'submit': {
                     const groupId = group.groupId;
                     submit({
-                        metadataFile: finalMetadataFile,
-                        sequenceFile: sequenceFile,
+                        metadataFile: metadataToUpload,
+                        sequenceFile: sequenceToUpload,
                         groupId,
                         dataUseTermsType,
                         restrictedUntil:
@@ -193,8 +198,8 @@ const InnerDataUploadForm = ({
                 }
                 case 'revise':
                     revise({
-                        metadataFile: finalMetadataFile,
-                        sequenceFile: sequenceFile,
+                        metadataFile: metadataToUpload,
+                        sequenceFile: sequenceToUpload,
                     });
                     break;
             }
@@ -206,10 +211,10 @@ const InnerDataUploadForm = ({
                     'You have selected the Open Data Use Terms. Once released under the Open Data Use Terms sequences will be deposited to INSDC and cannot be changed to the Restricted-Use Data Use Terms.',
                 confirmButtonText: 'Continue under Open terms',
                 closeButtonText: 'Cancel',
-                onConfirmation: submitSequenceData,
+                onConfirmation: () => void submitSequenceData(),
             });
         } else {
-            submitSequenceData();
+            await submitSequenceData();
         }
     };
 

--- a/website/src/components/Submission/FileUpload/compressForUpload.spec.ts
+++ b/website/src/components/Submission/FileUpload/compressForUpload.spec.ts
@@ -1,0 +1,37 @@
+import * as fzstd from 'fzstd';
+import { describe, expect, it } from 'vitest';
+
+import { compressForUpload } from './compressForUpload';
+
+const bigTsv = ['id\tcountry\tdate', ...Array.from({ length: 5000 }, (_, i) => `s${i}\tSwitzerland\t2026-01-01`)].join(
+    '\n',
+);
+
+describe('compressForUpload', () => {
+    it('compresses a file and appends .zst, roundtripping to the original bytes', async () => {
+        const original = new File([bigTsv], 'metadata.tsv');
+        const compressed = await compressForUpload(original);
+
+        expect(compressed.name).toBe('metadata.tsv.zst');
+        expect(compressed.size).toBeLessThan(original.size / 5);
+
+        const roundtripped = new TextDecoder().decode(fzstd.decompress(new Uint8Array(await compressed.arrayBuffer())));
+        expect(roundtripped).toBe(bigTsv);
+    });
+
+    it('handles two files compressed concurrently', async () => {
+        // Large enough that file.stream() yields many chunks, so the compressions interleave.
+        const bigA = bigTsv.repeat(40);
+        const bigB = bigTsv.replace(/Switzerland/g, 'Kenya').repeat(40);
+        const a = new File([bigA], 'metadata.tsv');
+        const b = new File([bigB], 'sequences.fasta');
+        const [ca, cb] = await Promise.all([compressForUpload(a), compressForUpload(b)]);
+        expect(new TextDecoder().decode(fzstd.decompress(new Uint8Array(await ca.arrayBuffer())))).toBe(await a.text());
+        expect(new TextDecoder().decode(fzstd.decompress(new Uint8Array(await cb.arrayBuffer())))).toBe(await b.text());
+    });
+
+    it('leaves already-compressed files untouched', async () => {
+        const file = new File([new Uint8Array([1, 2, 3])], 'sequences.fasta.zst');
+        expect(await compressForUpload(file)).toBe(file);
+    });
+});

--- a/website/src/components/Submission/FileUpload/compressForUpload.ts
+++ b/website/src/components/Submission/FileUpload/compressForUpload.ts
@@ -1,0 +1,57 @@
+const ALREADY_COMPRESSED = /\.(zst|xz|gz|zip|bz2|lzma)$/i;
+const ZSTD_LEVEL = 12;
+
+/**
+ * `Zstd.load()` returns a cached singleton holding the compression stream state, so concurrent
+ * compressions would interleave into one frame. Serialize all callers.
+ */
+let queue: Promise<unknown> = Promise.resolve();
+
+/**
+ * Compresses a file with zstd and appends `.zst` to its name, which is how the backend detects
+ * that it needs decompressing. Falls back to the original file if anything goes wrong.
+ */
+export async function compressForUpload(file: File): Promise<File> {
+    const run = queue.then(
+        () => compress(file),
+        () => compress(file),
+    );
+    queue = run;
+    return run;
+}
+
+async function compress(file: File): Promise<File> {
+    try {
+        if (ALREADY_COMPRESSED.test(file.name)) return file;
+
+        const { Zstd } = await import('@hpcc-js/wasm-zstd');
+        const zstd = await Zstd.load();
+        zstd.resetCompression(ZSTD_LEVEL);
+        zstd.setCompressionLevel(ZSTD_LEVEL);
+
+        const parts: Uint8Array[] = [];
+        const reader = file.stream().getReader();
+        for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            const compressed = zstd.compressChunk(value);
+            if (compressed.length > 0) parts.push(compressed);
+        }
+        parts.push(zstd.compressEnd());
+
+        return new File([concat(parts)], `${file.name}.zst`, { type: 'application/zstd' });
+    } catch (_error) {
+        return file;
+    }
+}
+
+function concat(chunks: Uint8Array[]): Uint8Array<ArrayBuffer> {
+    const total = chunks.reduce((sum, c) => sum + c.length, 0);
+    const out = new Uint8Array(new ArrayBuffer(total));
+    let offset = 0;
+    for (const c of chunks) {
+        out.set(c, offset);
+        offset += c.length;
+    }
+    return out;
+}

--- a/website/src/components/Submission/FileUpload/compressForUpload.ts
+++ b/website/src/components/Submission/FileUpload/compressForUpload.ts
@@ -3,7 +3,7 @@ const ZSTD_LEVEL = 12;
 
 /**
  * `Zstd.load()` returns a cached singleton holding the compression stream state, so concurrent
- * compressions would interleave into one frame. Serialize all callers.
+ * compressions would interleave into one frame. Every call is chained onto the previous one.
  */
 let queue: Promise<unknown> = Promise.resolve();
 
@@ -12,12 +12,19 @@ let queue: Promise<unknown> = Promise.resolve();
  * that it needs decompressing. Falls back to the original file if anything goes wrong.
  */
 export async function compressForUpload(file: File): Promise<File> {
-    const run = queue.then(
-        () => compress(file),
-        () => compress(file),
-    );
-    queue = run;
+    const run = queue.then(() => compress(file));
+    queue = run.catch(() => undefined);
     return run;
+}
+
+/** Loads the wasm module ahead of time so that submitting doesn't have to wait for it. */
+export async function warmCompressor(): Promise<void> {
+    try {
+        const { Zstd } = await import('@hpcc-js/wasm-zstd');
+        await Zstd.load();
+    } catch (_error) {
+        // Best effort; compressForUpload retries and falls back to no compression.
+    }
 }
 
 async function compress(file: File): Promise<File> {


### PR DESCRIPTION
For submitters on slow uplinks, upload of uncompressed submissions can take 60s or more (this is what caused #7147). While we can fix the timeout, it would be nice if people didn't have to wait 60s. They could compress themselves but that's tedious if we can do it for them within website code. The backend already decompresses uploads based on file extension, so compressing client-side and appending `.zst` needs no backend change.

Measured on mpox consensus FASTA: 37 MB → 0.38 MB (99x) in 185 ms at level 12. Metadata TSVs compress ~25x. Uses `@hpcc-js/wasm-zstd` (wasm inlined, no runtime deps), dynamically imported so it lands in its own lazy 247 KB chunk. Falls back to the uncompressed file on any error.

Note: `Zstd.load()` returns a cached singleton whose compression stream state is shared, so concurrent calls corrupt each other's output — hence the serialization, with a test that fails without it.

Draft: no upload progress/"compressing" UI yet, and the compression level is not yet tuned on real submission data (ratio is non-monotonic in level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable