### PR TITLE
test(integration): retry the tooltip hover until react has hydrated

### DIFF
--- a/integration-tests/tests/specs/features/single-submit.spec.ts
+++ b/integration-tests/tests/specs/features/single-submit.spec.ts
@@ -51,10 +51,13 @@ test('field description tooltip appears on hover', async ({ page, groupId }) => 
     const infoIcon = page.locator('[data-tooltip-id="field-tooltipsampleCollectionDate"]');
     await expect(infoIcon).toBeVisible();
 
-    await infoIcon.hover();
-
-    // The tooltip should become visible after the hover delay
     const tooltip = page.locator('#field-tooltipsampleCollectionDate');
-    await expect(tooltip).toBeVisible({ timeout: 2000 });
+    // The form is server-rendered before react hydrates, and a hover dispatched before the tooltip
+    // has attached its listeners is lost, so retry the hover instead of hovering once.
+    await expect(async () => {
+        await page.mouse.move(0, 0);
+        await infoIcon.hover();
+        await expect(tooltip).toBeVisible({ timeout: 2000 });
+    }).toPass({ timeout: 30_000 });
     await expect(tooltip).toContainText('sampleCollectionDate');
 });

--- a/integration-tests/tests/specs/features/single-submit.spec.ts
+++ b/integration-tests/tests/specs/features/single-submit.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test';
 import { test } from '../../fixtures/group.fixture';
 import { SingleSequenceSubmissionPage } from '../../pages/submission.page';
+import { hoverUntilVisible } from '../../utils/hover-helpers';
 
 test('submit a single sequence', async ({ page, groupId }) => {
     test.setTimeout(90_000);
@@ -52,12 +53,6 @@ test('field description tooltip appears on hover', async ({ page, groupId }) => 
     await expect(infoIcon).toBeVisible();
 
     const tooltip = page.locator('#field-tooltipsampleCollectionDate');
-    // The form is server-rendered before react hydrates, and a hover dispatched before the tooltip
-    // has attached its listeners is lost, so retry the hover instead of hovering once.
-    await expect(async () => {
-        await page.mouse.move(0, 0);
-        await infoIcon.hover();
-        await expect(tooltip).toBeVisible({ timeout: 2000 });
-    }).toPass({ timeout: 30_000 });
+    await hoverUntilVisible(page, infoIcon, tooltip);
     await expect(tooltip).toContainText('sampleCollectionDate');
 });

--- a/integration-tests/tests/utils/hover-helpers.ts
+++ b/integration-tests/tests/utils/hover-helpers.ts
@@ -1,0 +1,23 @@
+import { expect, Locator, Page } from '@playwright/test';
+
+/**
+ * Hovers `target` until `revealed` is visible, retrying the hover.
+ *
+ * A page is server-rendered before react hydrates, and a hover that arrives before the handlers
+ * are attached is lost for good: the mouse is already on the element, so no further mouseover
+ * fires once they are. Clicks do not need this because `Button`/`DisabledUntilHydrated` keep
+ * controls disabled until hydration, which playwright waits for - a hover has nothing to wait on.
+ */
+export async function hoverUntilVisible(
+    page: Page,
+    target: Locator,
+    revealed: Locator,
+    { timeout = 30_000, hoverTimeout = 2000 }: { timeout?: number; hoverTimeout?: number } = {},
+) {
+    await expect(async () => {
+        // move away first, so the next hover really does dispatch a mouseover
+        await page.mouse.move(0, 0);
+        await target.hover();
+        await expect(revealed).toBeVisible({ timeout: hoverTimeout });
+    }).toPass({ timeout });
+}


### PR DESCRIPTION
Seen on [this job](https://github.com/loculus-project/loculus/actions/runs/33638982103/job/100276978137) (firefox, 2026-09-02):

```
  1) [firefox-without-dep] › tests/specs/features/single-submit.spec.ts:45:5 › field description tooltip appears on hover

    Error: expect(locator).toBeVisible() failed

    Locator: locator('#field-tooltipsampleCollectionDate')
    Expected: visible
    Timeout: 2000ms
    Error: element(s) not found
```

React had not hydrated yet. The archived page snapshot shows every control on the form still disabled, which is `DisabledUntilHydrated` not having flipped:

```yaml
- textbox "Collection date" [disabled]
- button "Upload and proceed to Approval" [disabled]
```

The info icon is server-rendered, so `expect(infoIcon).toBeVisible()` passes regardless, but the hover reached a tree with no handlers attached. The part that makes this fatal rather than slow: the mouse is already resting on the icon, so no further `mouseover` fires once react-tooltip does attach — that one hover is lost for good and no timeout would have saved it.

So retry the hover, moving the mouse away first so the next one really dispatches a `mouseover`. Clicks do not need this because `Button`/`DisabledUntilHydrated` keep controls disabled until hydration and playwright waits for that; a hover on a `<span>` has nothing to wait on.

I checked this against a static page whose handler attaches only after 3 s: a single hover leaves the tooltip absent indefinitely, the retry recovers after 4.8 s.

The helper has exactly one caller today — this is the only `.hover()` in the test tree — so it is there to name the trap for the next tooltip test. Happy to inline it again if you would rather not have a util for one call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrBh9LRsnwC33S8WieMnPK

🚀 Preview: Add `preview` label to enable