### PR TITLE
ci(backend): make backend-test hangs diagnosable

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -14,9 +14,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
-    # Deliberately larger than the `Run tests` step timeout below: a *job* timeout cancels the job,
-    # which skips every remaining step, so the diagnostics upload would never run. The step timeout
-    # fails just that step and lets `if: always()` steps continue.
+    # larger than individual steps so logs can be collected
     timeout-minutes: 20
     env:
       RUN_EXTRA_TESTS: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'true' || 'false' }}

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -52,6 +52,8 @@ jobs:
           exit $rc
       - name: Collect diagnostics
         if: failure()
+        # bounded so a blocked Gradle lock can't eat the budget the upload needs
+        timeout-minutes: 2
         working-directory: ./backend
         run: |
           if ls build/test-results/test/*.xml >/dev/null 2>&1; then

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -50,18 +50,22 @@ jobs:
           ./gradlew test || rc=$?
           kill "$watchdog" 2>/dev/null || true
           exit $rc
-      - name: Recover test report
+      - name: Collect diagnostics
         if: failure()
-        run: ./gradlew recoverTestReport || true
         working-directory: ./backend
+        run: |
+          if ls build/test-results/test/*.xml >/dev/null 2>&1; then
+            rm -rf build/test-results/test/binary
+          else
+            ./gradlew recoverTestReport || true
+          fi
       - name: Upload test results
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: backend-test-results
           path: |
             backend/build/test-results/test/**
-            backend/build/reports/tests/**
             backend/build/reports/recovered/**
             backend/build/diagnostics/**
           if-no-files-found: warn

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -37,46 +37,21 @@ jobs:
         timeout-minutes: 15
         working-directory: ./backend
         run: |
-          # Threaddump collected to help debug test hangs
           mkdir -p build/diagnostics
-          dump() {
-            for pid in $(jcmd -l 2>/dev/null | grep -v 'sun.tools.jcmd' | awk '{print $1}'); do
-              jcmd "$pid" Thread.print > "build/diagnostics/threaddump-$1-$pid.txt" 2>&1 || true
-            done
-          }
-          ( sleep 660; dump at11min; sleep 120; dump at13min ) >/dev/null 2>&1 &
+          # Thread dumps before the step cap, so a hang shows where it is stuck.
+          # `jcmd Gradle` matches every JVM whose main class contains "Gradle": the daemon and the test executor.
+          ( sleep 660; jcmd Gradle Thread.print; sleep 120; jcmd Gradle Thread.print ) \
+            > build/diagnostics/threaddumps.txt 2>&1 &
           watchdog=$!
           rc=0
           ./gradlew test || rc=$?
           kill "$watchdog" 2>/dev/null || true
           exit $rc
-      - name: Collect diagnostics
+      - name: Show where the test run stopped
         if: failure()
-        # bounded so a blocked Gradle lock can't eat the budget the upload needs
-        timeout-minutes: 2
         working-directory: ./backend
-        run: |
-          # the only progress signal worth putting in the log: what never finished
-          progress=build/diagnostics/test-progress.log
-          if [ ! -f "$progress" ]; then
-            echo "No $progress, so the test task never got as far as running a test."
-          else
-            unfinished=$(awk '{ ts = $1; ev = $2; sub(/^[^ ]+ [^ ]+ /, "")
-                                if (ev == "STARTED") started[$0] = ts; else delete started[$0] }
-                              END { for (t in started) print started[t], t }' "$progress")
-            echo "Tests started: $(grep -c ' STARTED ' "$progress")"
-            if [ -n "$unfinished" ]; then
-              echo "Tests that started but never finished:"
-              echo "$unfinished"
-            else
-              echo "Every test that started also finished."
-            fi
-          fi
-          if ls build/test-results/test/*.xml >/dev/null 2>&1; then
-            rm -rf build/test-results/test/binary
-          else
-            ./gradlew recoverTestReport || true
-          fi
+        # the suite runs one test at a time, so the last line is the test a hang was stuck in
+        run: tail -n 5 build/diagnostics/test-progress.log || echo "No progress log, so no test ever started."
       - name: Upload test results
         if: failure()
         uses: actions/upload-artifact@v7
@@ -84,8 +59,7 @@ jobs:
           name: backend-test-results
           # index.html is the only place output from outside a test lands, e.g. a failed test env start
           path: |
-            backend/build/test-results/test/**
-            backend/build/reports/recovered/**
+            backend/build/test-results/test/*.xml
             backend/build/diagnostics/**
             backend/build/reports/tests/test/index.html
           if-no-files-found: warn

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -50,7 +50,6 @@ jobs:
           ./gradlew test || rc=$?
           kill "$watchdog" 2>/dev/null || true
           exit $rc
-      # A killed run leaves no XML or HTML report, only test-results/test/binary
       - name: Recover test report
         if: failure()
         run: ./gradlew recoverTestReport || true

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -14,7 +14,10 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Deliberately larger than the `Run tests` step timeout below: a *job* timeout cancels the job,
+    # which skips every remaining step, so the diagnostics upload would never run. The step timeout
+    # fails just that step and lets `if: always()` steps continue.
+    timeout-minutes: 20
     env:
       RUN_EXTRA_TESTS: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'true' || 'false' }}
     steps:
@@ -33,8 +36,21 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Run tests
+        timeout-minutes: 15
         run: ./gradlew test
         working-directory: ./backend
+      # Gradle already writes these; without an upload they die with the runner. The JUnit XML
+      # carries per-class start times and captured stdout, which is what localises a hang.
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: backend-test-results
+          path: |
+            backend/build/test-results/test/**/*.xml
+            backend/build/reports/tests/**
+          if-no-files-found: warn
+          retention-days: 14
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -37,8 +37,23 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
       - name: Run tests
         timeout-minutes: 15
-        run: ./gradlew test
         working-directory: ./backend
+        run: |
+          # The step timeout kills the JVM without a stack trace, so snapshot every live JVM
+          # shortly before that deadline. Two dumps, a couple of minutes apart, so a thread that
+          # is genuinely stuck can be told apart from one that is merely slow.
+          mkdir -p build/diagnostics
+          dump() {
+            for pid in $(jcmd -l 2>/dev/null | grep -v 'sun.tools.jcmd' | awk '{print $1}'); do
+              jcmd "$pid" Thread.print > "build/diagnostics/threaddump-$1-$pid.txt" 2>&1 || true
+            done
+          }
+          ( sleep 660; dump at11min; sleep 120; dump at13min ) >/dev/null 2>&1 &
+          watchdog=$!
+          rc=0
+          ./gradlew test || rc=$?
+          kill "$watchdog" 2>/dev/null || true
+          exit $rc
       # Gradle already writes these; without an upload they die with the runner. The JUnit XML
       # carries per-class start times and captured stdout, which is what localises a hang.
       - name: Upload test results
@@ -49,6 +64,7 @@ jobs:
           path: |
             backend/build/test-results/test/**/*.xml
             backend/build/reports/tests/**
+            backend/build/diagnostics/**
           if-no-files-found: warn
           retention-days: 14
 

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -39,9 +39,7 @@ jobs:
         timeout-minutes: 15
         working-directory: ./backend
         run: |
-          # The step timeout kills the JVM without a stack trace, so snapshot every live JVM
-          # shortly before that deadline. Two dumps, a couple of minutes apart, so a thread that
-          # is genuinely stuck can be told apart from one that is merely slow.
+          # Threaddump collected to help debug test hangs
           mkdir -p build/diagnostics
           dump() {
             for pid in $(jcmd -l 2>/dev/null | grep -v 'sun.tools.jcmd' | awk '{print $1}'); do
@@ -54,8 +52,6 @@ jobs:
           ./gradlew test || rc=$?
           kill "$watchdog" 2>/dev/null || true
           exit $rc
-      # Gradle already writes these; without an upload they die with the runner. The JUnit XML
-      # carries per-class start times and captured stdout, which is what localises a hang.
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -56,6 +56,22 @@ jobs:
         timeout-minutes: 2
         working-directory: ./backend
         run: |
+          # the only progress signal worth putting in the log: what never finished
+          progress=build/diagnostics/test-progress.log
+          if [ ! -f "$progress" ]; then
+            echo "No $progress, so the test task never got as far as running a test."
+          else
+            unfinished=$(awk '{ ts = $1; ev = $2; sub(/^[^ ]+ [^ ]+ /, "")
+                                if (ev == "STARTED") started[$0] = ts; else delete started[$0] }
+                              END { for (t in started) print started[t], t }' "$progress")
+            echo "Tests started: $(grep -c ' STARTED ' "$progress")"
+            if [ -n "$unfinished" ]; then
+              echo "Tests that started but never finished:"
+              echo "$unfinished"
+            else
+              echo "Every test that started also finished."
+            fi
+          fi
           if ls build/test-results/test/*.xml >/dev/null 2>&1; then
             rm -rf build/test-results/test/binary
           else

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -50,17 +50,22 @@ jobs:
           ./gradlew test || rc=$?
           kill "$watchdog" 2>/dev/null || true
           exit $rc
+      # A killed run leaves no XML or HTML report, only test-results/test/binary
+      - name: Recover test report
+        if: failure()
+        run: ./gradlew recoverTestReport || true
+        working-directory: ./backend
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: backend-test-results
           path: |
-            backend/build/test-results/test/**/*.xml
+            backend/build/test-results/test/**
             backend/build/reports/tests/**
+            backend/build/reports/recovered/**
             backend/build/diagnostics/**
           if-no-files-found: warn
-          retention-days: 14
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -57,7 +57,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: backend-test-results
-          # index.html is the only place output from outside a test lands, e.g. a failed test env start
           path: |
             backend/build/test-results/test/*.xml
             backend/build/diagnostics/**

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -82,10 +82,12 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: backend-test-results
+          # index.html is the only place output from outside a test lands, e.g. a failed test env start
           path: |
             backend/build/test-results/test/**
             backend/build/reports/recovered/**
             backend/build/diagnostics/**
+            backend/build/reports/tests/test/index.html
           if-no-files-found: warn
 
   lint:

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -133,14 +133,12 @@ tasks.named('test') {
         showExceptions = true
     }
     // Records each test's start and finish so a hung run names the test it was stuck in.
-    // It goes to a file rather than the console, which would flood the log of every normal run.
     def progressLog = layout.buildDirectory.file('diagnostics/test-progress.log')
     doFirst {
         def file = progressLog.get().asFile
         file.parentFile.mkdirs()
         file.text = ''
     }
-    // TestListener rather than the shorter beforeTest/afterTest closures, which Gradle 9 deprecated
     addTestListener(new TestListener() {
         void beforeSuite(TestDescriptor suite) {}
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -163,3 +163,9 @@ task downloadDependencies {
         }
     }
 }
+
+// Gradle only writes XML/HTML when `test` completes, so rebuild from the binary results
+tasks.register('recoverTestReport', TestReport) {
+    testResults.from(layout.buildDirectory.dir('test-results/test/binary'))
+    destinationDirectory = layout.buildDirectory.dir('reports/recovered')
+}

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -125,7 +125,13 @@ tasks.named('test') {
     useJUnitPlatform()
     jvmArgs '--enable-native-access=ALL-UNNAMED'
     testLogging {
-        events TestLogEvent.FAILED, TestLogEvent.STANDARD_ERROR
+        // STARTED + PASSED so an in-flight test is visible: on a hang, the last STARTED with no
+        // matching PASSED names the culprit. Without them the whole :test phase prints nothing,
+        // making a hung log indistinguishable from a green one.
+        events TestLogEvent.STARTED,
+            TestLogEvent.PASSED,
+            TestLogEvent.FAILED,
+            TestLogEvent.STANDARD_ERROR
         exceptionFormat = TestExceptionFormat.FULL
         showExceptions = true
     }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -125,9 +125,6 @@ tasks.named('test') {
     useJUnitPlatform()
     jvmArgs '--enable-native-access=ALL-UNNAMED'
     testLogging {
-        // STARTED + PASSED so an in-flight test is visible: on a hang, the last STARTED with no
-        // matching PASSED names the culprit. Without them the whole :test phase prints nothing,
-        // making a hung log indistinguishable from a green one.
         events TestLogEvent.STARTED,
             TestLogEvent.PASSED,
             TestLogEvent.FAILED,

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,3 +1,6 @@
+import org.gradle.api.tasks.testing.TestDescriptor
+import org.gradle.api.tasks.testing.TestListener
+import org.gradle.api.tasks.testing.TestResult
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
@@ -125,13 +128,30 @@ tasks.named('test') {
     useJUnitPlatform()
     jvmArgs '--enable-native-access=ALL-UNNAMED'
     testLogging {
-        events TestLogEvent.STARTED,
-            TestLogEvent.PASSED,
-            TestLogEvent.FAILED,
-            TestLogEvent.STANDARD_ERROR
+        events TestLogEvent.FAILED, TestLogEvent.STANDARD_ERROR
         exceptionFormat = TestExceptionFormat.FULL
         showExceptions = true
     }
+    // per-test progress goes to a file, not the console, so a killed run still names the test it was in
+    def progressLog = layout.buildDirectory.file('diagnostics/test-progress.log')
+    doFirst {
+        def file = progressLog.get().asFile
+        file.parentFile.mkdirs()
+        file.text = ''
+    }
+    addTestListener(new TestListener() {
+        void beforeSuite(TestDescriptor suite) {}
+
+        void afterSuite(TestDescriptor suite, TestResult result) {}
+
+        void beforeTest(TestDescriptor descriptor) {
+            progressLog.get().asFile << "${java.time.Instant.now()} STARTED ${descriptor.className}.${descriptor.name}\n"
+        }
+
+        void afterTest(TestDescriptor descriptor, TestResult result) {
+            progressLog.get().asFile << "${java.time.Instant.now()} ${result.resultType} ${descriptor.className}.${descriptor.name}\n"
+        }
+    })
 }
 
 tasks.named('bootBuildImage') {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -185,9 +185,3 @@ task downloadDependencies {
         }
     }
 }
-
-// Gradle only writes XML/HTML when `test` completes, so rebuild from the binary results
-tasks.register('recoverTestReport', TestReport) {
-    testResults.from(layout.buildDirectory.dir('test-results/test/binary'))
-    destinationDirectory = layout.buildDirectory.dir('reports/recovered')
-}

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -132,13 +132,15 @@ tasks.named('test') {
         exceptionFormat = TestExceptionFormat.FULL
         showExceptions = true
     }
-    // per-test progress goes to a file, not the console, so a killed run still names the test it was in
+    // Records each test's start and finish so a hung run names the test it was stuck in.
+    // It goes to a file rather than the console, which would flood the log of every normal run.
     def progressLog = layout.buildDirectory.file('diagnostics/test-progress.log')
     doFirst {
         def file = progressLog.get().asFile
         file.parentFile.mkdirs()
         file.text = ''
     }
+    // TestListener rather than the shorter beforeTest/afterTest closures, which Gradle 9 deprecated
     addTestListener(new TestListener() {
         void beforeSuite(TestDescriptor suite) {}
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitLargeBatchTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitLargeBatchTest.kt
@@ -10,8 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-// logback-test.xml puts Exposed at debug, which made this test's 100k inserts a 127 MB test-results XML
-@EndpointTest(properties = ["logging.level.Exposed=WARN"])
+// logback-test.xml puts Exposed at debug, so this test's 100k inserts make its test-results XML ~127 MB
+@EndpointTest
 @EnabledIfEnvironmentVariable(named = "RUN_EXTRA_TESTS", matches = "true")
 class SubmitLargeBatchTest(
     @Autowired val submissionControllerClient: SubmissionControllerClient,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitLargeBatchTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitLargeBatchTest.kt
@@ -10,7 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@EndpointTest
+// Logging 100k inserts at debug made the test-results XML 127 MB
+@EndpointTest(properties = ["logging.level.Exposed=WARN"])
 @EnabledIfEnvironmentVariable(named = "RUN_EXTRA_TESTS", matches = "true")
 class SubmitLargeBatchTest(
     @Autowired val submissionControllerClient: SubmissionControllerClient,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitLargeBatchTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitLargeBatchTest.kt
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-// logback-test.xml puts Exposed at debug, so this test's 100k inserts make its test-results XML ~127 MB
 @EndpointTest
 @EnabledIfEnvironmentVariable(named = "RUN_EXTRA_TESTS", matches = "true")
 class SubmitLargeBatchTest(

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitLargeBatchTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitLargeBatchTest.kt
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-// Logging 100k inserts at debug made the test-results XML 127 MB
+// logback-test.xml puts Exposed at debug, which made this test's 100k inserts a 127 MB test-results XML
 @EndpointTest(properties = ["logging.level.Exposed=WARN"])
 @EnabledIfEnvironmentVariable(named = "RUN_EXTRA_TESTS", matches = "true")
 class SubmitLargeBatchTest(


### PR DESCRIPTION
## Why

`backend-tests` dies at the 15-minute cap every so often, and no occurrence was diagnosable — the job recorded nothing about where it stopped. Six occurrences in 3390 runs (~0.18%) going back to 2025-07-09: [19969091729](https://github.com/loculus-project/loculus/actions/runs/19969091729), [24840664509](https://github.com/loculus-project/loculus/actions/runs/24840664509), [31117640303](https://github.com/loculus-project/loculus/actions/runs/31117640303), [31121527329](https://github.com/loculus-project/loculus/actions/runs/31121527329), [32712103886 att 1](https://github.com/loculus-project/loculus/actions/runs/32712103886/attempts/1), [32748302946 att 1](https://github.com/loculus-project/loculus/actions/runs/32748302946/attempts/1). Two of those only show up if you ask for earlier attempts explicitly, because a run that hung and was then re-run green reports as a fast success.

This PR improves logging and log collection and also adds a thread dump collection to be able to inspect exactly where the tests hang.

This has already proved useful, I'll make an issue or fix PRs for the reasons hangs happened (I did ~150 test runs of backend tests to find hangs to investigate).

## Worth knowing (according to Claude)

**Gradle writes the JUnit XML and HTML only when the `test` task completes.** So an artifact glob of `test-results/**/*.xml` uploads nothing on a timeout, which is the only case it would be written for. Measured by killing local runs at different points:

| state | XML | HTML | `test-results/test/binary/` |
|---|---|---|---|
| clean pass | 74 | yes | present |
| killed after all 580 tests ran | **0** | **no** | 118 KB + 18 MB `output-events.bin` |
| killed 12 s in (73 tests passed) | **0** | **no** | 12 KB + 1.7 MB |

Hence keeping the binary store when there's no XML, plus `recoverTestReport` to rebuild from it. **That recovery has a limit worth knowing before relying on it:** complete when all the tests had finished and the kill landed while the report was being written, but **empty** when the run is killed while tests are still running — 73 tests had passed across ~10 classes and none appeared, because Gradle only finalises that store at the end, rather than as each test finishes. So for a hang the useful evidence is the per-test progress log and the thread dumps; the recovery step only helps when a run is killed after the tests are done.

**Per-test progress goes to a file rather than the console.** Printing every test's start and finish to the job log made ordinary runs unreadable, so it now goes to `build/diagnostics/test-progress.log`, which the artifact already collects. Each line is written as it happens, so a killed run keeps everything up to the moment it died — checked by killing a run mid-suite, which left 509 lines with the last one naming the test still running. On a failure the job log gets only the tests that started and never finished, which is the part worth having there.

**The report's root page is the only place output from outside a test survives.** Anything logged before the first test class starts has no test to be attributed to, so Gradle files it as output of the run as a whole, and that appears only in `build/reports/tests/test/index.html`. It is where a failure to start the test database reports its real cause: on a deliberately broken startup, 74 per-class XML files were written and not one of them contained it. An earlier commit here dropped the HTML report as a duplicate of the XML, which holds for a normal run and not for that one, so the root page alone is back — 57 KB, against 9.4 MB for the whole report.

🚀 Preview: Add `preview` label to enable