### PR TITLE
feat!(website): also pass header in inputFields and add inputFields to values.schema.json

### DIFF
--- a/docs/src/content/docs/reference/helm-chart-config.mdx
+++ b/docs/src/content/docs/reference/helm-chart-config.mdx
@@ -149,6 +149,12 @@ into a single row.
   header: 'INSDC'
 ```
 
+### Extra input field (type)
+
+Definition of an additional, input-only field for the submission form (see `extraInputFields` on the [Organism schema](#organism-schema-type)). Unlike `metadata` fields, these are not searchable or displayed on the sequence details page; a preprocessing function can consume them to derive one or more `metadata` fields and they are shown in the metadata template.
+
+<SchemaDocs group='inputField' fieldColumnClass='w-56' />
+
 ### Preprocessing (type)
 
 <SchemaDocs group='preprocessing' fieldColumnClass='w-28' />

--- a/kubernetes/loculus/templates/_inputFieldsFromValues.tpl
+++ b/kubernetes/loculus/templates/_inputFieldsFromValues.tpl
@@ -2,7 +2,7 @@
 {{- $data := . }}
 {{- $metadata := $data.metadata }}
 {{- $extraFields := $data.extraInputFields }}
-{{- $TO_KEEP := list "name" "displayName" "definition" "guidance" "example" "required" "requiredWhen" "noEdit" "desired" "options"}}
+{{- $TO_KEEP := list "name" "displayName" "definition" "guidance" "example" "required" "requiredWhen" "noEdit" "desired" "options" "header"}}
 
 {{- /* Determine default id field based on maxSequencesPerEntry */}}
 {{- $maxSeq := 1 }}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -365,57 +365,57 @@
       "description": "An additional, input-only field for the submission form (see `extraInputFields`). Unlike `metadata` fields, these are not searchable or displayed on the sequence details page; a preprocessing function can consume them to derive one or more `metadata` fields and they are added to the metadata template.",
       "properties": {
         "name": {
-          "groups": ["inputField"],
+          "groups": ["extraInputField"],
           "type": "string",
           "description": "Key used to refer to this field. If set to 'id' or 'fastaIds', overrides the corresponding default field."
         },
         "displayName": {
-          "groups": ["inputField"],
+          "groups": ["extraInputField"],
           "type": "string",
           "description": "Name displayed to users."
         },
         "header": {
-          "groups": ["inputField"],
+          "groups": ["extraInputField"],
           "type": "string",
           "description": "Grouping of fields in the submission form."
         },
         "required": {
-          "groups": ["inputField"],
+          "groups": ["extraInputField"],
           "type": "boolean",
           "description": "Whether the field is required by backend."
         },
         "requiredWhen": {
-          "groups": ["inputField"],
+          "groups": ["extraInputField"],
           "type": "array",
           "description": "Array of conditions under which this field is required. When multiple conditions are provided they are ORed; a submission is rejected if at least one condition is not met. Conditions can be: the presence of a file category - specified as files.<file_category>; the input value of another metadata field - specified as <field_name>; or the processed value of another metadata field - specified as processed.<field_name>"
         },
         "desired": {
-          "groups": ["inputField"],
+          "groups": ["extraInputField"],
           "type": "boolean",
           "description": "Whether the field is a desired input field for submitters."
         },
         "noEdit": {
-          "groups": ["inputField"],
+          "groups": ["extraInputField"],
           "type": "boolean",
           "description": "If true, the field is only shown on the submission form, not on the revision form."
         },
         "definition": {
-          "groups": ["inputField"],
+          "groups": ["extraInputField"],
           "type": "string",
           "description": "Definition of input field for submitters."
         },
         "guidance": {
-          "groups": ["inputField"],
+          "groups": ["extraInputField"],
           "type": "string",
           "description": "Guidance for submitters on filling in input field."
         },
         "example": {
-          "groups": ["inputField"],
+          "groups": ["extraInputField"],
           "type": ["string", "number"],
           "description": "Example value for the field."
         },
         "options": {
-          "groups": ["inputField"],
+          "groups": ["extraInputField"],
           "type": "array",
           "description": "An array of options for the value of this field.",
           "placeholder": "option",
@@ -424,7 +424,7 @@
             "additionalProperties": false,
             "properties": {
               "name": {
-                "groups": ["inputField"],
+                "groups": ["extraInputField"],
                 "type": "string",
                 "description": "The name of the option."
               }
@@ -432,7 +432,7 @@
           }
         },
         "position": {
-          "groups": ["inputField"],
+          "groups": ["extraInputField"],
           "type": "string",
           "enum": ["first", "last"],
           "description": "Where to place this field relative to the organism's regular metadata fields when generating the submission form. Only affects ordering; the value itself is not passed through to the frontend."
@@ -597,7 +597,7 @@
               "docsIncludePrefix": false,
               "type": "array",
               "description": "Additional input fields for the submission form. If you add a field with name 'id' or 'fastaIds', it will overwrite the default 'id' or 'fastaIds' field. Note that the 'fastaIds' field is only automatically added if the organism has maxSequencesPerEntry > 1.",
-              "items": { "$ref": "#/definitions/inputField" }
+              "items": { "$ref": "#/definitions/extraInputField" }
             },
             "nucleotideSequences": {
               "groups": ["schema"],

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -438,7 +438,7 @@
           "description": "Where to place this field relative to the organism's regular metadata fields when generating the submission form. Only affects ordering; the value itself is not passed through to the frontend."
         }
       },
-      "required": ["name"],
+      "required": ["name", "position"],
       "allOf": [
         {
           "if": {

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -359,7 +359,7 @@
         }
       ]
     },
-    "inputField": {
+    "extraInputField": {
       "type": "object",
       "additionalProperties": false,
       "description": "An additional, input-only field for the submission form (see `extraInputFields`). Unlike `metadata` fields, these are not searchable or displayed on the sequence details page; a preprocessing function can consume them to derive one or more `metadata` fields and they are added to the metadata template.",

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -359,6 +359,99 @@
         }
       ]
     },
+    "inputField": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "An additional, input-only field for the submission form (see `extraInputFields`). Unlike `metadata` fields, these are not searchable or displayed on the sequence details page; a preprocessing function can consume them to derive one or more `metadata` fields and they are added to the metadata template.",
+      "properties": {
+        "name": {
+          "groups": ["inputField"],
+          "type": "string",
+          "description": "Key used to refer to this field. If set to 'id' or 'fastaIds', overrides the corresponding default field."
+        },
+        "displayName": {
+          "groups": ["inputField"],
+          "type": "string",
+          "description": "Name displayed to users."
+        },
+        "header": {
+          "groups": ["inputField"],
+          "type": "string",
+          "description": "Grouping of fields in the submission form."
+        },
+        "required": {
+          "groups": ["inputField"],
+          "type": "boolean",
+          "description": "Whether the field is required by backend."
+        },
+        "requiredWhen": {
+          "groups": ["inputField"],
+          "type": "array",
+          "description": "Array of conditions under which this field is required. When multiple conditions are provided they are ORed; a submission is rejected if at least one condition is not met. Conditions can be: the presence of a file category - specified as files.<file_category>; the input value of another metadata field - specified as <field_name>; or the processed value of another metadata field - specified as processed.<field_name>"
+        },
+        "desired": {
+          "groups": ["inputField"],
+          "type": "boolean",
+          "description": "Whether the field is a desired input field for submitters."
+        },
+        "noEdit": {
+          "groups": ["inputField"],
+          "type": "boolean",
+          "description": "If true, the field is only shown on the submission form, not on the revision form."
+        },
+        "definition": {
+          "groups": ["inputField"],
+          "type": "string",
+          "description": "Definition of input field for submitters."
+        },
+        "guidance": {
+          "groups": ["inputField"],
+          "type": "string",
+          "description": "Guidance for submitters on filling in input field."
+        },
+        "example": {
+          "groups": ["inputField"],
+          "type": ["string", "number"],
+          "description": "Example value for the field."
+        },
+        "options": {
+          "groups": ["inputField"],
+          "type": "array",
+          "description": "An array of options for the value of this field.",
+          "placeholder": "option",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "groups": ["inputField"],
+                "type": "string",
+                "description": "The name of the option."
+              }
+            }
+          }
+        },
+        "position": {
+          "groups": ["inputField"],
+          "type": "string",
+          "enum": ["first", "last"],
+          "description": "Where to place this field relative to the organism's regular metadata fields when generating the submission form. Only affects ordering; the value itself is not passed through to the frontend."
+        }
+      },
+      "required": ["name"],
+      "allOf": [
+        {
+          "if": {
+            "properties": { "required": { "const": true } },
+            "required": ["required"]
+          },
+          "then": {
+            "not": { "required": ["requiredWhen"] },
+            "errorMessage": "A field with 'required: true' cannot also set 'requiredWhen' (it is already always required)."
+          }
+        }
+      ]
+    },
     "organism": {
       "type": "object",
       "additionalProperties": false,
@@ -500,8 +593,11 @@
               }
             },
             "extraInputFields": {
+              "groups": ["schema"],
+              "docsIncludePrefix": false,
               "type": "array",
-              "description": "Additional input fields for the submission form. If you add a field with name 'id' or 'fastaIds', it will overwrite the default 'id' or 'fastaIds' field. Note that the 'fastaIds' field is only automatically added if the organism has maxSequencesPerEntry > 1."
+              "description": "Additional input fields for the submission form. If you add a field with name 'id' or 'fastaIds', it will overwrite the default 'id' or 'fastaIds' field. Note that the 'fastaIds' field is only automatically added if the organism has maxSequencesPerEntry > 1.",
+              "items": { "$ref": "#/definitions/inputField" }
             },
             "nucleotideSequences": {
               "groups": ["schema"],

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1755,6 +1755,7 @@ defaultOrganismConfig: &defaultOrganismConfig
     extraInputFields:
       - &hostConfig
         name: host
+        header: "Host"
         type: string
         displayName: "Host"
         definition: "NCBI taxon ID or scientific name that uniquely identifies the host from which the sample was collected."

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1756,13 +1756,10 @@ defaultOrganismConfig: &defaultOrganismConfig
       - &hostConfig
         name: host
         header: "Host"
-        type: string
         displayName: "Host"
         definition: "NCBI taxon ID or scientific name that uniquely identifies the host from which the sample was collected."
         guidance: "You can provide either the scientific name of the organism (e.g., `Aedes aegypti`) or its NCBI taxon ID (e.g., `7159`) in this field. We will validate your input and use it to populate the `host common name` and `host scientific name` fields. When uploading data from a pooled sample, we recommend using a higher-level taxon that includes all host organisms in the sample pool. For example, you can use `Culicidae` when uploading data for a pooled mosquito sample (in addition to setting the `specimenProcessing` field to `Samples pooled`, see [OBI:0600016])."
         example: "Aedes aegypti"
-        hideInSearchResultsTable: true
-        hideOnSequenceDetailsPage: true
         desired: true
         position: last
   preprocessing:

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -321,7 +321,7 @@ export function getGroupedInputFields(
 
     nonIdInputFields.forEach((field) => {
         const metadataEntry = schema.metadata.find((meta) => meta.name === field.name);
-        const header = metadataEntry?.header ?? 'Uncategorized';
+        const header = field.header ?? metadataEntry?.header ?? 'Uncategorized';
 
         if (!groups.has(header)) {
             groups.set(header, []);

--- a/website/src/types/config.ts
+++ b/website/src/types/config.ts
@@ -108,6 +108,7 @@ export const inputField = z.object({
     guidance: z.string().optional(),
     desired: z.boolean().optional(),
     options: z.array(inputFieldOption).optional(),
+    header: z.string().optional(),
 });
 
 export type InputFieldOption = z.infer<typeof inputFieldOption>;


### PR DESCRIPTION
Adding the header to the list of metadata fields that are kept for input only fields ensures metadata fields get grouped correctly when generating submission metadata docs and on revision/submission pages.

resolves live issue on Pathoplexus that host is showing in an "uncategorized" group in docs: https://github.com/pathoplexus/pathoplexus/pull/1121 - as soon as this PR is merged the linked PPX PR can be merged

This additionally updates the schema to only allow users to supply params that are actually kept/used by the template. Note certain fields are currently supplied that are actually not passed on from the values.yaml and can easily be removed.

### BREAKING CHANGES
requires https://github.com/pathoplexus/pathoplexus/pull/1121 be merged

### PR Checklist
- [x] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
Confirmed host is now part of "host" section in website docs (see https://fix-doc-headers.loculus.org/west-nile/submission/metadataformat)

🚀 Preview: https://fix-doc-headers.loculus.org