### PR TITLE
fix(deposition): identify raw reads by fileId, not by filename

### DIFF
--- a/ena-submission/src/ena_deposition/create_raw_reads.py
+++ b/ena-submission/src/ena_deposition/create_raw_reads.py
@@ -282,10 +282,7 @@ def parse_raw_reads_metadata_field(entry: str | None) -> list[str]:
     '[{"fileId":"341fac6f-c5ca-4138-ac4b-9aa9872d64d8","name":"rawReads.fastq.gz","url":"https://s3.loculus.org/files/8854565e6"}]'
 
     Return just the fileIds, sorted: only the fileId identifies the data. The URL is a
-    temporary S3 URL that changes even if files are unchanged, and the name never reaches ENA -
-    download_fastq_files names the uploaded file after the fileId - so renaming a file is not a
-    change to what we submitted. Sorted because the reads manifest has no R1/R2 designation,
-    so reordering the same files is not a change either.
+    temporary S3 URL that changes even if files are unchanged, and the name never reaches ENA
     """
     parsed_entry = json.loads(entry) if entry else []
     return sorted(item["fileId"] for item in parsed_entry)
@@ -303,7 +300,7 @@ def has_raw_reads_changed(
     )
     if current_raw_reads_metadata != last_raw_reads_metadata:
         logger.debug(
-            f"Raw read files have changed for {submission_row.accession}, "
+            f"Raw read fileIds have changed for {submission_row.accession}, "
             f"from {last_entry.version} to {submission_row.version} - should be revised"
             "(Metadata maybe also changed.)"
         )

--- a/ena-submission/src/ena_deposition/create_raw_reads.py
+++ b/ena-submission/src/ena_deposition/create_raw_reads.py
@@ -276,18 +276,19 @@ def can_revise_raw_reads(
     return True
 
 
-def parse_raw_reads_metadata_field(entry: str | None) -> dict[str, str]:
+def parse_raw_reads_metadata_field(entry: str | None) -> list[str]:
     """
     The fields inside config.raw_reads_metadata_field are strings of JSON objects, e.g.
     '[{"fileId":"341fac6f-c5ca-4138-ac4b-9aa9872d64d8","name":"rawReads.fastq.gz","url":"https://s3.loculus.org/files/8854565e6"}]'
 
-    Note the URL is created by S3 as a temporary reads URL (changes even if files are unchanged).
+    Return just the fileIds, sorted: only the fileId identifies the data. The URL is a
+    temporary S3 URL that changes even if files are unchanged, and the name never reaches ENA -
+    download_fastq_files names the uploaded file after the fileId - so renaming a file is not a
+    change to what we submitted. Sorted because the reads manifest has no R1/R2 designation,
+    so reordering the same files is not a change either.
     """
     parsed_entry = json.loads(entry) if entry else []
-    name_to_id: dict[str, str] = {}
-    for item in parsed_entry:
-        name_to_id[item["name"]] = item["fileId"]
-    return name_to_id
+    return sorted(item["fileId"] for item in parsed_entry)
 
 
 def has_raw_reads_changed(
@@ -302,7 +303,7 @@ def has_raw_reads_changed(
     )
     if current_raw_reads_metadata != last_raw_reads_metadata:
         logger.debug(
-            f"Raw read file URLs have changed for {submission_row.accession}, "
+            f"Raw read files have changed for {submission_row.accession}, "
             f"from {last_entry.version} to {submission_row.version} - should be revised"
             "(Metadata maybe also changed.)"
         )

--- a/ena-submission/test/test_ena_submission.py
+++ b/ena-submission/test/test_ena_submission.py
@@ -689,65 +689,6 @@ class RawReadsCreationTests(unittest.TestCase):
             )
 
 
-class ParseRawReadsMetadataFieldTests(unittest.TestCase):
-    """Only the fileIds decide whether the raw reads changed - not the names or the URLs."""
-
-    @staticmethod
-    def _field(*files: tuple[str, str], url: str = "https://s3.loculus.org/files/abc") -> str:
-        return json.dumps(
-            [{"fileId": file_id, "name": name, "url": url} for file_id, name in files]
-        )
-
-    def setUp(self):
-        self.version_1 = self._field(("id-1", "SRR1_1.fastq.gz"), ("id-2", "SRR1_2.fastq.gz"))
-
-    def test_empty_and_none(self):
-        assert parse_raw_reads_metadata_field(None) == []
-        assert parse_raw_reads_metadata_field("[]") == []
-
-    def test_returns_sorted_file_ids(self):
-        assert parse_raw_reads_metadata_field(self.version_1) == ["id-1", "id-2"]
-
-    def test_new_url_is_not_a_change(self):
-        # The S3 URL is regenerated on every release, even when the file is untouched.
-        version_2 = self._field(
-            ("id-1", "SRR1_1.fastq.gz"), ("id-2", "SRR1_2.fastq.gz"), url="https://s3/other"
-        )
-        assert parse_raw_reads_metadata_field(version_2) == parse_raw_reads_metadata_field(
-            self.version_1
-        )
-
-    def test_rename_is_not_a_change(self):
-        version_2 = self._field(("id-1", "sample_R1.fastq.gz"), ("id-2", "sample_R2.fastq.gz"))
-        assert parse_raw_reads_metadata_field(version_2) == parse_raw_reads_metadata_field(
-            self.version_1
-        )
-
-    def test_reorder_is_not_a_change(self):
-        version_2 = self._field(("id-2", "SRR1_2.fastq.gz"), ("id-1", "SRR1_1.fastq.gz"))
-        assert parse_raw_reads_metadata_field(version_2) == parse_raw_reads_metadata_field(
-            self.version_1
-        )
-
-    def test_swapped_file_is_a_change(self):
-        version_2 = self._field(("id-1", "SRR1_1.fastq.gz"), ("id-3", "SRR1_2.fastq.gz"))
-        assert parse_raw_reads_metadata_field(version_2) != parse_raw_reads_metadata_field(
-            self.version_1
-        )
-
-    def test_reupload_under_the_same_name_is_a_change(self):
-        version_2 = self._field(("id-3", "SRR1_1.fastq.gz"), ("id-4", "SRR1_2.fastq.gz"))
-        assert parse_raw_reads_metadata_field(version_2) != parse_raw_reads_metadata_field(
-            self.version_1
-        )
-
-    def test_same_file_listed_twice_is_a_change(self):
-        version_2 = self._field(("id-1", "SRR1_1.fastq.gz"), ("id-1", "SRR1_2.fastq.gz"))
-        assert parse_raw_reads_metadata_field(version_2) != parse_raw_reads_metadata_field(
-            self.version_1
-        )
-
-
 if __name__ == "__main__":
     import pytest
 

--- a/ena-submission/test/test_ena_submission.py
+++ b/ena-submission/test/test_ena_submission.py
@@ -21,6 +21,7 @@ from ena_deposition.create_project import construct_project_set_object
 from ena_deposition.create_raw_reads import (
     create_manifest_object as create_raw_reads_manifest_object,
 )
+from ena_deposition.create_raw_reads import parse_raw_reads_metadata_field
 from ena_deposition.create_sample import construct_sample_set_object
 from ena_deposition.ena_submission_helper import (
     create_chromosome_list,
@@ -686,6 +687,65 @@ class RawReadsCreationTests(unittest.TestCase):
                 submission_row,
                 dir=self.tmp_dir,
             )
+
+
+class ParseRawReadsMetadataFieldTests(unittest.TestCase):
+    """Only the fileIds decide whether the raw reads changed - not the names or the URLs."""
+
+    @staticmethod
+    def _field(*files: tuple[str, str], url: str = "https://s3.loculus.org/files/abc") -> str:
+        return json.dumps(
+            [{"fileId": file_id, "name": name, "url": url} for file_id, name in files]
+        )
+
+    def setUp(self):
+        self.version_1 = self._field(("id-1", "SRR1_1.fastq.gz"), ("id-2", "SRR1_2.fastq.gz"))
+
+    def test_empty_and_none(self):
+        assert parse_raw_reads_metadata_field(None) == []
+        assert parse_raw_reads_metadata_field("[]") == []
+
+    def test_returns_sorted_file_ids(self):
+        assert parse_raw_reads_metadata_field(self.version_1) == ["id-1", "id-2"]
+
+    def test_new_url_is_not_a_change(self):
+        # The S3 URL is regenerated on every release, even when the file is untouched.
+        version_2 = self._field(
+            ("id-1", "SRR1_1.fastq.gz"), ("id-2", "SRR1_2.fastq.gz"), url="https://s3/other"
+        )
+        assert parse_raw_reads_metadata_field(version_2) == parse_raw_reads_metadata_field(
+            self.version_1
+        )
+
+    def test_rename_is_not_a_change(self):
+        version_2 = self._field(("id-1", "sample_R1.fastq.gz"), ("id-2", "sample_R2.fastq.gz"))
+        assert parse_raw_reads_metadata_field(version_2) == parse_raw_reads_metadata_field(
+            self.version_1
+        )
+
+    def test_reorder_is_not_a_change(self):
+        version_2 = self._field(("id-2", "SRR1_2.fastq.gz"), ("id-1", "SRR1_1.fastq.gz"))
+        assert parse_raw_reads_metadata_field(version_2) == parse_raw_reads_metadata_field(
+            self.version_1
+        )
+
+    def test_swapped_file_is_a_change(self):
+        version_2 = self._field(("id-1", "SRR1_1.fastq.gz"), ("id-3", "SRR1_2.fastq.gz"))
+        assert parse_raw_reads_metadata_field(version_2) != parse_raw_reads_metadata_field(
+            self.version_1
+        )
+
+    def test_reupload_under_the_same_name_is_a_change(self):
+        version_2 = self._field(("id-3", "SRR1_1.fastq.gz"), ("id-4", "SRR1_2.fastq.gz"))
+        assert parse_raw_reads_metadata_field(version_2) != parse_raw_reads_metadata_field(
+            self.version_1
+        )
+
+    def test_same_file_listed_twice_is_a_change(self):
+        version_2 = self._field(("id-1", "SRR1_1.fastq.gz"), ("id-1", "SRR1_2.fastq.gz"))
+        assert parse_raw_reads_metadata_field(version_2) != parse_raw_reads_metadata_field(
+            self.version_1
+        )
 
 
 if __name__ == "__main__":

--- a/ena-submission/test/test_ena_submission.py
+++ b/ena-submission/test/test_ena_submission.py
@@ -21,7 +21,6 @@ from ena_deposition.create_project import construct_project_set_object
 from ena_deposition.create_raw_reads import (
     create_manifest_object as create_raw_reads_manifest_object,
 )
-from ena_deposition.create_raw_reads import parse_raw_reads_metadata_field
 from ena_deposition.create_sample import construct_sample_set_object
 from ena_deposition.ena_submission_helper import (
     create_chromosome_list,


### PR DESCRIPTION
`has_raw_reads_changed` compares a `name -> fileId` mapping, so renaming a raw read file while keeping the same `fileId` counts as a change to the data. The revision then re-uploads byte-identical FASTQs, mints a new ERR/ERX, and puts the old ERR on the list of run accessions that need a suppression email to ENA. For paired reads that is gigabytes of upload and a manual step at ENA, all to record a cosmetic rename.

The filename is the wrong thing to key on because it barely reaches ENA at all: `download_fastq_files` names the uploaded file after the `fileId`, so only the extension survives into the manifest, and the stem is discarded. The `fileId` is the faithful identity, and the docstring already excluded the URL for being a short-lived presigned S3 link that changes even when the file does not — this extends the same reasoning to the name.

The ids are sorted so that reordering the same two files is not a change either. The reads manifest has no R1/R2 designation, so order carries no meaning to ENA; pairing is inferred from the read names inside the files.

https://claude.ai/code/session_01HoLNKkpF4B6EZRynPotieW

🚀 Preview: Add `preview` label to enable