### PR TITLE
feat(deposition): make loculus metadata field names configurable and ENA db parameters Final

### DIFF
--- a/ena-submission/config/defaults.yaml
+++ b/ena-submission/config/defaults.yaml
@@ -121,4 +121,10 @@ slack_retry_substrings:
   - "does not exist in ENA"
 submitting_time_threshold_min: 15
 waiting_threshold_hours: 48
+loculus_accession_fields:
+  bioproject: bioprojectAccession
+  biosample: biosampleAccession
+  gca: gcaAccession
+  insdc_accession_prefix: insdcAccessionBase
+  versioned_insdc_accession_prefix: insdcAccessionFull
 allow_revision_with_manifest_changes: true

--- a/ena-submission/config/defaults.yaml
+++ b/ena-submission/config/defaults.yaml
@@ -126,5 +126,5 @@ loculus_accession_fields:
   biosample: biosampleAccession
   gca: gcaAccession
   insdc_accession_prefix: insdcAccessionBase
-  versioned_insdc_accession_prefix: insdcAccessionFull
+  insdc_accession_full_prefix: insdcAccessionFull
 allow_revision_with_manifest_changes: true

--- a/ena-submission/scripts/deposition_dry_run.py
+++ b/ena-submission/scripts/deposition_dry_run.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import click
 from ena_deposition.call_loculus import get_group_info
-from ena_deposition.config import BIOPROJECT_ENA_FIELD, BIOSAMPLE_ENA_FIELD, Config, get_config
+from ena_deposition.config import Config, EnaResultField, get_config
 from ena_deposition.create_assembly import create_manifest_object
 from ena_deposition.create_project import construct_project_set_object
 from ena_deposition.create_sample import construct_sample_set_object
