### PR TITLE
feat(preprocessing): run ReadTools in full mode

### DIFF
--- a/raw-reads-processing/README.md
+++ b/raw-reads-processing/README.md
@@ -63,10 +63,11 @@ Only FASTQ is currently accepted (`ACCEPTED_FORMATS`). If the file extension is 
 Once files are downloaded, they are validated using ENA's own validator,
 [readtools](https://github.com/loculus-project/readtools), which checks structural/content
 correctness (valid headers, IUPAC bases, matching sequence/quality lengths, etc.) and rejects
-truly duplicate read names within a single file:
+truly duplicate read names within a single file. Validation runs in full mode, which checks up to
+100 million reads per file instead of the default quick-mode limit of 100,000 reads:
 
 ```sh
-READTOOLS_JAR=readtools.jar java -jar readtools.jar read1.fastq [read2.fastq] --format FASTQ
+READTOOLS_JAR=readtools.jar java -jar readtools.jar read1.fastq [read2.fastq] --format FASTQ --full
 ```
 ## Validate sequences have been dehosted (deacon)
 

--- a/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
+++ b/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
@@ -140,6 +140,7 @@ def validate_with_readtools(
         + [
             "--format",
             format_type.value,
+            "--full",
         ]
     )
     logger.debug(f"Running validation on '{file_names}': {args}")

--- a/raw-reads-processing/test/test_file_validation.py
+++ b/raw-reads-processing/test/test_file_validation.py
@@ -322,6 +322,20 @@ def test_parse_validation_error_generic_fallback():
     assert message == "File validation failed while running ENA readtools."
 
 
+def test_readtools_uses_full_validation(tmp_path, monkeypatch):
+    reads = _write(tmp_path, "reads.fastq", VALID_SINGLE_END)
+    captured_args = []
+
+    def fake_run(args, **_kwargs):
+        captured_args.extend(args)
+
+    monkeypatch.setattr(file_format_validation.subprocess, "run", fake_run)
+
+    validate_with_readtools({"reads.fastq": Path(reads)}, FileFormat.FASTQ)
+
+    assert captured_args[-3:] == ["--format", "FASTQ", "--full"]
+
+
 def test_validation_timeout_is_reported_as_error(tmp_path, monkeypatch):
     reads = _write(tmp_path, "reads.fastq", VALID_SINGLE_END)
 


### PR DESCRIPTION
## Summary

Raw-read validation currently invokes ENA ReadTools in its default quick mode, which checks at most the first 100,000 reads in each submitted file. This changes the invocation to pass `--full`, increasing validation coverage to at most 100 million reads per file.

The raw-reads processing documentation now records the selected validation mode and its limit. A unit test verifies that the ReadTools command includes `--full`, while the existing integration tests continue to exercise the released ReadTools jar.

This is intentionally a draft because full validation can materially increase processing time for large submissions, and its performance should be measured in the preview environment before merging. The existing 300-second ReadTools timeout remains unchanged.

## Testing

- `PYTHONPATH=src READTOOLS_JAR=/tmp/readtools-2.15.1-all.jar pytest -q test/test_file_validation.py` (21 passed)
- Complete raw-reads-processing test suite in an isolated environment (26 passed, 2 Deacon tests skipped because the Deacon executable is unavailable)
- `ruff check src test`
- `git diff --check`

🚀 Preview: Add `preview` label to enable