### PR TITLE
feat(raw-reads-processing): mask all kmers from PPX consensus sequences in our deacon index

### DIFF
--- a/.github/workflows/deacon-index.yml
+++ b/.github/workflows/deacon-index.yml
@@ -45,7 +45,8 @@ jobs:
       - name: Create deacon index
         shell: bash -l {0}
         run: |
-          python3 ./raw-reads-processing/build-index.py -o "${INDEX_VERSIONED}"
+          ./raw-reads-processing/build-index.sh -o "${INDEX_VERSIONED}"
+          ls -lh "${INDEX_VERSIONED}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/deacon-index.yml
+++ b/.github/workflows/deacon-index.yml
@@ -2,9 +2,6 @@ name: Create and Upload Custom Deacon Index
 
 on:
   workflow_dispatch: # Only manual trigger for now, since this is a rare operation
-  push:
-    branches:
-      - deacon_index_improvements
 
 env:
   DEACON_INDEX_IMAGE: ghcr.io/loculus-project/deacon-index
@@ -96,8 +93,8 @@ jobs:
         run: |
           s3cmd put "${INDEX_VERSIONED}" s3://loculus-public/deacon-index/"${INDEX_VERSIONED}"
 
-          # s3cmd cp s3://loculus-public/deacon-index/"${INDEX_VERSIONED}" \
-          #   s3://loculus-public/deacon-index/"${INDEX_LATEST}"
+          s3cmd cp s3://loculus-public/deacon-index/"${INDEX_VERSIONED}" \
+            s3://loculus-public/deacon-index/"${INDEX_LATEST}"
 
   notify_on_success:
     needs: build-and-upload

--- a/.github/workflows/deacon-index.yml
+++ b/.github/workflows/deacon-index.yml
@@ -42,8 +42,7 @@ jobs:
       - name: Create deacon index
         shell: bash -l {0}
         run: |
-          curl -fL https://objectstorage.uk-london-1.oraclecloud.com/n/lrbvkel2wjot/b/human-genome-bucket/o/deacon/misc/panhuman-1.k31w15c8.idx -o "${INDEX_VERSIONED}"
-          ls -lh "${INDEX_VERSIONED}"
+          python3 ./raw-reads-processing/build-index.py -o "${INDEX_VERSIONED}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/deacon-index.yml
+++ b/.github/workflows/deacon-index.yml
@@ -2,6 +2,9 @@ name: Create and Upload Custom Deacon Index
 
 on:
   workflow_dispatch: # Only manual trigger for now, since this is a rare operation
+  push:
+    branches:
+      - deacon_index_improvements
 
 env:
   DEACON_INDEX_IMAGE: ghcr.io/loculus-project/deacon-index
@@ -92,8 +95,8 @@ jobs:
         run: |
           s3cmd put "${INDEX_VERSIONED}" s3://loculus-public/deacon-index/"${INDEX_VERSIONED}"
 
-          s3cmd cp s3://loculus-public/deacon-index/"${INDEX_VERSIONED}" \
-            s3://loculus-public/deacon-index/"${INDEX_LATEST}"
+          # s3cmd cp s3://loculus-public/deacon-index/"${INDEX_VERSIONED}" \
+          #   s3://loculus-public/deacon-index/"${INDEX_LATEST}"
 
   notify_on_success:
     needs: build-and-upload

--- a/raw-reads-processing/build-index.sh
+++ b/raw-reads-processing/build-index.sh
@@ -5,7 +5,6 @@ PATHOPLEXUS_URL="https://pathoplexus.org"
 LAPIS_URL="https://lapis.pathoplexus.org"
 
 KMER_LEN=31
-WINDOW_SIZE=15
 
 usage() {
     echo "Usage: $0 -o <output-index>" >&2
@@ -79,8 +78,6 @@ deacon index \
 deacon index \
     diff "$TEMP_INDEX" \
     "$TEMP_MASK" \
-    -k "$KMER_LEN" \
-    -w "$WINDOW_SIZE" \
     -o "$OUTPUT_FILE"
 
 echo "Output written to: $OUTPUT_FILE"

--- a/raw-reads-processing/build-index.sh
+++ b/raw-reads-processing/build-index.sh
@@ -62,10 +62,10 @@ for organism in "${organisms[@]}"; do
     echo "Downloading ${organism}..." >&2 
     curl -fsSL "${LAPIS_URL}/${organism}/sample/unalignedNucleotideSequences?dataUseTerms=OPEN&dataFormat=fasta&compression=zstd&versionStatus=LATEST_VERSION&isRevocation=false" | zstdcat > "$organism_fasta"
      
-    if [[ ! -s "$organism_fasta" ]]; 
-        then echo "Warning: empty FASTA returned for ${organism}; skipping." >&2 
-        continue 
-    fi 
+    if [[ ! -s "$organism_fasta" ]]; then
+        echo "Error: empty FASTA returned for ${organism}." >&2
+        exit 1
+    fi
     cat "$organism_fasta" >> "$COMBINED_FASTA" 
     # Ensure records from separate files cannot run together. 
     printf '\n' >> "$COMBINED_FASTA"

--- a/raw-reads-processing/build-index.sh
+++ b/raw-reads-processing/build-index.sh
@@ -45,17 +45,22 @@ COMBINED_FASTA="$TMP_DIR/combined.fasta"
 
 mkdir -p "$(dirname "$OUTPUT_FILE")"
 
-curl https://objectstorage.uk-london-1.oraclecloud.com/n/lrbvkel2wjot/b/human-genome-bucket/o/deacon/misc/panhuman-1.k31w15c8.idx > "$TEMP_INDEX"
+curl -fsSL https://objectstorage.uk-london-1.oraclecloud.com/n/lrbvkel2wjot/b/human-genome-bucket/o/deacon/misc/panhuman-1.k31w15c8.idx -o "$TEMP_INDEX"
 
 mapfile -t organisms < <(
     curl -fsSL "${PATHOPLEXUS_URL}/loculus-info" \
     | jq -r '.organisms | keys[]'
 )
 
+if [[ ${#organisms[@]} -eq 0 ]]; then
+    echo "Error: no organisms returned by ${PATHOPLEXUS_URL}/loculus-info" >&2
+    exit 1
+fi
+
 for organism in "${organisms[@]}"; do 
     organism_fasta="$TMP_DIR/${organism}.fasta" 
     echo "Downloading ${organism}..." >&2 
-    curl "${LAPIS_URL}/${organism}/sample/unalignedNucleotideSequences?dataUseTerms=OPEN&dataFormat=fasta&versionStatus=LATEST_VERSION&isRevocation=false" | zstdcat > "$organism_fasta" 
+    curl -fsSL "${LAPIS_URL}/${organism}/sample/unalignedNucleotideSequences?dataUseTerms=OPEN&dataFormat=fasta&compression=zstd&versionStatus=LATEST_VERSION&isRevocation=false" | zstdcat > "$organism_fasta"
      
     if [[ ! -s "$organism_fasta" ]]; 
         then echo "Warning: empty FASTA returned for ${organism}; skipping." >&2 

--- a/raw-reads-processing/build-index.sh
+++ b/raw-reads-processing/build-index.sh
@@ -69,8 +69,7 @@ done
 # Add all kmers from consensus sequences to the index mask 
 # (if a higher W is used this cannot be guaranteed and led e.g. to an mpox clade 1b insertion being incorrectly not filtered out)
 deacon index \
-    build "$TEMP_INDEX" \
-    "$COMBINED_FASTA" \
+    build "$COMBINED_FASTA" \
     -k "$KMER_LEN" \
     -w 1 \
     -o "$TEMP_MASK"

--- a/raw-reads-processing/build-index.sh
+++ b/raw-reads-processing/build-index.sh
@@ -45,7 +45,7 @@ COMBINED_FASTA="$TMP_DIR/combined.fasta"
 
 mkdir -p "$(dirname "$OUTPUT_FILE")"
 
-wget https://objectstorage.uk-london-1.oraclecloud.com/n/lrbvkel2wjot/b/human-genome-bucket/o/deacon/misc/panhuman-1.k31w15c8.idx -O "$TEMP_INDEX"
+curl https://objectstorage.uk-london-1.oraclecloud.com/n/lrbvkel2wjot/b/human-genome-bucket/o/deacon/misc/panhuman-1.k31w15c8.idx > "$TEMP_INDEX"
 
 mapfile -t organisms < <(
     curl -fsSL "${PATHOPLEXUS_URL}/loculus-info" \

--- a/raw-reads-processing/src/raw_reads_processing/build-index.sh
+++ b/raw-reads-processing/src/raw_reads_processing/build-index.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PATHOPLEXUS_URL="https://pathoplexus.org"
+LAPIS_URL="https://lapis.pathoplexus.org"
+
+KMER_LEN=31
+WINDOW_SIZE=15
+
+usage() {
+    echo "Usage: $0 -o <output-index>" >&2
+    exit 2
+}
+
+OUTPUT_FILE=""
+while getopts ":o:h" opt; do
+    case "$opt" in
+        o)
+            OUTPUT_FILE="$OPTARG"
+            ;;
+        h)
+            usage
+            ;;
+        :)
+            echo "Option -$OPTARG requires an argument." >&2
+            usage
+            ;;
+        \?)
+            echo "Unknown option: -$OPTARG" >&2
+            usage
+            ;;
+    esac
+done
+
+[[ -n "$OUTPUT_FILE" ]] || {
+    echo "Missing required option: -o <output-index>" >&2
+    usage
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
+
+TEMP_INDEX="$TMP_DIR/deacon_human_kdust_filtered.idx"
+TEMP_MASK="$TMP_DIR/viral_mask.idx"
+COMBINED_FASTA="$TMP_DIR/combined.fasta"
+
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+
+wget https://objectstorage.uk-london-1.oraclecloud.com/n/lrbvkel2wjot/b/human-genome-bucket/o/deacon/misc/panhuman-1.k31w15c8.idx -O "$TEMP_INDEX"
+
+mapfile -t organisms < <(
+    curl -fsSL "${PATHOPLEXUS_URL}/loculus-info" \
+    | jq -r '.organisms | keys[]'
+)
+
+for organism in "${organisms[@]}"; do 
+    organism_fasta="$TMP_DIR/${organism}.fasta" 
+    echo "Downloading ${organism}..." >&2 
+    curl "${LAPIS_URL}/${organism}/sample/unalignedNucleotideSequences?dataUseTerms=OPEN&dataFormat=fasta&versionStatus=LATEST_VERSION&isRevocation=false" | zstdcat > "$organism_fasta" 
+     
+    if [[ ! -s "$organism_fasta" ]]; 
+        then echo "Warning: empty FASTA returned for ${organism}; skipping." >&2 
+        continue 
+    fi 
+    cat "$organism_fasta" >> "$COMBINED_FASTA" 
+    # Ensure records from separate files cannot run together. 
+    printf '\n' >> "$COMBINED_FASTA"
+done
+
+# Add all kmers from consensus sequences to the index mask 
+# (if a higher W is used this cannot be guaranteed and led e.g. to an mpox clade 1b insertion being incorrectly not filtered out)
+deacon index \
+    build "$TEMP_INDEX" \
+    "$COMBINED_FASTA" \
+    -k "$KMER_LEN" \
+    -w 1 \
+    -o "$TEMP_MASK"
+
+deacon index \
+    diff "$TEMP_INDEX" \
+    "$TEMP_MASK" \
+    -k "$KMER_LEN" \
+    -w "$WINDOW_SIZE" \
+    -o "$OUTPUT_FILE"
+
+echo "Output written to: $OUTPUT_FILE"


### PR DESCRIPTION
…es in our deacon index

Alternative to https://github.com/loculus-project/loculus/pull/7127 but masks kmers from all consensus sequences.

see discussion in https://loculus.slack.com/archives/C0ALH6CB9NY/p1787906522667209

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable