### PR TITLE
feat(backend): human-readable file ids

### DIFF
--- a/backend/docs/db/schema.sql
+++ b/backend/docs/db/schema.sql
@@ -4,8 +4,8 @@
 
 \restrict dummy
 
--- Dumped from database version 15.18 (Debian 15.18-1.pgdg13+1)
--- Dumped by pg_dump version 16.14 (Debian 16.14-1.pgdg13+1)
+-- Dumped from database version 15.19 (Debian 15.19-1.pgdg13+2)
+-- Dumped by pg_dump version 16.15 (Debian 16.15-1.pgdg13+2)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -321,11 +321,25 @@ CREATE TABLE public.external_metadata (
 ALTER TABLE public.external_metadata OWNER TO postgres;
 
 --
+-- Name: file_id_sequence; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.file_id_sequence
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.file_id_sequence OWNER TO postgres;
+
+--
 -- Name: files; Type: TABLE; Schema: public; Owner: postgres
 --
 
 CREATE TABLE public.files (
-    id uuid NOT NULL,
+    id text NOT NULL,
     upload_requested_at timestamp without time zone NOT NULL,
     uploader text NOT NULL,
     group_id integer NOT NULL,

--- a/backend/src/main/kotlin/org/loculus/backend/api/FileTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/FileTypes.kt
@@ -11,11 +11,11 @@ import org.loculus.backend.service.files.FileId
 data class FileIdAndWriteUrl(
     @Schema(
         description = "The id of the file.",
-        example = "8D8AC610-566D-4EF0-9C22-186B2A5ED793",
+        example = "FILE_K7M2QX9PB4TN",
     ) val fileId: FileId,
     @Schema(
         description = "A presigned URL, allowing users to PUT an object.",
-        example = "https://dummyendpoint.com/dummybucket/files/2ea137d0-8773-4e0a-a9aa-5591de12ff23?" +
+        example = "https://dummyendpoint.com/dummybucket/files/FILE_K7M2QX9PB4TN?" +
             "X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=dummyaccesskey%2F20250330%2F" +
             "dummyregion%2Fs3%2Faws4_request&X-Amz-Date=20250330T184050Z&X-Amz-Expires=1800" +
             "&X-Amz-SignedHeaders=host%3Bif-none-match" +
@@ -33,7 +33,7 @@ data class FileIdAndWriteUrl(
 data class FileIdAndMultipartWriteUrl(
     @Schema(
         description = "The id of the file.",
-        example = "8D8AC610-566D-4EF0-9C22-186B2A5ED793",
+        example = "FILE_K7M2QX9PB4TN",
     ) val fileId: FileId,
     @Schema(
         description = "A list of presigned URL, allowing users to PUT parts of an object.",

--- a/backend/src/main/kotlin/org/loculus/backend/api/FileTypes.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/FileTypes.kt
@@ -11,11 +11,11 @@ import org.loculus.backend.service.files.FileId
 data class FileIdAndWriteUrl(
     @Schema(
         description = "The id of the file.",
-        example = "FILE_K7M2QX9PB4TN",
+        example = "FILE_2K7Q",
     ) val fileId: FileId,
     @Schema(
         description = "A presigned URL, allowing users to PUT an object.",
-        example = "https://dummyendpoint.com/dummybucket/files/FILE_K7M2QX9PB4TN?" +
+        example = "https://dummyendpoint.com/dummybucket/files/FILE_2K7Q?" +
             "X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=dummyaccesskey%2F20250330%2F" +
             "dummyregion%2Fs3%2Faws4_request&X-Amz-Date=20250330T184050Z&X-Amz-Expires=1800" +
             "&X-Amz-SignedHeaders=host%3Bif-none-match" +
@@ -33,7 +33,7 @@ data class FileIdAndWriteUrl(
 data class FileIdAndMultipartWriteUrl(
     @Schema(
         description = "The id of the file.",
-        example = "FILE_K7M2QX9PB4TN",
+        example = "FILE_2K7Q",
     ) val fileId: FileId,
     @Schema(
         description = "A list of presigned URL, allowing users to PUT parts of an object.",

--- a/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
@@ -20,7 +20,7 @@ import org.loculus.backend.service.files.S3Service
 import org.loculus.backend.service.submission.AccessionPreconditionValidator
 import org.loculus.backend.service.submission.SubmissionDatabaseService
 import org.loculus.backend.utils.Accession
-import org.loculus.backend.utils.generateFileId
+import org.loculus.backend.utils.generateFileIds
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.ResponseEntity
@@ -135,17 +135,14 @@ class FilesController(
         numberFiles: Int = 1,
     ): List<FileIdAndWriteUrl> {
         filesPreconditionValidator.validateUserIsAllowedToUploadFileForGroup(groupId, authenticatedUser)
-        val response = mutableListOf<FileIdAndWriteUrl>()
         if (numberFiles < 1) {
             throw BadRequestException("Number of files must be at least 1")
         }
-        repeat(numberFiles) {
-            val fileId = generateFileId()
-            val presignedUploadUrl = s3Service.createUrlToUploadPrivateFile(fileId)
-            filesDatabaseService.createFileEntry(fileId, authenticatedUser.username, groupId)
-            response.add(FileIdAndWriteUrl(fileId, presignedUploadUrl))
+        val fileIds = generateFileIds(numberFiles)
+        filesDatabaseService.createFileEntries(fileIds, authenticatedUser.username, groupId)
+        return fileIds.map { fileId ->
+            FileIdAndWriteUrl(fileId, s3Service.createUrlToUploadPrivateFile(fileId))
         }
-        return response
     }
 
     @Operation(
@@ -173,9 +170,10 @@ class FilesController(
         numberParts: Int = 1,
     ): List<FileIdAndMultipartWriteUrl> {
         filesPreconditionValidator.validateUserIsAllowedToUploadFileForGroup(groupId, authenticatedUser)
-        val response = mutableListOf<FileIdAndMultipartWriteUrl>()
-        repeat(numberFiles) {
-            val fileId = generateFileId()
+        if (numberFiles < 1) {
+            throw BadRequestException("Number of files must be at least 1")
+        }
+        return generateFileIds(numberFiles).map { fileId ->
             val multipartUploadHandler = s3Service.initiateMultipartUploadAndCreateUrlsToUpload(fileId, numberParts)
             filesDatabaseService.createFileEntry(
                 fileId,
@@ -183,9 +181,8 @@ class FilesController(
                 groupId,
                 multipartUploadHandler.uploadId,
             )
-            response.add(FileIdAndMultipartWriteUrl(fileId, multipartUploadHandler.presignedUrls))
+            FileIdAndMultipartWriteUrl(fileId, multipartUploadHandler.presignedUrls)
         }
-        return response
     }
 
     @Operation(

--- a/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/controller/FilesController.kt
@@ -134,10 +134,9 @@ class FilesController(
         @RequestParam
         numberFiles: Int = 1,
     ): List<FileIdAndWriteUrl> {
+        filesPreconditionValidator.validateNumberFiles(numberFiles)
         filesPreconditionValidator.validateUserIsAllowedToUploadFileForGroup(groupId, authenticatedUser)
-        if (numberFiles < 1) {
-            throw BadRequestException("Number of files must be at least 1")
-        }
+
         val fileIds = generateFileIds(numberFiles)
         filesDatabaseService.createFileEntries(fileIds, authenticatedUser.username, groupId)
         return fileIds.map { fileId ->
@@ -169,10 +168,9 @@ class FilesController(
         @RequestParam
         numberParts: Int = 1,
     ): List<FileIdAndMultipartWriteUrl> {
+        filesPreconditionValidator.validateNumberFiles(numberFiles)
         filesPreconditionValidator.validateUserIsAllowedToUploadFileForGroup(groupId, authenticatedUser)
-        if (numberFiles < 1) {
-            throw BadRequestException("Number of files must be at least 1")
-        }
+
         return generateFileIds(numberFiles).map { fileId ->
             val multipartUploadHandler = s3Service.initiateMultipartUploadAndCreateUrlsToUpload(fileId, numberParts)
             filesDatabaseService.createFileEntry(

--- a/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
@@ -47,9 +47,6 @@ const val FILES_HEADER_PREFIX = "files."
 const val FILES_SEPARATOR = " "
 const val FILE_NAME_ID_SEPARATOR = ":"
 
-// File IDs are currently validated to be UUIDs of standard length
-const val FILE_ID_LENGTH = 36
-
 const val ACCESSION_HEADER = "accession"
 private val log = KotlinLogging.logger { }
 

--- a/backend/src/main/kotlin/org/loculus/backend/service/GenerateAccessionFromNumberService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/GenerateAccessionFromNumberService.kt
@@ -2,27 +2,16 @@ package org.loculus.backend.service
 
 import org.loculus.backend.config.BackendConfig
 import org.loculus.backend.utils.Accession
+import org.loculus.backend.utils.CODE_POINTS
+import org.loculus.backend.utils.base34Encode
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
-
-const val CODE_POINTS = "0123456789ABCDEFGHJKLMNPQRSTUVWXYZ"
 
 @Service
 class GenerateAccessionFromNumberService(@Autowired val backendConfig: BackendConfig) {
 
     fun generateCustomId(sequenceNumber: Long): String {
-        val base34Digits: MutableList<Char> = mutableListOf()
-        var remainder: Long = sequenceNumber
-
-        do {
-            val digit = (remainder % 34).toInt()
-            base34Digits.addFirst(CODE_POINTS[digit])
-            remainder /= 34
-        } while (remainder > 0)
-
-        val serialAccessionPart = base34Digits
-            .joinToString("")
-            .padStart(6, '0')
+        val serialAccessionPart = base34Encode(sequenceNumber, 6)
         return backendConfig.accessionPrefix + serialAccessionPart + generateCheckCharacter(serialAccessionPart)
     }
 

--- a/backend/src/main/kotlin/org/loculus/backend/service/GenerateAccessionFromNumberService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/GenerateAccessionFromNumberService.kt
@@ -5,6 +5,8 @@ import org.loculus.backend.utils.Accession
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 
+const val CODE_POINTS = "0123456789ABCDEFGHJKLMNPQRSTUVWXYZ"
+
 @Service
 class GenerateAccessionFromNumberService(@Autowired val backendConfig: BackendConfig) {
 
@@ -71,7 +73,6 @@ class GenerateAccessionFromNumberService(@Autowired val backendConfig: BackendCo
     }
 
     companion object {
-        const val CODE_POINTS = "0123456789ABCDEFGHJKLMNPQRSTUVWXYZ"
         fun getCodePointFromCharacter(character: Char): Int = CODE_POINTS.indexOf(character)
         const val NUMBER_OF_VALID_CHARACTERS = CODE_POINTS.length
     }

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/FilesDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/FilesDatabaseService.kt
@@ -26,7 +26,7 @@ import java.util.*
 @Transactional
 class FilesDatabaseService(private val dateProvider: DateProvider) {
 
-    fun createFileEntry(fileId: UUID, uploader: String, groupId: Int, multipartUploadId: String? = null) {
+    fun createFileEntry(fileId: FileId, uploader: String, groupId: Int, multipartUploadId: String? = null) {
         val now = dateProvider.getCurrentDateTime()
         FilesTable.insert {
             it[idColumn] = fileId
@@ -37,7 +37,7 @@ class FilesDatabaseService(private val dateProvider: DateProvider) {
         }
     }
 
-    fun deleteFileEntry(fileId: UUID) {
+    fun deleteFileEntry(fileId: FileId) {
         FilesTable.deleteWhere { FilesTable.idColumn eq fileId }
     }
 
@@ -80,7 +80,7 @@ class FilesDatabaseService(private val dateProvider: DateProvider) {
             -- archive_of_submitted_data and processed_data jsonb objects
             WITH referenced AS (
                 -- fetch ids for files uploaded by users and referenced in submissions
-                SELECT (fil->>'fileId')::uuid AS file_id
+                SELECT (fil->>'fileId') AS file_id
                 FROM sequence_entries se,
                     LATERAL (
                         VALUES
@@ -94,7 +94,7 @@ class FilesDatabaseService(private val dateProvider: DateProvider) {
                 UNION
                 -- also need to check processed_data since preprocessing
                 -- can create files that are never referenced in submissions
-                SELECT (fil->>'fileId')::uuid AS file_id
+                SELECT (fil->>'fileId') AS file_id
                 FROM sequence_entries_preprocessed_data sepd
                 JOIN sequence_entries se
                     ON se.accession = sepd.accession
@@ -115,7 +115,7 @@ class FilesDatabaseService(private val dateProvider: DateProvider) {
             ) { rs ->
                 buildList<DeletionCandidateFile> {
                     while (rs.next()) {
-                        val id = rs.getObject("id", UUID::class.java)
+                        val id = rs.getString("id")
                         val markedAt = rs.getTimestamp("marked_for_deletion_at")?.toLocalDateTime()?.let { ldt ->
                             LocalDateTime(
                                 ldt.year,

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/FilesDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/FilesDatabaseService.kt
@@ -10,6 +10,7 @@ import org.jetbrains.exposed.v1.core.neq
 import org.jetbrains.exposed.v1.core.not
 import org.jetbrains.exposed.v1.core.statements.StatementType
 import org.jetbrains.exposed.v1.datetime.KotlinLocalDateTimeColumnType
+import org.jetbrains.exposed.v1.jdbc.batchInsert
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.select
@@ -34,6 +35,18 @@ class FilesDatabaseService(private val dateProvider: DateProvider) {
             it[uploaderColumn] = uploader
             it[groupIdColumn] = groupId
             it[FilesTable.multipartUploadId] = multipartUploadId
+        }
+    }
+
+    fun createFileEntries(fileIds: List<FileId>, uploader: String, groupId: Int) {
+        val now = dateProvider.getCurrentDateTime()
+        fileIds.processInDatabaseSafeChunks { chunk ->
+            FilesTable.batchInsert(chunk) { fileId ->
+                this[FilesTable.idColumn] = fileId
+                this[FilesTable.uploadRequestedAtColumn] = now
+                this[FilesTable.uploaderColumn] = uploader
+                this[FilesTable.groupIdColumn] = groupId
+            }
         }
     }
 

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/FilesDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/FilesDatabaseService.kt
@@ -46,6 +46,8 @@ class FilesDatabaseService(private val dateProvider: DateProvider) {
                 this[FilesTable.uploadRequestedAtColumn] = now
                 this[FilesTable.uploaderColumn] = uploader
                 this[FilesTable.groupIdColumn] = groupId
+                // Exposed does not apply DB-side defaults in batch inserts, so this has to be set explicitly.
+                this[FilesTable.multipartCompleted] = false
             }
         }
     }

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/FilesDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/FilesDatabaseService.kt
@@ -21,7 +21,6 @@ import org.loculus.backend.utils.chunkedForDatabase
 import org.loculus.backend.utils.processInDatabaseSafeChunks
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.util.*
 
 @Service
 @Transactional

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/FilesPreconditionValidator.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/FilesPreconditionValidator.kt
@@ -1,6 +1,7 @@
 package org.loculus.backend.service.files
 
 import org.loculus.backend.auth.AuthenticatedUser
+import org.loculus.backend.controller.BadRequestException
 import org.loculus.backend.service.groupmanagement.GroupManagementPreconditionValidator
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -9,6 +10,12 @@ import org.springframework.transaction.annotation.Transactional
 class FilesPreconditionValidator(
     private val groupManagementPreconditionValidator: GroupManagementPreconditionValidator,
 ) {
+    fun validateNumberFiles(numberFiles: Int) {
+        if (numberFiles < 1) {
+            throw BadRequestException("Number of files must be at least 1")
+        }
+    }
+
     /**
      * Users who can modify the group and the preprocessing pipeline can
      * upload files for a group.

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/FilesTable.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/FilesTable.kt
@@ -5,7 +5,7 @@ import org.jetbrains.exposed.v1.core.java.javaUUID
 import org.jetbrains.exposed.v1.datetime.datetime
 import java.util.UUID
 
-typealias FileId = UUID
+typealias FileId = String
 typealias MultipartUploadId = String
 const val FILES_TABLE_NAME = "files"
 

--- a/backend/src/main/kotlin/org/loculus/backend/service/files/FilesTable.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/files/FilesTable.kt
@@ -1,9 +1,7 @@
 package org.loculus.backend.service.files
 
 import org.jetbrains.exposed.v1.core.Table
-import org.jetbrains.exposed.v1.core.java.javaUUID
 import org.jetbrains.exposed.v1.datetime.datetime
-import java.util.UUID
 
 typealias FileId = String
 typealias MultipartUploadId = String
@@ -17,7 +15,7 @@ const val FILES_TABLE_NAME = "files"
  */
 object FilesTable : Table(FILES_TABLE_NAME) {
 
-    val idColumn = javaUUID("id")
+    val idColumn = text("id")
 
     /**
      * When the file upload was requested, i.e. the row in the table was created.

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/S3GarbageCollectionTask.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/S3GarbageCollectionTask.kt
@@ -5,6 +5,7 @@ import kotlinx.datetime.minus
 import kotlinx.datetime.toLocalDateTime
 import org.loculus.backend.config.BackendSpringProperty
 import org.loculus.backend.log.AuditLogger
+import org.loculus.backend.service.files.FileId
 import org.loculus.backend.service.files.FilesDatabaseService
 import org.loculus.backend.service.files.S3Service
 import org.loculus.backend.service.scheduler.TaskLock
@@ -13,7 +14,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import java.util.UUID
 import java.util.concurrent.TimeUnit
 import kotlin.math.max
 
@@ -84,7 +84,7 @@ class S3GarbageCollectionTask(
         }
     }
 
-    private fun deleteFiles(fileIds: Set<UUID>, orphanRetentionPeriod: Int) {
+    private fun deleteFiles(fileIds: Set<FileId>, orphanRetentionPeriod: Int) {
         var deleteFailures = 0
         fileIds.forEach { fileId ->
             try {

--- a/backend/src/main/kotlin/org/loculus/backend/utils/Base34.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/Base34.kt
@@ -1,0 +1,18 @@
+package org.loculus.backend.utils
+
+const val CODE_POINTS = "0123456789ABCDEFGHJKLMNPQRSTUVWXYZ"
+
+fun base34Encode(sequenceNumber: Long, minLength: Int): String {
+    val base34Digits: MutableList<Char> = mutableListOf()
+    var remainder: Long = sequenceNumber
+
+    do {
+        val digit = (remainder % 34).toInt()
+        base34Digits.addFirst(CODE_POINTS[digit])
+        remainder /= 34
+    } while (remainder > 0)
+
+    return base34Digits
+        .joinToString("")
+        .padStart(minLength, '0')
+}

--- a/backend/src/main/kotlin/org/loculus/backend/utils/GenerateFileId.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/GenerateFileId.kt
@@ -1,15 +1,9 @@
 package org.loculus.backend.utils
 
-import org.loculus.backend.service.CODE_POINTS
 import org.loculus.backend.service.files.FileId
-import java.security.SecureRandom
 
 private const val FILE_ID_PREFIX = "FILE_"
-private const val FILE_ID_RANDOM_PART_LENGTH = 12
+private const val FILE_ID_MIN_SERIAL_LENGTH = 4
 
-private val secureRandom = SecureRandom()
-
-fun generateFileId(): FileId = buildString {
-    append(FILE_ID_PREFIX)
-    repeat(FILE_ID_RANDOM_PART_LENGTH) { append(CODE_POINTS[secureRandom.nextInt(CODE_POINTS.length)]) }
-}
+fun generateFileIds(count: Int): List<FileId> = getNextSequenceNumbers("file_id_sequence", count)
+    .map { FILE_ID_PREFIX + base34Encode(it, FILE_ID_MIN_SERIAL_LENGTH) }

--- a/backend/src/main/kotlin/org/loculus/backend/utils/GenerateFileId.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/GenerateFileId.kt
@@ -1,5 +1,15 @@
 package org.loculus.backend.utils
 
-import java.util.UUID
+import org.loculus.backend.service.CODE_POINTS
+import org.loculus.backend.service.files.FileId
+import java.security.SecureRandom
 
-fun generateFileId() = UUID.randomUUID()
+private const val FILE_ID_PREFIX = "FILE_"
+private const val FILE_ID_RANDOM_PART_LENGTH = 12
+
+private val secureRandom = SecureRandom()
+
+fun generateFileId(): FileId = buildString {
+    append(FILE_ID_PREFIX)
+    repeat(FILE_ID_RANDOM_PART_LENGTH) { append(CODE_POINTS[secureRandom.nextInt(CODE_POINTS.length)]) }
+}

--- a/backend/src/main/kotlin/org/loculus/backend/utils/MetadataEntry.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/MetadataEntry.kt
@@ -12,7 +12,6 @@ import org.loculus.backend.model.FASTA_IDS_HEADER
 import org.loculus.backend.model.FASTA_IDS_SEPARATOR
 import org.loculus.backend.model.FILES_HEADER_PREFIX
 import org.loculus.backend.model.FILES_SEPARATOR
-import org.loculus.backend.model.FILE_ID_LENGTH
 import org.loculus.backend.model.FILE_NAME_ID_SEPARATOR
 import org.loculus.backend.model.FastaId
 import org.loculus.backend.model.METADATA_ID_HEADER
@@ -20,7 +19,6 @@ import org.loculus.backend.model.METADATA_ID_HEADER_ALTERNATE_FOR_BACKCOMPAT
 import org.loculus.backend.model.SubmissionId
 import java.io.InputStream
 import java.io.InputStreamReader
-import java.util.UUID
 
 data class MetadataEntry(
     val submissionId: SubmissionId,
@@ -160,7 +158,7 @@ private fun extractAndValidateFileIdAndName(
     }
 
     val fileName = token.substring(0, separatorIndex)
-    val fileIdString = token.substring(separatorIndex + 1)
+    val fileId = token.substring(separatorIndex + 1)
 
     if (fileName.isEmpty()) {
         throw UnprocessableEntityException(
@@ -168,26 +166,6 @@ private fun extractAndValidateFileIdAndName(
                 "file entry '$token' in column '$header' is missing a file name. " +
                 "Expected format 'fileName${FILE_NAME_ID_SEPARATOR}fileId'. " +
                 "Please also ensure file names do not contain whitespace.",
-        )
-    }
-
-    // TODO: Update when moving away from UUIDs to more user-friendly file IDs
-    // Issue: https://github.com/loculus-project/loculus/issues/6907
-    val fileId = try {
-        UUID.fromString(fileIdString)
-    } catch (e: IllegalArgumentException) {
-        throw UnprocessableEntityException(
-            "In metadata file: record #$recordNumber with id '$submissionId': " +
-                "file entry '$token' in column '$header' has an invalid file ID '$fileIdString'. " +
-                "Expected a UUID.",
-        )
-    }
-
-    if (fileIdString.length != FILE_ID_LENGTH) {
-        throw UnprocessableEntityException(
-            "In metadata file: record #$recordNumber with id '$submissionId': " +
-                "file entry '$token' in column '$header' has an invalid file ID '$fileIdString'. " +
-                "Expected a UUID of length $FILE_ID_LENGTH but received a UUID of length ${fileIdString.length}.",
         )
     }
 

--- a/backend/src/main/kotlin/org/loculus/backend/utils/MetadataEntry.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/MetadataEntry.kt
@@ -99,7 +99,7 @@ fun extractAndValidateFastaIds(record: CSVRecord, submissionId: String, recordNu
 
 /**
  * Parses the `files.<category>` columns of a record into a [FileCategoryFilesMap].
- * Each cell is a space-separated list of `fileName:fileId` pairs, e.g. `reads_1.fq:<uuid> reads_2.fq:<uuid>`.
+ * Each cell is a space-separated list of `fileName:fileId` pairs, e.g. `reads_1.fq:<id> reads_2.fq:<id>`.
  * Returns `null` if the metadata file has no `files.*` columns at all. Categories with a blank cell are omitted.
  */
 fun extractAndValidateFiles(
@@ -166,6 +166,14 @@ private fun extractAndValidateFileIdAndName(
                 "file entry '$token' in column '$header' is missing a file name. " +
                 "Expected format 'fileName${FILE_NAME_ID_SEPARATOR}fileId'. " +
                 "Please also ensure file names do not contain whitespace.",
+        )
+    }
+
+    if (fileId.isEmpty()) {
+        throw UnprocessableEntityException(
+            "In metadata file: record #$recordNumber with id '$submissionId': " +
+                "file entry '$token' in column '$header' is missing a file ID. " +
+                "Expected format 'fileName${FILE_NAME_ID_SEPARATOR}fileId'.",
         )
     }
 

--- a/backend/src/main/resources/db/migration/V1.35__file_id_text.sql
+++ b/backend/src/main/resources/db/migration/V1.35__file_id_text.sql
@@ -1,0 +1,1 @@
+ALTER TABLE files ALTER COLUMN id TYPE text;

--- a/backend/src/main/resources/db/migration/V1.35__file_id_text.sql
+++ b/backend/src/main/resources/db/migration/V1.35__file_id_text.sql
@@ -1,1 +1,3 @@
 ALTER TABLE files ALTER COLUMN id TYPE text;
+
+CREATE SEQUENCE file_id_sequence START WITH 1;

--- a/backend/src/test/kotlin/org/loculus/backend/controller/files/FilesClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/files/FilesClient.kt
@@ -95,7 +95,7 @@ fun ResultActions.andGetFileIds(): List<FileId> = andReturn()
     .contentAsString
     .let {
         val responseJson = jacksonObjectMapper().readTree(it)
-        responseJson.map { UUID.fromString(it.get("fileId").textValue()) }
+        responseJson.map { it.get("fileId").textValue() }
     }
 
 fun ResultActions.andGetFileIdsAndUrls(): List<FileIdAndWriteUrl> = andReturn()
@@ -103,7 +103,7 @@ fun ResultActions.andGetFileIdsAndUrls(): List<FileIdAndWriteUrl> = andReturn()
     .contentAsString
     .let {
         val responseJson = jacksonObjectMapper().readTree(it)
-        responseJson.map { FileIdAndWriteUrl(UUID.fromString(it.get("fileId").textValue()), it.get("url").textValue()) }
+        responseJson.map { FileIdAndWriteUrl(it.get("fileId").textValue(), it.get("url").textValue()) }
     }
 
 fun ResultActions.andGetFileIdsAndMultipartUrls(): List<FileIdAndMultipartWriteUrl> = andReturn()
@@ -112,7 +112,7 @@ fun ResultActions.andGetFileIdsAndMultipartUrls(): List<FileIdAndMultipartWriteU
     .let { body ->
         val root = jacksonObjectMapper().readTree(body)
         root.map { node ->
-            val fileId = UUID.fromString(node.get("fileId").textValue())
+            val fileId = node.get("fileId").textValue()
             val urls = node.get("urls").map { it.textValue() }
             FileIdAndMultipartWriteUrl(fileId, urls)
         }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/files/FilesClient.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/files/FilesClient.kt
@@ -17,7 +17,6 @@ import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.head
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
-import java.util.*
 
 class FilesClient(private val mockMvc: MockMvc) {
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/files/RequestUploadEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/files/RequestUploadEndpointTest.kt
@@ -8,6 +8,7 @@ import org.apache.http.impl.client.HttpClients
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.matchesPattern
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.loculus.backend.config.BackendSpringProperty
@@ -47,6 +48,7 @@ class RequestUploadEndpointTest(
         responseJson.forEach {
             assert(it.has("fileId"))
             assert(it.has("url"))
+            assertThat(it.get("fileId").textValue(), matchesPattern("FILE_[0-9A-HJ-NP-Z]{4,}"))
         }
     }
 

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ReviseEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ReviseEndpointTest.kt
@@ -40,6 +40,7 @@ import org.loculus.backend.controller.groupmanagement.andGetGroupId
 import org.loculus.backend.controller.jwtForDefaultUser
 import org.loculus.backend.controller.jwtForSuperUser
 import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles
+import org.loculus.backend.service.files.dummyFileId
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
@@ -49,7 +50,6 @@ import org.springframework.test.web.servlet.ResultMatcher
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import java.util.UUID
 
 @EndpointTest(
     properties = ["${BackendSpringProperty.BACKEND_CONFIG_PATH}=$S3_CONFIG"],
@@ -378,8 +378,8 @@ class ReviseEndpointTest(
                         mapOf(
                             "myFileCategory" to
                                 listOf(
-                                    FileIdAndName(UUID.randomUUID(), "foo.txt"),
-                                    FileIdAndName(UUID.randomUUID(), "foo.txt"),
+                                    FileIdAndName(dummyFileId(), "foo.txt"),
+                                    FileIdAndName(dummyFileId(), "foo.txt"),
                                 ),
                         ),
                 ),
@@ -412,7 +412,7 @@ class ReviseEndpointTest(
                         mapOf(
                             "unknownCategory" to
                                 listOf(
-                                    FileIdAndName(UUID.randomUUID(), "foo.txt"),
+                                    FileIdAndName(dummyFileId(), "foo.txt"),
                                 ),
                         ),
                 ),

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEditedSequenceEntryVersionEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEditedSequenceEntryVersionEndpointTest.kt
@@ -240,7 +240,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
     fun `WHEN submitting files with duplicate file IDs THEN an error is returned`() {
         val accessions = convenienceClient.prepareDataTo(Status.PROCESSED).map { it.accession }
 
-        val reusedFileId = UUID.randomUUID()
+        val reusedFileId = dummyFileId()
         val editedData = EditedSequenceEntryData(
             accession = accessions.first(),
             version = 1,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEditedSequenceEntryVersionEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEditedSequenceEntryVersionEndpointTest.kt
@@ -28,10 +28,10 @@ import org.loculus.backend.controller.generateJwtFor
 import org.loculus.backend.controller.groupmanagement.GroupManagementControllerClient
 import org.loculus.backend.controller.groupmanagement.andGetGroupId
 import org.loculus.backend.controller.jwtForSuperUser
+import org.loculus.backend.service.files.dummyFileId
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import java.util.UUID
 
 @EndpointTest(
     properties = ["${BackendSpringProperty.BACKEND_CONFIG_PATH}=$S3_CONFIG"],
@@ -222,8 +222,8 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
                 files = mapOf(
                     "myFileCategory" to
                         listOf(
-                            FileIdAndName(UUID.randomUUID(), "foo.txt"),
-                            FileIdAndName(UUID.randomUUID(), "foo.txt"),
+                            FileIdAndName(dummyFileId(), "foo.txt"),
+                            FileIdAndName(dummyFileId(), "foo.txt"),
                         ),
                 ),
             ),
@@ -283,7 +283,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
                 files = mapOf(
                     "unknownCategory" to
                         listOf(
-                            FileIdAndName(UUID.randomUUID(), "foo.txt"),
+                            FileIdAndName(dummyFileId(), "foo.txt"),
                         ),
                 ),
             ),
@@ -301,7 +301,7 @@ class SubmitEditedSequenceEntryVersionEndpointTest(
 
     @Test
     fun `WHEN submitting a non-existing file ID THEN an error is returned`() {
-        val randomFileId = UUID.randomUUID()
+        val randomFileId = dummyFileId()
         val accessions = convenienceClient.prepareDataTo(Status.PROCESSED).map { it.accession }
 
         val editedData = EditedSequenceEntryData(

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
@@ -19,13 +19,13 @@ import org.loculus.backend.controller.groupmanagement.andGetGroupId
 import org.loculus.backend.controller.jwtForAlternativeUser
 import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles
 import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles.NUMBER_OF_SEQUENCES
+import org.loculus.backend.service.files.dummyFileId
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import java.util.*
 
 @EndpointTest(
     properties = ["${BackendSpringProperty.BACKEND_CONFIG_PATH}=$S3_CONFIG"],
@@ -67,7 +67,7 @@ class SubmitEndpointFileSharingTest(
 
     @Test
     fun `GIVEN a non-existing file ID is given in submit THEN the request is not valid`() {
-        val randomId = UUID.randomUUID()
+        val randomId = dummyFileId()
 
         submissionControllerClient.submit(
             DefaultFiles.metadataFile.withFileMapping(

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointFileSharingTest.kt
@@ -1,7 +1,9 @@
 package org.loculus.backend.controller.submission
 
+import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.`is`
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.loculus.backend.api.FileIdAndName
@@ -19,7 +21,9 @@ import org.loculus.backend.controller.groupmanagement.andGetGroupId
 import org.loculus.backend.controller.jwtForAlternativeUser
 import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles
 import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles.NUMBER_OF_SEQUENCES
+import org.loculus.backend.service.files.daysAgo
 import org.loculus.backend.service.files.dummyFileId
+import org.loculus.backend.service.files.insertFile
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
@@ -63,6 +67,45 @@ class SubmitEndpointFileSharingTest(
             .andExpect(jsonPath("\$[0].submissionId").value("custom0"))
             .andExpect(jsonPath("\$[0].accession", containsString(backendConfig.accessionPrefix)))
             .andExpect(jsonPath("\$[0].version").value(1))
+    }
+
+    @Test
+    fun `GIVEN a legacy UUID file ID next to a current one THEN both are accepted and stored`() {
+        // File IDs are FILE_xxxx now, but rows written before that change hold UUIDs and must keep working.
+        val legacyFileId = "123e4567-e89b-12d3-a456-426614174000"
+        insertFile(legacyFileId, groupId, daysAgo(1))
+        val currentFileIdAndUrl = filesClient.requestUploads(groupId).andGetFileIdsAndUrls()[0]
+        convenienceClient.uploadFile(
+            currentFileIdAndUrl.presignedWriteUrl,
+            DEFAULT_SIMPLE_FILE_CONTENT,
+            currentFileIdAndUrl.headers,
+        )
+
+        submissionControllerClient.submit(
+            DefaultFiles.metadataFile.withFileMapping(
+                mapOf(
+                    "custom0" to mapOf(
+                        "myFileCategory" to listOf(
+                            FileIdAndName(legacyFileId, "legacy.txt"),
+                            FileIdAndName(currentFileIdAndUrl.fileId, "current.txt"),
+                        ),
+                    ),
+                ),
+            ),
+            DefaultFiles.sequencesFile,
+            organism = DEFAULT_ORGANISM,
+            groupId = groupId,
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("\$[0].submissionId").value("custom0"))
+
+        val storedFiles = convenienceClient.extractUnprocessedData()
+            .single { it.submissionId == "custom0" }
+            .data.files!!["myFileCategory"]!!
+        assertThat(
+            storedFiles.map { it.fileId to it.name },
+            `is`(listOf(legacyFileId to "legacy.txt", currentFileIdAndUrl.fileId to "current.txt")),
+        )
     }
 
     @Test

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
@@ -30,6 +30,7 @@ import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles
 import org.loculus.backend.controller.submission.SubmitFiles.DefaultFiles.NUMBER_OF_SEQUENCES
 import org.loculus.backend.model.SubmitModel.AcceptedFileTypes.metadataFileTypes
 import org.loculus.backend.model.SubmitModel.AcceptedFileTypes.sequenceFileTypes
+import org.loculus.backend.service.files.dummyFileId
 import org.loculus.backend.service.submission.CompressionAlgorithm
 import org.loculus.backend.utils.DateProvider
 import org.springframework.beans.factory.annotation.Autowired
@@ -42,7 +43,6 @@ import org.springframework.test.web.servlet.ResultMatcher
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import java.util.UUID
 import kotlin.time.Clock
 
 @EndpointTest
@@ -172,7 +172,7 @@ class SubmitEndpointTest(
     fun `GIVEN submission with file mapping for organism without file support THEN returns an error`() {
         submissionControllerClient.submit(
             DefaultFiles.multiSegmentedMetadataFile.withFileMapping(
-                mapOf("custom0" to mapOf("bar" to listOf(FileIdAndName(UUID.randomUUID(), "baz")))),
+                mapOf("custom0" to mapOf("bar" to listOf(FileIdAndName(dummyFileId(), "baz")))),
             ),
             DefaultFiles.sequencesFileMultiSegmented,
             organism = OTHER_ORGANISM,

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitProcessedDataEndpointTest.kt
@@ -57,7 +57,6 @@ import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
-import java.util.UUID
 
 @EndpointTest(
     properties = [
@@ -606,7 +605,7 @@ class SubmitProcessedDataEndpointTest(
         val groupId = groupManagementClient
             .createNewGroup(group = DEFAULT_GROUP, jwt = jwtForDefaultUser)
             .andGetGroupId()
-        val fileId = UUID.fromString("caaf8c66-e1ba-4c47-99b1-8c368adb9850")
+        val fileId = "FILE_DOESNOTEXIST"
         val accession = prepareUnprocessedSequenceEntry(DEFAULT_ORGANISM, groupId = groupId)
 
         submissionControllerClient.submitProcessedData(

--- a/backend/src/test/kotlin/org/loculus/backend/service/files/DisabledS3ServiceTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/files/DisabledS3ServiceTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.assertThrows
 import org.loculus.backend.config.BackendSpringProperty
 import org.loculus.backend.controller.EndpointTest
 import org.springframework.beans.factory.annotation.Autowired
-import java.util.UUID
 
 @EndpointTest(
     properties = ["${BackendSpringProperty.S3_ENABLED}=false"],
@@ -16,7 +15,7 @@ class DisabledS3ServiceTest(@Autowired val s3Service: S3Service) {
     @Test
     fun `WHEN calling createUrlToUploadPrivateFile THEN an error is thrown`() {
         assertThrows<IllegalStateException> {
-            s3Service.createUrlToUploadPrivateFile(UUID.randomUUID())
+            s3Service.createUrlToUploadPrivateFile(dummyFileId())
         }.also {
             Assertions.assertEquals("S3 is not enabled", it.message)
         }

--- a/backend/src/test/kotlin/org/loculus/backend/service/files/EnabledS3ServiceTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/files/EnabledS3ServiceTest.kt
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.loculus.backend.config.BackendSpringProperty
 import org.loculus.backend.controller.EndpointTest
 import org.springframework.beans.factory.annotation.Autowired
-import java.util.UUID
 
 @EndpointTest(
     properties = ["${BackendSpringProperty.S3_ENABLED}=true"],
@@ -15,7 +14,7 @@ class EnabledS3ServiceTest(@Autowired val s3Service: S3Service) {
     @Test
     fun `WHEN calling createUrlToUploadPrivateFile THEN no error is thrown`() {
         assertDoesNotThrow {
-            s3Service.createUrlToUploadPrivateFile(UUID.randomUUID())
+            s3Service.createUrlToUploadPrivateFile(dummyFileId())
         }
     }
 }

--- a/backend/src/test/kotlin/org/loculus/backend/service/files/GetDeletionCandidateFilesTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/files/GetDeletionCandidateFilesTest.kt
@@ -18,7 +18,6 @@ import org.loculus.backend.service.files.daysAgo
 import org.loculus.backend.service.files.insertFile
 import org.loculus.backend.service.submission.UseNewerProcessingPipelineVersionTask
 import org.springframework.beans.factory.annotation.Autowired
-import java.util.UUID
 
 /**
  * Testing of orphan file detection logic in [FilesDatabaseService.getDeletionCandidateFiles].
@@ -47,8 +46,8 @@ class GetDeletionCandidateFilesTest(
 
     @Test
     fun `GIVEN unreferenced files THEN only those whose upload was requested before the threshold are orphaned`() {
-        val old = UUID.randomUUID()
-        val recent = UUID.randomUUID()
+        val old = dummyFileId()
+        val recent = dummyFileId()
         insertFile(old, groupId, daysAgo(10))
         insertFile(recent, groupId, daysAgo(1))
 
@@ -59,16 +58,16 @@ class GetDeletionCandidateFilesTest(
 
     @Test
     fun `GIVEN multiple pipeline versions THEN files from all pipeline versions are protected`() {
-        val fileFromOldPipeline = UUID.randomUUID()
-        val fileFromCurrentPipeline = UUID.randomUUID()
-        val fileFromNewerPipeline = UUID.randomUUID()
+        val fileFromOldPipeline = dummyFileId()
+        val fileFromCurrentPipeline = dummyFileId()
+        val fileFromNewerPipeline = dummyFileId()
         listOf(fileFromOldPipeline, fileFromCurrentPipeline, fileFromNewerPipeline)
             .forEach { insertFile(it, groupId, daysAgo(10)) }
 
         val submissions = convenienceClient.submitDefaultFiles(groupId = groupId).submissionIdMappings
         val targetAccession = submissions.first().accession
 
-        fun processedDataAtPipeline(file: UUID) = submissions.map { av ->
+        fun processedDataAtPipeline(file: FileId) = submissions.map { av ->
             if (av.accession == targetAccession) {
                 PreparedProcessedData.withFiles(
                     av.accession,
@@ -93,14 +92,14 @@ class GetDeletionCandidateFilesTest(
             filesDatabaseService.getDeletionCandidateFiles(daysAgo(5)).map {
                 it.id
             }.toSet(),
-            `is`(emptySet<UUID>()),
+            `is`(emptySet<FileId>()),
         )
     }
 
     @Suppress("ktlint:standard:max-line-length")
     @Test
     fun `GIVEN a file only in preprocessed data of a pipeline version cleaned up after upgrade THEN it becomes orphaned`() {
-        val fileInOldPipelineVersion = UUID.randomUUID()
+        val fileInOldPipelineVersion = dummyFileId()
         insertFile(fileInOldPipelineVersion, groupId, daysAgo(10))
 
         val submissions = convenienceClient.submitDefaultFiles(groupId = groupId).submissionIdMappings
@@ -132,7 +131,7 @@ class GetDeletionCandidateFilesTest(
             filesDatabaseService.getDeletionCandidateFiles(daysAgo(5)).map {
                 it.id
             }.toSet(),
-            `is`(emptySet<UUID>()),
+            `is`(emptySet<FileId>()),
         )
 
         // Upgrades to v3, deletes v1 preprocessed data (keeps v2 as the one retained older version)

--- a/backend/src/test/kotlin/org/loculus/backend/service/files/S3GarbageCollectionTaskTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/files/S3GarbageCollectionTaskTest.kt
@@ -18,14 +18,15 @@ import org.loculus.backend.controller.jwtForDefaultUser
 import org.loculus.backend.controller.submission.PreparedProcessedData
 import org.loculus.backend.controller.submission.SubmissionConvenienceClient
 import org.loculus.backend.log.AuditLogger
+import org.loculus.backend.service.files.FileId
 import org.loculus.backend.service.files.FilesDatabaseService
 import org.loculus.backend.service.files.S3Service
 import org.loculus.backend.service.files.daysAgo
+import org.loculus.backend.service.files.dummyFileId
 import org.loculus.backend.service.files.insertFile
 import org.loculus.backend.service.scheduler.TASK_LOCK_TABLE_NAME
 import org.loculus.backend.utils.DateProvider
 import org.springframework.beans.factory.annotation.Autowired
-import java.util.UUID
 
 @EndpointTest(
     properties = [
@@ -48,7 +49,7 @@ class S3GarbageCollectionTaskTest(
 
     private var groupId = 0
 
-    private fun createProcessedSubmissionReferencingFile(file: UUID) {
+    private fun createProcessedSubmissionReferencingFile(file: FileId) {
         val submissions = convenienceClient.submitDefaultFiles(groupId = groupId).submissionIdMappings
         val targetAccession = submissions.first().accession
 
@@ -77,7 +78,7 @@ class S3GarbageCollectionTaskTest(
 
     @Test
     fun `GIVEN GC is disabled WHEN the task runs THEN orphaned files are not deleted`() {
-        val orphan = UUID.randomUUID()
+        val orphan = dummyFileId()
         insertFile(orphan, groupId, daysAgo(2))
 
         S3GarbageCollectionTask(
@@ -96,7 +97,7 @@ class S3GarbageCollectionTaskTest(
     @Suppress("ktlint:standard:max-line-length")
     @Test
     fun `GIVEN an orphaned file WHEN the task runs once THEN the orphan is marked but not yet deleted from S3 or the DB`() {
-        val orphan = UUID.randomUUID()
+        val orphan = dummyFileId()
         insertFile(orphan, groupId, daysAgo(2))
 
         s3GarbageCollectionTask.task()
@@ -108,7 +109,7 @@ class S3GarbageCollectionTaskTest(
 
     @Test
     fun `GIVEN a file marked in a previous run WHEN the task runs again THEN the file is deleted`() {
-        val orphan = UUID.randomUUID()
+        val orphan = dummyFileId()
         insertFile(orphan, groupId, daysAgo(2))
 
         s3GarbageCollectionTask.task() // phase 1: marks the file
@@ -122,8 +123,8 @@ class S3GarbageCollectionTaskTest(
     @Suppress("ktlint:standard:max-line-length")
     @Test
     fun `GIVEN an orphan and a referenced file WHEN the task runs THEN only the orphan is marked and the referenced file is untouched`() {
-        val orphan = UUID.randomUUID()
-        val referenced = UUID.randomUUID()
+        val orphan = dummyFileId()
+        val referenced = dummyFileId()
         listOf(orphan, referenced).forEach { insertFile(it, groupId, daysAgo(2)) }
 
         createProcessedSubmissionReferencingFile(referenced)
@@ -143,7 +144,7 @@ class S3GarbageCollectionTaskTest(
     @Suppress("ktlint:standard:max-line-length")
     @Test
     fun `GIVEN a referenced file that is marked for deletion WHEN the task runs THEN the file is NOT deleted (race condition fix)`() {
-        val file = UUID.randomUUID()
+        val file = dummyFileId()
         insertFile(file, groupId, daysAgo(2))
 
         createProcessedSubmissionReferencingFile(file)

--- a/backend/src/test/kotlin/org/loculus/backend/service/files/TestHelpers.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/files/TestHelpers.kt
@@ -8,10 +8,15 @@ import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.loculus.backend.service.files.FilesTable
 import org.loculus.backend.utils.DateProvider
-import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Clock
 
-fun insertFile(id: UUID, groupId: Int, requestedAt: LocalDateTime, uploader: String = "testuser") = transaction {
+private val fileIdCounter = AtomicInteger()
+
+/** A unique file ID for tests that just need some file to point at. */
+fun dummyFileId(): FileId = "FILE_TEST${fileIdCounter.incrementAndGet()}"
+
+fun insertFile(id: FileId, groupId: Int, requestedAt: LocalDateTime, uploader: String = "testuser") = transaction {
     FilesTable.insert {
         it[idColumn] = id
         it[uploadRequestedAtColumn] = requestedAt

--- a/backend/src/test/kotlin/org/loculus/backend/service/submission/ValidateFileNameTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/service/submission/ValidateFileNameTest.kt
@@ -14,7 +14,7 @@ import org.loculus.backend.config.BackendConfig
 import org.loculus.backend.controller.UnprocessableEntityException
 import org.loculus.backend.service.files.FilesDatabaseService
 import org.loculus.backend.service.files.S3Service
-import java.util.UUID
+import org.loculus.backend.service.files.dummyFileId
 
 class ValidateFileNameTest {
     private val backendConfig: BackendConfig = mockk()
@@ -34,7 +34,7 @@ class ValidateFileNameTest {
     }
 
     private fun createFileMapping(category: FileCategory, filenames: List<String>): FileCategoryFilesMap {
-        val files = filenames.map { FileIdAndName(UUID.randomUUID(), it) }
+        val files = filenames.map { FileIdAndName(dummyFileId(), it) }
         return mapOf(category to files)
     }
 

--- a/backend/src/test/kotlin/org/loculus/backend/utils/Base34Test.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/utils/Base34Test.kt
@@ -1,0 +1,34 @@
+package org.loculus.backend.utils
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.not
+import org.junit.jupiter.api.Test
+
+class Base34Test {
+
+    @Test
+    fun `pads the encoded value up to the minimum length`() {
+        assertThat(base34Encode(0, 4), `is`("0000"))
+        assertThat(base34Encode(1, 4), `is`("0001"))
+        assertThat(base34Encode(34, 4), `is`("0010"))
+    }
+
+    @Test
+    fun `grows beyond the minimum length once the value no longer fits`() {
+        val largestValueOfLengthFour = 34L * 34 * 34 * 34 - 1
+
+        assertThat(base34Encode(largestValueOfLengthFour, 4), `is`("ZZZZ"))
+        assertThat(base34Encode(largestValueOfLengthFour + 1, 4), `is`("10000"))
+    }
+
+    @Test
+    fun `encodes digits with an alphabet that omits the ambiguous I and O`() {
+        val allDigits = (0L until 34L).joinToString("") { base34Encode(it, 1) }
+
+        assertThat(allDigits, `is`(CODE_POINTS))
+        assertThat(allDigits, not(containsString("I")))
+        assertThat(allDigits, not(containsString("O")))
+    }
+}

--- a/backend/src/test/kotlin/org/loculus/backend/utils/MetadataEntryTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/utils/MetadataEntryTest.kt
@@ -15,6 +15,7 @@ import org.loculus.backend.model.FASTA_IDS_SEPARATOR
 import org.loculus.backend.model.FILES_HEADER_PREFIX
 import org.loculus.backend.model.FILES_SEPARATOR
 import org.loculus.backend.model.FILE_NAME_ID_SEPARATOR
+import org.loculus.backend.service.files.dummyFileId
 import java.io.ByteArrayInputStream
 
 class MetadataEntryTest {
@@ -185,8 +186,8 @@ class MetadataEntryTest {
 
     @Test
     fun `test files columns are parsed and excluded from metadata`() {
-        val fileId1 = "123e4567-e89b-12d3-a456-426614174000"
-        val fileId2 = "223e4567-e89b-12d3-a456-426614174001"
+        val fileId1 = dummyFileId()
+        val fileId2 = dummyFileId()
         val files = listOf(
             "reads_1.fq$FILE_NAME_ID_SEPARATOR$fileId1",
             "reads_2.fq$FILE_NAME_ID_SEPARATOR$fileId2",
@@ -215,8 +216,8 @@ class MetadataEntryTest {
 
     @Test
     fun `test multiple files categories are parsed`() {
-        val fileId1 = "123e4567-e89b-12d3-a456-426614174000"
-        val fileId2 = "223e4567-e89b-12d3-a456-426614174001"
+        val fileId1 = dummyFileId()
+        val fileId2 = dummyFileId()
         val str = """
             submissionId${'\t'}${FILES_HEADER_PREFIX}raw_reads${'\t'}${FILES_HEADER_PREFIX}assemblies${'\t'}Country
             foo${'\t'}reads.fq$FILE_NAME_ID_SEPARATOR$fileId1${'\t'}asm.fa$FILE_NAME_ID_SEPARATOR$fileId2${'\t'}bar
@@ -235,7 +236,7 @@ class MetadataEntryTest {
 
     @Test
     fun `test blank files cell omits that category`() {
-        val fileId1 = "123e4567-e89b-12d3-a456-426614174000"
+        val fileId1 = dummyFileId()
         val str = """
             submissionId${'\t'}${FILES_HEADER_PREFIX}raw_reads${'\t'}${FILES_HEADER_PREFIX}assemblies${'\t'}Country
             foo${'\t'}reads.fq$FILE_NAME_ID_SEPARATOR$fileId1${'\t'}${'\t'}bar
@@ -268,7 +269,7 @@ class MetadataEntryTest {
 
     @Test
     fun `test files entry missing file name is rejected`() {
-        val fileId1 = "123e4567-e89b-12d3-a456-426614174000"
+        val fileId1 = dummyFileId()
         val str = """
             submissionId${'\t'}${FILES_HEADER_PREFIX}raw_reads${'\t'}Country
             foo${'\t'}$FILE_NAME_ID_SEPARATOR$fileId1${'\t'}bar
@@ -281,8 +282,8 @@ class MetadataEntryTest {
 
     @Test
     fun `test duplicate file names within a category are rejected`() {
-        val fileId1 = "123e4567-e89b-12d3-a456-426614174000"
-        val fileId2 = "223e4567-e89b-12d3-a456-426614174001"
+        val fileId1 = dummyFileId()
+        val fileId2 = dummyFileId()
         val files = listOf(
             "reads.fq$FILE_NAME_ID_SEPARATOR$fileId1",
             "reads.fq$FILE_NAME_ID_SEPARATOR$fileId2",
@@ -300,7 +301,7 @@ class MetadataEntryTest {
 
     @Test
     fun `test the same fileId reused under two names in one category is rejected`() {
-        val sharedFileId = "123e4567-e89b-12d3-a456-426614174000"
+        val sharedFileId = dummyFileId()
         val files = listOf(
             "reads_1.fq$FILE_NAME_ID_SEPARATOR$sharedFileId",
             "reads_2.fq$FILE_NAME_ID_SEPARATOR$sharedFileId",
@@ -318,8 +319,8 @@ class MetadataEntryTest {
 
     @Test
     fun `test distinct fileIds under distinct names in one category are accepted`() {
-        val fileId1 = "123e4567-e89b-12d3-a456-426614174000"
-        val fileId2 = "223e4567-e89b-12d3-a456-426614174001"
+        val fileId1 = dummyFileId()
+        val fileId2 = dummyFileId()
         val files = listOf(
             "reads_1.fq$FILE_NAME_ID_SEPARATOR$fileId1",
             "reads_2.fq$FILE_NAME_ID_SEPARATOR$fileId2",
@@ -338,8 +339,8 @@ class MetadataEntryTest {
 
     @Test
     fun `test duplicate files columns for the same category are rejected`() {
-        val fileId1 = "123e4567-e89b-12d3-a456-426614174000"
-        val fileId2 = "223e4567-e89b-12d3-a456-426614174001"
+        val fileId1 = dummyFileId()
+        val fileId2 = dummyFileId()
         val str = """
             submissionId${'\t'}${FILES_HEADER_PREFIX}raw_reads${'\t'}${FILES_HEADER_PREFIX}raw_reads${'\t'}Country
             foo${'\t'}reads_1.fq$FILE_NAME_ID_SEPARATOR$fileId1${'\t'}reads_2.fq$FILE_NAME_ID_SEPARATOR$fileId2${'\t'}bar
@@ -353,7 +354,7 @@ class MetadataEntryTest {
 
     @Test
     fun `test file name containing a separator splits on the last separator`() {
-        val fileId1 = "123e4567-e89b-12d3-a456-426614174000"
+        val fileId1 = dummyFileId()
         val str = """
             submissionId${'\t'}${FILES_HEADER_PREFIX}raw_reads${'\t'}Country
             foo${'\t'}weird${FILE_NAME_ID_SEPARATOR}name.fq$FILE_NAME_ID_SEPARATOR$fileId1${'\t'}bar
@@ -503,7 +504,7 @@ class RevisionEntryTest {
 
     @Test
     fun `test revision files column is parsed and excluded from metadata`() {
-        val fileId1 = "123e4567-e89b-12d3-a456-426614174000"
+        val fileId1 = dummyFileId()
         val str = """
             submissionId${'\t'}$ACCESSION_HEADER${'\t'}${FILES_HEADER_PREFIX}raw_reads${'\t'}Country
             foo${'\t'}ACC123${'\t'}reads.fq$FILE_NAME_ID_SEPARATOR$fileId1${'\t'}bar

--- a/backend/src/test/kotlin/org/loculus/backend/utils/MetadataEntryTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/utils/MetadataEntryTest.kt
@@ -14,10 +14,8 @@ import org.loculus.backend.model.FASTA_IDS_HEADER
 import org.loculus.backend.model.FASTA_IDS_SEPARATOR
 import org.loculus.backend.model.FILES_HEADER_PREFIX
 import org.loculus.backend.model.FILES_SEPARATOR
-import org.loculus.backend.model.FILE_ID_LENGTH
 import org.loculus.backend.model.FILE_NAME_ID_SEPARATOR
 import java.io.ByteArrayInputStream
-import java.util.UUID
 
 class MetadataEntryTest {
     @Test
@@ -204,8 +202,8 @@ class MetadataEntryTest {
             equalTo(
                 mapOf(
                     "raw_reads" to listOf(
-                        FileIdAndName(UUID.fromString(fileId1), "reads_1.fq"),
-                        FileIdAndName(UUID.fromString(fileId2), "reads_2.fq"),
+                        FileIdAndName(fileId1, "reads_1.fq"),
+                        FileIdAndName(fileId2, "reads_2.fq"),
                     ),
                 ),
             ),
@@ -227,11 +225,11 @@ class MetadataEntryTest {
         assertThat(entries[0].files!!.keys, equalTo(setOf("raw_reads", "assemblies")))
         assertThat(
             entries[0].files!!["raw_reads"],
-            equalTo(listOf(FileIdAndName(UUID.fromString(fileId1), "reads.fq"))),
+            equalTo(listOf(FileIdAndName(fileId1, "reads.fq"))),
         )
         assertThat(
             entries[0].files!!["assemblies"],
-            equalTo(listOf(FileIdAndName(UUID.fromString(fileId2), "asm.fa"))),
+            equalTo(listOf(FileIdAndName(fileId2, "asm.fa"))),
         )
     }
 
@@ -279,31 +277,6 @@ class MetadataEntryTest {
             metadataEntryStreamAsSequence(ByteArrayInputStream(str.toByteArray())).toList()
         }
         assertThat(exception.message, containsString("missing a file name"))
-    }
-
-    @Test
-    fun `test files entry with invalid UUID is rejected`() {
-        val str = """
-            submissionId${'\t'}${FILES_HEADER_PREFIX}raw_reads${'\t'}Country
-            foo${'\t'}reads_1.fq${FILE_NAME_ID_SEPARATOR}not-a-uuid${'\t'}bar
-        """.trimIndent()
-        val exception = assertThrows<UnprocessableEntityException> {
-            metadataEntryStreamAsSequence(ByteArrayInputStream(str.toByteArray())).toList()
-        }
-        assertThat(exception.message, containsString("invalid file ID"))
-    }
-
-    @Test
-    fun `test files entry with UUID of non-standard length is rejected`() {
-        val str = """
-            submissionId${'\t'}${FILES_HEADER_PREFIX}raw_reads${'\t'}Country
-            foo${'\t'}reads_1.fq${FILE_NAME_ID_SEPARATOR}1-2-3-4-5${'\t'}bar
-        """.trimIndent()
-        val exception = assertThrows<UnprocessableEntityException> {
-            metadataEntryStreamAsSequence(ByteArrayInputStream(str.toByteArray())).toList()
-        }
-        assertThat(exception.message, containsString("invalid file ID"))
-        assertThat(exception.message, containsString("Expected a UUID of length $FILE_ID_LENGTH"))
     }
 
     @Test
@@ -388,7 +361,7 @@ class MetadataEntryTest {
         val entries = metadataEntryStreamAsSequence(ByteArrayInputStream(str.toByteArray())).toList()
         assertThat(
             entries[0].files!!["raw_reads"],
-            equalTo(listOf(FileIdAndName(UUID.fromString(fileId1), "weird${FILE_NAME_ID_SEPARATOR}name.fq"))),
+            equalTo(listOf(FileIdAndName(fileId1, "weird${FILE_NAME_ID_SEPARATOR}name.fq"))),
         )
     }
 }
@@ -538,7 +511,7 @@ class RevisionEntryTest {
         val entries = revisionEntryStreamAsSequence(ByteArrayInputStream(str.toByteArray())).toList()
         assertThat(
             entries[0].files,
-            equalTo(mapOf("raw_reads" to listOf(FileIdAndName(UUID.fromString(fileId1), "reads.fq")))),
+            equalTo(mapOf("raw_reads" to listOf(FileIdAndName(fileId1, "reads.fq")))),
         )
         assertThat(entries[0].metadata.containsKey("${FILES_HEADER_PREFIX}raw_reads"), equalTo(false))
     }

--- a/docs/src/content/docs/for-users/submit-extra-files.md
+++ b/docs/src/content/docs/for-users/submit-extra-files.md
@@ -52,8 +52,8 @@ The endpoint returns an array of file IDs and pre-signed URLs to use to upload t
 ```json
 [
   {
-    "fileId": "8D8AC610-566D-4EF0-9C22-186B2A5ED793",
-    "url": "https://dummyendpoint.com/dummybucket/files/2ea137d0-8773-4e0a-a9aa-5591de12ff23?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=dummyaccesskey%2F20250330%2Fdummyregion%2Fs3%2Faws4_request&X-Amz-Date=20250330T184050Z&X-Amz-Expires=1800&X-Amz-SignedHeaders=host&X-Amz-Signature=9717e8d8c8242d0d266f816c665d78b1d842de5286fb59e37329f090e9bb0b9e"
+    "fileId": "FILE_K7M2QX9PB4TN",
+    "url": "https://dummyendpoint.com/dummybucket/files/FILE_K7M2QX9PB4TN?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=dummyaccesskey%2F20250330%2Fdummyregion%2Fs3%2Faws4_request&X-Amz-Date=20250330T184050Z&X-Amz-Expires=1800&X-Amz-SignedHeaders=host&X-Amz-Signature=9717e8d8c8242d0d266f816c665d78b1d842de5286fb59e37329f090e9bb0b9e"
   },
   ...
 ]
@@ -94,11 +94,11 @@ The endpoint returns an array with file IDs and presigned URLs for each part:
 ```json
 [
   {
-    "fileId": "8D8AC610-566D-4EF0-9C22-186B2A5ED793",
+    "fileId": "FILE_K7M2QX9PB4TN",
     "urls": [
-      "https://dummyendpoint.com/dummybucket/files/8D8AC610-566D-4EF0-9C22-186B2A5ED793?partNumber=1&X-Amz-Algorithm=...",
-      "https://dummyendpoint.com/dummybucket/files/8D8AC610-566D-4EF0-9C22-186B2A5ED793?partNumber=2&X-Amz-Algorithm=...",
-      "https://dummyendpoint.com/dummybucket/files/8D8AC610-566D-4EF0-9C22-186B2A5ED793?partNumber=3&X-Amz-Algorithm=..."
+      "https://dummyendpoint.com/dummybucket/files/FILE_K7M2QX9PB4TN?partNumber=1&X-Amz-Algorithm=...",
+      "https://dummyendpoint.com/dummybucket/files/FILE_K7M2QX9PB4TN?partNumber=2&X-Amz-Algorithm=...",
+      "https://dummyendpoint.com/dummybucket/files/FILE_K7M2QX9PB4TN?partNumber=3&X-Amz-Algorithm=..."
     ]
   }
 ]
@@ -140,7 +140,7 @@ curl -X POST \
   -H 'Content-Type: application/json' \
   -d '[
     {
-      "fileId": "8D8AC610-566D-4EF0-9C22-186B2A5ED793",
+      "fileId": "FILE_K7M2QX9PB4TN",
       "etags": [
         "d41d8cd98f00b204e9800998ecf8427e",
         "098f6bcd4621d373cade4e832627b4f6",
@@ -164,7 +164,7 @@ The cell value for a given submission ID is a space-separated list of `fileName:
 
 ```
 files.rawReads
-reads_1.fq:8D8AC610-566D-4EF0-9C22-186B2A5ED793 reads_2.fq:2ea137d0-8773-4e0a-a9aa-5591de12ff23
+reads_1.fq:FILE_K7M2QX9PB4TN reads_2.fq:FILE_R3W8HD5YCJ2M
 ```
 
 - The `fileId` is the ID received in the previous step, which identifies the actual file.

--- a/docs/src/content/docs/for-users/submit-extra-files.md
+++ b/docs/src/content/docs/for-users/submit-extra-files.md
@@ -52,8 +52,8 @@ The endpoint returns an array of file IDs and pre-signed URLs to use to upload t
 ```json
 [
   {
-    "fileId": "FILE_K7M2QX9PB4TN",
-    "url": "https://dummyendpoint.com/dummybucket/files/FILE_K7M2QX9PB4TN?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=dummyaccesskey%2F20250330%2Fdummyregion%2Fs3%2Faws4_request&X-Amz-Date=20250330T184050Z&X-Amz-Expires=1800&X-Amz-SignedHeaders=host&X-Amz-Signature=9717e8d8c8242d0d266f816c665d78b1d842de5286fb59e37329f090e9bb0b9e"
+    "fileId": "FILE_2K7Q",
+    "url": "https://dummyendpoint.com/dummybucket/files/FILE_2K7Q?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=dummyaccesskey%2F20250330%2Fdummyregion%2Fs3%2Faws4_request&X-Amz-Date=20250330T184050Z&X-Amz-Expires=1800&X-Amz-SignedHeaders=host&X-Amz-Signature=9717e8d8c8242d0d266f816c665d78b1d842de5286fb59e37329f090e9bb0b9e"
   },
   ...
 ]
@@ -94,11 +94,11 @@ The endpoint returns an array with file IDs and presigned URLs for each part:
 ```json
 [
   {
-    "fileId": "FILE_K7M2QX9PB4TN",
+    "fileId": "FILE_2K7Q",
     "urls": [
-      "https://dummyendpoint.com/dummybucket/files/FILE_K7M2QX9PB4TN?partNumber=1&X-Amz-Algorithm=...",
-      "https://dummyendpoint.com/dummybucket/files/FILE_K7M2QX9PB4TN?partNumber=2&X-Amz-Algorithm=...",
-      "https://dummyendpoint.com/dummybucket/files/FILE_K7M2QX9PB4TN?partNumber=3&X-Amz-Algorithm=..."
+      "https://dummyendpoint.com/dummybucket/files/FILE_2K7Q?partNumber=1&X-Amz-Algorithm=...",
+      "https://dummyendpoint.com/dummybucket/files/FILE_2K7Q?partNumber=2&X-Amz-Algorithm=...",
+      "https://dummyendpoint.com/dummybucket/files/FILE_2K7Q?partNumber=3&X-Amz-Algorithm=..."
     ]
   }
 ]
@@ -140,7 +140,7 @@ curl -X POST \
   -H 'Content-Type: application/json' \
   -d '[
     {
-      "fileId": "FILE_K7M2QX9PB4TN",
+      "fileId": "FILE_2K7Q",
       "etags": [
         "d41d8cd98f00b204e9800998ecf8427e",
         "098f6bcd4621d373cade4e832627b4f6",
@@ -164,7 +164,7 @@ The cell value for a given submission ID is a space-separated list of `fileName:
 
 ```
 files.rawReads
-reads_1.fq:FILE_K7M2QX9PB4TN reads_2.fq:FILE_R3W8HD5YCJ2M
+reads_1.fq:FILE_2K7Q reads_2.fq:FILE_2K7R
 ```
 
 - The `fileId` is the ID received in the previous step, which identifies the actual file.

--- a/website/src/types/backend.ts
+++ b/website/src/types/backend.ts
@@ -342,7 +342,7 @@ export type Info = z.infer<typeof info>;
 
 export const requestMultipartUploadResponse = z.array(
     z.object({
-        fileId: z.string().uuid(),
+        fileId: z.string(),
         urls: z.array(z.string()),
     }),
 );
@@ -351,7 +351,7 @@ export type RequestMultipartUploadResponse = z.infer<typeof requestMultipartUplo
 
 export const completeMultipartUploadRequest = z.array(
     z.object({
-        fileId: z.string().uuid(),
+        fileId: z.string(),
         etags: z.array(z.string()),
     }),
 );


### PR DESCRIPTION
resolves #6907 

Users see `fileIds` in the `files.<category>` column of metadata files produced when they download original metadata for a revision. If they want to edit the `files` column, they need to visually parse the space-separated list of `file:fileId` where `fileId` is a 36 character UUID, and modify it where appropriate. This PR makes it so file ids have the format `FILE_<accession>`, e.g., `FILE_00G3`. This is similar to how sequence accessions are made, except they're shorter and don't have a checksum character appended (see linked issue).

_**Note:** existing deployments that already have file sharing enabled don't have to change existing file ids. The uuid-style ids are still supported, they are now just treated as strings (see 'Manual testing' below)_

### Summary

- `FileId` changes from a `UUID` to a `String`
- Added a sequence to the DB to track file ids
- Extract base 34 encoding functionality into `Base34.kt`
- Added `createFileEntries` to `FilesDatabaseService.kt` to do batch creation of files. Let me know if this is beyond the scope, but previous state was to have a loop where each file insert was a separate DB transaction (although most usage will prob go through multipart uploads, which can't be batched since it calls out to S3...).

### Why does this touch so many files?

- Refactoring `FileId` from `UUID` to `String` meant all call sites that specified `UUID` or did `UUID.fromString()` etc. had to be updated
- Docs/swagger showed example file ids that were 36-char UUIDs, I updated these to the new format for consistency

### Manual testing

#### First test

I did a submission with raw reads on the preview, downloaded original metadata, and confirmed that the file id is now in the new format:

<img width="560" height="71" alt="grafik" src="https://github.com/user-attachments/assets/fc55040a-633c-41f3-9c76-859891b96b85" />

#### Second test

To test that legacy uuid-style IDs will keep working, I uploaded two files, changed the id for one of them to uuid-style, and submitted sequences pointing to those raw reads (see 'Testing details' below). When I download original metadata for these two sequences, the uuid-style and new id show up next to each other without issue:

<img width="953" height="278" alt="grafik" src="https://github.com/user-attachments/assets/9f60a318-2562-4bc7-8612-1a4dfe96512a" />

I also confirmed that I can still download the renamed raw reads file from the website.

<details>
<summary>Testing details</summary>
All file upload requests on the current branch's preview will get the new FILE_xxxx style ids. To test that the system will keep supporting legacy uuid-style ids, I had to edit the id of an uploaded raw reads file after submission. I did this through the API as follows:

**Set backend url, get token**
```sh
BACKEND=https://backend-readable-file-ids.loculus.org
TOKEN=$(curl -X POST "https://authentication-readable-file-ids.loculus.org/realms/loculus/protocol/openid-connect/token" -d 'username=testuser&password=testuser&grant_type=password&client_id=backend-client' | jq -r .access_token)
```

**Request upload of two files**
(I made a test group for testuser with groupId=2 on the preview first)
```sh
curl -s -X POST "$BACKEND/files/request-upload?groupId=2&numberFiles=2" -H "Authorization: Bearer $TOKEN"
```

**PUT two raw reads files to the returned presigned urls**
(Saved presigned urls into URL1 and URL2 first)
```sh
curl -X PUT -H 'If-None-Match: *' -T raw_reads_1.fq.gz "$URL1"
curl -X PUT -H 'If-None-Match: *' -T raw_reads_2.fq.gz "$URL2"
```

**Rename one of the files on S3 and in the DB**
```sh
kubectl exec -n prev-readable-file-ids deploy/minio -- sh -c 'mc alias set l http://localhost:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" && mc mv l/loculus-preview-private/files/FILE_0TJS l/loculus-preview-private/files/8d8ac610-566d-4ef0-9c22-186b2a5ed793'
Added `l` successfully.
`l/loculus-preview-private/files/FILE_0TJS` -> `l/loculus-preview-private/files/8d8ac610-566d-4ef0-9c22-186b2a5ed793`
┌────────────┬─────────────┬──────────┬────────────┐
│ Total      │ Transferred │ Duration │ Speed      │
│ 254.88 KiB │ 254.88 KiB  │ 00m00s   │ 9.58 MiB/s │
└────────────┴─────────────┴──────────┴────────────┘

kubectl exec -n prev-readable-file-ids deploy/loculus-database -- psql -U postgres -d loculus -c "UPDATE files SET id = '8d8ac610-566d-4ef0-9c22-186b2a5ed793' WHERE id = 'FILE_0TJS';"
UPDATE 1
```

**Submit files**
(I had prepared some test metadata and sequences for west-nile)
```sh
curl -X POST "$BACKEND/west-nile/submit?groupId=2&dataUseTermsType=OPEN" -H "Authorization: Bearer $TOKEN" -F metadataFile=@west_nile_metadata.tsv -F sequenceFile=@west_nile_sequences.fasta
[{"accession":"LOC_001JZ7H","version":1,"submissionId":"test_WNV/mosquito/Larimer-CO-USA/2016-06-27/W1819"},{"accession":"LOC_001JZ8F","version":1,"submissionId":"test_WNV/mosquito/Polk-IA-USA/2017-07-17/W1959"}]%
```

Then, I went to the preview website, went to west-nile -> review sequences -> approved the sequences. They showed up on the preview a little while later, and then I downloaded original metadata to confirm that both styles of file id still work

</details>

#### Third test

Finally, I ran additional tests that @anna-parker suggested:
1. I created a new branch off of main: https://github.com/loculus-project/loculus/pull/7306
2. uploaded files there, confirmed they got UUID identifiers
3. cherry-picked the changes from this PR onto that branch 
4. uploaded more files.
5. revised a submission from the first round by adding an additional raw reads file

The result was that the first files I submitted got UUID ids, then the new commit with the SQL migration changed these to strings, and the second round of files I uploaded got the new ids:

<img width="585" height="301" alt="grafik" src="https://github.com/user-attachments/assets/fa8951f7-68eb-4ada-8a5f-8975029c03ab" />


### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable