### PR TITLE
test(integration): wait for uploads to complete, not for N checkmarks

### DIFF
--- a/integration-tests/tests/pages/edit.page.ts
+++ b/integration-tests/tests/pages/edit.page.ts
@@ -1,6 +1,7 @@
 import { expect, Page } from '@playwright/test';
 import { ReviewPage } from './review.page';
 import { prepareTmpDirForSingleUpload, uploadFilesFromTmpDir } from '../utils/file-upload-helpers';
+import { waitForUrlReportingAlerts } from '../utils/navigation-helpers';
 
 export class EditPage {
     constructor(private page: Page) {}
@@ -33,7 +34,7 @@ export class EditPage {
         await this.page.getByRole('button', { name: /proceed to Approval/ }).click();
         await expect(this.page.getByText('Do you really want to submit?')).toBeVisible();
         await this.page.getByRole('button', { name: 'Confirm' }).click();
-        await this.page.waitForURL('**/review', { timeout: 15_000 });
+        await waitForUrlReportingAlerts(this.page, '**/review', { timeout: 15_000 });
         return new ReviewPage(this.page);
     }
 

--- a/integration-tests/tests/pages/submission.page.ts
+++ b/integration-tests/tests/pages/submission.page.ts
@@ -7,6 +7,7 @@ import {
     prepareTmpDirForSingleUpload,
     uploadFilesFromTmpDir,
 } from '../utils/file-upload-helpers';
+import { waitForUrlReportingAlerts } from '../utils/navigation-helpers';
 
 class SubmissionPage {
     protected page: Page;
@@ -66,7 +67,7 @@ class SubmissionPage {
             .click({ timeout: 3_000 })
             .catch(() => {});
 
-        await this.page.waitForURL('**/review', { timeout: 15_000 });
+        await waitForUrlReportingAlerts(this.page, '**/review', { timeout: 15_000 });
         return new ReviewPage(this.page);
     }
 

--- a/integration-tests/tests/specs/features/revise-sequence.spec.ts
+++ b/integration-tests/tests/specs/features/revise-sequence.spec.ts
@@ -6,6 +6,7 @@ import { ReviewPage } from '../../pages/review.page';
 import { RevisionPage } from '../../pages/revision.page';
 import { NavigationPage } from '../../pages/navigation.page';
 import { SingleSequenceSubmissionPage } from '../../pages/submission.page';
+import { waitForUrlReportingAlerts } from '../../utils/navigation-helpers';
 import {
     CCHF_S_SEGMENT_FULL_SEQUENCE,
     createFastaContent,
@@ -124,7 +125,7 @@ groupTest.describe('Bulk sequence revision', () => {
         await revisionPage.acceptTerms();
         await revisionPage.clickSubmit();
 
-        await expect(page).toHaveURL(/\/review/);
+        await waitForUrlReportingAlerts(page, /\/review/, { timeout: 15_000 });
         await reviewPage.waitForZeroProcessing();
 
         const overview = await reviewPage.getReviewPageOverview();

--- a/integration-tests/tests/specs/features/revise-sequence.spec.ts
+++ b/integration-tests/tests/specs/features/revise-sequence.spec.ts
@@ -125,7 +125,7 @@ groupTest.describe('Bulk sequence revision', () => {
         await revisionPage.acceptTerms();
         await revisionPage.clickSubmit();
 
-        await waitForUrlReportingAlerts(page, /\/review/, { timeout: 15_000 });
+        await waitForUrlReportingAlerts(page, '**/review', { timeout: 15_000 });
         await reviewPage.waitForZeroProcessing();
 
         const overview = await reviewPage.getReviewPageOverview();

--- a/integration-tests/tests/utils/file-upload-helpers.ts
+++ b/integration-tests/tests/utils/file-upload-helpers.ts
@@ -58,7 +58,7 @@ export async function uploadFilesFromTmpDir(
     timeout = 30_000,
 ) {
     await page.getByRole('heading', { name: 'Extra files' }).scrollIntoViewIfNeeded();
-    // Not awaited: playwright's own idea of when the upload is done was the flake fixed in #5462.
+    // Not awaited: playwright sometimes never returns, deflaked in #5462.
     void page.getByTestId(fileCategory).setInputFiles(tmpDir);
     await Promise.all([
         expect(

--- a/integration-tests/tests/utils/file-upload-helpers.ts
+++ b/integration-tests/tests/utils/file-upload-helpers.ts
@@ -53,12 +53,9 @@ export async function prepareTmpDirForSingleUpload(
 /**
  * Selects `tmpDir` for the given file category and waits until the upload has finished.
  *
- * Do not wait for `fileCount` checkmarks here: in bulk mode the "N files uploaded and linked to
- * metadata!" status line renders a checkmark of its own, so the page already holds N checkmarks
- * once N-1 files have uploaded, and a subsequent submit is rejected with "Please wait for all
- * files to finish uploading before submitting.". Wait instead for the state that the submit
- * handler actually checks - the category being in `uploadCompleted`, which is the only state in
- * which the per-category buttons are enabled.
+ * Do not count checkmarks across the whole page: in bulk mode the "N files uploaded and linked to
+ * metadata!" line renders a checkmark of its own, so N checkmarks are on the page once N-1 files
+ * have uploaded, and submitting then fails with "Please wait for all files to finish uploading".
  */
 export async function uploadFilesFromTmpDir(
     page: Page,
@@ -68,12 +65,12 @@ export async function uploadFilesFromTmpDir(
     timeout = 30_000,
 ) {
     await page.getByRole('heading', { name: 'Extra files' }).scrollIntoViewIfNeeded();
-    // Trigger the file upload without awaiting, so the waits below can observe it progressing.
-    const filesSelected = page.getByTestId(fileCategory).setInputFiles(tmpDir);
-    await expect(page.getByTestId(new RegExp(`^discard_${fileCategory}_`))).toHaveCount(fileCount, {
-        timeout,
-    });
-    await expect(page.getByTestId(`add_button_${fileCategory}`)).toBeEnabled({ timeout });
-    // Awaited last so a failure to select the files is reported rather than swallowed.
-    await filesSelected;
+    await Promise.all([
+        page.getByTestId(fileCategory).setInputFiles(tmpDir),
+        expect(
+            page.getByTestId(new RegExp(`^status_${fileCategory}_`)).filter({ hasText: '✓' }),
+        ).toHaveCount(fileCount, { timeout }),
+        // Enabled only while the category is 'uploadCompleted', which is what submitting requires.
+        expect(page.getByTestId(`add_button_${fileCategory}`)).toBeEnabled({ timeout }),
+    ]);
 }

--- a/integration-tests/tests/utils/file-upload-helpers.ts
+++ b/integration-tests/tests/utils/file-upload-helpers.ts
@@ -58,8 +58,9 @@ export async function uploadFilesFromTmpDir(
     timeout = 30_000,
 ) {
     await page.getByRole('heading', { name: 'Extra files' }).scrollIntoViewIfNeeded();
+    // Not awaited: playwright's own idea of when the upload is done was the flake fixed in #5462.
+    void page.getByTestId(fileCategory).setInputFiles(tmpDir);
     await Promise.all([
-        page.getByTestId(fileCategory).setInputFiles(tmpDir),
         expect(
             page.getByTestId(new RegExp(`^status_${fileCategory}_`)).filter({ hasText: '✓' }),
         ).toHaveCount(fileCount, { timeout }),

--- a/integration-tests/tests/utils/file-upload-helpers.ts
+++ b/integration-tests/tests/utils/file-upload-helpers.ts
@@ -50,13 +50,6 @@ export async function prepareTmpDirForSingleUpload(
     );
 }
 
-/**
- * Selects `tmpDir` for the given file category and waits until the upload has finished.
- *
- * Do not count checkmarks across the whole page: in bulk mode the "N files uploaded and linked to
- * metadata!" line renders a checkmark of its own, so N checkmarks are on the page once N-1 files
- * have uploaded, and submitting then fails with "Please wait for all files to finish uploading".
- */
 export async function uploadFilesFromTmpDir(
     page: Page,
     fileCategory: string,

--- a/integration-tests/tests/utils/file-upload-helpers.ts
+++ b/integration-tests/tests/utils/file-upload-helpers.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test';
+import { expect, Page } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
 import { clearTmpDir } from './tmpdir';
@@ -50,18 +50,30 @@ export async function prepareTmpDirForSingleUpload(
     );
 }
 
+/**
+ * Selects `tmpDir` for the given file category and waits until the upload has finished.
+ *
+ * Do not wait for `fileCount` checkmarks here: in bulk mode the "N files uploaded and linked to
+ * metadata!" status line renders a checkmark of its own, so the page already holds N checkmarks
+ * once N-1 files have uploaded, and a subsequent submit is rejected with "Please wait for all
+ * files to finish uploading before submitting.". Wait instead for the state that the submit
+ * handler actually checks - the category being in `uploadCompleted`, which is the only state in
+ * which the per-category buttons are enabled.
+ */
 export async function uploadFilesFromTmpDir(
     page: Page,
-    testId: string,
+    fileCategory: string,
     tmpDir: string,
     fileCount: number,
+    timeout = 30_000,
 ) {
     await page.getByRole('heading', { name: 'Extra files' }).scrollIntoViewIfNeeded();
-    // Trigger file upload (don't await) and wait for checkmarks to appear (indicates success)
-    void page.getByTestId(testId).setInputFiles(tmpDir);
-    return Promise.all(
-        Array.from({ length: fileCount }, (_, i) =>
-            page.getByText('✓').nth(i).waitFor({ state: 'visible' }),
-        ),
-    );
+    // Trigger the file upload without awaiting, so the waits below can observe it progressing.
+    const filesSelected = page.getByTestId(fileCategory).setInputFiles(tmpDir);
+    await expect(page.getByTestId(new RegExp(`^discard_${fileCategory}_`))).toHaveCount(fileCount, {
+        timeout,
+    });
+    await expect(page.getByTestId(`add_button_${fileCategory}`)).toBeEnabled({ timeout });
+    // Awaited last so a failure to select the files is reported rather than swallowed.
+    await filesSelected;
 }

--- a/integration-tests/tests/utils/navigation-helpers.ts
+++ b/integration-tests/tests/utils/navigation-helpers.ts
@@ -1,0 +1,24 @@
+import { Page } from '@playwright/test';
+
+export async function waitForUrlReportingAlerts(
+    page: Page,
+    url: string | RegExp,
+    options?: { timeout?: number },
+) {
+    try {
+        await page.waitForURL(url, options);
+    } catch (error) {
+        const alerts = (
+            await page
+                .getByRole('alert')
+                .allInnerTexts()
+                .catch((): string[] => [])
+        )
+            .map((text) => text.replace(/\s+/g, ' ').trim())
+            .filter((text) => text.length > 0);
+        if (alerts.length === 0) {
+            throw error;
+        }
+        throw new Error(`Did not navigate to ${url.toString()}: ${alerts.join(' | ')}`);
+    }
+}

--- a/integration-tests/tsconfig.json
+++ b/integration-tests/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "target": "ES2022",
         "esModuleInterop": true,
         "moduleResolution": "node"
     }

--- a/integration-tests/tsconfig.json
+++ b/integration-tests/tsconfig.json
@@ -1,6 +1,5 @@
 {
     "compilerOptions": {
-        "target": "ES2022",
         "esModuleInterop": true,
         "moduleResolution": "node"
     }


### PR DESCRIPTION
File upload completion was inferred from number of tick marks on page. A new component unrelated to file upload added a new tick so completion was inferred too quickly causing an error when submitting.

We now scope the tick count just to the file upload section.

How this flake looked in logs:

```
  1) [firefox-without-dep] › tests/specs/features/file-sharing.spec.ts:303:5 › bulk submit blocks a submission with an invalid file name

    Error: expect(locator).toBeVisible() failed

    Locator: getByText('Invalid filename \'CON.fastq\'').first()
    Expected: visible
    Timeout: 5000ms
    Error: element(s) not found
```

```ts
// before: satisfied once fileCount - 1 files have uploaded
page.getByText('✓').nth(i).waitFor({ state: 'visible' })

// after
expect(page.getByTestId(new RegExp(`^status_${fileCategory}_`)).filter({ hasText: '✓' }))
    .toHaveCount(fileCount, { timeout })
expect(page.getByTestId(`add_button_${fileCategory}`)).toBeEnabled({ timeout })
```

<details>

The helper waits for `fileCount` elements containing `✓` anywhere on the page (from #5462). Since [#6922](https://github.com/loculus-project/loculus/pull/6922) bulk mode also renders `✓ N files uploaded and linked to metadata!` as soon as the first file is linked, so the page holds one tick per uploaded file **plus one for that line** and the wait for N ticks is satisfied at N−1. In the failing trace the second file finished uploading 215 ms after submit was clicked.

`status_<category>_<path>` holds only the status icon, so the summary line cannot inflate the count, and the button is enabled only while the category is `uploadCompleted`, which is what submitting requires. `setInputFiles` stays un-awaited: that is #5462's fix for #5463, and since we set no `actionTimeout` awaiting it would be bounded only by the test timeout.

Also improve error informativeness when review page never loads: alert text now ends up in the playwright error message so it's fast to debug.

</details>

https://claude.ai/code/session_01QrBh9LRsnwC33S8WieMnPK

🚀 Preview: Add `preview` label to enable