### PR TITLE
ci(backend): enable extra tests on manual dispatch

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -8,15 +8,21 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      run_extra_tests:
+        description: "Run the extended backend test collection"
+        required: false
+        default: false
+        type: boolean
 concurrency:
-  group: ci-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}-backend-tests
+  group: ci-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref == 'refs/heads/main' && github.run_id || github.ref }}-backend-tests
   cancel-in-progress: true
 jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      RUN_EXTRA_TESTS: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'true' || 'false' }}
+      RUN_EXTRA_TESTS: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.run_extra_tests && 'true' || 'false' }}
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@v4

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -15,7 +15,7 @@ on:
         default: false
         type: boolean
 concurrency:
-  group: ci-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref == 'refs/heads/main' && github.run_id || github.ref }}-backend-tests
+  group: ci-${{ (github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main') && github.run_id || github.ref }}-backend-tests
   cancel-in-progress: true
 jobs:
   test:

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      RUN_EXTRA_TESTS: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.run_extra_tests && 'true' || 'false' }}
+      RUN_EXTRA_TESTS: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.run_extra_tests == true }}
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@v4


### PR DESCRIPTION
## Summary

Adds a `run_extra_tests` boolean input to the backend test workflow so the extended test collection can be manually dispatched from a PR commit.

Manual dispatches use a run-specific concurrency key, allowing multiple diagnostic runs to proceed without cancelling each other.

## Validation

Dispatched ten `backend-tests` runs with `run_extra_tests=true` from this branch.

🚀 Preview: Add `preview` label to enable