### PR TITLE
fix(deployment): correct Ebola Sudan reference accession

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1836,7 +1836,7 @@ defaultOrganisms:
         references:
           - name: singleReference
             sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/reference.fasta]]"
-            insdcAccessionFull: NC_002549.1
+            insdcAccessionFull: NC_006432.1
             genes:
               - name: NP
                 sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/NP.fasta]]"


### PR DESCRIPTION
Correct the Ebola Sudan reference accession from NC_002549.1 (Zaire ebolavirus) to NC_006432.1 (Sudan ebolavirus), matching the configured reference and Pathoplexus configuration. The incorrect accession points to a different reference.

Only one configuration line changes. Validation: YAML parsing and `helm lint kubernetes/loculus -f kubernetes/loculus/values.yaml` pass.

🚀 Preview: Add `preview` label to enable