### PR TITLE
chore(deployment): raise default CPU limit to 500m

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -3045,7 +3045,7 @@ defaultResources:
     cpu: "20m"
   limits:
     memory: "1Gi"
-    cpu: "20m"
+    cpu: "500m"
 ingest:
   ncbiGatewayUrl: null
   mirrorBucket: null

--- a/kubernetes/loculus/values_preview_server.yaml
+++ b/kubernetes/loculus/values_preview_server.yaml
@@ -163,7 +163,7 @@ defaultResources:
     cpu: "20m"
   limits:
     memory: "1Gi"
-    cpu: "20m"
+    cpu: "500m"
 defaultOrganisms:
   ebola-sudan: &fileSharingOrganismDefaults
     schema:


### PR DESCRIPTION
Fix the footgun of small default cpu limits by default, discovered through https://github.com/loculus-project/loculus/pull/7169

🚀 Preview: Add `preview` label to enable