### PR TITLE
test(backend): report the real cause when the test environment fails to start

### DIFF
--- a/backend/src/test/kotlin/org/loculus/backend/controller/EndpointTestExtension.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/EndpointTestExtension.kt
@@ -5,6 +5,7 @@ import io.minio.MakeBucketArgs
 import io.minio.MinioClient
 import io.minio.SetBucketPolicyArgs
 import mu.KotlinLogging
+import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.ExtensionContext
@@ -127,6 +128,7 @@ val MINIO_TEST_BUCKET = "testbucket"
 private val log = KotlinLogging.logger { }
 
 class EndpointTestExtension :
+    BeforeAllCallback,
     BeforeEachCallback,
     TestExecutionListener {
     companion object {
@@ -134,9 +136,25 @@ class EndpointTestExtension :
 
         private var isStarted = false
         private var isBucketCreated = false
+        private var startupFailure: Throwable? = null
     }
 
     override fun testPlanExecutionStarted(testPlan: TestPlan) {
+        try {
+            startTestEnvironment(testPlan)
+        } catch (e: Throwable) {
+            // JUnit only logs exceptions thrown from a listener, so remember this one for beforeAll to report
+            startupFailure = e
+            throw e
+        }
+    }
+
+    /** Fails the class with the real startup cause instead of letting every test report a missing JDBC url. */
+    override fun beforeAll(context: ExtensionContext) {
+        startupFailure?.let { throw IllegalStateException("Test environment failed to start", it) }
+    }
+
+    private fun startTestEnvironment(testPlan: TestPlan) {
         if (!isStarted) {
             isAnnotatedWithEndpointTest(testPlan) {
                 try {


### PR DESCRIPTION
Related to what [loculus-project/loculus#5972](https://github.com/loculus-project/loculus/pull/5972) tried to achieve (but seems to have failed for reasons outlined below).

Noticed that backend logs were overwhelming on a few failed backend test CI runs. Turns out there was a shared cause (db testcontainer pull failed) and each test was failing with its own precondition failure hiding the simplicity of the actual underlying cause.

<details>

## Why

When the backend test environment fails to start, every test class that uses `@EndpointTest` fails with `Failed to determine suitable jdbc url`, the run still takes its full ~520 s, and the real cause appears nowhere in the summary. One problem gets reported as roughly 440 failures out of 580.

`EndpointTestExtension` starts Postgres and MinIO from a JUnit `TestExecutionListener`, and JUnit only *logs* an exception thrown from a listener rather than failing anything. So the suite carries on with no database configured, and each class then fails for a reason that has nothing to do with the actual fault.

This is not hypothetical, and it is not specific to one cause. Two runs with the identical shape and completely unrelated roots:

| run | real cause | `ContainerFetchException` | `Failed to determine suitable jdbc url` |
| --- | --- | --- | --- |
| [32857533977](https://github.com/loculus-project/loculus/actions/runs/32857533977) | timed out pulling the `postgres:latest` image | 1 | 102 |
| [32711049779](https://github.com/loculus-project/loculus/actions/runs/32711049779) | Exposed table definitions out of sync with the Flyway migrations | 0 | 0 |

The second one matters most. It is on `prevent_db_state_divergence`, a branch written to detect exactly that kind of schema drift, so there the noise was hiding a genuine defect the branch was built to find. Anyone who learns to read this shape as "infrastructure being flaky, ignore it" will eventually ignore a real bug.

## This is not the first attempt, and that is the point

[#5972](https://github.com/loculus-project/loculus/pull/5972) (commit 966148388, February) already tried the obvious fix. Its commit message describes this exact symptom — "the exception was silently caught by JUnit's CompositeTestExecutionListener, causing all database tests to fail with an opaque 'Failed to determine suitable jdbc url' error" — and it wraps `env.start()` to log the error and rethrow it. That code is still in place, and this PR keeps it.

It did not work, for two independent reasons, both visible in [run 32861307373](https://github.com/loculus-project/loculus/actions/runs/32861307373).

The rethrow is still swallowed. Line 400 of that job log is `WARNING: TestExecutionListener [EndpointTestExtension] threw exception for method: testPlanExecutionStarted`. The exception is thrown, and JUnit catches it and downgrades it to a warning, because that is what it does with anything a listener throws. Rethrowing from the listener cannot fail the run no matter how the throw is written, which is why this PR defers the rethrow to `beforeAll`, where JUnit does treat it as a failure.

The log line never reaches the job output either. Searching that log for `Failed to start test environment` returns nothing. It goes through logback to stdout, and Gradle's test logging is configured to forward standard error but not standard output, so the one diagnostic #5972 added is dropped before anyone can read it.

So the reason this needs a second attempt is structural rather than an oversight in the first one, and it is worth knowing that any diagnostic logged through logback is currently invisible in CI.

## Things worth knowing that are not obvious from the diff

The 440-of-580 shape means "exactly one root cause, and it is not in the tests". The `Failed to determine suitable jdbc url` message is a good tell-tale but it is absent in half these cases, so the thing to read is the root `Caused by` chain.

Whichever test class happens to run first takes the blame. Here that was `PipelineStatisticsEndpointTest`, and a summary showing only its two test names made a whole-suite outage look like one flaky test failing about 15% of the time. That sent me down a wrong path for a while, which is the main reason this PR exists.

The check has to run in `beforeAll` rather than `beforeEach`, because the test instance is constructed before `beforeEach` runs, so a `beforeEach` guard would never be reached.

One implicit detail that is worth a reviewer's eye: `@SpringBootTest` is listed before `@ExtendWith(EndpointTestExtension::class)` on the `@EndpointTest` annotation, so Spring's own `beforeAll` runs first. This still works because Spring loads the application context lazily when it injects the test instance, not in `beforeAll`. If that ever changes, this check would stop firing first and the old confusing failures would come back.

## How it was checked, and the gap in that

The real failure needs a Docker image pull to time out, which cannot be reproduced without a Docker daemon, so I forced the equivalent instead by pointing the local Postgres at a path that does not exist. That produces a single `initializationError` naming the real cause, instead of the misleading database-url failures. The code path is shared, so I expect the same behaviour for the container case, but that specific case is reasoning rather than something I ran.

## It also makes the cause readable, which today it is not

Worth knowing because it is not visible from the diff: on main the real cause is readable nowhere useful. I forced a startup failure locally and checked where the existing `log.error` from #5972 ends up. It is in **no** per-class JUnit XML — those only carry output belonging to a test, and this is logged before any test starts — and it is not in the console either. It survives in exactly one place, the root "standard output" tab of `build/reports/tests/test/index.html`, which is not part of what the test job archives.

With this change the same failure reports as an ordinary test failure, so it prints to the job log through the existing failure logging:

```
PipelineStatisticsEndpointTest > initializationError FAILED
    java.lang.IllegalStateException: Test environment failed to start
        at org.loculus.backend.controller.EndpointTestExtension.beforeAll(EndpointTestExtension.kt:154)
        Caused by:
        java.lang.RuntimeException: Command .../pg_ctl -D /tmp/pgdata -o -F -p 5432 -w start failed
```

It lands in the per-class XML as well, so it survives into the archive too. Both come for free from it being a real failure rather than a logged one — no logging configuration is changed and nothing extra is written, which also means it still works if the whole job is cancelled and no archive is uploaded.

## Deliberately not in this PR

It does not pin the `postgres:latest` and `minio/minio:latest` tags. Pinning is worth doing, but it would not have prevented a slow pull, and it deserves its own change alongside picking a version that matches what we deploy.

It does not make the pull itself more reliable, and it does not claim to save time. It should turn many failed context loads into a handful of fast class failures, which is where most of the wasted ~520 s goes, but I did not measure that, so please do not read a speedup into it.

Happy to change the exception type or the message wording if you would rather they read differently.

</details>
