### PR TITLE
fix(kubernetes): make MinIO report its health and fail loudly on bucket setup

### DIFF
--- a/kubernetes/loculus/templates/minio-deployment.yaml
+++ b/kubernetes/loculus/templates/minio-deployment.yaml
@@ -75,13 +75,6 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
-          livenessProbe:
-            httpGet:
-              path: /minio/health/live
-              port: 9000
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
           lifecycle:
             postStart:
               exec:

--- a/kubernetes/loculus/templates/minio-deployment.yaml
+++ b/kubernetes/loculus/templates/minio-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             name: minio-policies
       containers:
         - name: minio
-          image: minio/minio:latest
+          image: minio/minio:RELEASE.2025-09-07T16-13-09Z
           {{- include "loculus.resources" (list "minio" $.Values) | nindent 10 }}
           args: ["server", "/data"]
           ports:
@@ -70,11 +70,11 @@ spec:
             {{- end }}
           readinessProbe:
             httpGet:
-              path: /minio/health/live
+              path: /minio/health/ready
               port: 9000
             periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: 3
+            failureThreshold: 6
           lifecycle:
             postStart:
               exec:
@@ -84,16 +84,16 @@ spec:
                   - |
                     set -e
                     attempt=0
-                    until mc alias set local http://localhost:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do
+                    until mc alias set local http://localhost:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" \
+                      && mc mb --ignore-existing local/{{ .Values.s3.bucket.bucket }} \
+                      && mc anonymous set-json /policy/policy.json local/{{ .Values.s3.bucket.bucket }}; do
                       attempt=$((attempt + 1))
                       if [ "$attempt" -ge 60 ]; then
-                        echo "MinIO did not answer on localhost:9000 within 120s" >&2
+                        echo "Could not set up bucket {{ .Values.s3.bucket.bucket }} after 60 attempts" >&2
                         exit 1
                       fi
                       sleep 2
                     done
-                    mc mb -p local/{{ .Values.s3.bucket.bucket }}
-                    mc anonymous set-json /policy/policy.json local/{{ .Values.s3.bucket.bucket }}
                     echo "Bucket {{ .Values.s3.bucket.bucket }} ensured."
           volumeMounts:
             - name: policy-volume

--- a/kubernetes/loculus/templates/minio-deployment.yaml
+++ b/kubernetes/loculus/templates/minio-deployment.yaml
@@ -82,7 +82,6 @@ spec:
                   - /bin/sh
                   - -c
                   - |
-                    # foreground, so a failed bucket setup fails the container instead of vanishing
                     set -e
                     attempt=0
                     until mc alias set local http://localhost:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do

--- a/kubernetes/loculus/templates/minio-deployment.yaml
+++ b/kubernetes/loculus/templates/minio-deployment.yaml
@@ -68,6 +68,20 @@ spec:
             - name: LOCULUS_VERSION
               value: {{ $dockerTag }}
             {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: 9000
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: 9000
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           lifecycle:
             postStart:
               exec:
@@ -75,13 +89,20 @@ spec:
                   - /bin/sh
                   - -c
                   - |
-                    (
-                      sleep 10
-                      mc alias set local http://localhost:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
-                      mc mb -p local/{{ .Values.s3.bucket.bucket }}
-                      echo "Bucket {{ .Values.s3.bucket.bucket }} ensured."
-                      mc anonymous set-json /policy/policy.json local/{{ .Values.s3.bucket.bucket }}
-                    ) &
+                    # foreground, so a failed bucket setup fails the container instead of vanishing
+                    set -e
+                    attempt=0
+                    until mc alias set local http://localhost:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do
+                      attempt=$((attempt + 1))
+                      if [ "$attempt" -ge 60 ]; then
+                        echo "MinIO did not answer on localhost:9000 within 120s" >&2
+                        exit 1
+                      fi
+                      sleep 2
+                    done
+                    mc mb -p local/{{ .Values.s3.bucket.bucket }}
+                    mc anonymous set-json /policy/policy.json local/{{ .Values.s3.bucket.bucket }}
+                    echo "Bucket {{ .Values.s3.bucket.bucket }} ensured."
           volumeMounts:
             - name: policy-volume
               mountPath: /policy


### PR DESCRIPTION
## Why

In [run 33881830926](https://github.com/loculus-project/loculus/actions/runs/33881830926) 28 integration tests failed in one chromium job because the MinIO bucket did not exist. The pod reported `1/1 Running` with 0 restarts, and `wait_for_pods_to_be_ready.py` passed.

Two things combine to hide it. The bucket is created by a `postStart` hook that backgrounds itself with `( … ) &`, so nothing can fail if it goes wrong and kubelet discards its output; and its entire readiness strategy is `sleep 10`, so if MinIO is not serving ten seconds after the container starts, `mc alias set` fails and `mc mb` never runs. That run was on a heavily loaded runner — postgres took 33.9 s to pull onto the same node. MinIO also declares no probes at all, so it is Ready the instant the process starts, which is why a bucketless MinIO sailed through the wait step.

## What this changes

The hook now runs in the foreground under `set -e`, polling until MinIO answers instead of sleeping a fixed ten seconds, and gives up after 120 s. A failure now kills the container and restarts it, which is both self-healing and visible as a restart count. MinIO also gets a readiness probe on its health endpoint, so the pod stops claiming to be Ready before it is.

## Things worth knowing

`postStart` blocking is deliberate and safe here: kubelet does not report the container as Running until the hook returns, but the MinIO process itself is already running and serving, so the hook's own poll is what waits. There is no deadlock, and the probes only start once the hook has proved the API answers.

This was a separate `minio/mc` sidecar container until #3978 replaced it with the backgrounded hook. I kept the hook rather than going back to a sidecar or moving to a post-install `Job`, because a Job brings Helm hook semantics and Argo CD sync-phase behaviour for what is a dev- and CI-only path (`s3.enabled` and `runDevelopmentS3`).

I used `/minio/health/live`, which is what MinIO's own chart does.

I deliberately did not add a liveness or startup probe. Readiness is the field `wait_for_pods_to_be_ready.py` actually reads. During `postStart` the status still says the container is starting, and liveness, readiness and startup probes are all inert.

That has a nice consequence for this PR: because the hook now runs in the foreground, the container cannot be reported Running — and therefore cannot be Ready — until the bucket exists. It also explains the original bug precisely. With `( … ) &` the hook returned in milliseconds, so the container went Running immediately, and with no readiness probe a running container is Ready by definition. The pod was Ready while `sleep 10; mc mb` was still running detached, or had failed.

## The image pin is part of the same fix

I originally left `image: minio/minio:latest` for a follow-up, and that was the wrong call once the hook fails fast: bucket problems now become container restarts, and with a `latest` tag Kubernetes defaults `imagePullPolicy` to `Always`, so every restart re-pulls from Docker Hub — on the loaded runner this PR is about.

Pinning is the whole fix, with no new field: Kubernetes defaults the pull policy to `IfNotPresent` for any tag that is not `latest`. And it is behaviour-neutral today — `latest` and `RELEASE.2025-09-07T16-13-09Z` are the same digest, `sha256:14cea49...`, which is also the digest CI has been running. MinIO's community image is not moving anyway, so a pin costs nothing in updates.

🚀 Preview: https://fix-minio-startup-probe-a.loculus.org