### PR TITLE
feat(raw-reads-processing): improve error message if user submits interleaved fastq files

### DIFF
--- a/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
+++ b/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
@@ -57,6 +57,7 @@ def _condense_duplicate_read_name_errors(details: str) -> str:
         "interleaved FASTQ, with forward and reverse mates stored together. "
         f"{PAIRED_END_SUBMISSION_HINT} "
         "Please submit one file for the forward reads and one for the reverse reads."
+        "Only a maximum of 2 FASTQ files are allowed per submission."  # keep in sync with validate_file_numbers()
     )
     stripped = _DUPLICATE_READ_NAME_RE.sub("", details)
     remainder = "; ".join(filter(None, (part.strip() for part in stripped.split(";"))))
@@ -143,6 +144,7 @@ def validate_file_numbers(file_format: FileFormat, file_names: list[FileName]) -
         # but it treats every 1+i file as a paired read of the first file.
         # ENA documents that multi-FASTQs should be submitted using a JSON manifest,
         # which we don't support, so we enforce a stricter limit here.
+        # Keep in sync with the message in _condense_duplicate_read_name_errors().
         raise InvalidSubmission(
             error=Annotation(
                 fileNames=file_names,

--- a/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
+++ b/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
@@ -28,6 +28,7 @@ ACCEPTED_FORMATS = [FileFormat.FASTQ]
 PAIRED_END_SUBMISSION_HINT = (
     "Paired-end FASTQ files must be submitted as separate, de-interleaved files."
 )
+FASTQ_NUMBER_HINT = "We only allow 1 FASTQ file for single-end reads or 2 FASTQ files for paired-end reads."
 
 
 _DUPLICATE_READ_NAME_RE = re.compile(
@@ -57,7 +58,7 @@ def _condense_duplicate_read_name_errors(details: str) -> str:
         "interleaved FASTQ, with forward and reverse mates stored together. "
         f"{PAIRED_END_SUBMISSION_HINT} "
         "Please submit one file for the forward reads and one for the reverse reads."
-        "Only a maximum of 2 FASTQ files are allowed per submission."  # keep in sync with validate_file_numbers()
+        f" {FASTQ_NUMBER_HINT}"
     )
     stripped = _DUPLICATE_READ_NAME_RE.sub("", details)
     remainder = "; ".join(filter(None, (part.strip() for part in stripped.split(";"))))
@@ -144,13 +145,11 @@ def validate_file_numbers(file_format: FileFormat, file_names: list[FileName]) -
         # but it treats every 1+i file as a paired read of the first file.
         # ENA documents that multi-FASTQs should be submitted using a JSON manifest,
         # which we don't support, so we enforce a stricter limit here.
-        # Keep in sync with the message in _condense_duplicate_read_name_errors().
         raise InvalidSubmission(
             error=Annotation(
                 fileNames=file_names,
                 message=(
-                    f"Too many FASTQ files submitted ({len(file_names)}). We only allow"
-                    " 1 FASTQ file for single-end reads or 2 FASTQ files for paired-end reads."
+                    f"Too many FASTQ files submitted ({len(file_names)}). {FASTQ_NUMBER_HINT}"
                 ),
             )
         )

--- a/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
+++ b/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
@@ -48,7 +48,7 @@ def _condense_duplicate_read_name_errors(details: str) -> str:
     of them with a single message that states what was found, the likely cause,
     and what to do, quoting only the first offending read name as an example.
     """
-    first_match = _DUPLICATE_READ_NAME_RE.match(details.lstrip())
+    first_match = _DUPLICATE_READ_NAME_RE.search(details)
     if first_match is None:
         return details
     condensed = (
@@ -58,7 +58,8 @@ def _condense_duplicate_read_name_errors(details: str) -> str:
         f"{PAIRED_END_SUBMISSION_HINT} "
         "Please submit one file for the forward reads and one for the reverse reads."
     )
-    remainder = _DUPLICATE_READ_NAME_RE.sub("", details).strip(" ;")
+    stripped = _DUPLICATE_READ_NAME_RE.sub("", details)
+    remainder = "; ".join(filter(None, (part.strip() for part in stripped.split(";"))))
     return f"{condensed}; {remainder}" if remainder else condensed
 
 

--- a/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
+++ b/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
@@ -42,8 +42,9 @@ def _condense_duplicate_read_name_errors(details: str) -> str:
 
         Multiple (2) occurrences of read name "ERR17356121.13 ..."
 
-    for *every* mate pair that shares a name, so the error can run to hundreds of
-    near-identical entries. If the details start with such an entry, replace all
+    for *every* mate pair that shares a name.
+    
+    If the details start with such an entry, replace all
     of them with a single message that states what was found, the likely cause,
     and what to do, quoting only the first offending read name as an example.
     """

--- a/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
+++ b/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
@@ -43,7 +43,7 @@ def _condense_duplicate_read_name_errors(details: str) -> str:
         Multiple (2) occurrences of read name "ERR17356121.13 ..."
 
     for *every* mate pair that shares a name.
-    
+
     If the details start with such an entry, replace all
     of them with a single message that states what was found, the likely cause,
     and what to do, quoting only the first offending read name as an example.

--- a/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
+++ b/raw-reads-processing/src/raw_reads_processing/file_format_validation.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import subprocess  # noqa: S404
 from enum import StrEnum
 from pathlib import Path
@@ -24,6 +25,41 @@ ACCEPTED_CRAM_EXTENSIONS = {".cram"}
 
 ACCEPTED_FORMATS = [FileFormat.FASTQ]
 
+PAIRED_END_SUBMISSION_HINT = (
+    "Paired-end FASTQ files must be submitted as separate, de-interleaved files."
+)
+
+
+_DUPLICATE_READ_NAME_RE = re.compile(
+    r'Multiple \(\d+\) occurrences of read name "([^"]*)"'
+)
+
+
+def _condense_duplicate_read_name_errors(details: str) -> str:
+    """Collapse readtools' per-read duplicate-name complaints into one hint.
+
+    When a single interleaved FASTQ is validated as unpaired, readtools emits
+
+        Multiple (2) occurrences of read name "ERR17356121.13 ..."
+
+    for *every* mate pair that shares a name, so the error can run to hundreds of
+    near-identical entries. If the details start with such an entry, replace all
+    of them with a single message that states what was found, the likely cause,
+    and what to do, quoting only the first offending read name as an example.
+    """
+    first_match = _DUPLICATE_READ_NAME_RE.match(details.lstrip())
+    if first_match is None:
+        return details
+    condensed = (
+        "The same read name appears more than once in this file "
+        f'(for example "{first_match.group(1)}"). This usually means the file is an '
+        "interleaved FASTQ, with forward and reverse mates stored together. "
+        f"{PAIRED_END_SUBMISSION_HINT} "
+        "Please submit one file for the forward reads and one for the reverse reads."
+    )
+    remainder = _DUPLICATE_READ_NAME_RE.sub("", details).strip(" ;")
+    return f"{condensed}; {remainder}" if remainder else condensed
+
 
 def _parse_validation_error(stdout: str, stderr: str) -> str:
     """Extract the reason readtools reported RESULT: INVALID.
@@ -43,6 +79,7 @@ def _parse_validation_error(stdout: str, stderr: str) -> str:
 
     details = stdout[marker_pos:].partition("\n")[2]
     details = "; ".join(filter(None, map(str.strip, details.splitlines())))
+    details = _condense_duplicate_read_name_errors(details)
     return f"File validation failed while running ENA readtools. {details}".rstrip()
 
 
@@ -71,9 +108,6 @@ def validate_file_extensions(
 ) -> FileFormat:
     """Validate that all files have extensions consistent with the accepted formats."""
     file_formats = {determine_file_format(file_name) for file_name in file_names}
-    paired_end_info = (
-        "Paired-end FASTQ files must be submitted as separate, de-interleaved files."
-    )
     if len(file_formats) > 1:
         raise InvalidSubmission(
             error=Annotation(
@@ -81,7 +115,7 @@ def validate_file_extensions(
                 message=(
                     "Input files have mixed formats. Please provide files with consistent and "
                     f"supported formats: {', '.join(accepted_formats)} "
-                    f"{paired_end_info}"
+                    f"{PAIRED_END_SUBMISSION_HINT}"
                 ),
             )
         )
@@ -92,7 +126,7 @@ def validate_file_extensions(
                 fileNames=file_names,
                 message=(
                     f"File is not in accepted format: {', '.join(accepted_formats)}. "
-                    f"{paired_end_info}"
+                    f"{PAIRED_END_SUBMISSION_HINT}"
                 ),
             )
         )

--- a/raw-reads-processing/test/test_file_validation.py
+++ b/raw-reads-processing/test/test_file_validation.py
@@ -206,8 +206,12 @@ def test_interleaved_fastq_in_single_file_is_rejected(tmp_path):
     reads = _write(tmp_path, "interleaved.fastq", INTERLEAVED_SAME_NAME)
     with pytest.raises(InvalidSubmission) as exc_info:
         validate_with_readtools({"interleaved.fastq": Path(reads)}, FileFormat.FASTQ)
-    assert "Multiple" in exc_info.value.error.message
-    assert "occurrences of read name" in exc_info.value.error.message
+    message = exc_info.value.error.message
+    assert "The same read name appears more than once in this file" in message
+    assert 'for example "read1"' in message
+    assert "de-interleaved files" in message
+    # The verbose per-read readtools lines are collapsed into the single hint.
+    assert "occurrences of read name" not in message
 
 
 @pytest.mark.usefixtures("readtools_jar")
@@ -304,6 +308,49 @@ def test_parse_validation_error_handles_qualified_result_line():
     assert (
         message
         == "File validation failed while running ENA readtools. htsjdk.samtools.FileTruncatedException: Premature end of file: data stream"
+    )
+
+
+def test_parse_validation_error_condenses_duplicate_read_name_spam():
+    """An interleaved FASTQ trips readtools' duplicate-read-name check once per
+    shared pair, so the raw error is a huge run of near-identical lines. We
+    collapse them into one hint that names only the first offending read.
+    """
+    raw = (
+        'Multiple (2) occurrences of read name "ERR17356121.13 VH00852:178:AAJ7F5MM5:1:1101:5734:28792 length=121"'
+        'Multiple (2) occurrences of read name "ERR17356121.17 VH00852:178:AAJ7F5MM5:1:1101:5866:23661 length=49"'
+        'Multiple (2) occurrences of read name "ERR17356121.20 VH00852:178:AAJ7F5MM5:1:1101:5885:25952 length=120"'
+    )
+    message = _parse_validation_error(f"RESULT: INVALID\n  {raw}\n", "")
+    assert message == (
+        "File validation failed while running ENA readtools. Detected read pairs with "
+        "the same name, if you are submitting interleaved fastq files please split your "
+        'fastq file into two files (first shared read name: "ERR17356121.13 '
+        'VH00852:178:AAJ7F5MM5:1:1101:5734:28792 length=121")'
+    )
+
+
+def test_parse_validation_error_condenses_newline_separated_duplicate_read_names():
+    message = _parse_validation_error(
+        "RESULT: INVALID\n"
+        '  Multiple (2) occurrences of read name "read1"\n'
+        '  Multiple (2) occurrences of read name "read2"\n',
+        "",
+    )
+    assert message == (
+        "File validation failed while running ENA readtools. Detected read pairs with "
+        "the same name, if you are submitting interleaved fastq files please split your "
+        'fastq file into two files (first shared read name: "read1")'
+    )
+
+
+def test_parse_validation_error_leaves_unrelated_errors_untouched():
+    message = _parse_validation_error(
+        "RESULT: INVALID\n  Sequence and quality strings must be the same length\n", ""
+    )
+    assert message == (
+        "File validation failed while running ENA readtools. "
+        "Sequence and quality strings must be the same length"
     )
 
 

--- a/raw-reads-processing/test/test_file_validation.py
+++ b/raw-reads-processing/test/test_file_validation.py
@@ -208,7 +208,8 @@ def test_interleaved_fastq_in_single_file_is_rejected(tmp_path):
         validate_with_readtools({"interleaved.fastq": Path(reads)}, FileFormat.FASTQ)
     message = exc_info.value.error.message
     assert "The same read name appears more than once in this file" in message
-    assert 'for example "read1"' in message
+    # readtools reports its duplicate read names in an unspecified order
+    assert 'for example "read1"' in message or 'for example "read2"' in message
     assert "de-interleaved files" in message
     # The verbose per-read readtools lines are collapsed into the single hint.
     assert "occurrences of read name" not in message

--- a/raw-reads-processing/test/test_file_validation.py
+++ b/raw-reads-processing/test/test_file_validation.py
@@ -323,10 +323,12 @@ def test_parse_validation_error_condenses_duplicate_read_name_spam():
     )
     message = _parse_validation_error(f"RESULT: INVALID\n  {raw}\n", "")
     assert message == (
-        "File validation failed while running ENA readtools. Detected read pairs with "
-        "the same name, if you are submitting interleaved fastq files please split your "
-        'fastq file into two files (first shared read name: "ERR17356121.13 '
-        'VH00852:178:AAJ7F5MM5:1:1101:5734:28792 length=121")'
+        "File validation failed while running ENA readtools. The same read name appears "
+        'more than once in this file (for example "ERR17356121.13 '
+        'VH00852:178:AAJ7F5MM5:1:1101:5734:28792 length=121"). This usually means the '
+        "file is an interleaved FASTQ, with forward and reverse mates stored together. "
+        "Paired-end FASTQ files must be submitted as separate, de-interleaved files. "
+        "Please submit one file for the forward reads and one for the reverse reads."
     )
 
 
@@ -338,9 +340,11 @@ def test_parse_validation_error_condenses_newline_separated_duplicate_read_names
         "",
     )
     assert message == (
-        "File validation failed while running ENA readtools. Detected read pairs with "
-        "the same name, if you are submitting interleaved fastq files please split your "
-        'fastq file into two files (first shared read name: "read1")'
+        "File validation failed while running ENA readtools. The same read name appears "
+        'more than once in this file (for example "read1"). This usually means the file '
+        "is an interleaved FASTQ, with forward and reverse mates stored together. "
+        "Paired-end FASTQ files must be submitted as separate, de-interleaved files. "
+        "Please submit one file for the forward reads and one for the reverse reads."
     )
 
 

--- a/raw-reads-processing/test/test_file_validation.py
+++ b/raw-reads-processing/test/test_file_validation.py
@@ -333,13 +333,23 @@ def test_parse_validation_error_condenses_duplicate_read_name_spam(separator):
         f'Multiple (2) occurrences of read name "{name}"' for name in read_names
     )
     message = _parse_validation_error(f"RESULT: INVALID\n  {raw}\n", "")
-    assert message == (
-        "File validation failed while running ENA readtools. The same read name appears "
+    assert (
         f'more than once in this file (for example "{read_names[0]}"). This usually '
-        "means the file is an interleaved FASTQ, with forward and reverse mates stored "
-        "together. Paired-end FASTQ files must be submitted as separate, de-interleaved "
-        "files. Please submit one file for the forward reads and one for the reverse reads."
+        in message
     )
+    assert "occurrences of read name" not in message
+
+    def test_parse_validation_error_condenses_duplicates_among_other_errors():
+        message = _parse_validation_error(
+            "RESULT: INVALID\n"
+            "  Sequence and quality strings must be the same length\n"
+            '  Multiple (2) occurrences of read name "read1"\n'
+            '  Multiple (2) occurrences of read name "read2"\n',
+            "",
+        )
+        assert "The same read name appears more than once" in message
+        assert "Sequence and quality strings must be the same length" in message
+        assert "occurrences of read name" not in message
 
 
 def test_parse_validation_error_leaves_unrelated_errors_untouched():

--- a/raw-reads-processing/test/test_file_validation.py
+++ b/raw-reads-processing/test/test_file_validation.py
@@ -311,40 +311,33 @@ def test_parse_validation_error_handles_qualified_result_line():
     )
 
 
-def test_parse_validation_error_condenses_duplicate_read_name_spam():
+@pytest.mark.parametrize(
+    "separator",
+    [
+        "",
+        "\n  ",
+    ],
+)
+def test_parse_validation_error_condenses_duplicate_read_name_spam(separator):
     """An interleaved FASTQ trips readtools' duplicate-read-name check once per
-    shared pair, so the raw error is a huge run of near-identical lines. We
-    collapse them into one hint that names only the first offending read.
+    shared pair. Test we collapse them into one hint with the first offending
+    read name, and that it works for different separators.
     """
-    raw = (
-        'Multiple (2) occurrences of read name "ERR17356121.13 VH00852:178:AAJ7F5MM5:1:1101:5734:28792 length=121"'
-        'Multiple (2) occurrences of read name "ERR17356121.17 VH00852:178:AAJ7F5MM5:1:1101:5866:23661 length=49"'
-        'Multiple (2) occurrences of read name "ERR17356121.20 VH00852:178:AAJ7F5MM5:1:1101:5885:25952 length=120"'
+    read_names = [
+        "ERR17356121.13 VH00852:178:AAJ7F5MM5:1:1101:5734:28792 length=121",
+        "ERR17356121.17 VH00852:178:AAJ7F5MM5:1:1101:5866:23661 length=49",
+        "ERR17356121.20 VH00852:178:AAJ7F5MM5:1:1101:5885:25952 length=120",
+    ]
+    raw = separator.join(
+        f'Multiple (2) occurrences of read name "{name}"' for name in read_names
     )
     message = _parse_validation_error(f"RESULT: INVALID\n  {raw}\n", "")
     assert message == (
         "File validation failed while running ENA readtools. The same read name appears "
-        'more than once in this file (for example "ERR17356121.13 '
-        'VH00852:178:AAJ7F5MM5:1:1101:5734:28792 length=121"). This usually means the '
-        "file is an interleaved FASTQ, with forward and reverse mates stored together. "
-        "Paired-end FASTQ files must be submitted as separate, de-interleaved files. "
-        "Please submit one file for the forward reads and one for the reverse reads."
-    )
-
-
-def test_parse_validation_error_condenses_newline_separated_duplicate_read_names():
-    message = _parse_validation_error(
-        "RESULT: INVALID\n"
-        '  Multiple (2) occurrences of read name "read1"\n'
-        '  Multiple (2) occurrences of read name "read2"\n',
-        "",
-    )
-    assert message == (
-        "File validation failed while running ENA readtools. The same read name appears "
-        'more than once in this file (for example "read1"). This usually means the file '
-        "is an interleaved FASTQ, with forward and reverse mates stored together. "
-        "Paired-end FASTQ files must be submitted as separate, de-interleaved files. "
-        "Please submit one file for the forward reads and one for the reverse reads."
+        f'more than once in this file (for example "{read_names[0]}"). This usually '
+        "means the file is an interleaved FASTQ, with forward and reverse mates stored "
+        "together. Paired-end FASTQ files must be submitted as separate, de-interleaved "
+        "files. Please submit one file for the forward reads and one for the reverse reads."
     )
 
 


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/7203, partially resolves https://github.com/loculus-project/loculus/issues/6856

### Screenshot
<img width="1459" height="649" alt="image" src="https://github.com/user-attachments/assets/2d4e6f53-6920-432f-b9f1-3a4b3c03b2f3" />
instead of 
<img width="1842" height="586" alt="Image" src="https://github.com/user-attachments/assets/480a9256-893e-4ecd-8c6a-58d9d6bdf263" />

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [x] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
I submitted interleaved raw reads fastq files that I downloaded from INSDC (https://trace.ncbi.nlm.nih.gov/Traces/?view=run_browser&acc=ERR17773643&display=download) and confirmed they error as expected

🚀 Preview: https://interleaved-fastq.loculus.org