### PR TITLE
ci(backend): take test progress off the console, keep it in the artifact

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -56,6 +56,22 @@ jobs:
         timeout-minutes: 2
         working-directory: ./backend
         run: |
+          # the only progress signal worth putting in the log: what never finished
+          progress=build/diagnostics/test-progress.log
+          if [ ! -f "$progress" ]; then
+            echo "No $progress, so the test task never got as far as running a test."
+          else
+            unfinished=$(awk '{ ts = $1; ev = $2; sub(/^[^ ]+ [^ ]+ /, "")
+                                if (ev == "STARTED") started[$0] = ts; else delete started[$0] }
+                              END { for (t in started) print started[t], t }' "$progress")
+            echo "Tests started: $(grep -c ' STARTED ' "$progress")"
+            if [ -n "$unfinished" ]; then
+              echo "Tests that started but never finished:"
+              echo "$unfinished"
+            else
+              echo "Every test that started also finished."
+            fi
+          fi
           if ls build/test-results/test/*.xml >/dev/null 2>&1; then
             rm -rf build/test-results/test/binary
           else

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -82,10 +82,12 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: backend-test-results
+          # index.html is the only place output from outside a test lands, e.g. a failed test env start
           path: |
             backend/build/test-results/test/**
             backend/build/reports/recovered/**
             backend/build/diagnostics/**
+            backend/build/reports/tests/test/index.html
           if-no-files-found: warn
 
   lint:

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,3 +1,6 @@
+import org.gradle.api.tasks.testing.TestDescriptor
+import org.gradle.api.tasks.testing.TestListener
+import org.gradle.api.tasks.testing.TestResult
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
@@ -125,13 +128,30 @@ tasks.named('test') {
     useJUnitPlatform()
     jvmArgs '--enable-native-access=ALL-UNNAMED'
     testLogging {
-        events TestLogEvent.STARTED,
-            TestLogEvent.PASSED,
-            TestLogEvent.FAILED,
-            TestLogEvent.STANDARD_ERROR
+        events TestLogEvent.FAILED, TestLogEvent.STANDARD_ERROR
         exceptionFormat = TestExceptionFormat.FULL
         showExceptions = true
     }
+    // per-test progress goes to a file, not the console, so a killed run still names the test it was in
+    def progressLog = layout.buildDirectory.file('diagnostics/test-progress.log')
+    doFirst {
+        def file = progressLog.get().asFile
+        file.parentFile.mkdirs()
+        file.text = ''
+    }
+    addTestListener(new TestListener() {
+        void beforeSuite(TestDescriptor suite) {}
+
+        void afterSuite(TestDescriptor suite, TestResult result) {}
+
+        void beforeTest(TestDescriptor descriptor) {
+            progressLog.get().asFile << "${java.time.Instant.now()} STARTED ${descriptor.className}.${descriptor.name}\n"
+        }
+
+        void afterTest(TestDescriptor descriptor, TestResult result) {
+            progressLog.get().asFile << "${java.time.Instant.now()} ${result.resultType} ${descriptor.className}.${descriptor.name}\n"
+        }
+    })
 }
 
 tasks.named('bootBuildImage') {


### PR DESCRIPTION
Targets `ci/backend-test-hang-diagnostics` (#7154), not `main`.

## Why

#7154 streams every test's start and finish to the console so that a hung run names the test it died in. That works, but it costs about 1160 lines on every run, including the green ones, which makes the ordinary log much harder to read. The progress is genuinely what identifies a hang, so this keeps it and moves it out of the console into a file that the existing artifact upload already collects.

The file is timestamped, which the console version could not be, so it also gives per-test durations and shows exactly when progress stopped rather than only what was last reached.

## The bit that needed proving

The whole value of this depends on the file surviving a kill, since that is the only situation it exists for. Each line is written and flushed as it happens, and a mid-suite `SIGKILL` of a real run left 509 lines on disk, ending in a start with no matching finish. The `Collect diagnostics` step turns that into one line naming the test, so the useful part is still in the job log without the other 1159.

## Why `addTestListener` and not `beforeTest`/`afterTest`

The closure form is the obvious way to write this and is what most examples show, but Gradle 9.7 deprecates it and Gradle 10 removes it. Using it makes the whole build report as Gradle 10 incompatible, which is a needless thing to take on for a diagnostics change.

## Putting the test report's front page back in the artifact

This is the second commit, and it fixes something introduced earlier in this same branch rather than something that was always broken.

Anything logged before the first test class starts has no test to be attributed to, so Gradle files it as output of the run as a whole. That only appears in `build/reports/tests/test/index.html`. It matters because that is where a failure to start the test database or object store reports its actual cause.

Measured on a deliberately broken test environment: 74 per-class result files were written, and the underlying error appeared in none of them and in no console line, only in that one page. `16bd0ce49` had dropped the report as a duplicate of the result files, which is true for a run that passes or fails normally and false for one that never got started. Rather than restoring the whole 9.4 MB report, this takes only the front page, at 57 KB, so the deduplication still holds for the per-class pages it was aimed at.

The general version, since this will come up again: when pruning archived diagnostics, judge each copy by what it holds on the worst run, not the typical one.

## Things you might reasonably want changed

The finish token in the file is `SUCCESS`, not `PASSED`, because that is what Gradle's own result type is called. Anyone with a habit of grepping for `PASSED` will find nothing. Happy to map it if the familiar word is worth more than matching Gradle.

On failure the log prints only the tests that started and never finished, plus a count of how many started. I kept it that narrow on purpose, but I can print more if it reads as too little.

## Considered and rejected

Piping the Gradle output through `tee` so the console log rides along in the artifact. It would duplicate what the result files and the report front page already hold, and it means putting a pipe in the step that decides whether the build passed. Without `pipefail` the exit status would come from `tee` rather than from Gradle, so a failing suite could report success. That is a worse failure than the one it would fix.

A logback file appender writing alongside the other diagnostics. Test-level logging already reaches the per-class result files, and the `Exposed` logger is at debug, which is what produced a 127 MB results file on the 100k-sequence test. It would mostly re-record what is already kept.

## Not covered here

A failure to start the test environment still says nothing useful on the console; it only becomes readable in the artifact. #7157 addresses the console side by turning it into a real test failure, and the two are complementary.

## If you are checking this locally

Worth knowing before you conclude anything from a run: after a completed run, a plain `./gradlew test` reports `:test UP-TO-DATE` and does nothing at all. Two of my "killed mid-run" experiments produced no file for exactly that reason and looked like the change was broken. Use `--rerun`.

🚀 Preview: Add `preview` label to enable