### PR TITLE
feat(website): add optional Gensplore viewer on sequence details

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -29,6 +29,7 @@
                 "fflate": "^0.8.3",
                 "flowbite-react": "^0.12.17",
                 "fzstd": "^0.1.1",
+                "gensplore": "^0.0.9",
                 "immer": "^11.1.18",
                 "jsonwebtoken": "^9.0.3",
                 "jszip": "^3.10.1",
@@ -9434,6 +9435,15 @@
             "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
             "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==",
             "license": "MIT"
+        },
+        "node_modules/gensplore": {
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/gensplore/-/gensplore-0.0.9.tgz",
+            "integrity": "sha512-L2HkweqYdZ9YLpLAHeeP7Te/KJd5Q1cpinyihNTlI2J5LRiBEPZsfuw8V5lnGBShXev0/Ls9bNgBvTiZZTcTdQ==",
+            "peerDependencies": {
+                "react": "^18.3.1 || ^19.0.0",
+                "react-dom": "^18.3.1 || ^19.0.0"
+            }
         },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",

--- a/website/package.json
+++ b/website/package.json
@@ -39,6 +39,7 @@
         "fflate": "^0.8.3",
         "flowbite-react": "^0.12.17",
         "fzstd": "^0.1.1",
+        "gensplore": "^0.0.9",
         "immer": "^11.1.18",
         "jsonwebtoken": "^9.0.3",
         "jszip": "^3.10.1",

--- a/website/src/components/SequenceDetailsPage/GenomePreview/GenomePreviewToggle.spec.tsx
+++ b/website/src/components/SequenceDetailsPage/GenomePreview/GenomePreviewToggle.spec.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { GenomePreviewToggle } from './GenomePreviewToggle';
+import { testServer } from '../../../../vitest.setup';
+
+const segments = [
+    { name: 'first', lapisName: 'first', displayName: 'First segment' },
+    { name: 'second', lapisName: 'second' },
+];
+
+describe('GenomePreviewToggle', () => {
+    it('loads only when enabled, switches segments, and unloads when disabled', async () => {
+        testServer.use(http.get('http://localhost:3000/seq/TEST1.1/genome', () => HttpResponse.html('<html></html>')));
+        const user = userEvent.setup();
+        const { container } = render(<GenomePreviewToggle accessionVersion='TEST1.1' segments={segments} />);
+        expect(container.querySelector('iframe')).toBeNull();
+        const toggle = screen.getByRole('button', { name: 'Genome viewer' });
+        await user.click(toggle);
+        expect(toggle).toHaveAttribute('aria-pressed', 'true');
+        expect(screen.getByTitle('Genome viewer for TEST1.1, First segment')).toHaveAttribute(
+            'src',
+            '/seq/TEST1.1/genome?segment=first',
+        );
+        await user.selectOptions(screen.getByRole('combobox'), 'second');
+        expect(screen.getByTitle('Genome viewer for TEST1.1, second')).toHaveAttribute(
+            'src',
+            '/seq/TEST1.1/genome?segment=second',
+        );
+        await user.click(toggle);
+        expect(container.querySelector('iframe')).toBeNull();
+    });
+
+    it('hides the control when no reference segment is available', () => {
+        const { container } = render(<GenomePreviewToggle accessionVersion='TEST1.1' segments={[]} />);
+        expect(container).toBeEmptyDOMElement();
+    });
+});

--- a/website/src/components/SequenceDetailsPage/GenomePreview/GenomePreviewToggle.tsx
+++ b/website/src/components/SequenceDetailsPage/GenomePreview/GenomePreviewToggle.tsx
@@ -1,0 +1,60 @@
+import { useId, useState } from 'react';
+
+import { routes } from '../../../routes/routes';
+import type { SegmentInfo } from '../../../utils/sequenceTypeHelpers';
+import { Button } from '../../common/Button';
+import { Select } from '../../common/Select';
+
+export function GenomePreviewToggle({
+    accessionVersion,
+    segments,
+}: {
+    accessionVersion: string;
+    segments: SegmentInfo[];
+}) {
+    const [visible, setVisible] = useState(false);
+    const [selected, setSelected] = useState(segments.at(0)?.name ?? '');
+    const id = useId();
+    const segment = segments.find(({ name }) => name === selected) ?? segments.at(0);
+    if (segment === undefined) return null;
+
+    return (
+        <section className='my-4' aria-label='Genome viewer'>
+            <div className='flex items-center gap-3'>
+                <Button
+                    size='sm'
+                    variant='outline-neutral'
+                    aria-pressed={visible}
+                    aria-controls={id}
+                    onClick={() => setVisible(!visible)}
+                >
+                    Genome viewer
+                </Button>
+                {visible && segments.length > 1 && (
+                    <Select
+                        styled
+                        aria-label='Genome segment'
+                        value={segment.name}
+                        onChange={(event) => setSelected(event.target.value)}
+                    >
+                        {segments.map(({ name, displayName }) => (
+                            <option key={name} value={name}>
+                                {displayName ?? name}
+                            </option>
+                        ))}
+                    </Select>
+                )}
+            </div>
+            {visible && (
+                <iframe
+                    key={`${accessionVersion}:${segment.name}`}
+                    id={id}
+                    title={`Genome viewer for ${accessionVersion}, ${segment.displayName ?? segment.name}`}
+                    src={routes.sequenceEntryGenomePreviewPage(accessionVersion, segment.name)}
+                    className='mt-3 h-[650px] w-full rounded border border-gray-200 bg-white'
+                    allow='clipboard-write'
+                />
+            )}
+        </section>
+    );
+}

--- a/website/src/components/SequenceDetailsPage/GenomePreview/GenomeViewer.tsx
+++ b/website/src/components/SequenceDetailsPage/GenomePreview/GenomeViewer.tsx
@@ -1,0 +1,16 @@
+import Gensplore from 'gensplore';
+
+import type { GenomePreviewData } from './types';
+
+export default function GenomeViewer({ genbankString, alignedSequence, annotationNotice }: GenomePreviewData) {
+    return (
+        <>
+            {annotationNotice !== undefined && (
+                <p style={{ margin: '12px 20px', fontFamily: 'sans-serif', fontSize: 14 }} role='status'>
+                    {annotationNotice}
+                </p>
+            )}
+            <Gensplore genbankString={genbankString} alignedSequence={alignedSequence} />
+        </>
+    );
+}

--- a/website/src/components/SequenceDetailsPage/GenomePreview/getGenomePreviewData.spec.ts
+++ b/website/src/components/SequenceDetailsPage/GenomePreview/getGenomePreviewData.spec.ts
@@ -1,0 +1,73 @@
+import { ok } from 'neverthrow';
+import { describe, expect, it, vi } from 'vitest';
+
+import { getGenomePreviewData, previewInsertions, previewReference } from './getGenomePreviewData';
+import type { LapisClient } from '../../../services/lapisClient';
+import type { InsertionCount } from '../../../types/lapis';
+
+const references = [
+    {
+        name: 'main',
+        references: [
+            { name: 'ref1', sequence: 'ACGTACGT' },
+            { name: 'ref2', sequence: 'AAAAAAAA' },
+        ],
+    },
+];
+const insertion = (sequenceName: string | null): InsertionCount => ({
+    sequenceName,
+    insertion: 'ins_4:GAC',
+    count: 1,
+    position: 4,
+    insertedSymbols: 'GAC',
+});
+
+describe('genome preview data', () => {
+    it('requires an assigned reference when several exist', () => {
+        expect(previewReference(references, undefined, 'main')).toBeUndefined();
+        expect(previewReference(references, { main: 'ref2' }, 'main')?.name).toBe('ref2');
+        expect(previewReference(references, { main: 'missing' }, 'main')).toBeUndefined();
+        expect(previewReference([references[0]], { main: null }, 'main')).toBeUndefined();
+    });
+
+    it('keeps insertion boundaries and filters other segments and references', () => {
+        const insertions = [insertion('ref1'), insertion('ref2'), insertion(null)];
+        expect(previewInsertions(insertions, 'ref1', true)).toEqual([{ position: 4, sequence: 'GAC' }]);
+        expect(previewInsertions([insertion(null)], 'main', false)).toEqual([{ position: 4, sequence: 'GAC' }]);
+    });
+
+    it('passes through supplied gaps and Ns without realigning', async () => {
+        const call = vi.fn().mockResolvedValue(ok('>TEST1.1\nAC--NCGT\n'));
+        const getSequenceInsertions = vi.fn().mockResolvedValue(ok({ data: [insertion('ref1'), insertion('ref2')] }));
+        const client = { call, getSequenceInsertions } as unknown as LapisClient;
+        const data = await getGenomePreviewData({
+            accessionVersion: 'TEST1.1',
+            segmentName: 'main',
+            references,
+            selections: { main: 'ref1' },
+            primaryKey: 'id',
+            client,
+        });
+        expect(call).toHaveBeenCalledWith(
+            'alignedNucleotideSequencesMultiSegment',
+            { id: 'TEST1.1', dataFormat: 'FASTA' },
+            { params: { segment: 'ref1' } },
+        );
+        expect(data.alignedSequence).toEqual({
+            name: 'TEST1.1',
+            sequence: 'AC--NCGT',
+            insertions: [{ position: 4, sequence: 'GAC' }],
+        });
+        call.mockResolvedValue(ok('>TEST1.1\nACGT\n'));
+        await expect(
+            getGenomePreviewData({
+                accessionVersion: 'TEST1.1',
+                segmentName: 'main',
+                references,
+                selections: { main: 'ref1' },
+                primaryKey: 'id',
+                client,
+            }),
+        ).rejects.toThrow('An alignment matching this reference is unavailable.');
+    });
+});

--- a/website/src/components/SequenceDetailsPage/GenomePreview/getGenomePreviewData.ts
+++ b/website/src/components/SequenceDetailsPage/GenomePreview/getGenomePreviewData.ts
@@ -1,0 +1,76 @@
+import { getReferenceGenbank } from './referenceGenbank';
+import type { GenomePreviewData } from './types';
+import type { LapisClient } from '../../../services/lapisClient';
+import type { InsertionCount } from '../../../types/lapis';
+import type { ReferenceGenomesSchema } from '../../../types/referencesGenomes';
+import { parseFasta } from '../../../utils/parseFasta';
+import {
+    getSegmentAndGeneInfo,
+    toReferenceGenomes,
+    type SegmentReferenceSelections,
+} from '../../../utils/sequenceTypeHelpers';
+
+export function previewReference(
+    references: ReferenceGenomesSchema,
+    selections: SegmentReferenceSelections | undefined,
+    segmentName: string,
+) {
+    const segment = references?.find(({ name }) => name === segmentName);
+    const selected = selections?.[segmentName];
+    return segment?.references.length === 1
+        ? segment.references[0]
+        : segment?.references.find(({ name }) => name === selected);
+}
+
+export function previewInsertions(insertions: InsertionCount[], lapisName: string, multiSegmented: boolean) {
+    return insertions
+        .filter(({ sequenceName }) => sequenceName === lapisName || (!multiSegmented && sequenceName === null))
+        .map(({ position, insertedSymbols }) => ({ position, sequence: insertedSymbols }));
+}
+
+export async function getGenomePreviewData({
+    accessionVersion,
+    segmentName,
+    references,
+    selections,
+    primaryKey,
+    client,
+}: {
+    accessionVersion: string;
+    segmentName: string;
+    references: ReferenceGenomesSchema;
+    selections: SegmentReferenceSelections | undefined;
+    primaryKey: string;
+    client: LapisClient;
+}): Promise<GenomePreviewData> {
+    const reference = previewReference(references, selections, segmentName);
+    const info = toReferenceGenomes(references);
+    const segment = getSegmentAndGeneInfo(info, selections).nucleotideSegmentInfos.find(
+        ({ name }) => name === segmentName,
+    );
+    if (reference === undefined || segment === undefined) throw new Error('No reference is assigned to this segment.');
+    const request = { [primaryKey]: accessionVersion, dataFormat: 'FASTA' as const };
+    const [aligned, insertions] = await Promise.all([
+        info.useLapisMultiSegmentedEndpoint
+            ? client.call('alignedNucleotideSequencesMultiSegment', request, { params: { segment: segment.lapisName } })
+            : client.call('alignedNucleotideSequences', request),
+        client.getSequenceInsertions(accessionVersion, 'nucleotide'),
+    ]);
+    if (aligned.isErr() || insertions.isErr())
+        throw new Error('The sequence data could not be loaded. Please try again.');
+    const records = parseFasta(aligned.value);
+    if (records.length !== 1 || records[0].sequence.length !== reference.sequence.replace(/\s/g, '').length)
+        throw new Error('An alignment matching this reference is unavailable.');
+    return {
+        ...(await getReferenceGenbank(reference)),
+        alignedSequence: {
+            name: accessionVersion,
+            sequence: records[0].sequence,
+            insertions: previewInsertions(
+                insertions.value.data,
+                segment.lapisName,
+                info.useLapisMultiSegmentedEndpoint,
+            ),
+        },
+    };
+}

--- a/website/src/components/SequenceDetailsPage/GenomePreview/referenceGenbank.spec.ts
+++ b/website/src/components/SequenceDetailsPage/GenomePreview/referenceGenbank.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { getReferenceGenbank, referenceMatchesGenbank, unannotatedGenbank } from './referenceGenbank';
+
+const reference = { name: 'Synthetic reference', sequence: 'ACGTACGT' };
+
+describe('reference GenBank', () => {
+    it('creates a nucleotide-only record when no accession is configured', async () => {
+        const load = vi.fn();
+        const result = await getReferenceGenbank(reference, load);
+        expect(load).not.toHaveBeenCalled();
+        expect(result.annotationNotice).toBeDefined();
+        expect(referenceMatchesGenbank(reference.sequence, result.genbankString)).toBe(true);
+    });
+
+    it('uses annotations only when the reference bases match exactly', async () => {
+        const genbank = unannotatedGenbank(reference);
+        const load = vi.fn().mockResolvedValue(genbank);
+        expect(await getReferenceGenbank({ ...reference, insdcAccessionFull: 'TEST.1' }, load)).toEqual({
+            genbankString: genbank,
+        });
+        expect(load).toHaveBeenCalledWith('TEST.1');
+        expect(
+            (await getReferenceGenbank({ ...reference, sequence: 'AAAAAAAA', insdcAccessionFull: 'TEST.1' }, load))
+                .annotationNotice,
+        ).toBeDefined();
+    });
+
+    it('falls back when the annotation service is unavailable', async () => {
+        const result = await getReferenceGenbank({ ...reference, insdcAccessionFull: 'TEST.1' }, () =>
+            Promise.resolve(undefined),
+        );
+        expect(result.annotationNotice).toBeDefined();
+        expect(referenceMatchesGenbank(reference.sequence, result.genbankString)).toBe(true);
+        expect(referenceMatchesGenbank(reference.sequence, 'not a GenBank record')).toBe(false);
+    });
+});

--- a/website/src/components/SequenceDetailsPage/GenomePreview/referenceGenbank.ts
+++ b/website/src/components/SequenceDetailsPage/GenomePreview/referenceGenbank.ts
@@ -1,0 +1,46 @@
+type Reference = { name: string; sequence: string; insdcAccessionFull?: string };
+type ReferenceGenbank = { genbankString: string; annotationNotice?: string };
+
+export function unannotatedGenbank(reference: Reference): string {
+    const name = reference.name.replace(/\s/g, '_');
+    const sequence = reference.sequence.replace(/\s/g, '').toLowerCase();
+    const lines =
+        sequence.match(/.{1,60}/g)?.map((line, index) => `${String(index * 60 + 1).padStart(9)} ${line}`) ?? [];
+    return `LOCUS       ${name} ${sequence.length} bp DNA\nDEFINITION  ${reference.name.replace(/[\r\n]/g, ' ')}\nFEATURES             Location/Qualifiers\nORIGIN\n${lines.join('\n')}\n//\n`;
+}
+
+export function referenceMatchesGenbank(reference: string, genbank: string): boolean {
+    const origin = /^ORIGIN[^\n]*\n([\s\S]*?)^\/\//m.exec(genbank)?.[1];
+    return origin?.replace(/[\s0-9]/g, '').toUpperCase() === reference.replace(/\s/g, '').toUpperCase();
+}
+
+const cache = new Map<string, { expires: number; result: Promise<string | undefined> }>();
+async function fetchGenbank(accession: string): Promise<string | undefined> {
+    const previous = cache.get(accession);
+    if (previous !== undefined && previous.expires > Date.now()) return previous.result;
+    const url = new URL('https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi');
+    url.search = new URLSearchParams({
+        db: 'nuccore',
+        id: accession,
+        rettype: 'gbwithparts',
+        retmode: 'text',
+    }).toString();
+    const result = fetch(url, { signal: AbortSignal.timeout(10000) })
+        .then(async (response) => (response.ok ? response.text() : undefined))
+        .catch(() => undefined);
+    if (cache.size >= 128) cache.delete(cache.keys().next().value!);
+    cache.set(accession, { expires: Date.now() + 5 * 60 * 1000, result });
+    return result;
+}
+
+export async function getReferenceGenbank(reference: Reference, load = fetchGenbank): Promise<ReferenceGenbank> {
+    if (reference.insdcAccessionFull !== undefined) {
+        const genbankString = await load(reference.insdcAccessionFull);
+        if (genbankString !== undefined && referenceMatchesGenbank(reference.sequence, genbankString))
+            return { genbankString };
+    }
+    return {
+        genbankString: unannotatedGenbank(reference),
+        annotationNotice: 'Reference annotations are unavailable. Showing nucleotide changes only.',
+    };
+}

--- a/website/src/components/SequenceDetailsPage/GenomePreview/types.ts
+++ b/website/src/components/SequenceDetailsPage/GenomePreview/types.ts
@@ -1,0 +1,9 @@
+export type GenomePreviewData = {
+    genbankString: string;
+    alignedSequence: {
+        name: string;
+        sequence: string;
+        insertions: { position: number; sequence: string }[];
+    };
+    annotationNotice?: string;
+};

--- a/website/src/components/SequenceDetailsPage/SequenceDataUI.tsx
+++ b/website/src/components/SequenceDetailsPage/SequenceDataUI.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react';
 
 import DataTable from './DataTable';
+import { GenomePreviewToggle } from './GenomePreview/GenomePreviewToggle';
 import { SequenceManagement } from './SequenceManagement.tsx';
 import { SequencesContainer } from './SequencesDisplay/SequencesContainer.tsx';
 import { getDataTableData } from './getDataTableData';
@@ -25,6 +26,7 @@ import { type Schema, type SequenceFlaggingConfig } from '../../types/config';
 import { type ReferenceGenomesInfo } from '../../types/referencesGenomes';
 import { type ClientConfig } from '../../types/runtimeConfig';
 import { type SequenceCitation } from '../../types/seqSetCitation.ts';
+import { getSegmentAndGeneInfo } from '../../utils/sequenceTypeHelpers';
 import { Button } from '../common/Button';
 import RestrictedUseWarning from '../common/RestrictedUseWarning';
 
@@ -40,6 +42,7 @@ interface Props {
     referenceGenomesInfo: ReferenceGenomesInfo;
     sequenceCitations?: SequenceCitation[];
     onRevokeSuccess?: () => void;
+    enableGenomePreview?: boolean;
 }
 
 const REVOCATION_VERSION_FIELDS = [
@@ -69,6 +72,7 @@ export const SequenceDataUI: FC<Props> = ({
     referenceGenomesInfo,
     sequenceCitations,
     onRevokeSuccess,
+    enableGenomePreview = false,
 }: Props) => {
     const { tableData, dataUseTermsHistory, segmentReferences, sequenceEntryHistory, isRevocation } = sequenceData;
 
@@ -84,6 +88,13 @@ export const SequenceDataUI: FC<Props> = ({
     return (
         <>
             {isRestricted && <RestrictedUseWarning />}
+            {enableGenomePreview && schema.submissionDataTypes.consensusSequences && !isRevocation && (
+                <GenomePreviewToggle
+                    key={accessionVersion}
+                    accessionVersion={accessionVersion}
+                    segments={getSegmentAndGeneInfo(referenceGenomesInfo, segmentReferences).nucleotideSegmentInfos}
+                />
+            )}
             <DataTable
                 dataTableData={dataTableData}
                 segmentReferences={segmentReferences}

--- a/website/src/pages/seq/[accessionVersion]/genome.astro
+++ b/website/src/pages/seq/[accessionVersion]/genome.astro
@@ -1,0 +1,60 @@
+---
+import { findOrganismAndData } from './findOrganismAndData';
+import { SequenceDetailsTableResultType } from './getSequenceDetailsTableData';
+import GenomeViewer from '../../../components/SequenceDetailsPage/GenomePreview/GenomeViewer';
+import { getGenomePreviewData } from '../../../components/SequenceDetailsPage/GenomePreview/getGenomePreviewData';
+import type { GenomePreviewData } from '../../../components/SequenceDetailsPage/GenomePreview/types';
+import { getWebsiteConfig } from '../../../config';
+import { LapisClient } from '../../../services/lapisClient';
+import { normalizeAccessionCase } from '../../../utils/normalizeAccessionCase';
+
+const accessionVersion = normalizeAccessionCase(Astro.params.accessionVersion!, getWebsiteConfig().accessionPrefix);
+const details = await findOrganismAndData(accessionVersion);
+let data: GenomePreviewData | undefined;
+let error: string | undefined;
+Astro.response.headers.set('Cache-Control', 'no-store');
+if (
+    details.isErr() ||
+    details.value.result.type !== SequenceDetailsTableResultType.TABLE_DATA ||
+    details.value.result.isRevocation
+) {
+    Astro.response.status = 404;
+    error = 'Genome preview is unavailable for this entry.';
+} else {
+    const { organism, result } = details.value;
+    const config = getWebsiteConfig().organisms[organism];
+    try {
+        if (!config.schema.submissionDataTypes.consensusSequences)
+            throw new Error('This entry has no consensus sequence.');
+        data = await getGenomePreviewData({
+            accessionVersion,
+            segmentName: Astro.url.searchParams.get('segment') ?? '',
+            references: config.referenceGenomes,
+            selections: result.segmentReferences,
+            primaryKey: config.schema.primaryKey,
+            client: LapisClient.createForOrganism(organism),
+        });
+    } catch (cause) {
+        error = cause instanceof Error ? cause.message : 'Genome preview could not be loaded.';
+    }
+}
+---
+
+<html lang='en'>
+    <head
+        ><meta charset='utf-8' /><meta name='viewport' content='width=device-width' /><meta
+            name='robots'
+            content='noindex'
+        /><title>Genome viewer — {accessionVersion}</title></head
+    >
+    <body>
+        {data !== undefined && <GenomeViewer {...data} client:only='react' />}
+        {
+            error !== undefined && (
+                <p role='alert' style='font-family: sans-serif; padding: 1rem'>
+                    {error}
+                </p>
+            )
+        }
+    </body>
+</html>

--- a/website/src/pages/seq/[accessionVersion]/index.astro
+++ b/website/src/pages/seq/[accessionVersion]/index.astro
@@ -90,6 +90,7 @@ const sequenceFlaggingConfig = getWebsiteConfig().sequenceFlagging;
                         {result.type === SequenceDetailsTableResultType.TABLE_DATA && (
                             <SequenceDataUI
                                 sequenceData={result}
+                                enableGenomePreview
                                 organism={organism}
                                 referenceGenomesInfo={getReferenceGenomes(organism)}
                                 accessionVersion={accessionVersion}

--- a/website/src/routes/routes.ts
+++ b/website/src/routes/routes.ts
@@ -29,6 +29,8 @@ export const routes = {
         }),
     sequenceEntryDetailsPage: (accessionVersion: AccessionVersion | string) =>
         `/seq/${getAccessionVersionString(accessionVersion)}`,
+    sequenceEntryGenomePreviewPage: (accessionVersion: string, segment: string) =>
+        `/seq/${encodeURIComponent(accessionVersion)}/genome?${new URLSearchParams({ segment }).toString()}`,
     sequenceEntryVersionsPage: (accessionVersion: AccessionVersion | string) =>
         `/seq/${getAccessionVersionString(accessionVersion)}/versions`,
     sequenceEntryFastaPage: (accessionVersion: AccessionVersion | string, download = false) =>


### PR DESCRIPTION
Adds an optional **Genome viewer** toggle to the full sequence details page, using the published `gensplore@0.0.9` component. Enabling it shows the entry alongside its configured reference, with substitutions, contiguous deletions, insertions, and ambiguous bases marked above the reference. Turning it off unloads the viewer. Existing sequence downloads and text displays remain available.

The viewer consumes LAPIS's existing alignment and separate insertion calls directly, retaining gap placement and Ns rather than realigning. Segmented entries have a segment selector; entries with multiple references use their assigned reference and do not guess when one is missing. The toggle is hidden for revoked entries, entries without consensus sequences, and segments without an available reference. It is not added to the search results preview modal.

A same-origin iframe loads the component only after enabling the toggle and contains its viewport toolbar, styles, scrolling, and keyboard shortcuts. The preview route checks the public entry before loading its data. Reference annotations are fetched server-side from NCBI using the configured public INSDC reference accession, cached, and accepted only when the sequence exactly matches Loculus's configured reference. No submitted sequence is sent to NCBI. Without a matching annotation record, the viewer uses the configured nucleotide reference and displays a short notice. This introduces an optional dependency on NCBI availability for annotations; nucleotide visualization continues without it.

Validation:
- All 873 website tests pass, including new tests for lazy toggling, segment switching, reference selection, insertion filtering, preserved gaps/Ns, and annotation fallback.
- `CHOKIDAR_USEPOLLING=true npm run check-types`: no errors or warnings.
- `npm run format` and production build pass.
- Chromium smoke check of the built Loculus page using synthetic reference/data: toggle loads the packaged component, sample/reference titles and deletion/substitution/ambiguous/insertion labels render, and disabling removes the iframe. Screenshot inspected locally.

Gensplore's aligned-input support is released in 0.0.9 (theosanderson/gensplore#59).

🚀 Preview: https://feat-gensplore-sequence-p.loculus.org