### PR TITLE
fix(deployment): increase time before LAPIS readiness probe fails to 1min from 30s

### DIFF
--- a/kubernetes/loculus/templates/lapis-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-deployment.yaml
@@ -56,7 +56,6 @@ spec:
             httpGet:
               path: /sample/info
               port: 8080
-            # 60s of continuous failure before eviction; LAPIS gives its SILO call only 100ms
             periodSeconds: 5
             failureThreshold: 12
             timeoutSeconds: 5

--- a/kubernetes/loculus/templates/lapis-deployment.yaml
+++ b/kubernetes/loculus/templates/lapis-deployment.yaml
@@ -56,8 +56,9 @@ spec:
             httpGet:
               path: /sample/info
               port: 8080
-            periodSeconds: 10
-            failureThreshold: 3
+            # 60s of continuous failure before eviction; LAPIS gives its SILO call only 100ms
+            periodSeconds: 5
+            failureThreshold: 12
             timeoutSeconds: 5
           livenessProbe:
             httpGet:


### PR DESCRIPTION
Chromium e2e sometimes fails with 503 (from traefik) because LAPIS fails readiness probe when it times out (timeout just 100ms) asking silo whether it's up. Silo actually replies just fine, delay seems to be on LAPIS side. 100ms is definitely too short for this but we can't make that change here - needs to be upstream LAPIS. 100ms can be breached under load.

Quick mitigations we can make ourselves here:
- require more evidence of issues before declaring unready (increase readiness probe failure threshold)
- increase readiness probe frequency from once every 10s to 5s to recover more quickly

I'll make some PRs on LAPIS side as well but these changes here wouldn't harm.

<details>
<summary>Claude desc</summary>

One chromium integration test failed in [run 33877810215](https://github.com/loculus-project/loculus/actions/runs/33877810215/job/101038909532) on a single `503` that had nothing to do with the test: the group page asks every organism's LAPIS for its sequence count, and the pod for `dummy-organism-with-files` had just been dropped from its Service endpoints, so Traefik answered with an empty backend list. SILO was never down — it answered its own `/info` in under a millisecond throughout, never restarted, and its importer was idle. What had happened is that LAPIS's readiness probe failed four times in a row, crossing `failureThreshold: 3`, and the pod stayed out of rotation for about ten seconds.

The probe fails because `/sample/info` makes a live call to SILO on every request, and that call is given a hard-coded budget of 100 milliseconds ([SiloClient.kt:179](https://github.com/GenSpectrum/LAPIS/blob/511965390e2f6c13d38c093c4402e9bee404cf8f/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt#L179), added in [LAPIS #1593](https://github.com/GenSpectrum/LAPIS/pull/1593) so that the health endpoint would not block). Since SILO itself was answering instantly, that 100 ms was spent somewhere on the LAPIS side under load, which on a CI runner hosting seven organisms' worth of services is easy to believe. Worth knowing before anyone tries to tune this from the chart: the `timeoutSeconds: 5` on the probe is inert, because the application gives up long before the probe does.

Counting every probe in that job's archived logs, all eight organisms together, gives 30 failures out of 683 probes, and the failures arrive in bursts rather than independently — the one burst that actually evicted a pod lasted 20 seconds of observed failure and at most 40 seconds. What matters is how long a bad window LAPIS can ride out, which is `periodSeconds` multiplied by `failureThreshold`: 30 seconds today, so a 40-second window wins. This change makes that 60 seconds. Going to a shorter period with a proportionally higher threshold, rather than just raising the threshold, keeps the same tolerance while halving how long recovery takes after an eviction and logging the first failure sooner. It cannot delay a pod becoming ready in the first place: Kubernetes starts a container not-ready and promotes it on the first successful probe, and `failureThreshold` only governs the demotion, so `wait_for_pods_to_be_ready.py` still waits for genuine readiness.

Two judgement calls to push back on if you disagree. The numbers come from one burst in one job on one runner, so the 60 seconds is a reasoned guess with roughly 1.5x margin rather than a measured requirement — 10 seconds with a threshold of 6 gets the same tolerance if you would rather not double the probe rate, at the cost of slower recovery. And the threshold is deliberately left finite rather than made enormous: a LAPIS that genuinely cannot reach SILO, say from a wrong URL, should still go not-ready so that it shows up in `kubectl get pods` and fails the deployment's readiness wait. Deliberately not addressed here: the 100 ms budget itself, and the fact that a timeout is currently classified as an unexpected error and returns `500` rather than taking LAPIS's existing "SILO not reachable" path to a `503` with a message ([SiloClient.kt:246-250](https://github.com/GenSpectrum/LAPIS/blob/511965390e2f6c13d38c093c4402e9bee404cf8f/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt#L246-L250) — `HttpTimeoutException` is not a `ConnectException`), both of which live upstream in LAPIS. I also left the CPU requests for `silo` and `lapis` alone, though they are the only knob here that would address the cause rather than the symptom.

</details>

🚀 Preview: Add `preview` label to enable