### PR TITLE
ci(integration-tests): type-check in CI, and set a tsconfig target

### DIFF
--- a/.github/workflows/format-integration-tests.yml
+++ b/.github/workflows/format-integration-tests.yml
@@ -37,3 +37,6 @@ jobs:
       
       - name: Check formatting
         run: npm run format:check
+
+      - name: Check types
+        run: npm run check-types

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -19,6 +19,7 @@
                 "eslint-plugin-unicorn": "^74.0.0",
                 "papaparse": "^5.7.0",
                 "prettier": "^3.9.6",
+                "typescript": "^5.8.3",
                 "typescript-eslint": "^8.69.0",
                 "uuid": "^14.0.2"
             }
@@ -312,6 +313,7 @@
             "integrity": "sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.69.0",
                 "@typescript-eslint/types": "8.69.0",
@@ -516,6 +518,7 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -606,6 +609,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.11.12",
                 "caniuse-lite": "^1.0.30001809",
@@ -809,6 +813,7 @@
             "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "workspaces": [
                 "packages/*"
             ],
@@ -1541,6 +1546,7 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -5,6 +5,7 @@
     "scripts": {
         "format": "eslint --cache --fix && prettier --write \"**/*.{ts,js,mjs,json}\"",
         "format:check": "eslint --cache && prettier --check \"**/*.{ts,js,mjs,json}\"",
+        "check-types": "tsc --noEmit",
         "test": "npx playwright test"
     },
     "devDependencies": {
@@ -19,6 +20,7 @@
         "eslint-plugin-unicorn": "^74.0.0",
         "papaparse": "^5.7.0",
         "prettier": "^3.9.6",
+        "typescript": "^5.8.3",
         "typescript-eslint": "^8.69.0",
         "uuid": "^14.0.2"
     }

--- a/integration-tests/tsconfig.json
+++ b/integration-tests/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "target": "ES2022",
         "esModuleInterop": true,
         "moduleResolution": "node"
     }


### PR DESCRIPTION
Check type in `integration-tests`. 

`target: ES2022` instead of `"lib": ["ES2021"]` because DOM types would be missing.

`skipLibCheck: true` stops `tsc` from type-checking every dependency's `.d.ts` and breaking on something we don't control.

`module`/`moduleResolution: NodeNext` replaces the legacy node10 algorithm, which ignores packages' `exports` maps and therefore resolves imports differently from the loader that actually runs the tests.

**Follow-up:** `strict` is still off, so implicit `any`, possibly-`undefined` locator results and unchecked optional access all pass this new check. Turning it on is 12 errors across 6 files where Playwright's `textContent()` and `getAttribute()` return `string | null` and the result is used as `string`.

🚀 Preview: Add `preview` label to enable