### PR TITLE
fix(backend): stop the update-tracker triggers going quadratic on bulk inserts

### DIFF
--- a/backend/docs/db/schema.sql
+++ b/backend/docs/db/schema.sql
@@ -4,8 +4,8 @@
 
 \restrict dummy
 
--- Dumped from database version 15.18 (Debian 15.18-1.pgdg13+1)
--- Dumped by pg_dump version 16.14 (Debian 16.14-1.pgdg13+1)
+-- Dumped from database version 15.19 (Debian 15.19-1.pgdg13+2)
+-- Dumped by pg_dump version 16.15 (Debian 16.15-1.pgdg13+2)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -58,12 +58,14 @@ CREATE FUNCTION public.update_current_processing_pipeline_tracker() RETURNS trig
     LANGUAGE plpgsql
     AS $$
 BEGIN
-    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated)
-    SELECT TG_TABLE_NAME, cr.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP)
+    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
+    SELECT TG_TABLE_NAME, cr.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id()
     FROM changed_rows cr
     GROUP BY cr.organism
-    ON CONFLICT (table_name, organism, pipeline_version)
-    DO UPDATE SET last_time_updated = timezone('UTC', CURRENT_TIMESTAMP);
+    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
+        last_time_updated = EXCLUDED.last_time_updated,
+        last_xid = EXCLUDED.last_xid
+    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
     RETURN NULL;
 END;
 $$;
@@ -79,14 +81,15 @@ CREATE FUNCTION public.update_data_use_terms_table_tracker() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
-    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated)
-    SELECT TG_TABLE_NAME, se.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP)
+    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
+    SELECT TG_TABLE_NAME, se.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id()
     FROM changed_rows cr
-    JOIN sequence_entries se
-      ON se.accession = cr.accession
+    JOIN sequence_entries se ON se.accession = cr.accession
     GROUP BY se.organism
-    ON CONFLICT (table_name, organism, pipeline_version)
-    DO UPDATE SET last_time_updated = timezone('UTC', CURRENT_TIMESTAMP);
+    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
+        last_time_updated = EXCLUDED.last_time_updated,
+        last_xid = EXCLUDED.last_xid
+    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
     RETURN NULL;
 END;
 $$;
@@ -102,14 +105,15 @@ CREATE FUNCTION public.update_external_metadata_tracker() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
-    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated)
-    SELECT TG_TABLE_NAME, se.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP)
+    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
+    SELECT TG_TABLE_NAME, se.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id()
     FROM changed_rows cr
-    JOIN sequence_entries se
-      ON se.accession = cr.accession AND se.version = cr.version
+    JOIN sequence_entries se ON se.accession = cr.accession AND se.version = cr.version
     GROUP BY se.organism
-    ON CONFLICT (table_name, organism, pipeline_version)
-    DO UPDATE SET last_time_updated = timezone('UTC', CURRENT_TIMESTAMP);
+    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
+        last_time_updated = EXCLUDED.last_time_updated,
+        last_xid = EXCLUDED.last_xid
+    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
     RETURN NULL;
 END;
 $$;
@@ -125,14 +129,15 @@ CREATE FUNCTION public.update_preprocessed_data_tracker() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
-    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated)
-    SELECT TG_TABLE_NAME, se.organism, cr.pipeline_version, timezone('UTC', CURRENT_TIMESTAMP)
+    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
+    SELECT TG_TABLE_NAME, se.organism, cr.pipeline_version, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id()
     FROM changed_rows cr
-    JOIN sequence_entries se
-      ON se.accession = cr.accession AND se.version = cr.version
+    JOIN sequence_entries se ON se.accession = cr.accession AND se.version = cr.version
     GROUP BY se.organism, cr.pipeline_version
-    ON CONFLICT (table_name, organism, pipeline_version)
-    DO UPDATE SET last_time_updated = timezone('UTC', CURRENT_TIMESTAMP);
+    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
+        last_time_updated = EXCLUDED.last_time_updated,
+        last_xid = EXCLUDED.last_xid
+    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
     RETURN NULL;
 END;
 $$;
@@ -148,12 +153,14 @@ CREATE FUNCTION public.update_sequence_entries_tracker() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
-    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated)
-    SELECT TG_TABLE_NAME, cr.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP)
+    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
+    SELECT TG_TABLE_NAME, cr.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id()
     FROM changed_rows cr
     GROUP BY cr.organism
-    ON CONFLICT (table_name, organism, pipeline_version)
-    DO UPDATE SET last_time_updated = timezone('UTC', CURRENT_TIMESTAMP);
+    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
+        last_time_updated = EXCLUDED.last_time_updated,
+        last_xid = EXCLUDED.last_xid
+    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
     RETURN NULL;
 END;
 $$;
@@ -170,10 +177,12 @@ CREATE FUNCTION public.update_table_tracker() RETURNS trigger
     AS $$
 BEGIN
     IF TG_TABLE_NAME != 'table_update_tracker' THEN
-        INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated)
-        VALUES (TG_TABLE_NAME, NULL, NULL, timezone('UTC', CURRENT_TIMESTAMP))
-        ON CONFLICT (table_name, organism, pipeline_version)
-        DO UPDATE SET last_time_updated = timezone('UTC', CURRENT_TIMESTAMP);
+        INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
+        VALUES (TG_TABLE_NAME, NULL, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id())
+        ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
+            last_time_updated = EXCLUDED.last_time_updated,
+            last_xid = EXCLUDED.last_xid
+        WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
     END IF;
     RETURN NULL;
 END;
@@ -692,7 +701,8 @@ CREATE TABLE public.table_update_tracker (
     table_name text NOT NULL,
     last_time_updated timestamp without time zone DEFAULT timezone('UTC'::text, CURRENT_TIMESTAMP),
     organism text,
-    pipeline_version bigint
+    pipeline_version bigint,
+    last_xid xid8
 );
 
 

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/dbtables/UpdateTrackerTable.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/dbtables/UpdateTrackerTable.kt
@@ -13,8 +13,5 @@ object UpdateTrackerTable : Table(UPDATE_TRACKER_TABLE_NAME) {
     val organismColumn = text("organism").nullable()
     val pipelineVersionColumn = long("pipeline_version").nullable()
     val lastTimeUpdatedDbColumn = text("last_time_updated")
-
-    // Written only by the tracker triggers, which use it to skip their upsert when this
-    // transaction already wrote the row. NULL until a row is first written by them.
     val lastXidColumn = text("last_xid").nullable()
 }

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/dbtables/UpdateTrackerTable.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/dbtables/UpdateTrackerTable.kt
@@ -13,4 +13,8 @@ object UpdateTrackerTable : Table(UPDATE_TRACKER_TABLE_NAME) {
     val organismColumn = text("organism").nullable()
     val pipelineVersionColumn = long("pipeline_version").nullable()
     val lastTimeUpdatedDbColumn = text("last_time_updated")
+
+    // Written only by the tracker triggers, which use it to skip their upsert when this
+    // transaction already wrote the row. NULL until a row is first written by them.
+    val lastXidColumn = text("last_xid").nullable()
 }

--- a/backend/src/main/resources/db/migration/V1.35__make_update_tracker_upserts_idempotent.sql
+++ b/backend/src/main/resources/db/migration/V1.35__make_update_tracker_upserts_idempotent.sql
@@ -1,0 +1,123 @@
+-- Skip the tracker upsert when this transaction already wrote the row.
+--
+-- Exposed's batchInsert sends one single-row INSERT per row, so these FOR EACH STATEMENT
+-- triggers fire once per row and rewrite the same tracker row 100k times in one
+-- transaction. Those versions cannot be pruned while it is open, so the insert goes
+-- quadratic: 48.9 s for 100k rows, against ~1 s here.
+--
+-- Two guards that look right and are not: xmin instead of a stored id (xmin is the
+-- SUBtransaction id, so the guard never fires -- it silently did nothing on CI), and
+-- `last_time_updated < EXCLUDED...` (that column is transaction START time, so a
+-- transaction starting earlier but committing later would have its write dropped and
+-- readers holding the cached value would never refetch).
+--
+-- GREATEST(existing + 1us, ...) makes the column monotonic in commit order, so unlike
+-- before it is now safe to compare with `>` and not just for equality.
+
+ALTER TABLE table_update_tracker ADD COLUMN IF NOT EXISTS last_xid xid8;
+
+CREATE OR REPLACE FUNCTION update_table_tracker()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_TABLE_NAME != 'table_update_tracker' THEN
+        INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
+        VALUES (TG_TABLE_NAME, NULL, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id())
+        ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
+            last_time_updated = GREATEST(
+                table_update_tracker.last_time_updated + interval '1 microsecond',
+                EXCLUDED.last_time_updated),
+            last_xid = EXCLUDED.last_xid
+        WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION update_preprocessed_data_tracker()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
+    SELECT TG_TABLE_NAME, se.organism, cr.pipeline_version, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id()
+    FROM changed_rows cr
+    JOIN sequence_entries se ON se.accession = cr.accession AND se.version = cr.version
+    GROUP BY se.organism, cr.pipeline_version
+    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
+        last_time_updated = GREATEST(
+            table_update_tracker.last_time_updated + interval '1 microsecond',
+            EXCLUDED.last_time_updated),
+        last_xid = EXCLUDED.last_xid
+    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION update_external_metadata_tracker()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
+    SELECT TG_TABLE_NAME, se.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id()
+    FROM changed_rows cr
+    JOIN sequence_entries se ON se.accession = cr.accession AND se.version = cr.version
+    GROUP BY se.organism
+    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
+        last_time_updated = GREATEST(
+            table_update_tracker.last_time_updated + interval '1 microsecond',
+            EXCLUDED.last_time_updated),
+        last_xid = EXCLUDED.last_xid
+    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION update_data_use_terms_table_tracker()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
+    SELECT TG_TABLE_NAME, se.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id()
+    FROM changed_rows cr
+    JOIN sequence_entries se ON se.accession = cr.accession
+    GROUP BY se.organism
+    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
+        last_time_updated = GREATEST(
+            table_update_tracker.last_time_updated + interval '1 microsecond',
+            EXCLUDED.last_time_updated),
+        last_xid = EXCLUDED.last_xid
+    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION update_sequence_entries_tracker()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
+    SELECT TG_TABLE_NAME, cr.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id()
+    FROM changed_rows cr
+    GROUP BY cr.organism
+    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
+        last_time_updated = GREATEST(
+            table_update_tracker.last_time_updated + interval '1 microsecond',
+            EXCLUDED.last_time_updated),
+        last_xid = EXCLUDED.last_xid
+    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION update_current_processing_pipeline_tracker()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
+    SELECT TG_TABLE_NAME, cr.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id()
+    FROM changed_rows cr
+    GROUP BY cr.organism
+    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
+        last_time_updated = GREATEST(
+            table_update_tracker.last_time_updated + interval '1 microsecond',
+            EXCLUDED.last_time_updated),
+        last_xid = EXCLUDED.last_xid
+    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+

--- a/backend/src/main/resources/db/migration/V1.35__make_update_tracker_upserts_idempotent.sql
+++ b/backend/src/main/resources/db/migration/V1.35__make_update_tracker_upserts_idempotent.sql
@@ -11,30 +11,24 @@
 -- transaction starting earlier but committing later would have its write dropped and
 -- readers holding the cached value would never refetch).
 --
--- The upsert now lives in one function rather than being repeated in each trigger, so
--- there is a single place to get this wrong.
+-- last_time_updated keeps its existing last-writer-wins behaviour, including that it can
+-- move backwards, so it stays safe to compare only for equality.
+--
+-- The upsert is repeated rather than factored into a shared function on purpose: calling
+-- one costs about 10us per firing, which is a second across a 100k-row insert.
 
 ALTER TABLE table_update_tracker ADD COLUMN IF NOT EXISTS last_xid xid8;
-
-CREATE OR REPLACE FUNCTION record_table_update(
-    p_table_name TEXT,
-    p_organism TEXT,
-    p_pipeline_version BIGINT
-)
-RETURNS VOID AS $$
-    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
-    VALUES (p_table_name, p_organism, p_pipeline_version, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id())
-    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
-        last_time_updated = EXCLUDED.last_time_updated,
-        last_xid = EXCLUDED.last_xid
-    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
-$$ LANGUAGE sql;
 
 CREATE OR REPLACE FUNCTION update_table_tracker()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_TABLE_NAME != 'table_update_tracker' THEN
-        PERFORM record_table_update(TG_TABLE_NAME, NULL, NULL);
+        INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
+        VALUES (TG_TABLE_NAME, NULL, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id())
+        ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
+            last_time_updated = EXCLUDED.last_time_updated,
+            last_xid = EXCLUDED.last_xid
+        WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
     END IF;
     RETURN NULL;
 END;
@@ -43,10 +37,15 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION update_preprocessed_data_tracker()
 RETURNS TRIGGER AS $$
 BEGIN
-    PERFORM record_table_update(TG_TABLE_NAME, se.organism, cr.pipeline_version)
+    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
+    SELECT TG_TABLE_NAME, se.organism, cr.pipeline_version, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id()
     FROM changed_rows cr
     JOIN sequence_entries se ON se.accession = cr.accession AND se.version = cr.version
-    GROUP BY se.organism, cr.pipeline_version;
+    GROUP BY se.organism, cr.pipeline_version
+    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
+        last_time_updated = EXCLUDED.last_time_updated,
+        last_xid = EXCLUDED.last_xid
+    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
@@ -54,10 +53,15 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION update_external_metadata_tracker()
 RETURNS TRIGGER AS $$
 BEGIN
-    PERFORM record_table_update(TG_TABLE_NAME, se.organism, NULL)
+    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
+    SELECT TG_TABLE_NAME, se.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id()
     FROM changed_rows cr
     JOIN sequence_entries se ON se.accession = cr.accession AND se.version = cr.version
-    GROUP BY se.organism;
+    GROUP BY se.organism
+    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
+        last_time_updated = EXCLUDED.last_time_updated,
+        last_xid = EXCLUDED.last_xid
+    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
@@ -65,10 +69,15 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION update_data_use_terms_table_tracker()
 RETURNS TRIGGER AS $$
 BEGIN
-    PERFORM record_table_update(TG_TABLE_NAME, se.organism, NULL)
+    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
+    SELECT TG_TABLE_NAME, se.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id()
     FROM changed_rows cr
     JOIN sequence_entries se ON se.accession = cr.accession
-    GROUP BY se.organism;
+    GROUP BY se.organism
+    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
+        last_time_updated = EXCLUDED.last_time_updated,
+        last_xid = EXCLUDED.last_xid
+    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
@@ -76,9 +85,14 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION update_sequence_entries_tracker()
 RETURNS TRIGGER AS $$
 BEGIN
-    PERFORM record_table_update(TG_TABLE_NAME, cr.organism, NULL)
+    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
+    SELECT TG_TABLE_NAME, cr.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id()
     FROM changed_rows cr
-    GROUP BY cr.organism;
+    GROUP BY cr.organism
+    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
+        last_time_updated = EXCLUDED.last_time_updated,
+        last_xid = EXCLUDED.last_xid
+    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
@@ -86,9 +100,15 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION update_current_processing_pipeline_tracker()
 RETURNS TRIGGER AS $$
 BEGIN
-    PERFORM record_table_update(TG_TABLE_NAME, cr.organism, NULL)
+    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
+    SELECT TG_TABLE_NAME, cr.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id()
     FROM changed_rows cr
-    GROUP BY cr.organism;
+    GROUP BY cr.organism
+    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
+        last_time_updated = EXCLUDED.last_time_updated,
+        last_xid = EXCLUDED.last_xid
+    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
+

--- a/backend/src/main/resources/db/migration/V1.35__make_update_tracker_upserts_idempotent.sql
+++ b/backend/src/main/resources/db/migration/V1.35__make_update_tracker_upserts_idempotent.sql
@@ -11,8 +11,8 @@
 -- transaction starting earlier but committing later would have its write dropped and
 -- readers holding the cached value would never refetch).
 --
--- GREATEST(existing + 1us, ...) makes the column monotonic in commit order, so unlike
--- before it is now safe to compare with `>` and not just for equality.
+-- last_time_updated keeps its existing last-writer-wins behaviour, including that it can
+-- move backwards, so it stays safe to compare only for equality.
 
 ALTER TABLE table_update_tracker ADD COLUMN IF NOT EXISTS last_xid xid8;
 
@@ -23,9 +23,7 @@ BEGIN
         INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
         VALUES (TG_TABLE_NAME, NULL, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id())
         ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
-            last_time_updated = GREATEST(
-                table_update_tracker.last_time_updated + interval '1 microsecond',
-                EXCLUDED.last_time_updated),
+            last_time_updated = EXCLUDED.last_time_updated,
             last_xid = EXCLUDED.last_xid
         WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
     END IF;
@@ -42,9 +40,7 @@ BEGIN
     JOIN sequence_entries se ON se.accession = cr.accession AND se.version = cr.version
     GROUP BY se.organism, cr.pipeline_version
     ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
-        last_time_updated = GREATEST(
-            table_update_tracker.last_time_updated + interval '1 microsecond',
-            EXCLUDED.last_time_updated),
+        last_time_updated = EXCLUDED.last_time_updated,
         last_xid = EXCLUDED.last_xid
     WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
     RETURN NULL;
@@ -60,9 +56,7 @@ BEGIN
     JOIN sequence_entries se ON se.accession = cr.accession AND se.version = cr.version
     GROUP BY se.organism
     ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
-        last_time_updated = GREATEST(
-            table_update_tracker.last_time_updated + interval '1 microsecond',
-            EXCLUDED.last_time_updated),
+        last_time_updated = EXCLUDED.last_time_updated,
         last_xid = EXCLUDED.last_xid
     WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
     RETURN NULL;
@@ -78,9 +72,7 @@ BEGIN
     JOIN sequence_entries se ON se.accession = cr.accession
     GROUP BY se.organism
     ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
-        last_time_updated = GREATEST(
-            table_update_tracker.last_time_updated + interval '1 microsecond',
-            EXCLUDED.last_time_updated),
+        last_time_updated = EXCLUDED.last_time_updated,
         last_xid = EXCLUDED.last_xid
     WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
     RETURN NULL;
@@ -95,9 +87,7 @@ BEGIN
     FROM changed_rows cr
     GROUP BY cr.organism
     ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
-        last_time_updated = GREATEST(
-            table_update_tracker.last_time_updated + interval '1 microsecond',
-            EXCLUDED.last_time_updated),
+        last_time_updated = EXCLUDED.last_time_updated,
         last_xid = EXCLUDED.last_xid
     WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
     RETURN NULL;
@@ -112,9 +102,7 @@ BEGIN
     FROM changed_rows cr
     GROUP BY cr.organism
     ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
-        last_time_updated = GREATEST(
-            table_update_tracker.last_time_updated + interval '1 microsecond',
-            EXCLUDED.last_time_updated),
+        last_time_updated = EXCLUDED.last_time_updated,
         last_xid = EXCLUDED.last_xid
     WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
     RETURN NULL;

--- a/backend/src/main/resources/db/migration/V1.35__make_update_tracker_upserts_idempotent.sql
+++ b/backend/src/main/resources/db/migration/V1.35__make_update_tracker_upserts_idempotent.sql
@@ -11,21 +11,30 @@
 -- transaction starting earlier but committing later would have its write dropped and
 -- readers holding the cached value would never refetch).
 --
--- last_time_updated keeps its existing last-writer-wins behaviour, including that it can
--- move backwards, so it stays safe to compare only for equality.
+-- The upsert now lives in one function rather than being repeated in each trigger, so
+-- there is a single place to get this wrong.
 
 ALTER TABLE table_update_tracker ADD COLUMN IF NOT EXISTS last_xid xid8;
+
+CREATE OR REPLACE FUNCTION record_table_update(
+    p_table_name TEXT,
+    p_organism TEXT,
+    p_pipeline_version BIGINT
+)
+RETURNS VOID AS $$
+    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
+    VALUES (p_table_name, p_organism, p_pipeline_version, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id())
+    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
+        last_time_updated = EXCLUDED.last_time_updated,
+        last_xid = EXCLUDED.last_xid
+    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
+$$ LANGUAGE sql;
 
 CREATE OR REPLACE FUNCTION update_table_tracker()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_TABLE_NAME != 'table_update_tracker' THEN
-        INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
-        VALUES (TG_TABLE_NAME, NULL, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id())
-        ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
-            last_time_updated = EXCLUDED.last_time_updated,
-            last_xid = EXCLUDED.last_xid
-        WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
+        PERFORM record_table_update(TG_TABLE_NAME, NULL, NULL);
     END IF;
     RETURN NULL;
 END;
@@ -34,15 +43,10 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION update_preprocessed_data_tracker()
 RETURNS TRIGGER AS $$
 BEGIN
-    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
-    SELECT TG_TABLE_NAME, se.organism, cr.pipeline_version, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id()
+    PERFORM record_table_update(TG_TABLE_NAME, se.organism, cr.pipeline_version)
     FROM changed_rows cr
     JOIN sequence_entries se ON se.accession = cr.accession AND se.version = cr.version
-    GROUP BY se.organism, cr.pipeline_version
-    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
-        last_time_updated = EXCLUDED.last_time_updated,
-        last_xid = EXCLUDED.last_xid
-    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
+    GROUP BY se.organism, cr.pipeline_version;
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
@@ -50,15 +54,10 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION update_external_metadata_tracker()
 RETURNS TRIGGER AS $$
 BEGIN
-    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
-    SELECT TG_TABLE_NAME, se.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id()
+    PERFORM record_table_update(TG_TABLE_NAME, se.organism, NULL)
     FROM changed_rows cr
     JOIN sequence_entries se ON se.accession = cr.accession AND se.version = cr.version
-    GROUP BY se.organism
-    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
-        last_time_updated = EXCLUDED.last_time_updated,
-        last_xid = EXCLUDED.last_xid
-    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
+    GROUP BY se.organism;
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
@@ -66,15 +65,10 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION update_data_use_terms_table_tracker()
 RETURNS TRIGGER AS $$
 BEGIN
-    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
-    SELECT TG_TABLE_NAME, se.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id()
+    PERFORM record_table_update(TG_TABLE_NAME, se.organism, NULL)
     FROM changed_rows cr
     JOIN sequence_entries se ON se.accession = cr.accession
-    GROUP BY se.organism
-    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
-        last_time_updated = EXCLUDED.last_time_updated,
-        last_xid = EXCLUDED.last_xid
-    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
+    GROUP BY se.organism;
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
@@ -82,14 +76,9 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION update_sequence_entries_tracker()
 RETURNS TRIGGER AS $$
 BEGIN
-    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
-    SELECT TG_TABLE_NAME, cr.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id()
+    PERFORM record_table_update(TG_TABLE_NAME, cr.organism, NULL)
     FROM changed_rows cr
-    GROUP BY cr.organism
-    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
-        last_time_updated = EXCLUDED.last_time_updated,
-        last_xid = EXCLUDED.last_xid
-    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
+    GROUP BY cr.organism;
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
@@ -97,15 +86,9 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION update_current_processing_pipeline_tracker()
 RETURNS TRIGGER AS $$
 BEGIN
-    INSERT INTO table_update_tracker (table_name, organism, pipeline_version, last_time_updated, last_xid)
-    SELECT TG_TABLE_NAME, cr.organism, NULL, timezone('UTC', CURRENT_TIMESTAMP), pg_current_xact_id()
+    PERFORM record_table_update(TG_TABLE_NAME, cr.organism, NULL)
     FROM changed_rows cr
-    GROUP BY cr.organism
-    ON CONFLICT (table_name, organism, pipeline_version) DO UPDATE SET
-        last_time_updated = EXCLUDED.last_time_updated,
-        last_xid = EXCLUDED.last_xid
-    WHERE table_update_tracker.last_xid IS DISTINCT FROM EXCLUDED.last_xid;
+    GROUP BY cr.organism;
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
-


### PR DESCRIPTION
## Why

Every push to `main` runs `SubmitLargeBatchTest`, which submits 100,000 sequences. Its test job has a median duration of 464 s, against roughly 200 s for a pull-request run, and this one test is essentially the whole difference. About 95 s of it is a database trigger doing work that is thrown away. That cost is paid on every merge, is entirely avoidable, and is the motivation for this change on its own.

The same code runs in production, where there is no JDBC socket timeout anywhere in the backend or the chart, so a large enough submission does not fail — it just gets slow with nothing bounding it.

### The 15-minute timeout, and how often it actually bites

`backend-tests` has timed out on a push to `main` three times, all with the same signature:

| run | date | test job |
|---|---|---|
| [24840664509](https://github.com/loculus-project/loculus/actions/runs/24840664509) | 2026-04-23 | cancelled at 903 s |
| [32712103886](https://github.com/loculus-project/loculus/actions/runs/32712103886) attempt 1 | 2026-08-24 | cancelled at 916 s |
| [32748302946](https://github.com/loculus-project/loculus/actions/runs/32748302946) attempt 1 | 2026-08-24 | cancelled at 916 s |

The two August ones were re-run and went green, so both runs report `success` at the top level and neither appears in any listing keyed on a run's conclusion. Only the first attempt hung. That is worth knowing before anyone quotes a rate from `gh run list`: durations of the *latest* attempt hide exactly the failures someone cared enough to re-run.

Split by period rather than averaged, the observed counts are 1 timeout in 847 `main` runs from 2025-10-21 (when the 15-minute cap landed) to 2026-08-01, and 2 in the 63 runs since. Two events in three weeks is consistent with a real increase and equally consistent with a blip on a low base rate, so I am not claiming a regime change or a cause for one. The denominators are all `main` runs in each window; the timeout search itself walked every attempt of every run whose history contains a non-success attempt, which is where a hang always leaves a trace.

What this does settle is that the recent rate on `main` — 2 in 63 — sits in the same range as the 3 in 44 I measured on the instrumented baseline branch, so the cohort measurements are not some artifact of dispatching runs by hand.

**That still does not make this PR a fix for the timeout, and I would not merge it on that basis.** On branches differing only by this migration: 3 hangs in 44 runs without it, 0 in 40 with it. Fisher gives p = 0.24. Suggestive, not conclusive, and 40 runs cannot exclude the change having no effect on the hang at all.

What the instrumentation does show is that a hung run is not stuck. It is grinding through the very same work, with Postgres pinned at exactly one core of CPU, no wait event, no lock contention, and the insert still progressing at roughly 60 rows/s against about 1000 rows/s in a healthy run. The CPU being burned in both cases is this trigger. So removing it plausibly removes the hang too, but that is an inference. Note also that of the six timeouts across all branches that started this investigation, three were `pull_request` runs where this test never runs at all, so at least one unrelated cause exists regardless.

### What is actually slow

Every table that feeds the released-data ETag has a trigger that stamps "this table changed" into a single row of `table_update_tracker`. The triggers are `FOR EACH STATEMENT`, which sounds like one firing per chunk. It is not: Exposed's `batchInsert` sends one *single-row* `INSERT` per row over JDBC — batching bundles the round trips, it does not merge the statements. `pg_stat_activity` on a dying run shows exactly that, a single-row `VALUES` executing, about 5 ms each, with nothing blocked and no ungranted lock.

So 100,000 rows means 100,000 trigger firings, all upserting the *same* row, inside one transaction. Postgres implements `UPDATE` as "write a new version and chain it behind the old one", and versions written by a transaction that is still open cannot be pruned. That one row accumulates up to 100,000 versions, and every subsequent update has to walk the chain. Linear per statement, quadratic overall.

In CI, six runs each on `main` with and without this change: `SubmitLargeBatchTest` goes from a median of 138 s (87.8, 134.9, 138.1, 138.8, 155.4) to 61 s (36.2, 43.4, 60.7, 62.2, 77.6, 78.8), and the whole `Run tests` step from 283–365 s to 185–289 s. Isolated in plain SQL the same 100k inserts go from 48.9 s to about 1 s, and on CI the tracker table now stays on a single 8 kB page for a whole run instead of growing past 3 MB — that last one is the pathology itself being removed rather than inferred from timings.

### How this was found, and what to reuse next time

Most of the elapsed effort went into instrumentation that did not work, so the order below matters more than the conclusion. If the hang comes back, start at step 2.

**1. Thread dumps alone were not enough, and actively misled.** Dumping the JVM on timeout gives you a stack inside the batch-insert machinery. That stack looks like a smoking gun and is not — it is simply where a slow-but-progressing insert always is. Earlier rounds of this investigation named a culprit from such a dump three separate times and each was later retracted. A stack showing work in progress is not evidence of where the time goes.

**2. Per-test `STARTED`/`PASSED` logging is the single highest-value thing here.** `main`'s Gradle config logs neither, so a timed-out job's log simply stops, and every previous identification of the culprit test was inference. Turning on [`TestLogEvent.STARTED` and `PASSED`](https://github.com/loculus-project/loculus/commit/8d47dd118) makes a hang self-identifying: diff started against passed and exactly one test is left. That is how [run 32892333366](https://github.com/loculus-project/loculus/actions/runs/32892333366), cancelled at 894 s, named `SubmitLargeBatchTest` directly for the first time. It costs nothing. It is worth considering for `main` permanently.

**3. Sample the database continuously, not on failure.** A post-mortem is useless when the process is killed by a job timeout, and a job timeout also skips the upload step, so [the sampler](https://github.com/loculus-project/loculus/commit/a32e0b73a) runs in the background every 10 s and the step timeout (13 min) is deliberately shorter than the job cap (15 min) so diagnostics still upload. What it collects, and why each one earned its place: `pg_stat_activity` with `wait_event` and `pg_blocking_pids` (this is what ruled out locks and I/O waits — a hung Postgres shows *no* wait event at all), `docker stats` (showed exactly 100 % of one core, i.e. CPU-bound not blocked), ungranted `pg_locks` (always empty), and table sizes.

**4. Measure insert progress with `pg_relation_size`, not `pg_stat_user_tables.n_tup_ins`.** This one wasted a whole CI cohort. Tuple counters are transactional and stay frozen until `COMMIT`, so during exactly the window you care about they report nothing — an earlier round read that as "the insert is stopped" when it was progressing fine. Relation size moves live. [Commit 9b951161b](https://github.com/loculus-project/loculus/commit/9b951161b) switches it.

**5. Comparing against historical `main` timings is not a control.** Numbers from a probe branch were compared to a historical `main` p50 and produced a large fake improvement, because the probe branch also carried five unrelated Kotlin and test changes. Every number in this PR instead comes from paired branches built for the purpose: [`ci/main-baseline`](https://github.com/loculus-project/loculus/tree/ci/main-baseline) is clean `main` plus instrumentation only, and [`ci/main-plus-fix`](https://github.com/loculus-project/loculus/tree/ci/main-plus-fix) is [that same branch plus this one migration](https://github.com/loculus-project/loculus/commit/074b25320) and nothing else. Dispatch both with `workflow_dispatch` in alternating batches.

**6. Two different ways a CI survey silently undercounts.** First, the Actions API reports a run's conclusion from its **latest** attempt only, so a job that hit the cap and was then re-run green shows up as `success` — walk `/actions/runs/<id>/attempts/<n>/jobs` for every `n` below `run_attempt`. Second, and this is the one that actually bit me here: `gh api --paginate` on a listing whose `total_count` exceeds 1000 handed back a 1000-row window whose newest entry was five weeks stale, so a survey that looked complete was missing the most recent runs entirely — including two of the three timeouts. Before filtering anything, assert that the newest row's date is what you expect. I reported "one timeout on `main`" off that listing and it was wrong.

**7. What still is not instrumented.** The unexplained part is that the timing is bimodal: a run is either 239–366 s or it hits the cap, with nothing in between, and nothing observable differs between the two modes before the insert starts. Both modes are CPU-bound on the same work; the only measured difference is that a hung run produces about 4× more tracker bloat per row inserted. Settling it needs `pg_stat_database.blks_hit` sampled over the run, or a server-side profile of the Postgres process — neither of which the sampler collects today. One loose thread worth keeping: the hangs clustered by dispatch batch (1/16, then 2/16, then 0/12), which looks time-correlated rather than like an independent per-run coin flip.

These branches are kept deliberately rather than deleted, so the workflow files and the diagnostic artifacts stay reachable.

### Two guards that look right and are not

Both of these were written, pushed, and caught by CI rather than by reasoning, so they are worth recording.

**Guarding on the timestamp** ([`WHERE last_time_updated < EXCLUDED.last_time_updated`](https://github.com/loculus-project/loculus/commit/79deb4a76)) is fast but wrong. `last_time_updated` is transaction *start* time, which does not follow commit order: a transaction that starts earlier but commits later would have its write dropped, leaving the tracker on a value a client has already cached, so that client gets a 304 and never sees the newer data. Today's unconditional write is safe from this only because it always changes the value, even though it can move it backwards.

**Guarding on the system column `xmin`** ([commit 3cd0d04e5](https://github.com/loculus-project/loculus/commit/3cd0d04e5)) instead of a stored id skips correctly in a plain transaction and then silently does nothing on the real JDBC path, because `xmin` is the *sub*transaction id and never equals the top-level id. It cost a full CI cohort to notice, since the only symptom is that the table keeps bloating. [Commit 68ecd320b](https://github.com/loculus-project/loculus/commit/68ecd320b) is the replacement, and is what this PR ships.

A third thing was tried and reverted: factoring the six near-identical upserts into one shared `record_table_update` function. It reads much better and costs about 10 µs per trigger firing, which is around 1 s per 100,000 rows — roughly doubling the fixed case from 1.2 s to 2.2 s. Verbosity won.

### Deliberate scope

Only the trigger side is here. The complementary change — rewriting `DataUseTermsDatabaseService.setNewDataUseTerms` to insert each chunk with one `unnest` statement instead of a batch — is a separate piece of work and does not conflict with this. Both are worth having: `unnest` fixes that one call site and changes no semantics, while this fixes every bulk path at once, including `sequence_entries` and the two upload aux tables, which the same 100,000-sequence submission writes to before it ever reaches data-use terms.

Not addressed here: the missing JDBC socket timeout, and the bimodality described above.

### Things you may want to push back on

`xid8` needs Postgres 13+. CI is on 18 and the chart uses `postgres:latest`, so this is fine today, but it is a version floor nothing else in the repo states.

`last_xid` backfills as NULL and `IS DISTINCT FROM` treats NULL as distinct, so the first write to each row after deploy always fires and then guards normally. On a populated table the `ALTER` is metadata-only and took 0.4 ms.

`last_time_updated` keeps exactly its current behaviour, including that it can move backwards under concurrency, so it remains safe to compare only for equality — which is all either reader does. Making it monotonic is a real improvement but a separate change, deliberately not bundled here.

🚀 Preview: Add `preview` label to enable