### PR TITLE
feat(deposition): add a test that asserts insdcRawReadsAccession is passed as run_ref in assembly manifest.tsv if supplied in metadata

### DIFF
--- a/ena-submission/config/defaults.yaml
+++ b/ena-submission/config/defaults.yaml
@@ -125,6 +125,7 @@ loculus_accession_fields:
   bioproject: bioprojectAccession
   biosample: biosampleAccession
   gca: gcaAccession
+  run: insdcRawReadsAccession
   insdc_accession_prefix: insdcAccessionBase
   insdc_accession_full_prefix: insdcAccessionFull
 allow_revision_with_manifest_changes: true

--- a/ena-submission/src/ena_deposition/config.py
+++ b/ena-submission/src/ena_deposition/config.py
@@ -23,6 +23,7 @@ class EnaResultField(StrEnum):
     BIOSAMPLE = "biosample_accession"
     BIOPROJECT = "bioproject_accession"
     GCA = "gca_accession"
+    RUN = "run_accession"
     INSDC_ACCESSION_PREFIX = "insdc_accession"
     INSDC_ACCESSION_FULL_PREFIX = "insdc_accession_full"
 
@@ -55,6 +56,7 @@ class LoculusAccessionFieldNames(BaseModel):
     gca: str
     insdc_accession_prefix: str
     insdc_accession_full_prefix: str
+    run: str
 
 
 class ExternalMetadataField(BaseModel):

--- a/ena-submission/src/ena_deposition/create_assembly.py
+++ b/ena-submission/src/ena_deposition/create_assembly.py
@@ -215,7 +215,7 @@ def submission_table_start(db_engine: Engine, config: Config) -> None:
     for row in ready_to_submit:
         seq_key = asdict(row.pkey)
 
-        run_ref = row.seq_metadata.get("insdcRawReadsAccession")
+        run_ref = row.seq_metadata.get(config.loculus_accession_fields.run)
         if run_ref and not accession_exists(run_ref, config):
             set_accession_does_not_exist_error(
                 conditions=seq_key,

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -1265,12 +1265,8 @@ class TestInsdcRawReadsAccessionInManifest(TestSubmission):
         upload_sequences(self.db_engine, sequences_to_upload)
         check_sequences_uploaded(self.db_engine, sequences_to_upload)
 
-        _test_successful_project_submission(
-            self.db_engine, self.config, sequences_to_upload
-        )
-        _test_successful_sample_submission(
-            self.db_engine, self.config, sequences_to_upload
-        )
+        _test_successful_project_submission(self.db_engine, self.config, sequences_to_upload)
+        _test_successful_sample_submission(self.db_engine, self.config, sequences_to_upload)
 
         mock_post_webin_with_retry.assert_not_called()
 

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -17,6 +17,7 @@ import uuid
 from dataclasses import asdict
 from datetime import datetime, timedelta
 from itertools import chain, repeat
+from pathlib import Path
 from typing import Any, Final
 from unittest.mock import Mock, patch
 
@@ -57,6 +58,7 @@ from ena_deposition.create_sample import (
 from ena_deposition.create_sample import (
     sync_state_with_submission_table as create_sample_sync_state_with_submission_table,
 )
+from ena_deposition.ena_submission_helper import CreationResult
 from ena_deposition.loculus_models import Group
 from ena_deposition.notifications import SlackConfig
 from ena_deposition.submission_db_helper import (
@@ -1216,6 +1218,72 @@ class TestRevisionWithManifestChangeTests(TestSubmission):
         _test_assembly_submission_errored(
             self.db_engine, self.config, self.slack_config, sequences_to_upload, mock_notify
         )
+
+
+class TestInsdcRawReadsAccessionInManifest(TestSubmission):
+    @patch("ena_deposition.ena_submission_helper.post_webin_with_retry", autospec=True)
+    @patch("ena_deposition.create_assembly.create_ena_assembly", autospec=True)
+    @patch("ena_deposition.call_loculus.get_group_info", autospec=True)
+    def test_run_ref_written_to_manifest(
+        self,
+        mock_get_group_info: Mock,
+        mock_create_ena_assembly: Mock,
+        mock_post_webin_with_retry: Mock,
+    ) -> None:
+        """When ``insdcRawReadsAccession`` is present in the metadata it must be sent to ENA
+        as the ``RUN_REF`` field of the assembly manifest.tsv.
+
+        No data is submitted to ENA as known public bioproject, biosample
+        (and insdcRawReadsAccession) accessions are supplied, so no new project/sample is created.
+
+        The test captures the manifest.tsv file that would be sent to ENA and checks that the
+        correct RUN_REF is present.
+        """
+        run_ref_accession = "ERR17356121"
+
+        mock_get_group_info.return_value = TEST_GROUP
+
+        captured_manifests: list[str] = []
+
+        def spy_create_ena_assembly(
+            config: Config,  # noqa: ARG001
+            manifest_filename: str,
+            center_name: str | None = None,  # noqa: ARG001
+        ) -> CreationResult:
+            captured_manifests.append(Path(manifest_filename).read_text(encoding="utf-8"))
+            return CreationResult(errors=[], warnings=[], result={"erz_accession": "ERZ_TEST"})
+
+        mock_create_ena_assembly.side_effect = spy_create_ena_assembly
+
+        sequences_to_upload = get_sequences()
+        for entry in sequences_to_upload.values():
+            # known public accessions
+            entry["metadata"]["bioprojectAccession"] = "PRJNA231221"
+            entry["metadata"]["biosampleAccession"] = "SAMN11077987"
+            entry["metadata"]["insdcRawReadsAccession"] = run_ref_accession
+
+        upload_sequences(self.db_engine, sequences_to_upload)
+        check_sequences_uploaded(self.db_engine, sequences_to_upload)
+
+        _test_successful_project_submission(
+            self.db_engine, self.config, sequences_to_upload
+        )
+        _test_successful_sample_submission(
+            self.db_engine, self.config, sequences_to_upload
+        )
+
+        mock_post_webin_with_retry.assert_not_called()
+
+        create_assembly_submission_table_start(self.db_engine, self.config)
+        check_assembly_submission_started(self.db_engine, sequences_to_upload)
+        assembly_table_create(self.db_engine, self.config)
+
+        assert mock_create_ena_assembly.called, "create_ena_assembly (webin-cli) was never called"
+        assert captured_manifests, "No manifest.tsv was produced for the assembly submission"
+        for manifest_contents in captured_manifests:
+            assert f"RUN_REF\t{run_ref_accession}" in manifest_contents, (
+                f"RUN_REF line missing from the manifest.tsv sent to ENA:\n{manifest_contents}"
+            )
 
 
 if __name__ == "__main__":

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -1273,13 +1273,22 @@ class TestInsdcRawReadsAccessionInManifest(TestSubmission):
         create_assembly_submission_table_start(self.db_engine, self.config)
         check_assembly_submission_started(self.db_engine, sequences_to_upload)
         assembly_table_create(self.db_engine, self.config)
+        check_assembly_submission_waiting(self.db_engine, sequences_to_upload)
 
         assert mock_create_ena_assembly.called, "create_ena_assembly (webin-cli) was never called"
-        assert captured_manifests, "No manifest.tsv was produced for the assembly submission"
+        assert len(captured_manifests) == len(sequences_to_upload), (
+            f"Expected one manifest.tsv per sequence, got {len(captured_manifests)}"
+        )
         for manifest_contents in captured_manifests:
-            assert f"RUN_REF\t{run_ref_accession}" in manifest_contents, (
-                f"RUN_REF line missing from the manifest.tsv sent to ENA:\n{manifest_contents}"
-            )
+            for expected_line in (
+                f"RUN_REF\t{run_ref_accession}",
+                "STUDY\tPRJNA231221",
+                "SAMPLE\tSAMN11077987",
+            ):
+                assert expected_line in manifest_contents, (
+                    f"'{expected_line}' missing from the manifest.tsv sent to ENA:"
+                    f"\n{manifest_contents}"
+                )
 
 
 if __name__ == "__main__":

--- a/ena-submission/test/test_ena_submission_integration.py
+++ b/ena-submission/test/test_ena_submission_integration.py
@@ -1240,6 +1240,8 @@ class TestInsdcRawReadsAccessionInManifest(TestSubmission):
         correct RUN_REF is present.
         """
         run_ref_accession = "ERR17356121"
+        bioproject_accession = "PRJNA231221"
+        biosample_accession = "SAMN11077987"
 
         mock_get_group_info.return_value = TEST_GROUP
 
@@ -1258,9 +1260,11 @@ class TestInsdcRawReadsAccessionInManifest(TestSubmission):
         sequences_to_upload = get_sequences()
         for entry in sequences_to_upload.values():
             # known public accessions
-            entry["metadata"]["bioprojectAccession"] = "PRJNA231221"
-            entry["metadata"]["biosampleAccession"] = "SAMN11077987"
-            entry["metadata"]["insdcRawReadsAccession"] = run_ref_accession
+            entry["metadata"][self.config.loculus_accession_fields.bioproject] = (
+                bioproject_accession
+            )
+            entry["metadata"][self.config.loculus_accession_fields.biosample] = biosample_accession
+            entry["metadata"][self.config.loculus_accession_fields.run] = run_ref_accession
 
         upload_sequences(self.db_engine, sequences_to_upload)
         check_sequences_uploaded(self.db_engine, sequences_to_upload)
@@ -1282,8 +1286,8 @@ class TestInsdcRawReadsAccessionInManifest(TestSubmission):
         for manifest_contents in captured_manifests:
             for expected_line in (
                 f"RUN_REF\t{run_ref_accession}",
-                "STUDY\tPRJNA231221",
-                "SAMPLE\tSAMN11077987",
+                f"STUDY\t{bioproject_accession}",
+                f"SAMPLE\t{biosample_accession}",
             ):
                 assert expected_line in manifest_contents, (
                     f"'{expected_line}' missing from the manifest.tsv sent to ENA:"


### PR DESCRIPTION
In preparation for https://github.com/loculus-project/loculus/pull/6816 I think its important that this submission flow is captured in the user tests. 

This test adds coverage for the case where a submitters includes the bioproject, biosample and insdcRawReadsAccession (run accession) in the submitted metadata. In this case the deposition pod will use the bioproject and biosample accessions (after checking they are live) and then create a new assembly linked to the bioproject, biosample and insdcRawReadsAccession in the assembly manifest.tsv.

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable