### PR TITLE
refactor(deposition): return the previous raw-reads row instead of a raise_on_empty flag

### DIFF
--- a/ena-submission/src/ena_deposition/create_raw_reads.py
+++ b/ena-submission/src/ena_deposition/create_raw_reads.py
@@ -328,9 +328,14 @@ def has_raw_reads_changed(
     return False
 
 
-def last_raw_reads_entry(
-    db_engine: Engine, seq_key: AccessionVersion, raise_on_empty: bool = True
-) -> list[RawReadsTableEntry]:
+def previous_version_raw_reads_entry(
+    db_engine: Engine, seq_key: AccessionVersion
+) -> RawReadsTableEntry | None:
+    """The raw_reads_table row of the version this one revises, or None if there is none.
+
+    A previous raw_reads_table row is not guaranteed to exist even for a revision: the
+    previous version may simply not have had raw reads attached.
+    """
     version_to_revise = previous_version(db_engine, seq_key)
     last_version_rows = find_conditions_in_db(
         db_engine,
@@ -340,17 +345,19 @@ def last_raw_reads_entry(
             "version": version_to_revise,
         },
     )
-    if len(last_version_rows) == 0 and raise_on_empty:
-        error_msg = f"Last version {version_to_revise} not found in raw_reads_table"
-        raise RuntimeError(error_msg)
-    return last_version_rows
+    return last_version_rows[0] if last_version_rows else None
 
 
 def update_raw_reads_results_with_latest_version(db_engine: Engine, seq_key: AccessionVersion):
-    last_version_rows = last_raw_reads_entry(db_engine, seq_key)
+    last_version_entry = previous_version_raw_reads_entry(db_engine, seq_key)
+    if last_version_entry is None:
+        error_msg = (
+            f"Version preceding {seq_key.accession}.{seq_key.version} not found in raw_reads_table"
+        )
+        raise RuntimeError(error_msg)
     logger.info(
         f"Updating raw reads results for accession {seq_key.accession} version "
-        f"{seq_key.version} using results from version {last_version_rows[0].version} as there was"
+        f"{seq_key.version} using results from version {last_version_entry.version} as there was "
         "no change in raw read data."
     )
     update_with_retry(
@@ -358,7 +365,7 @@ def update_raw_reads_results_with_latest_version(db_engine: Engine, seq_key: Acc
         conditions=asdict(seq_key),
         update_values={
             "status": Status.SUBMITTED,
-            "result": last_version_rows[0].result,
+            "result": last_version_entry.result,
         },
         model_class=RawReadsTableEntry,
         reraise=False,
@@ -461,10 +468,10 @@ def raw_reads_table_create(db_engine: Engine, config: Config, slack_config: Slac
             if not has_raw_reads_changed(config, db_engine, submission_row):
                 update_raw_reads_results_with_latest_version(db_engine, seq_key)
                 continue
-            last_version_raw_reads = last_raw_reads_entry(db_engine, seq_key, raise_on_empty=False)
+            last_version_entry = previous_version_raw_reads_entry(db_engine, seq_key)
             old_run_accession = (
-                last_version_raw_reads[0].result.get(EnaResultField.RUN)
-                if last_version_raw_reads and last_version_raw_reads[0].result
+                (last_version_entry.result or {}).get(EnaResultField.RUN)
+                if last_version_entry
                 else None
             )
 


### PR DESCRIPTION
Small refactor - it's better to handle errors in the caller rather than passing in a boolean `raise_on_empty`. Also make function names clearer (we're looking for previous version not last version - last can mean latest)

<details>

Stacked on `ena-test-improvements`, so review that one first — the diff here is just the top commit.

`last_raw_reads_entry` grew a `raise_on_empty` boolean because its two callers want different things. That flag is really carrying a piece of domain knowledge that is easy to lose: a revision is *not* guaranteed to have a previous raw_reads_table row, because the previous version may simply not have had raw reads attached. Meanwhile `update_raw_reads_results_with_latest_version` genuinely cannot proceed without one, since it copies that row's `result` forward.

Rather than a parameter that switches whether the function raises, the lookup is now total — it returns the row or `None` — and the one caller that needs an error raises it. The fact that an empty result is legitimate moves into a docstring where it can be read.

The knock-on effects are the actual readability win: both call sites stop indexing `[0]` into a list that can only ever hold one row, and the `old_run_accession` expression drops from a three-part conditional to a two-part one.

I renamed it to `previous_version_raw_reads_entry` for two reasons — it is the entry for `previous_version(...)` rather than the last entry in any general sense, and `last_raw_reads_entry` sitting next to the existing `get_last_entry` invited exactly the confusion between the submission_table and raw_reads_table lookups that this area already has. Happy to drop the rename if you would rather keep the diff smaller.

One unrelated one-character fix rode along, since it is inside the function being edited: the log line read "as there wasno change in raw read data".

Deliberately not touched here: mypy already reports three errors in this file for `library_source`, `library_selection` and `library_strategy` being passed as possibly-`None` to fields typed non-optional. That is a separate question about the removed `from_value` defaults, not something this refactor should decide, and the error count is identical before and after this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

https://claude.ai/code/session_01XVDB6dSsq7JHadkgyTkq7d

🚀 Preview: Add `preview` label to enable