### PR TITLE
feat(raw-reads-processing): ensure correct deacon thresholds are used when reads are short

### DIFF
--- a/raw-reads-processing/config/defaults.yaml
+++ b/raw-reads-processing/config/defaults.yaml
@@ -6,6 +6,7 @@ file_service_host: "0.0.0.0"
 deacon_max_host_reads_proportion: 0.1
 deacon_max_host_bp: 300000 # 300kBp - or 10^-4 coverage of the human genome
 deacon_a: 2
+# We can only guarantee 2 minimizer hits (even if it is a fragment from the exact same reference) if the read has (K + W -1)x2 bp
+short_reads_threshold: 90 # (31 + 15 - 1) x 2 = 90bp
 deacon_a_short_reads: 1 # k-mer threshold used instead of deacon_a when reads are short
-short_reads_threshold: 90 # mean read length (bp) below which short-read params apply
 deacon_r: 0.05

--- a/raw-reads-processing/config/defaults.yaml
+++ b/raw-reads-processing/config/defaults.yaml
@@ -6,4 +6,6 @@ file_service_host: "0.0.0.0"
 deacon_max_host_reads_proportion: 0.1
 deacon_max_host_bp: 300000 # 300kBp - or 10^-4 coverage of the human genome
 deacon_a: 2
+deacon_a_short_reads: 1 # k-mer threshold used instead of deacon_a when reads are short
+short_reads_threshold: 90 # mean read length (bp) below which short-read params apply
 deacon_r: 0.05

--- a/raw-reads-processing/environment.yml
+++ b/raw-reads-processing/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
+  - biopython=1.88
   - fastapi=0.135.1
   - pydantic=2.12.5
   - pytest=9.0.2

--- a/raw-reads-processing/environment.yml
+++ b/raw-reads-processing/environment.yml
@@ -15,3 +15,4 @@ dependencies:
   - pyyaml=6.0.3
   - deacon=0.17.0
   - openjdk=21
+  - xopen=2.1.0

--- a/raw-reads-processing/src/raw_reads_processing/config.py
+++ b/raw-reads-processing/src/raw_reads_processing/config.py
@@ -22,9 +22,7 @@ class Config(BaseModel):
     deacon_a_short_reads: int = (
         1  # absolute k-mer threshold used instead of deacon_a for short-read libraries
     )
-    short_reads_threshold: int = (
-        90  # mean read length (bp) below (or at) which short-read deacon params are used
-    )
+    short_reads_threshold: int = 90  # mean read length (bp) below (or at) which short-read deacon params are used
     deacon_r: float = (
         0.05  # relative proportion of k-mers in a read that need to map to index
     )

--- a/raw-reads-processing/src/raw_reads_processing/config.py
+++ b/raw-reads-processing/src/raw_reads_processing/config.py
@@ -22,7 +22,7 @@ class Config(BaseModel):
     deacon_a_short_reads: int = (
         1  # absolute k-mer threshold used instead of deacon_a for short-read libraries
     )
-    short_reads_threshold: int = 90  # mean read length (bp) below (or at) which short-read deacon params are used
+    short_reads_threshold: int = 90  # mean read length (bp) below which short-read deacon params are used
     deacon_r: float = (
         0.05  # relative proportion of k-mers in a read that need to map to index
     )

--- a/raw-reads-processing/src/raw_reads_processing/config.py
+++ b/raw-reads-processing/src/raw_reads_processing/config.py
@@ -19,6 +19,12 @@ class Config(BaseModel):
     deacon_a: int = (
         2  # absolute number of k-mers in a read that need to map to index to be flagged
     )
+    deacon_a_short_reads: int = (
+        1  # absolute k-mer threshold used instead of deacon_a for short-read libraries
+    )
+    short_reads_threshold: int = (
+        90  # mean read length (bp) below (or at) which short-read deacon params are used
+    )
     deacon_r: float = (
         0.05  # relative proportion of k-mers in a read that need to map to index
     )

