### PR TITLE
test(deposition): run get_ena_submission_list test in a tmp dir

### DIFF
--- a/ena-submission/scripts/get_ena_submission_list.py
+++ b/ena-submission/scripts/get_ena_submission_list.py
@@ -258,6 +258,9 @@ def send_slack_notification_with_file(
 @click.option(
     "--output-dir",
     required=False,
+    default=".",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Directory to write the ENA submission list JSON files to.",
 )
 def get_ena_submission_list(config_file, output_dir) -> None:
     """
@@ -271,7 +274,6 @@ def get_ena_submission_list(config_file, output_dir) -> None:
     logger.info(f"Config: {config}")
 
     output_file_suffix = "ena_submission_list.json"
-    output_dir = output_dir or "."
 
     db_engine = db_init(
         db_password_default=config.db_password,
@@ -302,7 +304,7 @@ def get_ena_submission_list(config_file, output_dir) -> None:
                 f"{config.backend_url}: {loculus_organism} - ENA Submission pipeline wants to "
                 f"submit {len(submission_results.entries_to_submit)} sequences"
             )
-            output_file = Path(f"{output_dir}/{loculus_organism}_{output_file_suffix}")
+            output_file = Path(output_dir) / f"{loculus_organism}_{output_file_suffix}"
             send_slack_notification_with_file(
                 slack_config, message, submission_results.entries_to_submit, output_file
             )
@@ -316,8 +318,8 @@ def get_ena_submission_list(config_file, output_dir) -> None:
                 " Bioprojects should be public and SRA accessions should also include bioprojects"
                 " and biosamples."
             )
-            output_file = Path(
-                f"{output_dir}/{loculus_organism}_with_ena_fields_{output_file_suffix}"
+            output_file = (
+                Path(output_dir) / f"{loculus_organism}_with_ena_fields_{output_file_suffix}"
             )
             send_slack_notification_with_file(
                 slack_config,
@@ -331,7 +333,7 @@ def get_ena_submission_list(config_file, output_dir) -> None:
                 f"{len(submission_results.revoked_entries)} sequences that have been revoked"
                 " investigate if these need to be suppressed on ENA."
             )
-            output_file = Path(f"{output_dir}/{loculus_organism}_revoked_{output_file_suffix}")
+            output_file = Path(output_dir) / f"{loculus_organism}_revoked_{output_file_suffix}"
             send_slack_notification_with_file(
                 slack_config,
                 message,

--- a/ena-submission/scripts/get_ena_submission_list.py
+++ b/ena-submission/scripts/get_ena_submission_list.py
@@ -26,7 +26,6 @@ from sqlalchemy import Engine
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(
-    encoding="utf-8",
     level=logging.INFO,
     format="%(asctime)s %(levelname)8s (%(filename)20s:%(lineno)4d) - %(message)s ",
     datefmt="%H:%M:%S",
@@ -256,7 +255,11 @@ def send_slack_notification_with_file(
     required=True,
     type=click.Path(exists=True),
 )
-def get_ena_submission_list(config_file) -> None:
+@click.option(
+    "--output-dir",
+    required=False,
+)
+def get_ena_submission_list(config_file, output_dir) -> None:
     """
     Get a list of all sequences in state APPROVED_FOR_RELEASE without insdc-specific
     metadata fields and not already in the ena_submission.submission_table.
@@ -268,6 +271,7 @@ def get_ena_submission_list(config_file) -> None:
     logger.info(f"Config: {config}")
 
     output_file_suffix = "ena_submission_list.json"
+    output_dir = output_dir or "."
 
     db_engine = db_init(
         db_password_default=config.db_password,
@@ -298,7 +302,7 @@ def get_ena_submission_list(config_file) -> None:
                 f"{config.backend_url}: {loculus_organism} - ENA Submission pipeline wants to "
                 f"submit {len(submission_results.entries_to_submit)} sequences"
             )
-            output_file = f"{loculus_organism}_{output_file_suffix}"
+            output_file = Path(f"{output_dir}/{loculus_organism}_{output_file_suffix}")
             send_slack_notification_with_file(
                 slack_config, message, submission_results.entries_to_submit, output_file
             )
@@ -312,7 +316,9 @@ def get_ena_submission_list(config_file) -> None:
                 " Bioprojects should be public and SRA accessions should also include bioprojects"
                 " and biosamples."
             )
-            output_file = f"{loculus_organism}_with_ena_fields_{output_file_suffix}"
+            output_file = Path(
+                f"{output_dir}/{loculus_organism}_with_ena_fields_{output_file_suffix}"
+            )
             send_slack_notification_with_file(
                 slack_config,
                 message,
@@ -325,7 +331,7 @@ def get_ena_submission_list(config_file) -> None:
                 f"{len(submission_results.revoked_entries)} sequences that have been revoked"
                 " investigate if these need to be suppressed on ENA."
             )
-            output_file = f"{loculus_organism}_revoked_{output_file_suffix}"
+            output_file = Path(f"{output_dir}/{loculus_organism}_revoked_{output_file_suffix}")
             send_slack_notification_with_file(
                 slack_config,
                 message,

--- a/ena-submission/test/test_get_ena_submission_list.py
+++ b/ena-submission/test/test_get_ena_submission_list.py
@@ -1,7 +1,9 @@
 # ruff: noqa: S101 (allow asserts in tests))
 import json
+import tempfile
 import unittest
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Any
 from unittest.mock import ANY, Mock, patch
 
@@ -58,19 +60,22 @@ class GetSubmissionListTests(unittest.TestCase):
         mock_fetch_released_entries.side_effect = fake_fetch_released_entries
         mock_fetch_suppressed_accessions.return_value = {"LOC01.1"}
 
-        get_ena_submission_list.get_ena_submission_list.callback(config_file=str(CONFIG_FILE))  # type: ignore
-        mock_upload_file_with_comment.assert_called()
-        mock_upload_file_with_comment.assert_any_call(
-            ANY,
-            "cchf_ena_submission_list.json",
-            "http://localhost:8079: cchf - ENA Submission pipeline wants to submit 1 sequences",
-        )
-        assert mock_upload_file_with_comment.call_args.args[2].startswith(
-            "http://localhost:8079: cchf - ENA Submission pipeline found 1 sequences with ena"
-        )
-        json_diff(
-            mock_upload_file_with_comment.call_args_list[0].args[1], APPROVED_RELEASED_DATA_PATH
-        )
+        with tempfile.TemporaryDirectory() as output_dir:
+            get_ena_submission_list.get_ena_submission_list.callback(  # type: ignore
+                config_file=str(CONFIG_FILE), output_dir=output_dir
+            )
+            mock_upload_file_with_comment.assert_called()
+            mock_upload_file_with_comment.assert_any_call(
+                ANY,
+                Path(output_dir) / "cchf_ena_submission_list.json",
+                "http://localhost:8079: cchf - ENA Submission pipeline wants to submit 1 sequences",
+            )
+            assert mock_upload_file_with_comment.call_args.args[2].startswith(
+                "http://localhost:8079: cchf - ENA Submission pipeline found 1 sequences with ena"
+            )
+            json_diff(
+                mock_upload_file_with_comment.call_args_list[0].args[1], APPROVED_RELEASED_DATA_PATH
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Alternative to https://github.com/loculus-project/loculus/pull/7260

Running the ena-submission unit tests leaves two untracked JSON files in the repo: ena-submission/cchf_ena_submission_list.json and ena-submission/cchf_with_ena_fields_ena_submission_list.json.

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable