### PR TITLE
style(raw-reads): use the repo's 100-character line length

### DIFF
--- a/raw-reads-processing/pyproject.toml
+++ b/raw-reads-processing/pyproject.toml
@@ -15,6 +15,10 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/raw_reads_processing"]
 
+[tool.ruff]
+# Match the rest of the repo (root ruff.toml); ruff defaults to 88 otherwise.
+line-length = 100
+
 [tool.ruff.lint.per-file-ignores]
 "test/**" = ["S101"]
 

--- a/raw-reads-processing/src/raw_reads_processing/api.py
+++ b/raw-reads-processing/src/raw_reads_processing/api.py
@@ -11,9 +11,7 @@ from .config import Config
 
 logger = logging.getLogger()
 
-app = FastAPI(
-    title="Raw Reads Processing Service", description="Loculus raw reads processing API"
-)
+app = FastAPI(title="Raw Reads Processing Service", description="Loculus raw reads processing API")
 
 
 @app.get("/")
@@ -55,9 +53,7 @@ def start_api(config: Config, deacon_process: subprocess.Popen):
     port = config.file_service_port or 5000
     logger.info(f"Starting raw reads processing service API on port {port}")
 
-    uvicorn_config = uvicorn.Config(
-        app, host=host, port=port, log_level="info", workers=1
-    )
+    uvicorn_config = uvicorn.Config(app, host=host, port=port, log_level="info", workers=1)
     server = uvicorn.Server(uvicorn_config)
 
     server.run()

--- a/raw-reads-processing/src/raw_reads_processing/config.py
+++ b/raw-reads-processing/src/raw_reads_processing/config.py
@@ -16,18 +16,14 @@ class Config(BaseModel):
     deacon_max_host_bp: int  # maximum number of host base pairs allowed in a sample before it is flagged as contaminated
 
     # deacon parameters
-    deacon_a: int = (
-        2  # absolute number of k-mers in a read that need to map to index to be flagged
-    )
+    deacon_a: int = 2  # absolute number of k-mers in a read that need to map to index to be flagged
     deacon_a_short_reads: int = (
         1  # absolute k-mer threshold used instead of deacon_a for short-read libraries
     )
     short_reads_threshold: int = (
         90  # mean read length (bp) below which short-read deacon params are used
     )
-    deacon_r: float = (
-        0.05  # relative proportion of k-mers in a read that need to map to index
-    )
+    deacon_r: float = 0.05  # relative proportion of k-mers in a read that need to map to index
 
 
 def get_config(config_file: str | Path) -> Config:

--- a/raw-reads-processing/src/raw_reads_processing/deacon.py
+++ b/raw-reads-processing/src/raw_reads_processing/deacon.py
@@ -71,8 +71,7 @@ def median_read_length(
     """
     with xopen(path, "rt", threads=0) as fh:
         lengths = [
-            len(seq)
-            for _, seq, _ in itertools.islice(FastqGeneralIterator(fh), sample_size)
+            len(seq) for _, seq, _ in itertools.islice(FastqGeneralIterator(fh), sample_size)
         ]
     if not lengths:
         message = f"Failed to determine median read length for file '{file_name}'. File may be empty or corrupted."
@@ -86,10 +85,7 @@ def _deacon_a_for_reads(file_name_to_path: dict[FileName, Path], config: Config)
     files to decide whether this is a short-read library.
     """
     observed_length = min(
-        [
-            median_read_length(path, file_name)
-            for file_name, path in file_name_to_path.items()
-        ],
+        [median_read_length(path, file_name) for file_name, path in file_name_to_path.items()],
         default=0.0,
     )
     short_reads = observed_length < config.short_reads_threshold

--- a/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
+++ b/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
@@ -71,9 +71,7 @@ def validate_file_extensions(
 ) -> FileFormat:
     """Validate that all files have extensions consistent with the accepted formats."""
     file_formats = {determine_file_format(file_name) for file_name in file_names}
-    paired_end_info = (
-        "Paired-end FASTQ files must be submitted as separate, de-interleaved files."
-    )
+    paired_end_info = "Paired-end FASTQ files must be submitted as separate, de-interleaved files."
     if len(file_formats) > 1:
         raise InvalidSubmission(
             error=Annotation(

--- a/raw-reads-processing/src/raw_reads_processing/process_files.py
+++ b/raw-reads-processing/src/raw_reads_processing/process_files.py
@@ -59,7 +59,5 @@ def validate_raw_reads_submission(
             download_file(config, file, downloaded_file_path)
             local_files[file.name] = downloaded_file_path
 
-        validate_with_readtools(
-            local_files, file_format, config.read_validation_timeout_seconds
-        )
+        validate_with_readtools(local_files, file_format, config.read_validation_timeout_seconds)
         validate_with_deacon(local_files, tmp_dir, config)

--- a/raw-reads-processing/test/test_api.py
+++ b/raw-reads-processing/test/test_api.py
@@ -55,9 +55,7 @@ def test_invalid_submission_is_returned_as_validation_result(client, monkeypatch
     def fake_process_submitted_files(**kwargs):
         raise InvalidSubmission(error=error)
 
-    monkeypatch.setattr(
-        api, "validate_raw_reads_submission", fake_process_submitted_files
-    )
+    monkeypatch.setattr(api, "validate_raw_reads_submission", fake_process_submitted_files)
 
     response = client.post("/process-files", json=VALID_PAYLOAD)
 
@@ -69,9 +67,7 @@ def test_processing_failure_is_returned_as_internal_server_error(client, monkeyp
     def fake_process_submitted_files(**kwargs):
         raise ProcessingFailure("readtools jar not found")
 
-    monkeypatch.setattr(
-        api, "validate_raw_reads_submission", fake_process_submitted_files
-    )
+    monkeypatch.setattr(api, "validate_raw_reads_submission", fake_process_submitted_files)
 
     response = client.post("/process-files", json=VALID_PAYLOAD)
 

--- a/raw-reads-processing/test/test_deacon.py
+++ b/raw-reads-processing/test/test_deacon.py
@@ -58,9 +58,7 @@ def mock_downstream(monkeypatch):
     monkeypatch.setattr(
         process_files,
         "download_file",
-        lambda config, file, save_path: save_path.write_bytes(
-            Path(file.url).read_bytes()
-        ),
+        lambda config, file, save_path: save_path.write_bytes(Path(file.url).read_bytes()),
     )
     monkeypatch.setattr(process_files, "validate_with_readtools", lambda *a, **k: None)
 
@@ -84,17 +82,13 @@ def deacon_server():
 @pytest.fixture
 def deacon_index(monkeypatch, deacon_server):
     # Index created with `deacon index build test/fixtures/test_small_1.fastq -k 31 -w 15 -o deacon.idx`
-    monkeypatch.setattr(
-        deacon_module, "DEACON_INDEX_PATH", str(FIXTURES_DIR / "deacon.idx")
-    )
+    monkeypatch.setattr(deacon_module, "DEACON_INDEX_PATH", str(FIXTURES_DIR / "deacon.idx"))
 
 
 def test_median_read_length_plain_fastq(tmp_path):
     reads = tmp_path / "reads.fastq"
     _write_fastq(reads, [_random_read(100), _random_read(200), _random_read(150)])
-    assert deacon_module.median_read_length(reads, "reads.fastq") == pytest.approx(
-        150.0
-    )
+    assert deacon_module.median_read_length(reads, "reads.fastq") == pytest.approx(150.0)
 
 
 def test_median_read_length_gzipped_fastq(tmp_path):
@@ -102,9 +96,7 @@ def test_median_read_length_gzipped_fastq(tmp_path):
     reads = tmp_path / "reads.fastq.gz"
     _write_fastq(tmp_path / "plain.fastq", [_random_read(80), _random_read(100)])
     reads.write_bytes(gzip.compress((tmp_path / "plain.fastq").read_bytes()))
-    assert deacon_module.median_read_length(reads, "reads.fastq.gz") == pytest.approx(
-        90.0
-    )
+    assert deacon_module.median_read_length(reads, "reads.fastq.gz") == pytest.approx(90.0)
     assert deacon_module._deacon_a_for_reads({"boundary.fastq": reads}, config) == 2
 
 
@@ -119,10 +111,7 @@ def test_deacon_a_for_reads_switches_on_short_reads(tmp_path):
     assert deacon_module._deacon_a_for_reads({"long.fastq": long}, config) == 2
     # min() over mates: a short R2 still triggers short-read params
     assert (
-        deacon_module._deacon_a_for_reads(
-            {"long.fastq": long, "short.fastq": short}, config
-        )
-        == 1
+        deacon_module._deacon_a_for_reads({"long.fastq": long, "short.fastq": short}, config) == 1
     )
 
 

--- a/raw-reads-processing/test/test_file_validation.py
+++ b/raw-reads-processing/test/test_file_validation.py
@@ -141,9 +141,7 @@ def _find_jar() -> str | None:
 def readtools_jar(monkeypatch):
     jar_path = _find_jar()
     if jar_path is None:
-        pytest.skip(
-            "readtools jar not found; set READTOOLS_JAR to its path to run this test"
-        )
+        pytest.skip("readtools jar not found; set READTOOLS_JAR to its path to run this test")
     monkeypatch.setattr(file_format_validation, "VALIDATION_JAR_PATH", jar_path)
 
 
@@ -156,9 +154,7 @@ def _write(tmp_path: Path, name: str, content: str) -> str:
 @pytest.mark.usefixtures("readtools_jar")
 def test_valid_single_end_fastq_passes(tmp_path):
     reads = _write(tmp_path, "reads.fastq", VALID_SINGLE_END)
-    assert (
-        validate_with_readtools({"reads.fastq": Path(reads)}, FileFormat.FASTQ) is None
-    )
+    assert validate_with_readtools({"reads.fastq": Path(reads)}, FileFormat.FASTQ) is None
 
 
 @pytest.mark.usefixtures("readtools_jar")
@@ -166,9 +162,7 @@ def test_valid_paired_end_fastq_passes(tmp_path):
     r1 = _write(tmp_path, "R1.fastq", VALID_R1)
     r2 = _write(tmp_path, "R2.fastq", VALID_R2)
     assert (
-        validate_with_readtools(
-            {"R1.fastq": Path(r1), "R2.fastq": Path(r2)}, FileFormat.FASTQ
-        )
+        validate_with_readtools({"R1.fastq": Path(r1), "R2.fastq": Path(r2)}, FileFormat.FASTQ)
         is None
     )
 
@@ -226,9 +220,7 @@ def test_deinterleaved_paired_reads_pass(tmp_path):
         "@read1\nTGCATGCATG\n+\nIIIIIIIIII\n@read2\nTGCATGCATG\n+\nIIIIIIIIII\n",
     )
     assert (
-        validate_with_readtools(
-            {"R1.fastq": Path(r1), "R2.fastq": Path(r2)}, FileFormat.FASTQ
-        )
+        validate_with_readtools({"R1.fastq": Path(r1), "R2.fastq": Path(r2)}, FileFormat.FASTQ)
         is None
     )
 
@@ -241,10 +233,7 @@ def test_casava_style_interleaved_single_file_passes(tmp_path):
     """
     reads = _write(tmp_path, "interleaved_casava.fastq", CASAVA_INTERLEAVED_SINGLE_FILE)
     assert (
-        validate_with_readtools(
-            {"interleaved_casava.fastq": Path(reads)}, FileFormat.FASTQ
-        )
-        is None
+        validate_with_readtools({"interleaved_casava.fastq": Path(reads)}, FileFormat.FASTQ) is None
     )
 
 
@@ -253,10 +242,7 @@ def test_gzipped_fastq_is_recognized_and_passes(tmp_path):
     gz_path = tmp_path / "reads.fastq.gz"
     with gzip.open(gz_path, "wt") as f:
         f.write(VALID_SINGLE_END)
-    assert (
-        validate_with_readtools({"reads.fastq.gz": Path(gz_path)}, FileFormat.FASTQ)
-        is None
-    )
+    assert validate_with_readtools({"reads.fastq.gz": Path(gz_path)}, FileFormat.FASTQ) is None
 
 
 def _write_bytes(tmp_path: Path, name: str, data: bytes) -> str:
@@ -330,9 +316,7 @@ def test_validation_timeout_is_reported_as_error(tmp_path, monkeypatch):
 
     monkeypatch.setattr(file_format_validation.subprocess, "run", fake_run)
     with pytest.raises(ProcessingFailure) as exc_info:
-        validate_with_readtools(
-            {"reads.fastq": Path(reads)}, FileFormat.FASTQ, timeout_seconds=1
-        )
+        validate_with_readtools({"reads.fastq": Path(reads)}, FileFormat.FASTQ, timeout_seconds=1)
     assert "timed out" in str(exc_info.value)
     assert "1 second" in str(exc_info.value)
 


### PR DESCRIPTION
## Why

`raw-reads-processing/pyproject.toml` declares `[tool.ruff.lint.per-file-ignores]`, and that alone makes it a ruff configuration root. Ruff does not merge configs across directories, so the package inherits nothing from the root `ruff.toml` — including its `line-length = 100`. It has been silently using ruff's default of 88.

That makes it the odd one out, and by accident rather than by choice:

| package | line length | how |
|---|---|---|
| `ena-submission`, `taxonomy` | 100 | inherits root `ruff.toml` |
| `ingest`, `preprocessing/nextclade` | 100 | own `ruff.toml`, set explicitly |
| `cli` | 88 | own config, set explicitly — deliberate |
| `raw-reads-processing` | **88** | **own config, never set — ruff's default** |

The practical cost is that running `ruff format` from the repo root, where the length is 100, does not reproduce what CI checks from inside the package. I hit exactly that on #7266: the check passed locally and failed in CI.

Worth noting the same inheritance gap applies to the lint rules — the package gets ruff's defaults rather than the root's `extend-select` list. The `"test/**" = ["S101"]` ignore that is already there is inert for that reason, since `S` is not selected. I have not changed that here; it would surface a batch of new findings and deserves its own decision.

## What a reviewer should check

The reformat is mechanical (`ruff format` at the new width) and touches 8 files. Tests pass unchanged.

Note this overlaps #7266, which touches three of the same files. Whichever merges second will need a reformat — happy to rebase this one on top of that if you would rather land #7266 first.

🚀 Preview: Add `preview` label to enable