--- a/raw-reads-processing/src/raw_reads_processing/config.py
+++ b/raw-reads-processing/src/raw_reads_processing/config.py
@@ -22,7 +22,9 @@ class Config(BaseModel):
     deacon_a_short_reads: int = (
         1  # absolute k-mer threshold used instead of deacon_a for short-read libraries
     )
-    short_reads_threshold: int = 90  # mean read length (bp) below which short-read deacon params are used
+    short_reads_threshold: int = (
+        90  # mean read length (bp) below which short-read deacon params are used
+    )
     deacon_r: float = (
         0.05  # relative proportion of k-mers in a read that need to map to index
     )

--- a/raw-reads-processing/src/raw_reads_processing/deacon.py
+++ b/raw-reads-processing/src/raw_reads_processing/deacon.py
@@ -60,7 +60,7 @@ _READ_LENGTH_SAMPLE_SIZE = 100
 
 def median_read_length(
     path: Path, sample_size: int = _READ_LENGTH_SAMPLE_SIZE
-) -> float:
+) -> float | None:
     """Median read length over the first `sample_size` reads.
 
     xopen sniffs compression from the magic bytes, which matters because downloads
@@ -74,15 +74,26 @@ def median_read_length(
             len(seq)
             for _, seq, _ in itertools.islice(FastqGeneralIterator(fh), sample_size)
         ]
-    return statistics.median(lengths) if lengths else 0.0
+    return statistics.median(lengths) if lengths else None
 
 
 def _deacon_a_for_reads(file_name_to_path: dict[FileName, Path], config: Config) -> int:
     """Pick the deacon `-a` k-mer threshold, sampling the first one or two input
     files to decide whether this is a short-read library.
     """
-    sample_paths = list(file_name_to_path.values())
-    observed_length = min((median_read_length(p) for p in sample_paths), default=0.0)
+    median_lengths = {
+        file_name: median_read_length(path)
+        for file_name, path in file_name_to_path.items()
+    }
+    for file_name, median_length in median_lengths.items():
+        if median_length is None:
+            message = f"Failed to determine median read length for file '{file_name}'. File may be empty or corrupted."
+            logging.error(message)
+            raise InvalidSubmission(Annotation(fileNames=[file_name], message=message))
+    observed_length = min(
+        [length for length in median_lengths.values() if length is not None],
+        default=0.0,
+    )
     short_reads = observed_length < config.short_reads_threshold
     deacon_a = config.deacon_a_short_reads if short_reads else config.deacon_a
     logger.info(

--- a/raw-reads-processing/src/raw_reads_processing/deacon.py
+++ b/raw-reads-processing/src/raw_reads_processing/deacon.py
@@ -65,6 +65,9 @@ def median_read_length(
 
     xopen sniffs compression from the magic bytes, which matters because downloads
     are stored without their original extension.
+
+    Read length should be homogeneous within a sequencing run, so a small sample from
+    the start of the file is representative and costs only a few milliseconds.
     """
     with xopen(path, "rt", threads=0) as fh:
         lengths = [

--- a/raw-reads-processing/src/raw_reads_processing/deacon.py
+++ b/raw-reads-processing/src/raw_reads_processing/deacon.py
@@ -1,9 +1,12 @@
 import gzip
+import itertools
 import logging
 import os
 import subprocess  # noqa: S404
 from pathlib import Path
 from typing import IO, cast
+
+from Bio import SeqIO
 
 from raw_reads_processing.config import Config
 from raw_reads_processing.datatypes import Annotation, DeaconSummary, FileName
@@ -51,8 +54,6 @@ def stop_deacon_server(proc: subprocess.Popen) -> None:
         proc.wait()
 
 
-# 0-based line offset of the sequence within each 4-line FASTQ record
-_FASTQ_SEQ_LINE = 1
 _READ_LENGTH_SAMPLE_SIZE = 100
 
 
@@ -75,12 +76,9 @@ def mean_read_length(path: Path, sample_size: int = _READ_LENGTH_SAMPLE_SIZE) ->
     """
     total = count = 0
     with _open_maybe_gzipped(path) as fh:
-        for i, line in enumerate(fh):
-            if i % 4 == _FASTQ_SEQ_LINE:
-                total += len(line.rstrip("\n"))
-                count += 1
-                if count >= sample_size:
-                    break
+        for record in itertools.islice(SeqIO.parse(fh, "fastq"), sample_size):
+            total += len(record.seq)
+            count += 1
     return total / count if count else 0.0
 
 

--- a/raw-reads-processing/src/raw_reads_processing/deacon.py
+++ b/raw-reads-processing/src/raw_reads_processing/deacon.py
@@ -3,7 +3,7 @@ import logging
 import os
 import subprocess  # noqa: S404
 from pathlib import Path
-from typing import cast
+from typing import IO, cast
 
 from raw_reads_processing.config import Config
 from raw_reads_processing.datatypes import Annotation, DeaconSummary, FileName
@@ -56,7 +56,7 @@ _FASTQ_SEQ_LINE = 1
 _READ_LENGTH_SAMPLE_SIZE = 100
 
 
-def _open_maybe_gzipped(path: Path):
+def _open_maybe_gzipped(path: Path) -> IO[str]:
     """Open a FASTQ file for text reading, transparently handling gzip.
 
     Downloaded files are stored without their original extension, so gzip is
@@ -90,7 +90,7 @@ def _deacon_a_for_reads(file_name_to_path: dict[FileName, Path], config: Config)
     """
     sample_paths = list(file_name_to_path.values())
     observed_length = min((mean_read_length(p) for p in sample_paths), default=0.0)
-    short_reads = observed_length <= config.short_reads_threshold
+    short_reads = observed_length < config.short_reads_threshold
     deacon_a = config.deacon_a_short_reads if short_reads else config.deacon_a
     logger.info(
         f"Mean read length ~{observed_length:.0f}bp "

--- a/raw-reads-processing/src/raw_reads_processing/deacon.py
+++ b/raw-reads-processing/src/raw_reads_processing/deacon.py
@@ -5,6 +5,7 @@ import os
 import subprocess  # noqa: S404
 from pathlib import Path
 from typing import IO, cast
+import numpy as np
 
 from Bio import SeqIO
 
@@ -68,18 +69,22 @@ def _open_maybe_gzipped(path: Path) -> IO[str]:
     return gzip.open(path, "rt") if is_gzip else path.open("rt")
 
 
-def mean_read_length(path: Path, sample_size: int = _READ_LENGTH_SAMPLE_SIZE) -> float:
-    """Mean sequence length over the first `sample_size` reads of a FASTQ file.
+def median_read_length(
+    path: Path,
+    sample_size: int = _READ_LENGTH_SAMPLE_SIZE,
+) -> float:
+    """Median sequence length over the first `sample_size` reads of a FASTQ file.
 
     Read length should be homogeneous within a sequencing run, so a small sample from
     the start of the file is representative and costs only a few milliseconds.
     """
-    total = count = 0
     with _open_maybe_gzipped(path) as fh:
-        for record in itertools.islice(SeqIO.parse(fh, "fastq"), sample_size):
-            total += len(record.seq)
-            count += 1
-    return total / count if count else 0.0
+        lengths = [
+            len(record.seq)
+            for record in itertools.islice(SeqIO.parse(fh, "fastq"), sample_size)
+        ]
+
+    return np.median(lengths) if lengths else 0.0
 
 
 def _deacon_a_for_reads(file_name_to_path: dict[FileName, Path], config: Config) -> int:
@@ -87,11 +92,11 @@ def _deacon_a_for_reads(file_name_to_path: dict[FileName, Path], config: Config)
     files to decide whether this is a short-read library.
     """
     sample_paths = list(file_name_to_path.values())
-    observed_length = min((mean_read_length(p) for p in sample_paths), default=0.0)
+    observed_length = min((median_read_length(p) for p in sample_paths), default=0.0)
     short_reads = observed_length < config.short_reads_threshold
     deacon_a = config.deacon_a_short_reads if short_reads else config.deacon_a
     logger.info(
-        f"Mean read length ~{observed_length:.0f}bp "
+        f"Median read length ~{observed_length:.0f}bp "
         f"({'short' if short_reads else 'normal'}-read deacon params: -a {deacon_a})"
     )
     return deacon_a

--- a/raw-reads-processing/src/raw_reads_processing/deacon.py
+++ b/raw-reads-processing/src/raw_reads_processing/deacon.py
@@ -59,8 +59,8 @@ _READ_LENGTH_SAMPLE_SIZE = 100
 
 
 def median_read_length(
-    path: Path, sample_size: int = _READ_LENGTH_SAMPLE_SIZE
-) -> float | None:
+    path: Path, file_name: str, sample_size: int = _READ_LENGTH_SAMPLE_SIZE
+) -> float:
     """Median read length over the first `sample_size` reads.
 
     xopen sniffs compression from the magic bytes, which matters because downloads
@@ -74,24 +74,22 @@ def median_read_length(
             len(seq)
             for _, seq, _ in itertools.islice(FastqGeneralIterator(fh), sample_size)
         ]
-    return statistics.median(lengths) if lengths else None
+    if not lengths:
+        message = f"Failed to determine median read length for file '{file_name}'. File may be empty or corrupted."
+        logging.error(message)
+        raise InvalidSubmission(Annotation(fileNames=[file_name], message=message))
+    return statistics.median(lengths)
 
 
 def _deacon_a_for_reads(file_name_to_path: dict[FileName, Path], config: Config) -> int:
     """Pick the deacon `-a` k-mer threshold, sampling the first one or two input
     files to decide whether this is a short-read library.
     """
-    median_lengths = {
-        file_name: median_read_length(path)
-        for file_name, path in file_name_to_path.items()
-    }
-    for file_name, median_length in median_lengths.items():
-        if median_length is None:
-            message = f"Failed to determine median read length for file '{file_name}'. File may be empty or corrupted."
-            logging.error(message)
-            raise InvalidSubmission(Annotation(fileNames=[file_name], message=message))
     observed_length = min(
-        [length for length in median_lengths.values() if length is not None],
+        [
+            median_read_length(path, file_name)
+            for file_name, path in file_name_to_path.items()
+        ],
         default=0.0,
     )
     short_reads = observed_length < config.short_reads_threshold

--- a/raw-reads-processing/src/raw_reads_processing/deacon.py
+++ b/raw-reads-processing/src/raw_reads_processing/deacon.py
@@ -1,13 +1,13 @@
-import gzip
 import itertools
 import logging
 import os
+import statistics
 import subprocess  # noqa: S404
 from pathlib import Path
-from typing import IO, cast
-import numpy as np
+from typing import cast
 
-from Bio import SeqIO
+from Bio.SeqIO.QualityIO import FastqGeneralIterator
+from xopen import xopen
 
 from raw_reads_processing.config import Config
 from raw_reads_processing.datatypes import Annotation, DeaconSummary, FileName
@@ -58,33 +58,20 @@ def stop_deacon_server(proc: subprocess.Popen) -> None:
 _READ_LENGTH_SAMPLE_SIZE = 100
 
 
-def _open_maybe_gzipped(path: Path) -> IO[str]:
-    """Open a FASTQ file for text reading, transparently handling gzip.
-
-    Downloaded files are stored without their original extension, so gzip is
-    detected from the magic bytes rather than the file name.
-    """
-    with path.open("rb") as fh:
-        is_gzip = fh.read(2) == b"\x1f\x8b"
-    return gzip.open(path, "rt") if is_gzip else path.open("rt")
-
-
 def median_read_length(
-    path: Path,
-    sample_size: int = _READ_LENGTH_SAMPLE_SIZE,
+    path: Path, sample_size: int = _READ_LENGTH_SAMPLE_SIZE
 ) -> float:
-    """Median sequence length over the first `sample_size` reads of a FASTQ file.
+    """Median read length over the first `sample_size` reads.
 
-    Read length should be homogeneous within a sequencing run, so a small sample from
-    the start of the file is representative and costs only a few milliseconds.
+    xopen sniffs compression from the magic bytes, which matters because downloads
+    are stored without their original extension.
     """
-    with _open_maybe_gzipped(path) as fh:
+    with xopen(path, "rt", threads=0) as fh:
         lengths = [
-            len(record.seq)
-            for record in itertools.islice(SeqIO.parse(fh, "fastq"), sample_size)
+            len(seq)
+            for _, seq, _ in itertools.islice(FastqGeneralIterator(fh), sample_size)
         ]
-
-    return np.median(lengths) if lengths else 0.0
+    return statistics.median(lengths) if lengths else 0.0
 
 
 def _deacon_a_for_reads(file_name_to_path: dict[FileName, Path], config: Config) -> int:

--- a/raw-reads-processing/src/raw_reads_processing/deacon.py
+++ b/raw-reads-processing/src/raw_reads_processing/deacon.py
@@ -1,3 +1,4 @@
+import gzip
 import logging
 import os
 import subprocess  # noqa: S404
@@ -50,10 +51,59 @@ def stop_deacon_server(proc: subprocess.Popen) -> None:
         proc.wait()
 
 
+# 0-based line offset of the sequence within each 4-line FASTQ record
+_FASTQ_SEQ_LINE = 1
+_READ_LENGTH_SAMPLE_SIZE = 100
+
+
+def _open_maybe_gzipped(path: Path):
+    """Open a FASTQ file for text reading, transparently handling gzip.
+
+    Downloaded files are stored without their original extension, so gzip is
+    detected from the magic bytes rather than the file name.
+    """
+    with path.open("rb") as fh:
+        is_gzip = fh.read(2) == b"\x1f\x8b"
+    return gzip.open(path, "rt") if is_gzip else path.open("rt")
+
+
+def mean_read_length(path: Path, sample_size: int = _READ_LENGTH_SAMPLE_SIZE) -> float:
+    """Mean sequence length over the first `sample_size` reads of a FASTQ file.
+
+    Read length should be homogeneous within a sequencing run, so a small sample from
+    the start of the file is representative and costs only a few milliseconds.
+    """
+    total = count = 0
+    with _open_maybe_gzipped(path) as fh:
+        for i, line in enumerate(fh):
+            if i % 4 == _FASTQ_SEQ_LINE:
+                total += len(line.rstrip("\n"))
+                count += 1
+                if count >= sample_size:
+                    break
+    return total / count if count else 0.0
+
+
+def _deacon_a_for_reads(file_name_to_path: dict[FileName, Path], config: Config) -> int:
+    """Pick the deacon `-a` k-mer threshold, sampling the first one or two input
+    files to decide whether this is a short-read library.
+    """
+    sample_paths = list(file_name_to_path.values())[:2]
+    observed_length = min(mean_read_length(p) for p in sample_paths)
+    short_reads = observed_length <= config.short_reads_threshold
+    deacon_a = config.deacon_a_short_reads if short_reads else config.deacon_a
+    logger.info(
+        f"Mean read length ~{observed_length:.0f}bp "
+        f"({'short' if short_reads else 'normal'}-read deacon params: -a {deacon_a})"
+    )
+    return deacon_a
+
+
 def run_deacon_filter(
     file_name_to_path: dict[FileName, Path], data_dir: str, config: Config
 ) -> DeaconSummary:
     summary_json_path = Path(data_dir) / "summary.json"
+    deacon_a = _deacon_a_for_reads(file_name_to_path, config)
     args = [
         "deacon",
         "--use-server",
@@ -61,7 +111,7 @@ def run_deacon_filter(
         "--summary",
         summary_json_path,
         "-a",
-        str(config.deacon_a),
+        str(deacon_a),
         "-r",
         str(config.deacon_r),
         DEACON_INDEX_PATH,

--- a/raw-reads-processing/src/raw_reads_processing/deacon.py
+++ b/raw-reads-processing/src/raw_reads_processing/deacon.py
@@ -88,8 +88,8 @@ def _deacon_a_for_reads(file_name_to_path: dict[FileName, Path], config: Config)
     """Pick the deacon `-a` k-mer threshold, sampling the first one or two input
     files to decide whether this is a short-read library.
     """
-    sample_paths = list(file_name_to_path.values())[:2]
-    observed_length = min(mean_read_length(p) for p in sample_paths)
+    sample_paths = list(file_name_to_path.values())
+    observed_length = min((mean_read_length(p) for p in sample_paths), default=0.0)
     short_reads = observed_length <= config.short_reads_threshold
     deacon_a = config.deacon_a_short_reads if short_reads else config.deacon_a
     logger.info(

--- a/raw-reads-processing/test/test_deacon.py
+++ b/raw-reads-processing/test/test_deacon.py
@@ -1,5 +1,6 @@
 # ruff: noqa: S101
 
+import gzip
 import shutil
 import time
 from pathlib import Path
@@ -85,6 +86,37 @@ def deacon_index(monkeypatch, deacon_server):
     # Index created with `deacon index build test/fixtures/test_small_1.fastq -k 31 -w 15 -o deacon.idx`
     monkeypatch.setattr(
         deacon_module, "DEACON_INDEX_PATH", str(FIXTURES_DIR / "deacon.idx")
+    )
+
+
+def test_mean_read_length_plain_fastq(tmp_path):
+    reads = tmp_path / "reads.fastq"
+    _write_fastq(reads, [_random_read(100), _random_read(200), _random_read(150)])
+    assert deacon_module.mean_read_length(reads) == pytest.approx(150.0)
+
+
+def test_mean_read_length_gzipped_fastq(tmp_path):
+    reads = tmp_path / "reads.fastq.gz"
+    _write_fastq(tmp_path / "plain.fastq", [_random_read(80), _random_read(120)])
+    reads.write_bytes(gzip.compress((tmp_path / "plain.fastq").read_bytes()))
+    assert deacon_module.mean_read_length(reads) == pytest.approx(100.0)
+
+
+def test_deacon_a_for_reads_switches_on_short_reads(tmp_path):
+    config = _config()
+    short = tmp_path / "short.fastq"
+    _write_fastq(short, [_random_read(75)] * 5)
+    long = tmp_path / "long.fastq"
+    _write_fastq(long, [_random_read(100)] * 5)
+
+    assert deacon_module._deacon_a_for_reads({"short.fastq": short}, config) == 1
+    assert deacon_module._deacon_a_for_reads({"long.fastq": long}, config) == 2
+    # min() over mates: a short R2 still triggers short-read params
+    assert (
+        deacon_module._deacon_a_for_reads(
+            {"long.fastq": long, "short.fastq": short}, config
+        )
+        == 1
     )
 
 

--- a/raw-reads-processing/test/test_deacon.py
+++ b/raw-reads-processing/test/test_deacon.py
@@ -96,10 +96,12 @@ def test_mean_read_length_plain_fastq(tmp_path):
 
 
 def test_mean_read_length_gzipped_fastq(tmp_path):
+    config = _config()
     reads = tmp_path / "reads.fastq.gz"
-    _write_fastq(tmp_path / "plain.fastq", [_random_read(80), _random_read(120)])
+    _write_fastq(tmp_path / "plain.fastq", [_random_read(80), _random_read(100)])
     reads.write_bytes(gzip.compress((tmp_path / "plain.fastq").read_bytes()))
-    assert deacon_module.mean_read_length(reads) == pytest.approx(100.0)
+    assert deacon_module.mean_read_length(reads) == pytest.approx(90.0)
+    assert deacon_module._deacon_a_for_reads({"boundary.fastq": reads}, config) == 2
 
 
 def test_deacon_a_for_reads_switches_on_short_reads(tmp_path):

--- a/raw-reads-processing/test/test_deacon.py
+++ b/raw-reads-processing/test/test_deacon.py
@@ -92,7 +92,9 @@ def deacon_index(monkeypatch, deacon_server):
 def test_median_read_length_plain_fastq(tmp_path):
     reads = tmp_path / "reads.fastq"
     _write_fastq(reads, [_random_read(100), _random_read(200), _random_read(150)])
-    assert deacon_module.median_read_length(reads) == pytest.approx(150.0)
+    assert deacon_module.median_read_length(reads, "reads.fastq") == pytest.approx(
+        150.0
+    )
 
 
 def test_median_read_length_gzipped_fastq(tmp_path):
@@ -100,7 +102,9 @@ def test_median_read_length_gzipped_fastq(tmp_path):
     reads = tmp_path / "reads.fastq.gz"
     _write_fastq(tmp_path / "plain.fastq", [_random_read(80), _random_read(100)])
     reads.write_bytes(gzip.compress((tmp_path / "plain.fastq").read_bytes()))
-    assert deacon_module.median_read_length(reads) == pytest.approx(90.0)
+    assert deacon_module.median_read_length(reads, "reads.fastq.gz") == pytest.approx(
+        90.0
+    )
     assert deacon_module._deacon_a_for_reads({"boundary.fastq": reads}, config) == 2
 
 
@@ -120,6 +124,17 @@ def test_deacon_a_for_reads_switches_on_short_reads(tmp_path):
         )
         == 1
     )
+
+
+def test_deacon_a_for_reads_raises_when_read_length_cannot_be_parsed(tmp_path):
+    config = _config()
+    empty = tmp_path / "empty.fastq"
+    empty.write_text("")
+
+    with pytest.raises(InvalidSubmission) as exc_info:
+        deacon_module._deacon_a_for_reads({"empty.fastq": empty}, config)
+    assert exc_info.value.error.fileNames == ["empty.fastq"]
+    assert "Failed to determine median read length" in exc_info.value.error.message
 
 
 @pytest.mark.usefixtures("mock_downstream", "deacon_index")

--- a/raw-reads-processing/test/test_deacon.py
+++ b/raw-reads-processing/test/test_deacon.py
@@ -89,18 +89,18 @@ def deacon_index(monkeypatch, deacon_server):
     )
 
 
-def test_mean_read_length_plain_fastq(tmp_path):
+def test_median_read_length_plain_fastq(tmp_path):
     reads = tmp_path / "reads.fastq"
     _write_fastq(reads, [_random_read(100), _random_read(200), _random_read(150)])
-    assert deacon_module.mean_read_length(reads) == pytest.approx(150.0)
+    assert deacon_module.median_read_length(reads) == pytest.approx(150.0)
 
 
-def test_mean_read_length_gzipped_fastq(tmp_path):
+def test_median_read_length_gzipped_fastq(tmp_path):
     config = _config()
     reads = tmp_path / "reads.fastq.gz"
     _write_fastq(tmp_path / "plain.fastq", [_random_read(80), _random_read(100)])
     reads.write_bytes(gzip.compress((tmp_path / "plain.fastq").read_bytes()))
-    assert deacon_module.mean_read_length(reads) == pytest.approx(90.0)
+    assert deacon_module.median_read_length(reads) == pytest.approx(90.0)
     assert deacon_module._deacon_a_for_reads({"boundary.fastq": reads}, config) == 2
 
 


### PR DESCRIPTION
see simulation results and discussion in https://loculus.slack.com/archives/C0ALH6CB9NY/p1787345188080329?thread_ts=1787231662.262079&cid=C0ALH6CB9NY

### Screenshot

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable