### PR TITLE
test(deposition): run get_ena_submission_list test in a tmp dir

### DIFF
--- a/ena-submission/test/test_get_ena_submission_list.py
+++ b/ena-submission/test/test_get_ena_submission_list.py
@@ -2,17 +2,22 @@
 import json
 import unittest
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Any
 from unittest.mock import ANY, Mock, patch
 
 import get_ena_submission_list
 import orjsonl
+import pytest
 from deepdiff import DeepDiff
 
-CONFIG_FILE = "./test/test_config.yaml"
-GET_RELEASED_ENTRIES_PATH = "./test/data/get-released-data.ndjson"
+# Absolute, because the tests run with the working directory set to a tmp dir
+TEST_DIR = Path(__file__).parent
+MODULE_DIR = TEST_DIR.parent
+CONFIG_FILE = TEST_DIR / "test_config.yaml"
+GET_RELEASED_ENTRIES_PATH = TEST_DIR / "data/get-released-data.ndjson"
 
-APPROVED_RELEASED_DATA_PATH = "./test/data/approved_ena_submission_list_test.json"
+APPROVED_RELEASED_DATA_PATH = TEST_DIR / "data/approved_ena_submission_list_test.json"
 
 
 def json_diff(path_a, path_b):
@@ -35,6 +40,16 @@ def fake_fetch_released_entries(config, organism) -> Iterator[dict[str, Any]]:  
 
 
 class GetSubmissionListTests(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def _run_in_tmp_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Run in a tmp dir, so the output files the code writes don't land in the repo.
+
+        get_config reads config/defaults.yaml relative to the working directory
+        (in the container that's the module root), so link it into place.
+        """
+        (tmp_path / "config").symlink_to(MODULE_DIR / "config")
+        monkeypatch.chdir(tmp_path)
+
     @patch("get_ena_submission_list.fetch_suppressed_accessions")
     @patch("get_ena_submission_list.fetch_released_entries")
     @patch("get_ena_submission_list.upload_file_with_comment")


### PR DESCRIPTION
Running the ena-submission unit tests leaves two untracked JSON files in the repo: `ena-submission/cchf_ena_submission_list.json` and `ena-submission/cchf_with_ena_fields_ena_submission_list.json`.

The fix is to run the test with the working directory set to a pytest `tmp_path`, which means the three repo-relative constants at the top of the module have to become absolute first.

https://claude.ai/code/session_019qnUGUTdCU5PpUb9Lp78Vc

🚀 Preview: Add `preview` label to enable