### PR TITLE
fix(website): wait for the metadata file when submitting, don't reject

### DIFF
--- a/website/src/components/Submission/DataUploadForm.tsx
+++ b/website/src/components/Submission/DataUploadForm.tsx
@@ -2,7 +2,7 @@ import { isErrorFromAlias } from '@zodios/core';
 import type { AxiosError } from 'axios';
 import { DateTime } from 'luxon';
 import type { Result } from 'neverthrow';
-import { type FormEvent, useState, type Dispatch, type SetStateAction, useMemo } from 'react';
+import { type FormEvent, useEffect, useState, type Dispatch, type SetStateAction, useMemo } from 'react';
 
 import { type FileFactory, FormOrUploadWrapper, type InputMode } from './FormOrUploadWrapper.tsx';
 import { getClientLogger } from '../../clientLogger.ts';
@@ -39,6 +39,7 @@ import {
     type CategoryLinkage,
     type FileLinkage,
     type SubmissionFileMapping,
+    type SubmissionFileMappingPromise,
     validateSubmissionFileMapping,
 } from './FileUpload/fileMapping.ts';
 import { extraFilesUploadDocsUrl } from './extraFilesUploadDocsUrl.ts';
@@ -84,9 +85,25 @@ const InnerDataUploadForm = ({
     const [fileFactory, setFileFactory] = useState<FileFactory | undefined>(undefined);
     const [fileUploadStates, setFileUploadStates] = useState<Map<string, FileUploadState>>(new Map());
     const fileMapping = useMemo(() => deriveFileMapping(fileUploadStates), [fileUploadStates]);
-    const [submissionFileMapping, setSubmissionFileMapping] = useState<
+    const [submissionFileMappingPromise, setSubmissionFileMapping] = useState<SubmissionFileMappingPromise>(undefined);
+    // Kept separately from the promise above, because rendering needs the resolved value
+    const [submissionFileMapping, setResolvedSubmissionFileMapping] = useState<
         Result<SubmissionFileMapping, Error> | undefined
     >(undefined);
+
+    useEffect(() => {
+        if (submissionFileMappingPromise === undefined) {
+            setResolvedSubmissionFileMapping(undefined);
+            return;
+        }
+        const state = { cancelled: false };
+        void submissionFileMappingPromise.then((mapping: Result<SubmissionFileMapping, Error>) => {
+            if (!state.cancelled) setResolvedSubmissionFileMapping(mapping);
+        });
+        return () => {
+            state.cancelled = true;
+        };
+    }, [submissionFileMappingPromise]);
     const [dataUseTermsType, setDataUseTermsType] = useState<DataUseTermsOption>(openDataUseTermsOption);
     const [restrictedUntil, setRestrictedUntil] = useState<DateTime>(dateTimeInMonths(6));
 
@@ -161,24 +178,27 @@ const InnerDataUploadForm = ({
                     finalMetadataFile = finalMetadataFileResult.value;
                 }
             } else {
-                if (submissionFileMapping === undefined) {
-                    onError('Cannot submit: metadata file is still being processed.');
+                if (submissionFileMappingPromise === undefined) {
+                    onError('Cannot submit: no metadata file has been selected.');
                     return;
                 }
 
-                if (submissionFileMapping.isErr()) {
-                    onError(submissionFileMapping.error.message);
+                // Waits for the metadata file to be read, if it still is
+                const parsedFileMapping = await submissionFileMappingPromise;
+
+                if (parsedFileMapping.isErr()) {
+                    onError(parsedFileMapping.error.message);
                     return;
                 }
 
-                const validationResult = validateSubmissionFileMapping(submissionFileMapping.value, fileSharingConfig);
+                const validationResult = validateSubmissionFileMapping(parsedFileMapping.value, fileSharingConfig);
                 if (validationResult.isErr()) {
                     onError(validationResult.error.message);
                     return;
                 }
 
                 const { submissionFileMapping: resolvedSubmissionFileMapping, fileLinkage } = resolveFileMappings(
-                    submissionFileMapping.value,
+                    parsedFileMapping.value,
                     fileMapping,
                 );
 

--- a/website/src/components/Submission/FileUpload/fileMapping.ts
+++ b/website/src/components/Submission/FileUpload/fileMapping.ts
@@ -520,6 +520,9 @@ export async function applyFileMappings(
     return ok(new File([content], 'metadata.tsv', { type: 'text/tab-separated-values' }));
 }
 
+/** The parse of the uploaded metadata file, still in flight; it resolves rather than rejects. */
+export type SubmissionFileMappingPromise = Promise<Result<SubmissionFileMapping, Error>> | undefined;
+
 export function validateSubmissionFileMapping<T>(
     submissionFileMapping: SubmissionFileMapping<T>,
     fileSharingConfig: FileSharingConfig,

--- a/website/src/components/Submission/FileUpload/fileMapping.ts
+++ b/website/src/components/Submission/FileUpload/fileMapping.ts
@@ -520,7 +520,6 @@ export async function applyFileMappings(
     return ok(new File([content], 'metadata.tsv', { type: 'text/tab-separated-values' }));
 }
 
-/** The parse of the uploaded metadata file, still in flight; it resolves rather than rejects. */
 export type SubmissionFileMappingPromise = Promise<Result<SubmissionFileMapping, Error>> | undefined;
 
 export function validateSubmissionFileMapping<T>(

--- a/website/src/components/Submission/FormOrUploadWrapper.tsx
+++ b/website/src/components/Submission/FormOrUploadWrapper.tsx
@@ -1,4 +1,4 @@
-import type { Result } from 'neverthrow';
+import { ResultAsync } from 'neverthrow';
 import { useEffect, useState, type Dispatch, type FC, type SetStateAction } from 'react';
 
 import type { UploadAction } from './DataUploadForm';
@@ -9,7 +9,7 @@ import type { InputField, SubmissionDataTypes } from '../../types/config';
 import { EditableSequences } from '../Edit/EditableSequences';
 import { EditableMetadata, MetadataForm } from '../Edit/MetadataForm';
 import { SequencesForm } from '../Edit/SequencesForm';
-import { parseSubmissionFileMapping, type SubmissionFileMapping } from './FileUpload/fileMapping';
+import { parseSubmissionFileMapping, type SubmissionFileMappingPromise } from './FileUpload/fileMapping';
 
 export type InputMode = 'form' | 'bulk';
 
@@ -41,7 +41,7 @@ export type FileFactory = () => Promise<SequenceData | InputError>;
 type FormOrUploadWrapperProps = {
     inputMode: InputMode;
     setFileFactory: Dispatch<SetStateAction<FileFactory | undefined>>;
-    setSubmissionFileMapping: Dispatch<SetStateAction<Result<SubmissionFileMapping, Error> | undefined>>;
+    setSubmissionFileMapping: Dispatch<SetStateAction<SubmissionFileMappingPromise>>;
     organism: string;
     action: UploadAction;
     metadataTemplateFields: Map<string, InputField[]>;
@@ -80,26 +80,33 @@ export const FormOrUploadWrapper: FC<FormOrUploadWrapperProps> = ({
 
     useEffect(() => {
         if (!extraFilesEnabled) return;
+        if (!metadataFile) {
+            setSubmissionFileMapping(undefined);
+            return;
+        }
 
         const state = { cancelled: false };
-        void (async () => {
-            if (!metadataFile) {
-                setSubmissionFileMapping(undefined);
-                return;
-            }
-            const text = columnMapping
-                ? await (await columnMapping.applyTo(metadataFile)).text()
-                : await metadataFile.text();
-
-            if (state.cancelled) return;
-
-            const submissionFileMapping = parseSubmissionFileMapping(
-                text,
-                submissionDataTypes.files?.categories?.map((category) => category.name) ?? [],
-            );
-            setSubmissionFileMapping(submissionFileMapping);
-            if (submissionFileMapping.isErr()) onError(submissionFileMapping.error.message);
-        })();
+        setSubmissionFileMapping(
+            (async () => {
+                const textResult = await ResultAsync.fromPromise(
+                    columnMapping ? (await columnMapping.applyTo(metadataFile)).text() : metadataFile.text(),
+                    (error) =>
+                        new Error(
+                            `Could not read the metadata file: ${error instanceof Error ? error.message : String(error)}`,
+                        ),
+                );
+                const submissionFileMapping = textResult.andThen((text) =>
+                    parseSubmissionFileMapping(
+                        text,
+                        submissionDataTypes.files?.categories?.map((category) => category.name) ?? [],
+                    ),
+                );
+                if (submissionFileMapping.isErr() && !state.cancelled) {
+                    onError(submissionFileMapping.error.message);
+                }
+                return submissionFileMapping;
+            })(),
+        );
         return () => {
             state.cancelled = true;
         };

--- a/website/src/components/Submission/SubmissionForm.spec.tsx
+++ b/website/src/components/Submission/SubmissionForm.spec.tsx
@@ -44,10 +44,12 @@ function renderSubmissionForm({
     inputMode = 'bulk',
     allowSubmissionOfConsensusSequences = true,
     dataUseTermsEnabled = true,
+    extraFilesEnabled = false,
 }: {
     inputMode?: InputMode;
     allowSubmissionOfConsensusSequences?: boolean;
     dataUseTermsEnabled?: boolean;
+    extraFilesEnabled?: boolean;
 } = {}) {
     return render(
         <SubmissionForm
@@ -72,6 +74,7 @@ function renderSubmissionForm({
             submissionDataTypes={{
                 consensusSequences: allowSubmissionOfConsensusSequences,
                 maxSequencesPerEntry: 1,
+                files: extraFilesEnabled ? { enabled: true, categories: [{ name: 'rawReads' }] } : undefined,
             }}
             dataUseTermsEnabled={dataUseTermsEnabled}
             fileSharingConfig={{ disableStrictFilenameValidation: false }}
@@ -128,6 +131,58 @@ describe('SubmitForm', () => {
             });
         },
     );
+
+    test('submitting while the metadata file is still being read waits for it', async () => {
+        mockRequest.backend.submit(200, testResponse);
+        mockRequest.backend.getGroupsOfUser();
+
+        let releaseMetadataText!: (text: string) => void;
+        const slowMetadataFile = new File(['content'], 'metadata.tsv', { type: 'text/plain' });
+        vi.spyOn(slowMetadataFile, 'text').mockReturnValue(
+            new Promise<string>((resolve) => {
+                releaseMetadataText = resolve;
+            }),
+        );
+
+        const { getByLabelText, getByRole, findByRole } = renderSubmissionForm({ extraFilesEnabled: true });
+
+        await userEvent.upload(getByLabelText(/metadata file/i), slowMetadataFile);
+        await userEvent.upload(getByLabelText(/sequence file/i), sequencesFile);
+        await userEvent.click(
+            getByLabelText(/I confirm I have not and will not submit this data independently to INSDC/i),
+        );
+        await userEvent.click(getByLabelText(/I confirm that I have the legal right to submit this data/i));
+
+        // Submit before the metadata file has been read
+        await userEvent.click(getByRole('button', { name: 'Upload and proceed to Approval' }));
+        expect(toast.error).not.toHaveBeenCalled();
+
+        releaseMetadataText('submissionId\trawReads_fileName\n');
+
+        // The submission goes through once the file has been read, rather than being rejected
+        await userEvent.click(await findByRole('button', { name: 'Continue under Open terms' }));
+        await waitFor(() => {
+            expect(toast.error).not.toHaveBeenCalled();
+        });
+    });
+
+    test('reports a metadata file that cannot be read', async () => {
+        mockRequest.backend.getGroupsOfUser();
+
+        const unreadableFile = new File(['content'], 'metadata.tsv', { type: 'text/plain' });
+        vi.spyOn(unreadableFile, 'text').mockRejectedValue(new Error('disk is on fire'));
+
+        const { getByLabelText } = renderSubmissionForm({ extraFilesEnabled: true });
+
+        await userEvent.upload(getByLabelText(/metadata file/i), unreadableFile);
+
+        await waitFor(() => {
+            expect(toast.error).toHaveBeenCalledWith(
+                expect.stringContaining('Could not read the metadata file: disk is on fire'),
+                expect.anything(),
+            );
+        });
+    });
 
     test('should answer with feedback that a file is missing', async () => {
         mockRequest.backend.submit(200, testResponse);


### PR DESCRIPTION
Improve UX and deflake by having the submit handler await metadata file parsing rather than toasting "not yet parsed". The original motivation was that deflaking integration tests on this is hard: logic would have to depend on whether the click happened before parsing was done or not.

Turns out that the solution that's easy to test is also one that's good for general ux - I think this is clearly better and (according to Claude) also avoids a confusing and unrecoverable edge case error state when the file can't be read.

Code changes are fairly minimal, the majority is tests and indentation of an existing block.

Fixes a flake seen on [this job](https://github.com/loculus-project/loculus/actions/runs/34096648264/job/101661701168) (firefox, 2026-09-07):

```
  1) [firefox-without-dep] › tests/specs/features/submission-flow.spec.ts:21:9 › Submission flow › basic file upload submission flow works

    Test timeout of 120000ms exceeded.

    Error: locator.click: Test timeout of 120000ms exceeded.
    Call log:
      - waiting for getByRole('button', { name: 'Continue under Open terms' })

      38 |         await page.getByRole('button', { name: 'Upload and proceed to Approval' }).click();
    > 39 |         await page.getByRole('button', { name: 'Continue under Open terms' }).click();
```

The data use terms dialog never opened because the submission never happened. The archived page snapshot says why:

```yaml
- region "Notifications Alt+T":
  - alert:
    - text: "Cannot submit: metadata file is still being processed."
```

Apparent bug fix according to Claude:

> A read that fails now reports itself, which it never did: the exception disappeared into a `void (async () => …)()`, the mapping stayed undefined forever, and every later submit claimed the file was still being processed — a state nothing could get out of.

https://claude.ai/code/session_01QrBh9LRsnwC33S8WieMnPK

🚀 Preview: Add `preview` label to enable