### PR TITLE
fix(website): derive the file mapping instead of maintaining a copy of it

### DIFF
--- a/website/src/components/Edit/EditPage.tsx
+++ b/website/src/components/Edit/EditPage.tsx
@@ -1,5 +1,5 @@
 import { isErrorFromAlias } from '@zodios/core';
-import { type FC, useState } from 'react';
+import { type FC, useMemo, useState } from 'react';
 import { toast } from 'react-toastify';
 
 import { EditableSequences } from './EditableSequences.ts';
@@ -18,12 +18,9 @@ import { getAccessionVersionString, parseAccessionVersionFromString } from '../.
 import { displayConfirmationDialog } from '../ConfirmationDialog.tsx';
 import { SequenceEntryHistoryMenu } from '../SequenceDetailsPage/SequenceEntryHistoryMenu.tsx';
 import { ExtraFilesUpload } from '../Submission/DataUploadForm.tsx';
+import { applyFileMappings, getSingleSubmissionFileMapping } from '../Submission/FileUpload/fileMapping.ts';
 import {
-    applyFileMappings,
-    getSingleSubmissionFileMapping,
-    type FileMapping,
-} from '../Submission/FileUpload/fileMapping.ts';
-import {
+    deriveFileMapping,
     getPreviousFileUploadStates,
     validateFileUploadStates,
     type FileUploadState,
@@ -76,7 +73,8 @@ const InnerEditPage: FC<EditPageProps> = ({
     const [fileUploadStates, setFileUploadStates] = useState<Map<string, FileUploadState>>(() =>
         dataToEdit.submittedData.files ? getPreviousFileUploadStates(dataToEdit.submittedData.files) : new Map(),
     );
-    const [fileMapping, setFileMapping] = useState<FileMapping | undefined>(undefined);
+
+    const fileMapping = useMemo(() => deriveFileMapping(fileUploadStates), [fileUploadStates]);
 
     const isCreatingRevision = dataToEdit.status === approvedForReleaseStatus;
 
@@ -248,7 +246,6 @@ const InnerEditPage: FC<EditPageProps> = ({
                         fileCategories={submissionDataTypes.files?.categories ?? []}
                         fileUploadStates={fileUploadStates}
                         setFileUploadStates={setFileUploadStates}
-                        setFileMapping={setFileMapping}
                         onError={(msg) => toast.error(msg, { position: 'top-center', autoClose: false })}
                     />
                 </div>

--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -7,7 +7,7 @@ import { type FormEvent, useState, type Dispatch, type SetStateAction, useMemo }
 import { type FileFactory, FormOrUploadWrapper, type InputMode } from './FormOrUploadWrapper.tsx';
 import { getClientLogger } from '../../clientLogger.ts';
 import { FolderUploadComponent } from './FileUpload/FolderUploadComponent.tsx';
-import { validateFileUploadStates, type FileUploadState } from './FileUpload/fileUpload.ts';
+import { deriveFileMapping, validateFileUploadStates, type FileUploadState } from './FileUpload/fileUpload.ts';
 import DataUseTermsSelector from '../../components/DataUseTerms/DataUseTermsSelector';
 import { SubmissionRouteUtils } from '../../routes/SubmissionRoute.ts';
 import { backendApi } from '../../services/backendApi.ts';
@@ -36,7 +36,6 @@ import {
     getSingleSubmissionFileMapping,
     type CategoryLinkage,
     type FileLinkage,
-    type FileMapping,
     type SubmissionFileMapping,
 } from './FileUpload/fileMapping.ts';
 import { extraFilesUploadDocsUrl } from './extraFilesUploadDocsUrl.ts';
@@ -79,7 +78,7 @@ const InnerDataUploadForm = ({
     const { submit, revise, isPending } = useSubmitFiles(accessToken, organism, clientConfig, onSuccess, onError);
     const [fileFactory, setFileFactory] = useState<FileFactory | undefined>(undefined);
     const [fileUploadStates, setFileUploadStates] = useState<Map<string, FileUploadState>>(new Map());
-    const [fileMapping, setFileMapping] = useState<FileMapping | undefined>(undefined);
+    const fileMapping = useMemo(() => deriveFileMapping(fileUploadStates), [fileUploadStates]);
     const [submissionFileMapping, setSubmissionFileMapping] = useState<
         Result<SubmissionFileMapping, Error> | undefined
     >(undefined);
@@ -245,7 +244,6 @@ const InnerDataUploadForm = ({
                             onError={onError}
                             fileUploadStates={fileUploadStates}
                             setFileUploadStates={setFileUploadStates}
-                            setFileMapping={setFileMapping}
                             fileLinkage={fileLinkage}
                         />
                         <hr />
@@ -406,7 +404,6 @@ export const ExtraFilesUpload = ({
     fileCategories,
     fileUploadStates,
     setFileUploadStates,
-    setFileMapping,
     fileLinkage,
     onError,
 }: {
@@ -417,7 +414,6 @@ export const ExtraFilesUpload = ({
     fileCategories: FileCategory[];
     fileUploadStates: Map<string, FileUploadState>;
     setFileUploadStates: Dispatch<SetStateAction<Map<string, FileUploadState>>>;
-    setFileMapping: Dispatch<SetStateAction<FileMapping | undefined>>;
     fileLinkage?: FileLinkage;
     onError: (message: string) => void;
 }) => {
@@ -459,7 +455,6 @@ export const ExtraFilesUpload = ({
                             onError={onError}
                             fileUploadState={fileUploadStates.get(fileCategory.name)}
                             setFileUploadState={setCategoryFileUploadState(fileCategory.name)}
-                            setFileMapping={setFileMapping}
                         />
                         {inputMode === 'bulk' && (
                             <CategoryLinkageStatus categoryLinkage={fileLinkage?.get(fileCategory.name)} />

--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.spec.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.spec.tsx
@@ -6,7 +6,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import { FolderUploadComponent } from './FolderUploadComponent';
 import { type FileMapping } from './fileMapping';
-import { type FileUploadState } from './fileUpload';
+import { deriveFileMapping, type FileUploadState } from './fileUpload';
 import * as multipartUpload from '../../../utils/multipartUpload';
 
 const mockRequestMultipartUpload = vi.fn();
@@ -36,24 +36,22 @@ vi.mock('../../../utils/multipartUpload', async () => {
 
 const FolderUploadComponentWithState = ({
     initialState,
-    initialMapping,
+    otherCategories,
     onMapping,
     ...props
-}: Omit<ComponentProps<typeof FolderUploadComponent>, 'fileUploadState' | 'setFileUploadState' | 'setFileMapping'> & {
+}: Omit<ComponentProps<typeof FolderUploadComponent>, 'fileUploadState' | 'setFileUploadState'> & {
     initialState?: FileUploadState;
-    initialMapping?: FileMapping;
+    otherCategories?: Map<string, FileUploadState>;
     onMapping?: (mapping: FileMapping | undefined) => void;
 }) => {
     const [fileUploadState, setFileUploadState] = useState(initialState);
-    const [mapping, setMapping] = useState<FileMapping | undefined>(initialMapping);
-    useEffect(() => onMapping?.(mapping), [mapping, onMapping]);
+    // Stands in for the parent, which derives the mapping from the states of all its categories.
+    const states = new Map(otherCategories);
+    if (fileUploadState !== undefined) states.set(props.fileCategory.name, fileUploadState);
+    const mapping = deriveFileMapping(states);
+    useEffect(() => onMapping?.(mapping));
     return (
-        <FolderUploadComponent
-            {...props}
-            fileUploadState={fileUploadState}
-            setFileUploadState={setFileUploadState}
-            setFileMapping={setMapping}
-        />
+        <FolderUploadComponent {...props} fileUploadState={fileUploadState} setFileUploadState={setFileUploadState} />
     );
 };
 
@@ -503,7 +501,17 @@ describe('FolderUploadComponent', () => {
             render(
                 <FolderUploadComponentWithState
                     {...defaultPropsWithFiles}
-                    initialMapping={new Map([['otherFiles', otherCategoryFiles]])}
+                    otherCategories={
+                        new Map([
+                            [
+                                'otherFiles',
+                                {
+                                    type: 'uploadCompleted',
+                                    files: [{ type: 'previousUpload', fileId: 'file-3', path: 'other-file.txt' }],
+                                } satisfies FileUploadState,
+                            ],
+                        ])
+                    }
                     onMapping={onMapping}
                 />,
             );

--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.spec.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.spec.tsx
@@ -49,7 +49,7 @@ const FolderUploadComponentWithState = ({
     const states = new Map(otherCategories);
     if (fileUploadState !== undefined) states.set(props.fileCategory.name, fileUploadState);
     const mapping = deriveFileMapping(states);
-    useEffect(() => onMapping?.(mapping));
+useEffect(() => onMapping?.(mapping), [mapping, onMapping]);
     return (
         <FolderUploadComponent {...props} fileUploadState={fileUploadState} setFileUploadState={setFileUploadState} />
     );

--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.spec.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.spec.tsx
@@ -49,7 +49,7 @@ const FolderUploadComponentWithState = ({
     const states = new Map(otherCategories);
     if (fileUploadState !== undefined) states.set(props.fileCategory.name, fileUploadState);
     const mapping = deriveFileMapping(states);
-useEffect(() => onMapping?.(mapping), [mapping, onMapping]);
+    useEffect(() => onMapping?.(mapping), [mapping, onMapping]);
     return (
         <FolderUploadComponent {...props} fileUploadState={fileUploadState} setFileUploadState={setFileUploadState} />
     );

--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.tsx
@@ -2,7 +2,6 @@ import { produce } from 'immer';
 import React, { useEffect, useState, type Dispatch, type FC, type SetStateAction } from 'react';
 import { toast } from 'react-toastify';
 
-import { type FileMapping } from './fileMapping';
 import type {
     Awaiting,
     FileUploadState,
@@ -32,7 +31,6 @@ type FolderUploadComponentProps = {
     groupId: number;
     fileUploadState: FileUploadState | undefined;
     setFileUploadState: Dispatch<SetStateAction<FileUploadState | undefined>>;
-    setFileMapping: Dispatch<SetStateAction<FileMapping | undefined>>;
     onError: (message: string) => void;
 };
 
@@ -90,7 +88,6 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
     groupId,
     fileUploadState,
     setFileUploadState,
-    setFileMapping,
     onError,
 }) => {
     const [isDragging, setIsDragging] = useState(false);
@@ -197,15 +194,7 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
     }
 
     useEffect(() => {
-        if (fileUploadState === undefined) {
-            setFileMapping((currentMapping) => {
-                if (currentMapping === undefined) return undefined;
-                const newMapping = new Map(currentMapping);
-                newMapping.delete(fileCategory.name);
-                return newMapping.size === 0 ? undefined : newMapping;
-            });
-            return;
-        }
+        if (fileUploadState === undefined) return;
 
         switch (fileUploadState.type) {
             // If awaiting URLS, request pre signed upload URLs from the backend, assign them to the files,
@@ -225,17 +214,6 @@ export const FolderUploadComponent: FC<FolderUploadComponentProps> = ({
                         files: fileUploadState.files as (Uploaded | PreviousUpload)[],
                     });
                 }
-                break;
-            }
-            case 'uploadCompleted': {
-                setFileMapping((currentMapping) => {
-                    const newMapping = new Map(currentMapping);
-                    newMapping.set(
-                        fileCategory.name,
-                        new Map(fileUploadState.files.map((file) => [file.path, file.fileId])),
-                    );
-                    return newMapping;
-                });
                 break;
             }
         }

--- a/website/src/components/Submission/FileUpload/fileUpload.spec.ts
+++ b/website/src/components/Submission/FileUpload/fileUpload.spec.ts
@@ -1,11 +1,34 @@
 import { describe, expect, it } from 'vitest';
 
-import { deriveFileMapping, validateFileUploadStates, type FileUploadState } from './fileUpload';
+import {
+    deriveFileMapping,
+    getPreviousFileUploadStates,
+    validateFileUploadStates,
+    type FileUploadState,
+    type Pending,
+} from './fileUpload';
 
-const uploaded = { type: 'uploaded', fileId: 'file-1', path: 'a.txt', size: 7 } as const;
-const previousUpload = { type: 'previousUpload', fileId: 'file-2', path: 'b.txt' } as const;
+const RAW_READS = 'rawReads';
+const ANNOTATIONS = 'annotations';
 
-const statesOf = (...states: FileUploadState[]) => new Map(states.map((state, index) => [`category${index}`, state]));
+const uploaded = { type: 'uploaded', fileId: 'file-1', path: 'uploaded.txt', size: 7 } as const;
+const previousUpload = { type: 'previousUpload', fileId: 'file-2', path: 'previousUpload.txt' } as const;
+const awaiting = { type: 'awaiting', file: new File([], 'awaiting.txt'), path: 'awaiting.txt', size: 7 } as const;
+const pending: Pending = {
+    type: 'pending',
+    file: new File([], 'pending.txt'),
+    path: 'pending.txt',
+    size: 7,
+    fileId: 'file-3',
+    urls: ['url'],
+    uploadedParts: 0,
+    totalParts: 1,
+    partSize: 7,
+};
+const errored = { type: 'error', path: 'errored.txt', size: 7, msg: 'upload failed' } as const;
+
+const submittedReads = { fileId: 'file-4', name: 'reads.fastq' };
+const submittedAnnotations = { fileId: 'file-5', name: 'annotations.gff' };
 
 describe('validateFileUploadStates', () => {
     it('accepts a submission without any file categories', () => {
@@ -14,17 +37,19 @@ describe('validateFileUploadStates', () => {
 
     it('accepts categories whose uploads have all completed', () => {
         const result = validateFileUploadStates(
-            statesOf(
-                { type: 'uploadCompleted', files: [uploaded] },
-                { type: 'uploadCompleted', files: [previousUpload] },
-            ),
+            new Map<string, FileUploadState>([
+                [RAW_READS, { type: 'uploadCompleted', files: [uploaded] }],
+                [ANNOTATIONS, { type: 'uploadCompleted', files: [previousUpload] }],
+            ]),
         );
 
         expect(result.isOk()).toBeTruthy();
     });
 
     it('rejects a category which is still awaiting upload urls', () => {
-        const result = validateFileUploadStates(statesOf({ type: 'awaitingUrls', files: [] }));
+        const result = validateFileUploadStates(
+            new Map<string, FileUploadState>([[RAW_READS, { type: 'awaitingUrls', files: [] }]]),
+        );
 
         expect(result.isErr()).toBeTruthy();
         expect(result._unsafeUnwrapErr().message).toContain('wait for all files to finish uploading');
@@ -32,7 +57,10 @@ describe('validateFileUploadStates', () => {
 
     it('rejects a category whose upload is still in progress', () => {
         const result = validateFileUploadStates(
-            statesOf({ type: 'uploadCompleted', files: [uploaded] }, { type: 'uploadInProgress', files: [uploaded] }),
+            new Map<string, FileUploadState>([
+                [RAW_READS, { type: 'uploadCompleted', files: [uploaded] }],
+                [ANNOTATIONS, { type: 'uploadInProgress', files: [uploaded] }],
+            ]),
         );
 
         expect(result.isErr()).toBeTruthy();
@@ -41,43 +69,91 @@ describe('validateFileUploadStates', () => {
 });
 
 describe('deriveFileMapping', () => {
-    it('returns undefined rather than an empty map when nothing was uploaded', () => {
-        // Callers treat undefined as "no file mapping to apply"; an empty map is not equivalent.
+    it('returns undefined when no files have been uploaded', () => {
         expect(deriveFileMapping(new Map())).toBeUndefined();
-        expect(deriveFileMapping(statesOf({ type: 'uploadInProgress', files: [uploaded] }))).toBeUndefined();
+        expect(
+            deriveFileMapping(
+                new Map<string, FileUploadState>([
+                    [RAW_READS, { type: 'awaitingUrls', files: [awaiting] }],
+                    [ANNOTATIONS, { type: 'uploadInProgress', files: [pending] }],
+                ]),
+            ),
+        ).toBeUndefined();
     });
 
-    it('maps every completed category by path to file id', () => {
+    it('maps the path of every uploaded and previously uploaded file to its file id', () => {
         const mapping = deriveFileMapping(
-            statesOf(
-                { type: 'uploadCompleted', files: [uploaded] },
-                { type: 'uploadCompleted', files: [previousUpload] },
-            ),
+            new Map<string, FileUploadState>([
+                [
+                    RAW_READS,
+                    { type: 'uploadInProgress', files: [uploaded, previousUpload, awaiting, pending, errored] },
+                ],
+                [ANNOTATIONS, { type: 'uploadCompleted', files: [previousUpload] }],
+            ]),
         );
 
         expect(mapping).toEqual(
             new Map([
-                ['category0', new Map([['a.txt', 'file-1']])],
-                ['category1', new Map([['b.txt', 'file-2']])],
+                [
+                    RAW_READS,
+                    new Map([
+                        [uploaded.path, uploaded.fileId],
+                        [previousUpload.path, previousUpload.fileId],
+                    ]),
+                ],
+                [ANNOTATIONS, new Map([[previousUpload.path, previousUpload.fileId]])],
             ]),
         );
     });
 
-    it('omits categories which are not yet complete, mirroring validateFileUploadStates', () => {
+    it('omits categories without any uploaded files', () => {
         const mapping = deriveFileMapping(
-            statesOf({ type: 'uploadCompleted', files: [uploaded] }, { type: 'uploadInProgress', files: [uploaded] }),
+            new Map<string, FileUploadState>([
+                [RAW_READS, { type: 'uploadCompleted', files: [uploaded] }],
+                [ANNOTATIONS, { type: 'uploadInProgress', files: [pending] }],
+            ]),
         );
 
-        expect(mapping).toEqual(new Map([['category0', new Map([['a.txt', 'file-1']])]]));
+        expect(mapping).toEqual(new Map([[RAW_READS, new Map([[uploaded.path, uploaded.fileId]])]]));
+    });
+});
+
+describe('getPreviousFileUploadStates', () => {
+    it('presents already submitted files as previous uploads', () => {
+        const states = getPreviousFileUploadStates({
+            [RAW_READS]: [submittedReads],
+            [ANNOTATIONS]: [submittedAnnotations],
+        });
+
+        expect(states).toEqual(
+            new Map([
+                [
+                    RAW_READS,
+                    {
+                        type: 'uploadCompleted',
+                        files: [{ type: 'previousUpload', fileId: submittedReads.fileId, path: submittedReads.name }],
+                    },
+                ],
+                [
+                    ANNOTATIONS,
+                    {
+                        type: 'uploadCompleted',
+                        files: [
+                            {
+                                type: 'previousUpload',
+                                fileId: submittedAnnotations.fileId,
+                                path: submittedAnnotations.name,
+                            },
+                        ],
+                    },
+                ],
+            ]),
+        );
     });
 
-    it('yields the replacement file id for a replaced file, not the id it replaced', () => {
-        // The regression this exists for: a file replaced on the edit page was submitted under
-        // the fileId of the file it replaced, silently publishing the old content.
-        const replaced = { type: 'uploaded', fileId: 'file-new', path: 'b.txt', size: 7 } as const;
+    it('omits categories without any files', () => {
+        const states = getPreviousFileUploadStates({ [RAW_READS]: [submittedReads], [ANNOTATIONS]: [] });
 
-        const mapping = deriveFileMapping(statesOf({ type: 'uploadCompleted', files: [uploaded, replaced] }));
-
-        expect(mapping?.get('category0')?.get('b.txt')).toBe('file-new');
+        expect([...states.keys()]).toEqual([RAW_READS]);
     });
 });

--- a/website/src/components/Submission/FileUpload/fileUpload.spec.ts
+++ b/website/src/components/Submission/FileUpload/fileUpload.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { validateFileUploadStates, type FileUploadState } from './fileUpload';
+import { deriveFileMapping, validateFileUploadStates, type FileUploadState } from './fileUpload';
 
 const uploaded = { type: 'uploaded', fileId: 'file-1', path: 'a.txt', size: 7 } as const;
 const previousUpload = { type: 'previousUpload', fileId: 'file-2', path: 'b.txt' } as const;
@@ -37,5 +37,47 @@ describe('validateFileUploadStates', () => {
 
         expect(result.isErr()).toBeTruthy();
         expect(result._unsafeUnwrapErr().message).toContain('wait for all files to finish uploading');
+    });
+});
+
+describe('deriveFileMapping', () => {
+    it('returns undefined rather than an empty map when nothing was uploaded', () => {
+        // Callers treat undefined as "no file mapping to apply"; an empty map is not equivalent.
+        expect(deriveFileMapping(new Map())).toBeUndefined();
+        expect(deriveFileMapping(statesOf({ type: 'uploadInProgress', files: [uploaded] }))).toBeUndefined();
+    });
+
+    it('maps every completed category by path to file id', () => {
+        const mapping = deriveFileMapping(
+            statesOf(
+                { type: 'uploadCompleted', files: [uploaded] },
+                { type: 'uploadCompleted', files: [previousUpload] },
+            ),
+        );
+
+        expect(mapping).toEqual(
+            new Map([
+                ['category0', new Map([['a.txt', 'file-1']])],
+                ['category1', new Map([['b.txt', 'file-2']])],
+            ]),
+        );
+    });
+
+    it('omits categories which are not yet complete, mirroring validateFileUploadStates', () => {
+        const mapping = deriveFileMapping(
+            statesOf({ type: 'uploadCompleted', files: [uploaded] }, { type: 'uploadInProgress', files: [uploaded] }),
+        );
+
+        expect(mapping).toEqual(new Map([['category0', new Map([['a.txt', 'file-1']])]]));
+    });
+
+    it('yields the replacement file id for a replaced file, not the id it replaced', () => {
+        // The regression this exists for: a file replaced on the edit page was submitted under
+        // the fileId of the file it replaced, silently publishing the old content.
+        const replaced = { type: 'uploaded', fileId: 'file-new', path: 'b.txt', size: 7 } as const;
+
+        const mapping = deriveFileMapping(statesOf({ type: 'uploadCompleted', files: [uploaded, replaced] }));
+
+        expect(mapping?.get('category0')?.get('b.txt')).toBe('file-new');
     });
 });

--- a/website/src/components/Submission/FileUpload/fileUpload.ts
+++ b/website/src/components/Submission/FileUpload/fileUpload.ts
@@ -87,14 +87,16 @@ export const getPreviousFileUploadStates = (files: FilesByCategory): Map<string,
             ]),
     );
 
-/** The file mapping is a projection of the upload states, so derive it rather than storing a copy that lags a render behind. */
 export const deriveFileMapping = (fileUploadStates: Map<string, FileUploadState>): FileMapping | undefined => {
     const mapping: FileMapping = new Map(
-        Array.from(fileUploadStates.entries()).flatMap(([category, state]) =>
-            state.type === 'uploadCompleted'
-                ? [[category, new Map(state.files.map((file) => [file.path, file.fileId]))] as const]
-                : [],
-        ),
+        Array.from(fileUploadStates.entries()).flatMap(([category, fileUploadState]) => {
+            // Only files that have finished uploading are included in the file mapping and can be claimed as linked
+            const uploads = fileUploadState.files.filter(
+                (file) => file.type === 'uploaded' || file.type === 'previousUpload',
+            ) as (Uploaded | PreviousUpload)[];
+
+            return uploads.length === 0 ? [] : [[category, new Map(uploads.map((file) => [file.path, file.fileId]))]];
+        }),
     );
     return mapping.size === 0 ? undefined : mapping;
 };

--- a/website/src/components/Submission/FileUpload/fileUpload.ts
+++ b/website/src/components/Submission/FileUpload/fileUpload.ts
@@ -1,5 +1,6 @@
 import { err, ok, Result } from 'neverthrow';
 
+import type { FileMapping } from './fileMapping';
 import type { FilesByCategory } from '../../../types/backend';
 
 export type Awaiting = {
@@ -85,6 +86,18 @@ export const getPreviousFileUploadStates = (files: FilesByCategory): Map<string,
                 },
             ]),
     );
+
+/** The file mapping is a projection of the upload states, so derive it rather than storing a copy that lags a render behind. */
+export const deriveFileMapping = (fileUploadStates: Map<string, FileUploadState>): FileMapping | undefined => {
+    const mapping: FileMapping = new Map(
+        Array.from(fileUploadStates.entries()).flatMap(([category, state]) =>
+            state.type === 'uploadCompleted'
+                ? [[category, new Map(state.files.map((file) => [file.path, file.fileId]))] as const]
+                : [],
+        ),
+    );
+    return mapping.size === 0 ? undefined : mapping;
+};
 
 export const validateFileUploadStates = (fileUploadStates: Map<string, FileUploadState>): Result<void, Error> => {
     if (Array.from(fileUploadStates.values()).some((state) => state.type !== 'uploadCompleted'))


### PR DESCRIPTION
Follow-up to #7132, and related to the umbrella flake issue #6096.

I've noticed a integration test failure that looked like this (there were actually 5 instances of this in the past few days):

```
1) [chromium-without-dep] › tests/specs/features/file-sharing.spec.ts:451:5 › single revise seq via edit page reuses, replaces, discards and adds files 

    Error: expect(received).toBe(expected) // Object.is equality

    - Expected  - 1
    + Received  + 1

    - @SRR123456.1 1/1
    + @SRR123456.1 1/2
      ATGGATAAACGGGTGAGAGGTTCATGGGCCCTGGGAGGACAATCTGAAGTTGATCTTGACTACCACAAAA
      +
      IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
      ↵

       at utils/link-helpers.ts:20

      18 |     expect(response.status()).toBe(200);
      19 |     const content = await response.text();
    > 20 |     expect(content).toBe(expectedContent);
```

(https://github.com/loculus-project/loculus/actions/runs/32844888050/job/97792281964)

This refactor here should fix the flakes (by fixing the underlying bug) and also how the `fileMapping` is derived, simplifying flow.

One can probably drop the unit tests - not sure how much they add. I guess they're good to have for Claude to check its work but not sure they are necessary.

<details>
<summary>Claude PR desc</summary>

## Why

Submitting is gated on `validateFileUploadStates(fileUploadStates)`, but the file mapping that gets submitted alongside it was a *different* value: `fileMapping`, which `FolderUploadComponent` kept in sync from an effect. An effect runs after the render that triggered it, so the mapping was always written a render after the state it describes, and the two could disagree at the moment someone pressed submit. Nothing needed it to be state — both parents already hold `fileUploadStates`, and the mapping is a pure function of it.

Three places where they could disagree:

- The `uploadInProgress` to `uploadCompleted` promotion and the mapping write happen in two separate effect passes, so there is a render with the new state and the previous mapping. Submitting there submits a replaced file under the id of the file it replaced — the user publishes the old file and nothing reports an error.
- On the edit page `fileUploadStates` is seeded from previous uploads by the `useState` initialiser, while `fileMapping` started as `undefined`. Submitting before the first effect took the "no files" branch and dropped every file from the revision.
- Discarding a file wrote the new state a render before the mapping caught up, so a discarded file could still be submitted.

Making it worse, the confirmation dialog captures the submit function at click time, so a mapping that was stale when the button was pressed stayed stale however long the user then took to press Confirm.

## What you may want to argue with

**The bulk linkage display changes.** While files are being added to a category that was already complete, that category's declared files now count as `missing`, so the status line reads "referenced in metadata but not uploaded" until the upload finishes. Previously it kept showing the previous upload's links throughout. I think showing the current truth is right, and it is the same class of stale affordance #7132 removed from the status tick, but it is a visible change and it is a judgement call — say so if you would prefer the old display and I will keep a stored copy for that one consumer. Submit-time linkage errors are unaffected, since validation already refuses to submit mid-upload.

## Deliberately not done

- A test that submits from `EditPage` or `DataUploadForm` with files and asserts the resulting ids. None exists, so this wiring was uncovered before this PR and still is; the new unit tests cover the derivation only. I checked equivalence by reading instead: the effect wrote `new Map(files.map(f => [f.path, f.fileId]))` under `fileCategory.name`, and `fileUploadStates` is keyed by that same name.
- `expectExtraFileUploaded` still asserts on a `✓`. #7132 made that assertion meaningful again by rendering a spinner for a file being replaced, so it no longer passes vacuously, but it would be sturdier asserting on the upload state directly.

### Screenshot

n/a, no visual change outside the bulk linkage status line described above.

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

Unit tests only: four new cases for the derivation, and `FolderUploadComponent.spec.tsx` reworked so its harness derives the mapping the way a parent does, keeping its existing assertions meaningful. Full website suite passes (752 tests), types and format clean. No manual browser testing.

</details>

🚀 Preview: https://fix-derive-file-mapping-a.loculus.org