### PR TITLE
feat(raw-reads): reject files whose name and compression disagree

### DIFF
--- a/raw-reads-processing/src/raw_reads_processing/api.py
+++ b/raw-reads-processing/src/raw_reads_processing/api.py
@@ -44,8 +44,11 @@ def process_files(
     except Exception as e:
         # A bug on our side: report it as internal rather than blaming the submission.
         logger.exception("Unexpected error validating %s", payload.accessionVersion)
+        # Name the exception type so this annotation, which is permanent, can be
+        # correlated with the logged stacktrace.
         raise HTTPException(
-            status_code=500, detail="Internal error validating files"
+            status_code=500,
+            detail=f"Internal error validating files ({type(e).__name__})",
         ) from e
     return ValidationResult()
 

--- a/raw-reads-processing/src/raw_reads_processing/api.py
+++ b/raw-reads-processing/src/raw_reads_processing/api.py
@@ -41,6 +41,10 @@ def process_files(
         return ValidationResult(errors=[e.error])
     except ProcessingFailure as e:
         raise HTTPException(status_code=500, detail=str(e)) from e
+    except Exception as e:
+        # A bug on our side: report it as internal rather than blaming the submission.
+        logger.exception("Unexpected error validating %s", payload.accessionVersion)
+        raise HTTPException(status_code=500, detail="Internal error validating files") from e
     return ValidationResult()
 
 

--- a/raw-reads-processing/src/raw_reads_processing/api.py
+++ b/raw-reads-processing/src/raw_reads_processing/api.py
@@ -44,7 +44,9 @@ def process_files(
     except Exception as e:
         # A bug on our side: report it as internal rather than blaming the submission.
         logger.exception("Unexpected error validating %s", payload.accessionVersion)
-        raise HTTPException(status_code=500, detail="Internal error validating files") from e
+        raise HTTPException(
+            status_code=500, detail="Internal error validating files"
+        ) from e
     return ValidationResult()
 
 

--- a/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
+++ b/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
@@ -19,11 +19,7 @@ class FileFormat(StrEnum):
     CRAM = "CRAM"
 
 
-# Matched case-insensitively (see _has_extension), so "READS.FASTQ.GZ" is accepted.
-# Consumers that pass these names to case-sensitive tools must lower-case them first:
-# ENA's webin-cli compares suffixes with String.endsWith and rejects anything not
-# literally ".gz"/".bz2". ena-submission mirrors this set in
-# ena-submission/src/ena_deposition/call_loculus.py - keep the two in sync.
+# Keep in sync with ena-submission/src/ena_deposition/call_loculus.py
 ACCEPTED_FASTQ_EXTENSIONS = {".fastq", ".fq", ".fastq.gz", ".fq.gz"}
 ACCEPTED_BAM_EXTENSIONS = {".bam", ".sam"}
 ACCEPTED_CRAM_EXTENSIONS = {".cram"}

--- a/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
+++ b/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
@@ -20,7 +20,8 @@ class FileFormat(StrEnum):
     CRAM = "CRAM"
 
 
-# Keep in sync with ena-submission/src/ena_deposition/call_loculus.py (added in #7265)
+# Keep in sync with ACCEPTED_FASTQ_EXTENSIONS in
+# ena-submission/src/ena_deposition/call_loculus.py (~L220)
 ACCEPTED_FASTQ_EXTENSIONS = {".fastq", ".fq", ".fastq.gz", ".fq.gz"}
 ACCEPTED_BAM_EXTENSIONS = {".bam", ".sam"}
 ACCEPTED_CRAM_EXTENSIONS = {".cram"}
@@ -133,6 +134,15 @@ def validate_file_numbers(file_format: FileFormat, file_names: list[FileName]) -
 
 GZIP_MAGIC = b"\x1f\x8b"
 
+_FALSE_POSITIVE_HINT = (
+    "If you believe this file is valid, please contact the administrators."
+)
+_DECOMPRESSION_ERRORS = {
+    gzip.BadGzipFile: "is named as gzip-compressed but is not a valid gzip file.",
+    EOFError: "appears to be truncated - the gzip stream ends early.",
+    zlib.error: "appears to be corrupt - its compressed data could not be read.",
+}
+
 
 def _is_gzip(path: Path) -> bool:
     with path.open("rb") as f:
@@ -177,14 +187,17 @@ def validate_compression(
             try:
                 with gzip.open(path, "rb") as f:
                     inner_is_gzip = f.read(2) == GZIP_MAGIC
-            except (OSError, EOFError, zlib.error) as error:
+            # Only these three mean the submitter's file is bad; anything else (a missing
+            # temp file, a disk error) is ours and must not be blamed on them.
+            except (gzip.BadGzipFile, EOFError, zlib.error) as error:
+                logger.exception("Could not decompress '%s'", file_name)
+                reason = _DECOMPRESSION_ERRORS.get(
+                    type(error), "could not be decompressed."
+                )
                 raise InvalidSubmission(
                     error=Annotation(
                         fileNames=[file_name],
-                        message=(
-                            f"File '{file_name}' could not be decompressed - it may be "
-                            "truncated or corrupt."
-                        ),
+                        message=f"File '{file_name}' {reason} {_FALSE_POSITIVE_HINT}",
                     )
                 ) from error
             if inner_is_gzip:

--- a/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
+++ b/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
@@ -139,16 +139,8 @@ def _is_gzip(path: Path) -> bool:
 
 
 def validate_compression(file_name_to_path: dict[FileName, Path]) -> None:
-    """Check each file's actual compression against the one its name claims.
-
-    readtools detects compression from content and ignores the file name, so a
-    plain FASTQ called "reads.fastq.gz" - or a gzipped one called "reads.fastq" -
-    validates cleanly here and only fails much later, at ENA. Catch the mismatch at
-    submission time, where the submitter can act on it.
-
-    Also rejects doubly-gzipped files: gzip that decompresses to more gzip is never
-    what a submitter intended, and ENA's webin-cli does not detect it at manifest
-    validation (it only unwraps one layer).
+    """Check each file's compression extension (`.gz` or none) matches actual compression.
+    Allow at most one level of compression.
     """
     for file_name, path in file_name_to_path.items():
         claims_gzip = file_name.lower().endswith(".gz")

--- a/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
+++ b/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
@@ -2,6 +2,7 @@ import gzip
 import logging
 import os
 import subprocess  # noqa: S404
+import zlib
 from enum import StrEnum
 from pathlib import Path
 
@@ -19,7 +20,7 @@ class FileFormat(StrEnum):
     CRAM = "CRAM"
 
 
-# Keep in sync with ena-submission/src/ena_deposition/call_loculus.py
+# Keep in sync with ena-submission/src/ena_deposition/call_loculus.py (added in #7265)
 ACCEPTED_FASTQ_EXTENSIONS = {".fastq", ".fq", ".fastq.gz", ".fq.gz"}
 ACCEPTED_BAM_EXTENSIONS = {".bam", ".sam"}
 ACCEPTED_CRAM_EXTENSIONS = {".cram"}
@@ -138,10 +139,16 @@ def _is_gzip(path: Path) -> bool:
         return f.read(2) == GZIP_MAGIC
 
 
-def validate_compression(file_name_to_path: dict[FileName, Path]) -> None:
+def validate_compression(
+    file_name_to_path: dict[FileName, Path], file_format: FileFormat
+) -> None:
     """Check each file's compression extension (`.gz` or none) matches actual compression.
     Allow at most one level of compression.
     """
+    # FASTQ only: BAM is BGZF, i.e. a valid gzip stream, so the name check would misfire.
+    if file_format != FileFormat.FASTQ:
+        return
+
     for file_name, path in file_name_to_path.items():
         claims_gzip = file_name.lower().endswith(".gz")
         is_gzip = _is_gzip(path)
@@ -170,11 +177,14 @@ def validate_compression(file_name_to_path: dict[FileName, Path]) -> None:
             try:
                 with gzip.open(path, "rb") as f:
                     inner_is_gzip = f.read(2) == GZIP_MAGIC
-            except OSError as error:
+            except (OSError, EOFError, zlib.error) as error:
                 raise InvalidSubmission(
                     error=Annotation(
                         fileNames=[file_name],
-                        message=f"File '{file_name}' could not be decompressed: {error}",
+                        message=(
+                            f"File '{file_name}' could not be decompressed - it may be "
+                            "truncated or corrupt."
+                        ),
                     )
                 ) from error
             if inner_is_gzip:

--- a/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
+++ b/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
@@ -1,3 +1,4 @@
+import gzip
 import logging
 import os
 import subprocess  # noqa: S404
@@ -18,6 +19,11 @@ class FileFormat(StrEnum):
     CRAM = "CRAM"
 
 
+# Matched case-insensitively (see _has_extension), so "READS.FASTQ.GZ" is accepted.
+# Consumers that pass these names to case-sensitive tools must lower-case them first:
+# ENA's webin-cli compares suffixes with String.endsWith and rejects anything not
+# literally ".gz"/".bz2". ena-submission mirrors this set in
+# ena-submission/src/ena_deposition/call_loculus.py - keep the two in sync.
 ACCEPTED_FASTQ_EXTENSIONS = {".fastq", ".fq", ".fastq.gz", ".fq.gz"}
 ACCEPTED_BAM_EXTENSIONS = {".bam", ".sam"}
 ACCEPTED_CRAM_EXTENSIONS = {".cram"}
@@ -126,6 +132,73 @@ def validate_file_numbers(file_format: FileFormat, file_names: list[FileName]) -
                 ),
             )
         )
+
+
+GZIP_MAGIC = b"\x1f\x8b"
+
+
+def _is_gzip(path: Path) -> bool:
+    with path.open("rb") as f:
+        return f.read(2) == GZIP_MAGIC
+
+
+def validate_compression(file_name_to_path: dict[FileName, Path]) -> None:
+    """Check each file's actual compression against the one its name claims.
+
+    readtools detects compression from content and ignores the file name, so a
+    plain FASTQ called "reads.fastq.gz" - or a gzipped one called "reads.fastq" -
+    validates cleanly here and only fails much later, at ENA. Catch the mismatch at
+    submission time, where the submitter can act on it.
+
+    Also rejects doubly-gzipped files: gzip that decompresses to more gzip is never
+    what a submitter intended, and ENA's webin-cli does not detect it at manifest
+    validation (it only unwraps one layer).
+    """
+    for file_name, path in file_name_to_path.items():
+        claims_gzip = file_name.lower().endswith(".gz")
+        is_gzip = _is_gzip(path)
+
+        if claims_gzip and not is_gzip:
+            raise InvalidSubmission(
+                error=Annotation(
+                    fileNames=[file_name],
+                    message=(
+                        f"File '{file_name}' is named as gzip-compressed but its contents "
+                        "are not gzip-compressed. Please compress it, or rename it."
+                    ),
+                )
+            )
+        if not claims_gzip and is_gzip:
+            raise InvalidSubmission(
+                error=Annotation(
+                    fileNames=[file_name],
+                    message=(
+                        f"File '{file_name}' is gzip-compressed but its name does not end "
+                        "in '.gz'. Please rename it, or upload it uncompressed."
+                    ),
+                )
+            )
+        if is_gzip:
+            try:
+                with gzip.open(path, "rb") as f:
+                    inner_is_gzip = f.read(2) == GZIP_MAGIC
+            except OSError as error:
+                raise InvalidSubmission(
+                    error=Annotation(
+                        fileNames=[file_name],
+                        message=f"File '{file_name}' could not be decompressed: {error}",
+                    )
+                ) from error
+            if inner_is_gzip:
+                raise InvalidSubmission(
+                    error=Annotation(
+                        fileNames=[file_name],
+                        message=(
+                            f"File '{file_name}' is gzip-compressed more than once. "
+                            "Please compress it exactly once."
+                        ),
+                    )
+                )
 
 
 def validate_with_readtools(

--- a/raw-reads-processing/src/raw_reads_processing/process_files.py
+++ b/raw-reads-processing/src/raw_reads_processing/process_files.py
@@ -60,8 +60,6 @@ def validate_raw_reads_submission(
             download_file(config, file, downloaded_file_path)
             local_files[file.name] = downloaded_file_path
 
-        # Name-vs-content agreement first: readtools reads the content and ignores the
-        # name, so it cannot catch a mislabelled file.
         validate_compression(local_files)
         validate_with_readtools(
             local_files, file_format, config.read_validation_timeout_seconds

--- a/raw-reads-processing/src/raw_reads_processing/process_files.py
+++ b/raw-reads-processing/src/raw_reads_processing/process_files.py
@@ -60,7 +60,7 @@ def validate_raw_reads_submission(
             download_file(config, file, downloaded_file_path)
             local_files[file.name] = downloaded_file_path
 
-        validate_compression(local_files)
+        validate_compression(local_files, file_format)
         validate_with_readtools(
             local_files, file_format, config.read_validation_timeout_seconds
         )

--- a/raw-reads-processing/src/raw_reads_processing/process_files.py
+++ b/raw-reads-processing/src/raw_reads_processing/process_files.py
@@ -12,6 +12,7 @@ from raw_reads_processing.datatypes import (
 )
 from raw_reads_processing.errors import ProcessingFailure
 from raw_reads_processing.file_format_validation import (
+    validate_compression,
     validate_file_extensions,
     validate_file_numbers,
     validate_with_readtools,
@@ -59,6 +60,9 @@ def validate_raw_reads_submission(
             download_file(config, file, downloaded_file_path)
             local_files[file.name] = downloaded_file_path
 
+        # Name-vs-content agreement first: readtools reads the content and ignores the
+        # name, so it cannot catch a mislabelled file.
+        validate_compression(local_files)
         validate_with_readtools(
             local_files, file_format, config.read_validation_timeout_seconds
         )

--- a/raw-reads-processing/test/test_file_validation.py
+++ b/raw-reads-processing/test/test_file_validation.py
@@ -396,9 +396,6 @@ def test_accepted_fastq_extensions(file_name):
     ["READS.FASTQ.GZ", "reads.Fq.Gz", "Reads.FastQ"],
 )
 def test_fastq_extension_matching_is_case_insensitive(file_name):
-    """Pins the contract consumers rely on: mixed-case names are accepted here, so
-    anything handing these names to a case-sensitive tool (ENA's webin-cli compares
-    suffixes with String.endsWith) must lower-case them itself."""
     assert validate_file_extensions([file_name]) == FileFormat.FASTQ
 
 

--- a/raw-reads-processing/test/test_file_validation.py
+++ b/raw-reads-processing/test/test_file_validation.py
@@ -275,7 +275,8 @@ def test_compression_matching_name_and_content_passes(tmp_path):
     assert (
         validate_compression(
             {"reads.fastq": plain, "reads2.fastq.gz": gzipped}, FileFormat.FASTQ
-        ) is None
+        )
+        is None
     )
 
 

--- a/raw-reads-processing/test/test_file_validation.py
+++ b/raw-reads-processing/test/test_file_validation.py
@@ -12,6 +12,7 @@ from raw_reads_processing.errors import InvalidSubmission, ProcessingFailure
 from raw_reads_processing.file_format_validation import (
     FileFormat,
     _parse_validation_error,
+    validate_compression,
     validate_file_extensions,
     validate_file_numbers,
     validate_with_readtools,
@@ -259,6 +260,51 @@ def test_gzipped_fastq_is_recognized_and_passes(tmp_path):
     )
 
 
+def _gz(tmp_path: Path, name: str, payload: bytes) -> Path:
+    path = tmp_path / name
+    with gzip.open(path, "wb") as f:
+        f.write(payload)
+    return path
+
+
+def test_compression_matching_name_and_content_passes(tmp_path):
+    plain = tmp_path / "reads.fastq"
+    plain.write_text(VALID_SINGLE_END)
+    gzipped = _gz(tmp_path, "reads2.fastq.gz", VALID_SINGLE_END.encode())
+    assert (
+        validate_compression({"reads.fastq": plain, "reads2.fastq.gz": gzipped}) is None
+    )
+
+
+def test_plain_file_named_gz_is_rejected(tmp_path):
+    path = tmp_path / "stored"
+    path.write_text(VALID_SINGLE_END)
+    with pytest.raises(InvalidSubmission) as exc_info:
+        validate_compression({"reads.fastq.gz": path})
+    assert "named as gzip-compressed" in exc_info.value.error.message
+
+
+def test_gzipped_file_not_named_gz_is_rejected(tmp_path):
+    """This is the one that used to reach ENA and get gzipped a second time."""
+    path = _gz(tmp_path, "stored", VALID_SINGLE_END.encode())
+    with pytest.raises(InvalidSubmission) as exc_info:
+        validate_compression({"reads.fastq": path})
+    assert "does not end in '.gz'" in exc_info.value.error.message
+
+
+def test_double_gzipped_file_is_rejected(tmp_path):
+    inner = gzip.compress(VALID_SINGLE_END.encode())
+    path = _gz(tmp_path, "stored", inner)
+    with pytest.raises(InvalidSubmission) as exc_info:
+        validate_compression({"reads.fastq.gz": path})
+    assert "more than once" in exc_info.value.error.message
+
+
+def test_compression_check_is_case_insensitive_about_the_name(tmp_path):
+    path = _gz(tmp_path, "stored", VALID_SINGLE_END.encode())
+    assert validate_compression({"READS.FASTQ.GZ": path}) is None
+
+
 def _write_bytes(tmp_path: Path, name: str, data: bytes) -> str:
     file_path = tmp_path / name
     file_path.write_bytes(data)
@@ -335,6 +381,32 @@ def test_validation_timeout_is_reported_as_error(tmp_path, monkeypatch):
         )
     assert "timed out" in str(exc_info.value)
     assert "1 second" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "file_name",
+    ["reads.fastq", "reads.fq", "reads.fastq.gz", "reads.fq.gz"],
+)
+def test_accepted_fastq_extensions(file_name):
+    assert validate_file_extensions([file_name]) == FileFormat.FASTQ
+
+
+@pytest.mark.parametrize(
+    "file_name",
+    ["READS.FASTQ.GZ", "reads.Fq.Gz", "Reads.FastQ"],
+)
+def test_fastq_extension_matching_is_case_insensitive(file_name):
+    """Pins the contract consumers rely on: mixed-case names are accepted here, so
+    anything handing these names to a case-sensitive tool (ENA's webin-cli compares
+    suffixes with String.endsWith) must lower-case them itself."""
+    assert validate_file_extensions([file_name]) == FileFormat.FASTQ
+
+
+@pytest.mark.parametrize("file_name", ["reads.fastq.zst", "reads.fastq.bz2"])
+def test_other_compression_formats_are_rejected(file_name):
+    with pytest.raises(InvalidSubmission) as exc_info:
+        validate_file_extensions([file_name])
+    assert "File is not in accepted format" in exc_info.value.error.message
 
 
 def test_unsupported_extension_is_rejected():

--- a/raw-reads-processing/test/test_file_validation.py
+++ b/raw-reads-processing/test/test_file_validation.py
@@ -314,7 +314,7 @@ def test_truncated_gzip_is_reported_as_invalid_submission(tmp_path):
     path.write_bytes(GZIP_MAGIC)
     with pytest.raises(InvalidSubmission) as exc_info:
         validate_compression({"reads.fastq.gz": path}, FileFormat.FASTQ)
-    assert "could not be decompressed" in exc_info.value.error.message
+    assert "appears to be truncated" in exc_info.value.error.message
 
 
 def test_corrupt_gzip_is_reported_as_invalid_submission(tmp_path):
@@ -322,7 +322,7 @@ def test_corrupt_gzip_is_reported_as_invalid_submission(tmp_path):
     path.write_bytes(GZIP_MAGIC + b"\x08\x00\x00\x00\x00\x00\x00\x03" + b"\xff" * 20)
     with pytest.raises(InvalidSubmission) as exc_info:
         validate_compression({"reads.fastq.gz": path}, FileFormat.FASTQ)
-    assert "could not be decompressed" in exc_info.value.error.message
+    assert "appears to be corrupt" in exc_info.value.error.message
 
 
 def test_empty_file_named_gz_is_rejected(tmp_path):
@@ -339,6 +339,14 @@ def test_compression_check_skipped_for_non_fastq(tmp_path):
     with gzip.open(path, "wb") as f:
         f.write(b"anything")
     assert validate_compression({"reads.bam": path}, FileFormat.BAM) is None
+
+
+def test_invalid_gzip_body_is_reported_as_invalid_submission(tmp_path):
+    path = tmp_path / "stored"
+    path.write_bytes(GZIP_MAGIC + b"not really a gzip member")
+    with pytest.raises(InvalidSubmission) as exc_info:
+        validate_compression({"reads.fastq.gz": path}, FileFormat.FASTQ)
+    assert "contact the administrators" in exc_info.value.error.message
 
 
 def _write_bytes(tmp_path: Path, name: str, data: bytes) -> str:

--- a/raw-reads-processing/test/test_file_validation.py
+++ b/raw-reads-processing/test/test_file_validation.py
@@ -10,6 +10,7 @@ import pytest
 from raw_reads_processing import file_format_validation
 from raw_reads_processing.errors import InvalidSubmission, ProcessingFailure
 from raw_reads_processing.file_format_validation import (
+    GZIP_MAGIC,
     FileFormat,
     _parse_validation_error,
     validate_compression,
@@ -272,7 +273,9 @@ def test_compression_matching_name_and_content_passes(tmp_path):
     plain.write_text(VALID_SINGLE_END)
     gzipped = _gz(tmp_path, "reads2.fastq.gz", VALID_SINGLE_END.encode())
     assert (
-        validate_compression({"reads.fastq": plain, "reads2.fastq.gz": gzipped}) is None
+        validate_compression(
+            {"reads.fastq": plain, "reads2.fastq.gz": gzipped}, FileFormat.FASTQ
+        ) is None
     )
 
 
@@ -280,7 +283,7 @@ def test_plain_file_named_gz_is_rejected(tmp_path):
     path = tmp_path / "stored"
     path.write_text(VALID_SINGLE_END)
     with pytest.raises(InvalidSubmission) as exc_info:
-        validate_compression({"reads.fastq.gz": path})
+        validate_compression({"reads.fastq.gz": path}, FileFormat.FASTQ)
     assert "named as gzip-compressed" in exc_info.value.error.message
 
 
@@ -288,7 +291,7 @@ def test_gzipped_file_not_named_gz_is_rejected(tmp_path):
     """This is the one that used to reach ENA and get gzipped a second time."""
     path = _gz(tmp_path, "stored", VALID_SINGLE_END.encode())
     with pytest.raises(InvalidSubmission) as exc_info:
-        validate_compression({"reads.fastq": path})
+        validate_compression({"reads.fastq": path}, FileFormat.FASTQ)
     assert "does not end in '.gz'" in exc_info.value.error.message
 
 
@@ -296,13 +299,46 @@ def test_double_gzipped_file_is_rejected(tmp_path):
     inner = gzip.compress(VALID_SINGLE_END.encode())
     path = _gz(tmp_path, "stored", inner)
     with pytest.raises(InvalidSubmission) as exc_info:
-        validate_compression({"reads.fastq.gz": path})
+        validate_compression({"reads.fastq.gz": path}, FileFormat.FASTQ)
     assert "more than once" in exc_info.value.error.message
 
 
 def test_compression_check_is_case_insensitive_about_the_name(tmp_path):
     path = _gz(tmp_path, "stored", VALID_SINGLE_END.encode())
-    assert validate_compression({"READS.FASTQ.GZ": path}) is None
+    assert validate_compression({"READS.FASTQ.GZ": path}, FileFormat.FASTQ) is None
+
+
+def test_truncated_gzip_is_reported_as_invalid_submission(tmp_path):
+    """gzip raises EOFError here, not OSError - it must still become an annotation."""
+    path = tmp_path / "stored"
+    path.write_bytes(GZIP_MAGIC)
+    with pytest.raises(InvalidSubmission) as exc_info:
+        validate_compression({"reads.fastq.gz": path}, FileFormat.FASTQ)
+    assert "could not be decompressed" in exc_info.value.error.message
+
+
+def test_corrupt_gzip_is_reported_as_invalid_submission(tmp_path):
+    path = tmp_path / "stored"
+    path.write_bytes(GZIP_MAGIC + b"\x08\x00\x00\x00\x00\x00\x00\x03" + b"\xff" * 20)
+    with pytest.raises(InvalidSubmission) as exc_info:
+        validate_compression({"reads.fastq.gz": path}, FileFormat.FASTQ)
+    assert "could not be decompressed" in exc_info.value.error.message
+
+
+def test_empty_file_named_gz_is_rejected(tmp_path):
+    path = tmp_path / "stored"
+    path.write_bytes(b"")
+    with pytest.raises(InvalidSubmission) as exc_info:
+        validate_compression({"reads.fastq.gz": path}, FileFormat.FASTQ)
+    assert "named as gzip-compressed" in exc_info.value.error.message
+
+
+def test_compression_check_skipped_for_non_fastq(tmp_path):
+    """BAM is BGZF, so a .bam would otherwise trip the 'gzipped but not named .gz' branch."""
+    path = tmp_path / "stored"
+    with gzip.open(path, "wb") as f:
+        f.write(b"anything")
+    assert validate_compression({"reads.bam": path}, FileFormat.BAM) is None
 
 
 def _write_bytes(tmp_path: Path, name: str, data: bytes) -> str:


### PR DESCRIPTION
Nothing currently checks that a raw-read file's name agrees with its actual compression. readtools decides compression by reading the content and ignores the name entirely. ENA deposition code gzips files that don't have `.gz` extension causing double compression.

The fix is to have raw reads validation service ensure that the compression extension matches the actual file compression state.

Compression status can be inferred by the file's magic bytes.

Valildation here prevents bugs later on when submitting to ENA. Related to #7265

🚀 Preview: Add `preview` label to enable