### PR TITLE
fix(website): disable submitting while the metadata file is being read

### DIFF
--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -1,7 +1,6 @@
 import { isErrorFromAlias } from '@zodios/core';
 import type { AxiosError } from 'axios';
 import { DateTime } from 'luxon';
-import type { Result } from 'neverthrow';
 import { type FormEvent, useState, type Dispatch, type SetStateAction, useMemo } from 'react';
 
 import { type FileFactory, FormOrUploadWrapper, type InputMode } from './FormOrUploadWrapper.tsx';
@@ -38,7 +37,7 @@ import {
     getSingleSubmissionFileMapping,
     type CategoryLinkage,
     type FileLinkage,
-    type SubmissionFileMapping,
+    type SubmissionFileMappingState,
     validateSubmissionFileMapping,
 } from './FileUpload/fileMapping.ts';
 import { extraFilesUploadDocsUrl } from './extraFilesUploadDocsUrl.ts';
@@ -84,9 +83,9 @@ const InnerDataUploadForm = ({
     const [fileFactory, setFileFactory] = useState<FileFactory | undefined>(undefined);
     const [fileUploadStates, setFileUploadStates] = useState<Map<string, FileUploadState>>(new Map());
     const fileMapping = useMemo(() => deriveFileMapping(fileUploadStates), [fileUploadStates]);
-    const [submissionFileMapping, setSubmissionFileMapping] = useState<
-        Result<SubmissionFileMapping, Error> | undefined
-    >(undefined);
+    const [submissionFileMappingState, setSubmissionFileMapping] = useState<SubmissionFileMappingState>(undefined);
+    const metadataFileIsProcessing = submissionFileMappingState === 'processing';
+    const submissionFileMapping = metadataFileIsProcessing ? undefined : submissionFileMappingState;
     const [dataUseTermsType, setDataUseTermsType] = useState<DataUseTermsOption>(openDataUseTermsOption);
     const [restrictedUntil, setRestrictedUntil] = useState<DateTime>(dateTimeInMonths(6));
 
@@ -308,7 +307,7 @@ const InnerDataUploadForm = ({
                         type='submit'
                         className='rounded-md py-2 text-sm font-semibold shadow-xs focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 bg-primary-600 text-white hover:bg-primary-500'
                         onClick={(e) => void handleSubmit(e)}
-                        alsoDisabledIf={isPending}
+                        alsoDisabledIf={isPending || metadataFileIsProcessing}
                     >
                         <div className={`absolute ml-1.5 inline-flex ${isPending ? 'visible' : 'invisible'}`}>
                             <Spinner size='sm' />

--- a/website/src/components/Submission/FileUpload/fileMapping.ts
+++ b/website/src/components/Submission/FileUpload/fileMapping.ts
@@ -520,6 +520,11 @@ export async function applyFileMappings(
     return ok(new File([content], 'metadata.tsv', { type: 'text/tab-separated-values' }));
 }
 
+/**
+ * The parsed file mapping of the uploaded metadata file, or `'processing'` while it is being read.
+ */
+export type SubmissionFileMappingState = Result<SubmissionFileMapping, Error> | 'processing' | undefined;
+
 export function validateSubmissionFileMapping<T>(
     submissionFileMapping: SubmissionFileMapping<T>,
     fileSharingConfig: FileSharingConfig,

--- a/website/src/components/Submission/FormOrUploadWrapper.tsx
+++ b/website/src/components/Submission/FormOrUploadWrapper.tsx
@@ -1,4 +1,3 @@
-import type { Result } from 'neverthrow';
 import { useEffect, useState, type Dispatch, type FC, type SetStateAction } from 'react';
 
 import type { UploadAction } from './DataUploadForm';
@@ -9,7 +8,7 @@ import type { InputField, SubmissionDataTypes } from '../../types/config';
 import { EditableSequences } from '../Edit/EditableSequences';
 import { EditableMetadata, MetadataForm } from '../Edit/MetadataForm';
 import { SequencesForm } from '../Edit/SequencesForm';
-import { parseSubmissionFileMapping, type SubmissionFileMapping } from './FileUpload/fileMapping';
+import { parseSubmissionFileMapping, type SubmissionFileMappingState } from './FileUpload/fileMapping';
 
 export type InputMode = 'form' | 'bulk';
 
@@ -41,7 +40,7 @@ export type FileFactory = () => Promise<SequenceData | InputError>;
 type FormOrUploadWrapperProps = {
     inputMode: InputMode;
     setFileFactory: Dispatch<SetStateAction<FileFactory | undefined>>;
-    setSubmissionFileMapping: Dispatch<SetStateAction<Result<SubmissionFileMapping, Error> | undefined>>;
+    setSubmissionFileMapping: Dispatch<SetStateAction<SubmissionFileMappingState>>;
     organism: string;
     action: UploadAction;
     metadataTemplateFields: Map<string, InputField[]>;
@@ -87,6 +86,7 @@ export const FormOrUploadWrapper: FC<FormOrUploadWrapperProps> = ({
                 setSubmissionFileMapping(undefined);
                 return;
             }
+            setSubmissionFileMapping('processing');
             const text = columnMapping
                 ? await (await columnMapping.applyTo(metadataFile)).text()
                 : await metadataFile.text();

--- a/website/src/components/Submission/SubmissionForm.spec.tsx
+++ b/website/src/components/Submission/SubmissionForm.spec.tsx
@@ -44,10 +44,12 @@ function renderSubmissionForm({
     inputMode = 'bulk',
     allowSubmissionOfConsensusSequences = true,
     dataUseTermsEnabled = true,
+    extraFilesEnabled = false,
 }: {
     inputMode?: InputMode;
     allowSubmissionOfConsensusSequences?: boolean;
     dataUseTermsEnabled?: boolean;
+    extraFilesEnabled?: boolean;
 } = {}) {
     return render(
         <SubmissionForm
@@ -72,6 +74,7 @@ function renderSubmissionForm({
             submissionDataTypes={{
                 consensusSequences: allowSubmissionOfConsensusSequences,
                 maxSequencesPerEntry: 1,
+                files: extraFilesEnabled ? { enabled: true, categories: [{ name: 'rawReads' }] } : undefined,
             }}
             dataUseTermsEnabled={dataUseTermsEnabled}
             fileSharingConfig={{ disableStrictFilenameValidation: false }}
@@ -128,6 +131,31 @@ describe('SubmitForm', () => {
             });
         },
     );
+
+    test('disables submitting while the metadata file is still being read', async () => {
+        mockRequest.backend.getGroupsOfUser();
+
+        let releaseMetadataText: (text: string) => void;
+        const deferredText = new Promise<string>((resolve) => {
+            releaseMetadataText = resolve;
+        });
+        const slowMetadataFile = new File(['content'], 'metadata.tsv', { type: 'text/plain' });
+        vi.spyOn(slowMetadataFile, 'text').mockReturnValue(deferredText);
+
+        const { getByLabelText, getByRole } = renderSubmissionForm({ extraFilesEnabled: true });
+
+        await userEvent.upload(getByLabelText(/metadata file/i), slowMetadataFile);
+
+        const submitButton = getByRole('button', { name: 'Upload and proceed to Approval' });
+        await waitFor(() => {
+            expect(submitButton).toBeDisabled();
+        });
+
+        releaseMetadataText!('submissionId\tfoo\n');
+        await waitFor(() => {
+            expect(submitButton).toBeEnabled();
+        });
+    });
 
     test('should answer with feedback that a file is missing', async () => {
         mockRequest.backend.submit(200, testResponse);


### PR DESCRIPTION
Seen on [this job](https://github.com/loculus-project/loculus/actions/runs/34096648264/job/101661701168) (firefox, 2026-09-07):

```
  1) [firefox-without-dep] › tests/specs/features/submission-flow.spec.ts:21:9 › Submission flow › basic file upload submission flow works

    Test timeout of 120000ms exceeded.

    Error: locator.click: Test timeout of 120000ms exceeded.
    Call log:
      - waiting for getByRole('button', { name: 'Continue under Open terms' })

      38 |         await page.getByRole('button', { name: 'Upload and proceed to Approval' }).click();
    > 39 |         await page.getByRole('button', { name: 'Continue under Open terms' }).click();
```

The data use terms dialog never opened because the submission never happened. Its page snapshot shows why:

```yaml
- region "Notifications Alt+T":
  - alert:
    - text: "Cannot submit: metadata file is still being processed."
```

Selecting a metadata file starts an async effect that reads it and parses the file mapping out of it. Submitting before that finishes hits the guard in `handleSubmit` and produces only that toast, so the test waited out its whole 120 s for a dialog that was never coming. A person who clicks quickly gets the same dead end, which is why this is a website change rather than a wait added to the test.

The mapping state now carries a `'processing'` value while the file is being read, and the submit button is disabled while it does — so playwright's click auto-waits and the test needs no change. The guard in `handleSubmit` stays, because a form can also be submitted by pressing enter and no disabled button prevents that.

The unit test defers `metadataFile.text()` and asserts the button is disabled until it resolves. I checked it fails without the change (`expect(element).toBeDisabled()`) rather than passing vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrBh9LRsnwC33S8WieMnPK

🚀 Preview: Add `preview` label to enable