### PR TITLE
ci(ena-submission): add mypy type checking

### DIFF
--- a/.github/workflows/ena-submission-unit-tests.yaml
+++ b/.github/workflows/ena-submission-unit-tests.yaml
@@ -44,6 +44,23 @@ jobs:
           cache-environment: true
       - name: Run ruff check
         run: ruff check .
+  typeCheck:
+    name: Type Checking
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v3
+        with:
+          environment-file: "ena-submission/environment.yml"
+          micromamba-version: "latest"
+          cache-environment: true
+      - name: Install package
+        run: |
+            uv pip install --system .
+      - name: Run mypy (checks type hints)
+        run: mypy --config-file .mypy.ini
   unitTests:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/ena-submission/.mypy.ini
+++ b/ena-submission/.mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+python_version = 3.14
+# Only src/ is type checked for now; test/ still has errors, see the PR that added this.
+files = src

--- a/ena-submission/environment.yml
+++ b/ena-submission/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - click=8.4.2
   - ena-webin-cli=9.0.3
   - fastapi=0.141.1
+  - uvicorn=0.52.4
   - pydantic=2.13.5
   - jsonlines=4.0.0
   - pyyaml=6.0.3
@@ -25,6 +26,7 @@ dependencies:
   - biopython=1.88
   - pytz=2025.2
   - ruff=0.14.2 # if changing update .pre-commit-config.yaml as well
+  - mypy=2.3.1
   - tenacity=9.1.4
   - types-pytz=2025.2.0.20250809
   - types-psycopg2=2.9.21.20251012

