### PR TITLE
fix(website): Keep uploaded files in file mapping while other files are still uploading, update `fileUpload` tests

### DIFF
--- a/website/src/components/Submission/FileUpload/FolderUploadComponent.spec.tsx
+++ b/website/src/components/Submission/FileUpload/FolderUploadComponent.spec.tsx
@@ -49,7 +49,7 @@ const FolderUploadComponentWithState = ({
     const states = new Map(otherCategories);
     if (fileUploadState !== undefined) states.set(props.fileCategory.name, fileUploadState);
     const mapping = deriveFileMapping(states);
-useEffect(() => onMapping?.(mapping), [mapping, onMapping]);
+    useEffect(() => onMapping?.(mapping), [mapping, onMapping]);
     return (
         <FolderUploadComponent {...props} fileUploadState={fileUploadState} setFileUploadState={setFileUploadState} />
     );

--- a/website/src/components/Submission/FileUpload/fileUpload.spec.ts
+++ b/website/src/components/Submission/FileUpload/fileUpload.spec.ts
@@ -1,14 +1,23 @@
 import { describe, expect, it } from 'vitest';
 
-import { deriveFileMapping, validateFileUploadStates, type FileUploadState, type Pending } from './fileUpload';
+import {
+    deriveFileMapping,
+    getPreviousFileUploadStates,
+    validateFileUploadStates,
+    type FileUploadState,
+    type Pending,
+} from './fileUpload';
 
-const uploaded = { type: 'uploaded', fileId: 'file-1', path: 'a.txt', size: 7 } as const;
-const previousUpload = { type: 'previousUpload', fileId: 'file-2', path: 'b.txt' } as const;
-const awaiting = { type: 'awaiting', file: new File([], 'c.txt'), path: 'c.txt', size: 7 } as const;
+const RAW_READS = 'rawReads';
+const ANNOTATIONS = 'annotations';
+
+const uploaded = { type: 'uploaded', fileId: 'file-1', path: 'uploaded.txt', size: 7 } as const;
+const previousUpload = { type: 'previousUpload', fileId: 'file-2', path: 'previousUpload.txt' } as const;
+const awaiting = { type: 'awaiting', file: new File([], 'awaiting.txt'), path: 'awaiting.txt', size: 7 } as const;
 const pending: Pending = {
     type: 'pending',
-    file: new File([], 'd.txt'),
-    path: 'd.txt',
+    file: new File([], 'pending.txt'),
+    path: 'pending.txt',
     size: 7,
     fileId: 'file-3',
     urls: ['url'],
@@ -16,8 +25,10 @@ const pending: Pending = {
     totalParts: 1,
     partSize: 7,
 };
+const errored = { type: 'error', path: 'errored.txt', size: 7, msg: 'upload failed' } as const;
 
-const statesOf = (...states: FileUploadState[]) => new Map(states.map((state, index) => [`category${index}`, state]));
+const submittedReads = { fileId: 'file-4', name: 'reads.fastq' };
+const submittedAnnotations = { fileId: 'file-5', name: 'annotations.gff' };
 
 describe('validateFileUploadStates', () => {
     it('accepts a submission without any file categories', () => {
@@ -26,17 +37,19 @@ describe('validateFileUploadStates', () => {
 
     it('accepts categories whose uploads have all completed', () => {
         const result = validateFileUploadStates(
-            statesOf(
-                { type: 'uploadCompleted', files: [uploaded] },
-                { type: 'uploadCompleted', files: [previousUpload] },
-            ),
+            new Map<string, FileUploadState>([
+                [RAW_READS, { type: 'uploadCompleted', files: [uploaded] }],
+                [ANNOTATIONS, { type: 'uploadCompleted', files: [previousUpload] }],
+            ]),
         );
 
         expect(result.isOk()).toBeTruthy();
     });
 
     it('rejects a category which is still awaiting upload urls', () => {
-        const result = validateFileUploadStates(statesOf({ type: 'awaitingUrls', files: [] }));
+        const result = validateFileUploadStates(
+            new Map<string, FileUploadState>([[RAW_READS, { type: 'awaitingUrls', files: [] }]]),
+        );
 
         expect(result.isErr()).toBeTruthy();
         expect(result._unsafeUnwrapErr().message).toContain('wait for all files to finish uploading');
@@ -44,7 +57,10 @@ describe('validateFileUploadStates', () => {
 
     it('rejects a category whose upload is still in progress', () => {
         const result = validateFileUploadStates(
-            statesOf({ type: 'uploadCompleted', files: [uploaded] }, { type: 'uploadInProgress', files: [uploaded] }),
+            new Map<string, FileUploadState>([
+                [RAW_READS, { type: 'uploadCompleted', files: [uploaded] }],
+                [ANNOTATIONS, { type: 'uploadInProgress', files: [uploaded] }],
+            ]),
         );
 
         expect(result.isErr()).toBeTruthy();
@@ -53,45 +69,91 @@ describe('validateFileUploadStates', () => {
 });
 
 describe('deriveFileMapping', () => {
-    it('returns undefined rather than an empty map when nothing has finished uploading', () => {
-        // Callers treat undefined as "no file mapping to apply"; an empty map is not equivalent.
+    it('returns undefined when no files have been uploaded', () => {
         expect(deriveFileMapping(new Map())).toBeUndefined();
         expect(
             deriveFileMapping(
-                statesOf({ type: 'awaitingUrls', files: [awaiting] }, { type: 'uploadInProgress', files: [pending] }),
+                new Map<string, FileUploadState>([
+                    [RAW_READS, { type: 'awaitingUrls', files: [awaiting] }],
+                    [ANNOTATIONS, { type: 'uploadInProgress', files: [pending] }],
+                ]),
             ),
         ).toBeUndefined();
     });
 
-    it('maps every completed category by path to file id', () => {
+    it('maps the path of every uploaded and previously uploaded file to its file id', () => {
         const mapping = deriveFileMapping(
-            statesOf(
-                { type: 'uploadCompleted', files: [uploaded] },
-                { type: 'uploadCompleted', files: [previousUpload] },
-            ),
+            new Map<string, FileUploadState>([
+                [
+                    RAW_READS,
+                    { type: 'uploadInProgress', files: [uploaded, previousUpload, awaiting, pending, errored] },
+                ],
+                [ANNOTATIONS, { type: 'uploadCompleted', files: [previousUpload] }],
+            ]),
         );
 
         expect(mapping).toEqual(
             new Map([
-                ['category0', new Map([['a.txt', 'file-1']])],
-                ['category1', new Map([['b.txt', 'file-2']])],
+                [
+                    RAW_READS,
+                    new Map([
+                        [uploaded.path, uploaded.fileId],
+                        [previousUpload.path, previousUpload.fileId],
+                    ]),
+                ],
+                [ANNOTATIONS, new Map([[previousUpload.path, previousUpload.fileId]])],
             ]),
         );
     });
 
-    it('includes a finished file while others in the same category are still in flight', () => {
-        const mapping = deriveFileMapping(statesOf({ type: 'uploadInProgress', files: [uploaded, awaiting, pending] }));
+    it('omits categories without any uploaded files', () => {
+        const mapping = deriveFileMapping(
+            new Map<string, FileUploadState>([
+                [RAW_READS, { type: 'uploadCompleted', files: [uploaded] }],
+                [ANNOTATIONS, { type: 'uploadInProgress', files: [pending] }],
+            ]),
+        );
 
-        expect(mapping).toEqual(new Map([['category0', new Map([['a.txt', 'file-1']])]]));
+        expect(mapping).toEqual(new Map([[RAW_READS, new Map([[uploaded.path, uploaded.fileId]])]]));
+    });
+});
+
+describe('getPreviousFileUploadStates', () => {
+    it('presents already submitted files as previous uploads', () => {
+        const states = getPreviousFileUploadStates({
+            [RAW_READS]: [submittedReads],
+            [ANNOTATIONS]: [submittedAnnotations],
+        });
+
+        expect(states).toEqual(
+            new Map([
+                [
+                    RAW_READS,
+                    {
+                        type: 'uploadCompleted',
+                        files: [{ type: 'previousUpload', fileId: submittedReads.fileId, path: submittedReads.name }],
+                    },
+                ],
+                [
+                    ANNOTATIONS,
+                    {
+                        type: 'uploadCompleted',
+                        files: [
+                            {
+                                type: 'previousUpload',
+                                fileId: submittedAnnotations.fileId,
+                                path: submittedAnnotations.name,
+                            },
+                        ],
+                    },
+                ],
+            ]),
+        );
     });
 
-    it('yields the replacement file id for a replaced file, not the id it replaced', () => {
-        // The regression this exists for: a file replaced on the edit page was submitted under
-        // the fileId of the file it replaced, silently publishing the old content.
-        const replaced = { type: 'uploaded', fileId: 'file-new', path: 'b.txt', size: 7 } as const;
+    it('omits categories without any files', () => {
+        const states = getPreviousFileUploadStates({ [RAW_READS]: [submittedReads], [ANNOTATIONS]: [] });
 
-        const mapping = deriveFileMapping(statesOf({ type: 'uploadCompleted', files: [uploaded, replaced] }));
-
-        expect(mapping?.get('category0')?.get('b.txt')).toBe('file-new');
+        expect([...states.keys()]).toEqual([RAW_READS]);
     });
 });

--- a/website/src/components/Submission/FileUpload/fileUpload.spec.ts
+++ b/website/src/components/Submission/FileUpload/fileUpload.spec.ts
@@ -1,9 +1,21 @@
 import { describe, expect, it } from 'vitest';
 
-import { deriveFileMapping, validateFileUploadStates, type FileUploadState } from './fileUpload';
+import { deriveFileMapping, validateFileUploadStates, type FileUploadState, type Pending } from './fileUpload';
 
 const uploaded = { type: 'uploaded', fileId: 'file-1', path: 'a.txt', size: 7 } as const;
 const previousUpload = { type: 'previousUpload', fileId: 'file-2', path: 'b.txt' } as const;
+const awaiting = { type: 'awaiting', file: new File([], 'c.txt'), path: 'c.txt', size: 7 } as const;
+const pending: Pending = {
+    type: 'pending',
+    file: new File([], 'd.txt'),
+    path: 'd.txt',
+    size: 7,
+    fileId: 'file-3',
+    urls: ['url'],
+    uploadedParts: 0,
+    totalParts: 1,
+    partSize: 7,
+};
 
 const statesOf = (...states: FileUploadState[]) => new Map(states.map((state, index) => [`category${index}`, state]));
 
@@ -41,10 +53,14 @@ describe('validateFileUploadStates', () => {
 });
 
 describe('deriveFileMapping', () => {
-    it('returns undefined rather than an empty map when nothing was uploaded', () => {
+    it('returns undefined rather than an empty map when nothing has finished uploading', () => {
         // Callers treat undefined as "no file mapping to apply"; an empty map is not equivalent.
         expect(deriveFileMapping(new Map())).toBeUndefined();
-        expect(deriveFileMapping(statesOf({ type: 'uploadInProgress', files: [uploaded] }))).toBeUndefined();
+        expect(
+            deriveFileMapping(
+                statesOf({ type: 'awaitingUrls', files: [awaiting] }, { type: 'uploadInProgress', files: [pending] }),
+            ),
+        ).toBeUndefined();
     });
 
     it('maps every completed category by path to file id', () => {
@@ -63,10 +79,8 @@ describe('deriveFileMapping', () => {
         );
     });
 
-    it('omits categories which are not yet complete, mirroring validateFileUploadStates', () => {
-        const mapping = deriveFileMapping(
-            statesOf({ type: 'uploadCompleted', files: [uploaded] }, { type: 'uploadInProgress', files: [uploaded] }),
-        );
+    it('includes a finished file while others in the same category are still in flight', () => {
+        const mapping = deriveFileMapping(statesOf({ type: 'uploadInProgress', files: [uploaded, awaiting, pending] }));
 
         expect(mapping).toEqual(new Map([['category0', new Map([['a.txt', 'file-1']])]]));
     });

--- a/website/src/components/Submission/FileUpload/fileUpload.ts
+++ b/website/src/components/Submission/FileUpload/fileUpload.ts
@@ -87,14 +87,21 @@ export const getPreviousFileUploadStates = (files: FilesByCategory): Map<string,
             ]),
     );
 
-/** The file mapping is a projection of the upload states, so derive it rather than storing a copy that lags a render behind. */
+const isUploaded = (file: SingleFileUpload): file is Uploaded | PreviousUpload =>
+    file.type === 'uploaded' || file.type === 'previousUpload';
+
+/**
+ * The file mapping is derived from the upload states.
+ * A file enters the mapping as soon as its own upload has finished, so files still uploading cannot be claimed as linked.
+ */
 export const deriveFileMapping = (fileUploadStates: Map<string, FileUploadState>): FileMapping | undefined => {
     const mapping: FileMapping = new Map(
-        Array.from(fileUploadStates.entries()).flatMap(([category, state]) =>
-            state.type === 'uploadCompleted'
-                ? [[category, new Map(state.files.map((file) => [file.path, file.fileId]))] as const]
-                : [],
-        ),
+        Array.from(fileUploadStates.entries()).flatMap(([category, state]) => {
+            const uploads = [...state.files].filter(isUploaded);
+            return uploads.length === 0
+                ? []
+                : [[category, new Map(uploads.map((file) => [file.path, file.fileId]))] as const];
+        }),
     );
     return mapping.size === 0 ? undefined : mapping;
 };

--- a/website/src/components/Submission/FileUpload/fileUpload.ts
+++ b/website/src/components/Submission/FileUpload/fileUpload.ts
@@ -87,20 +87,15 @@ export const getPreviousFileUploadStates = (files: FilesByCategory): Map<string,
             ]),
     );
 
-const isUploaded = (file: SingleFileUpload): file is Uploaded | PreviousUpload =>
-    file.type === 'uploaded' || file.type === 'previousUpload';
-
-/**
- * The file mapping is derived from the upload states.
- * A file enters the mapping as soon as its own upload has finished, so files still uploading cannot be claimed as linked.
- */
 export const deriveFileMapping = (fileUploadStates: Map<string, FileUploadState>): FileMapping | undefined => {
     const mapping: FileMapping = new Map(
-        Array.from(fileUploadStates.entries()).flatMap(([category, state]) => {
-            const uploads = [...state.files].filter(isUploaded);
-            return uploads.length === 0
-                ? []
-                : [[category, new Map(uploads.map((file) => [file.path, file.fileId]))] as const];
+        Array.from(fileUploadStates.entries()).flatMap(([category, fileUploadState]) => {
+            // Only files that have finished uploading are included in the file mapping and can be claimed as linked
+            const uploads = fileUploadState.files.filter(
+                (file) => file.type === 'uploaded' || file.type === 'previousUpload',
+            ) as (Uploaded | PreviousUpload)[];
+
+            return uploads.length === 0 ? [] : [[category, new Map(uploads.map((file) => [file.path, file.fileId]))]];
         }),
     );
     return mapping.size === 0 ? undefined : mapping;


### PR DESCRIPTION
### Summary

PR #7155 simplifies the file mapping to be derived from the upload state. However, this changes how the file linkage is displayed to users - before, it was updated with linkage each time the file upload state was in state `uploadCompleted`. Now, it updates after each change to the file upload state - and currently this results in the file linkage disappearing each time the upload state is in `uploadInProgress`.

This PR updates to show a live linkage count: the file mapping is computed to have all files which are uploaded.

#### Other changes

This PR also updates the tests in `fileUpload.spec.ts`.

### Screenshot

(Excuse my disorganised test files)

#### Current behaviour on `main`:

https://github.com/user-attachments/assets/0964aace-5d2b-4e0f-8654-b7068bee5df2

#### PR #7155 :

https://github.com/user-attachments/assets/68c485e9-1254-4ff1-ac4e-aaca56955e82

#### This PR:

https://github.com/user-attachments/assets/5f0a437b-abe2-45e6-9745-5be7b2ac8ae4

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable