### PR TITLE
feat(preprocessing): process a batch's raw read files concurrently

### DIFF
--- a/kubernetes/loculus/templates/loculus-preprocessing-config.yaml
+++ b/kubernetes/loculus/templates/loculus-preprocessing-config.yaml
@@ -23,6 +23,9 @@ data:
     {{- if hasKey $.Values.rawReadsProcessingService "raw_reads_processing_service_timeout_seconds" }}
     raw_reads_processing_service_timeout_seconds: {{ $.Values.rawReadsProcessingService.raw_reads_processing_service_timeout_seconds }}
     {{- end }}
+    {{- if hasKey $.Values.rawReadsProcessingService "raw_reads_processing_concurrency" }}
+    raw_reads_processing_concurrency: {{ $.Values.rawReadsProcessingService.raw_reads_processing_concurrency }}
+    {{- end }}
     {{- end }}
     {{- if and (hasKey $organismConfig.schema "submissionDataTypes") (hasKey $organismConfig.schema.submissionDataTypes "maxSequencesPerEntry") }}
     max_sequences_per_entry: {{ $organismConfig.schema.submissionDataTypes.maxSequencesPerEntry }}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1923,6 +1923,10 @@
           "type": "integer",
           "description": "Timeout in seconds for raw reads processing service requests"
         },
+        "raw_reads_processing_concurrency": {
+          "type": "integer",
+          "description": "How many entries of a preprocessing batch have their files processed concurrently"
+        },
         "rawReadsProcessingConfig": {
           "type": "object",
           "description": "Configuration for the raw reads processing service"

--- a/preprocessing/nextclade/src/loculus_preprocessing/config.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/config.py
@@ -142,6 +142,10 @@ class Config(BaseModel):
     _taxonomy_service: TaxonomyService = PrivateAttr(default=TaxonomyService(None))
     raw_reads_processing_service_url: str | None = None
     raw_reads_processing_service_timeout_seconds: int = 600
+    # How many entries of a batch have their files processed at the same time.
+    # Note the load on the single raw reads processing pod is this times
+    # the number of preprocessing replicas of all organisms using it.
+    raw_reads_processing_concurrency: int = 4
     _file_processing_service: FileProcessingService = PrivateAttr(
         default=FileProcessingService(None, 600)
     )

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -1,7 +1,8 @@
 import logging
 import time
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
+from concurrent.futures import Future, ThreadPoolExecutor
 from tempfile import TemporaryDirectory
 from typing import Any
 
@@ -571,18 +572,60 @@ def unpack_annotations(config, nextclade_metadata: dict[str, Any] | None) -> dic
     return annotations
 
 
+SubmissionFiles = dict[FileCategory, list[FileIdAndNameAndReadUrl]] | None
+
+
+def process_files(
+    accession_version: AccessionVersion,
+    files: SubmissionFiles,
+    config: Config,
+) -> list[ProcessingAnnotation]:
+    """Send an entry's files to the file processing service, if it has any"""
+    if not files or not any(files.values()):
+        return []
+    return config._file_processing_service.process_files(files, accession_version=accession_version)
+
+
+def submit_file_processing(
+    entries: Iterable[tuple[AccessionVersion, SubmissionFiles]],
+    config: Config,
+    executor: ThreadPoolExecutor,
+) -> dict[AccessionVersion, Future[list[ProcessingAnnotation]]]:
+    """Start processing the files of all entries in a batch concurrently
+
+    Each entry costs one blocking HTTP request to the raw reads processing service, so
+    running them in threads rather than one after another is what makes a batch fast.
+    Entries without files are not submitted; `prefetched_file_errors` treats them as clean.
+    """
+    return {
+        accession_version: executor.submit(process_files, accession_version, files, config)
+        for accession_version, files in entries
+        if files and any(files.values())
+    }
+
+
+def prefetched_file_errors(
+    futures: dict[AccessionVersion, Future[list[ProcessingAnnotation]]],
+    accession_version: AccessionVersion,
+) -> list[ProcessingAnnotation]:
+    """Wait for an entry's file processing to finish, re-raising in the calling thread"""
+    future = futures.get(accession_version)
+    return future.result() if future else []
+
+
 def process_single(
     accession_version: AccessionVersion,
     unprocessed: UnprocessedAfterNextclade,
     config: Config,
+    file_errors: list[ProcessingAnnotation] | None = None,
 ) -> SubmissionData:
-    """Process a single sequence per config"""
-    # process files first as S3 read URLs have a limited lifetime
-    file_errors = []
-    if unprocessed.files and any(unprocessed.files.values()):
-        file_errors = config._file_processing_service.process_files(
-            unprocessed.files, accession_version=accession_version
-        )
+    """Process a single sequence per config
+
+    `file_errors` can be passed in when files were already processed for the whole batch
+    (see `process_all`); otherwise files are processed here.
+    """
+    if file_errors is None:
+        file_errors = process_files(accession_version, unprocessed.files, config)
 
     iupac_errors = errors_if_non_iupac(unprocessed.unalignedNucleotideSequences)
 
@@ -638,14 +681,15 @@ def process_single_unaligned(
     accession_version: AccessionVersion,
     unprocessed: UnprocessedData,
     config: Config,
+    file_errors: list[ProcessingAnnotation] | None = None,
 ) -> SubmissionData:
-    """Process a single sequence per config"""
-    # process files first as S3 read URLs have a limited lifetime
-    file_errors = []
-    if unprocessed.files and any(unprocessed.files.values()):
-        file_errors = config._file_processing_service.process_files(
-            unprocessed.files, accession_version=accession_version
-        )
+    """Process a single sequence per config
+
+    `file_errors` can be passed in when files were already processed for the whole batch
+    (see `process_all`); otherwise files are processed here.
+    """
+    if file_errors is None:
+        file_errors = process_files(accession_version, unprocessed.files, config)
 
     segment_assignment = assign_segment_using_header(
         input_unaligned_sequences=unprocessed.unalignedNucleotideSequences,
@@ -706,25 +750,38 @@ def process_all(
 ) -> Sequence[SubmissionData]:
     processed_results = []
     logger.debug(f"Processing {len(unprocessed)} unprocessed sequences")
-    if config.alignment_requirement != AlignmentRequirement.NONE:
-        nextclade_results = enrich_with_nextclade(unprocessed, dataset_dir, config)
-        for id, result in nextclade_results.items():
-            try:
-                processed_single = process_single(id, result, config)
-            except Exception as e:
-                logger.error(f"Processing failed for {id} with error: {e}")
-                processed_single = processed_entry_with_errors(id)
-            processed_results.append(processed_single)
-    else:
-        for entry in unprocessed:
-            try:
-                processed_single = process_single_unaligned(
-                    entry.accessionVersion, entry.data, config
-                )
-            except Exception as e:
-                logger.error(f"Processing failed for {entry.accessionVersion} with error: {e}")
-                processed_single = processed_entry_with_errors(entry.accessionVersion)
-            processed_results.append(processed_single)
+    # Files are processed for the whole batch up front, and concurrently: the S3 read URLs
+    # have a limited lifetime, and one entry's file processing takes seconds.
+    max_workers = max(1, config.raw_reads_processing_concurrency)
+    with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="file-processing") as pool:
+        if config.alignment_requirement != AlignmentRequirement.NONE:
+            nextclade_results = enrich_with_nextclade(unprocessed, dataset_dir, config)
+            file_futures = submit_file_processing(
+                ((id, result.files) for id, result in nextclade_results.items()), config, pool
+            )
+            for id, result in nextclade_results.items():
+                try:
+                    processed_single = process_single(
+                        id, result, config, file_errors=prefetched_file_errors(file_futures, id)
+                    )
+                except Exception as e:
+                    logger.error(f"Processing failed for {id} with error: {e}")
+                    processed_single = processed_entry_with_errors(id)
+                processed_results.append(processed_single)
+        else:
+            file_futures = submit_file_processing(
+                ((entry.accessionVersion, entry.data.files) for entry in unprocessed), config, pool
+            )
+            for entry in unprocessed:
+                id = entry.accessionVersion
+                try:
+                    processed_single = process_single_unaligned(
+                        id, entry.data, config, file_errors=prefetched_file_errors(file_futures, id)
+                    )
+                except Exception as e:
+                    logger.error(f"Processing failed for {id} with error: {e}")
+                    processed_single = processed_entry_with_errors(id)
+                processed_results.append(processed_single)
 
     return processed_results
 

--- a/preprocessing/nextclade/tests/test_batch_file_processing.py
+++ b/preprocessing/nextclade/tests/test_batch_file_processing.py
@@ -1,0 +1,110 @@
+# ruff: noqa: S101
+
+import threading
+from unittest.mock import MagicMock
+
+from loculus_preprocessing.config import Config
+from loculus_preprocessing.datatypes import (
+    FileCategory,
+    FileIdAndNameAndReadUrl,
+    ProcessingAnnotation,
+    UnprocessedData,
+    UnprocessedEntry,
+)
+from loculus_preprocessing.external_services import FileProcessingService
+from loculus_preprocessing.prepro import process_all
+
+
+class ConcurrencyRecordingService(FileProcessingService):
+    """Stands in for the raw reads processing service and records how many calls overlap"""
+
+    def __init__(self, entries_expected: int) -> None:
+        super().__init__(raw_reads_processing_service_url=None)
+        self.max_in_flight = 0
+        self.accession_versions: list[str] = []
+        self._in_flight = 0
+        self._lock = threading.Lock()
+        # Every call waits for all the others, so a serial caller would hang here
+        self._barrier = threading.Barrier(entries_expected, timeout=10)
+
+    def process_files(
+        self,
+        files: dict[FileCategory, list[FileIdAndNameAndReadUrl]],
+        accession_version: str,
+    ) -> list[ProcessingAnnotation]:
+        with self._lock:
+            self._in_flight += 1
+            self.max_in_flight = max(self.max_in_flight, self._in_flight)
+            self.accession_versions.append(accession_version)
+        self._barrier.wait()
+        with self._lock:
+            self._in_flight -= 1
+        return []
+
+
+def make_entry(index: int) -> UnprocessedEntry:
+    return UnprocessedEntry(
+        accessionVersion=f"LOC_{index}.1",
+        data=UnprocessedData(
+            submitter="test",
+            group_id=1,
+            submittedAt="1704067200",
+            submissionId=f"submission-{index}",
+            metadata={},
+            unalignedNucleotideSequences={},
+            files={
+                FileCategory.RAW_READS: [
+                    FileIdAndNameAndReadUrl(
+                        fileId=f"file-{index}",
+                        name=f"reads_{index}.fastq.gz",
+                        url=f"http://example/file-{index}",
+                    )
+                ]
+            },
+        ),
+    )
+
+
+def make_config(concurrency: int) -> Config:
+    # No segments, so alignment_requirement is forced to NONE and no nextclade run is needed
+    return Config(organism="dummy", raw_reads_processing_concurrency=concurrency)
+
+
+def test_process_all_processes_files_of_a_batch_concurrently() -> None:
+    entries = [make_entry(index) for index in range(4)]
+    service = ConcurrencyRecordingService(entries_expected=len(entries))
+    config = make_config(concurrency=len(entries))
+    config._file_processing_service = service
+
+    results = process_all(entries, dataset_dir="unused", config=config)
+
+    assert service.max_in_flight == len(entries)
+    assert sorted(service.accession_versions) == [entry.accessionVersion for entry in entries]
+    # Results stay in input order even though files were processed out of order
+    assert [
+        f"{result.processed_entry.accession}.{result.processed_entry.version}" for result in results
+    ] == [entry.accessionVersion for entry in entries]
+
+
+def test_process_all_respects_the_concurrency_limit() -> None:
+    entries = [make_entry(index) for index in range(4)]
+    # Two calls at a time, so the barrier is only ever released in pairs
+    service = ConcurrencyRecordingService(entries_expected=2)
+    config = make_config(concurrency=2)
+    config._file_processing_service = service
+
+    process_all(entries, dataset_dir="unused", config=config)
+
+    assert service.max_in_flight == 2  # noqa: PLR2004
+
+
+def test_process_all_without_files_does_not_call_the_service() -> None:
+    entry = make_entry(0)
+    entry.data.files = None
+    service = MagicMock()
+    config = make_config(concurrency=4)
+    config._file_processing_service = service
+
+    process_all([entry], dataset_dir="unused", config=config)
+
+    service.process_files.assert_not_called()

--- a/raw-reads-processing/src/raw_reads_processing/process_files.py
+++ b/raw-reads-processing/src/raw_reads_processing/process_files.py
@@ -1,4 +1,5 @@
 import logging
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -39,6 +40,28 @@ def download_file(
     logger.debug(f"Successfully downloaded file '{file.name}' to '{save_path}'")
 
 
+def download_files(
+    config: Config, files: list[FileIdAndNameAndReadUrl], target_dir: Path
+) -> dict[FileName, Path]:
+    """Download all files of a submission into target_dir, both mates at the same time"""
+    with ThreadPoolExecutor(
+        max_workers=max(1, len(files)), thread_name_prefix="s3-download"
+    ) as pool:
+        futures = [
+            pool.submit(download_file, config, file, target_dir / f"{file.fileId}")
+            for file in files
+        ]
+        # Wait for every download, so that a failing one is not raised while the other
+        # is still writing into target_dir.
+        errors = [future.exception() for future in futures]
+
+    for error in errors:
+        if error is not None:
+            raise error
+
+    return {file.name: target_dir / f"{file.fileId}" for file in files}
+
+
 def validate_raw_reads_submission(
     config: Config,
     request_with_files: RequestWithFiles,
@@ -53,11 +76,7 @@ def validate_raw_reads_submission(
     validate_file_numbers(file_format, [file.name for file in files])
 
     with TemporaryDirectory() as tmp_dir:
-        local_files: dict[FileName, Path] = {}
-        for file in files:
-            downloaded_file_path = Path(tmp_dir) / f"{file.fileId}"
-            download_file(config, file, downloaded_file_path)
-            local_files[file.name] = downloaded_file_path
+        local_files = download_files(config, files, Path(tmp_dir))
 
         validate_with_readtools(
             local_files, file_format, config.read_validation_timeout_seconds

--- a/raw-reads-processing/test/test_process_files.py
+++ b/raw-reads-processing/test/test_process_files.py
@@ -1,0 +1,75 @@
+# ruff: noqa: S101
+import threading
+
+import pytest
+
+from raw_reads_processing import process_files as process_files_module
+from raw_reads_processing.config import Config
+from raw_reads_processing.datatypes import FileIdAndNameAndReadUrl
+from raw_reads_processing.errors import ProcessingFailure
+from raw_reads_processing.process_files import download_files
+
+
+@pytest.fixture
+def config():
+    return Config(
+        log_level="INFO",
+        s3_request_timeout_seconds=10,
+        read_validation_timeout_seconds=10,
+        deacon_filter_timeout_seconds=10,
+        deacon_max_host_reads_proportion=0.05,
+        deacon_max_host_bp=1000,
+    )
+
+
+def paired_files() -> list[FileIdAndNameAndReadUrl]:
+    return [
+        FileIdAndNameAndReadUrl(
+            fileId=f"file-{mate}",
+            name=f"reads_{mate}.fastq.gz",
+            url=f"http://example/{mate}",
+        )
+        for mate in (1, 2)
+    ]
+
+
+def test_both_mates_are_downloaded_at_the_same_time(config, monkeypatch, tmp_path):
+    files = paired_files()
+    # Each download waits for the other, so a sequential implementation would time out
+    barrier = threading.Barrier(len(files), timeout=10)
+
+    def fake_download(config, file, save_path):
+        barrier.wait()
+        save_path.write_bytes(b"")
+
+    monkeypatch.setattr(process_files_module, "download_file", fake_download)
+
+    local_files = download_files(config, files, tmp_path)
+
+    assert local_files == {file.name: tmp_path / file.fileId for file in files}
+    assert all(path.exists() for path in local_files.values())
+
+
+def test_a_failing_download_propagates(config, monkeypatch, tmp_path):
+    def fake_download(config, file, save_path):
+        if file.fileId == "file-2":
+            raise ProcessingFailure(f"Error downloading file '{file.name}' from S3")
+        save_path.write_bytes(b"")
+
+    monkeypatch.setattr(process_files_module, "download_file", fake_download)
+
+    with pytest.raises(ProcessingFailure, match="reads_2.fastq.gz"):
+        download_files(config, paired_files(), tmp_path)
+
+
+def test_single_end_submission_downloads_one_file(config, monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        process_files_module,
+        "download_file",
+        lambda config, file, save_path: save_path.write_bytes(b""),
+    )
+    files = paired_files()[:1]
+
+    local_files = download_files(config, files, tmp_path)
+
+    assert local_files == {files[0].name: tmp_path / files[0].fileId}


### PR DESCRIPTION
Submitting raw reads is slow in batches, and the reason is that preprocessing talks to the raw reads processing service strictly one entry at a time. `process_all` loops over the batch and each iteration makes a blocking HTTP call that has to come back before the next entry starts. On `preview-raw-reads-feature.pathoplexus.org` a 100-entry batch ran at about 5.2 s per entry with no overlap at all, which is just the per-entry cost multiplied by the batch size. Nextclade alignment is already batched across the whole batch before this loop, so file processing is the one step that is still serialised per entry.

This sends the files of the whole batch to the service up front from a thread pool and then resolves each entry's result inside the existing per-entry loop, so entries still get processed and returned in the same order as before. Only the waiting is overlapped; metadata processing, nextclade handling and error handling are untouched. Both mates of a paired submission are also now downloaded from S3 at the same time inside the service, which was a sequential loop over the two files.

The thing worth knowing that is not visible in the diff: `process_single_unaligned` calls the file processing service too, and `Config.finalize` forces `alignment_requirement` to `NONE` whenever an organism has no segments or no nextclade dataset — which is plausible for an organism that only takes raw reads. Parallelising only the aligned branch would have been a no-op for exactly the case this is meant to speed up, so the prefetch sits above the branch and both arms use it.

## What I'd like a decision on

The default concurrency of 4 is a guess on the conservative side, and it is the number I would most like a second opinion on. The load that actually reaches the single raw reads processing pod is this number times the number of preprocessing replicas across all organisms pointing at it. Each concurrent request forks its own `java -jar readtools.jar` on top of the roughly 4.9 GB that the deacon index occupies in an 8 Gi pod, so the ceiling is memory, not CPU. Happy to raise it, but I would want it load-tested against a preview first rather than reasoned about.

There is also a failure mode that this change makes more likely, and I deliberately did not fix it here. `raw_reads_processing_service_timeout_seconds` (default 600) is a socket timeout on each request. With concurrent requests, a request can sit queued inside the pod — in FastAPI's thread pool, and then behind deacon, which serves filter requests one at a time — and burn its timeout while waiting rather than working. If that timeout fires, the client closes the socket mid-request, and a client that disconnects part-way through is what drives the deacon server into a busy loop it never recovers from: every later filter hangs, the health probe does not notice, and the pod needs restarting. At a concurrency of 4 with a 600 s budget this is unlikely, but the clean fix is a semaphore inside `raw-reads-processing` so that excess requests wait in FastAPI with no socket at risk yet, instead of waiting inside a half-served deacon call. That felt like a separate change; I would do it before raising the concurrency much.

## On the numbers

I did not measure this against a preview. Locally, driving the real client code against a stub service that sleeps 3 s per request (the readtools plus deacon cost measured on the preview), a batch of 20 goes from 60.1 s at concurrency 1 to 15.0 s at 4 and 6.1 s at 16. That only demonstrates that the requests really do overlap and that the setting bounds them — the stub has no server-side cost, so it scales perfectly and the real curve will flatten much earlier, bounded by deacon's serial handling and by how many JVMs fit in the pod. Please don't read those numbers as expected production speedups.

Both new test files use a `threading.Barrier` in the fake service so that they would time out rather than quietly pass if the calls were still sequential, which a wall-clock assertion would not catch reliably in CI.

🚀 Preview: https://rawreads-parallel-file-pr.loculus.org