--- a/ena-submission/src/ena_deposition/__main__.py
+++ b/ena-submission/src/ena_deposition/__main__.py
@@ -35,7 +35,6 @@ logger = logging.getLogger(__name__)
 )
 def run(config_file: str, input_file: str | None) -> None:
     logging.basicConfig(
-        encoding="utf-8",
         level=logging.INFO,
         format="%(asctime)s %(levelname)8s (%(filename)20s:%(lineno)4d) - %(message)s ",
         datefmt="%H:%M:%S",

--- a/ena-submission/src/ena_deposition/check_external_visibility.py
+++ b/ena-submission/src/ena_deposition/check_external_visibility.py
@@ -236,7 +236,7 @@ def get_accessions_to_check(
     Returns:
         Set of accessions to check
     """
-    accessions = set()
+    accessions: set[str] = set()
 
     if not isinstance(entity.result, dict):
         msg = (
@@ -246,7 +246,7 @@ def get_accessions_to_check(
         raise TypeError(msg)
 
     for key, value in entity.result.items():
-        if key.startswith(column_config.accession_field_name_prefix) and value:
+        if key.startswith(column_config.accession_field_name_prefix) and isinstance(value, str):
             accessions.add(value)
 
     return accessions

--- a/ena-submission/src/ena_deposition/submission_db_helper.py
+++ b/ena-submission/src/ena_deposition/submission_db_helper.py
@@ -10,6 +10,7 @@ from typing import Any, Final, cast
 
 import pytz
 from sqlalchemy import (
+    CursorResult,
     DateTime,
     Engine,
     Enum,
@@ -146,7 +147,9 @@ class SubmissionTableEntry(Base):
     """Maps to submission_table. Primary key: (accession, version)."""
 
     __tablename__ = "submission_table"
-    __table_args__: typing.ClassVar[dict[str, Any]] = {"schema": "ena_deposition_schema"}
+    __table_args__: typing.ClassVar[dict[str, Any]] = {  # type: ignore[misc]
+        "schema": "ena_deposition_schema"
+    }
 
     # Required fields (no defaults) must come first for dataclass ordering.
     accession: Mapped[str] = mapped_column(primary_key=True)
@@ -185,7 +188,7 @@ class ProjectTableEntry(Base):
     """Maps to project_table. Primary key: project_id (BIGSERIAL)."""
 
     __tablename__ = "project_table"
-    __table_args__: typing.ClassVar[tuple[Any, ...]] = (
+    __table_args__: typing.ClassVar[tuple[Any, ...]] = (  # type: ignore[misc]
         Index("idx_project_table_group_id", "group_id"),
         Index("idx_project_table_organism", "organism"),
         {"schema": "ena_deposition_schema"},
@@ -223,7 +226,9 @@ class SampleTableEntry(Base):
     """Maps to sample_table. Primary key: (accession, version)."""
 
     __tablename__ = "sample_table"
-    __table_args__: typing.ClassVar[dict[str, Any]] = {"schema": "ena_deposition_schema"}
+    __table_args__: typing.ClassVar[dict[str, Any]] = {  # type: ignore[misc]
+        "schema": "ena_deposition_schema"
+    }
 
     accession: Mapped[str] = mapped_column(primary_key=True)
     version: Mapped[int] = mapped_column(primary_key=True)
@@ -252,7 +257,9 @@ class AssemblyTableEntry(Base):
     """Maps to assembly_table. Primary key: (accession, version)."""
 
     __tablename__ = "assembly_table"
-    __table_args__: typing.ClassVar[dict[str, Any]] = {"schema": "ena_deposition_schema"}
+    __table_args__: typing.ClassVar[dict[str, Any]] = {  # type: ignore[misc]
+        "schema": "ena_deposition_schema"
+    }
 
     accession: Mapped[str] = mapped_column(primary_key=True)
     version: Mapped[int] = mapped_column(primary_key=True)
@@ -340,7 +347,7 @@ def delete_records_in_db[T: TableEntry](
             stmt = stmt.where(col.is_(None)) if value is None else stmt.where(col == value)
         result = session.execute(stmt)
         session.commit()
-        deleted_rows = result.rowcount
+        deleted_rows = cast("CursorResult[Any]", result).rowcount
     logger.debug(f"Deleted {deleted_rows} rows from '{model_class.__name__}' where {conditions}")
     return deleted_rows
 
@@ -431,7 +438,7 @@ def update_db_where_conditions[T: TableEntry](
             stmt = stmt.values(**update_values)
             result = session.execute(stmt)
             session.commit()
-            updated_row_count = result.rowcount
+            updated_row_count = cast("CursorResult[Any]", result).rowcount
     except Exception as e:
         logger.warning(f"update_db_where_conditions errored with: {e}")
     logger.debug(


### PR DESCRIPTION
`ena-submission` was the only Python module besides `ingest` with no type checking in CI — even though its `pyproject.toml` already declares `types-pytz`, `types-xmltodict`, `types-requests` and `types-pyyaml` in the `test` extra. The stubs were there; the checker never ran. This adds it, mirroring what `preprocessing` and `loculus-silo` already do.

Prompted by review discussion on #7290, where an annotation regression went unnoticed because nothing checks this module.

### What's here

A `typeCheck` job in `ena-submission-unit-tests.yaml`, `mypy=2.3.1` pinned in `environment.yml` next to the existing `ruff` pin, and a minimal `.mypy.ini`. Then the 8 errors mypy found on `main`.

### Two of the fixes change behaviour — please look at these

**`check_external_visibility.py`** — `get_accessions_to_check` returns `set[str]`, but the JSONB `result` column is typed `dict[str, str | Sequence[str]]`, so a list value would reach `set.add()` and raise `TypeError: unhashable type`. I added an `isinstance(value, str)` guard, which skips non-string values instead of crashing. If a list there should instead be flattened into the set, say so and I'll change it.

**`__main__.py`** — dropped `encoding="utf-8"` from `logging.basicConfig`. It's only honoured alongside `filename`, and I verified it's a silent no-op as called here.

### The `__table_args__` ignores

The four `# type: ignore[misc]` comments in `submission_db_helper.py` are a genuine ruff-vs-mypy conflict, not laziness. Ruff's RUF012 requires the mutable class attribute to be annotated `typing.ClassVar`; SQLAlchemy declares `__table_args__: Any` as an instance attribute, so mypy rejects the `ClassVar` override. I confirmed RUF012 does fire on these lines with the annotation removed. Suppressing the mypy side keeps the annotation that ruff wants.

### Also

`uvicorn` is imported by `api.py` but was declared nowhere — not in `environment.yml`, and `pyproject.toml` has no runtime dependencies at all. Added to `environment.yml`. Worth a sanity check that the API server actually starts today.

### Scope

`.mypy.ini` sets `files = src`, so `test/` is not checked — it has ~31 errors (mostly `arg-type`), which is a separate PR. Local `mypy` runs then match CI rather than showing errors the gate ignores.

### Testing

`mypy --config-file .mypy.ini` clean (16 files), `ruff check`/`ruff format` baseline unchanged from `main`, and the CI unit-test subset passes (19 tests).

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests. (No new tests: this adds a CI gate and fixes what it flagged. The gate itself is the check. The `isinstance` guard is a behaviour change with no test covering it — flagged above.)
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174FTG71ACpTDWqAEpFy9WQ

🚀 Preview: Add `preview` label to enable