@@ -101,13 +101,13 @@ def local_ena_submission_generator(
         project_entry = ProjectTableEntry(
             group_id=data["metadata"]["groupId"],
             organism=data["organism"],
-            result={BIOPROJECT_ENA_FIELD: bioproject} if bioproject else None,
+            result={EnaResultField.BIOPROJECT: bioproject} if bioproject else None,
             center_name=center_name,
         )
         sample_entry = SampleTableEntry(
             accession=accession,
             version=int(version),
-            result={BIOSAMPLE_ENA_FIELD: biosample} if biosample else None,
+            result={EnaResultField.BIOSAMPLE: biosample} if biosample else None,
         )
 
     if mode == "project":

--- a/ena-submission/scripts/deposition_dry_run.py
+++ b/ena-submission/scripts/deposition_dry_run.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import click
 from ena_deposition.call_loculus import get_group_info
-from ena_deposition.config import Config, get_config
+from ena_deposition.config import BIOPROJECT_ENA_FIELD, BIOSAMPLE_ENA_FIELD, Config, get_config
 from ena_deposition.create_assembly import create_manifest_object
 from ena_deposition.create_project import construct_project_set_object
 from ena_deposition.create_sample import construct_sample_set_object
@@ -26,7 +26,6 @@ from ena_deposition.submission_db_helper import (
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(
-    encoding="utf-8",
     level=logging.INFO,
     format="%(asctime)s %(levelname)8s (%(filename)20s:%(lineno)4d) - %(message)s ",
     datefmt="%H:%M:%S",
@@ -102,13 +101,13 @@ def local_ena_submission_generator(
         project_entry = ProjectTableEntry(
             group_id=data["metadata"]["groupId"],
             organism=data["organism"],
-            result={"bioproject_accession": bioproject} if bioproject else None,
+            result={BIOPROJECT_ENA_FIELD: bioproject} if bioproject else None,
             center_name=center_name,
         )
         sample_entry = SampleTableEntry(
             accession=accession,
             version=int(version),
-            result={"biosample_accession": biosample} if biosample else None,
+            result={BIOSAMPLE_ENA_FIELD: biosample} if biosample else None,
         )
 
     if mode == "project":

--- a/ena-submission/src/ena_deposition/api.py
+++ b/ena-submission/src/ena_deposition/api.py
@@ -43,7 +43,7 @@ def get_insdc_accessions(engine: Engine) -> dict[str, list[str]]:
         row.accession: [
             cast(str, row.result[key])
             for key in row.result
-            if key.startswith(EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX)
+            if key.startswith(EnaResultField.INSDC_ACCESSION_FULL_PREFIX)
         ]
         for row in results
         if row.result

--- a/ena-submission/src/ena_deposition/api.py
+++ b/ena-submission/src/ena_deposition/api.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from sqlalchemy import Engine, select
 from sqlalchemy.orm import Session
 
-from .config import Config
+from .config import BIOSAMPLE_ENA_FIELD, VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX, Config
 from .submission_db_helper import AssemblyTableEntry, SampleTableEntry, Status, db_init
 
 logger = logging.getLogger(__name__)
@@ -27,7 +27,7 @@ def get_bio_sample_accessions(engine: Engine) -> dict[str, str]:
         stmt = select(SampleTableEntry).where(SampleTableEntry.status == Status.SUBMITTED)
         results = list(session.scalars(stmt).all())
     return {
-        row.accession: cast(str, row.result["biosample_accession"]) for row in results if row.result
+        row.accession: cast(str, row.result[BIOSAMPLE_ENA_FIELD]) for row in results if row.result
     }
 
 
@@ -41,7 +41,7 @@ def get_insdc_accessions(engine: Engine) -> dict[str, list[str]]:
         row.accession: [
             cast(str, row.result[key])
             for key in row.result
-            if key.startswith("insdc_accession_full")
+            if key.startswith(VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX)
         ]
         for row in results
         if row.result

--- a/ena-submission/src/ena_deposition/api.py
+++ b/ena-submission/src/ena_deposition/api.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from sqlalchemy import Engine, select
 from sqlalchemy.orm import Session
 
-from .config import BIOSAMPLE_ENA_FIELD, VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX, Config
+from .config import Config, EnaResultField
 from .submission_db_helper import AssemblyTableEntry, SampleTableEntry, Status, db_init
 
 logger = logging.getLogger(__name__)
@@ -27,7 +27,9 @@ def get_bio_sample_accessions(engine: Engine) -> dict[str, str]:
         stmt = select(SampleTableEntry).where(SampleTableEntry.status == Status.SUBMITTED)
         results = list(session.scalars(stmt).all())
     return {
-        row.accession: cast(str, row.result[BIOSAMPLE_ENA_FIELD]) for row in results if row.result
+        row.accession: cast(str, row.result[EnaResultField.BIOSAMPLE])
+        for row in results
+        if row.result
     }
 
 
@@ -41,7 +43,7 @@ def get_insdc_accessions(engine: Engine) -> dict[str, list[str]]:
         row.accession: [
             cast(str, row.result[key])
             for key in row.result
-            if key.startswith(VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX)
+            if key.startswith(EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX)
         ]
         for row in results
         if row.result

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -21,7 +21,13 @@ import requests
 from sqlalchemy import Engine
 from tenacity import Retrying, retry_if_exception_type, stop_after_attempt, wait_fixed
 
-from ena_deposition.config import Config
+from ena_deposition.config import (
+    BIOPROJECT_ENA_FIELD,
+    BIOSAMPLE_ENA_FIELD,
+    GCA_ENA_FIELD,
+    VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX,
+    Config,
+)
 from ena_deposition.ena_submission_helper import log_before_retry
 from ena_deposition.submission_db_helper import (
     AssemblyTableEntry,
@@ -165,45 +171,45 @@ COLUMN_CONFIGS = {
     (EntityType.PROJECT, "ena_first_publicly_visible"): ColumnCheckConfig(
         entry_class=ProjectTableEntry,
         visibility_column="ena_first_publicly_visible",
-        accession_field_name_prefix="bioproject_accession",
+        accession_field_name_prefix=BIOPROJECT_ENA_FIELD,
         checker_class=ENAVisibilityChecker,
     ),
     (EntityType.PROJECT, "ncbi_first_publicly_visible"): ColumnCheckConfig(
         entry_class=ProjectTableEntry,
         visibility_column="ncbi_first_publicly_visible",
-        accession_field_name_prefix="bioproject_accession",
+        accession_field_name_prefix=BIOPROJECT_ENA_FIELD,
         checker_class=NCBIVisibilityChecker,
     ),
     (EntityType.SAMPLE, "ena_first_publicly_visible"): ColumnCheckConfig(
         entry_class=SampleTableEntry,
         visibility_column="ena_first_publicly_visible",
-        accession_field_name_prefix="biosample_accession",
+        accession_field_name_prefix=BIOSAMPLE_ENA_FIELD,
         checker_class=ENAVisibilityChecker,
     ),
     (EntityType.SAMPLE, "ncbi_first_publicly_visible"): ColumnCheckConfig(
         entry_class=SampleTableEntry,
         visibility_column="ncbi_first_publicly_visible",
-        accession_field_name_prefix="biosample_accession",
+        accession_field_name_prefix=BIOSAMPLE_ENA_FIELD,
         checker_class=NCBIVisibilityChecker,
     ),
     # Assemblies - ENA nucleotide accessions
     (EntityType.ASSEMBLY, "ena_nucleotide_first_publicly_visible"): ColumnCheckConfig(
         entry_class=AssemblyTableEntry,
         visibility_column="ena_nucleotide_first_publicly_visible",
-        accession_field_name_prefix="insdc_accession_full",  # Prefix for multi-segment accessions
+        accession_field_name_prefix=VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX,
         checker_class=ENAVisibilityChecker,
     ),
     (EntityType.ASSEMBLY, "ncbi_nucleotide_first_publicly_visible"): ColumnCheckConfig(
         entry_class=AssemblyTableEntry,
         visibility_column="ncbi_nucleotide_first_publicly_visible",
-        accession_field_name_prefix="insdc_accession_full",  # Prefix for multi-segment accessions
+        accession_field_name_prefix=VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX,
         checker_class=NCBIVisibilityChecker,
     ),
     # Assemblies - ENA GCA accessions
     (EntityType.ASSEMBLY, "ena_gca_first_publicly_visible"): ColumnCheckConfig(
         entry_class=AssemblyTableEntry,
         visibility_column="ena_gca_first_publicly_visible",
-        accession_field_name_prefix="gca_accession",
+        accession_field_name_prefix=GCA_ENA_FIELD,
         checker_class=ENAVisibilityChecker,
     ),
 }

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -22,11 +22,8 @@ from sqlalchemy import Engine
 from tenacity import Retrying, retry_if_exception_type, stop_after_attempt, wait_fixed
 
 from ena_deposition.config import (
-    BIOPROJECT_ENA_FIELD,
-    BIOSAMPLE_ENA_FIELD,
-    GCA_ENA_FIELD,
-    VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX,
     Config,
+    EnaResultField,
 )
 from ena_deposition.ena_submission_helper import log_before_retry
 from ena_deposition.submission_db_helper import (
@@ -171,45 +168,45 @@ COLUMN_CONFIGS = {
     (EntityType.PROJECT, "ena_first_publicly_visible"): ColumnCheckConfig(
         entry_class=ProjectTableEntry,
         visibility_column="ena_first_publicly_visible",
-        accession_field_name_prefix=BIOPROJECT_ENA_FIELD,
+        accession_field_name_prefix=EnaResultField.BIOPROJECT,
         checker_class=ENAVisibilityChecker,
     ),
     (EntityType.PROJECT, "ncbi_first_publicly_visible"): ColumnCheckConfig(
         entry_class=ProjectTableEntry,
         visibility_column="ncbi_first_publicly_visible",
-        accession_field_name_prefix=BIOPROJECT_ENA_FIELD,
+        accession_field_name_prefix=EnaResultField.BIOPROJECT,
         checker_class=NCBIVisibilityChecker,
     ),
     (EntityType.SAMPLE, "ena_first_publicly_visible"): ColumnCheckConfig(
         entry_class=SampleTableEntry,
         visibility_column="ena_first_publicly_visible",
-        accession_field_name_prefix=BIOSAMPLE_ENA_FIELD,
+        accession_field_name_prefix=EnaResultField.BIOSAMPLE,
         checker_class=ENAVisibilityChecker,
     ),
     (EntityType.SAMPLE, "ncbi_first_publicly_visible"): ColumnCheckConfig(
         entry_class=SampleTableEntry,
         visibility_column="ncbi_first_publicly_visible",
-        accession_field_name_prefix=BIOSAMPLE_ENA_FIELD,
+        accession_field_name_prefix=EnaResultField.BIOSAMPLE,
         checker_class=NCBIVisibilityChecker,
     ),
     # Assemblies - ENA nucleotide accessions
     (EntityType.ASSEMBLY, "ena_nucleotide_first_publicly_visible"): ColumnCheckConfig(
         entry_class=AssemblyTableEntry,
         visibility_column="ena_nucleotide_first_publicly_visible",
-        accession_field_name_prefix=VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX,
+        accession_field_name_prefix=EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX,
         checker_class=ENAVisibilityChecker,
     ),
     (EntityType.ASSEMBLY, "ncbi_nucleotide_first_publicly_visible"): ColumnCheckConfig(
         entry_class=AssemblyTableEntry,
         visibility_column="ncbi_nucleotide_first_publicly_visible",
-        accession_field_name_prefix=VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX,
+        accession_field_name_prefix=EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX,
         checker_class=NCBIVisibilityChecker,
     ),
     # Assemblies - ENA GCA accessions
     (EntityType.ASSEMBLY, "ena_gca_first_publicly_visible"): ColumnCheckConfig(
         entry_class=AssemblyTableEntry,
         visibility_column="ena_gca_first_publicly_visible",
-        accession_field_name_prefix=GCA_ENA_FIELD,
+        accession_field_name_prefix=EnaResultField.GCA,
         checker_class=ENAVisibilityChecker,
     ),
 }

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -193,13 +193,13 @@ COLUMN_CONFIGS = {
     (EntityType.ASSEMBLY, "ena_nucleotide_first_publicly_visible"): ColumnCheckConfig(
         entry_class=AssemblyTableEntry,
         visibility_column="ena_nucleotide_first_publicly_visible",
-        accession_field_name_prefix=EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX,
+        accession_field_name_prefix=EnaResultField.INSDC_ACCESSION_FULL_PREFIX,
         checker_class=ENAVisibilityChecker,
     ),
     (EntityType.ASSEMBLY, "ncbi_nucleotide_first_publicly_visible"): ColumnCheckConfig(
         entry_class=AssemblyTableEntry,
         visibility_column="ncbi_nucleotide_first_publicly_visible",
-        accession_field_name_prefix=EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX,
+        accession_field_name_prefix=EnaResultField.INSDC_ACCESSION_FULL_PREFIX,
         checker_class=NCBIVisibilityChecker,
     ),
     # Assemblies - ENA GCA accessions

--- a/ena-submission/src/ena_deposition/config.py
+++ b/ena-submission/src/ena_deposition/config.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from dataclasses import field
-from typing import Final
+from enum import StrEnum
 
 import dotenv
 import yaml
@@ -11,14 +11,20 @@ from ena_deposition.ena_types import MoleculeType, Topology
 
 logger = logging.getLogger(__name__)
 
-# Constants for names used to index ENA accessions stored in the ena_deposition_schema.
-# The corresponding Loculus schema field names are configurable per deployment - see
-# LoculusAccessionFieldNames and Config.loculus_accession_fields below.
-BIOSAMPLE_ENA_FIELD: Final = "biosample_accession"
-BIOPROJECT_ENA_FIELD: Final = "bioproject_accession"
-GCA_ENA_FIELD: Final = "gca_accession"
-INSDC_ACCESSION_ENA_FIELD_PREFIX: Final = "insdc_accession"
-VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX: Final = "insdc_accession_full"
+
+class EnaResultField(StrEnum):
+    """Keys used to store ENA accessions in the `result` column of the
+    ena_deposition_schema project/sample/assembly tables.
+
+    The corresponding Loculus schema field names are configurable per deployment - see
+    LoculusAccessionFieldNames and Config.loculus_accession_fields below.
+    """
+
+    BIOSAMPLE = "biosample_accession"
+    BIOPROJECT = "bioproject_accession"
+    GCA = "gca_accession"
+    INSDC_ACCESSION_PREFIX = "insdc_accession"
+    VERSIONED_INSDC_ACCESSION_PREFIX = "insdc_accession_full"
 
 
 class MetadataMapping(BaseModel):

--- a/ena-submission/src/ena_deposition/config.py
+++ b/ena-submission/src/ena_deposition/config.py
@@ -24,7 +24,7 @@ class EnaResultField(StrEnum):
     BIOPROJECT = "bioproject_accession"
     GCA = "gca_accession"
     INSDC_ACCESSION_PREFIX = "insdc_accession"
-    VERSIONED_INSDC_ACCESSION_PREFIX = "insdc_accession_full"
+    INSDC_ACCESSION_FULL_PREFIX = "insdc_accession_full"
 
 
 class MetadataMapping(BaseModel):

--- a/ena-submission/src/ena_deposition/config.py
+++ b/ena-submission/src/ena_deposition/config.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from dataclasses import field
+from typing import Final
 
 import dotenv
 import yaml
@@ -9,6 +10,15 @@ from pydantic import BaseModel
 from ena_deposition.ena_types import MoleculeType, Topology
 
 logger = logging.getLogger(__name__)
+
+# Constants for names used to index ENA accessions stored in the ena_deposition_schema.
+# The corresponding Loculus schema field names are configurable per deployment - see
+# LoculusAccessionFieldNames and Config.loculus_accession_fields below.
+BIOSAMPLE_ENA_FIELD: Final = "biosample_accession"
+BIOPROJECT_ENA_FIELD: Final = "bioproject_accession"
+GCA_ENA_FIELD: Final = "gca_accession"
+INSDC_ACCESSION_ENA_FIELD_PREFIX: Final = "insdc_accession"
+VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX: Final = "insdc_accession_full"
 
 
 class MetadataMapping(BaseModel):
@@ -29,6 +39,16 @@ class ManifestFieldDetails(BaseModel):
     loculus_fields: list[str] = field(default_factory=list)
     function: str | None = None
     default: str | None = None
+
+
+class LoculusAccessionFieldNames(BaseModel):
+    """Names of the Loculus schema fields used to exchange accessions with ENA/NCBI."""
+
+    bioproject: str
+    biosample: str
+    gca: str
+    insdc_accession_prefix: str
+    versioned_insdc_accession_prefix: str
 
 
 class ExternalMetadataField(BaseModel):
@@ -106,6 +126,7 @@ class Config(BaseModel):
     metadata_mapping: dict[str, MetadataMapping]
     metadata_fallback_fields: dict[str, str]
     assembly_manifest_fields_mapping: dict[str, ManifestFieldDetails]
+    loculus_accession_fields: LoculusAccessionFieldNames
     ingest_pipeline_submission_group: int
     ena_checklist: str | None = None
     set_alias_suffix: str | None = None  # Add to test revisions in dev

--- a/ena-submission/src/ena_deposition/config.py
+++ b/ena-submission/src/ena_deposition/config.py
@@ -54,7 +54,7 @@ class LoculusAccessionFieldNames(BaseModel):
     biosample: str
     gca: str
     insdc_accession_prefix: str
-    versioned_insdc_accession_prefix: str
+    insdc_accession_full_prefix: str
 
 
 class ExternalMetadataField(BaseModel):

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -14,10 +14,9 @@ from sqlalchemy import Engine
 from ena_deposition import call_loculus
 
 from .config import (
-    GCA_ENA_FIELD,
-    VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX,
     Config,
     EnaOrganismDetails,
+    EnaResultField,
 )
 from .ena_submission_helper import (
     CreationResult,
@@ -610,9 +609,9 @@ def assembly_table_update(db_engine: Engine, config: Config, time_threshold: int
             if not new_result.result:
                 continue
 
-            result_contains_gca_accession = GCA_ENA_FIELD in new_result.result
+            result_contains_gca_accession = EnaResultField.GCA in new_result.result
             result_contains_insdc_accession = any(
-                key.startswith(VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX)
+                key.startswith(EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX)
                 for key in new_result.result
             )
 

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -611,7 +611,7 @@ def assembly_table_update(db_engine: Engine, config: Config, time_threshold: int
 
             result_contains_gca_accession = EnaResultField.GCA in new_result.result
             result_contains_insdc_accession = any(
-                key.startswith(EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX)
+                key.startswith(EnaResultField.INSDC_ACCESSION_FULL_PREFIX)
                 for key in new_result.result
             )
 

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -13,7 +13,12 @@ from sqlalchemy import Engine
 
 from ena_deposition import call_loculus
 
-from .config import Config, EnaOrganismDetails
+from .config import (
+    GCA_ENA_FIELD,
+    VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX,
+    Config,
+    EnaOrganismDetails,
+)
 from .ena_submission_helper import (
     CreationResult,
     accession_exists,
@@ -288,7 +293,7 @@ def update_assembly_error(
     db_engine: Engine,
     error: list[str],
     seq_key: dict[str, Any],
-    update_type: Literal["revision"] | Literal["creation"],
+    update_type: Literal["revision", "creation"],
 ) -> None:
     logger.error(
         f"Assembly {update_type} failed for accession {seq_key['accession']} "
@@ -353,7 +358,7 @@ def can_be_revised(config: Config, db_engine: Engine, submission_row: Submission
         f"previous study accession: {previous_study_accession}"
     )
     linked_accession_mismatches = linked_accession_diff(
-        submission_row, previous_sample_accession, previous_study_accession
+        config, submission_row, previous_sample_accession, previous_study_accession
     )
     if linked_accession_mismatches:
         error = (
@@ -605,9 +610,10 @@ def assembly_table_update(db_engine: Engine, config: Config, time_threshold: int
             if not new_result.result:
                 continue
 
-            result_contains_gca_accession = "gca_accession" in new_result.result
+            result_contains_gca_accession = GCA_ENA_FIELD in new_result.result
             result_contains_insdc_accession = any(
-                key.startswith("insdc_accession_full") for key in new_result.result
+                key.startswith(VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX)
+                for key in new_result.result
             )
 
             if not (result_contains_gca_accession and result_contains_insdc_accession):

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -9,7 +9,7 @@ from sqlalchemy import Engine
 from ena_deposition import call_loculus
 from ena_deposition.loculus_models import Group
 
-from .config import BIOPROJECT_ENA_FIELD, Config
+from .config import Config, EnaResultField
 from .ena_submission_helper import (
     CreationResult,
     accession_exists,
@@ -113,7 +113,7 @@ def update_with_existing_bioproject(
         f"Group {row.group_id} and organism {row.organism} already has "
         f"bioprojectAccession, adding to project_table"
     )
-    bioproject = row.result.get(BIOPROJECT_ENA_FIELD) if row.result else None
+    bioproject = row.result.get(EnaResultField.BIOPROJECT) if row.result else None
 
     logger.info("Checking if bioproject actually exists and is public")
     if not bioproject or not accession_exists(str(bioproject), config):
@@ -133,7 +133,7 @@ def update_with_existing_bioproject(
         {
             "group_id": row.group_id,
             "organism": row.organism,
-            "result": {BIOPROJECT_ENA_FIELD: bioproject},
+            "result": {EnaResultField.BIOPROJECT: bioproject},
             "status": Status.SUBMITTED,
             "center_name": center_name,
         },
@@ -172,7 +172,7 @@ def sync_state_with_submission_table(db_engine: Engine, config: Config):
                 project
                 for project in existing_corresponding_projects
                 if project.result
-                and project.result.get(BIOPROJECT_ENA_FIELD) == submitter_provided_bioproject
+                and project.result.get(EnaResultField.BIOPROJECT) == submitter_provided_bioproject
             ]
         else:
             corresponding_project = existing_corresponding_projects
@@ -211,7 +211,7 @@ def sync_state_with_submission_table(db_engine: Engine, config: Config):
             ProjectTableEntry(
                 group_id=row.group_id,
                 organism=row.organism,
-                result={BIOPROJECT_ENA_FIELD: submitter_provided_bioproject}
+                result={EnaResultField.BIOPROJECT: submitter_provided_bioproject}
                 if submitter_provided_bioproject
                 else None,
             ),
@@ -257,7 +257,7 @@ def project_table_create(
             logger.error(f"Was unable to get group info for group: {row.group_id}, {e}")
             continue
 
-        if row.result and row.result.get(BIOPROJECT_ENA_FIELD):
+        if row.result and row.result.get(EnaResultField.BIOPROJECT):
             update_with_existing_bioproject(
                 db_engine, config, row, center_name=group_info.institution
             )

--- a/ena-submission/src/ena_deposition/create_project.py
+++ b/ena-submission/src/ena_deposition/create_project.py
@@ -9,7 +9,7 @@ from sqlalchemy import Engine
 from ena_deposition import call_loculus
 from ena_deposition.loculus_models import Group
 
-from .config import Config
+from .config import BIOPROJECT_ENA_FIELD, Config
 from .ena_submission_helper import (
     CreationResult,
     accession_exists,
@@ -113,7 +113,7 @@ def update_with_existing_bioproject(
         f"Group {row.group_id} and organism {row.organism} already has "
         f"bioprojectAccession, adding to project_table"
     )
-    bioproject = row.result.get("bioproject_accession") if row.result else None
+    bioproject = row.result.get(BIOPROJECT_ENA_FIELD) if row.result else None
 
     logger.info("Checking if bioproject actually exists and is public")
     if not bioproject or not accession_exists(str(bioproject), config):
@@ -133,14 +133,14 @@ def update_with_existing_bioproject(
         {
             "group_id": row.group_id,
             "organism": row.organism,
-            "result": {"bioproject_accession": bioproject},
+            "result": {BIOPROJECT_ENA_FIELD: bioproject},
             "status": Status.SUBMITTED,
             "center_name": center_name,
         },
     )
 
 
-def sync_state_with_submission_table(db_engine: Engine):
+def sync_state_with_submission_table(db_engine: Engine, config: Config):
     """
     1. Find all entries in submission_table in state READY_TO_SUBMIT
     2. If (exists entry/entries in the project_table for (group_id, organism)):
@@ -157,7 +157,9 @@ def sync_state_with_submission_table(db_engine: Engine):
     for row in ready_to_submit:
         group_key = {"group_id": row.group_id, "organism": row.organism}
         seq_key = asdict(row.pkey)
-        submitter_provided_bioproject: str | None = row.seq_metadata.get("bioprojectAccession")
+        submitter_provided_bioproject: str | None = row.seq_metadata.get(
+            config.loculus_accession_fields.bioproject
+        )
 
         # Check if there exist entries in the project table for (group_id, organism)
         existing_corresponding_projects = find_conditions_in_db(
@@ -170,7 +172,7 @@ def sync_state_with_submission_table(db_engine: Engine):
                 project
                 for project in existing_corresponding_projects
                 if project.result
-                and project.result.get("bioproject_accession") == submitter_provided_bioproject
+                and project.result.get(BIOPROJECT_ENA_FIELD) == submitter_provided_bioproject
             ]
         else:
             corresponding_project = existing_corresponding_projects
@@ -209,7 +211,7 @@ def sync_state_with_submission_table(db_engine: Engine):
             ProjectTableEntry(
                 group_id=row.group_id,
                 organism=row.organism,
-                result={"bioproject_accession": submitter_provided_bioproject}
+                result={BIOPROJECT_ENA_FIELD: submitter_provided_bioproject}
                 if submitter_provided_bioproject
                 else None,
             ),
@@ -255,7 +257,7 @@ def project_table_create(
             logger.error(f"Was unable to get group info for group: {row.group_id}, {e}")
             continue
 
-        if row.result and row.result.get("bioproject_accession"):
+        if row.result and row.result.get(BIOPROJECT_ENA_FIELD):
             update_with_existing_bioproject(
                 db_engine, config, row, center_name=group_info.institution
             )
@@ -368,10 +370,12 @@ def create_project(config: Config, stop_event: threading.Event):
             logger.warning("create_project stopped due to exception in another task")
             return
         logger.debug("Checking for projects to create")
-        sync_state_with_submission_table(db_engine)
+        sync_state_with_submission_table(db_engine, config)
 
         project_table_create(db_engine, config)
-        sync_state_with_submission_table(db_engine)  # update submission_table state after creation
+        sync_state_with_submission_table(
+            db_engine, config
+        )  # update submission_table state after creation
         last_retry_time = project_table_handle_errors(
             db_engine, config, slack_config, last_retry_time
         )

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import pytz
 from sqlalchemy import Engine
 
-from .config import Config, MetadataMapping
+from .config import BIOSAMPLE_ENA_FIELD, Config, MetadataMapping
 from .ena_submission_helper import (
     CreationResult,
     accession_exists,
@@ -170,7 +170,7 @@ def update_with_existing_biosample(db_engine: Engine, row: SubmissionTableEntry,
     logger.debug(
         f"Accession: {row.accession} already has biosampleAccession, updating sample_table"
     )
-    biosample = row.seq_metadata["biosampleAccession"]
+    biosample = row.seq_metadata[config.loculus_accession_fields.biosample]
 
     logger.info("Checking if biosample actually exists and is public")
     seq_key = asdict(row.pkey)
@@ -191,18 +191,18 @@ def update_with_existing_biosample(db_engine: Engine, row: SubmissionTableEntry,
         update_values={
             "accession": row.accession,
             "version": row.version,
-            "result": {"ena_sample_accession": biosample, "biosample_accession": biosample},
+            "result": {"ena_sample_accession": biosample, BIOSAMPLE_ENA_FIELD: biosample},
             "status": Status.SUBMITTED,
         },
     )
 
 
-def sync_state_with_submission_table(db_engine: Engine):
+def sync_state_with_submission_table(db_engine: Engine, config: Config):
     """
     1. Find all entries in submission_table in state SUBMITTED_PROJECT
     2. If (exists an entry in the sample_table for (accession, version)):
     a.      If (in state SUBMITTED) update state in submission_table to SUBMITTED_SAMPLE
-    3. If (exists "biosampleAccession" in "metadata"):
+    3. If (exists config.loculus_accession_fields.biosample in "metadata"):
         create entry in sample_table, update state to SUBMITTED_SAMPLE
     4. Else create corresponding entry in sample_table
     """
@@ -242,12 +242,12 @@ def sync_state_with_submission_table(db_engine: Engine):
             )
             continue
         biosample = None
-        if row and row.seq_metadata.get("biosampleAccession"):
-            biosample = row.seq_metadata["biosampleAccession"]
+        if row and row.seq_metadata.get(config.loculus_accession_fields.biosample):
+            biosample = row.seq_metadata[config.loculus_accession_fields.biosample]
         add_to_sample_table(
             db_engine,
             SampleTableEntry(
-                **seq_key, result={"biosample_accession": biosample} if biosample else None
+                **seq_key, result={BIOSAMPLE_ENA_FIELD: biosample} if biosample else None
             ),
         )
 
@@ -281,7 +281,7 @@ def sample_table_create(db_engine: Engine, config: Config):
             db_engine, SubmissionTableEntry, conditions=asdict(seq_key)
         )
 
-        if row.result and row.result.get("biosample_accession"):
+        if row.result and row.result.get(BIOSAMPLE_ENA_FIELD):
             update_with_existing_biosample(db_engine, sample_data_in_submission_table[0], config)
             continue
 
@@ -388,10 +388,12 @@ def create_sample(config: Config, stop_event: threading.Event):
             logger.warning("create_sample stopped due to exception in another task")
             return
         logger.debug("Checking for samples to create")
-        sync_state_with_submission_table(db_engine)
+        sync_state_with_submission_table(db_engine, config)
 
         sample_table_create(db_engine, config)
-        sync_state_with_submission_table(db_engine)  # update submission_table state after creation
+        sync_state_with_submission_table(
+            db_engine, config
+        )  # update submission_table state after creation
         last_retry_time = sample_table_handle_errors(
             db_engine, config, slack_config, last_retry_time
         )

--- a/ena-submission/src/ena_deposition/create_sample.py
+++ b/ena-submission/src/ena_deposition/create_sample.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import pytz
 from sqlalchemy import Engine
 
-from .config import BIOSAMPLE_ENA_FIELD, Config, MetadataMapping
+from .config import Config, EnaResultField, MetadataMapping
 from .ena_submission_helper import (
     CreationResult,
     accession_exists,
@@ -191,7 +191,7 @@ def update_with_existing_biosample(db_engine: Engine, row: SubmissionTableEntry,
         update_values={
             "accession": row.accession,
             "version": row.version,
-            "result": {"ena_sample_accession": biosample, BIOSAMPLE_ENA_FIELD: biosample},
+            "result": {"ena_sample_accession": biosample, EnaResultField.BIOSAMPLE: biosample},
             "status": Status.SUBMITTED,
         },
     )
@@ -247,7 +247,7 @@ def sync_state_with_submission_table(db_engine: Engine, config: Config):
         add_to_sample_table(
             db_engine,
             SampleTableEntry(
-                **seq_key, result={BIOSAMPLE_ENA_FIELD: biosample} if biosample else None
+                **seq_key, result={EnaResultField.BIOSAMPLE: biosample} if biosample else None
             ),
         )
 
@@ -281,7 +281,7 @@ def sample_table_create(db_engine: Engine, config: Config):
             db_engine, SubmissionTableEntry, conditions=asdict(seq_key)
         )
 
-        if row.result and row.result.get(BIOSAMPLE_ENA_FIELD):
+        if row.result and row.result.get(EnaResultField.BIOSAMPLE):
             update_with_existing_biosample(db_engine, sample_data_in_submission_table[0], config)
             continue
 

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -36,13 +36,9 @@ from tenacity import (
 from unidecode import unidecode
 
 from ena_deposition.config import (
-    BIOPROJECT_ENA_FIELD,
-    BIOSAMPLE_ENA_FIELD,
-    GCA_ENA_FIELD,
-    INSDC_ACCESSION_ENA_FIELD_PREFIX,
-    VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX,
     Config,
     EnaOrganismDetails,
+    EnaResultField,
     ManifestFieldDetails,
 )
 
@@ -283,7 +279,7 @@ def create_ena_project(config: Config, project_set: ProjectSet) -> CreationResul
         errors.append(error_message)
         return CreationResult(errors=errors, warnings=warnings)
     project_results = {
-        BIOPROJECT_ENA_FIELD: parsed_response["RECEIPT"]["PROJECT"]["@accession"],
+        EnaResultField.BIOPROJECT: parsed_response["RECEIPT"]["PROJECT"]["@accession"],
         "ena_submission_accession": parsed_response["RECEIPT"]["SUBMISSION"]["@accession"],
     }
     return CreationResult(result=project_results, errors=errors, warnings=warnings)
@@ -356,7 +352,7 @@ def create_ena_sample(
         return CreationResult(errors=errors, warnings=warnings)
     sample_results = {
         "ena_sample_accession": parsed_response["RECEIPT"]["SAMPLE"]["@accession"],
-        BIOSAMPLE_ENA_FIELD: parsed_response["RECEIPT"]["SAMPLE"]["EXT_ID"]["@accession"],
+        EnaResultField.BIOSAMPLE: parsed_response["RECEIPT"]["SAMPLE"]["EXT_ID"]["@accession"],
         "ena_submission_accession": parsed_response["RECEIPT"]["SUBMISSION"]["@accession"],
     }
     return CreationResult(result=sample_results, errors=errors, warnings=warnings)
@@ -813,7 +809,7 @@ def get_ena_analysis_process(
             if gca_accession:
                 assembly_results.update(
                     {
-                        GCA_ENA_FIELD: gca_accession,
+                        EnaResultField.GCA: gca_accession,
                     }
                 )
             insdc_accession_range = acc_dict.get("chromosomes")
@@ -878,14 +874,16 @@ def get_chromsome_accessions(
         if not is_multi_segment:
             accession = f"{start_letters}{start_num:0{num_digits}d}"
             return {
-                INSDC_ACCESSION_ENA_FIELD_PREFIX: accession,
-                VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX: f"{accession}.1",
+                EnaResultField.INSDC_ACCESSION_PREFIX: accession,
+                EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX: f"{accession}.1",
             }
         results = {}
         for i, segment in enumerate(segment_order):
             accession = f"{start_letters}{(start_num + i):0{num_digits}d}"
-            results[f"{INSDC_ACCESSION_ENA_FIELD_PREFIX}_{segment}"] = accession
-            results[f"{VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX}_{segment}"] = f"{accession}.1"
+            results[f"{EnaResultField.INSDC_ACCESSION_PREFIX}_{segment}"] = accession
+            results[f"{EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX}_{segment}"] = (
+                f"{accession}.1"
+            )
         return results
 
     # Don't handle the Value error here, let it propagate
@@ -935,7 +933,10 @@ def set_accession_does_not_exist_error(
                 {
                     "status": Status.HAS_ERRORS,
                     "errors": [error_text],
-                    "result": {BIOSAMPLE_ENA_FIELD: accession, "ena_sample_accession": accession},
+                    "result": {
+                        EnaResultField.BIOSAMPLE: accession,
+                        "ena_sample_accession": accession,
+                    },
                 },
             )
         case "BIOPROJECT":
@@ -946,7 +947,7 @@ def set_accession_does_not_exist_error(
                 {
                     "status": Status.HAS_ERRORS,
                     "errors": [error_text],
-                    "result": {BIOPROJECT_ENA_FIELD: accession},
+                    "result": {EnaResultField.BIOPROJECT: accession},
                 },
             )
         case "RUN_REF":

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -875,15 +875,13 @@ def get_chromsome_accessions(
             accession = f"{start_letters}{start_num:0{num_digits}d}"
             return {
                 EnaResultField.INSDC_ACCESSION_PREFIX: accession,
-                EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX: f"{accession}.1",
+                EnaResultField.INSDC_ACCESSION_FULL_PREFIX: f"{accession}.1",
             }
         results = {}
         for i, segment in enumerate(segment_order):
             accession = f"{start_letters}{(start_num + i):0{num_digits}d}"
             results[f"{EnaResultField.INSDC_ACCESSION_PREFIX}_{segment}"] = accession
-            results[f"{EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX}_{segment}"] = (
-                f"{accession}.1"
-            )
+            results[f"{EnaResultField.INSDC_ACCESSION_FULL_PREFIX}_{segment}"] = f"{accession}.1"
         return results
 
     # Don't handle the Value error here, let it propagate

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -35,7 +35,16 @@ from tenacity import (
 )
 from unidecode import unidecode
 
-from ena_deposition.config import Config, EnaOrganismDetails, ManifestFieldDetails
+from ena_deposition.config import (
+    BIOPROJECT_ENA_FIELD,
+    BIOSAMPLE_ENA_FIELD,
+    GCA_ENA_FIELD,
+    INSDC_ACCESSION_ENA_FIELD_PREFIX,
+    VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX,
+    Config,
+    EnaOrganismDetails,
+    ManifestFieldDetails,
+)
 
 from .ena_types import (
     DEFAULT_EMBL_PROPERTY_FIELDS,
@@ -274,7 +283,7 @@ def create_ena_project(config: Config, project_set: ProjectSet) -> CreationResul
         errors.append(error_message)
         return CreationResult(errors=errors, warnings=warnings)
     project_results = {
-        "bioproject_accession": parsed_response["RECEIPT"]["PROJECT"]["@accession"],
+        BIOPROJECT_ENA_FIELD: parsed_response["RECEIPT"]["PROJECT"]["@accession"],
         "ena_submission_accession": parsed_response["RECEIPT"]["SUBMISSION"]["@accession"],
     }
     return CreationResult(result=project_results, errors=errors, warnings=warnings)
@@ -347,7 +356,7 @@ def create_ena_sample(
         return CreationResult(errors=errors, warnings=warnings)
     sample_results = {
         "ena_sample_accession": parsed_response["RECEIPT"]["SAMPLE"]["@accession"],
-        "biosample_accession": parsed_response["RECEIPT"]["SAMPLE"]["EXT_ID"]["@accession"],
+        BIOSAMPLE_ENA_FIELD: parsed_response["RECEIPT"]["SAMPLE"]["EXT_ID"]["@accession"],
         "ena_submission_accession": parsed_response["RECEIPT"]["SUBMISSION"]["@accession"],
     }
     return CreationResult(result=sample_results, errors=errors, warnings=warnings)
@@ -456,7 +465,7 @@ def create_flatfile(
     authors = get_authors(metadata.get(DEFAULT_EMBL_PROPERTY_FIELDS.authors_property) or "")
     # BioPython's EMBL writer automatically adds a terminating semicolon,
     # so we need to strip it from our formatted authors string to avoid duplication
-    authors = authors.removesuffix(";")
+    authors = authors.removesuffix(";")  # type: ignore
     country = get_country(metadata)
     organism = organism_metadata.scientific_name
     accession = metadata["accession"]
@@ -616,6 +625,7 @@ def manifest_fields_diff(
 
 
 def linked_accession_diff(
+    config: Config,
     submission_row: SubmissionTableEntry,
     previous_sample_accession: str,
     previous_study_accession: str,
@@ -624,8 +634,8 @@ def linked_accession_diff(
     are linked to an already-existing sample/project), check it still matches the accession
     used for the previous version."""
     previous_accessions = {
-        "biosampleAccession": previous_sample_accession,
-        "bioprojectAccession": previous_study_accession,
+        config.loculus_accession_fields.biosample: previous_sample_accession,
+        config.loculus_accession_fields.bioproject: previous_study_accession,
     }
     differing_fields = {}
     for field, previous_accession in previous_accessions.items():
@@ -803,7 +813,7 @@ def get_ena_analysis_process(
             if gca_accession:
                 assembly_results.update(
                     {
-                        "gca_accession": gca_accession,
+                        GCA_ENA_FIELD: gca_accession,
                     }
                 )
             insdc_accession_range = acc_dict.get("chromosomes")
@@ -868,14 +878,14 @@ def get_chromsome_accessions(
         if not is_multi_segment:
             accession = f"{start_letters}{start_num:0{num_digits}d}"
             return {
-                "insdc_accession": accession,
-                "insdc_accession_full": f"{accession}.1",
+                INSDC_ACCESSION_ENA_FIELD_PREFIX: accession,
+                VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX: f"{accession}.1",
             }
         results = {}
         for i, segment in enumerate(segment_order):
             accession = f"{start_letters}{(start_num + i):0{num_digits}d}"
-            results[f"insdc_accession_{segment}"] = accession
-            results[f"insdc_accession_full_{segment}"] = f"{accession}.1"
+            results[f"{INSDC_ACCESSION_ENA_FIELD_PREFIX}_{segment}"] = accession
+            results[f"{VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX}_{segment}"] = f"{accession}.1"
         return results
 
     # Don't handle the Value error here, let it propagate
@@ -909,7 +919,7 @@ def accession_exists(
 def set_accession_does_not_exist_error(
     conditions: dict[str, Any],
     accession: str,
-    accession_type: Literal["BIOPROJECT"] | Literal["BIOSAMPLE"] | Literal["RUN_REF"],
+    accession_type: Literal["BIOPROJECT", "BIOSAMPLE", "RUN_REF"],
     db_engine: Engine,
 ):
     error_text = f"Accession {accession} of type {accession_type} does not exist in ENA."
@@ -925,7 +935,7 @@ def set_accession_does_not_exist_error(
                 {
                     "status": Status.HAS_ERRORS,
                     "errors": [error_text],
-                    "result": {"biosample_accession": accession, "ena_sample_accession": accession},
+                    "result": {BIOSAMPLE_ENA_FIELD: accession, "ena_sample_accession": accession},
                 },
             )
         case "BIOPROJECT":
@@ -936,7 +946,7 @@ def set_accession_does_not_exist_error(
                 {
                     "status": Status.HAS_ERRORS,
                     "errors": [error_text],
-                    "result": {"bioproject_accession": accession},
+                    "result": {BIOPROJECT_ENA_FIELD: accession},
                 },
             )
         case "RUN_REF":

--- a/ena-submission/src/ena_deposition/ena_submission_helper.py
+++ b/ena-submission/src/ena_deposition/ena_submission_helper.py
@@ -459,9 +459,6 @@ def create_flatfile(
 ):
     collection_date = metadata.get(DEFAULT_EMBL_PROPERTY_FIELDS.collection_date_property, "Unknown")
     authors = get_authors(metadata.get(DEFAULT_EMBL_PROPERTY_FIELDS.authors_property) or "")
-    # BioPython's EMBL writer automatically adds a terminating semicolon,
-    # so we need to strip it from our formatted authors string to avoid duplication
-    authors = authors.removesuffix(";")  # type: ignore
     country = get_country(metadata)
     organism = organism_metadata.scientific_name
     accession = metadata["accession"]
@@ -488,7 +485,11 @@ def create_flatfile(
         if not isinstance(sequence_str, str) or len(sequence_str) == 0:
             continue
         reference = Reference()
-        reference.authors = authors
+        if authors:
+            # BioPython's EMBL writer automatically adds a terminating semicolon,
+            # so we need to strip it from our formatted authors string to avoid duplication
+            authors = authors.removesuffix(";")
+            reference.authors = authors
         sequence = SeqRecord(
             seq=Seq(sequence_str),
             id=f"{accession}_{seq_name}" if multi_segment else accession,

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -39,7 +39,7 @@ from tenacity import (
     wait_fixed,
 )
 
-from ena_deposition.config import BIOPROJECT_ENA_FIELD
+from ena_deposition.config import EnaResultField
 
 logger = logging.getLogger(__name__)
 
@@ -633,7 +633,7 @@ def get_project_and_sample_results(
         sample_rows[0].result.get("ena_sample_accession") if sample_rows[0].result else None
     )
     study_accession = (
-        project_rows[0].result.get(BIOPROJECT_ENA_FIELD) if project_rows[0].result else None
+        project_rows[0].result.get(EnaResultField.BIOPROJECT) if project_rows[0].result else None
     )
     if not sample_accession or not study_accession:
         error_msg = (

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -39,6 +39,8 @@ from tenacity import (
     wait_fixed,
 )
 
+from ena_deposition.config import BIOPROJECT_ENA_FIELD
+
 logger = logging.getLogger(__name__)
 
 
@@ -631,7 +633,7 @@ def get_project_and_sample_results(
         sample_rows[0].result.get("ena_sample_accession") if sample_rows[0].result else None
     )
     study_accession = (
-        project_rows[0].result.get("bioproject_accession") if project_rows[0].result else None
+        project_rows[0].result.get(BIOPROJECT_ENA_FIELD) if project_rows[0].result else None
     )
     if not sample_accession or not study_accession:
         error_msg = (

--- a/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
+++ b/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
@@ -123,7 +123,7 @@ def get_assembly_accessions_from_db(
         else:
             all_present = False
 
-        full_key = f"{EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX}{segment_suffix}"
+        full_key = f"{EnaResultField.INSDC_ACCESSION_FULL_PREFIX}{segment_suffix}"
         if full_key in result:
             data[
                 f"{config.loculus_accession_fields.versioned_insdc_accession_prefix}{segment_suffix}"

--- a/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
+++ b/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
@@ -126,7 +126,7 @@ def get_assembly_accessions_from_db(
         full_key = f"{EnaResultField.INSDC_ACCESSION_FULL_PREFIX}{segment_suffix}"
         if full_key in result:
             data[
-                f"{config.loculus_accession_fields.versioned_insdc_accession_prefix}{segment_suffix}"
+                f"{config.loculus_accession_fields.insdc_accession_full_prefix}{segment_suffix}"
             ] = result[full_key]
         else:
             all_present = False

--- a/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
+++ b/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
@@ -11,7 +11,15 @@ from sqlalchemy import Engine
 
 from ena_deposition.call_loculus import submit_external_metadata
 
-from .config import Config, EnaOrganismDetails
+from .config import (
+    BIOPROJECT_ENA_FIELD,
+    BIOSAMPLE_ENA_FIELD,
+    GCA_ENA_FIELD,
+    INSDC_ACCESSION_ENA_FIELD_PREFIX,
+    VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX,
+    Config,
+    EnaOrganismDetails,
+)
 from .notifications import SlackConfig, send_slack_notification, slack_conn_init
 from .submission_db_helper import (
     AssemblyTableEntry,
@@ -53,21 +61,23 @@ def _get_result_of_single_db_record[T: SampleTableEntry | ProjectTableEntry | As
     return result
 
 
-def get_bioproject_accession_from_db(db_engine: Engine, project_id: int | None) -> dict[str, str]:
+def get_bioproject_accession_from_db(
+    db_engine: Engine, config: Config, project_id: int | None
+) -> dict[str, str]:
     if project_id is None:
         return {}
     result = _get_result_of_single_db_record(
         db_engine, ProjectTableEntry, conditions={"project_id": project_id}
     )
 
-    if not result or "bioproject_accession" not in result:
+    if not result or BIOPROJECT_ENA_FIELD not in result:
         return {}
 
-    return {"bioprojectAccession": result["bioproject_accession"]}
+    return {config.loculus_accession_fields.bioproject: result[BIOPROJECT_ENA_FIELD]}
 
 
 def get_biosample_accession_from_db(
-    db_engine: Engine, accession: str, version: int
+    db_engine: Engine, config: Config, accession: str, version: int
 ) -> dict[str, str]:
     result = _get_result_of_single_db_record(
         db_engine,
@@ -75,14 +85,15 @@ def get_biosample_accession_from_db(
         conditions={"accession": accession, "version": version},
     )
 
-    if not result or "biosample_accession" not in result:
+    if not result or BIOSAMPLE_ENA_FIELD not in result:
         return {}
 
-    return {"biosampleAccession": result["biosample_accession"]}
+    return {config.loculus_accession_fields.biosample: result[BIOSAMPLE_ENA_FIELD]}
 
 
 def get_assembly_accessions_from_db(
     db_engine: Engine,
+    config: Config,
     accession: str,
     version: int,
     organism: EnaOrganismDetails,
@@ -99,8 +110,8 @@ def get_assembly_accessions_from_db(
     data = {}
     all_present = True
 
-    if gca := result.get("gca_accession"):
-        data["gcaAccession"] = gca
+    if gca := result.get(GCA_ENA_FIELD):
+        data[config.loculus_accession_fields.gca] = gca
     else:
         all_present = False
 
@@ -108,15 +119,19 @@ def get_assembly_accessions_from_db(
     for segment in segment_names:
         segment_suffix = f"_{segment}" if organism.is_multi_segment() else ""
 
-        base_key = f"insdc_accession{segment_suffix}"
+        base_key = f"{INSDC_ACCESSION_ENA_FIELD_PREFIX}{segment_suffix}"
         if base_key in result:
-            data[f"insdcAccessionBase{segment_suffix}"] = result[base_key]
+            data[f"{config.loculus_accession_fields.insdc_accession_prefix}{segment_suffix}"] = (
+                result[base_key]
+            )
         else:
             all_present = False
 
-        full_key = f"insdc_accession_full{segment_suffix}"
+        full_key = f"{VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX}{segment_suffix}"
         if full_key in result:
-            data[f"insdcAccessionFull{segment_suffix}"] = result[full_key]
+            data[
+                f"{config.loculus_accession_fields.versioned_insdc_accession_prefix}{segment_suffix}"
+            ] = result[full_key]
         else:
             all_present = False
 
@@ -130,10 +145,10 @@ def get_external_metadata_to_upload(
     version = entry.version
     organism = config.enaOrganisms[entry.organism]
 
-    bioproject_accession = get_bioproject_accession_from_db(db_engine, entry.project_id)
-    biosample_accession = get_biosample_accession_from_db(db_engine, accession, version)
+    bioproject_accession = get_bioproject_accession_from_db(db_engine, config, entry.project_id)
+    biosample_accession = get_biosample_accession_from_db(db_engine, config, accession, version)
     assembly_accession, all_assemblies_present = get_assembly_accessions_from_db(
-        db_engine, accession, version, organism
+        db_engine, config, accession, version, organism
     )
 
     return {

--- a/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
+++ b/ena-submission/src/ena_deposition/upload_external_metadata_to_loculus.py
@@ -12,13 +12,9 @@ from sqlalchemy import Engine
 from ena_deposition.call_loculus import submit_external_metadata
 
 from .config import (
-    BIOPROJECT_ENA_FIELD,
-    BIOSAMPLE_ENA_FIELD,
-    GCA_ENA_FIELD,
-    INSDC_ACCESSION_ENA_FIELD_PREFIX,
-    VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX,
     Config,
     EnaOrganismDetails,
+    EnaResultField,
 )
 from .notifications import SlackConfig, send_slack_notification, slack_conn_init
 from .submission_db_helper import (
@@ -70,10 +66,10 @@ def get_bioproject_accession_from_db(
         db_engine, ProjectTableEntry, conditions={"project_id": project_id}
     )
 
-    if not result or BIOPROJECT_ENA_FIELD not in result:
+    if not result or EnaResultField.BIOPROJECT not in result:
         return {}
 
-    return {config.loculus_accession_fields.bioproject: result[BIOPROJECT_ENA_FIELD]}
+    return {config.loculus_accession_fields.bioproject: result[EnaResultField.BIOPROJECT]}
 
 
 def get_biosample_accession_from_db(
@@ -85,10 +81,10 @@ def get_biosample_accession_from_db(
         conditions={"accession": accession, "version": version},
     )
 
-    if not result or BIOSAMPLE_ENA_FIELD not in result:
+    if not result or EnaResultField.BIOSAMPLE not in result:
         return {}
 
-    return {config.loculus_accession_fields.biosample: result[BIOSAMPLE_ENA_FIELD]}
+    return {config.loculus_accession_fields.biosample: result[EnaResultField.BIOSAMPLE]}
 
 
 def get_assembly_accessions_from_db(
@@ -110,7 +106,7 @@ def get_assembly_accessions_from_db(
     data = {}
     all_present = True
 
-    if gca := result.get(GCA_ENA_FIELD):
+    if gca := result.get(EnaResultField.GCA):
         data[config.loculus_accession_fields.gca] = gca
     else:
         all_present = False
@@ -119,7 +115,7 @@ def get_assembly_accessions_from_db(
     for segment in segment_names:
         segment_suffix = f"_{segment}" if organism.is_multi_segment() else ""
 
-        base_key = f"{INSDC_ACCESSION_ENA_FIELD_PREFIX}{segment_suffix}"
+        base_key = f"{EnaResultField.INSDC_ACCESSION_PREFIX}{segment_suffix}"
         if base_key in result:
             data[f"{config.loculus_accession_fields.insdc_accession_prefix}{segment_suffix}"] = (
                 result[base_key]
@@ -127,7 +123,7 @@ def get_assembly_accessions_from_db(
         else:
             all_present = False
 
-        full_key = f"{VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX}{segment_suffix}"
+        full_key = f"{EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX}{segment_suffix}"
         if full_key in result:
             data[
                 f"{config.loculus_accession_fields.versioned_insdc_accession_prefix}{segment_suffix}"

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -28,11 +28,8 @@ from ena_deposition.check_external_visibility import (
     check_and_update_visibility_for_column,
 )
 from ena_deposition.config import (
-    BIOPROJECT_ENA_FIELD,
-    BIOSAMPLE_ENA_FIELD,
-    GCA_ENA_FIELD,
-    VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX,
     Config,
+    EnaResultField,
     get_config,
 )
 from ena_deposition.create_assembly import (
@@ -99,7 +96,7 @@ def assert_biosample_accession(
     assert len(rows) == 1, f"Sample for {full_accession} not found in sample table."
     if biosample_accession:
         assert rows[0].result, f"No result for sample {full_accession} in sample table."
-        assert rows[0].result.get(BIOSAMPLE_ENA_FIELD) == biosample_accession, (
+        assert rows[0].result.get(EnaResultField.BIOSAMPLE) == biosample_accession, (
             "Incorrect biosample accession in sample table."
         )
 
@@ -110,7 +107,7 @@ def assert_bioproject_accession(
     assert len(rows) == 1, f"Project {group_id} for {full_accession} not found in project table."
     if bioproject_accession:
         assert rows[0].result, f"No result for project {group_id} in project table."
-        assert rows[0].result.get(BIOPROJECT_ENA_FIELD) == bioproject_accession, (
+        assert rows[0].result.get(EnaResultField.BIOPROJECT) == bioproject_accession, (
             "Incorrect bioproject accession in project table."
         )
 
@@ -284,9 +281,11 @@ def check_assembly_submission_with_nuc_without_gca(
             f"Assembly for {full_accession} not in state 'WAITING' in assembly table."
         )
         assert rows[0].result, f"No result for assembly {full_accession} in assembly table."
-        assert rows[0].result.get(f"{VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX}_L") is not None
-        assert rows[0].result.get(f"{VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX}_M") is None
-        assert rows[0].result.get(GCA_ENA_FIELD) is None
+        assert (
+            rows[0].result.get(f"{EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX}_L") is not None
+        )
+        assert rows[0].result.get(f"{EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX}_M") is None
+        assert rows[0].result.get(EnaResultField.GCA) is None
 
 
 def check_sent_to_loculus(db_engine: Engine, sequences_to_upload: dict[str, Any]) -> None:
@@ -632,8 +631,8 @@ class TestSubmission:
 
 class TestFirstPublicUpdate(TestSubmission):
     PROJECT_CONFIG: Final = {
-        "invalid_result": {BIOPROJECT_ENA_FIELD: "PRJEB2"},
-        "valid_result": {BIOPROJECT_ENA_FIELD: "PRJEB53055"},
+        "invalid_result": {EnaResultField.BIOPROJECT: "PRJEB2"},
+        "valid_result": {EnaResultField.BIOPROJECT: "PRJEB53055"},
         "base_entry": {
             "group_id": 1,
             "organism": "test_organism",
@@ -643,8 +642,8 @@ class TestFirstPublicUpdate(TestSubmission):
     }
 
     SAMPLE_CONFIG: Final = {
-        "invalid_result": {BIOSAMPLE_ENA_FIELD: "SAMEA999999999"},
-        "valid_result": {BIOSAMPLE_ENA_FIELD: "SAMEA7997453"},
+        "invalid_result": {EnaResultField.BIOSAMPLE: "SAMEA999999999"},
+        "valid_result": {EnaResultField.BIOSAMPLE: "SAMEA7997453"},
         "base_entry": {
             "accession": "test_accession",
             "version": 1,
@@ -655,12 +654,12 @@ class TestFirstPublicUpdate(TestSubmission):
 
     NUCLEOTIDE_CONFIG: Final = {
         "invalid_result": {
-            f"{VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX}_seg1": "XY999999.1",
-            f"{VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX}_seg2": "XY999998.1",
+            f"{EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX}_seg1": "XY999999.1",
+            f"{EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX}_seg2": "XY999998.1",
         },
         "valid_result": {
-            f"{VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX}_seg1": "OZ271453.1",
-            f"{VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX}_seg2": "OZ271454.1",
+            f"{EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX}_seg1": "OZ271453.1",
+            f"{EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX}_seg2": "OZ271454.1",
         },
         "base_entry": {
             "accession": "test_accession",
@@ -671,8 +670,8 @@ class TestFirstPublicUpdate(TestSubmission):
     }
 
     GCA_CONFIG: Final = {
-        "invalid_result": {GCA_ENA_FIELD: "GCA_999999999.1"},
-        "valid_result": {GCA_ENA_FIELD: "GCA_965196905.1"},
+        "invalid_result": {EnaResultField.GCA: "GCA_999999999.1"},
+        "valid_result": {EnaResultField.GCA: "GCA_965196905.1"},
         "base_entry": {
             "accession": "test_accession",
             "version": 1,

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -281,10 +281,8 @@ def check_assembly_submission_with_nuc_without_gca(
             f"Assembly for {full_accession} not in state 'WAITING' in assembly table."
         )
         assert rows[0].result, f"No result for assembly {full_accession} in assembly table."
-        assert (
-            rows[0].result.get(f"{EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX}_L") is not None
-        )
-        assert rows[0].result.get(f"{EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX}_M") is None
+        assert rows[0].result.get(f"{EnaResultField.INSDC_ACCESSION_FULL_PREFIX}_L") is not None
+        assert rows[0].result.get(f"{EnaResultField.INSDC_ACCESSION_FULL_PREFIX}_M") is None
         assert rows[0].result.get(EnaResultField.GCA) is None
 
 
@@ -654,12 +652,12 @@ class TestFirstPublicUpdate(TestSubmission):
 
     NUCLEOTIDE_CONFIG: Final = {
         "invalid_result": {
-            f"{EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX}_seg1": "XY999999.1",
-            f"{EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX}_seg2": "XY999998.1",
+            f"{EnaResultField.INSDC_ACCESSION_FULL_PREFIX}_seg1": "XY999999.1",
+            f"{EnaResultField.INSDC_ACCESSION_FULL_PREFIX}_seg2": "XY999998.1",
         },
         "valid_result": {
-            f"{EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX}_seg1": "OZ271453.1",
-            f"{EnaResultField.VERSIONED_INSDC_ACCESSION_PREFIX}_seg2": "OZ271454.1",
+            f"{EnaResultField.INSDC_ACCESSION_FULL_PREFIX}_seg1": "OZ271453.1",
+            f"{EnaResultField.INSDC_ACCESSION_FULL_PREFIX}_seg2": "OZ271454.1",
         },
         "base_entry": {
             "accession": "test_accession",

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -27,7 +27,14 @@ from ena_deposition.check_external_visibility import (
     EntityType,
     check_and_update_visibility_for_column,
 )
-from ena_deposition.config import Config, get_config
+from ena_deposition.config import (
+    BIOPROJECT_ENA_FIELD,
+    BIOSAMPLE_ENA_FIELD,
+    GCA_ENA_FIELD,
+    VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX,
+    Config,
+    get_config,
+)
 from ena_deposition.create_assembly import (
     assembly_table_create,
     assembly_table_handle_errors,
@@ -92,7 +99,7 @@ def assert_biosample_accession(
     assert len(rows) == 1, f"Sample for {full_accession} not found in sample table."
     if biosample_accession:
         assert rows[0].result, f"No result for sample {full_accession} in sample table."
-        assert rows[0].result.get("biosample_accession") == biosample_accession, (
+        assert rows[0].result.get(BIOSAMPLE_ENA_FIELD) == biosample_accession, (
             "Incorrect biosample accession in sample table."
         )
 
@@ -103,7 +110,7 @@ def assert_bioproject_accession(
     assert len(rows) == 1, f"Project {group_id} for {full_accession} not found in project table."
     if bioproject_accession:
         assert rows[0].result, f"No result for project {group_id} in project table."
-        assert rows[0].result.get("bioproject_accession") == bioproject_accession, (
+        assert rows[0].result.get(BIOPROJECT_ENA_FIELD) == bioproject_accession, (
             "Incorrect bioproject accession in project table."
         )
 
@@ -161,7 +168,7 @@ def check_sample_submission_started(db_engine: Engine, sequences_to_upload: dict
 
 
 def check_sample_submission_submitted(
-    db_engine: Engine, sequences_to_upload: dict[str, Any]
+    db_engine: Engine, config: Config, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession, data in sequences_to_upload.items():
         accession, version = full_accession.split(".")
@@ -170,7 +177,9 @@ def check_sample_submission_submitted(
             SampleTableEntry,
             conditions={"accession": accession, "version": version, "status": "SUBMITTED"},
         )
-        assert_biosample_accession(rows, data["metadata"]["biosampleAccession"], full_accession)
+        assert_biosample_accession(
+            rows, data["metadata"][config.loculus_accession_fields.biosample], full_accession
+        )
         assert in_submission_table(
             db_engine,
             {"accession": accession, "version": version, "status_all": StatusAll.SUBMITTED_SAMPLE},
@@ -178,7 +187,7 @@ def check_sample_submission_submitted(
 
 
 def check_sample_submission_has_errors(
-    db_engine: Engine, sequences_to_upload: dict[str, Any]
+    db_engine: Engine, config: Config, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession, data in sequences_to_upload.items():
         accession, version = full_accession.split(".")
@@ -187,7 +196,9 @@ def check_sample_submission_has_errors(
             SampleTableEntry,
             conditions={"accession": accession, "version": version, "status": "HAS_ERRORS"},
         )
-        assert_biosample_accession(rows, data["metadata"]["biosampleAccession"], full_accession)
+        assert_biosample_accession(
+            rows, data["metadata"][config.loculus_accession_fields.biosample], full_accession
+        )
 
 
 def check_assembly_submission_waiting(
@@ -273,9 +284,9 @@ def check_assembly_submission_with_nuc_without_gca(
             f"Assembly for {full_accession} not in state 'WAITING' in assembly table."
         )
         assert rows[0].result, f"No result for assembly {full_accession} in assembly table."
-        assert rows[0].result.get("insdc_accession_full_L") is not None
-        assert rows[0].result.get("insdc_accession_full_M") is None
-        assert rows[0].result.get("gca_accession") is None
+        assert rows[0].result.get(f"{VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX}_L") is not None
+        assert rows[0].result.get(f"{VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX}_M") is None
+        assert rows[0].result.get(GCA_ENA_FIELD) is None
 
 
 def check_sent_to_loculus(db_engine: Engine, sequences_to_upload: dict[str, Any]) -> None:
@@ -292,7 +303,7 @@ def check_sent_to_loculus(db_engine: Engine, sequences_to_upload: dict[str, Any]
 
 
 def check_project_submission_submitted(
-    db_engine: Engine, sequences_to_upload: dict[str, Any]
+    db_engine: Engine, config: Config, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession, data in sequences_to_upload.items():
         accession, version = full_accession.split(".")
@@ -304,7 +315,10 @@ def check_project_submission_submitted(
             conditions={"group_id": group_id, "organism": organism, "status": "SUBMITTED"},
         )
         assert_bioproject_accession(
-            rows, data["metadata"]["bioprojectAccession"], group_id, full_accession
+            rows,
+            data["metadata"][config.loculus_accession_fields.bioproject],
+            group_id,
+            full_accession,
         )
         assert in_submission_table(
             db_engine,
@@ -313,7 +327,7 @@ def check_project_submission_submitted(
 
 
 def check_project_submission_has_errors(
-    db_engine: Engine, sequences_to_upload: dict[str, Any]
+    db_engine: Engine, config: Config, sequences_to_upload: dict[str, Any]
 ) -> None:
     for full_accession, data in sequences_to_upload.items():
         group_id = data["metadata"]["groupId"]
@@ -324,7 +338,10 @@ def check_project_submission_has_errors(
             conditions={"group_id": group_id, "organism": organism, "status": "HAS_ERRORS"},
         )
         assert_bioproject_accession(
-            rows, data["metadata"]["bioprojectAccession"], group_id, full_accession
+            rows,
+            data["metadata"][config.loculus_accession_fields.bioproject],
+            group_id,
+            full_accession,
         )
 
 
@@ -426,23 +443,23 @@ def _test_assembly_submission_errored(
 def _test_successful_sample_submission(
     db_engine: Engine, config: Config, sequences_to_upload: dict[str, Any]
 ) -> None:
-    create_sample_sync_state_with_submission_table(db_engine)
+    create_sample_sync_state_with_submission_table(db_engine, config)
     check_sample_submission_started(db_engine, sequences_to_upload)
 
     sample_table_create(db_engine, config)
-    create_sample_sync_state_with_submission_table(db_engine)
-    check_sample_submission_submitted(db_engine, sequences_to_upload)
+    create_sample_sync_state_with_submission_table(db_engine, config)
+    check_sample_submission_submitted(db_engine, config, sequences_to_upload)
 
 
 def _test_successful_project_submission(
     db_engine: Engine, config: Config, sequences_to_upload: dict[str, Any]
 ) -> None:
-    create_project_sync_state_with_submission_table(db_engine)
+    create_project_sync_state_with_submission_table(db_engine, config)
     check_project_submission_started(db_engine, sequences_to_upload)
 
     project_table_create(db_engine, config)
-    create_project_sync_state_with_submission_table(db_engine)
-    check_project_submission_submitted(db_engine, sequences_to_upload)
+    create_project_sync_state_with_submission_table(db_engine, config)
+    check_project_submission_submitted(db_engine, config, sequences_to_upload)
 
 
 def get_sequences() -> dict[str, Any]:
@@ -512,8 +529,10 @@ def multi_segment_submission(
     payload = args[0][0][0]  # first positional argument of first call
     assert payload["accession"] == "LOC_0001TLY"
     assert payload["version"] == 1
-    assert set(payload["externalMetadata"]) == {"bioprojectAccession"}
-    assert payload["externalMetadata"]["bioprojectAccession"].startswith("PRJEB")
+    assert set(payload["externalMetadata"]) == {config.loculus_accession_fields.bioproject}
+    assert payload["externalMetadata"][config.loculus_accession_fields.bioproject].startswith(
+        "PRJEB"
+    )
 
     _test_successful_sample_submission(db_engine, config, sequences_to_upload)
     get_external_metadata_and_send_to_loculus(db_engine, config)
@@ -522,9 +541,16 @@ def multi_segment_submission(
     payload = args[1][0][0]  # first positional argument of second call
     assert payload["accession"] == "LOC_0001TLY"
     assert payload["version"] == 1
-    assert set(payload["externalMetadata"]) == {"bioprojectAccession", "biosampleAccession"}
-    assert payload["externalMetadata"]["bioprojectAccession"].startswith("PRJEB")
-    assert payload["externalMetadata"]["biosampleAccession"].startswith("SAMEA")
+    assert set(payload["externalMetadata"]) == {
+        config.loculus_accession_fields.bioproject,
+        config.loculus_accession_fields.biosample,
+    }
+    assert payload["externalMetadata"][config.loculus_accession_fields.bioproject].startswith(
+        "PRJEB"
+    )
+    assert payload["externalMetadata"][config.loculus_accession_fields.biosample].startswith(
+        "SAMEA"
+    )
 
     _test_successful_assembly_submission(db_engine, config, sequences_to_upload, single_segment)
     get_external_metadata_and_send_to_loculus(db_engine, config)
@@ -538,16 +564,24 @@ def multi_segment_submission(
     assert payload["version"] == 1
     extra_items = set()
     if not single_segment:
-        extra_items = {"gcaAccession", "insdcAccessionBase_M", "insdcAccessionFull_M"}
+        extra_items = {
+            config.loculus_accession_fields.gca,
+            "insdcAccessionBase_M",
+            "insdcAccessionFull_M",
+        }
     assert set(payload["externalMetadata"]) == {
-        "bioprojectAccession",
-        "biosampleAccession",
+        config.loculus_accession_fields.bioproject,
+        config.loculus_accession_fields.biosample,
         "insdcAccessionBase_L",
         "insdcAccessionFull_L",
         *extra_items,
     }
-    assert payload["externalMetadata"]["bioprojectAccession"].startswith("PRJEB")
-    assert payload["externalMetadata"]["biosampleAccession"].startswith("SAMEA")
+    assert payload["externalMetadata"][config.loculus_accession_fields.bioproject].startswith(
+        "PRJEB"
+    )
+    assert payload["externalMetadata"][config.loculus_accession_fields.biosample].startswith(
+        "SAMEA"
+    )
 
     insdc_full_pattern = r"^[A-Z]{2}[0-9]{6}\.[0-9]+$"
     insdc_base_pattern = r"^[A-Z]{2}[0-9]{6}$"
@@ -562,7 +596,9 @@ def multi_segment_submission(
         f"does not match INSDC base pattern {insdc_base_pattern}"
     )
     if not single_segment:
-        assert re.match(gca_pattern, payload["externalMetadata"]["gcaAccession"]), (
+        assert re.match(
+            gca_pattern, payload["externalMetadata"][config.loculus_accession_fields.gca]
+        ), (
             f"gcaAccession '{payload['externalMetadata']['gcaAccession']}' "
             f"does not match GCA pattern {gca_pattern}"
         )
@@ -596,8 +632,8 @@ class TestSubmission:
 
 class TestFirstPublicUpdate(TestSubmission):
     PROJECT_CONFIG: Final = {
-        "invalid_result": {"bioproject_accession": "PRJEB2"},
-        "valid_result": {"bioproject_accession": "PRJEB53055"},
+        "invalid_result": {BIOPROJECT_ENA_FIELD: "PRJEB2"},
+        "valid_result": {BIOPROJECT_ENA_FIELD: "PRJEB53055"},
         "base_entry": {
             "group_id": 1,
             "organism": "test_organism",
@@ -607,8 +643,8 @@ class TestFirstPublicUpdate(TestSubmission):
     }
 
     SAMPLE_CONFIG: Final = {
-        "invalid_result": {"biosample_accession": "SAMEA999999999"},
-        "valid_result": {"biosample_accession": "SAMEA7997453"},
+        "invalid_result": {BIOSAMPLE_ENA_FIELD: "SAMEA999999999"},
+        "valid_result": {BIOSAMPLE_ENA_FIELD: "SAMEA7997453"},
         "base_entry": {
             "accession": "test_accession",
             "version": 1,
@@ -619,12 +655,12 @@ class TestFirstPublicUpdate(TestSubmission):
 
     NUCLEOTIDE_CONFIG: Final = {
         "invalid_result": {
-            "insdc_accession_full_seg1": "XY999999.1",
-            "insdc_accession_full_seg2": "XY999998.1",
+            f"{VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX}_seg1": "XY999999.1",
+            f"{VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX}_seg2": "XY999998.1",
         },
         "valid_result": {
-            "insdc_accession_full_seg1": "OZ271453.1",
-            "insdc_accession_full_seg2": "OZ271454.1",
+            f"{VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX}_seg1": "OZ271453.1",
+            f"{VERSIONED_INSDC_ACCESSION_ENA_FIELD_PREFIX}_seg2": "OZ271454.1",
         },
         "base_entry": {
             "accession": "test_accession",
@@ -635,8 +671,8 @@ class TestFirstPublicUpdate(TestSubmission):
     }
 
     GCA_CONFIG: Final = {
-        "invalid_result": {"gca_accession": "GCA_999999999.1"},
-        "valid_result": {"gca_accession": "GCA_965196905.1"},
+        "invalid_result": {GCA_ENA_FIELD: "GCA_999999999.1"},
+        "valid_result": {GCA_ENA_FIELD: "GCA_965196905.1"},
         "base_entry": {
             "accession": "test_accession",
             "version": 1,
@@ -789,7 +825,7 @@ class TestKnownBioproject(TestSubmission):
         mock_submit_external_metadata.return_value = mock_requests_post()
         sequences_to_upload = get_sequences()
         for entry in sequences_to_upload.values():  # set to known public bioproject
-            entry["metadata"]["bioprojectAccession"] = "PRJNA231221"
+            entry["metadata"][self.config.loculus_accession_fields.bioproject] = "PRJNA231221"
 
         # upload sequences
         upload_sequences(self.db_engine, sequences_to_upload)
@@ -817,16 +853,16 @@ class TestIncorrectBioprojectPassed(TestSubmission):
         mock_notify.return_value = None
         sequences_to_upload = get_sequences()
         for entry in sequences_to_upload.values():  # set to invalid bioproject
-            entry["metadata"]["bioprojectAccession"] = "INVALID_ACCESSION"
+            entry["metadata"][self.config.loculus_accession_fields.bioproject] = "INVALID_ACCESSION"
 
         # upload sequences
         upload_sequences(self.db_engine, sequences_to_upload)
         check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # check project submission fails and sends notification
-        create_project_sync_state_with_submission_table(self.db_engine)
+        create_project_sync_state_with_submission_table(self.db_engine, self.config)
         project_table_create(self.db_engine, self.config)
-        check_project_submission_has_errors(self.db_engine, sequences_to_upload)
+        check_project_submission_has_errors(self.db_engine, self.config, sequences_to_upload)
         project_table_handle_errors(
             self.db_engine,
             self.config,
@@ -850,9 +886,9 @@ class TestIncorrectBioprojectPassed(TestSubmission):
         check_project_submission_started(self.db_engine, sequences_to_upload)
 
         # Confirm DB entry is still in error state after retrying submission
-        create_project_sync_state_with_submission_table(self.db_engine)
+        create_project_sync_state_with_submission_table(self.db_engine, self.config)
         project_table_create(self.db_engine, self.config)
-        check_project_submission_has_errors(self.db_engine, sequences_to_upload)
+        check_project_submission_has_errors(self.db_engine, self.config, sequences_to_upload)
 
         # Confirm retries dont change state
         project_table_handle_errors(
@@ -862,9 +898,9 @@ class TestIncorrectBioprojectPassed(TestSubmission):
             last_retry_time=datetime.now(tz=pytz.utc) - timedelta(hours=10),
         )
         check_project_submission_started(self.db_engine, sequences_to_upload)
-        create_project_sync_state_with_submission_table(self.db_engine)
+        create_project_sync_state_with_submission_table(self.db_engine, self.config)
         project_table_create(self.db_engine, self.config)
-        check_project_submission_has_errors(self.db_engine, sequences_to_upload)
+        check_project_submission_has_errors(self.db_engine, self.config, sequences_to_upload)
 
 
 class TestKnownBioprojectAndBioSample(TestSubmission):
@@ -881,8 +917,8 @@ class TestKnownBioprojectAndBioSample(TestSubmission):
         mock_submit_external_metadata.return_value = mock_requests_post()
         sequences_to_upload = get_sequences()
         for entry in sequences_to_upload.values():  # set to public bioproject and biosample
-            entry["metadata"]["bioprojectAccession"] = "PRJNA231221"
-            entry["metadata"]["biosampleAccession"] = "SAMN11077987"
+            entry["metadata"][self.config.loculus_accession_fields.bioproject] = "PRJNA231221"
+            entry["metadata"][self.config.loculus_accession_fields.biosample] = "SAMN11077987"
 
         # upload
         upload_sequences(self.db_engine, sequences_to_upload)
@@ -923,17 +959,17 @@ class TestKnownBioprojectAndBioSample(TestSubmission):
 
         sequences_to_upload = get_sequences()
         for entry in sequences_to_upload.values():  # set to public bioproject and biosample
-            entry["metadata"]["bioprojectAccession"] = "PRJNA231221"
-            entry["metadata"]["biosampleAccession"] = "SAMN11077987"
+            entry["metadata"][self.config.loculus_accession_fields.bioproject] = "PRJNA231221"
+            entry["metadata"][self.config.loculus_accession_fields.biosample] = "SAMN11077987"
 
         # upload
         upload_sequences(self.db_engine, sequences_to_upload)
         check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # check project submission fails
-        create_project_sync_state_with_submission_table(self.db_engine)
+        create_project_sync_state_with_submission_table(self.db_engine, self.config)
         project_table_create(self.db_engine, self.config)
-        check_project_submission_has_errors(self.db_engine, sequences_to_upload)
+        check_project_submission_has_errors(self.db_engine, self.config, sequences_to_upload)
 
         # Confirm DB entry is reset to READY to retry submission
         project_table_handle_errors(
@@ -979,8 +1015,8 @@ class TestKnownBioprojectAndBioSample(TestSubmission):
 
         sequences_to_upload = get_sequences()
         for entry in sequences_to_upload.values():  # set to public bioproject and biosample
-            entry["metadata"]["bioprojectAccession"] = "PRJNA231221"
-            entry["metadata"]["biosampleAccession"] = "SAMN11077987"
+            entry["metadata"][self.config.loculus_accession_fields.bioproject] = "PRJNA231221"
+            entry["metadata"][self.config.loculus_accession_fields.biosample] = "SAMN11077987"
 
         # upload
         upload_sequences(self.db_engine, sequences_to_upload)
@@ -990,9 +1026,9 @@ class TestKnownBioprojectAndBioSample(TestSubmission):
         _test_successful_project_submission(self.db_engine, self.config, sequences_to_upload)
 
         # check sample submission fails and sends notification
-        create_sample_sync_state_with_submission_table(self.db_engine)
+        create_sample_sync_state_with_submission_table(self.db_engine, self.config)
         sample_table_create(self.db_engine, self.config)
-        check_sample_submission_has_errors(self.db_engine, sequences_to_upload)
+        check_sample_submission_has_errors(self.db_engine, self.config, sequences_to_upload)
         sample_table_handle_errors(
             self.db_engine,
             self.config,
@@ -1007,10 +1043,10 @@ class TestKnownBioprojectAndBioSample(TestSubmission):
 
         # Confirm DB entry is reset to READY to retry submission
         check_sample_submission_started(self.db_engine, sequences_to_upload)
-        create_sample_sync_state_with_submission_table(self.db_engine)
+        create_sample_sync_state_with_submission_table(self.db_engine, self.config)
         sample_table_create(self.db_engine, self.config)
-        create_sample_sync_state_with_submission_table(self.db_engine)
-        check_sample_submission_submitted(self.db_engine, sequences_to_upload)
+        create_sample_sync_state_with_submission_table(self.db_engine, self.config)
+        check_sample_submission_submitted(self.db_engine, self.config, sequences_to_upload)
         _test_successful_assembly_submission(self.db_engine, self.config, sequences_to_upload)
 
         # send to loculus
@@ -1030,8 +1066,8 @@ class TestKnownBioprojectAndIncorrectBioSample(TestSubmission):
         mock_notify.return_value = None
         sequences_to_upload = get_sequences()
         for entry in sequences_to_upload.values():  # set to invalid biosample
-            entry["metadata"]["bioprojectAccession"] = "PRJNA231221"
-            entry["metadata"]["biosampleAccession"] = "INVALID_ACCESSION"
+            entry["metadata"][self.config.loculus_accession_fields.bioproject] = "PRJNA231221"
+            entry["metadata"][self.config.loculus_accession_fields.biosample] = "INVALID_ACCESSION"
 
         # upload
         upload_sequences(self.db_engine, sequences_to_upload)
@@ -1041,9 +1077,9 @@ class TestKnownBioprojectAndIncorrectBioSample(TestSubmission):
         _test_successful_project_submission(self.db_engine, self.config, sequences_to_upload)
 
         # check sample submission fails and sends notification
-        create_sample_sync_state_with_submission_table(self.db_engine)
+        create_sample_sync_state_with_submission_table(self.db_engine, self.config)
         sample_table_create(self.db_engine, self.config)
-        check_sample_submission_has_errors(self.db_engine, sequences_to_upload)
+        check_sample_submission_has_errors(self.db_engine, self.config, sequences_to_upload)
         sample_table_handle_errors(
             self.db_engine,
             self.config,
@@ -1058,11 +1094,9 @@ class TestKnownBioprojectAndIncorrectBioSample(TestSubmission):
 
         # Confirm DB entry is reset to READY to retry submission
         check_sample_submission_started(self.db_engine, sequences_to_upload)
-
-        # Confirm DB entry is still in error state after retrying submission
-        create_project_sync_state_with_submission_table(self.db_engine)
+        create_sample_sync_state_with_submission_table(self.db_engine, self.config)
         sample_table_create(self.db_engine, self.config)
-        check_sample_submission_has_errors(self.db_engine, sequences_to_upload)
+        check_sample_submission_has_errors(self.db_engine, self.config, sequences_to_upload)
 
         # Confirm retries dont change state
         sample_table_handle_errors(
@@ -1072,9 +1106,9 @@ class TestKnownBioprojectAndIncorrectBioSample(TestSubmission):
             last_retry_time=datetime.now(tz=pytz.utc) - timedelta(hours=10),
         )
         check_sample_submission_started(self.db_engine, sequences_to_upload)
-        create_project_sync_state_with_submission_table(self.db_engine)
+        create_project_sync_state_with_submission_table(self.db_engine, self.config)
         sample_table_create(self.db_engine, self.config)
-        check_sample_submission_has_errors(self.db_engine, sequences_to_upload)
+        check_sample_submission_has_errors(self.db_engine, self.config, sequences_to_upload)
 
 
 class TestRevisionAssemblyModificationTests(TestSubmission):
@@ -1114,9 +1148,9 @@ class TestRevisionAssemblyModificationTests(TestSubmission):
         check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # submit
-        create_project_sync_state_with_submission_table(self.db_engine)
+        create_project_sync_state_with_submission_table(self.db_engine, self.config)
         project_table_create(self.db_engine, self.config)
-        check_project_submission_submitted(self.db_engine, sequences_to_upload)
+        check_project_submission_submitted(self.db_engine, self.config, sequences_to_upload)
         _test_successful_sample_submission(self.db_engine, self.config, sequences_to_upload)
         _test_successful_assembly_submission(self.db_engine, self.config, sequences_to_upload)
 
@@ -1146,9 +1180,9 @@ class TestRevisionNoAssemblyModificationTests(TestSubmission):
         check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # submit
-        create_project_sync_state_with_submission_table(self.db_engine)
+        create_project_sync_state_with_submission_table(self.db_engine, self.config)
         project_table_create(self.db_engine, self.config)
-        check_project_submission_submitted(self.db_engine, sequences_to_upload)
+        check_project_submission_submitted(self.db_engine, self.config, sequences_to_upload)
         _test_successful_sample_submission(self.db_engine, self.config, sequences_to_upload)
         _test_successful_assembly_submission_no_wait(
             self.db_engine, self.config, sequences_to_upload
@@ -1186,8 +1220,8 @@ class TestRevisionWithManifestChangeTests(TestSubmission):
         check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
         # submit
-        create_project_sync_state_with_submission_table(self.db_engine)
-        check_project_submission_submitted(self.db_engine, sequences_to_upload)
+        create_project_sync_state_with_submission_table(self.db_engine, self.config)
+        check_project_submission_submitted(self.db_engine, self.config, sequences_to_upload)
         _test_successful_sample_submission(self.db_engine, self.config, sequences_to_upload)
 
         # check notified cannot submit assembly

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -563,14 +563,14 @@ def multi_segment_submission(
     if not single_segment:
         extra_items = {
             config.loculus_accession_fields.gca,
-            "insdcAccessionBase_M",
-            "insdcAccessionFull_M",
+            config.loculus_accession_fields.insdc_accession_prefix + "_M",
+            config.loculus_accession_fields.insdc_accession_full_prefix + "_M",
         }
     assert set(payload["externalMetadata"]) == {
         config.loculus_accession_fields.bioproject,
         config.loculus_accession_fields.biosample,
-        "insdcAccessionBase_L",
-        "insdcAccessionFull_L",
+        config.loculus_accession_fields.insdc_accession_prefix + "_L",
+        config.loculus_accession_fields.insdc_accession_full_prefix + "_L",
         *extra_items,
     }
     assert payload["externalMetadata"][config.loculus_accession_fields.bioproject].startswith(
@@ -583,20 +583,26 @@ def multi_segment_submission(
     insdc_full_pattern = r"^[A-Z]{2}[0-9]{6}\.[0-9]+$"
     insdc_base_pattern = r"^[A-Z]{2}[0-9]{6}$"
     gca_pattern = r"^GCA_[0-9]{9}\.[0-9]+$"
-
-    assert re.match(insdc_full_pattern, payload["externalMetadata"]["insdcAccessionFull_L"]), (
-        f"insdcAccessionFull_L '{payload['externalMetadata']['insdcAccessionFull_L']}' "
+    insdc_accession_full_l = config.loculus_accession_fields.insdc_accession_full_prefix + "_L"
+    insdc_accession_base_l = config.loculus_accession_fields.insdc_accession_prefix + "_L"
+    gca_accession = config.loculus_accession_fields.gca
+    assert re.match(
+        insdc_full_pattern,
+        payload["externalMetadata"][insdc_accession_full_l],
+    ), (
+        f"{insdc_accession_full_l} '{payload['externalMetadata'][insdc_accession_full_l]}' "
         f"does not match INSDC full pattern {insdc_full_pattern}"
     )
-    assert re.match(insdc_base_pattern, payload["externalMetadata"]["insdcAccessionBase_L"]), (
-        f"insdcAccessionBase_L '{payload['externalMetadata']['insdcAccessionBase_L']}' "
+    assert re.match(
+        insdc_base_pattern,
+        payload["externalMetadata"][insdc_accession_base_l],
+    ), (
+        f"{insdc_accession_base_l} '{payload['externalMetadata'][insdc_accession_base_l]}' "
         f"does not match INSDC base pattern {insdc_base_pattern}"
     )
     if not single_segment:
-        assert re.match(
-            gca_pattern, payload["externalMetadata"][config.loculus_accession_fields.gca]
-        ), (
-            f"gcaAccession '{payload['externalMetadata']['gcaAccession']}' "
+        assert re.match(gca_pattern, payload["externalMetadata"][gca_accession]), (
+            f"{gca_accession} '{payload['externalMetadata'][gca_accession]}' "
             f"does not match GCA pattern {gca_pattern}"
         )
 

--- a/kubernetes/loculus/templates/ena-submission-config.yaml
+++ b/kubernetes/loculus/templates/ena-submission-config.yaml
@@ -25,5 +25,8 @@ data:
     keycloak_token_url: {{ $keycloakHost -}}/realms/loculus/protocol/openid-connect/token
     approved_list_test_url: {{ $enaApprovedListTestUrl }}
     suppressed_list_test_url: {{ $enaSuppressedListTestUrl }}
+    {{- with .Values.enaDeposition.configFile }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
     {{- include "loculus.generateENASubmissionConfig" . | nindent 4 }}
 {{- end }}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1900,6 +1900,11 @@
         "enaSuppressedListTestUrl": {
           "type": "string",
           "description": "URL to the ENA suppressed sequence list (typically hosted on a Github repo)"
+        },
+        "configFile": {
+          "type": "object",
+          "description": "Additional fields merged into the ena-submission config file. Keys set here override the values generated from the other enaDeposition settings and the pipeline's own config/defaults.yaml (but not the generated per-organism enaOrganisms block).",
+          "additionalProperties": true
         }
       }
     },

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -2946,6 +2946,7 @@ enaDeposition:
   enaUniqueSuffix: Loculus
   enaIsBroker: False
   enaSuppressedListTestUrl: "https://loculus-project.github.io/ena-submission/suppressed/ppx-accessions-suppression-list.txt"
+  configFile: {}
 rawReadsProcessingService:
   raw_reads_processing_service_url: http://loculus-raw-reads-processing:5000
 subdomainSeparator: "-"


### PR DESCRIPTION
I realised the deposition code is hardcoding the names of Loculus metadata fields. As we have been planning to change these names this is dangerous. Additionally, we hard-coded the names with strings that are error-prone.

The config was also designed to be configurable but we only pass on certain fields, ideally we would like the defaults to be configurable via the values.yaml on loculus instances - this PR gives us the ability to do that.

This refactors the code to make all loculus metadata field names configurable (structured similarly to the assembly manifest fields in the config) and turns strings used in the ENA db schema as internal constants into actual constants to prevent any accidental issues.

### Screenshot

### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable