### PR TITLE
fix(e2e): Eliminate race condition by asserting row-count=1, refactor shared logic

### DIFF
--- a/integration-tests/tests/pages/search.page.ts
+++ b/integration-tests/tests/pages/search.page.ts
@@ -223,6 +223,24 @@ export class SearchPage {
         ).toBeVisible();
     }
 
+    /**
+     * Waits for the result table to settle on exactly one row (guarding against reading a
+     * stale/unfiltered result set while a filter is still being applied) and returns the
+     * accession/version of that row.
+     */
+    async getUniqueAccessionVersion(): Promise<AccessionVersion> {
+        const rows = this.getSequenceRows();
+        await expect(rows).toHaveCount(1);
+
+        const rowText = await rows.first().innerText();
+        const match = rowText.match(accessionVersionRegex);
+        if (!match) {
+            throw new Error(`Expected an accession version in the result row, got: ${rowText}`);
+        }
+        const [accession, version] = match[0].split('.');
+        return makeAccessionVersion({ accession, version: Number.parseInt(version) });
+    }
+
     async waitForSequences(role: 'link' | 'cell', name: string | RegExp) {
         while (!(await this.page.getByRole(role, { name: name }).isVisible())) {
             await this.page.reload();

--- a/integration-tests/tests/pages/search.page.ts
+++ b/integration-tests/tests/pages/search.page.ts
@@ -196,15 +196,6 @@ export class SearchPage {
         await expect(this.page.getByText('Sequence revoked successfully.')).toBeVisible();
     }
 
-    async clickOnSequenceAndGetAccession(rowIndex = 0): Promise<string | null> {
-        const rows = this.getSequenceRows();
-        const row = rows.nth(rowIndex);
-        const rowText = await row.innerText();
-        const accessionVersion = parseAccessionVersion(rowText)?.accessionVersion ?? null;
-        await row.click();
-        return accessionVersion;
-    }
-
     getSequencePreviewModal() {
         return this.page.locator('[data-testid="sequence-preview-modal"]');
     }

--- a/integration-tests/tests/pages/search.page.ts
+++ b/integration-tests/tests/pages/search.page.ts
@@ -16,6 +16,15 @@ export type AccessionVersion = { accession: string; version: number; accessionVe
 
 const accessionVersionRegex = /LOC_[A-Z0-9]+\.[0-9]+/;
 
+function parseAccessionVersion(rowText: string): AccessionVersion | undefined {
+    const match = rowText.match(accessionVersionRegex);
+    if (!match) {
+        return undefined;
+    }
+    const [accession, version] = match[0].split('.');
+    return makeAccessionVersion({ accession, version: Number.parseInt(version) });
+}
+
 export class SearchPage {
     constructor(private page: Page) {}
 
@@ -187,12 +196,11 @@ export class SearchPage {
         await expect(this.page.getByText('Sequence revoked successfully.')).toBeVisible();
     }
 
-    async clickOnSequenceAndGetAccession(rowIndex = 0): Promise<string> {
+    async clickOnSequenceAndGetAccession(rowIndex = 0): Promise<string | null> {
         const rows = this.getSequenceRows();
         const row = rows.nth(rowIndex);
         const rowText = await row.innerText();
-        const accessionVersionMatch = rowText.match(accessionVersionRegex);
-        const accessionVersion = accessionVersionMatch ? accessionVersionMatch[0] : null;
+        const accessionVersion = parseAccessionVersion(rowText)?.accessionVersion ?? null;
         await row.click();
         return accessionVersion;
     }
@@ -233,12 +241,11 @@ export class SearchPage {
         await expect(rows).toHaveCount(1);
 
         const rowText = await rows.first().innerText();
-        const match = rowText.match(accessionVersionRegex);
-        if (!match) {
+        const accessionVersion = parseAccessionVersion(rowText);
+        if (!accessionVersion) {
             throw new Error(`Expected an accession version in the result row, got: ${rowText}`);
         }
-        const [accession, version] = match[0].split('.');
-        return makeAccessionVersion({ accession, version: Number.parseInt(version) });
+        return accessionVersion;
     }
 
     async waitForSequences(role: 'link' | 'cell', name: string | RegExp) {
@@ -292,19 +299,12 @@ export class SearchPage {
         const rows = this.getSequenceRows();
         const count = await rows.count();
 
-        if (count === 0) {
-            return [];
-        }
-
         const accessions: AccessionVersion[] = [];
         for (let i = 0; i < count; i++) {
             const rowText = await rows.nth(i).innerText();
-            const match = rowText.match(accessionVersionRegex);
-            if (match) {
-                const [accession, version] = match[0].split('.');
-                accessions.push(
-                    makeAccessionVersion({ accession, version: Number.parseInt(version) }),
-                );
+            const accessionVersion = parseAccessionVersion(rowText);
+            if (accessionVersion) {
+                accessions.push(accessionVersion);
             }
         }
 

--- a/integration-tests/tests/pages/search.page.ts
+++ b/integration-tests/tests/pages/search.page.ts
@@ -22,7 +22,7 @@ function parseAccessionVersion(rowText: string): AccessionVersion | undefined {
         return undefined;
     }
     const [accession, version] = match[0].split('.');
-    return makeAccessionVersion({ accession, version: Number.parseInt(version) });
+    return makeAccessionVersion({ accession, version: Number.parseInt(version, 10) });
 }
 
 export class SearchPage {
@@ -223,13 +223,14 @@ export class SearchPage {
     }
 
     /**
-     * Waits for the result table to settle on exactly one row (guarding against reading a
-     * stale/unfiltered result set while a filter is still being applied) and returns the
-     * accession/version of that row.
+     * Waits for the result table to settle on exactly one row and returns that row's
+     * accession/version. The table keeps showing the previous results while a query is in flight,
+     * so this only catches a stale read when the previous result set had a different row count.
+     * The timeout covers the LAPIS round trip, so it must exceed the default 5s expect timeout.
      */
     async getUniqueAccessionVersion(): Promise<AccessionVersion> {
         const rows = this.getSequenceRows();
-        await expect(rows).toHaveCount(1);
+        await expect(rows).toHaveCount(1, { timeout: 30_000 });
 
         const rowText = await rows.first().innerText();
         const accessionVersion = parseAccessionVersion(rowText);

--- a/integration-tests/tests/specs/features/annotations.dependent.spec.ts
+++ b/integration-tests/tests/specs/features/annotations.dependent.spec.ts
@@ -18,8 +18,8 @@ test.describe('Sequence Preview Annotations', () => {
         await searchPage.fill('Submission ID', 'foobar');
         await searchPage.fill('Author affiliations', 'Patho Institute, Paris');
 
-        const accessionVersion = await searchPage.clickOnSequenceAndGetAccession(0);
-        const accession = accessionVersion.split('.')[0];
+        const { accession, accessionVersion } = await searchPage.getUniqueAccessionVersion();
+        await searchPage.openPreviewOfAccessionVersion(accessionVersion);
 
         await expect(page.getByTestId('sequence-preview-modal')).toBeVisible();
 

--- a/integration-tests/tests/specs/features/annotations.dependent.spec.ts
+++ b/integration-tests/tests/specs/features/annotations.dependent.spec.ts
@@ -19,7 +19,7 @@ test.describe('Sequence Preview Annotations', () => {
         await searchPage.fill('Author affiliations', 'Patho Institute, Paris');
 
         const { accession, accessionVersion } = await searchPage.getUniqueAccessionVersion();
-        await searchPage.openPreviewOfAccessionVersion(accessionVersion);
+        await searchPage.clickOnSequence();
 
         await expect(page.getByTestId('sequence-preview-modal')).toBeVisible();
 

--- a/integration-tests/tests/specs/features/search/override-hidden-fields.spec.ts
+++ b/integration-tests/tests/specs/features/search/override-hidden-fields.spec.ts
@@ -70,9 +70,7 @@ test('Override hidden fields', async ({ page, groupId }) => {
     await search.select('Collection country', 'Uganda');
     await search.enableSearchFields('Author affiliations');
     await search.fill('Author affiliations', uuid);
-    await search.expectSequenceCount(1);
-    const revokedId = await page.getByRole('link', { name: /LOC_[A-Z0-9]{2,20}\.1/ }).textContent();
-    const revokedAccession = revokedId.split('.')[0];
+    const { accession: revokedAccession } = await search.getUniqueAccessionVersion();
     const expectedRevocationAccessionVersion = `${revokedAccession}.2`;
     await page.getByRole('cell', { name: 'Uganda' }).click();
     await search.revokeSequence();

--- a/integration-tests/tests/specs/features/sequence-version-banners.spec.ts
+++ b/integration-tests/tests/specs/features/sequence-version-banners.spec.ts
@@ -87,9 +87,7 @@ test.describe('Sequence version banners', () => {
         await search.select('Collection country', 'France');
 
         // Get the accession of the sequence to revise
-        const toReviseLink = page.getByRole('link', { name: /LOC_[A-Z0-9]+\.1/ });
-        const toReviseId = await toReviseLink.textContent();
-        const toReviseAccession = toReviseId.split('.')[0];
+        const { accession: toReviseAccession } = await search.getUniqueAccessionVersion();
 
         // Click on the sequence and revise it
         await page.getByRole('cell', { name: 'France' }).click();
@@ -106,10 +104,7 @@ test.describe('Sequence version banners', () => {
         await search.select('Collection country', 'Germany');
 
         // Get the accession of the sequence to revoke
-        await search.expectSequenceCount(1);
-        const toRevokeLink = page.getByRole('link', { name: /LOC_[A-Z0-9]+\.1/ });
-        const toRevokeId = await toRevokeLink.textContent();
-        const toRevokeAccession = toRevokeId.split('.')[0];
+        const { accession: toRevokeAccession } = await search.getUniqueAccessionVersion();
 
         // Click on the sequence and revoke it (auto-approves on confirmation)
         await page.getByRole('cell', { name: 'Germany' }).click();
@@ -190,9 +185,7 @@ test.describe('Sequence version banners', () => {
         await search.enableSearchFields('Author affiliations');
         await search.fill('Author affiliations', uuid);
 
-        const seqLink = page.getByRole('link', { name: /LOC_[A-Z0-9]+\.1/ });
-        const seqId = await seqLink.textContent();
-        const accession = seqId.split('.')[0];
+        const { accession } = await search.getUniqueAccessionVersion();
 
         // Revise the sequence
         await page.getByRole('cell', { name: 'Spain' }).click();


### PR DESCRIPTION
Fixes some integration test flakes that have come up where we click without checking that the filter has been applied yet.

Flakes look like this:

```
 1) [firefox-without-dep] › tests/specs/features/sequence-version-banners.spec.ts:39:9 › Sequence version banners › shows correct banners for revoked, revocation, deprecated, and revised entries

     Error: locator.textContent: Error: strict mode violation: getByRole('link', { name: /LOC_[A-Z0-9]+\.1/ }) resolved to 2 elements:
         1) <a href="/seq/LOC_00001E5.1" class="text-primary-900 hover:text-primary-800 hover:no-underline">LOC_00001E5.1</a> aka getByRole('link', { name: 'LOC_00001E5.1' })
         2) <a href="/seq/LOC_00001D7.1" class="text-primary-900 hover:text-primary-800 hover:no-underline">LOC_00001D7.1</a> aka getByRole('link', { name: 'LOC_00001D7.1' })

     Call log:
       - waiting for getByRole('link', { name: /LOC_[A-Z0-9]+\.1/ })


       89 |         // Get the accession of the sequence to revise
       90 |         const toReviseLink = page.getByRole('link', { name: /LOC_[A-Z0-9]+\.1/ });
     > 91 |         const toReviseId = await toReviseLink.textContent();
          |                                               ^
       92 |         const toReviseAccession = toReviseId.split('.')[0];
       93 |
       94 |         // Click on the sequence and revise it
         at /home/runner/work/loculus/loculus/integration-tests/tests/specs/features/sequence-version-banners.spec.ts:91:47
```

🚀 Preview: Add `preview` label to enable