### PR TITLE
fix(deployment): reject unknown keys under resources in values.schema.json

### DIFF
--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -2034,6 +2034,10 @@
         "silo-importer": { "$ref": "#/definitions/resourceSpec" },
         "backend": { "$ref": "#/definitions/resourceSpec" },
         "preprocessing": { "$ref": "#/definitions/resourceSpec" },
+        "minio": { "$ref": "#/definitions/resourceSpec" },
+        "taxonomy-service": { "$ref": "#/definitions/resourceSpec" },
+        "raw-reads-processing": { "$ref": "#/definitions/resourceSpec" },
+        "ingest-init": { "$ref": "#/definitions/resourceSpec" },
         "organismSpecific": {
           "type": "object",
           "patternProperties": {
@@ -2058,7 +2062,8 @@
           },
           "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "secrets": {
       "description": "TODO"


### PR DESCRIPTION
Make resource specifications in values.yaml safer by adding the expected/allowed keys and setting `additionalProperties: false`. This is so that a typo in a resource key doesn't pass silently.

## Things worth knowing

`ingest-init` is the one key here that nothing sets. `_ingest-pod-spec.tpl` looks it up, but no values file in this repo or in the Pathoplexus overlay provides it, so it is declared only to keep a future entry from being rejected. Happy to drop it and declare only what is actually set today, if you would rather the schema describe reality than intent.

`ingest-init` really does inherit the 20m CPU limit right now. I checked before deciding it was not worth an entry: it is a busybox `grep` for a version string, so the limit costs it about a second.

I also checked the Pathoplexus overlay in `pathoplexus/pathoplexus` `loculus_values` before tightening: every `resources` key it sets across all four environments is in the allowed set.

🚀 Preview: Add `preview` label to enable