### PR TITLE
ci(backend): capture Postgres and host state alongside the thread dumps

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -44,7 +44,29 @@ jobs:
               jcmd "$pid" Thread.print > "build/diagnostics/threaddump-$1-$pid.txt" 2>&1 || true
             done
           }
-          ( sleep 660; dump at11min; sleep 120; dump at13min ) >/dev/null 2>&1 &
+          probe() {
+            {
+              df -h; echo; free -m; echo; timeout 10 docker ps -a
+              # The ancestor filter misses if the image is referenced by digest, so match the name too
+              containers=$(timeout 10 docker ps -a --format '{{.ID}} {{.Image}}')
+              pg=$(echo "$containers" | awk '/postgres/{print $1; exit}')
+              minio=$(echo "$containers" | awk '/minio/{print $1; exit}')
+              echo "postgres=${pg:-none} minio=${minio:-none}"
+              for c in $pg $minio; do
+                # OOMKilled separates "container died" from "container alive but silent"
+                timeout 10 docker inspect --format '{{.Name}} {{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} restarting={{.State.Restarting}}' "$c"
+                echo "===== docker logs $c"; timeout 10 docker logs --tail 200 "$c" 2>&1
+              done
+              [ -n "$pg" ] || return 0
+              for q in \
+                "select pid,state,wait_event_type,wait_event,now()-xact_start as xact_age,now()-query_start as query_age,pg_blocking_pids(pid) as blocked_by,left(query,300) as query from pg_stat_activity order by xact_start" \
+                "select locktype,relation::regclass,mode,granted,pid from pg_locks order by granted,pid"; do
+                echo "===== $q"
+                timeout 10 docker exec "$pg" psql -U test -d test -c "$q" 2>&1
+              done
+            } > "build/diagnostics/resources-$1.txt" 2>&1
+          }
+          ( sleep 660; dump at11min; probe at11min; sleep 120; dump at13min; probe at13min ) >/dev/null 2>&1 &
           watchdog=$!
           rc=0
           ./gradlew test || rc=$?


### PR DESCRIPTION
Stacked on #7154, because it extends the watchdog that PR adds. Review and merge that one first.

## Why

The thread dumps #7154 collects proved what the hang is not. In both captured hangs the test worker sits in `PGStream.receiveChar` waiting for a reply from Postgres, and it is genuinely stuck rather than slow — CPU advanced 2.92 ms across the 120 seconds between the two dumps, with every other thread idle or garbage collecting. Across all eight dumps that worker is the only thread anywhere in the database driver, so nothing inside the test process is holding it up.

That points at the database server or the machine, and we record nothing at all about either. So the dumps can tell us the hang is server-side and then stop, which is where the investigation currently ends.

This adds, at the same two moments the thread dumps are taken, disk and memory, container state, the Postgres and MinIO logs, and two queries against Postgres itself: what every backend is doing and what is blocking it, and what locks are held.

Between them these separate the possibilities that are currently indistinguishable. A backend waiting on a lock names the process holding it. A backend actively running means the statement is genuinely slow and the timeout is too tight. No backend at all means the connection is dead and the client is waiting for a reply that will never come. A container killed for running out of memory, or a full disk, points at the runner rather than at us.

## Worth knowing

Every `docker` and `psql` call is wrapped in `timeout 10`. The entire premise is that Postgres may be unresponsive, so an unbounded probe would hang inside the watchdog and eat the 13-minute thread dump — the one that matters most, because comparing it against the 11-minute dump is how we tell stuck from slow.

Containers are matched by image name rather than with `docker ps --filter ancestor`, because that filter does not match when an image is referenced by digest, which is how these are pulled.

## Not in this PR

It does not fix anything, and it is not meant to. The cause of the hang is still unknown; this is the instrumentation that should identify it the next time it happens, which on recent evidence is roughly one push to main in eight.

The upload step is unchanged. Everything written here goes to `build/diagnostics/`, which #7154 already archives on failure.

🚀 Preview: Add `preview` label to enable