### PR TITLE
feat!(config): declare and default the ingest batch size in the chart

### DIFF
--- a/ingest/config/defaults.yaml
+++ b/ingest/config/defaults.yaml
@@ -70,7 +70,7 @@ subsample_fraction: 1.0
 db_username: postgres
 db_password: unsecure
 db_url: "jdbc:postgresql://127.0.0.1:5432/loculus"
-batch_chunk_size: 10000 # Batch size for submitting sequences to Loculus backend
+batch_chunk_size: 1000 # Batch size for submitting sequences to Loculus backend
 nextclade_dataset_server: https://data.clades.nextstrain.org/v3
 backend_request_timeout_seconds: 600
 match_previous_accession_versions: false

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -939,7 +939,7 @@
                   "groups": ["ingest"],
                   "docsIncludePrefix": false,
                   "type": "integer",
-                  "minimum": 1,
+                  "minimum": 2,
                   "default": 1000,
                   "description": "Number of sequences submitted to the backend per request."
                 }

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -934,6 +934,13 @@
                   "docsIncludePrefix": false,
                   "type": "object",
                   "description": "Filter ingested sequences based on value in metadata. Filter should be a list of metadata field and value pairs."
+                },
+                "batch_chunk_size": {
+                  "groups": ["ingest"],
+                  "docsIncludePrefix": false,
+                  "type": "integer",
+                  "default": 1000,
+                  "description": "Number of sequences submitted to the backend per request. Smaller batches lose less work if a request fails, at the cost of more requests."
                 }
               },
               "required": ["taxon_id"]

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -939,8 +939,9 @@
                   "groups": ["ingest"],
                   "docsIncludePrefix": false,
                   "type": "integer",
+                  "minimum": 1,
                   "default": 1000,
-                  "description": "Number of sequences submitted to the backend per request. Smaller batches lose less work if a request fails, at the cost of more requests."
+                  "description": "Number of sequences submitted to the backend per request."
                 }
               },
               "required": ["taxon_id"]

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1785,6 +1785,7 @@ defaultOrganismConfig: &defaultOrganismConfig
     image: ghcr.io/loculus-project/ingest
     configFile: &defaultIngestConfigFile
       muted_hashes_url: "https://pathoplexus.github.io/curation_data/muted_hashes/muted_hashes.tsv"
+      batch_chunk_size: 1000
 defaultOrganisms:
   ebola-sudan:
     <<: *defaultOrganismConfig


### PR DESCRIPTION
Stacked on #7182 — merge that first.

Two reasons to make batch size smaller for ingest:
- 10k often times out at least for mpox, hence it's not safe
- Timeouts contributed to the double ingest of mpox on PPX demo - smaller batch size would have likely avoided that double ingest there.

## Breaking changes
Technically not breaking but this should also be applied to the PPX values.yaml in https://github.com/pathoplexus/pathoplexus/pull/1124

Also declares `batch_chunk_size` in the values schema — it worked per organism only as an undeclared passthrough key, so it never showed up in the config docs — and sets it in the chart values.

🚀 Preview: Add `preview` label to enable