### PR TITLE
feat(raw-reads-processing): use the deacon Python bindings instead of the CLI server

### DIFF
--- a/raw-reads-processing/config/defaults.yaml
+++ b/raw-reads-processing/config/defaults.yaml
@@ -1,7 +1,7 @@
 log_level: DEBUG
 s3_request_timeout_seconds: 300
-deacon_filter_timeout_seconds: 600
 read_validation_timeout_seconds: 300
+max_input_file_bytes: 21474836480 # 20GiB per file; bounds deacon runtime now that an in-process filter call cannot be timed out
 file_service_host: "0.0.0.0"
 deacon_max_host_reads_proportion: 0.1
 deacon_max_host_bp: 300000 # 300kBp - or 10^-4 coverage of the human genome
@@ -10,3 +10,7 @@ deacon_a: 2
 short_reads_threshold: 90 # (31 + 15 - 1) x 2 = 90bp
 deacon_a_short_reads: 1 # k-mer threshold used instead of deacon_a when reads are short
 deacon_r: 0.05
+# Threads per filter call x concurrent filters is the pod's deacon thread budget.
+# Starting values only - tune against a real preview instance.
+deacon_threads: 4
+deacon_max_concurrent_filters: 2

--- a/raw-reads-processing/environment.yml
+++ b/raw-reads-processing/environment.yml
@@ -4,6 +4,7 @@ channels:
   - bioconda
 dependencies:
   - biopython=1.88
+  - deacon=0.17.0 # CLI, used only by build-index.sh; the service itself uses the Python bindings (see pyproject.toml)
   - fastapi=0.135.1
   - pydantic=2.12.5
   - pytest=9.0.2
@@ -13,6 +14,5 @@ dependencies:
   - uv=0.10.9
   - uvicorn=0.41.0
   - pyyaml=6.0.3
-  - deacon=0.17.0
   - openjdk=21
   - xopen=2.1.0

--- a/raw-reads-processing/pyproject.toml
+++ b/raw-reads-processing/pyproject.toml
@@ -4,6 +4,8 @@
 name = "raw_reads_processing"
 version = "0.1.0"
 requires-python = ">=3.12"
+# The bindings are PyPI-only; keep in step with the conda CLI pin in environment.yml.
+dependencies = ["deacon==0.17.0"]
 
 [project.scripts]
 raw_reads_processing = "raw_reads_processing.__main__:run"

--- a/raw-reads-processing/src/raw_reads_processing/__main__.py
+++ b/raw-reads-processing/src/raw_reads_processing/__main__.py
@@ -4,7 +4,7 @@ import click
 
 from .api import start_api
 from .config import get_config
-from .deacon import prepare_deacon_index, start_deacon_server
+from .deacon import DeaconFilter, load_deacon_index
 
 logger = logging.getLogger(__name__)
 
@@ -23,12 +23,11 @@ def run(config_file: str):
     logging.getLogger("requests").setLevel(logging.INFO)
     logger.info(f"Config: {config}")
 
-    logger.info("Preparing deacon index and starting deacon server...")
-    prepare_deacon_index()
-    deacon_process = start_deacon_server()
+    # Load before the API binds, so the pod is only ready once filtering can work.
+    deacon_filter = DeaconFilter(load_deacon_index(), config)
 
     logger.info("Starting API...")
-    start_api(config, deacon_process)
+    start_api(config, deacon_filter)
 
 
 if __name__ == "__main__":

--- a/raw-reads-processing/src/raw_reads_processing/api.py
+++ b/raw-reads-processing/src/raw_reads_processing/api.py
@@ -23,9 +23,9 @@ def read_root() -> dict[str, str]:
 
 @app.get("/health")
 def health() -> dict[str, str]:
-    # The index lives in this process, so "we are serving and the index is loaded" is
-    # the whole health condition; there is no separate daemon that can die or wedge
-    # underneath us while the process stays up.
+    # The index lives in this process, so there is no separate daemon that can die or
+    # wedge underneath us. This does not cover a filter call that hangs in-process:
+    # that leaks a concurrency slot while /health keeps answering 200.
     if getattr(app.state, "deacon_filter", None) is None:
         raise HTTPException(status_code=503, detail="Deacon index is not loaded")
     return {"message": "Deacon index is loaded"}

--- a/raw-reads-processing/src/raw_reads_processing/api.py
+++ b/raw-reads-processing/src/raw_reads_processing/api.py
@@ -1,10 +1,10 @@
 import logging
-import subprocess  # noqa: S404
 
-from raw_reads_processing.errors import InvalidSubmission, ProcessingFailure
 import uvicorn
 from fastapi import FastAPI, HTTPException
 from raw_reads_processing.datatypes import RequestWithFiles, ValidationResult
+from raw_reads_processing.deacon import DeaconFilter
+from raw_reads_processing.errors import InvalidSubmission, ProcessingFailure
 from raw_reads_processing.process_files import validate_raw_reads_submission
 
 from .config import Config
@@ -23,9 +23,12 @@ def read_root() -> dict[str, str]:
 
 @app.get("/health")
 def health() -> dict[str, str]:
-    if app.state.deacon_process.poll() is not None:
-        raise HTTPException(status_code=503, detail="Deacon server process has exited")
-    return {"message": "Deacon server is running"}
+    # The index lives in this process, so "we are serving and the index is loaded" is
+    # the whole health condition; there is no separate daemon that can die or wedge
+    # underneath us while the process stays up.
+    if getattr(app.state, "deacon_filter", None) is None:
+        raise HTTPException(status_code=503, detail="Deacon index is not loaded")
+    return {"message": "Deacon index is loaded"}
 
 
 @app.post("/process-files")
@@ -35,6 +38,7 @@ def process_files(
     try:
         validate_raw_reads_submission(
             config=app.state.config,
+            deacon_filter=app.state.deacon_filter,
             request_with_files=payload,
         )
     except InvalidSubmission as e:
@@ -44,17 +48,20 @@ def process_files(
     return ValidationResult()
 
 
-def init_app(config: Config, deacon_process: subprocess.Popen):
+def init_app(config: Config, deacon_filter: DeaconFilter):
     app.state.config = config
-    app.state.deacon_process = deacon_process
+    app.state.deacon_filter = deacon_filter
 
 
-def start_api(config: Config, deacon_process: subprocess.Popen):
-    init_app(config, deacon_process)
+def start_api(config: Config, deacon_filter: DeaconFilter):
+    init_app(config, deacon_filter)
     host = config.file_service_host or "127.0.0.1"
     port = config.file_service_port or 5000
     logger.info(f"Starting raw reads processing service API on port {port}")
 
+    # workers=1 is load-bearing, not incidental: the deacon index is ~4.5GB on this
+    # process's heap and is shared between requests by threads, not by processes.
+    # A second worker would load a second copy and exceed the pod's memory limit.
     uvicorn_config = uvicorn.Config(
         app, host=host, port=port, log_level="info", workers=1
     )

--- a/raw-reads-processing/src/raw_reads_processing/config.py
+++ b/raw-reads-processing/src/raw_reads_processing/config.py
@@ -8,7 +8,9 @@ class Config(BaseModel):
     log_level: str
     s3_request_timeout_seconds: int
     read_validation_timeout_seconds: int
-    deacon_filter_timeout_seconds: int
+    # deacon runs in-process, so a released-GIL filter call cannot be interrupted the
+    # way a subprocess could be killed on timeout; input size is what bounds its runtime.
+    max_input_file_bytes: int
     file_service_host: str | None = None
     file_service_port: int | None = None
 
@@ -28,6 +30,8 @@ class Config(BaseModel):
     deacon_r: float = (
         0.05  # relative proportion of k-mers in a read that need to map to index
     )
+    deacon_threads: int = 4  # worker threads within a single deacon filter call
+    deacon_max_concurrent_filters: int = 2  # filter calls allowed to run at once
 
 
 def get_config(config_file: str | Path) -> Config:

--- a/raw-reads-processing/src/raw_reads_processing/datatypes.py
+++ b/raw-reads-processing/src/raw_reads_processing/datatypes.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass, fields
-import json
-from pathlib import Path
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -40,8 +39,6 @@ class DeaconSummary:
     bp_out_proportion: float
 
     @classmethod
-    def from_json(cls, json_path: Path):
-        with open(json_path, encoding="utf-8") as f:
-            data = json.load(f)
+    def from_dict(cls, data: dict[str, Any]):
         wanted = {f.name for f in fields(cls)}
         return cls(**{k: v for k, v in data.items() if k in wanted})

--- a/raw-reads-processing/src/raw_reads_processing/deacon.py
+++ b/raw-reads-processing/src/raw_reads_processing/deacon.py
@@ -2,57 +2,84 @@ import itertools
 import logging
 import os
 import statistics
-import subprocess  # noqa: S404
 from pathlib import Path
+from threading import BoundedSemaphore
 from typing import cast
 
 from Bio.SeqIO.QualityIO import FastqGeneralIterator
+from deacon import Index
 from xopen import xopen
 
 from raw_reads_processing.config import Config
 from raw_reads_processing.datatypes import Annotation, DeaconSummary, FileName
-from raw_reads_processing.errors import InvalidSubmission, ProcessingFailure
+from raw_reads_processing.errors import InvalidSubmission
 
 logger = logging.getLogger(__name__)
 
 DEACON_INDEX_PATH = os.environ.get("DEACON_INDEX_PATH", "/data/deacon.idx")
 
 
-def prepare_deacon_index() -> None:
+def load_deacon_index() -> Index:
+    """Load the deacon index into this process, once, at startup.
+
+    The index is a full in-memory deserialize (~4.5GB peak RSS for panhuman-1), not an
+    mmap, so every process that loads it pays for its own copy. There must be exactly
+    one, which is why the API is pinned to a single uvicorn worker (see api.py).
+    """
     if not Path(DEACON_INDEX_PATH).is_file():
         raise RuntimeError(
             f"Deacon index not found at '{DEACON_INDEX_PATH}'. Please ensure the deacon index is mounted at the correct path."
         )
+    logger.info(f"Loading deacon index from '{DEACON_INDEX_PATH}' (takes ~5-30s)")
+    index = Index(DEACON_INDEX_PATH)
+    logger.info(f"Loaded deacon index: {index.info()}")
+    return index
 
 
-def start_deacon_server() -> subprocess.Popen:
-    args = [
-        "deacon",
-        "server",
-        "start",
-    ]
-    logger.debug("Starting Deacon server")
+class DeaconFilter:
+    """The one loaded index, plus a cap on how many filters run against it at once.
 
-    return subprocess.Popen(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)  # noqa: S603
+    deacon.Index is immutable and releases the GIL while filtering, so a single index
+    can serve concurrent requests from the FastAPI threadpool in genuine parallel
+    without duplicating it in memory. The semaphore is what stops that threadpool
+    (~40 slots) from multiplying deacon_threads into hundreds of worker threads.
+    """
 
+    def __init__(self, index: Index, config: Config):
+        self._index = index
+        self._threads = config.deacon_threads
+        self._slots = BoundedSemaphore(config.deacon_max_concurrent_filters)
 
-def stop_deacon_server(proc: subprocess.Popen) -> None:
-    args = ["deacon", "--use-server", "server", "stop"]
-    logger.debug("Stopping Deacon server")
+    def run(
+        self, file_name_to_path: dict[FileName, Path], config: Config
+    ) -> DeaconSummary:
+        # Files arrive in submission order, so the first is R1 and an optional second
+        # is R2. Name them explicitly: deacon treats two inputs as mates of one pair.
+        paths = list(file_name_to_path.values())
+        read1 = str(paths[0])
+        read2 = str(paths[1]) if len(paths) > 1 else None
 
-    subprocess.run(  # noqa: S603
-        args,
-        check=False,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+        deacon_a = _deacon_a_for_reads(file_name_to_path, config)
+        logger.debug(
+            f"Running deacon filter on '{', '.join(str(f) for f in file_name_to_path)}' "
+            f"with -a {deacon_a} -r {config.deacon_r}, threads={self._threads}"
+        )
 
-    try:
-        proc.wait(timeout=5)
-    except subprocess.TimeoutExpired:
-        logger.warning("Failed to stop Deacon server gracefully, sending SIGKILL")
-        proc.kill()
-        proc.wait()
+        with self._slots:
+            summary = self._index.filter(
+                read1,
+                input2=read2,
+                deplete=False,
+                # Search mode keeps the reads that MATCH the human index, so the output
+                # is human sequence: discard it rather than letting it reach stdout.
+                output=os.devnull,
+                output2=os.devnull if read2 else None,
+                abs_threshold=deacon_a,
+                rel_threshold=config.deacon_r,
+                threads=self._threads,
+                quiet=True,
+            )
+        return DeaconSummary.from_dict(summary)
 
 
 _READ_LENGTH_SAMPLE_SIZE = 100
@@ -101,51 +128,6 @@ def _deacon_a_for_reads(file_name_to_path: dict[FileName, Path], config: Config)
     return deacon_a
 
 
-def run_deacon_filter(
-    file_name_to_path: dict[FileName, Path], data_dir: str, config: Config
-) -> DeaconSummary:
-    summary_json_path = Path(data_dir) / "summary.json"
-    deacon_a = _deacon_a_for_reads(file_name_to_path, config)
-    args = [
-        "deacon",
-        "--use-server",
-        "filter",
-        "--summary",
-        summary_json_path,
-        "-a",
-        str(deacon_a),
-        "-r",
-        str(config.deacon_r),
-        DEACON_INDEX_PATH,
-        *file_name_to_path.values(),
-    ]
-    logger.debug(
-        f"Running Deacon filter on '{', '.join(str(f) for f in file_name_to_path.keys())}': {args}"
-    )
-
-    try:
-        subprocess.run(  # noqa: S603
-            args,
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=config.deacon_filter_timeout_seconds,
-        )
-        return DeaconSummary.from_json(summary_json_path)
-    except subprocess.TimeoutExpired:
-        message = (
-            f"Validation of files '{','.join(str(f) for f in file_name_to_path.values())}' "
-            f"timed out after {config.deacon_filter_timeout_seconds} seconds."
-        )
-        logger.error(message)
-        raise ProcessingFailure(message) from None
-    except subprocess.CalledProcessError as error:
-        # TODO: send a slack notification to alert the team that deacon is failing
-        message = f"Deacon filter failed with exit code {error.returncode}."
-        logger.error(message + f" stdout: {error.stdout} stderr: {error.stderr}")
-        raise ProcessingFailure(message) from error
-
-
 # TODO: Add a link to the documentation for removing host reads
 DEACON_ERROR_PROMPT = (
     "We cannot accept files with a high proportion of human reads, as they may contain "
@@ -180,12 +162,10 @@ def log_deacon_summary(deacon_summary: DeaconSummary, config: Config) -> None:
     )
 
 
-def validate_with_deacon(files: dict[FileName, Path], data_dir: str, config: Config):
-    deacon_summary = run_deacon_filter(
-        files,
-        data_dir=data_dir,
-        config=config,
-    )
+def validate_with_deacon(
+    deacon_filter: DeaconFilter, files: dict[FileName, Path], config: Config
+) -> None:
+    deacon_summary = deacon_filter.run(files, config)
     log_deacon_summary(deacon_summary, config)
 
     if deacon_summary.seqs_out_proportion > cast(

--- a/raw-reads-processing/src/raw_reads_processing/deacon.py
+++ b/raw-reads-processing/src/raw_reads_processing/deacon.py
@@ -12,7 +12,7 @@ from xopen import xopen
 
 from raw_reads_processing.config import Config
 from raw_reads_processing.datatypes import Annotation, DeaconSummary, FileName
-from raw_reads_processing.errors import InvalidSubmission
+from raw_reads_processing.errors import InvalidSubmission, ProcessingFailure
 
 logger = logging.getLogger(__name__)
 
@@ -65,20 +65,29 @@ class DeaconFilter:
             f"with -a {deacon_a} -r {config.deacon_r}, threads={self._threads}"
         )
 
-        with self._slots:
-            summary = self._index.filter(
-                read1,
-                input2=read2,
-                deplete=False,
-                # Search mode keeps the reads that MATCH the human index, so the output
-                # is human sequence: discard it rather than letting it reach stdout.
-                output=os.devnull,
-                output2=os.devnull if read2 else None,
-                abs_threshold=deacon_a,
-                rel_threshold=config.deacon_r,
-                threads=self._threads,
-                quiet=True,
-            )
+        try:
+            with self._slots:
+                summary = self._index.filter(
+                    read1,
+                    input2=read2,
+                    deplete=False,
+                    # Search mode keeps the reads that MATCH the human index, so the
+                    # output is human sequence: discard it rather than let it reach
+                    # this process's stdout, which is the pod log.
+                    output=os.devnull,
+                    output2=os.devnull if read2 else None,
+                    abs_threshold=deacon_a,
+                    rel_threshold=config.deacon_r,
+                    threads=self._threads,
+                    quiet=True,
+                )
+        except Exception as error:
+            # Unreadable or mismatched input reaches us as a RuntimeError carrying
+            # deacon's own message; the index and the process are unaffected.
+            # TODO: send a slack notification to alert the team that deacon is failing
+            message = f"Deacon filter failed: {error}"
+            logger.error(message)
+            raise ProcessingFailure(message) from error
         return DeaconSummary.from_dict(summary)
 
 
@@ -96,13 +105,19 @@ def median_read_length(
     Read length should be homogeneous within a sequencing run, so a small sample from
     the start of the file is representative and costs only a few milliseconds.
     """
-    with xopen(path, "rt", threads=0) as fh:
-        lengths = [
-            len(seq)
-            for _, seq, _ in itertools.islice(FastqGeneralIterator(fh), sample_size)
-        ]
+    message = f"Failed to determine median read length for file '{file_name}'. File may be empty or corrupted."
+    try:
+        with xopen(path, "rt", threads=0) as fh:
+            lengths = [
+                len(seq)
+                for _, seq, _ in itertools.islice(FastqGeneralIterator(fh), sample_size)
+            ]
+    except (ValueError, OSError) as error:
+        logging.error(f"{message} {error}")
+        raise InvalidSubmission(
+            Annotation(fileNames=[file_name], message=message)
+        ) from error
     if not lengths:
-        message = f"Failed to determine median read length for file '{file_name}'. File may be empty or corrupted."
         logging.error(message)
         raise InvalidSubmission(Annotation(fileNames=[file_name], message=message))
     return statistics.median(lengths)

--- a/raw-reads-processing/src/raw_reads_processing/process_files.py
+++ b/raw-reads-processing/src/raw_reads_processing/process_files.py
@@ -10,13 +10,13 @@ from raw_reads_processing.datatypes import (
     FileName,
     RequestWithFiles,
 )
-from raw_reads_processing.errors import ProcessingFailure
+from raw_reads_processing.deacon import DeaconFilter, validate_with_deacon
+from raw_reads_processing.errors import InvalidSubmission, ProcessingFailure
 from raw_reads_processing.file_format_validation import (
     validate_file_extensions,
     validate_file_numbers,
     validate_with_readtools,
 )
-from raw_reads_processing.deacon import validate_with_deacon
 
 logger = logging.getLogger(__name__)
 
@@ -30,8 +30,25 @@ def download_file(
             file.url, stream=True, timeout=config.s3_request_timeout_seconds
         ) as response:
             response.raise_for_status()
+            written = 0
             with save_path.open("wb") as f:
-                f.writelines(response.iter_content(chunk_size=1024 * 1024))
+                for chunk in response.iter_content(chunk_size=1024 * 1024):
+                    written += len(chunk)
+                    # Stop as soon as the cap is passed rather than after writing the
+                    # whole file: this bound is what replaces the deacon filter timeout,
+                    # and it also keeps an oversized upload off the pod's disk.
+                    if written > config.max_input_file_bytes:
+                        raise InvalidSubmission(
+                            Annotation(
+                                fileNames=[file.name],
+                                message=(
+                                    f"File '{file.name}' is larger than the maximum accepted size of "
+                                    f"{config.max_input_file_bytes} bytes. Please split the submission "
+                                    "into smaller files."
+                                ),
+                            )
+                        )
+                    f.write(chunk)
     except requests.RequestException as e:
         message = f"Error downloading file '{file.name}' from S3: {e}"
         logger.error(message)
@@ -41,6 +58,7 @@ def download_file(
 
 def validate_raw_reads_submission(
     config: Config,
+    deacon_filter: DeaconFilter,
     request_with_files: RequestWithFiles,
 ) -> None:
     files = request_with_files.files
@@ -62,4 +80,4 @@ def validate_raw_reads_submission(
         validate_with_readtools(
             local_files, file_format, config.read_validation_timeout_seconds
         )
-        validate_with_deacon(local_files, tmp_dir, config)
+        validate_with_deacon(deacon_filter, local_files, config)

--- a/raw-reads-processing/test/test_api.py
+++ b/raw-reads-processing/test/test_api.py
@@ -28,11 +28,11 @@ def client():
             log_level="INFO",
             s3_request_timeout_seconds=10,
             read_validation_timeout_seconds=10,
-            deacon_filter_timeout_seconds=10,
+            max_input_file_bytes=1_000_000,
             deacon_max_host_reads_proportion=0.05,
             deacon_max_host_bp=1000,
         ),
-        deacon_process=Mock(poll=Mock(return_value=None)),
+        deacon_filter=Mock(),
     )
     return TestClient(api.app)
 
@@ -79,14 +79,14 @@ def test_processing_failure_is_returned_as_internal_server_error(client, monkeyp
     assert response.json() == {"detail": "readtools jar not found"}
 
 
-def test_health_is_ok_while_deacon_process_is_alive(client):
+def test_health_is_ok_once_the_index_is_loaded(client):
     response = client.get("/health")
 
     assert response.status_code == 200
 
 
-def test_health_is_unavailable_once_deacon_process_has_exited(client):
-    api.app.state.deacon_process.poll.return_value = 1  # exit code of the dead process
+def test_health_is_unavailable_before_the_index_is_loaded(client):
+    api.app.state.deacon_filter = None
 
     response = client.get("/health")
 

--- a/raw-reads-processing/test/test_config.py
+++ b/raw-reads-processing/test/test_config.py
@@ -1,0 +1,16 @@
+# ruff: noqa: S101
+
+from raw_reads_processing.config import get_config
+
+
+def test_defaults_yaml_alone_satisfies_every_required_config_field(tmp_path):
+    # Nothing else exercises get_config, so a key missing from defaults.yaml would
+    # otherwise only show up as a pydantic ValidationError at pod startup.
+    empty = tmp_path / "config.yaml"
+    empty.write_text("{}\n")
+
+    config = get_config(empty)
+
+    assert config.max_input_file_bytes > 0
+    assert config.deacon_threads > 0
+    assert config.deacon_max_concurrent_filters > 0

--- a/raw-reads-processing/test/test_deacon.py
+++ b/raw-reads-processing/test/test_deacon.py
@@ -1,11 +1,13 @@
 # ruff: noqa: S101
 
 import gzip
-import shutil
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
+from deacon import Index
 from raw_reads_processing import deacon as deacon_module, process_files
 from raw_reads_processing.config import Config
 from raw_reads_processing.datatypes import (
@@ -20,7 +22,7 @@ def _config() -> Config:
         log_level="DEBUG",
         s3_request_timeout_seconds=10,
         read_validation_timeout_seconds=10,
-        deacon_filter_timeout_seconds=10,
+        max_input_file_bytes=1_000_000,
         deacon_max_host_reads_proportion=0.05,
         deacon_max_host_bp=1000,
     )
@@ -65,27 +67,17 @@ def mock_downstream(monkeypatch):
     monkeypatch.setattr(process_files, "validate_with_readtools", lambda *a, **k: None)
 
 
-@pytest.fixture
-def deacon_server():
-    """Run validate_raw_reads_submission's deacon step against the real deacon
-    binary and the checked-in fixture index, instead of mocking it, so these
-    tests exercise the actual threshold/warning boundary logic end-to-end.
+@pytest.fixture(scope="session")
+def deacon_filter():
+    """Filter against the real bindings and the checked-in fixture index, instead of
+    mocking, so these tests exercise the actual threshold/warning boundary logic
+    end-to-end. Session-scoped because the index is loaded once per process, which is
+    exactly how the service uses it.
+
+    Index created with `deacon index build test/fixtures/test_small_1.fastq -k 31 -w 15 -o deacon.idx`
     """
-    if shutil.which("deacon") is None:
-        pytest.skip("deacon binary not found on PATH")
-    proc = deacon_module.start_deacon_server()
-    time.sleep(1)  # give the server a moment to start listening
-    try:
-        yield
-    finally:
-        deacon_module.stop_deacon_server(proc)
-
-
-@pytest.fixture
-def deacon_index(monkeypatch, deacon_server):
-    # Index created with `deacon index build test/fixtures/test_small_1.fastq -k 31 -w 15 -o deacon.idx`
-    monkeypatch.setattr(
-        deacon_module, "DEACON_INDEX_PATH", str(FIXTURES_DIR / "deacon.idx")
+    return deacon_module.DeaconFilter(
+        Index(str(FIXTURES_DIR / "deacon.idx")), _config()
     )
 
 
@@ -137,8 +129,8 @@ def test_deacon_a_for_reads_raises_when_read_length_cannot_be_parsed(tmp_path):
     assert "Failed to determine median read length" in exc_info.value.error.message
 
 
-@pytest.mark.usefixtures("mock_downstream", "deacon_index")
-def test_host_reads_above_threshold_is_an_error(tmp_path):
+@pytest.mark.usefixtures("mock_downstream")
+def test_host_reads_above_threshold_is_an_error(tmp_path, deacon_filter):
     # 3/4 reads (75%) are reused verbatim from test_small_1.fastq, so they hit
     # deacon.idx; config's deacon_max_host_reads_proportion is 0.05, so 75% > 5%.
     host_reads = _parse_fastq_records(FIXTURES_DIR / "test_small_1.fastq")[:3]
@@ -150,12 +142,12 @@ def test_host_reads_above_threshold_is_an_error(tmp_path):
         files=[_file("reads.fastq", url=str(reads))],
     )
     with pytest.raises(InvalidSubmission) as exc_info:
-        process_files.validate_raw_reads_submission(_config(), files)
+        process_files.validate_raw_reads_submission(_config(), deacon_filter, files)
     assert deacon_module.DEACON_ERROR_PROMPT in exc_info.value.error.message
 
 
-@pytest.mark.usefixtures("mock_downstream", "deacon_index")
-def test_host_reads_at_or_below_threshold_passes(tmp_path):
+@pytest.mark.usefixtures("mock_downstream")
+def test_host_reads_at_or_below_threshold_passes(tmp_path, deacon_filter):
     # 1/20 reads (5%) is reused verbatim from test_small_1.fastq, so it hits
     # deacon.idx; config's deacon_max_host_reads_proportion is 0.05, so this
     # lands exactly at the threshold: not > 0.05, so no error should be raised.
@@ -167,5 +159,50 @@ def test_host_reads_at_or_below_threshold_passes(tmp_path):
         accessionVersion="accession.1",
         files=[_file("reads.fastq", url=str(reads))],
     )
-    result = process_files.validate_raw_reads_submission(_config(), files)
+    result = process_files.validate_raw_reads_submission(
+        _config(), deacon_filter, files
+    )
     assert result is None  # no error raised
+
+
+class _CountingIndex:
+    """Stands in for deacon.Index, recording how many filters overlap."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.in_flight = 0
+        self.max_in_flight = 0
+
+    def filter(self, *args, **kwargs):
+        with self._lock:
+            self.in_flight += 1
+            self.max_in_flight = max(self.max_in_flight, self.in_flight)
+        time.sleep(0.05)
+        with self._lock:
+            self.in_flight -= 1
+        return {
+            "time": 0.0,
+            "seqs_in": 1,
+            "seqs_out": 0,
+            "seqs_out_proportion": 0.0,
+            "bp_in": 1,
+            "bp_out": 0,
+            "bp_out_proportion": 0.0,
+        }
+
+
+def test_concurrent_filters_are_capped_at_the_configured_limit(tmp_path):
+    # The FastAPI threadpool has ~40 slots; without this cap each of them could start
+    # its own deacon_threads worth of filter threads.
+    config = _config().model_copy(update={"deacon_max_concurrent_filters": 2})
+    index = _CountingIndex()
+    deacon_filter = deacon_module.DeaconFilter(index, config)
+    reads = tmp_path / "reads.fastq"
+    _write_fastq(reads, [_random_read(150)])
+    files = {"reads.fastq": reads}
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        for future in [pool.submit(deacon_filter.run, files, config) for _ in range(8)]:
+            future.result()
+
+    assert index.max_in_flight == 2

--- a/raw-reads-processing/test/test_deacon.py
+++ b/raw-reads-processing/test/test_deacon.py
@@ -14,7 +14,7 @@ from raw_reads_processing.datatypes import (
     FileIdAndNameAndReadUrl,
     RequestWithFiles,
 )
-from raw_reads_processing.errors import InvalidSubmission
+from raw_reads_processing.errors import InvalidSubmission, ProcessingFailure
 
 
 def _config() -> Config:
@@ -206,3 +206,64 @@ def test_concurrent_filters_are_capped_at_the_configured_limit(tmp_path):
             future.result()
 
     assert index.max_in_flight == 2
+
+
+def test_mismatched_pair_lengths_fail_the_submission_without_killing_the_index(
+    tmp_path, deacon_filter
+):
+    # deacon treats two inputs as mates of one pair and errors when they run out of
+    # step. Under the old server this killed the daemon and every later request with
+    # it; in-process it is an ordinary exception and the index stays usable.
+    read1, read2 = tmp_path / "reads_1.fastq", tmp_path / "reads_2.fastq"
+    _write_fastq(read1, [_random_read() for _ in range(1000)])
+    _write_fastq(read2, [_random_read() for _ in range(400)])
+
+    with pytest.raises(ProcessingFailure) as exc_info:
+        deacon_filter.run({"reads_1.fastq": read1, "reads_2.fastq": read2}, _config())
+
+    assert "Incompatible record set sizes" in str(exc_info.value)
+
+    healthy = tmp_path / "healthy.fastq"
+    _write_fastq(healthy, [_random_read()])
+    assert deacon_filter.run({"healthy.fastq": healthy}, _config()).seqs_in == 1
+
+
+@pytest.mark.parametrize(
+    ("description", "contents"),
+    [
+        ("truncated final record", "@r1\nACGT\n+\n"),
+        ("not fastq at all", "this is not a fastq file\n"),
+    ],
+)
+def test_unreadable_input_is_reported_to_the_submitter(
+    tmp_path, deacon_filter, description, contents
+):
+    # Malformed FASTQ never reaches deacon: sampling the read length to pick -a trips
+    # over it first, and that has to be an annotation rather than an unhandled 500.
+    unreadable = tmp_path / "reads.fastq"
+    unreadable.write_text(contents)
+
+    with pytest.raises(InvalidSubmission) as exc_info:
+        deacon_filter.run({"reads.fastq": unreadable}, _config())
+
+    assert "may be empty or corrupted" in exc_info.value.error.message
+
+
+def test_a_failing_filter_releases_its_concurrency_slot(tmp_path):
+    # The semaphore is held with `with`, so a raising filter must not leak a slot;
+    # leaking every slot would wedge all later requests.
+    config = _config().model_copy(update={"deacon_max_concurrent_filters": 1})
+    deacon_filter = deacon_module.DeaconFilter(_ExplodingIndex(), config)
+    reads = tmp_path / "reads.fastq"
+    _write_fastq(reads, [_random_read()])
+
+    for _ in range(3):
+        with pytest.raises(ProcessingFailure):
+            deacon_filter.run({"reads.fastq": reads}, config)
+
+    assert deacon_filter._slots.acquire(blocking=False)  # noqa: SLF001
+
+
+class _ExplodingIndex:
+    def filter(self, *args, **kwargs):
+        raise RuntimeError("Incompatible record set sizes: 1024 != 1000")

--- a/raw-reads-processing/test/test_process_files.py
+++ b/raw-reads-processing/test/test_process_files.py
@@ -1,0 +1,68 @@
+# ruff: noqa: S101
+
+import pytest
+from raw_reads_processing import process_files
+from raw_reads_processing.config import Config
+from raw_reads_processing.datatypes import FileIdAndNameAndReadUrl
+from raw_reads_processing.errors import InvalidSubmission
+
+
+def _config(max_input_file_bytes: int) -> Config:
+    return Config(
+        log_level="DEBUG",
+        s3_request_timeout_seconds=10,
+        read_validation_timeout_seconds=10,
+        max_input_file_bytes=max_input_file_bytes,
+        deacon_max_host_reads_proportion=0.05,
+        deacon_max_host_bp=1000,
+    )
+
+
+class _FakeResponse:
+    def __init__(self, chunks: list[bytes]):
+        self._chunks = chunks
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def iter_content(self, chunk_size: int):
+        yield from self._chunks
+
+
+@pytest.fixture
+def four_chunks_of_ten_bytes(monkeypatch):
+    monkeypatch.setattr(
+        process_files.requests,
+        "get",
+        lambda *a, **k: _FakeResponse([b"x" * 10] * 4),
+    )
+
+
+@pytest.mark.usefixtures("four_chunks_of_ten_bytes")
+def test_download_under_the_size_cap_is_kept(tmp_path):
+    save_path = tmp_path / "reads.fastq"
+    file = FileIdAndNameAndReadUrl(fileId="1", name="reads.fastq", url="http://s3/x")
+
+    process_files.download_file(_config(40), file, save_path)
+
+    assert save_path.stat().st_size == 40
+
+
+@pytest.mark.usefixtures("four_chunks_of_ten_bytes")
+def test_download_over_the_size_cap_is_rejected_before_it_completes(tmp_path):
+    # The size cap is what bounds deacon's runtime now that an in-process filter call
+    # cannot be killed on a timeout, so it has to stop mid-stream rather than after.
+    save_path = tmp_path / "reads.fastq"
+    file = FileIdAndNameAndReadUrl(fileId="1", name="reads.fastq", url="http://s3/x")
+
+    with pytest.raises(InvalidSubmission) as exc_info:
+        process_files.download_file(_config(25), file, save_path)
+
+    assert "larger than the maximum accepted size" in exc_info.value.error.message
+    assert save_path.stat().st_size < 40  # aborted, not written in full


### PR DESCRIPTION
The service ran a `deacon server` subprocess and shelled out to `deacon --use-server filter` once per request. The same deacon release (0.17.0) is published on PyPI with Python bindings, which load the index into our own process and filter against it directly. Same index, same thresholds, same verdicts — no daemon and no socket in between.

## Why

Server mode is the only way the CLI can share one loaded index, and it is fragile in exactly the way that matters for a service. A client that disconnects before finishing a request puts the daemon into a busy loop it never recovers from: the process stays alive so the liveness probe keeps passing, but every later filter hangs. When the daemon does die it leaves its socket file behind, so subsequent calls fail with a misleading "connection refused" instead of anything about deacon. And any error inside the daemon reaches us as an uninformative panic, because the protocol between client and server has no way to express an error at all. On top of that the daemon handles one request at a time, so our concurrent requests queued up behind each other.

All of that is gone. There is no second process to die, wedge, or lose its socket, and errors arrive as ordinary Python exceptions with real messages.

It is also faster, because requests now filter in parallel instead of queueing. The bindings hold the index immutably and release the interpreter lock while filtering, so one loaded index serves many threads at once without being copied.

Measured against the real 3.28 GB panhuman index, driving the actual service over HTTP with 602,800 read pairs per request:

| concurrent requests | wall clock | filtering work done | peak memory |
| --- | --- | --- | --- |
| 1 | 0.25 s | 0.25 s | 4.61 GB |
| 4 | 0.51 s | 1.60 s | 4.64 GB |
| 8 | 0.99 s | 5.26 s | 4.65 GB |

Memory stays flat as concurrency rises, which is the point: there is one index in RAM, not one per request. Index load at startup is about 5 seconds warm and 30 seconds cold, well inside the startup probe's budget.

## What a reviewer should look at

**One index now means one process.** The index is roughly 4.5 GB deserialised onto the heap, not memory-mapped, so each process that loads it pays for its own copy. Sharing between requests is now between threads rather than between processes — which is what the socket bought us before. That costs nothing today because we already run a single replica with a single uvicorn worker, but it makes `workers=1` load-bearing rather than incidental: a second worker would quietly load a second copy and blow the pod's 8Gi limit. There is a comment at the uvicorn config saying so. If we ever want several workers or several pods sharing one index, this is the wrong approach and we should talk about it before scaling.

**The filter call can no longer be timed out, so `deacon_filter_timeout_seconds` is gone.** Killing a subprocess on timeout was straightforward; a call that has handed control to Rust and released the interpreter lock cannot be interrupted from Python at all. Rather than leave a config key that silently does nothing, the bound is now on input size: `max_input_file_bytes` (20 GiB, per file) is checked while the file downloads, so an oversized submission is rejected before it reaches disk or deacon. Worth being explicit that this bounds a large input, not a hang — if a filter call ever wedges, that request waits forever and holds one of the concurrency slots, while `/health` still answers 200 because the index is loaded. That is the same "probe passes while filtering is broken" shape we just removed from the server, relocated rather than eliminated. A watchdog that fails the pod is the alternative; happy to add one if you'd rather not accept this.

**Thread budget is now configurable and needs tuning.** `deacon_threads: 4` and `deacon_max_concurrent_filters: 2` are starting values, not measured optima. Without a cap this would be dangerous: the endpoint is a plain `def`, so FastAPI runs it in a threadpool of about 40 slots, and eight worker threads in each of those is several hundred threads. A semaphore bounds how many filters run at once. Note the pod's 50m CPU request with no limit is unchanged by this PR — the old server also defaulted to eight threads.

## What happens on input deacon rejects

Worth its own section, because this is where the old setup was at its worst and the change is easiest to under-sell.

Hand deacon two supposedly-paired files with different numbers of reads and it stops with "Incompatible record set sizes". Under the server that killed the daemon, and because only a clean shutdown removes the socket file, every subsequent submission then failed with a confusing "connection refused" until someone restarted the pod. One bad submission broke host filtering for everybody.

In-process, submitting a mismatched pair three times in a row against the real index returns HTTP 500 each time with deacon's own message in it, and the very next good submission returns 200. Health stays green, and four concurrent good requests afterwards still complete in 0.46 s, so no concurrency slot was leaked. Same for a truncated record, a corrupt gzip file, a file that is not FASTQ at all, and a missing file: each is an ordinary Python exception carrying a specific message, and the loaded index is unaffected. Even the case that makes the command-line tool abort outright — pointing it at a compressed index — merely raises here, because the bindings convert errors where the command-line tool unwraps them.

One case deacon itself does not object to is an empty file — it filters to zero reads and reports success. That is caught before deacon twice over, so it is a caution for anyone else calling the bindings rather than a hole here: readtools rejects an empty FASTQ (plain or gzipped) with "Cannot determine candidate qualities: no qualities found", and if it were ever skipped, sampling the read length to choose `-a` rejects it too.

Testing this turned up two gaps that are fixed in the third commit. Nothing caught the exceptions, so any of the above would have surfaced as a generic 500 with no logged reason — the old code turned a non-zero deacon exit into a `ProcessingFailure`, and that is restored along with the note about alerting when deacon starts failing. Separately, malformed FASTQ never reaches deacon at all: we sample the first hundred reads to decide whether the library is short-read, and Biopython's parser throws first. That was an uncaught `ValueError`; it now produces the same "file may be empty or corrupted" message the submitter already gets for an empty file.

## Two things that would have been bugs in a literal port

Neither is visible from reading the old code, so flagging both.

The old call passed no output path. In the CLI that means "write to stdout", and it was harmless only because the *server* owned stdout and we had pointed it at `/dev/null`. In-process, stdout is ours, and we run deacon in search mode — meaning the reads it writes out are the ones that matched the human index. A faithful port would have printed human reads into the pod logs, which is the exact thing this service exists to prevent. Output now goes to `/dev/null` explicitly, with a comment. As a side effect this also stops us buffering those reads into memory, which the old `capture_output=True` did.

The bindings offer a `check_pairs` option that verifies R1 and R2 names line up, which looks like a natural safety net given we pass two files positionally. It is too strict to use: it rejected ordinary paired FASTQ from SRA whose names *do* end in `/1` and `/2`, because a description follows the read name. Left off. Instead R1 and R2 are named explicitly at the call site rather than relying on dictionary ordering to put them in the right order.

## Deliberately not changed

The conda `deacon` CLI stays in `environment.yml` even though the service no longer uses it: `build-index.sh` calls it, and the index-build workflow creates its environment from that same file. Removing it would have broken the nightly index build. There is a one-line comment recording why it is still there.

`local_files` is keyed by file name, so a submission with two files of the same name collapses to one entry and a paired submission would be filtered as if single-ended. That is pre-existing and the readtools step shares the assumption, so it belongs in its own change.

## Notes on testing

The two deacon threshold tests used to be skipped whenever the `deacon` binary was missing from `PATH`, which means they may not have been running everywhere. The bindings are an ordinary Python dependency, so those tests now always run; they produce the same 75% and 5% host proportions as before, so behaviour is unchanged. The index is loaded once per test session, which is also how the service uses it.

New tests cover the new behaviour: that an oversized download is rejected part-way through rather than after being written in full, that the semaphore really does cap concurrent filters and does not leak a slot when a filter fails, and that a mismatched pair fails the submission while leaving the index usable. One more covers `get_config` against `defaults.yaml`, because nothing did — every test built `Config` directly, so a key missing from the defaults file would only have shown up as a validation error at pod startup with the whole suite green.

The image build is green on this PR, and `uv` resolved a prebuilt wheel rather than falling back to building from source, so the switch to a PyPI dependency needs no Rust toolchain in the image. The package publishes no `deacon` command-line script, so it cannot shadow the conda binary that `build-index.sh` needs.

🚀 Preview: https://raw-reads-deacon-python-b.loculus.org