### PR TITLE
fix(deposition): use e-utilities for nuccore visibility checks

### DIFF
--- a/ena-submission/config/defaults.yaml
+++ b/ena-submission/config/defaults.yaml
@@ -22,6 +22,7 @@ ena_http_timeout_seconds: 60
 ena_public_search_timeout_seconds: 120
 ncbi_public_search_timeout_seconds: 120
 ena_http_get_retry_attempts: 3
+ncbi_http_get_retry_attempts: 3
 # Don't retry posts by default as they might not be idempotent
 ena_http_post_retry_attempts: 1
 # 12 hours in minutes

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -82,33 +82,82 @@ class TransientNCBIError(Exception):
 class NCBIVisibilityChecker(VisibilityChecker):
     """Checker for NCBI visibility"""
 
-    def check_visibility(self, config: Config, accession: str) -> datetime | None:
-        if accession.startswith("PRJ"):
-            path = "bioproject"
-        elif accession.startswith("SAM"):
-            path = "biosample"
-        else:
-            return self._check_nuccore_visibility(config, accession)
-        response = requests.get(
-            f"https://www.ncbi.nlm.nih.gov/{path}/{accession}/",
-            allow_redirects=False,
-            timeout=config.ncbi_public_search_timeout_seconds,
-        )
-        if response.status_code == HTTPStatus.OK:
-            return datetime.now(pytz.UTC)
-        return None
+    # Accession prefix -> E-utilities database name. Anything else is a nucleotide accession.
+    _DB_BY_PREFIX = (("PRJ", "bioproject"), ("SAM", "biosample"))
 
-    def _check_nuccore_visibility(self, config: Config, accession: str) -> datetime | None:
-        """The nuccore web page is behind a bot-check that returns HTTP 200 for any
-        request regardless of whether the accession exists, so query the E-utilities
-        esummary API instead, which returns a real JSON result. E-utilities rate-limits
-        unauthenticated requests to 3/second per IP, so retry on timeouts and transient
-        (429/5xx) errors."""
+    # A nuccore record can resolve to a UID while no longer being publicly available.
+    # Treat only these esummary statuses as live (empty/"live"); anything else
+    # (e.g. "suppressed", "withdrawn", "removed", "replaced") counts as not visible.
+    _LIVE_NUCCORE_STATUSES = frozenset({"", "live"})
+
+    def check_visibility(self, config: Config, accession: str) -> datetime | None:
+        db = next(
+            (db for prefix, db in self._DB_BY_PREFIX if accession.startswith(prefix)),
+            "nuccore",
+        )
+        return self._check_eutils_visibility(config, accession, db)
+
+    def _check_eutils_visibility(
+        self, config: Config, accession: str, db: str
+    ) -> datetime | None:
+        """The NCBI web pages (nuccore, bioproject, biosample) are behind a bot-check that
+        returns HTTP 200 for any request regardless of whether the accession exists, so
+        query the E-utilities API instead, which returns a real JSON result.
+
+        esearch resolves the accession to internal UID(s); an empty result means the
+        accession is not (yet) in NCBI. For nuccore we additionally fetch esummary to
+        make sure the record has not been suppressed/withdrawn after being assigned a UID.
+        """
+
+        esearch = self._eutils_get_json(
+            config,
+            "esearch.fcgi",
+            {"db": db, "term": accession, "retmode": "json"},
+            accession,
+            "esearch",
+        )
+        if esearch is None:
+            return None
+        uids = esearch.get("esearchresult", {}).get("idlist", [])
+        if not uids:
+            return None
+        if db != "nuccore":
+            return datetime.now(pytz.UTC)
+
+        summary = self._eutils_get_json(
+            config,
+            "esummary.fcgi",
+            {"db": db, "id": ",".join(uids), "retmode": "json"},
+            accession,
+            "esummary",
+        )
+        if summary is None:
+            return None
+        result = summary.get("result", {})
+        live = any(
+            uid in result
+            and not result[uid].get("error")
+            and result[uid].get("status", "") in self._LIVE_NUCCORE_STATUSES
+            for uid in result.get("uids", [])
+        )
+        return datetime.now(pytz.UTC) if live else None
+
+    def _eutils_get_json(
+        self,
+        config: Config,
+        endpoint: str,
+        params: dict[str, str],
+        accession: str,
+        label: str,
+    ) -> dict | None:
+        """GET an E-utilities endpoint and return the parsed JSON body, or None on a
+        non-OK / non-JSON response. E-utilities rate-limits unauthenticated requests to
+        3/second per IP, so retry on timeouts and transient (429/5xx) errors."""
 
         def _do_get() -> requests.Response:
             response = requests.get(
-                "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi",
-                params={"db": "nuccore", "id": accession, "retmode": "json"},
+                f"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/{endpoint}",
+                params=params,
                 timeout=config.ncbi_public_search_timeout_seconds,
             )
             is_transient = response.status_code == HTTPStatus.TOO_MANY_REQUESTS or (
@@ -116,10 +165,10 @@ class NCBIVisibilityChecker(VisibilityChecker):
             )
             if is_transient:
                 logger.info(
-                    f"NCBI nuccore esummary request failed for {accession}: "
+                    f"NCBI {label} request failed for {accession}: "
                     f"HTTP {response.status_code} - {response.text}"
                 )
-                msg = f"Transient NCBI esummary error {response.status_code} for {accession}"
+                msg = f"Transient NCBI {label} error {response.status_code} for {accession}"
                 raise TransientNCBIError(msg)
             return response
 
@@ -133,21 +182,18 @@ class NCBIVisibilityChecker(VisibilityChecker):
         response = retryer(_do_get)
         if response.status_code != HTTPStatus.OK:
             logger.info(
-                f"NCBI nuccore esummary request failed for {accession}: "
+                f"NCBI {label} request failed for {accession}: "
                 f"HTTP {response.status_code} - {response.text}"
             )
             return None
         try:
-            result = response.json().get("result", {})
+            return response.json()
         except ValueError:
             logger.info(
-                f"NCBI nuccore esummary returned a non-JSON response for {accession}: "
+                f"NCBI {label} returned a non-JSON response for {accession}: "
                 f"{response.text[:500]}"
             )
             return None
-        uids = result.get("uids", [])
-        visible = any(uid in result and not result[uid].get("error") for uid in uids)
-        return datetime.now(pytz.UTC) if visible else None
 
 
 # Configuration mapping: (EntityType, column_name) -> ColumnCheckConfig

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -82,9 +82,6 @@ class TransientNCBIError(Exception):
 class NCBIVisibilityChecker(VisibilityChecker):
     """Checker for NCBI visibility"""
 
-    # Accession prefix -> E-utilities database name. Anything else is a nucleotide accession.
-    _DB_BY_PREFIX = (("PRJ", "bioproject"), ("SAM", "biosample"))
-
     def check_visibility(self, config: Config, accession: str) -> datetime | None:
         """
         Check the visibility of an accession in the NCBI database.
@@ -93,10 +90,13 @@ class NCBIVisibilityChecker(VisibilityChecker):
 
         Note suppressed accessions will return a UID and will be marked as live.
         """
-        db = next(
-            (db for prefix, db in self._DB_BY_PREFIX if accession.startswith(prefix)),
-            "nuccore",
-        )
+        if accession.startswith("PRJ"):
+            db = "bioproject"
+        elif accession.startswith("SAM"):
+            db = "biosample"
+        else:
+            db = "nuccore"
+
         esearch = self._eutils_get_json(
             config,
             {"db": db, "term": accession, "retmode": "json"},

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -137,8 +137,17 @@ class NCBIVisibilityChecker(VisibilityChecker):
                 f"HTTP {response.status_code} - {response.text}"
             )
             return None
-        uids = response.json().get("result", {}).get("uids", [])
-        return datetime.now(pytz.UTC) if uids else None
+        try:
+            result = response.json().get("result", {})
+        except ValueError:
+            logger.info(
+                f"NCBI nuccore esummary returned a non-JSON response for {accession}: "
+                f"{response.text[:500]}"
+            )
+            return None
+        uids = result.get("uids", [])
+        visible = any(uid in result and not result[uid].get("error") for uid in uids)
+        return datetime.now(pytz.UTC) if visible else None
 
 
 # Configuration mapping: (EntityType, column_name) -> ColumnCheckConfig

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -138,7 +138,7 @@ class NCBIVisibilityChecker(VisibilityChecker):
             return response
 
         retryer = Retrying(
-            stop=stop_after_attempt(config.ena_http_get_retry_attempts),
+            stop=stop_after_attempt(config.ncbi_http_get_retry_attempts),
             wait=wait_fixed(2),
             retry=retry_if_exception_type((requests.exceptions.Timeout, TransientNCBIError)),
             reraise=True,

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -19,8 +19,10 @@ from http import HTTPStatus
 import pytz
 import requests
 from sqlalchemy import Engine
+from tenacity import Retrying, retry_if_exception_type, stop_after_attempt, wait_fixed
 
 from ena_deposition.config import Config
+from ena_deposition.ena_submission_helper import log_before_retry
 from ena_deposition.submission_db_helper import (
     AssemblyTableEntry,
     ProjectTableEntry,
@@ -73,6 +75,10 @@ class ENAVisibilityChecker(VisibilityChecker):
         return None
 
 
+class TransientNCBIError(Exception):
+    """Raised for a retryable (rate-limited/server) error from NCBI's E-utilities."""
+
+
 class NCBIVisibilityChecker(VisibilityChecker):
     """Checker for NCBI visibility"""
 
@@ -82,7 +88,7 @@ class NCBIVisibilityChecker(VisibilityChecker):
         elif accession.startswith("SAM"):
             path = "biosample"
         else:
-            path = "nuccore"
+            return self._check_nuccore_visibility(config, accession)
         response = requests.get(
             f"https://www.ncbi.nlm.nih.gov/{path}/{accession}/",
             allow_redirects=False,
@@ -91,6 +97,48 @@ class NCBIVisibilityChecker(VisibilityChecker):
         if response.status_code == HTTPStatus.OK:
             return datetime.now(pytz.UTC)
         return None
+
+    def _check_nuccore_visibility(self, config: Config, accession: str) -> datetime | None:
+        """The nuccore web page is behind a bot-check that returns HTTP 200 for any
+        request regardless of whether the accession exists, so query the E-utilities
+        esummary API instead, which returns a real JSON result. E-utilities rate-limits
+        unauthenticated requests to 3/second per IP, so retry on timeouts and transient
+        (429/5xx) errors."""
+
+        def _do_get() -> requests.Response:
+            response = requests.get(
+                "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi",
+                params={"db": "nuccore", "id": accession, "retmode": "json"},
+                timeout=config.ncbi_public_search_timeout_seconds,
+            )
+            is_transient = response.status_code == HTTPStatus.TOO_MANY_REQUESTS or (
+                response.status_code >= HTTPStatus.INTERNAL_SERVER_ERROR
+            )
+            if is_transient:
+                logger.info(
+                    f"NCBI nuccore esummary request failed for {accession}: "
+                    f"HTTP {response.status_code} - {response.text}"
+                )
+                msg = f"Transient NCBI esummary error {response.status_code} for {accession}"
+                raise TransientNCBIError(msg)
+            return response
+
+        retryer = Retrying(
+            stop=stop_after_attempt(config.ena_http_get_retry_attempts),
+            wait=wait_fixed(2),
+            retry=retry_if_exception_type((requests.exceptions.Timeout, TransientNCBIError)),
+            reraise=True,
+            before_sleep=log_before_retry,
+        )
+        response = retryer(_do_get)
+        if response.status_code != HTTPStatus.OK:
+            logger.info(
+                f"NCBI nuccore esummary request failed for {accession}: "
+                f"HTTP {response.status_code} - {response.text}"
+            )
+            return None
+        uids = response.json().get("result", {}).get("uids", [])
+        return datetime.now(pytz.UTC) if uids else None
 
 
 # Configuration mapping: (EntityType, column_name) -> ColumnCheckConfig

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -99,10 +99,8 @@ class NCBIVisibilityChecker(VisibilityChecker):
         )
         esearch = self._eutils_get_json(
             config,
-            "esearch.fcgi",
             {"db": db, "term": accession, "retmode": "json"},
             accession,
-            "esearch",
         )
         if esearch is None:
             return None
@@ -114,10 +112,8 @@ class NCBIVisibilityChecker(VisibilityChecker):
     def _eutils_get_json(
         self,
         config: Config,
-        endpoint: str,
         params: dict[str, str],
         accession: str,
-        label: str,
     ) -> dict | None:
         """GET an E-utilities endpoint and return the parsed JSON body, or None on a
         non-OK / non-JSON response. E-utilities rate-limits unauthenticated requests to
@@ -125,7 +121,7 @@ class NCBIVisibilityChecker(VisibilityChecker):
 
         def _do_get() -> requests.Response:
             response = requests.get(
-                f"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/{endpoint}",
+                "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
                 params=params,
                 timeout=config.ncbi_public_search_timeout_seconds,
             )
@@ -134,10 +130,10 @@ class NCBIVisibilityChecker(VisibilityChecker):
             )
             if is_transient:
                 logger.info(
-                    f"NCBI {label} request failed for {accession}: "
+                    f"NCBI esearch request failed for {accession}: "
                     f"HTTP {response.status_code} - {response.text}"
                 )
-                msg = f"Transient NCBI {label} error {response.status_code} for {accession}"
+                msg = f"Transient NCBI esearch error {response.status_code} for {accession}"
                 raise TransientNCBIError(msg)
             return response
 
@@ -151,7 +147,7 @@ class NCBIVisibilityChecker(VisibilityChecker):
         response = retryer(_do_get)
         if response.status_code != HTTPStatus.OK:
             logger.info(
-                f"NCBI {label} request failed for {accession}: "
+                f"NCBI esearch request failed for {accession}: "
                 f"HTTP {response.status_code} - {response.text}"
             )
             return None
@@ -159,7 +155,7 @@ class NCBIVisibilityChecker(VisibilityChecker):
             return response.json()
         except ValueError:
             logger.info(
-                f"NCBI {label} returned a non-JSON response for {accession}: {response.text[:500]}"
+                f"NCBI esearch returned a non-JSON response for {accession}: {response.text[:500]}"
             )
             return None
 

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -85,49 +85,40 @@ class NCBIVisibilityChecker(VisibilityChecker):
     # Accession prefix -> E-utilities database name. Anything else is a nucleotide accession.
     _DB_BY_PREFIX = (("PRJ", "bioproject"), ("SAM", "biosample"))
 
-    # A nuccore record can resolve to a UID while no longer being publicly available.
-    # Treat only these esummary statuses as live (empty/"live"); anything else
-    # (e.g. "suppressed", "withdrawn", "removed", "replaced") counts as not visible.
-    _LIVE_NUCCORE_STATUSES = frozenset({"", "live"})
+    # A live nuccore record has no status field, statuses like
+    # "suppressed", "withdrawn", "removed", "replaced"... count as not visible.
+    _LIVE_NUCCORE_STATUSES = frozenset({""})
 
     def check_visibility(self, config: Config, accession: str) -> datetime | None:
+        """
+        Check the visibility of an accession in the NCBI database.
+        esearch resolves the accession to internal UID(s); an empty result means the
+        accession is not (yet) in NCBI. For nuccore we query esummary to
+        make sure the record has not been suppressed/withdrawn after being assigned a UID.
+        """
         db = next(
             (db for prefix, db in self._DB_BY_PREFIX if accession.startswith(prefix)),
             "nuccore",
         )
-        return self._check_eutils_visibility(config, accession, db)
-
-    def _check_eutils_visibility(
-        self, config: Config, accession: str, db: str
-    ) -> datetime | None:
-        """The NCBI web pages (nuccore, bioproject, biosample) are behind a bot-check that
-        returns HTTP 200 for any request regardless of whether the accession exists, so
-        query the E-utilities API instead, which returns a real JSON result.
-
-        esearch resolves the accession to internal UID(s); an empty result means the
-        accession is not (yet) in NCBI. For nuccore we additionally fetch esummary to
-        make sure the record has not been suppressed/withdrawn after being assigned a UID.
-        """
-
-        esearch = self._eutils_get_json(
-            config,
-            "esearch.fcgi",
-            {"db": db, "term": accession, "retmode": "json"},
-            accession,
-            "esearch",
-        )
-        if esearch is None:
-            return None
-        uids = esearch.get("esearchresult", {}).get("idlist", [])
-        if not uids:
-            return None
         if db != "nuccore":
+            esearch = self._eutils_get_json(
+                config,
+                "esearch.fcgi",
+                {"db": db, "term": accession, "retmode": "json"},
+                accession,
+                "esearch",
+            )
+            if esearch is None:
+                return None
+            uids = esearch.get("esearchresult", {}).get("idlist", [])
+            if not uids:
+                return None
             return datetime.now(pytz.UTC)
 
         summary = self._eutils_get_json(
             config,
             "esummary.fcgi",
-            {"db": db, "id": ",".join(uids), "retmode": "json"},
+            {"db": db, "id": accession, "retmode": "json"},
             accession,
             "esummary",
         )
@@ -190,8 +181,7 @@ class NCBIVisibilityChecker(VisibilityChecker):
             return response.json()
         except ValueError:
             logger.info(
-                f"NCBI {label} returned a non-JSON response for {accession}: "
-                f"{response.text[:500]}"
+                f"NCBI {label} returned a non-JSON response for {accession}: {response.text[:500]}"
             )
             return None
 

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -85,53 +85,31 @@ class NCBIVisibilityChecker(VisibilityChecker):
     # Accession prefix -> E-utilities database name. Anything else is a nucleotide accession.
     _DB_BY_PREFIX = (("PRJ", "bioproject"), ("SAM", "biosample"))
 
-    # A live nuccore record has no status field, statuses like
-    # "suppressed", "withdrawn", "removed", "replaced"... count as not visible.
-    _LIVE_NUCCORE_STATUSES = frozenset({""})
-
     def check_visibility(self, config: Config, accession: str) -> datetime | None:
         """
         Check the visibility of an accession in the NCBI database.
         esearch resolves the accession to internal UID(s); an empty result means the
-        accession is not (yet) in NCBI. For nuccore we query esummary to
-        make sure the record has not been suppressed/withdrawn after being assigned a UID.
+        accession is not (yet) in NCBI.
+
+        Note suppressed accessions will return a UID and will be marked as live.
         """
         db = next(
             (db for prefix, db in self._DB_BY_PREFIX if accession.startswith(prefix)),
             "nuccore",
         )
-        if db != "nuccore":
-            esearch = self._eutils_get_json(
-                config,
-                "esearch.fcgi",
-                {"db": db, "term": accession, "retmode": "json"},
-                accession,
-                "esearch",
-            )
-            if esearch is None:
-                return None
-            uids = esearch.get("esearchresult", {}).get("idlist", [])
-            if not uids:
-                return None
-            return datetime.now(pytz.UTC)
-
-        summary = self._eutils_get_json(
+        esearch = self._eutils_get_json(
             config,
-            "esummary.fcgi",
-            {"db": db, "id": accession, "retmode": "json"},
+            "esearch.fcgi",
+            {"db": db, "term": accession, "retmode": "json"},
             accession,
-            "esummary",
+            "esearch",
         )
-        if summary is None:
+        if esearch is None:
             return None
-        result = summary.get("result", {})
-        live = any(
-            uid in result
-            and not result[uid].get("error")
-            and result[uid].get("status", "") in self._LIVE_NUCCORE_STATUSES
-            for uid in result.get("uids", [])
-        )
-        return datetime.now(pytz.UTC) if live else None
+        uids = esearch.get("esearchresult", {}).get("idlist", [])
+        if not uids:
+            return None
+        return datetime.now(pytz.UTC)
 
     def _eutils_get_json(
         self,

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -271,11 +271,13 @@ def check_and_update_visibility_for_column(
         # Check all accessions - mark as visible when ALL are visible
         all_visible = True
         first_visible_timestamp = None
+        visible_count = 0
 
         for accession in accessions:
             visible_timestamp = visibility_checker.check_visibility(config, accession)
 
             if visible_timestamp:
+                visible_count += 1
                 if first_visible_timestamp is None:
                     first_visible_timestamp = visible_timestamp
                 logger.debug(f"Accession {accession} is publicly visible")
@@ -304,9 +306,6 @@ def check_and_update_visibility_for_column(
                     f"Failed to update {column_name} for {entity_type.value} {entity_id}"
                 )
         else:
-            visible_count = sum(
-                1 for acc in accessions if visibility_checker.check_visibility(config, acc)
-            )
             logger.debug(
                 f"{entity_type.value.title()} {entity_id}: {visible_count}/{len(accessions)} "
                 "accessions are publicly visible (waiting for all)"

--- a/ena-submission/src/ena_deposition/config.py
+++ b/ena-submission/src/ena_deposition/config.py
@@ -116,6 +116,7 @@ class Config(BaseModel):
     ena_public_search_timeout_seconds: int = 120
     ncbi_public_search_timeout_seconds: int = 120
     ena_http_get_retry_attempts: int = 3
+    ncbi_http_get_retry_attempts: int = 3
     # By default, don't retry HTTP post requests to ENA
     ena_http_post_retry_attempts: int = 1
     min_between_github_requests: int = 2

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -619,12 +619,13 @@ class TestFirstPublicUpdate(TestSubmission):
 
     NUCLEOTIDE_CONFIG: Final = {
         "invalid_result": {
-            "insdc_accession_full_seg1": "XY999999",
-            "insdc_accession_full_seg2": "XY999998",
+            "insdc_accession_base_seg1": "XY999999",
+            "insdc_accession_base_seg2": "XY999998",
+            "insdc_accession_full_seg1": "OZ211366.1",  # suppressed sequences should be invalid
         },
         "valid_result": {
-            "insdc_accession_full_seg1": "OZ271453",
-            "insdc_accession_full_seg2": "OZ271454",
+            "insdc_accession_base_seg1": "OZ271453",
+            "insdc_accession_base_seg2": "OZ271454",
         },
         "base_entry": {
             "accession": "test_accession",

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -619,12 +619,12 @@ class TestFirstPublicUpdate(TestSubmission):
 
     NUCLEOTIDE_CONFIG: Final = {
         "invalid_result": {
-            "insdc_accession_full_segment1": "XY999999.1",
-            "insdc_accession_full_segment2": "XY999998.1",
+            "insdc_accession_full_seg1": "XY999999.1",
+            "insdc_accession_full_seg2": "XY999998.1",
         },
         "valid_result": {
-            "insdc_accession_full_segment1": "OZ271453.1",
-            "insdc_accession_full_segment2": "OZ271454.1",
+            "insdc_accession_full_seg1": "OZ271453.1",
+            "insdc_accession_full_seg2": "OZ271454.1",
         },
         "base_entry": {
             "accession": "test_accession",

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -619,12 +619,12 @@ class TestFirstPublicUpdate(TestSubmission):
 
     NUCLEOTIDE_CONFIG: Final = {
         "invalid_result": {
-            "insdc_accession_base_seg1": "XY999999",
-            "insdc_accession_base_seg2": "XY999998",
+            "insdc_accession_seg1": "XY999999",
+            "insdc_accession_seg2": "XY999998",
         },
         "valid_result": {
-            "insdc_accession_base_seg1": "OZ271453",
-            "insdc_accession_base_seg2": "OZ271454",
+            "insdc_accession_seg1": "OZ271453",
+            "insdc_accession_seg2": "OZ271454",
         },
         "base_entry": {
             "accession": "test_accession",

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -619,12 +619,12 @@ class TestFirstPublicUpdate(TestSubmission):
 
     NUCLEOTIDE_CONFIG: Final = {
         "invalid_result": {
-            "insdc_accession_seg1": "XY999999",
-            "insdc_accession_seg2": "XY999998",
+            "insdc_accession_full_segment1": "XY999999.1",
+            "insdc_accession_full_segment2": "XY999998.1",
         },
         "valid_result": {
-            "insdc_accession_seg1": "OZ271453",
-            "insdc_accession_seg2": "OZ271454",
+            "insdc_accession_full_segment1": "OZ271453.1",
+            "insdc_accession_full_segment2": "OZ271454.1",
         },
         "base_entry": {
             "accession": "test_accession",

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -621,7 +621,6 @@ class TestFirstPublicUpdate(TestSubmission):
         "invalid_result": {
             "insdc_accession_base_seg1": "XY999999",
             "insdc_accession_base_seg2": "XY999998",
-            "insdc_accession_full_seg1": "OZ211366.1",  # suppressed sequences should be invalid
         },
         "valid_result": {
             "insdc_accession_base_seg1": "OZ271453",


### PR DESCRIPTION
We no longer run ena integration tests on main due to the high number of ENA dev flakes, but I found that the liveness check tests are now failing: https://github.com/loculus-project/loculus/actions/runs/33619762911/job/100213831404 when adding a new feature (they are run on PRs with any changes to the deposition code).

The nuccore web page is behind a bot-check (RecaptchaChallengePageUi) that returns HTTP 200 for any request regardless of whether the accession exists, so query the E-utilities esummary API instead, which returns a real JSON result. 

E-utilities rate-limits unauthenticated requests to 3/second per IP, so retry on timeouts and transient (429/5xx) errors.

### Implications
We falsely marked INSDC nuccore accessions live on Genbank without actually checking... as this is an new bug we could potentially delete all liveness statuses for nuccore Genbank from the last month.

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
Ran curl to reproduce the test failure and see that the current nuccore status page that is downloaded is in fact a recaptcha challenge:
```
curl https://www.ncbi.nlm.nih.gov/nuccore/XY999999/
<!doctype html><html lang="en-US" dir="ltr"><head><base href="https://www.google.com/recaptcha/challengepage/"><link rel="preconnect" href="//www.gstatic.com"><meta name="referrer" content="origin"><script nonce="fDDXoBYzc-4DzTrYcL1ZiQ">window['ppConfig'] = {productName: 'RecaptchaChallengePageUi'...
```

🚀 Preview: Add `preview` label to enable