### PR TITLE
test(backend): stop re-stubbing DateProvider while a released-data stream is in flight

### DIFF
--- a/backend/src/test/kotlin/org/loculus/backend/controller/TestHelpers.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/TestHelpers.kt
@@ -20,6 +20,7 @@ import org.loculus.backend.api.ProcessingResult
 import org.loculus.backend.api.SequenceEntryStatus
 import org.loculus.backend.api.Status
 import org.loculus.backend.utils.DateProvider
+import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.ResultMatcher
@@ -88,6 +89,9 @@ fun awaitResponse(result: MvcResult): String {
 
     return result.response.contentAsString
 }
+
+/** Reads a streamed response's headers only after its async body finished, so no stream is left in flight. */
+fun ResultActions.awaitedResponse(): MockHttpServletResponse = andReturn().also { awaitResponse(it) }.response
 
 fun SequenceEntryStatus.assertStatusIs(status: Status): SequenceEntryStatus {
     assertThat(this.status, `is`(status))

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/GetReleasedDataEndpointTest.kt
@@ -55,6 +55,7 @@ import org.loculus.backend.controller.DEFAULT_PIPELINE_VERSION
 import org.loculus.backend.controller.DEFAULT_USER_NAME
 import org.loculus.backend.controller.EndpointTest
 import org.loculus.backend.controller.OTHER_ORGANISM
+import org.loculus.backend.controller.awaitedResponse
 import org.loculus.backend.controller.datauseterms.DataUseTermsControllerClient
 import org.loculus.backend.controller.dateMonthsFromNow
 import org.loculus.backend.controller.expectNdjsonAndGetContent
@@ -246,9 +247,9 @@ class GetReleasedDataEndpointTest(
         convenienceClient.approveProcessedSequenceEntries(accessionVersions)
 
         val initialEtagOtherOrganism = submissionControllerClient.getReleasedData(organism = OTHER_ORGANISM)
-            .andReturn().response.getHeader(ETAG)
+            .awaitedResponse().getHeader(ETAG)
         val initialEtagDefaultOrganism = submissionControllerClient.getReleasedData(organism = DEFAULT_ORGANISM)
-            .andReturn().response.getHeader(ETAG)
+            .awaitedResponse().getHeader(ETAG)
 
         // Reuse the existing group — submitDefaultFiles would otherwise create a new group and
         // write to the groups table (NULL-organism tracker), which would invalidate OTHER_ORGANISM's etag.
@@ -275,7 +276,7 @@ class GetReleasedDataEndpointTest(
         convenienceClient.submitProcessedData(processedData, pipelineVersion = 1)
         convenienceClient.approveProcessedSequenceEntries(accessionVersions)
 
-        val initialEtag = submissionControllerClient.getReleasedData().andReturn().response.getHeader(ETAG)
+        val initialEtag = submissionControllerClient.getReleasedData().awaitedResponse().getHeader(ETAG)
 
         // A newer pipeline version processes the same entries in the background. Released data is
         // still served from version 1, so this must not invalidate the etag.
@@ -300,7 +301,7 @@ class GetReleasedDataEndpointTest(
             convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(organism = OTHER_ORGANISM)
 
         val initialEtag = submissionControllerClient.getReleasedData(organism = DEFAULT_ORGANISM)
-            .andReturn().response.getHeader(ETAG)
+            .awaitedResponse().getHeader(ETAG)
 
         // A newer pipeline version reprocesses the OTHER organism. This only writes preprocessed data
         // tagged with the other organism, so it must not invalidate the default organism's etag.
@@ -330,8 +331,7 @@ class GetReleasedDataEndpointTest(
             convenienceClient.prepareDefaultSequenceEntriesToApprovedForRelease(organism = OTHER_ORGANISM)
 
         val initialEtag = submissionControllerClient.getReleasedData(organism = DEFAULT_ORGANISM)
-            .andReturn()
-            .response
+            .awaitedResponse()
             .getHeader(ETAG)
 
         convenienceClient.extractUnprocessedData(organism = OTHER_ORGANISM, pipelineVersion = 2)
@@ -607,6 +607,12 @@ fun expectIsTimestampWithCurrentYear(value: JsonNode) {
 private const val OPEN_DATA_USE_TERMS_URL = "openUrl"
 private const val RESTRICTED_DATA_USE_TERMS_URL = "restrictedUrl"
 
+// Tests move time by writing here: re-stubbing with `every` briefly installs an answerless stub.
+class FakeCurrentInstant {
+    @Volatile
+    var value: Instant? = null
+}
+
 @EndpointTest
 @Import(GetReleasedDataEndpointWithDataUseTermsUrlTestConfig::class)
 @TestPropertySource(properties = ["spring.main.allow-bean-definition-overriding=true"])
@@ -614,12 +620,16 @@ class GetReleasedDataEndpointWithDataUseTermsUrlTest(
     @Autowired val convenienceClient: SubmissionConvenienceClient,
     @Autowired val dataUseTermsClient: DataUseTermsControllerClient,
     @Autowired val submissionControllerClient: SubmissionControllerClient,
-    @Autowired var dateProvider: DateProvider,
+    @Autowired val dateProvider: DateProvider,
+    @Autowired val fakeCurrentInstant: FakeCurrentInstant,
 ) {
+    @BeforeEach
+    fun useRealTime() {
+        fakeCurrentInstant.value = null
+    }
+
     @Test
     fun `GIVEN sequence entry WHEN I change data use terms THEN returns updated data use terms`() {
-        every { dateProvider.getCurrentInstant() } answers { callOriginal() }
-
         val threeMonthsFromNow = dateMonthsFromNow(3)
 
         var accessionVersion = convenienceClient.prepareDataTo(
@@ -653,8 +663,6 @@ class GetReleasedDataEndpointWithDataUseTermsUrlTest(
 
     @Test
     fun `GIVEN sequence entry with expired restricted data use terms THEN returns open terms and new etag`() {
-        every { dateProvider.getCurrentInstant() } answers { callOriginal() }
-
         val threeMonthsFromNow = dateMonthsFromNow(3)
 
         var accessionVersion = convenienceClient.prepareDataTo(
@@ -665,7 +673,7 @@ class GetReleasedDataEndpointWithDataUseTermsUrlTest(
         assertAccessionVersionIsRestrictedUntil(accessionVersion, threeMonthsFromNow)
 
         val etagWhileRestricted = submissionControllerClient.getReleasedData()
-            .andReturn().response.getHeader(ETAG)!!
+            .awaitedResponse().getHeader(ETAG)!!
         submissionControllerClient.getReleasedData(ifNoneMatch = etagWhileRestricted)
             .andExpect(status().isNotModified)
 
@@ -673,20 +681,19 @@ class GetReleasedDataEndpointWithDataUseTermsUrlTest(
             date = dateMonthsFromNow(3).plus(1, DateTimeUnit.DAY),
             time = LocalTime.fromSecondOfDay(0),
         ).toInstant(DateProvider.timeZone)
-        every { dateProvider.getCurrentInstant() } answers { threeMonthsAndADayFromNow }
+        fakeCurrentInstant.value = threeMonthsAndADayFromNow
 
         // The restriction lapsing is not a database write, so the etag has to change on the date alone.
         submissionControllerClient.getReleasedData(ifNoneMatch = etagWhileRestricted)
             .andExpect(status().isOk)
             .andExpect(header().string(ETAG, greaterThan(etagWhileRestricted)))
+            .awaitedResponse()
 
         assertAccessionVersionIsOpen(accessionVersion)
     }
 
     @Test
     fun `GIVEN different data use terms scenarios THEN dataBecameOpenAt is computed correctly`() {
-        every { dateProvider.getCurrentInstant() } answers { callOriginal() }
-
         val threeMonthsFromNow = dateMonthsFromNow(3)
         val currentDate = dateProvider.getCurrentDate()
 
@@ -723,7 +730,7 @@ class GetReleasedDataEndpointWithDataUseTermsUrlTest(
             date = oneMonthFromNow,
             time = LocalTime.fromSecondOfDay(0),
         ).toInstant(DateProvider.timeZone)
-        every { dateProvider.getCurrentInstant() } answers { oneMonthFromNowInstant }
+        fakeCurrentInstant.value = oneMonthFromNowInstant
 
         dataUseTermsClient.changeDataUseTerms(
             newDataUseTerms = DataUseTermsChangeRequest(
@@ -741,7 +748,7 @@ class GetReleasedDataEndpointWithDataUseTermsUrlTest(
         )
 
         // Reset time for next scenario
-        every { dateProvider.getCurrentInstant() } answers { callOriginal() }
+        fakeCurrentInstant.value = null
 
         // Scenario 4: Expired RESTRICTED data - dataBecameOpenAt should be the restrictedUntil date
         val anotherRestrictedAccessionVersion = convenienceClient.prepareDataTo(
@@ -754,7 +761,7 @@ class GetReleasedDataEndpointWithDataUseTermsUrlTest(
             date = threeMonthsFromNow.plus(1, DateTimeUnit.DAY),
             time = LocalTime.fromSecondOfDay(0),
         ).toInstant(DateProvider.timeZone)
-        every { dateProvider.getCurrentInstant() } answers { threeMonthsAndADayFromNow }
+        fakeCurrentInstant.value = threeMonthsAndADayFromNow
 
         releasedData = getReleasedDataForAccessionVersion(anotherRestrictedAccessionVersion)
         assertThat(
@@ -832,9 +839,13 @@ class GetReleasedDataEndpointWithDataUseTermsUrlTest(
         }
 
         @Bean
+        fun fakeCurrentInstant() = FakeCurrentInstant()
+
+        @Bean
         @Primary
-        fun mockedDateProvider(): DateProvider {
-            val mock = mockk<DateProvider>(relaxed = true)
+        fun mockedDateProvider(fakeCurrentInstant: FakeCurrentInstant): DateProvider {
+            val mock = mockk<DateProvider>()
+            every { mock.getCurrentInstant() } answers { fakeCurrentInstant.value ?: callOriginal() }
             every { mock.getCurrentDateTime() } answers { callOriginal() }
             every { mock.getCurrentDate() } answers { callOriginal() }
             return mock


### PR DESCRIPTION
This is Claude's attempt to fix a really weird/complicated flake. Not sure this is the way to go, but it might be right that we have a bug in how things are set up - I just suspect there's an easier way out here.

<details>

`GetReleasedDataEndpointWithDataUseTermsUrlTest` fails intermittently in CI with `Status expected:<200> but was:<500>` in the test about expired restricted data use terms. Seen in [run 32856832097](https://github.com/loculus-project/loculus/actions/runs/32856832097); it was only diagnosable because that run archived the JUnit XML.

## What actually happens

The test changed the current time by re-running `every { dateProvider.getCurrentInstant() } answers { ... }` in the middle of the test. MockK does that in two steps: recording the `every { ... }` block adds an entry to the mock's answer list, and the `answers { ... }` call then fills in what that entry should return. In between there is an entry that matches the call but has no answer yet, and anything calling the method in that window gets `MockKException: no answer provided`. Because the entry matches, `relaxed = true` never comes into play, which is why a relaxed mock did not protect against this.

Something else was calling the method at that moment. Two statements earlier the test reads an ETag off `getReleasedData()` without waiting for the response body. `get-released-data` is a streaming endpoint, so the body keeps running on a background thread after the test moves on — 8-9 ms in that CI run, long enough to overlap. It hit the empty answer entry while building the data use terms for a record.

That exception on its own is harmless: the controller catches errors during streaming and writes them into the response body, and this response was being thrown away anyway. The damage is indirect. The exception was thrown from inside the mock, which left MockK's call recorder — shared across threads — stuck in a logging mode. One millisecond later the test thread computed the ETag for the next request, called the same mock, got `No other calls allowed in stdObjectAnswer` instead of a date, and the request came back as a 500.

## The change

Answers are installed once when the mock bean is created, and the tests now move time by writing to a `@Volatile` field that the answer reads. Nothing is stubbed after the Spring context is up, so the window with a matching-but-empty answer no longer exists at any point, on any thread. This is a stronger guarantee than making the test wait for the background work: waiting would only shrink a window that is microseconds wide.

`relaxed = true` is dropped. `DateProvider` has three methods and all three are stubbed, so strict mode now fails loudly if someone adds a fourth, rather than quietly returning a made-up value.

Separately, the streamed responses whose bodies these tests discard are now waited for. A stream still running when the next test starts also races the `TRUNCATE` that clears the tables between tests, which has no lock or statement timeout — a hazard worth closing even though it is not what broke this test.

## Non-obvious things worth knowing

Faking `getCurrentInstant()` alone is enough to move the whole clock: `getCurrentDateTime()` and `getCurrentDate()` are answered with `callOriginal()`, and MockK intercepts the calls the real implementations make back into the mock. The test that asserts the ETag changes on the date alone is what proves this still works.

This flake needs a loaded machine. On its own the test class is far too fast to hit it — I ran the test 60 times in a row without a single failure, and measured why: with one record the background stream finishes in well under a millisecond, so it is long gone by the time the test re-stubs. Six full-suite runs did not reproduce it either. To show the mechanism I widened the gap between `every` and `answers` by 3 ms and had a background thread call the date provider: 2 failures in 20, with exactly the `expected:<200> but was:<500>` signature from CI, and none in 120 runs after this change. Six clean full-suite runs before and five after prove nothing on their own — the argument for the fix is that the failure mode is now structurally impossible, not that the tests went green.

Two things this is *not*, both ruled out from the stack traces: it is not a scheduled background job (the two that use the date provider have initial delays of one hour and fifteen minutes, so neither runs during a test), and it is not state leaking in from another test class (the trace names this class's own mock bean and its own request).

Nothing else in the test suite mocks `DateProvider`, so the same bug cannot be lurking elsewhere. The same shape — stubbing a mock while a request is still streaming — could apply to the `keycloakAdapter` stubbing in the sibling classes, but nothing on the released-data path calls it, so I left those alone.

</details>

🚀 Preview: Add `preview` label to enable