### PR TITLE
fix(backend): Make SeqSet description optional for `/update-seqset`

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/api/SeqSetCitations.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/api/SeqSetCitations.kt
@@ -30,7 +30,7 @@ data class SubmittedSeqSet(val name: String, val description: String?, val recor
 data class SubmittedSeqSetUpdate(
     val seqSetId: String,
     val name: String,
-    val description: String,
+    val description: String?,
     val records: List<SubmittedSeqSetRecord>,
 )
 

--- a/backend/src/main/kotlin/org/loculus/backend/service/seqsetcitations/SeqSetCitationsDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/seqsetcitations/SeqSetCitationsDatabaseService.kt
@@ -699,7 +699,7 @@ class SeqSetCitationsDatabaseService(
         }
 
         if (oldSeqSet.name == newSeqSetName &&
-            oldSeqSet.description == newSeqSetDescription &&
+            oldSeqSet.description.orEmpty() == newSeqSetDescription.orEmpty() &&
             oldSubmittedSeqSetRecords == newSeqSetRecords
         ) {
             throw UnprocessableEntityException("SeqSet update must contain at least one change")


### PR DESCRIPTION
### Summary

The `description` parameter was required for `/update-seqset`, despite being optional for `/create-seqset` - updated to be optional for update as well.

Note this was/is a backend issue only - the website always provides a string for the SeqSet description.

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable