### PR TITLE
feat(deployment): make backend jvm options configurable

### DIFF
--- a/kubernetes/loculus/templates/loculus-backend.yaml
+++ b/kubernetes/loculus/templates/loculus-backend.yaml
@@ -100,7 +100,7 @@ spec:
             # If a flag in JVM_OPTS below changes object layout or other observable JVM
             # semantics, mirror it in the test task in backend/build.gradle
             - name: JVM_OPTS
-              value: -XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxHeapFreeRatio=5 -XX:MinHeapFreeRatio=2
+              value: -XX:+UseContainerSupport -XX:MaxRAMPercentage={{ .Values.backendMaxRamPercentage }} -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxHeapFreeRatio=5 -XX:MinHeapFreeRatio=2
           {{- if $.Values.seqSets.crossRef }}
             - name: CROSSREF_USERNAME
               valueFrom:

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1651,6 +1651,14 @@
       "default": false,
       "description": "If true, the instance runs in read-only mode: the backend rejects write requests (POST/PUT/DELETE/PATCH) with 503 Service Unavailable, and the website hides login/submission entry points and shows a read-only banner."
     },
+    "backendMaxRamPercentage": {
+      "groups": ["services"],
+      "type": "number",
+      "minimum": 1,
+      "maximum": 100,
+      "default": 75,
+      "description": "Share of the backend container memory limit the JVM may use as heap, passed as -XX:MaxRAMPercentage."
+    },
     "organisms": {
       "groups": ["organism-conf"],
       "type": "object",

--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -39,6 +39,7 @@ disableEnaSubmission: true
 disableTaxonomyService: false
 disableRawReadsProcessingService: true
 readOnlyMode: false
+backendMaxRamPercentage: 75
 website:
   websiteConfig:
     enableLoginNavigationItem: true

--- a/kubernetes/loculus/values_preview_server.yaml
+++ b/kubernetes/loculus/values_preview_server.yaml
@@ -1,5 +1,7 @@
 enableServiceMonitor: true
 createTestAccounts: true
+# Smaller backend heap, previews share one cluster
+backendMaxRamPercentage: 25
 secrets:
   smtp-password:
     type: sealedsecret


### PR DESCRIPTION
follow up to https://github.com/loculus-project/loculus/pull/7077#issuecomment-5393292442. adds `backendExtraJvmOpts` (default empty), appended after the built-in `JVM_OPTS` so any flag can be overridden, e.g. `-XX:MaxRAMPercentage=25`. previews use it to go back to the jvm default heap. default and e2e render identical to main. the new key changes `valuesHash`, so the first upgrade restarts all pods once. lapis stays out of scope.

### PR Checklist
- [x] All necessary documentation has been adapted.
- ~~The implemented feature is covered by appropriate, automated tests.~~
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
  - helm lint and template with default, e2e and preview values

🚀 Preview: Add `preview` label to enable