### PR TITLE
chore(kubernetes): update SILO 0.11.0 -> 0.13.3, LAPIS 0.8.0 -> 0.8.6

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2859,7 +2859,7 @@ images:
     pullPolicy: Always
   lapis:
     repository: "ghcr.io/genspectrum/lapis"
-    tag: "v0.8.0@sha256:4da71d94aceb36b7ea5963aa2e7b0566567c6423fe7fdd39448e69aebda2a8bb"
+    tag: "v0.8.6@sha256:541f52086ddf10b5ba242e88b0b32a2831ea0563e90deff2ae8a7aea1c95daa0"
     pullPolicy: Always
   website:
     repository: "ghcr.io/loculus-project/website"

--- a/loculus-silo/Dockerfile
+++ b/loculus-silo/Dockerfile
@@ -12,7 +12,7 @@ RUN cargo install --git $REPO --rev $COMMIT
 # --- SILO binary download stage ---
 FROM curlimages/curl:8.12.1 AS silo-downloader
 
-ARG SILO_VERSION=0.11.0
+ARG SILO_VERSION=0.13.3
 ARG TARGETARCH
 
 RUN curl -sL "https://github.com/GenSpectrum/LAPIS-SILO/releases/download/v${SILO_VERSION}/silo-linux-${TARGETARCH}.tar.gz" \


### PR DESCRIPTION
resolves #7140

# TLDR

### ⚠ BREAKING CHANGES

* **silo:** Insertions response: removed `insertion` field. Mutations response: removed `mutation` field. The string was constructed from information that is still present in the response.
* **preprocessing:** the database config options `defaultNucleotideSequence` and `defaultAminoAcidSequence` have been removed. `sequenceName` is now required on all nucleotide and amino acid filters (`nucleotideEquals`/`aminoAcidEquals`, `hasMutation`/`hasAAMutation`, `insertionContains`/`aminoAcidInsertionContains`, `symbolInSet` and the mutation profile filters).
* **preprocessing:** remove deprecated preprocessing config values `intermediateResultsDirectory`, `preprocessingDatabaseLocation`, `duckdbMemoryLimitInG` and database config values `dateToSortBy`, `partitionBy`
* **silo:** use date32 type for dates instead of converting to string
* **silo:** change query interface to saneql

### Summary

This version bump contains a large internal restructuring in SILO. Most notably, we changed the query language in SILO. None of that should affect Loculus since LAPIS encapsulates the breaking changes. We use the new version for a while on GenSpectrum now and are confident enough to roll it out to Loculus now.

<details>

<summary>AI analysis of the breaking changes</summary>

SILO 0.11.0 -> 0.13.3 Upgrade: Breaking Changes Impact on Loculus
==================================================================

Verdict: Safe. No Loculus code changes required.
Only operational effect: full re-preprocessing of all SILO instances on rollout
(serialization version bumped twice).


Breaking changes 0.11 -> 0.13.3 vs Loculus
------------------------------------------

SILO 0.12.0
- Serialization version changed -> DBs need re-preprocessing. Ops impact only:
  silo-importer re-imports all organisms from scratch on deploy (slow first
  import, e.g. mpox). No code change.
- Removed preprocessing config `intermediateResultsDirectory`,
  `preprocessingDatabaseLocation`, `duckdbMemoryLimitInG` + DB config
  `dateToSortBy`, `partitionBy` -> not used in Loculus (grep = none). OK
- Query interface -> SaneQL, date32 dates -> LAPIS<->SILO internal. Loculus
  talks to LAPIS, not SILO. OK
- Null sequences no longer match `N` symbol queries (bugfix) -> subtle
  query-semantics change, LAPIS-mediated.

SILO 0.13.0
- Serialization version changed again -> re-preprocess. Same ops note.
- Removed `insertion`/`mutation` fields from SILO responses -> LAPIS-facing.
  Verified LAPIS `MutationResponse` still returns `mutation: String?`
  (reconstructs it), so website zod schemas (lapis.ts:31,45 require
  `mutation`/`insertion`) stay satisfied. OK
- Removed `defaultNucleotideSequence`/`defaultAminoAcidSequence`; `sequenceName`
  now required on filters -> Loculus SILO DB config template
  (_siloDatabaseConfig.tpl) never set those defaults; LAPIS injects
  sequenceName. OK

</details>

<details>

<summary>LAPIS Changelog</summary>


## [0.8.6](https://github.com/GenSpectrum/LAPIS/compare/v0.8.5...v0.8.6) (2026-08-19)


### Bug Fixes

* **lapis-docs:** bump astro and @astrojs/starlight in /lapis-docs - fix table formatting ([#1799](https://github.com/GenSpectrum/LAPIS/issues/1799)) ([ec162c5](https://github.com/GenSpectrum/LAPIS/commit/ec162c5ab9a5f1f7277aaaef733c7b59c2022025))

## [0.8.5](https://github.com/GenSpectrum/LAPIS/compare/v0.8.4...v0.8.5) (2026-08-18)


### Features

* **lapis:** support scalar functions in aggregation fields via dot notation ([#1780](https://github.com/GenSpectrum/LAPIS/issues/1780)) ([80a55fd](https://github.com/GenSpectrum/LAPIS/commit/80a55fd5efb5e609c920107d77362b131c918bb4))


### Bug Fixes

* **lapis:** restore `insertion` and `mutation` format in response ([#1798](https://github.com/GenSpectrum/LAPIS/issues/1798)) ([58e1ed6](https://github.com/GenSpectrum/LAPIS/commit/58e1ed6e1b6b64aa84be91976a9311cabc3eb568))

## [0.8.4](https://github.com/GenSpectrum/LAPIS/compare/v0.8.3...v0.8.4) (2026-07-29)


### Features

* **lapis:** add sequence position fields syntax to aggregated endpoint ([#1768](https://github.com/GenSpectrum/LAPIS/issues/1768)) ([bd2c7c8](https://github.com/GenSpectrum/LAPIS/commit/bd2c7c8f84be59ac22030e76e7949ab303475948))
* **lapis:** also handle SILO returning arrow date values ([#1700](https://github.com/GenSpectrum/LAPIS/issues/1700)) ([0d5387c](https://github.com/GenSpectrum/LAPIS/commit/0d5387c9bc507e0fb4b7a208cea43075582e1829))
* **lapis:** send SILO queries as SaneQL ([#1698](https://github.com/GenSpectrum/LAPIS/issues/1698)) ([f561e1c](https://github.com/GenSpectrum/LAPIS/commit/f561e1c4cf0e1e4b0d2c1de265f860d82eb7b6b8))


### Bug Fixes

* **lapis-docs:** resolve TypeScript warnings and add astro check to CI ([#1681](https://github.com/GenSpectrum/LAPIS/issues/1681)) ([5829e17](https://github.com/GenSpectrum/LAPIS/commit/5829e17ea44cdecd99508a860a0334bc8af4dd17))
* **lapis:** send `isNull` to SILO on `isNull(date)` advanced query ([#1697](https://github.com/GenSpectrum/LAPIS/issues/1697)) ([d43345c](https://github.com/GenSpectrum/LAPIS/commit/d43345cdf27ce960b62bf4a71314593494c9b5b7))
* **lapis:** upgrade to Spring boot 4 ([#1719](https://github.com/GenSpectrum/LAPIS/issues/1719)) ([013129f](https://github.com/GenSpectrum/LAPIS/commit/013129fa39ee7d954211de17b560fd08f5ff7f2c))

## [0.8.3](https://github.com/GenSpectrum/LAPIS/compare/v0.8.2...v0.8.3) (2026-04-28)


### Features

* **lapis:** fetch data from SILO in the Apache Arrow format ([#1650](https://github.com/GenSpectrum/LAPIS/issues/1650)) ([6fde912](https://github.com/GenSpectrum/LAPIS/commit/6fde912c8698cc97f8726965392896ad6410f7e9))


### Bug Fixes

* **lapis:** logs in the query parse endpoint ([#1661](https://github.com/GenSpectrum/LAPIS/issues/1661)) ([9313868](https://github.com/GenSpectrum/LAPIS/commit/9313868723ee375ac04481dc52a3a0ddacfcbb9c))

## [0.8.2](https://github.com/GenSpectrum/LAPIS/compare/v0.8.1...v0.8.2) (2026-04-16)


### Bug Fixes

* **lapis:** allow non-ASCII characters in advanced queries ([#1628](https://github.com/GenSpectrum/LAPIS/issues/1628)) ([9cb6949](https://github.com/GenSpectrum/LAPIS/commit/9cb694921292b40b2c191686ebb746a304dda55f))

## [0.8.1](https://github.com/GenSpectrum/LAPIS/compare/v0.8.0...v0.8.1) (2026-04-10)


### Features

* **lapis:** also allow multiple value in int, float and date filters (and concatenate them with `or`) ([#1626](https://github.com/GenSpectrum/LAPIS/issues/1626)) ([7e2736c](https://github.com/GenSpectrum/LAPIS/commit/7e2736c829d305aa0cd121cca6909a68313a40ba))

</details>

<details>

<summary>SILO Changelog</summary>

## [0.13.3](https://github.com/GenSpectrum/LAPIS-SILO/compare/v0.13.2...v0.13.3) (2026-08-12)


### Features

* **python:** change pypi package name to `rhydb` ([c4e5e63](https://github.com/GenSpectrum/LAPIS-SILO/commit/c4e5e637f271d75d469c9314a91eb6118012492c))

## [0.13.2](https://github.com/GenSpectrum/LAPIS-SILO/compare/v0.13.1...v0.13.2) (2026-08-06)


### Features

* **silo:** add opt-in N-way clustered ingestion buffering ([eae375f](https://github.com/GenSpectrum/LAPIS-SILO/commit/eae375f9f20c65c79fbe15f9a107eeae806518d6))
* **silo:** materialize per-lineage relation tables during preprocessing ([3cafccb](https://github.com/GenSpectrum/LAPIS-SILO/commit/3cafccb72e091670ed3a896ed06af142c9dba986))


### Bug Fixes

* **query_engine:** do not invalidly reorder filter nodes ([#1431](https://github.com/GenSpectrum/LAPIS-SILO/issues/1431)) ([be8e0d7](https://github.com/GenSpectrum/LAPIS-SILO/commit/be8e0d7a6bf86e31bb79a88d71f313c7bddb5883))


### Performance Improvements

* **silo:** add clustered-ingestion benchmark modelling amplicon coverage classes ([d68cd98](https://github.com/GenSpectrum/LAPIS-SILO/commit/d68cd9862eca5f714bc0ea3b1cbca6176bd2dcfd))
* **silo:** process input sequences word-at-a-time ([b92fbb0](https://github.com/GenSpectrum/LAPIS-SILO/commit/b92fbb05fbf5d4f138887ee3e236617e2c631d51))

## [0.13.1](https://github.com/GenSpectrum/LAPIS-SILO/compare/v0.13.0...v0.13.1) (2026-07-31)


### Features

* **app:** add the plan Ordering as an http header to the response ([4b501d5](https://github.com/GenSpectrum/LAPIS-SILO/commit/4b501d562cb2e4f763ef7dc9767c299afaea58cf))
* **query_engine:** add a specialized OrderByWithLimit node ([34d3814](https://github.com/GenSpectrum/LAPIS-SILO/commit/34d38148611ba68e5ecac1ae461912b7412b3d62))
* **query_engine:** implement free IUs for boolean expressions ([#1377](https://github.com/GenSpectrum/LAPIS-SILO/issues/1377)) ([f366c81](https://github.com/GenSpectrum/LAPIS-SILO/commit/f366c811e9d10daf407554928b34c24ab1a7a87e))


### Bug Fixes

* **silo:** allow `limit` on `groupBy` ([035e244](https://github.com/GenSpectrum/LAPIS-SILO/commit/035e2442d6944936a9f3a73c8aee39c4c24f32e6))

## [0.13.0](https://github.com/GenSpectrum/LAPIS-SILO/compare/v0.12.1...v0.13.0) (2026-07-29)


### ⚠ BREAKING CHANGES

* **silo:** Insertions response: removed `insertion` field. Mutations response: removed `mutation` field. The string was constructed from information that is still present in the response.
* **preprocessing:** the database config options `defaultNucleotideSequence` and `defaultAminoAcidSequence` have been removed. `sequenceName` is now required on all nucleotide and amino acid filters (`nucleotideEquals`/`aminoAcidEquals`, `hasMutation`/`hasAAMutation`, `insertionContains`/`aminoAcidInsertionContains`, `symbolInSet` and the mutation profile filters).

### Features

* **app:** add a --version command to the silo binary ([8b3146e](https://github.com/GenSpectrum/LAPIS-SILO/commit/8b3146ec977f5fd643acb41b494ac381f085e1e3))
* **preprocessing:** remove default sequence names from database config ([#1386](https://github.com/GenSpectrum/LAPIS-SILO/issues/1386)) ([b8712ec](https://github.com/GenSpectrum/LAPIS-SILO/commit/b8712ec2fbee7b7df374c9091019858adb8bed46))
* **query_engine:** add join operator ([f7cbaf4](https://github.com/GenSpectrum/LAPIS-SILO/commit/f7cbaf480336399f6d07e25b4383d797210bef0d))
* **silo:** allow updating of string columns ([818a737](https://github.com/GenSpectrum/LAPIS-SILO/commit/818a737a0b0d8d8df86cd27447d695d0722e93b3))
* **silo:** remove `insertion` and `mutation` field from responses ([#1408](https://github.com/GenSpectrum/LAPIS-SILO/issues/1408)) ([72fca9f](https://github.com/GenSpectrum/LAPIS-SILO/commit/72fca9fd660733914b84cf2c3c322f3003e5da7d))

## [0.12.1](https://github.com/GenSpectrum/LAPIS-SILO/compare/v0.12.0...v0.12.1) (2026-07-27)


### Features

* **performance:** add co-occurrence query benchmark ([2c52241](https://github.com/GenSpectrum/LAPIS-SILO/commit/2c522413965259591d76925c778a22453147da9f))
* **query_engine:** bitmap-based aggregation for count group-bys ([a81fd24](https://github.com/GenSpectrum/LAPIS-SILO/commit/a81fd2422d07f555949b1fe4163ad01c7389a926))
* **SaneQL:** pipeline optimization step: map pull up through filter ([#1354](https://github.com/GenSpectrum/LAPIS-SILO/issues/1354)) ([b1966c4](https://github.com/GenSpectrum/LAPIS-SILO/commit/b1966c47bc68ab5ba66a830e32da772991dc67cd))
* **silo:** add update function to python bindings ([6e27cd5](https://github.com/GenSpectrum/LAPIS-SILO/commit/6e27cd52192014ab0856a05615cad25d820972c0))
* **silo:** add WebAssembly build ([#1320](https://github.com/GenSpectrum/LAPIS-SILO/issues/1320)) ([f41993a](https://github.com/GenSpectrum/LAPIS-SILO/commit/f41993a68f3d1f347d05759b4147b00cbcde1038))


### Bug Fixes

* **silo:** sort nulls consistently as smallest value ([00420f3](https://github.com/GenSpectrum/LAPIS-SILO/commit/00420f399cc4251aa0a40ba6198cc65dcc31ff5f))


### Performance Improvements

* **silo:** always prime Selection with most-selective predicate ([a8b458e](https://github.com/GenSpectrum/LAPIS-SILO/commit/a8b458e621cefa4f9556b4f4a5e480064b0263eb))
* **silo:** when adapting references, compute the coverage bitmaps only when necessary ([8f178dc](https://github.com/GenSpectrum/LAPIS-SILO/commit/8f178dc221081d88c4161a24e480251160ab101d))

## [0.12.0](https://github.com/GenSpectrum/LAPIS-SILO/compare/v0.11.3...v0.12.0) (2026-07-15)


### ⚠ BREAKING CHANGES

* **preprocessing:** remove deprecated preprocessing config values `intermediateResultsDirectory`, `preprocessingDatabaseLocation`, `duckdbMemoryLimitInG` and database config values `dateToSortBy`, `partitionBy`
* **silo:** use date32 type for dates instead of converting to string
* **silo:** change query interface to saneql

### Features

* add `unionAll` operator to SaneQL queries ([#1305](https://github.com/GenSpectrum/LAPIS-SILO/issues/1305)) ([53da65f](https://github.com/GenSpectrum/LAPIS-SILO/commit/53da65fa816e3c58029c98dff4b2ad8ccf0f1c35))
* **preprocessing:** remove deprecated preprocessing config and database config values ([#1287](https://github.com/GenSpectrum/LAPIS-SILO/issues/1287)) ([fbe4014](https://github.com/GenSpectrum/LAPIS-SILO/commit/fbe4014000651f67f86cb42dd462fb59c40f4b4d))
* **SaneQL:** add `schema` operator to get query result schema ([#1333](https://github.com/GenSpectrum/LAPIS-SILO/issues/1333)) ([f61955e](https://github.com/GenSpectrum/LAPIS-SILO/commit/f61955efc0e583ed263886be01b5c231538807e2))
* **silo:** add a dedicated filter-pushdown-pass and move node resolution to own file ([2da2f48](https://github.com/GenSpectrum/LAPIS-SILO/commit/2da2f483f2fdb18f881f968c7ee61aca2019f855))
* **silo:** add a references to input fields in `.map(...)` expressions ([2ce79f2](https://github.com/GenSpectrum/LAPIS-SILO/commit/2ce79f20ae45065308f6d1a0297875325784ea01))
* **silo:** add an at expression ([82f98b4](https://github.com/GenSpectrum/LAPIS-SILO/commit/82f98b4353f3bec217848f8eb72d0631693ee9ca))
* **silo:** add column narrowing to query planner ([90071f3](https://github.com/GenSpectrum/LAPIS-SILO/commit/90071f384750da77ba16576b36c81400ffa5713a))
* **silo:** change query interface to saneql ([daba3ea](https://github.com/GenSpectrum/LAPIS-SILO/commit/daba3eaf903f7b4bab56fd805c4619a984a73d8b))
* **silo:** log the query plan and optimization steps ([50e3e17](https://github.com/GenSpectrum/LAPIS-SILO/commit/50e3e17d703be2ff7e1867699437970840972269))
* **silo:** organize string columns in immutable chunks ([b8922e4](https://github.com/GenSpectrum/LAPIS-SILO/commit/b8922e49f121146aa1925fd8a4a5c5550eedb17b))
* **silo:** use date32 type for dates instead of converting to string ([f907787](https://github.com/GenSpectrum/LAPIS-SILO/commit/f907787e86a39520d21ade243abdb68613a0f694))


### Bug Fixes

* **preprocessing:** ignore bracketed comments in Newick tree files ([#1268](https://github.com/GenSpectrum/LAPIS-SILO/issues/1268)) ([9d0e323](https://github.com/GenSpectrum/LAPIS-SILO/commit/9d0e323a14ed8b3bb708fe23a9cabc39c3327358))
* **silo:** disambiguate unary/binary minus in SaneQL ([#1266](https://github.com/GenSpectrum/LAPIS-SILO/issues/1266)) ([e1739ff](https://github.com/GenSpectrum/LAPIS-SILO/commit/e1739ff765c5a3922af0357c92602887d32b81c4))
* **silo:** null sequences should not match N symbol queries ([004bba4](https://github.com/GenSpectrum/LAPIS-SILO/commit/004bba4dcf4c5197f6035e841dba13d23cfa53f0))


### Performance Improvements

* **silo:** replace charToSymbol switch with a lookup table ([4395af5](https://github.com/GenSpectrum/LAPIS-SILO/commit/4395af5af7edbf5fa29f9f156d8727e79ee54a66))

## [0.11.3](https://github.com/GenSpectrum/LAPIS-SILO/compare/v0.11.2...v0.11.3) (2026-05-18)


### Features

* **silo:** add a MutationProfile filter ([2d49d9b](https://github.com/GenSpectrum/LAPIS-SILO/commit/2d49d9b708f22e16139c4f221f13aafc26e8f522))

## [0.11.2](https://github.com/GenSpectrum/LAPIS-SILO/compare/v0.11.1...v0.11.2) (2026-04-17)


### Features

* **silo:** add option to ignore unknown lineage values ([16e1389](https://github.com/GenSpectrum/LAPIS-SILO/commit/16e1389a39e81e0206a93e12ba9d3eaf7cfafabd))

</details>

### PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
  - filtering on the search page still seems to work as expected (tested for CCHF and West Nile - filtering for mutations, date from, accession and country)
  - tested downloading metadata and sequences for CCHF

🚀 Preview: https://7140-update-silo-aka-rhyd.loculus.org