### PR TITLE
fix(deployment): retry transient errors when downloading config URLs

### DIFF
--- a/kubernetes/config-processor/config-processor.py
+++ b/kubernetes/config-processor/config-processor.py
@@ -50,8 +50,6 @@ def download_urls_with_workers(urls, max_workers):
 
 def download_url(url):
     if not hasattr(thread_local, "session"):
-        # Retry transient network errors; raise_on_status=False keeps the
-        # caller's error message when retries are exhausted.
         retry = Retry(total=5, backoff_factor=0.5, status_forcelist=(429, 500, 502, 503, 504),
                       raise_on_status=False)
         thread_local.session = requests.Session()

--- a/kubernetes/config-processor/config-processor.py
+++ b/kubernetes/config-processor/config-processor.py
@@ -5,6 +5,7 @@ import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import requests
+from requests.adapters import HTTPAdapter, Retry
 
 DEFAULT_MAX_WORKERS = 16
 thread_local = threading.local()
@@ -49,8 +50,14 @@ def download_urls_with_workers(urls, max_workers):
 
 def download_url(url):
     if not hasattr(thread_local, "session"):
+        # Retry transient network errors; raise_on_status=False keeps the
+        # caller's error message when retries are exhausted.
+        retry = Retry(total=5, backoff_factor=0.5, status_forcelist=(429, 500, 502, 503, 504),
+                      raise_on_status=False)
         thread_local.session = requests.Session()
-    return thread_local.session.get(url)
+        for scheme in ("https://", "http://"):
+            thread_local.session.mount(scheme, HTTPAdapter(max_retries=retry))
+    return thread_local.session.get(url, timeout=30)
 
 
 def replace_url_with_content(file_content, downloaded_content):


### PR DESCRIPTION
## Problem

`generate_configs` in `deploy.py` shells out to `kubernetes/config-processor/config-processor.py`, which resolves every `[[URL:...]]` placeholder found in the config templates. That is currently **97 unique URLs**, fetched with **16 parallel workers**, and essentially all of them live on two GitHub Pages hosts:

```
52  https://corneliusroemer.github.io
48  https://alejandra-gonzalezsanchez.github.io
 2  https://example.com
```

Opening 16 concurrent TLS connections against the same host is enough for the remote to occasionally drop one. When that happens the whole deployment dies:

```
ConnectionResetError: [Errno 104] Connection reset by peer
  ...
  File "kubernetes/config-processor/config-processor.py", line 53, in download_url
    return thread_local.session.get(url)
requests.exceptions.ConnectionError: ('Connection aborted.',
    ConnectionResetError(104, 'Connection reset by peer'))
subprocess.SubprocessError: None
Error: Process completed with exit code 1
```

There was no protection against this at either level:

- `download_urls` has a retry loop, but it is narrowly scoped — it only re-runs the batch when the error string contains `"Too many open files"`, halving the worker count. Every other `RequestException`, including this one, is re-raised immediately.
- The per-thread `requests.Session` had no retry configuration, so there was no transport-level recovery either.
- There was also no timeout — `requests`' default is `timeout=None`, i.e. wait forever — so a hung connection could block a worker indefinitely.

One unlucky TCP reset out of 97 requests therefore failed an otherwise perfectly good CI run.

## Fix

Configure the per-thread session with a retry policy and a timeout:

```python
def download_url(url):
    if not hasattr(thread_local, "session"):
        # Retry transient network errors; raise_on_status=False keeps the
        # caller's error message when retries are exhausted.
        retry = Retry(total=5, backoff_factor=0.5, status_forcelist=(429, 500, 502, 503, 504),
                      raise_on_status=False)
        thread_local.session = requests.Session()
        for scheme in ("https://", "http://"):
            thread_local.session.mount(scheme, HTTPAdapter(max_retries=retry))
    return thread_local.session.get(url, timeout=30)
```

Notes on the specific choices:

- **`requests` has no retry logic of its own.** `HTTPAdapter.max_retries` defaults to `0` (`DEFAULT_RETRIES = 0`), so out of the box nothing is retried. Passing a bare int would retry connection errors only — no backoff, no status handling — so a `Retry` object is needed. `Retry` is re-exported from `requests.adapters`, so this needs no direct `urllib3` import.
- **`status_forcelist`**: `Retry` treats any completed HTTP response as success regardless of status code, so retryable statuses must be listed explicitly. `429` (rate limited) plus `500/502/503/504` (transient server/gateway errors) are covered. Deterministic 4xx such as `403`/`404` are deliberately excluded — retrying them only delays an inevitable failure.
- **`raise_on_status=False`**: without it, exhausting retries on a forcelist status raises `requests.exceptions.RetryError` and the operator loses the detail. With it, the final response is handed back to `download_urls_with_workers`, which still reports the actual URL, status code and reason.
- **`backoff_factor=0.5`** produces sleeps of `0, 0, 1, 2, 4, 8` seconds (urllib3 does not sleep before the first two retries), so a fully-failing URL adds ~15s before it gives up. No retries fire on the happy path, so a healthy run is unaffected.
- **`allowed_methods`** is left at its default, which already includes `GET` — the only method used here.

## Behaviour changes

Three, all bounded:

1. **The 30s timeout is new.** Previously there was no timeout at all (`requests` defaults to `timeout=None`), so a stalled connection could hang the deployment forever. Note the timeout is *per request*, so with retries the worst-case wall time for a single pathological URL is ~6 × 30s + 15s backoff rather than 30s — still bounded, where before it was unbounded.
2. **Transient failures now cost time instead of failing instantly.** A URL that is genuinely down takes ~15s of backoff before reporting the same error it used to report immediately. Acceptable trade for not killing the deployment on a one-off reset.
3. **The existing `"Too many open files"` worker-halving path is slower to trigger.** Connection errors are now retried at the transport layer first, so an EMFILE storm burns its retry budget before the outer loop sees it. Verified that the guard still works: `MaxRetryError` embeds the underlying reason, so `"Too many open files" in str(error)` still matches after wrapping (checked against a live connection failure — the errno text is preserved through `requests.exceptions.ConnectionError`).

## Testing

Verified against a local HTTP server that fails in a scripted sequence, exercising the code path end-to-end through `download_urls`:

- Connection reset → `503` → `502` → `200`: recovered after 4 attempts and returned the correct (stripped) body, where the previous code aborted on the first reset.
- A non-retryable `404` still fails immediately with the original message: `Problem downloading URL: ..., Status Code: 404, Reason: Not Found` — confirming `raise_on_status=False` preserves the existing error reporting and that we have not made hard failures silently slow.
- Backoff schedule and error-message propagation checked directly against the installed `requests` 2.34 / `urllib3` 2.7.

`ruff` in `.pre-commit-config.yaml` is scoped to `ena-submission/` and `preprocessing/nextclade/`, so `kubernetes/config-processor/` is not linted or formatted; the file's pre-existing style is preserved and no unrelated reformatting is included.

## Context

Found while diagnosing a CI failure on #7199 (`fix/mirror-secret-generator-chart`). That failure was unrelated to the PR's own changes — this is the actual cause, and it is reproducible on `main`, hence a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019syqNswAmts2uHNK5Hsgzj
