### PR TITLE
fix(ingest): report every failed submit batch, not just the last

### DIFF
--- a/ingest/scripts/loculus_client.py
+++ b/ingest/scripts/loculus_client.py
@@ -189,57 +189,26 @@ class BatchSubmissionError(Exception):
     """Raised at the end of a run if one or more batches could not be submitted."""
 
 
-# Errors where we know the request never reached the backend, so re-sending it
-# cannot create a duplicate submission.
-RETRIABLE_ERRORS = (requests.exceptions.ConnectTimeout,)
-MAX_BATCH_ATTEMPTS = 3
-RETRY_BACKOFF_SECONDS = 10
-
-
-def build_batch_files(batch_it: BatchIterator) -> dict[str, Any]:
-    """Build a fresh multipart body. Must be called per attempt: requests reads the
-    BytesIO objects to EOF, so a reused dict uploads two empty files."""
-    return {
-        "metadataFile": (
-            "metadata.tsv",
-            BytesIO("".join(batch_it.metadata_batch_output).encode("utf-8")),
-            "text/tab-separated-values",
-        ),
-        "sequenceFile": (
-            "sequences.fasta",
-            BytesIO("".join(batch_it.sequences_batch_output).encode("utf-8")),
-            "text/plain",
-        ),
-    }
-
-
 def submit(
     url,
     config: Config,
     params: dict[str, str],
     batch_it: BatchIterator,
 ) -> list[dict[str, Any]]:
-    """Submit one batch, retrying only failures that provably never reached the backend.
-    Returns the submissionId mappings for this batch."""
+    """Submit one batch and return its submissionId mappings."""
     batch_num = -(int(batch_it.record_counter) // -config.batch_chunk_size)  # ceiling division
+    logger.info(f"Submitting batch {batch_num}")
 
-    for attempt in range(1, MAX_BATCH_ATTEMPTS + 1):
-        logger.info(f"Submitting batch {batch_num} (attempt {attempt}/{MAX_BATCH_ATTEMPTS})")
-        try:
-            response = make_request(
-                HTTPMethod.POST, url, config, params=params, files=build_batch_files(batch_it)
-            )
-        except RETRIABLE_ERRORS as e:
-            if attempt == MAX_BATCH_ATTEMPTS:
-                raise
-            logger.warning(f"Batch {batch_num} did not reach the backend ({e!r}), retrying")
-            sleep(RETRY_BACKOFF_SECONDS * attempt)
-            continue
-        logger.info(f"Batch {batch_num} response: {response.status_code}")
-        return response.json()
+    metadata_in_memory = BytesIO("".join(batch_it.metadata_batch_output).encode("utf-8"))
+    fasta_in_memory = BytesIO("".join(batch_it.sequences_batch_output).encode("utf-8"))
 
-    msg = f"unreachable: batch {batch_num} retry loop exited without returning"
-    raise AssertionError(msg)
+    files = {
+        "metadataFile": ("metadata.tsv", metadata_in_memory, "text/tab-separated-values"),
+        "sequenceFile": ("sequences.fasta", fasta_in_memory, "text/plain"),
+    }
+    response = make_request(HTTPMethod.POST, url, config, params=params, files=files)
+    logger.info(f"Batch {batch_num} Response: {response.status_code}")
+    return response.json()
 
 
 def add_seq_to_batch(

--- a/ingest/scripts/loculus_client.py
+++ b/ingest/scripts/loculus_client.py
@@ -110,11 +110,6 @@ def make_request(  # noqa: PLR0913, PLR0917
             msg = f"Unsupported HTTP method: {method}"
             raise ValueError(msg)
 
-    if response.status_code == 423:
-        logger.warning(f"Got 423 from {url}. Retrying after 30 seconds.")
-        sleep(30)
-        return make_request(method, url, config, params, files, json_body)
-
     if not response.ok:
         error_message = (
             f"Request failed:\n"
@@ -190,28 +185,61 @@ class BatchIterator:
     metadata_batch_output: list[str] = dataclasses.field(default_factory=list)
 
 
+class BatchSubmissionError(Exception):
+    """Raised at the end of a run if one or more batches could not be submitted."""
+
+
+# Errors where we know the request never reached the backend, so re-sending it
+# cannot create a duplicate submission.
+RETRIABLE_ERRORS = (requests.exceptions.ConnectTimeout,)
+MAX_BATCH_ATTEMPTS = 3
+RETRY_BACKOFF_SECONDS = 10
+
+
+def build_batch_files(batch_it: BatchIterator) -> dict[str, Any]:
+    """Build a fresh multipart body. Must be called per attempt: requests reads the
+    BytesIO objects to EOF, so a reused dict uploads two empty files."""
+    return {
+        "metadataFile": (
+            "metadata.tsv",
+            BytesIO("".join(batch_it.metadata_batch_output).encode("utf-8")),
+            "text/tab-separated-values",
+        ),
+        "sequenceFile": (
+            "sequences.fasta",
+            BytesIO("".join(batch_it.sequences_batch_output).encode("utf-8")),
+            "text/plain",
+        ),
+    }
+
+
 def submit(
     url,
     config: Config,
     params: dict[str, str],
     batch_it: BatchIterator,
-):
+) -> list[dict[str, Any]]:
+    """Submit one batch, retrying only failures that provably never reached the backend.
+    Returns the submissionId mappings for this batch."""
     batch_num = -(int(batch_it.record_counter) // -config.batch_chunk_size)  # ceiling division
-    logger.info(f"Submitting batch {batch_num}")
 
-    metadata_in_memory = BytesIO("".join(batch_it.metadata_batch_output).encode("utf-8"))
-    fasta_in_memory = BytesIO("".join(batch_it.sequences_batch_output).encode("utf-8"))
+    for attempt in range(1, MAX_BATCH_ATTEMPTS + 1):
+        logger.info(f"Submitting batch {batch_num} (attempt {attempt}/{MAX_BATCH_ATTEMPTS})")
+        try:
+            response = make_request(
+                HTTPMethod.POST, url, config, params=params, files=build_batch_files(batch_it)
+            )
+        except RETRIABLE_ERRORS as e:
+            if attempt == MAX_BATCH_ATTEMPTS:
+                raise
+            logger.warning(f"Batch {batch_num} did not reach the backend ({e!r}), retrying")
+            sleep(RETRY_BACKOFF_SECONDS * attempt)
+            continue
+        logger.info(f"Batch {batch_num} response: {response.status_code}")
+        return response.json()
 
-    files = {
-        "metadataFile": ("metadata.tsv", metadata_in_memory, "text/tab-separated-values"),
-        "sequenceFile": ("sequences.fasta", fasta_in_memory, "text/plain"),
-    }
-    response = make_request(HTTPMethod.POST, url, config, params=params, files=files)
-    logger.info(f"Batch {batch_num} Response: {response.status_code}")
-    if response.status_code != 200:  # noqa: PLR2004
-        logger.error(f"Error in batch {batch_num}: {response.text}")
-
-    return response
+    msg = f"unreachable: batch {batch_num} retry loop exited without returning"
+    raise AssertionError(msg)
 
 
 def add_seq_to_batch(
@@ -247,16 +275,39 @@ def add_seq_to_batch(
             batch_it.sequences_batch_output.append(line)  # Handle multi-line sequences
 
 
+def submit_batch(  # noqa: PLR0913, PLR0917
+    url,
+    config: Config,
+    params: dict[str, str],
+    batch_it: BatchIterator,
+    results: list[dict[str, Any]],
+    failures: list[str],
+) -> None:
+    """Submit one batch, recording the outcome instead of aborting the whole run."""
+    batch_num = -(int(batch_it.record_counter) // -config.batch_chunk_size)
+    try:
+        results.extend(submit(url, config, params, batch_it))
+    except (requests.RequestException, ValueError) as e:
+        logger.exception(f"Batch {batch_num} failed")
+        failures.append(f"batch {batch_num}: {e!r}")
+
+
 def post_fasta_batches(
     url,
     fasta_file: str,
     metadata_file: str,
     config: Config,
     params: dict[str, str],
-) -> requests.Response:
-    """Chunks metadata files, joins with sequences and submits each chunk via POST."""
+) -> list[dict[str, Any]]:
+    """Chunks metadata files, joins with sequences and submits each chunk via POST.
+
+    Every batch is attempted even if an earlier one failed - batches are independent, and
+    anything not submitted is re-derived by the next run's hash comparison. Returns the
+    submissionId mappings of all successful batches; raises if any batch failed."""
 
     batch_it = BatchIterator()
+    results: list[dict[str, Any]] = []
+    failures: list[str] = []
 
     with (
         open(fasta_file, encoding="utf-8") as fasta_file_stream,
@@ -295,20 +346,23 @@ def post_fasta_batches(
 
             # submit the batch if it is full
             if batch_it.record_counter % config.batch_chunk_size == 0:
-                response = submit(
-                    url,
-                    config,
-                    params,
-                    batch_it,
-                )
+                submit_batch(url, config, params, batch_it, results, failures)
                 batch_it.sequences_batch_output = []
                 batch_it.metadata_batch_output = []
 
     if batch_it.record_counter % config.batch_chunk_size != 0:
         # submit the last chunk
-        response = submit(url, config, params, batch_it)
+        submit_batch(url, config, params, batch_it, results, failures)
 
-    return response
+    if failures:
+        msg = (
+            f"{len(failures)} batch(es) failed to submit "
+            f"({len(results)} sequence entries submitted successfully): " + "; ".join(failures)
+        )
+        logger.error(msg)
+        raise BatchSubmissionError(msg)
+
+    return results
 
 
 def count_lines(path, chunk_size=1024 * 1024):
@@ -361,9 +415,7 @@ def submit_or_revise(
     if mode == "submit":
         params["dataUseTermsType"] = "OPEN"
 
-    response = post_fasta_batches(url, sequences, metadata, config, params=params)
-
-    return response.json()
+    return post_fasta_batches(url, sequences, metadata, config, params=params)
 
 
 def revoke(accession_to_revoke: str, message: str, config: Config) -> str:


### PR DESCRIPTION
Ingest submits sequences to the backend in batches of 10 000, but only the last batch's response ever survives. `post_fasta_batches` rebinds `response` on each loop iteration and returns whatever the final batch produced, so `submit_or_revise` hands its caller the accessions of one batch and silently drops the rest.

The only caller that actually reads that value is `regroup_and_revoke`. It builds a submission-id-to-accession map from the response and then looks up ids coming from `to_revoke.json`; any id that was in an earlier batch is missing, so it raises `KeyError` partway through — after it has already revoked some of the old sequence entries. This is latent rather than live: it needs a regrouping of more than 10 000 sequences to trigger, which a change to the segment-grouping heuristic or a bulk grouping override could produce. `call_loculus.py` discards the return value for plain submit and revise, so those paths were never affected.

A failing batch now gets recorded and the run carries on to the next one, ending with a single error naming the failed batches and how many entries did land. Batches are independent and anything unsubmitted is re-derived by the next run's hash comparison, so one bad batch in the middle should not stop the other nine from going in. The run still fails; it just fails with a summary instead of dying on batch 3 with no account of the rest.

There is deliberately **no retry**. Submitting is not idempotent — it mints new accessions — and the two ways of getting it wrong are not symmetric. A batch that never lands repairs itself on the next scheduled run at no cost. A batch that lands twice leaves two Loculus accessions for one INSDC accession, permanently, and that is the failure #5148's description calls *"a very confusing bug ... we battled this bug for a long time"*. Given that asymmetry, doing nothing and letting the next run clean up is the cheaper side of the trade, so nothing here re-sends anything.

## A second problem in the same file, which I think is the more interesting one

`make_request` had a retry for HTTP 423 that slept 30 seconds and called itself again with the same `files` dictionary. Those dictionary values are `BytesIO` objects, and `requests` reads them to the end when it builds the first request — so the retry uploaded a metadata file and a sequence file that were both completely empty. Confirmed against a stub server: the first request carries 363 bytes of body, the second carries two empty parts.

The backend's answer to that is not a helpful one. An empty metadata stream gives an empty header list, so `findAndValidateSubmissionIdHeader` rejects it with *"The metadata file does not contain either header 'id' or 'submissionId'"*. Anyone debugging that would go and read `prepare_files.py` looking for a malformed file that ingest never produced.

I removed it rather than fixing it. It was added in #2846 for `/get-original-metadata`, which is a GET with no files attached, and #5148 took the 423 off that endpoint last October once the real cause of the duplicate submissions was found — a kubernetes-reloader restarting stale cron jobs. Nothing in the backend returns 423 any more; `grep -rn 423 backend/src/main/kotlin` has no hits. So it was dead code guarding a dead status, and it would have corrupted its own request if it ever fired.

## Not fixed here

The record counter counts the header line, so the first batch of every run holds 9 999 records instead of 10 000 while every later batch holds the full 10 000. Nothing is lost or duplicated and the point where the header gets re-inserted into each batch is consistent with the off-by-one, so this is cosmetic. Fixing it means changing the counter and both of the modulo conditions that depend on it, which is more risk than one under-filled batch per run justifies. Left alone on purpose.

I also did not wire the new failure summary up to `slack_hook`, though it is the obvious place for an alert and `prepare_files.py` already has the helper. Say the word and I will add it.

## Checked and harmless

A metadata file containing only a header passes the `[ -s ]` guard in the Snakefile and produces a final batch with a header and an empty FASTA. The backend accepts it: the `id` header is present, both id sets come out empty, the cross-check passes and it returns an empty list.

🚀 Preview: Add `preview` label to enable