### PR TITLE
feat(website): add new rawReadsMetadata component and pass requiredWhen arg to website

### DIFF
--- a/kubernetes/loculus/templates/_inputFieldsFromValues.tpl
+++ b/kubernetes/loculus/templates/_inputFieldsFromValues.tpl
@@ -2,7 +2,7 @@
 {{- $data := . }}
 {{- $metadata := $data.metadata }}
 {{- $extraFields := $data.extraInputFields }}
-{{- $TO_KEEP := list "name" "displayName" "definition" "guidance" "example" "required" "noEdit" "desired" "options"}}
+{{- $TO_KEEP := list "name" "displayName" "definition" "guidance" "example" "required" "requiredWhen" "noEdit" "desired" "options"}}
 
 {{- /* Determine default id field based on maxSequencesPerEntry */}}
 {{- $maxSeq := 1 }}

--- a/website/src/components/OrganismMetadataTable/OrganismMetadataTable.tsx
+++ b/website/src/components/OrganismMetadataTable/OrganismMetadataTable.tsx
@@ -219,7 +219,7 @@ export const OrganismMetadataTable: FC<{ organism: OrganismMetadata }> = ({ orga
 
 type TypedInputField = InputField & { type: string };
 
-type MetadataTableProps =
+export type MetadataTableProps =
     | {
           header: string;
           fields: Metadata[];
@@ -248,7 +248,7 @@ function containsSearch(header: string, field: Metadata | TypedInputField, searc
     return searchTokens.every((searchToken) => contents.includes(searchToken));
 }
 
-const MetadataTableSection: FC<MetadataTableProps> = (props) => {
+export const MetadataTableSection: FC<MetadataTableProps> = (props) => {
     const [expandedHeader, setExpandedHeader] = useState<boolean>(true);
     const filteredFields = props.search
         ? props.fields.filter((field) => containsSearch(props.header, field, props.search))
@@ -259,7 +259,7 @@ const MetadataTableSection: FC<MetadataTableProps> = (props) => {
         <div className='mb-8'>
             <h3
                 id={getHeaderLinkId(props.header)}
-                className='text-lg font-semibold mb-4 pt-1 cursor-pointer'
+                className='text-lg! font-semibold mb-4! mt-0! pt-1! cursor-pointer'
                 onClick={() => setExpandedHeader((prev) => !prev)}
             >
                 {props.header}

--- a/website/src/components/OrganismMetadataTable/OrganismMetadataTable.tsx
+++ b/website/src/components/OrganismMetadataTable/OrganismMetadataTable.tsx
@@ -219,7 +219,7 @@ export const OrganismMetadataTable: FC<{ organism: OrganismMetadata }> = ({ orga
 
 type TypedInputField = InputField & { type: string };
 
-export type MetadataTableProps =
+export type MetadataTableProps = (
     | {
           header: string;
           fields: Metadata[];
@@ -231,7 +231,11 @@ export type MetadataTableProps =
           fields: TypedInputField[];
           search: string;
           isInputFields: true;
-      };
+      }
+) & {
+    /** Extra classes merged onto the section header's `<h3>`, appended after the default classes. */
+    headerClassName?: string;
+};
 
 function containsSearch(header: string, field: Metadata | TypedInputField, search: string): boolean {
     const searchTokens = search.toLowerCase().trim().split(/\s+/);
@@ -259,7 +263,7 @@ export const MetadataTableSection: FC<MetadataTableProps> = (props) => {
         <div className='mb-8'>
             <h3
                 id={getHeaderLinkId(props.header)}
-                className='text-lg! font-semibold mb-4! mt-0! pt-1! cursor-pointer'
+                className={`text-lg font-semibold mb-4 mt-0 cursor-pointer ${props.headerClassName ?? ''}`}
                 onClick={() => setExpandedHeader((prev) => !prev)}
             >
                 {props.header}

--- a/website/src/components/OrganismMetadataTable/OrganismMetadataTable.tsx
+++ b/website/src/components/OrganismMetadataTable/OrganismMetadataTable.tsx
@@ -225,12 +225,14 @@ export type MetadataTableProps = (
           fields: Metadata[];
           search: string;
           isInputFields?: false;
+          expandedHeader?: boolean;
       }
     | {
           header: string;
           fields: TypedInputField[];
           search: string;
           isInputFields: true;
+          expandedHeader?: boolean;
       }
 ) & {
     /** Extra classes merged onto the section header's `<h3>`, appended after the default classes. */
@@ -253,7 +255,7 @@ function containsSearch(header: string, field: Metadata | TypedInputField, searc
 }
 
 export const MetadataTableSection: FC<MetadataTableProps> = (props) => {
-    const [expandedHeader, setExpandedHeader] = useState<boolean>(true);
+    const [expandedHeader, setExpandedHeader] = useState<boolean>(props.expandedHeader ?? true);
     const filteredFields = props.search
         ? props.fields.filter((field) => containsSearch(props.header, field, props.search))
         : props.fields;

--- a/website/src/components/RawReadsMetadataTable.astro
+++ b/website/src/components/RawReadsMetadataTable.astro
@@ -1,0 +1,41 @@
+---
+import { getConfiguredOrganisms, getGroupedInputFields, getSchema } from '../config';
+import { MetadataTableSection } from './OrganismMetadataTable/OrganismMetadataTable';
+import { BoxWithTabsBox, BoxWithTabsTab, BoxWithTabsTabBar } from './common/BoxWithTabs';
+
+const SEQUENCING_HEADER = 'Sequencing';
+
+// The 'Sequencing' fields are the same for every organism, so any configured organism will do.
+const [organism] = getConfiguredOrganisms();
+if (organism === undefined) {
+    throw new Error('No organisms configured');
+}
+
+const schema = getSchema(organism.key);
+const groupedInputFields = getGroupedInputFields(organism.key, 'submit', 'bulk');
+const sequencingInputFields = groupedInputFields.get(SEQUENCING_HEADER) ?? [];
+
+const metadataByName = new Map(schema.metadata.map((meta) => [meta.name, meta]));
+const typedInputFields = sequencingInputFields.map((field) => ({
+    ...field,
+    type: metadataByName.get(field.name)?.type ?? 'string',
+}));
+const requiredFields = typedInputFields
+    .filter((field) => field.requiredWhen?.includes('files.rawReads'))
+    .map((field) => field);
+const desiredFields = typedInputFields
+    .filter((field) => !requiredFields.includes(field) && field.desired)
+    .map((field) => field);
+const optionalFields = typedInputFields
+    .filter((field) => !requiredFields.includes(field) && !desiredFields.includes(field))
+    .map((field) => field);
+---
+
+<BoxWithTabsTabBar>
+    <BoxWithTabsTab isActive label='Raw Reads Metadata Fields' className='text-base' />
+</BoxWithTabsTabBar>
+<BoxWithTabsBox>
+    <MetadataTableSection header={'Required Fields'} fields={requiredFields} search='' isInputFields client:load />
+    <MetadataTableSection header={'Desired Fields'} fields={desiredFields} search='' isInputFields client:load />
+    <MetadataTableSection header={'Optional Fields'} fields={optionalFields} search='' isInputFields client:load />
+</BoxWithTabsBox>

--- a/website/src/components/RawReadsMetadataTable.astro
+++ b/website/src/components/RawReadsMetadataTable.astro
@@ -3,7 +3,12 @@ import { getConfiguredOrganisms, getGroupedInputFields, getSchema } from '../con
 import { MetadataTableSection } from './OrganismMetadataTable/OrganismMetadataTable';
 import { BoxWithTabsBox, BoxWithTabsTab, BoxWithTabsTabBar } from './common/BoxWithTabs';
 
-const SEQUENCING_HEADER = 'Sequencing';
+interface Props {
+    sequencingHeader?: string;
+    requiredWhenField?: string;
+}
+
+const { sequencingHeader = 'Sequencing', requiredWhenField = 'files.rawReads' } = Astro.props;
 
 // The 'Sequencing' fields are the same for every organism, so any configured organism will do.
 const [organism] = getConfiguredOrganisms();
@@ -13,7 +18,7 @@ if (organism === undefined) {
 
 const schema = getSchema(organism.key);
 const groupedInputFields = getGroupedInputFields(organism.key, 'submit', 'bulk');
-const sequencingInputFields = groupedInputFields.get(SEQUENCING_HEADER) ?? [];
+const sequencingInputFields = groupedInputFields.get(sequencingHeader) ?? [];
 
 const metadataByName = new Map(schema.metadata.map((meta) => [meta.name, meta]));
 const typedInputFields = sequencingInputFields.map((field) => ({
@@ -21,7 +26,7 @@ const typedInputFields = sequencingInputFields.map((field) => ({
     type: metadataByName.get(field.name)?.type ?? 'string',
 }));
 const requiredFields = typedInputFields.filter(
-    (field) => field.requiredWhen?.includes('files.rawReads') || field.required,
+    (field) => field.requiredWhen?.includes(requiredWhenField) || field.required,
 );
 const desiredFields = typedInputFields.filter((field) => !requiredFields.includes(field) && field.desired);
 const optionalFields = typedInputFields.filter(

--- a/website/src/components/RawReadsMetadataTable.astro
+++ b/website/src/components/RawReadsMetadataTable.astro
@@ -54,7 +54,7 @@ const headerClassName = 'text-lg! mb-4! mt-0! pt-1!';
         search=''
         isInputFields
         headerClassName={headerClassName}
-        client:load
+        client:visible
     />
     <MetadataTableSection
         header={'Desired Fields'}
@@ -62,7 +62,7 @@ const headerClassName = 'text-lg! mb-4! mt-0! pt-1!';
         search=''
         isInputFields
         headerClassName={headerClassName}
-        client:load
+        client:visible
     />
     <MetadataTableSection
         header={'Optional Fields'}
@@ -70,6 +70,6 @@ const headerClassName = 'text-lg! mb-4! mt-0! pt-1!';
         search=''
         isInputFields
         headerClassName={headerClassName}
-        client:load
+        client:visible
     />
 </BoxWithTabsBox>

--- a/website/src/components/RawReadsMetadataTable.astro
+++ b/website/src/components/RawReadsMetadataTable.astro
@@ -21,7 +21,7 @@ const typedInputFields = sequencingInputFields.map((field) => ({
     type: metadataByName.get(field.name)?.type ?? 'string',
 }));
 const requiredFields = typedInputFields
-    .filter((field) => field.requiredWhen?.includes('files.rawReads'))
+    .filter((field) => field.requiredWhen?.includes('files.rawReads') || field.required)
     .map((field) => field);
 const desiredFields = typedInputFields
     .filter((field) => !requiredFields.includes(field) && field.desired)

--- a/website/src/components/RawReadsMetadataTable.astro
+++ b/website/src/components/RawReadsMetadataTable.astro
@@ -20,15 +20,13 @@ const typedInputFields = sequencingInputFields.map((field) => ({
     ...field,
     type: metadataByName.get(field.name)?.type ?? 'string',
 }));
-const requiredFields = typedInputFields
-    .filter((field) => field.requiredWhen?.includes('files.rawReads') || field.required)
-    .map((field) => field);
-const desiredFields = typedInputFields
-    .filter((field) => !requiredFields.includes(field) && field.desired)
-    .map((field) => field);
-const optionalFields = typedInputFields
-    .filter((field) => !requiredFields.includes(field) && !desiredFields.includes(field))
-    .map((field) => field);
+const requiredFields = typedInputFields.filter(
+    (field) => field.requiredWhen?.includes('files.rawReads') || field.required,
+);
+const desiredFields = typedInputFields.filter((field) => !requiredFields.includes(field) && field.desired);
+const optionalFields = typedInputFields.filter(
+    (field) => !requiredFields.includes(field) && !desiredFields.includes(field),
+);
 ---
 
 <BoxWithTabsTabBar>

--- a/website/src/components/RawReadsMetadataTable.astro
+++ b/website/src/components/RawReadsMetadataTable.astro
@@ -62,6 +62,7 @@ const headerClassName = 'text-lg! mb-4! mt-0! pt-1!';
         search=''
         isInputFields
         headerClassName={headerClassName}
+        expandedHeader={false}
         client:visible
     />
     <MetadataTableSection
@@ -70,6 +71,7 @@ const headerClassName = 'text-lg! mb-4! mt-0! pt-1!';
         search=''
         isInputFields
         headerClassName={headerClassName}
+        expandedHeader={false}
         client:visible
     />
 </BoxWithTabsBox>

--- a/website/src/components/RawReadsMetadataTable.astro
+++ b/website/src/components/RawReadsMetadataTable.astro
@@ -32,13 +32,39 @@ const desiredFields = typedInputFields.filter((field) => !requiredFields.include
 const optionalFields = typedInputFields.filter(
     (field) => !requiredFields.includes(field) && !desiredFields.includes(field),
 );
+
+// This page is rendered inside the docs layout's prose styles, which otherwise override the
+// section header's font size and spacing. The `!` (Tailwind v4 important-suffix) forces our
+// values to win over that external prose CSS.
+const headerClassName = 'text-lg! mb-4! mt-0! pt-1!';
 ---
 
 <BoxWithTabsTabBar>
     <BoxWithTabsTab isActive label='Raw Reads Metadata Fields' className='text-base' />
 </BoxWithTabsTabBar>
 <BoxWithTabsBox>
-    <MetadataTableSection header={'Required Fields'} fields={requiredFields} search='' isInputFields client:load />
-    <MetadataTableSection header={'Desired Fields'} fields={desiredFields} search='' isInputFields client:load />
-    <MetadataTableSection header={'Optional Fields'} fields={optionalFields} search='' isInputFields client:load />
+    <MetadataTableSection
+        header={'Required Fields'}
+        fields={requiredFields}
+        search=''
+        isInputFields
+        headerClassName={headerClassName}
+        client:load
+    />
+    <MetadataTableSection
+        header={'Desired Fields'}
+        fields={desiredFields}
+        search=''
+        isInputFields
+        headerClassName={headerClassName}
+        client:load
+    />
+    <MetadataTableSection
+        header={'Optional Fields'}
+        fields={optionalFields}
+        search=''
+        isInputFields
+        headerClassName={headerClassName}
+        client:load
+    />
 </BoxWithTabsBox>

--- a/website/src/components/RawReadsMetadataTable.astro
+++ b/website/src/components/RawReadsMetadataTable.astro
@@ -6,9 +6,14 @@ import { BoxWithTabsBox, BoxWithTabsTab, BoxWithTabsTabBar } from './common/BoxW
 interface Props {
     sequencingHeader?: string;
     requiredWhenField?: string;
+    tableName?: string;
 }
 
-const { sequencingHeader = 'Sequencing', requiredWhenField = 'files.rawReads' } = Astro.props;
+const {
+    sequencingHeader = 'Sequencing',
+    requiredWhenField = 'files.rawReads',
+    tableName = 'Raw Reads Metadata Fields',
+} = Astro.props;
 
 // The 'Sequencing' fields are the same for every organism, so any configured organism will do.
 const [organism] = getConfiguredOrganisms();
@@ -40,7 +45,7 @@ const headerClassName = 'text-lg! mb-4! mt-0! pt-1!';
 ---
 
 <BoxWithTabsTabBar>
-    <BoxWithTabsTab isActive label='Raw Reads Metadata Fields' className='text-base' />
+    <BoxWithTabsTab isActive label={tableName} className='text-base' />
 </BoxWithTabsTabBar>
 <BoxWithTabsBox>
     <MetadataTableSection

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -102,6 +102,7 @@ export const inputField = z.object({
     displayName: z.string().optional(),
     noEdit: z.boolean().optional(),
     required: z.boolean().optional(),
+    requiredWhen: z.array(z.string()).optional(),
     definition: z.string().optional(), // Definition, Example and Guidance for submitters
     example: z.union([z.string(), z.number()]).optional(),
     guidance: z.string().optional(),


### PR DESCRIPTION
Adds a new component (similar to the metadata picker) that shows all sequencing related fields, highlighting the fields that are required for raw reads - this can then hopefully be used in our raw reads submission docs on Pathoplexus.

I temporarily overwrote `
export const extraFilesUploadDocsUrl = '/docs/concepts/raw-reads-metadataformat';
` to test this.

https://github.com/user-attachments/assets/fc8bd45d-1ce0-4efa-97f9-b10a29779aa8

partially resolves https://github.com/loculus-project/loculus/issues/6760

On Pathoplexus this can be used as follows:

```
import RawReadsMetadataTable from '../../../components/RawReadsMetadataTable.astro';


<RawReadsMetadataTable />
```

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: https://rawreadsdocs.loculus.org