### PR TITLE
feat(raw-reads-processing): validate against a warm readtools JVM

### DIFF
--- a/raw-reads-processing/Dockerfile
+++ b/raw-reads-processing/Dockerfile
@@ -5,7 +5,7 @@ FROM curlimages/curl:latest AS downloader
 
 RUN curl --fail --location --show-error \
     --output /tmp/readtools.jar \
-    https://github.com/loculus-project/readtools/releases/download/v1.0.0/readtools-2.15.1-all.jar
+    https://github.com/loculus-project/readtools/releases/download/v1.1.0/readtools-2.15.1-all.jar
 
 # ── Runtime image ────────────────────────────────────────────────────────────
 FROM mambaorg/micromamba:2.3.3-ubuntu24.04

--- a/raw-reads-processing/Dockerfile
+++ b/raw-reads-processing/Dockerfile
@@ -3,9 +3,10 @@
 # ── Downloader image ────────────────────────────────────────────────────────
 FROM curlimages/curl:latest AS downloader
 
+# TODO: repoint at loculus-project/readtools once a release with the validation server is cut
 RUN curl --fail --location --show-error \
     --output /tmp/readtools.jar \
-    https://github.com/loculus-project/readtools/releases/download/v1.1.0/readtools-2.15.1-all.jar
+    https://github.com/corneliusroemer-agent/readtools/releases/download/v1.1.0-rc1/readtools-2.15.1-all.jar
 
 # ── Runtime image ────────────────────────────────────────────────────────────
 FROM mambaorg/micromamba:2.3.3-ubuntu24.04

--- a/raw-reads-processing/README.md
+++ b/raw-reads-processing/README.md
@@ -14,7 +14,7 @@ Download validation jar using:
 
 ```sh
 curl -L -o readtools.jar \
-  https://github.com/loculus-project/readtools/releases/download/v1.1.0/readtools-2.15.1-all.jar
+  https://github.com/corneliusroemer-agent/readtools/releases/download/v1.1.0-rc1/readtools-2.15.1-all.jar
 ```
 
 ## How to configure the service

--- a/raw-reads-processing/README.md
+++ b/raw-reads-processing/README.md
@@ -14,7 +14,7 @@ Download validation jar using:
 
 ```sh
 curl -L -o readtools.jar \
-  https://github.com/loculus-project/readtools/releases/download/v1.0.0/readtools-2.15.1-all.jar
+  https://github.com/loculus-project/readtools/releases/download/v1.1.0/readtools-2.15.1-all.jar
 ```
 
 ## How to configure the service
@@ -68,6 +68,29 @@ truly duplicate read names within a single file:
 ```sh
 READTOOLS_JAR=readtools.jar java -jar readtools.jar read1.fastq [read2.fastq] --format FASTQ
 ```
+
+### The warm validation server
+
+Forking a JVM per submission spends about half its wall time on classloading and JIT warm-up that
+the process then throws away. Instead the service starts one long-lived readtools JVM at startup
+(`raw_reads_processing.readtools_server`), warms it up, and POSTs each validation to it on
+loopback. On this codebase's benchmark data that takes a validation from ~1.3 s to ~0.9 s on its
+own, and to ~0.3 s when several run concurrently in the one JVM — which matters because the
+resident deacon index leaves too little memory to fork several JVMs instead.
+
+The server returns the exact stdout/stderr the CLI would have printed, so both paths produce the
+same error message for the same file; `test_server_and_subprocess_agree` pins that.
+
+Startup blocks until the JVM reports healthy, so no submission is ever served by a cold JVM. Set
+`readtools_server_enabled: false` to go back to forking a JVM per validation.
+
+| setting | default | |
+|---|---|---|
+| `readtools_server_enabled` | `true` | fall back to a JVM per validation when `false` |
+| `readtools_server_port` | `5001` | loopback only |
+| `readtools_server_threads` | `4` | concurrent validations; also bounds heap use |
+| `readtools_server_max_heap` | `1g` | `-Xmx` for the validation JVM |
+| `readtools_server_startup_timeout_seconds` | `300` | includes JIT warm-up |
 ## Validate sequences have been dehosted (deacon)
 
 Files that pass format validation are screened for human host reads with

--- a/raw-reads-processing/config/defaults.yaml
+++ b/raw-reads-processing/config/defaults.yaml
@@ -2,6 +2,7 @@ log_level: DEBUG
 s3_request_timeout_seconds: 300
 deacon_filter_timeout_seconds: 600
 read_validation_timeout_seconds: 300
+readtools_full_validation: false
 readtools_server_enabled: true
 readtools_server_port: 5001
 readtools_server_threads: 4

--- a/raw-reads-processing/config/defaults.yaml
+++ b/raw-reads-processing/config/defaults.yaml
@@ -2,6 +2,11 @@ log_level: DEBUG
 s3_request_timeout_seconds: 300
 deacon_filter_timeout_seconds: 600
 read_validation_timeout_seconds: 300
+readtools_server_enabled: true
+readtools_server_port: 5001
+readtools_server_threads: 4
+readtools_server_max_heap: 1g
+readtools_server_startup_timeout_seconds: 300
 file_service_host: "0.0.0.0"
 deacon_max_host_reads_proportion: 0.1
 deacon_max_host_bp: 300000 # 300kBp - or 10^-4 coverage of the human genome

--- a/raw-reads-processing/src/raw_reads_processing/__main__.py
+++ b/raw-reads-processing/src/raw_reads_processing/__main__.py
@@ -5,6 +5,7 @@ import click
 from .api import start_api
 from .config import get_config
 from .deacon import prepare_deacon_index, start_deacon_server
+from .readtools_server import start_readtools_server, wait_until_ready
 
 logger = logging.getLogger(__name__)
 
@@ -27,8 +28,15 @@ def run(config_file: str):
     prepare_deacon_index()
     deacon_process = start_deacon_server()
 
+    readtools_process = None
+    if config.readtools_server_enabled:
+        logger.info("Starting readtools validation server and warming it up...")
+        readtools_process = start_readtools_server(config)
+        # Warm-up takes a while; block so we never serve a request on a cold JVM.
+        wait_until_ready(config, readtools_process)
+
     logger.info("Starting API...")
-    start_api(config, deacon_process)
+    start_api(config, deacon_process, readtools_process)
 
 
 if __name__ == "__main__":

--- a/raw-reads-processing/src/raw_reads_processing/api.py
+++ b/raw-reads-processing/src/raw_reads_processing/api.py
@@ -6,6 +6,7 @@ import uvicorn
 from fastapi import FastAPI, HTTPException
 from raw_reads_processing.datatypes import RequestWithFiles, ValidationResult
 from raw_reads_processing.process_files import validate_raw_reads_submission
+from raw_reads_processing.readtools_server import readtools_server_healthy
 
 from .config import Config
 
@@ -25,6 +26,16 @@ def read_root() -> dict[str, str]:
 def health() -> dict[str, str]:
     if app.state.deacon_process.poll() is not None:
         raise HTTPException(status_code=503, detail="Deacon server process has exited")
+    if app.state.readtools_process is not None:
+        if app.state.readtools_process.poll() is not None:
+            raise HTTPException(
+                status_code=503, detail="readtools validation server process has exited"
+            )
+        # A live JVM whose validation path is broken or fully wedged still fails this.
+        if not readtools_server_healthy(app.state.config):
+            raise HTTPException(
+                status_code=503, detail="readtools validation server is not healthy"
+            )
     return {"message": "Deacon server is running"}
 
 
@@ -44,13 +55,22 @@ def process_files(
     return ValidationResult()
 
 
-def init_app(config: Config, deacon_process: subprocess.Popen):
+def init_app(
+    config: Config,
+    deacon_process: subprocess.Popen,
+    readtools_process: subprocess.Popen | None = None,
+):
     app.state.config = config
     app.state.deacon_process = deacon_process
+    app.state.readtools_process = readtools_process
 
 
-def start_api(config: Config, deacon_process: subprocess.Popen):
-    init_app(config, deacon_process)
+def start_api(
+    config: Config,
+    deacon_process: subprocess.Popen,
+    readtools_process: subprocess.Popen | None = None,
+):
+    init_app(config, deacon_process, readtools_process)
     host = config.file_service_host or "127.0.0.1"
     port = config.file_service_port or 5000
     logger.info(f"Starting raw reads processing service API on port {port}")

--- a/raw-reads-processing/src/raw_reads_processing/config.py
+++ b/raw-reads-processing/src/raw_reads_processing/config.py
@@ -12,6 +12,15 @@ class Config(BaseModel):
     file_service_host: str | None = None
     file_service_port: int | None = None
 
+    # readtools warm validation server: one long-lived JVM instead of one per validation
+    readtools_server_enabled: bool = True
+    readtools_server_port: int = 5001
+    # Bounds both concurrent validations and, with them, heap use.
+    readtools_server_threads: int = 4
+    readtools_server_max_heap: str = "1g"
+    # Startup includes a JIT warm-up of several synthetic validations.
+    readtools_server_startup_timeout_seconds: int = 300
+
     deacon_max_host_reads_proportion: float
     deacon_max_host_bp: int  # maximum number of host base pairs allowed in a sample before it is flagged as contaminated
 

--- a/raw-reads-processing/src/raw_reads_processing/config.py
+++ b/raw-reads-processing/src/raw_reads_processing/config.py
@@ -12,6 +12,10 @@ class Config(BaseModel):
     file_service_host: str | None = None
     file_service_port: int | None = None
 
+    # Validate every read rather than only the first 100k per file. Cost scales with read
+    # count instead of being capped, so this is materially slower on large submissions.
+    readtools_full_validation: bool = False
+
     # readtools warm validation server: one long-lived JVM instead of one per validation
     readtools_server_enabled: bool = True
     readtools_server_port: int = 5001

--- a/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
+++ b/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import subprocess  # noqa: S404
+import time
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -140,8 +141,6 @@ def _run_readtools_subprocess(
     args = (
         ["java", "-jar", VALIDATION_JAR_PATH] + files + ["--format", file_format.value]
     )
-    logger.debug(f"Running validation: {args}")
-
     try:
         result = subprocess.run(  # noqa: S603
             args,
@@ -169,9 +168,15 @@ def validate_with_readtools(
     """
     file_names = list(file_name_to_path.keys())
     files = [str(file) for file in file_name_to_path.values()]
+    use_server = config is not None and config.readtools_server_enabled
+    logger.debug(
+        f"Validating {file_names} with readtools "
+        f"({'warm server' if use_server else 'subprocess'})"
+    )
+    started = time.monotonic()
 
     try:
-        if config is not None and config.readtools_server_enabled:
+        if use_server:
             exit_code, stdout, stderr = readtools_server.run_validation(
                 config, files, format_type.value, timeout_seconds
             )
@@ -186,6 +191,11 @@ def validate_with_readtools(
         )
         logger.error(message)
         raise ProcessingFailure(message) from None
+
+    logger.info(
+        f"readtools validation of {file_names} finished in "
+        f"{time.monotonic() - started:.2f}s (exit code {exit_code})"
+    )
 
     if exit_code == 0:
         return

--- a/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
+++ b/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
@@ -3,9 +3,14 @@ import os
 import subprocess  # noqa: S404
 from enum import StrEnum
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+from raw_reads_processing import readtools_server
 from raw_reads_processing.datatypes import Annotation, FileName
 from raw_reads_processing.errors import InvalidSubmission, ProcessingFailure
+
+if TYPE_CHECKING:
+    from raw_reads_processing.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -128,46 +133,68 @@ def validate_file_numbers(file_format: FileFormat, file_names: list[FileName]) -
         )
 
 
-def validate_with_readtools(
-    file_name_to_path: dict[FileName, Path],
-    format_type: FileFormat,
-    timeout_seconds: int = 300,
-) -> None:
-    file_names = list(file_name_to_path.keys())
+def _run_readtools_subprocess(
+    files: list[str], file_format: FileFormat, timeout_seconds: int
+) -> tuple[int, str, str]:
+    """Validate by forking a fresh JVM, paying its classloading and JIT warm-up each time."""
     args = (
-        ["java", "-jar", VALIDATION_JAR_PATH]
-        + [str(file) for file in file_name_to_path.values()]
-        + [
-            "--format",
-            format_type.value,
-        ]
+        ["java", "-jar", VALIDATION_JAR_PATH] + files + ["--format", file_format.value]
     )
-    logger.debug(f"Running validation on '{file_names}': {args}")
+    logger.debug(f"Running validation: {args}")
 
     try:
-        subprocess.run(  # noqa: S603
+        result = subprocess.run(  # noqa: S603
             args,
-            check=True,
+            check=False,
             capture_output=True,
             text=True,
             timeout=timeout_seconds,
         )
     except subprocess.TimeoutExpired:
+        raise TimeoutError from None
+    return result.returncode, result.stdout, result.stderr
+
+
+def validate_with_readtools(
+    file_name_to_path: dict[FileName, Path],
+    format_type: FileFormat,
+    timeout_seconds: int = 300,
+    config: "Config | None" = None,
+) -> None:
+    """Validate the submitted files with ENA readtools.
+
+    Uses the warm validation server when one is configured, otherwise forks a JVM per call.
+    Both paths run identical validation code and return identical output, so the message a
+    submitter sees does not depend on which one ran.
+    """
+    file_names = list(file_name_to_path.keys())
+    files = [str(file) for file in file_name_to_path.values()]
+
+    try:
+        if config is not None and config.readtools_server_enabled:
+            exit_code, stdout, stderr = readtools_server.run_validation(
+                config, files, format_type.value, timeout_seconds
+            )
+        else:
+            exit_code, stdout, stderr = _run_readtools_subprocess(
+                files, format_type, timeout_seconds
+            )
+    except TimeoutError:
         message = (
             f"Validation of files '{','.join(file_names)}' "
             f"timed out after {timeout_seconds} seconds."
         )
         logger.error(message)
         raise ProcessingFailure(message) from None
-    except subprocess.CalledProcessError as error:
-        validation_error = _parse_validation_error(
-            stdout=error.stdout,
-            stderr=error.stderr,
+
+    if exit_code == 0:
+        return
+
+    validation_error = _parse_validation_error(stdout=stdout, stderr=stderr)
+    logger.error(validation_error)
+    raise InvalidSubmission(
+        error=Annotation(
+            fileNames=file_names,
+            message=validation_error,
         )
-        logger.error(validation_error)
-        raise InvalidSubmission(
-            error=Annotation(
-                fileNames=file_names,
-                message=validation_error,
-            )
-        ) from error
+    )

--- a/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
+++ b/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 
 VALIDATION_JAR_PATH = os.environ.get("READTOOLS_JAR", "/opt/app/lib/readtools.jar")
 
+# readtools exits 1 when it judges the files invalid, and 2 when it could not judge them at all.
+READTOOLS_INVALID_EXIT_CODE = 1
+
 
 class FileFormat(StrEnum):
     FASTQ = "FASTQ"
@@ -204,6 +207,17 @@ def validate_with_readtools(
 
     if exit_code == 0:
         return
+
+    # readtools reports a verdict of "invalid" as exit 1. Anything else is readtools failing to
+    # reach a verdict at all - a missing file, or the JVM running out of heap - which is our
+    # problem, not the submitter's, and must not be reported to them as a bad file.
+    if exit_code != READTOOLS_INVALID_EXIT_CODE:
+        message = (
+            f"readtools could not validate '{','.join(file_names)}' "
+            f"(exit code {exit_code}): {stderr.strip()[:200]}"
+        )
+        logger.error(message)
+        raise ProcessingFailure(message)
 
     validation_error = _parse_validation_error(stdout=stdout, stderr=stderr)
     logger.error(validation_error)

--- a/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
+++ b/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
@@ -135,12 +135,15 @@ def validate_file_numbers(file_format: FileFormat, file_names: list[FileName]) -
 
 
 def _run_readtools_subprocess(
-    files: list[str], file_format: FileFormat, timeout_seconds: int
+    files: list[str], file_format: FileFormat, timeout_seconds: int, full: bool = False
 ) -> tuple[int, str, str]:
     """Validate by forking a fresh JVM, paying its classloading and JIT warm-up each time."""
     args = (
         ["java", "-jar", VALIDATION_JAR_PATH] + files + ["--format", file_format.value]
     )
+    if full:
+        args.append("--full")
+
     try:
         result = subprocess.run(  # noqa: S603
             args,
@@ -169,20 +172,22 @@ def validate_with_readtools(
     file_names = list(file_name_to_path.keys())
     files = [str(file) for file in file_name_to_path.values()]
     use_server = config is not None and config.readtools_server_enabled
+    full = config is not None and config.readtools_full_validation
     logger.debug(
         f"Validating {file_names} with readtools "
-        f"({'warm server' if use_server else 'subprocess'})"
+        f"({'warm server' if use_server else 'subprocess'}, "
+        f"{'full' if full else 'quick'})"
     )
     started = time.monotonic()
 
     try:
         if use_server:
             exit_code, stdout, stderr = readtools_server.run_validation(
-                config, files, format_type.value, timeout_seconds
+                config, files, format_type.value, timeout_seconds, full=full
             )
         else:
             exit_code, stdout, stderr = _run_readtools_subprocess(
-                files, format_type, timeout_seconds
+                files, format_type, timeout_seconds, full=full
             )
     except TimeoutError:
         message = (

--- a/raw-reads-processing/src/raw_reads_processing/process_files.py
+++ b/raw-reads-processing/src/raw_reads_processing/process_files.py
@@ -60,6 +60,9 @@ def validate_raw_reads_submission(
             local_files[file.name] = downloaded_file_path
 
         validate_with_readtools(
-            local_files, file_format, config.read_validation_timeout_seconds
+            local_files,
+            file_format,
+            config.read_validation_timeout_seconds,
+            config=config,
         )
         validate_with_deacon(local_files, tmp_dir, config)

--- a/raw-reads-processing/src/raw_reads_processing/readtools_server.py
+++ b/raw-reads-processing/src/raw_reads_processing/readtools_server.py
@@ -99,6 +99,7 @@ def run_validation(
     files: list[str],
     file_format: str,
     timeout_seconds: int,
+    full: bool = False,
 ) -> tuple[int, str, str]:
     """Run one validation on the warm server.
 
@@ -108,7 +109,7 @@ def run_validation(
     try:
         response = requests.post(
             f"{server_url(config)}/validate",
-            json={"files": files, "format": file_format},
+            json={"files": files, "format": file_format, "full": full},
             timeout=timeout_seconds,
         )
     except requests.Timeout:

--- a/raw-reads-processing/src/raw_reads_processing/readtools_server.py
+++ b/raw-reads-processing/src/raw_reads_processing/readtools_server.py
@@ -1,0 +1,130 @@
+"""Client and lifecycle for the readtools warm validation server.
+
+A cold `java -jar readtools.jar` spends roughly half its wall time on classloading and JIT
+warm-up that the process then throws away. Keeping one JVM warm alongside the deacon server
+removes that, and lets several validations run concurrently in it instead of forking a JVM per
+submission -- which matters because the deacon index leaves little memory headroom for N JVMs.
+
+The server returns the exact stdout/stderr the CLI would have printed, so the validation error
+messages users see are produced by the same code either way.
+"""
+
+import logging
+import os
+import subprocess  # noqa: S404
+import time
+
+import requests
+
+from raw_reads_processing.config import Config
+from raw_reads_processing.errors import ProcessingFailure
+
+logger = logging.getLogger(__name__)
+
+VALIDATION_JAR_PATH = os.environ.get("READTOOLS_JAR", "/opt/app/lib/readtools.jar")
+
+
+def server_url(config: Config) -> str:
+    return f"http://127.0.0.1:{config.readtools_server_port}"
+
+
+def start_readtools_server(config: Config) -> subprocess.Popen:
+    """Start the JVM. It is not ready to serve until `wait_until_ready` returns."""
+    args = [
+        "java",
+        f"-Xmx{config.readtools_server_max_heap}",
+        "-jar",
+        VALIDATION_JAR_PATH,
+        "server",
+        # Loopback only: the server does no authentication and validates arbitrary local paths.
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(config.readtools_server_port),
+        "--threads",
+        str(config.readtools_server_threads),
+    ]
+    logger.info(f"Starting readtools validation server: {' '.join(args)}")
+
+    return subprocess.Popen(args)  # noqa: S603
+
+
+def wait_until_ready(config: Config, proc: subprocess.Popen) -> None:
+    """Block until the server reports healthy, i.e. has finished its JIT warm-up.
+
+    Returning early would hand the first real submission the cold-start cost this server exists
+    to remove.
+    """
+    deadline = time.monotonic() + config.readtools_server_startup_timeout_seconds
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise ProcessingFailure(
+                f"readtools validation server exited with code {proc.returncode} during startup"
+            )
+        if readtools_server_healthy(config):
+            logger.info("readtools validation server is ready")
+            return
+        time.sleep(1)
+
+    raise ProcessingFailure(
+        "readtools validation server did not become ready within "
+        f"{config.readtools_server_startup_timeout_seconds} seconds"
+    )
+
+
+def readtools_server_healthy(config: Config) -> bool:
+    """True if the server answers a health probe, which runs a real one-read validation."""
+    try:
+        response = requests.get(f"{server_url(config)}/health", timeout=10)
+    except requests.RequestException:
+        return False
+    return response.status_code == 200
+
+
+def stop_readtools_server(proc: subprocess.Popen) -> None:
+    logger.debug("Stopping readtools validation server")
+    proc.terminate()
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "Failed to stop readtools validation server gracefully, sending SIGKILL"
+        )
+        proc.kill()
+        proc.wait()
+
+
+def run_validation(
+    config: Config,
+    files: list[str],
+    file_format: str,
+    timeout_seconds: int,
+) -> tuple[int, str, str]:
+    """Run one validation on the warm server.
+
+    Returns the same (exit code, stdout, stderr) triple the CLI would have produced, so callers
+    can parse it exactly as they parse a subprocess result.
+    """
+    try:
+        response = requests.post(
+            f"{server_url(config)}/validate",
+            json={"files": files, "format": file_format},
+            timeout=timeout_seconds,
+        )
+    except requests.Timeout:
+        raise TimeoutError from None
+    except requests.RequestException as e:
+        message = f"Could not reach the readtools validation server: {e}"
+        logger.error(message)
+        raise ProcessingFailure(message) from e
+
+    if response.status_code != 200:  # noqa: PLR2004
+        message = (
+            f"readtools validation server returned {response.status_code}: "
+            f"{response.text[:200]}"
+        )
+        logger.error(message)
+        raise ProcessingFailure(message)
+
+    body = response.json()
+    return body["exitCode"], body.get("stdout", ""), body.get("stderr", "")

--- a/raw-reads-processing/test/test_readtools_server.py
+++ b/raw-reads-processing/test/test_readtools_server.py
@@ -1,0 +1,259 @@
+# ruff: noqa: S101
+
+import os
+import socket
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from raw_reads_processing import file_format_validation, readtools_server
+from raw_reads_processing.config import Config
+from raw_reads_processing.errors import InvalidSubmission, ProcessingFailure
+from raw_reads_processing.file_format_validation import (
+    FileFormat,
+    validate_with_readtools,
+)
+
+from test_file_validation import (  # reuse the same fixtures both paths must agree on
+    FASTA_STYLE_HEADER,
+    INTERLEAVED_SAME_NAME,
+    LENGTH_MISMATCH,
+    NON_IUPAC_BASE,
+    VALID_R1,
+    VALID_R2,
+    VALID_SINGLE_END,
+    _find_jar,
+)
+
+
+def _config(**overrides) -> Config:
+    defaults = dict(
+        log_level="INFO",
+        s3_request_timeout_seconds=10,
+        read_validation_timeout_seconds=10,
+        deacon_filter_timeout_seconds=10,
+        deacon_max_host_reads_proportion=0.05,
+        deacon_max_host_bp=1000,
+    )
+    defaults.update(overrides)
+    return Config(**defaults)
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    file_path = tmp_path / name
+    file_path.write_text(content)
+    return file_path
+
+
+# --------------------------------------------------------------------------
+# Client behaviour, without a real server
+# --------------------------------------------------------------------------
+
+
+def test_non_200_from_server_is_a_processing_failure(monkeypatch):
+    monkeypatch.setattr(
+        readtools_server.requests,
+        "post",
+        Mock(return_value=Mock(status_code=500, text="boom")),
+    )
+    with pytest.raises(ProcessingFailure) as exc_info:
+        readtools_server.run_validation(_config(), ["reads.fastq"], "FASTQ", 10)
+    assert "returned 500" in str(exc_info.value)
+
+
+def test_unreachable_server_is_a_processing_failure(monkeypatch):
+    monkeypatch.setattr(
+        readtools_server.requests,
+        "post",
+        Mock(side_effect=requests.ConnectionError("refused")),
+    )
+    with pytest.raises(ProcessingFailure) as exc_info:
+        readtools_server.run_validation(_config(), ["reads.fastq"], "FASTQ", 10)
+    assert "Could not reach the readtools validation server" in str(exc_info.value)
+
+
+def test_server_timeout_is_reported_like_the_subprocess_timeout(tmp_path, monkeypatch):
+    """The submitter-facing timeout message must not depend on which path ran."""
+    monkeypatch.setattr(
+        readtools_server.requests, "post", Mock(side_effect=requests.Timeout())
+    )
+    reads = _write(tmp_path, "reads.fastq", VALID_SINGLE_END)
+    with pytest.raises(ProcessingFailure) as exc_info:
+        validate_with_readtools(
+            {"reads.fastq": reads},
+            FileFormat.FASTQ,
+            timeout_seconds=1,
+            config=_config(),
+        )
+    assert "timed out" in str(exc_info.value)
+    assert "1 second" in str(exc_info.value)
+
+
+def test_invalid_verdict_from_server_is_parsed_like_cli_output(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        readtools_server.requests,
+        "post",
+        Mock(
+            return_value=Mock(
+                status_code=200,
+                json=Mock(
+                    return_value={
+                        "exitCode": 1,
+                        "stdout": "RESULT: INVALID\n  Reads must contain only valid IUPAC codes\n",
+                        "stderr": "",
+                    }
+                ),
+            )
+        ),
+    )
+    reads = _write(tmp_path, "reads.fastq", NON_IUPAC_BASE)
+    with pytest.raises(InvalidSubmission) as exc_info:
+        validate_with_readtools(
+            {"reads.fastq": reads}, FileFormat.FASTQ, config=_config()
+        )
+    assert exc_info.value.error.message == (
+        "File validation failed while running ENA readtools. "
+        "Reads must contain only valid IUPAC codes"
+    )
+
+
+def test_server_is_not_used_when_disabled(tmp_path, monkeypatch):
+    post = Mock()
+    monkeypatch.setattr(readtools_server.requests, "post", post)
+    monkeypatch.setattr(
+        file_format_validation,
+        "_run_readtools_subprocess",
+        Mock(return_value=(0, "RESULT: VALID\n", "")),
+    )
+    reads = _write(tmp_path, "reads.fastq", VALID_SINGLE_END)
+    validate_with_readtools(
+        {"reads.fastq": reads},
+        FileFormat.FASTQ,
+        config=_config(readtools_server_enabled=False),
+    )
+    post.assert_not_called()
+
+
+def test_startup_reports_a_server_that_dies_immediately():
+    config = _config(
+        readtools_server_port=_free_port(), readtools_server_startup_timeout_seconds=5
+    )
+    dead = subprocess.Popen(["false"])  # noqa: S607, S603
+    dead.wait()
+    with pytest.raises(ProcessingFailure) as exc_info:
+        readtools_server.wait_until_ready(config, dead)
+    assert "exited with code" in str(exc_info.value)
+
+
+# --------------------------------------------------------------------------
+# Against a real server: the two paths must agree, message for message
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def live_server():
+    jar = _find_jar()
+    if jar is None:
+        pytest.skip("readtools jar not found; set READTOOLS_JAR to its path")
+
+    config = _config(
+        readtools_server_port=_free_port(),
+        readtools_server_threads=2,
+        # Warm-up is about speed, not correctness; skip it to keep the test quick.
+        readtools_server_startup_timeout_seconds=120,
+    )
+    proc = subprocess.Popen(  # noqa: S603
+        [
+            "java",
+            "-jar",
+            jar,
+            "server",
+            "--port",
+            str(config.readtools_server_port),
+            "--threads",
+            "2",
+            "--warmup-rounds",
+            "0",
+        ]
+    )
+    try:
+        readtools_server.wait_until_ready(config, proc)
+        yield config
+    finally:
+        readtools_server.stop_readtools_server(proc)
+
+
+CASES = [
+    ("valid_single", {"reads.fastq": VALID_SINGLE_END}),
+    ("valid_paired", {"R1.fastq": VALID_R1, "R2.fastq": VALID_R2}),
+    ("fasta_header", {"bad.fastq": FASTA_STYLE_HEADER}),
+    ("non_iupac", {"bad.fastq": NON_IUPAC_BASE}),
+    ("length_mismatch", {"bad.fastq": LENGTH_MISMATCH}),
+    ("interleaved", {"interleaved.fastq": INTERLEAVED_SAME_NAME}),
+]
+
+
+def _outcome(files, config):
+    """Verdict plus exact message, so a drift in wording fails the test."""
+    try:
+        validate_with_readtools(files, FileFormat.FASTQ, config=config)
+    except InvalidSubmission as e:
+        return ("invalid", e.error.message)
+    return ("valid", None)
+
+
+@pytest.mark.parametrize(("name", "contents"), CASES, ids=[c[0] for c in CASES])
+def test_server_and_subprocess_agree(live_server, tmp_path, name, contents):
+    files = {
+        file_name: _write(tmp_path, file_name, content)
+        for file_name, content in contents.items()
+    }
+    via_server = _outcome(files, live_server)
+    via_subprocess = _outcome(files, _config(readtools_server_enabled=False))
+    assert via_server == via_subprocess
+
+
+def test_health_endpoint_validates_a_real_read(live_server):
+    assert readtools_server.readtools_server_healthy(live_server)
+
+
+def test_server_handles_concurrent_validations(live_server, tmp_path):
+    """Concurrent requests must each get their own verdict, not another request's."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    work = []
+    for i, (name, contents) in enumerate(CASES * 3):
+        case_dir = tmp_path / f"case{i}"
+        case_dir.mkdir()
+        files = {
+            file_name: _write(case_dir, file_name, content)
+            for file_name, content in contents.items()
+        }
+        work.append((name, files))
+
+    expected = {name: _outcome(files, live_server) for name, files in work}
+    with ThreadPoolExecutor(6) as pool:
+        results = list(
+            pool.map(lambda item: (item[0], _outcome(item[1], live_server)), work)
+        )
+
+    for name, outcome in results:
+        assert outcome == expected[name], f"{name} got another request's verdict"
+
+
+def test_environment_jar_path_is_shared_by_both_modules():
+    """Both paths must load the same jar, or they could validate differently."""
+    if os.environ.get("READTOOLS_JAR"):
+        assert (
+            readtools_server.VALIDATION_JAR_PATH
+            == file_format_validation.VALIDATION_JAR_PATH
+        )

--- a/raw-reads-processing/test/test_readtools_server.py
+++ b/raw-reads-processing/test/test_readtools_server.py
@@ -299,3 +299,29 @@ def test_environment_jar_path_is_shared_by_both_modules():
             readtools_server.VALIDATION_JAR_PATH
             == file_format_validation.VALIDATION_JAR_PATH
         )
+
+
+def test_readtools_failing_to_run_is_not_blamed_on_the_submitter(tmp_path, monkeypatch):
+    """An out-of-heap JVM exits 2; that is our problem, not a bad file."""
+    monkeypatch.setattr(
+        readtools_server.requests,
+        "post",
+        Mock(
+            return_value=Mock(
+                status_code=200,
+                json=Mock(
+                    return_value={
+                        "exitCode": 2,
+                        "stdout": "",
+                        "stderr": "java.lang.OutOfMemoryError: Java heap space",
+                    }
+                ),
+            )
+        ),
+    )
+    reads = _write(tmp_path, "reads.fastq", VALID_SINGLE_END)
+    with pytest.raises(ProcessingFailure) as exc_info:
+        validate_with_readtools(
+            {"reads.fastq": reads}, FileFormat.FASTQ, config=_config()
+        )
+    assert "OutOfMemoryError" in str(exc_info.value)

--- a/raw-reads-processing/test/test_readtools_server.py
+++ b/raw-reads-processing/test/test_readtools_server.py
@@ -143,6 +143,48 @@ def test_server_is_not_used_when_disabled(tmp_path, monkeypatch):
     post.assert_not_called()
 
 
+def test_full_validation_flag_reaches_the_server(tmp_path, monkeypatch):
+    post = Mock(
+        return_value=Mock(
+            status_code=200,
+            json=Mock(return_value={"exitCode": 0, "stdout": "", "stderr": ""}),
+        )
+    )
+    monkeypatch.setattr(readtools_server.requests, "post", post)
+    reads = _write(tmp_path, "reads.fastq", VALID_SINGLE_END)
+    validate_with_readtools(
+        {"reads.fastq": reads},
+        FileFormat.FASTQ,
+        config=_config(readtools_full_validation=True),
+    )
+    assert post.call_args.kwargs["json"]["full"] is True
+
+
+def test_full_validation_flag_reaches_the_subprocess(tmp_path):
+    """Both paths must agree on how much of the file gets validated."""
+    reads = _write(tmp_path, "reads.fastq", VALID_SINGLE_END)
+    if _find_jar() is None:
+        pytest.skip("readtools jar not found")
+    exit_code, stdout, _ = file_format_validation._run_readtools_subprocess(
+        [str(reads)], FileFormat.FASTQ, 120, full=True
+    )
+    assert exit_code == 0
+    assert "full (<=100M reads)" in stdout
+
+
+def test_quick_is_the_default(tmp_path, monkeypatch):
+    post = Mock(
+        return_value=Mock(
+            status_code=200,
+            json=Mock(return_value={"exitCode": 0, "stdout": "", "stderr": ""}),
+        )
+    )
+    monkeypatch.setattr(readtools_server.requests, "post", post)
+    reads = _write(tmp_path, "reads.fastq", VALID_SINGLE_END)
+    validate_with_readtools({"reads.fastq": reads}, FileFormat.FASTQ, config=_config())
+    assert post.call_args.kwargs["json"]["full"] is False
+
+
 def test_startup_reports_a_server_that_dies_immediately():
     config = _config(
         readtools_server_port=_free_port(), readtools_server_startup_timeout_seconds=5


### PR DESCRIPTION
Depends on loculus-project/readtools#1.

**The Dockerfile currently pulls the readtools jar from a personal fork**, `corneliusroemer-agent/readtools` v1.1.0-rc1, because the agent account cannot push to `loculus-project/readtools` to cut a release there. That makes this PR actually buildable and testable rather than pointing at a tag that does not exist, but it must not merge like this — cut the equivalent release on `loculus-project/readtools` and this becomes a one-line repoint. There is a TODO on the line.

That preview jar is built from the head of loculus-project/readtools#1 and was checked before upload: its CLI output is byte-identical to the released v1.0.0 jar across valid, content-error and structural cases.

Every raw-reads submission forks `java -jar readtools.jar`, and roughly half that call is classloading and JIT warm-up the process immediately throws away. The number that makes this worth doing: JVM boot to `main` is 0.036s, so this is not process-startup overhead that a lighter launcher would fix — it is the compiled parse loop being rebuilt from scratch for every submission.

This starts one long-lived readtools JVM alongside the deacon server, warms it, and POSTs each validation to it on loopback. On 100k-read pairs: ~1.3s per validation today, ~0.9s warm, ~0.3s once several run concurrently in that one JVM.

Be aware the ~0.3s figure does not land from this PR alone. `process_all` in the preprocessing pipeline still calls `/process-files` one entry at a time and waits for each, so today you get the warm-JVM half, roughly 1.3s to 0.9s. I've deliberately not touched `prepro.py` here — parallelising that loop is a separate change with its own risks (it needs a concurrency cap, and deacon's serial accept loop becomes the next bottleneck). What this PR does is make the service able to absorb that concurrency when it comes, and doing it inside one JVM is what makes it affordable at all: the resident deacon index leaves too little room under the 8Gi limit to fork several JVMs side by side.

## Measured on a live preview, not just locally

Four 53 MB paired-FASTQ submissions (SRR21755542, 1,455,282 reads / 190 Mbp) through the preview for this branch, all `NO_ISSUES`, then approved.

| step | before, same file | with the warm server |
|---|---|---|
| **readtools validation** | ~3 s | **0.90 / 0.96 / 1.01 / 1.13 s** |
| whole `/process-files` | ~4.6 s | **~2.3 s** |
| submit → PROCESSED | 8.2 s | **6.2 s first, then 3.1 s** |
| deacon | 0.57 s | 0.19 – 0.30 s |
| pod memory, peak | 4.89 – 5.05 GB | **5.15 GB** |

That is about **3x on the readtools step in production** — a bigger win than the ~1.5x measured on a 16-vCPU dev box, because the pod pays more for a cold JVM than a fat container does. Worth knowing for anyone who benchmarks this kind of change locally and assumes the local ratio carries over.

The pod's own startup log shows the JIT warm-up curve directly, which is the clearest evidence that the mechanism is what we think it is rather than noise:

```
23:00:46 Starting readtools validation server: java -Xmx1g -jar ... server --threads 4
23:00:48 warm-up 1/3: 1.06s
23:00:48 warm-up 2/3: 0.71s
23:00:49 warm-up 3/3: 0.55s
23:00:49 readtools validation server ready
```

Warm-up costs **3 seconds** of pod startup, against a `startupProbe` that allows 600 s. Memory moving 4.89 → 5.15 GB is the resident JVM, and is why I have not touched the pod's 8 Gi sizing — the deacon index still dominates it.

### Two things the live run taught us that the bench could not

**The service used to log nothing at all about readtools.** The only breadcrumb was a debug line inside the subprocess branch, so on the warm path the duration had to be reconstructed from the gap between the last "Successfully downloaded" line and deacon's first line. That is fixed here: both paths now log the elapsed time and which one ran. Found only by trying to measure the thing in production.

**A `Connection refused` to `loculus-raw-reads-processing:5000` is what an unscheduled pod looks like.** The pod requests 8 Gi and sat `Pending`/`unschedulable` for ~15 minutes because no preview node had that much free, producing zero log lines. Submissions during that window failed with a clean `Internal Error ... Connection refused`, which reads like an application bug and is not one. Incidentally this is a decent negative control: the pipeline does surface a missing validator rather than silently passing the submission, which is the failure mode that would actually matter.

## Full validation: measured, and off by default

`readtools_full_validation` validates every read instead of the first 100k per file. Measured on the same 53 MB submission (727,641 reads per mate, so 7.3x more data than the default cap):

| | quick (default) | full |
|---|---|---|
| fork per call | ~1.15 s | **~8.6 s** |
| warm server | 0.86 s | **7.40 s** |
| peak memory, one validation | 0.39 GB | **1.33 GB** |

Two things worth knowing before anyone turns this on.

**The warm server barely helps in full mode.** The win it provides is a roughly fixed amount of reclaimed JIT compilation, so it is most of a ~1 s job but only ~14% of an ~8.6 s one. The ~3x this PR buys in production becomes about 1.15x with full validation on.

**Memory does not scale with the file, it scales with the limit.** `ValidatorWrapper` sizes the pairing Bloom filter as `readCountLimit / 2`, so full mode allocates for 50M reads even for a tiny submission, and copies it per mate. Four concurrent full validations against a 1 GB heap ran out of memory on three of the four. That is why the flag defaults to off, and why turning it on needs `readtools_server_max_heap` raised or `readtools_server_threads` lowered rather than just flipping the boolean.

That experiment also turned up two real bugs, both fixed here and in loculus-project/readtools#1: the OOM left the HTTP exchange unanswered so callers hung for their full timeout instead of erroring, and any non-zero exit was reported to the submitter as an invalid file - meaning our validator running out of memory would have been shown to someone as a problem with their perfectly good FASTQ.

## What you should push on

A long-lived JVM is a genuinely new failure mode. Today a validation bug that leaks memory or wedges dies with the process and costs one submission; now it can affect every subsequent one. Three things buy that back, and none of them is free:

`readtools_server_enabled: false` restores the old fork-per-call path without a rebuild. I did not add an automatic fallback when the server is unreachable, on purpose — a silent fallback would hide a permanently broken server behind merely-slower validations, and I'd rather that page someone. Say the word if you'd prefer it fall back anyway.

The JVM runs under an explicit `-Xmx` with concurrency capped, so it cannot grow into deacon's memory. I did not raise the pod's 8Gi request: measured resident use of the warm JVM was ~440MB against a 1g heap, well inside the headroom the deacon index leaves, and this actually lowers peak use compared with several concurrent forked JVMs. Flagging it because it's the kind of thing worth disagreeing with.

Startup blocks until the JVM reports healthy, so no submission is ever served by a cold JVM. That makes pod startup slower by the warm-up, which the existing `startupProbe` already tolerates (600s allowance, warm-up takes seconds). `/health` now also fails if the JVM has exited, or if its own probe — a real one-read validation, not a liveness ping — fails.

## The part I care most about being right

The submitter-facing error message must not depend on which path ran. Rather than defining a JSON verdict schema, the server returns the exact stdout, stderr and exit code the CLI would have printed, so `_parse_validation_error` is untouched and both paths are literally the same text. `test_server_and_subprocess_agree` runs each fixture through both and compares the resulting message string, so any drift fails the suite rather than silently reaching a submitter.

There's also a test that fires mixed valid and invalid files concurrently and checks no request gets another request's verdict, which is the failure I'd most fear from sharing a JVM.

🚀 Preview: Add `preview` label to enable