### PR TITLE
experiment: refactor prepro datatypes

### DIFF
--- a/kubernetes/loculus/values.yaml
+++ b/kubernetes/loculus/values.yaml
@@ -1881,7 +1881,6 @@ defaultOrganisms:
               geoLocCountry: geoLocCountry
               sampleCollectionDateRangeLower: processed.sampleCollectionDateRangeLower
               specimenCollectorSampleId: specimenCollectorSampleId
-              submissionId: submissionId
             args:
               order: [geoLocCountry, IDENTIFIER, sampleCollectionDateRangeLower]
               type: [string, IDENTIFIER, string]

--- a/preprocessing/nextclade/src/loculus_preprocessing/backend.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/backend.py
@@ -22,7 +22,6 @@ from .datatypes import (
     FileUploadInfo,
     ProcessedEntry,
     SubmissionContext,
-    UnprocessedData,
     UnprocessedEntry,
 )
 from .processing_functions import trim_ns
@@ -108,7 +107,7 @@ def parse_ndjson(ndjson_data: str, config: Config) -> Sequence[UnprocessedEntry]
             if submitted_files
             else None
         )
-        unprocessed_data = UnprocessedData(
+        entry = UnprocessedEntry(
             submissionContext=SubmissionContext(
                 accessionVersion=f"{json_object['accession']}.{json_object['version']}",
                 submitter=json_object["submitter"],
@@ -123,7 +122,7 @@ def parse_ndjson(ndjson_data: str, config: Config) -> Sequence[UnprocessedEntry]
             else {},
             files=file_mapping,
         )
-        entries.append(UnprocessedEntry(data=unprocessed_data))
+        entries.append(entry)
     return entries
 
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/backend.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/backend.py
@@ -21,7 +21,7 @@ from .datatypes import (
     FileIdAndNameAndReadUrl,
     FileUploadInfo,
     ProcessedEntry,
-    SubmissionDetails,
+    SubmissionContext,
     UnprocessedData,
     UnprocessedEntry,
 )
@@ -108,8 +108,10 @@ def parse_ndjson(ndjson_data: str, config: Config) -> Sequence[UnprocessedEntry]
             if submitted_files
             else None
         )
+        accession_version = f"{json_object['accession']}.{json_object['version']}"
         unprocessed_data = UnprocessedData(
-            submissionDetails=SubmissionDetails(
+            submissionContext=SubmissionContext(
+                accessionVersion=accession_version,
                 submitter=json_object["submitter"],
                 group_id=json_object["groupId"],
                 submittedAt=json_object["submittedAt"],
@@ -123,7 +125,7 @@ def parse_ndjson(ndjson_data: str, config: Config) -> Sequence[UnprocessedEntry]
             files=file_mapping,
         )
         entry = UnprocessedEntry(
-            accessionVersion=f"{json_object['accession']}.{json_object['version']}",
+            accessionVersion=accession_version,
             data=unprocessed_data,
         )
         entries.append(entry)

--- a/preprocessing/nextclade/src/loculus_preprocessing/backend.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/backend.py
@@ -108,15 +108,14 @@ def parse_ndjson(ndjson_data: str, config: Config) -> Sequence[UnprocessedEntry]
             if submitted_files
             else None
         )
-        accession_version = f"{json_object['accession']}.{json_object['version']}"
         unprocessed_data = UnprocessedData(
             submissionContext=SubmissionContext(
-                accessionVersion=accession_version,
+                accessionVersion=f"{json_object['accession']}.{json_object['version']}",
                 submitter=json_object["submitter"],
-                group_id=json_object["groupId"],
+                group_id=int(json_object["groupId"]),
                 submittedAt=json_object["submittedAt"],
                 submissionId=json_object["submissionId"],
-                is_insdc_ingest_group=json_object["groupId"] == config.insdc_ingest_group_id,
+                insdc_ingest_group_id=config.insdc_ingest_group_id,
             ),
             metadata=json_object["data"]["metadata"],
             unalignedNucleotideSequences=trimmed_unaligned_nucleotide_sequences
@@ -124,11 +123,7 @@ def parse_ndjson(ndjson_data: str, config: Config) -> Sequence[UnprocessedEntry]
             else {},
             files=file_mapping,
         )
-        entry = UnprocessedEntry(
-            accessionVersion=accession_version,
-            data=unprocessed_data,
-        )
-        entries.append(entry)
+        entries.append(UnprocessedEntry(data=unprocessed_data))
     return entries
 
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/backend.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/backend.py
@@ -21,6 +21,7 @@ from .datatypes import (
     FileIdAndNameAndReadUrl,
     FileUploadInfo,
     ProcessedEntry,
+    SubmissionDetails,
     UnprocessedData,
     UnprocessedEntry,
 )
@@ -76,7 +77,7 @@ def get_jwt(config: Config) -> str:
         raise Exception(error_msg)
 
 
-def parse_ndjson(ndjson_data: str) -> Sequence[UnprocessedEntry]:
+def parse_ndjson(ndjson_data: str, config: Config) -> Sequence[UnprocessedEntry]:
     entries: list[UnprocessedEntry] = []
     if len(ndjson_data) == 0:
         return entries
@@ -108,10 +109,13 @@ def parse_ndjson(ndjson_data: str) -> Sequence[UnprocessedEntry]:
             else None
         )
         unprocessed_data = UnprocessedData(
-            submitter=json_object["submitter"],
-            group_id=json_object["groupId"],
-            submittedAt=json_object["submittedAt"],
-            submissionId=json_object["submissionId"],
+            submissionDetails=SubmissionDetails(
+                submitter=json_object["submitter"],
+                group_id=json_object["groupId"],
+                submittedAt=json_object["submittedAt"],
+                submissionId=json_object["submissionId"],
+                is_insdc_ingest_group=json_object["groupId"] == config.insdc_ingest_group_id,
+            ),
             metadata=json_object["data"]["metadata"],
             unalignedNucleotideSequences=trimmed_unaligned_nucleotide_sequences
             if unaligned_nucleotide_sequences
@@ -152,7 +156,7 @@ def fetch_unprocessed_sequences(
             return etag, None
         case HTTPStatus.OK:
             try:
-                parsed_ndjson = parse_ndjson(response.text)
+                parsed_ndjson = parse_ndjson(response.text, config)
             except ValueError as e:
                 logger.error(f"[{request_id}] {e}")
                 time.sleep(10 * 1)

--- a/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Iterable
-from dataclasses import dataclass, field
+from dataclasses import InitVar, dataclass, field
 from enum import StrEnum, unique
 from typing import Any, Final
 
@@ -93,16 +93,18 @@ class FileIdAndNameAndReadUrl:
 
 @dataclass
 class SubmissionContext:
-    """Information about the submission that's not provided by the submitter
-    but assigned or attached by Loculus itself
-    """
+    """Submission-level information supplied by the backend alongside the submitted metadata."""
 
     accessionVersion: AccessionVersion  # noqa: N815
     submitter: str
     group_id: int
     submittedAt: str  # timestamp  # noqa: N815
     submissionId: str  # noqa: N815
-    is_insdc_ingest_group: bool
+    insdc_ingest_group_id: InitVar[int]
+    is_insdc_ingest_group: bool = field(init=False)
+
+    def __post_init__(self, insdc_ingest_group_id: int) -> None:
+        self.is_insdc_ingest_group = self.group_id == insdc_ingest_group_id
 
 
 @dataclass
@@ -115,8 +117,11 @@ class UnprocessedData:
 
 @dataclass
 class UnprocessedEntry:
-    accessionVersion: AccessionVersion  # {accession}.{version}  # noqa: N815
     data: UnprocessedData
+
+    @property
+    def accessionVersion(self) -> AccessionVersion:  # {accession}.{version}  # noqa: N802
+        return self.data.submissionContext.accessionVersion
 
 
 FunctionInputs = dict[ArgName, InputField]
@@ -182,8 +187,8 @@ class SubmissionData:
     but the annotations need to be uploaded separately."""
 
     processed_entry: ProcessedEntry
-    submitter: str | None
-    group_id: int | None = None
+    submitter: str
+    group_id: int
     annotations: dict[str, Any] | None = None
 
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
@@ -108,20 +108,15 @@ class SubmissionContext:
 
 
 @dataclass
-class UnprocessedData:
+class UnprocessedEntry:
     submissionContext: SubmissionContext  # noqa: N815
     metadata: InputMetadata
     unalignedNucleotideSequences: dict[SequenceName, NucleotideSequence | None]  # noqa: N815
     files: dict[FileCategory, list[FileIdAndNameAndReadUrl]] | None
 
-
-@dataclass
-class UnprocessedEntry:
-    data: UnprocessedData
-
     @property
     def accessionVersion(self) -> AccessionVersion:  # {accession}.{version}  # noqa: N802
-        return self.data.submissionContext.accessionVersion
+        return self.submissionContext.accessionVersion
 
 
 FunctionInputs = dict[ArgName, InputField]

--- a/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
@@ -92,7 +92,12 @@ class FileIdAndNameAndReadUrl:
 
 
 @dataclass
-class SubmissionDetails:
+class SubmissionContext:
+    """Information about the submission that's not provided by the submitter
+    but assigned or attached by Loculus itself
+    """
+
+    accessionVersion: AccessionVersion  # noqa: N815
     submitter: str
     group_id: int
     submittedAt: str  # timestamp  # noqa: N815
@@ -102,7 +107,7 @@ class SubmissionDetails:
 
 @dataclass
 class UnprocessedData:
-    submissionDetails: SubmissionDetails  # noqa: N815
+    submissionContext: SubmissionContext  # noqa: N815
     metadata: InputMetadata
     unalignedNucleotideSequences: dict[SequenceName, NucleotideSequence | None]  # noqa: N815
     files: dict[FileCategory, list[FileIdAndNameAndReadUrl]] | None
@@ -120,7 +125,7 @@ FunctionArgs = dict[ArgName, ArgValue]
 
 @dataclass
 class UnprocessedAfterNextclade:
-    submissionDetails: SubmissionDetails  # noqa: N815
+    submissionContext: SubmissionContext  # noqa: N815
     inputMetadata: InputMetadata  # noqa: N815
     files: dict[FileCategory, list[FileIdAndNameAndReadUrl]] | None
     # Derived metadata produced by Nextclade

--- a/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/datatypes.py
@@ -92,11 +92,17 @@ class FileIdAndNameAndReadUrl:
 
 
 @dataclass
-class UnprocessedData:
+class SubmissionDetails:
     submitter: str
     group_id: int
     submittedAt: str  # timestamp  # noqa: N815
     submissionId: str  # noqa: N815
+    is_insdc_ingest_group: bool
+
+
+@dataclass
+class UnprocessedData:
+    submissionDetails: SubmissionDetails  # noqa: N815
     metadata: InputMetadata
     unalignedNucleotideSequences: dict[SequenceName, NucleotideSequence | None]  # noqa: N815
     files: dict[FileCategory, list[FileIdAndNameAndReadUrl]] | None
@@ -114,6 +120,7 @@ FunctionArgs = dict[ArgName, ArgValue]
 
 @dataclass
 class UnprocessedAfterNextclade:
+    submissionDetails: SubmissionDetails  # noqa: N815
     inputMetadata: InputMetadata  # noqa: N815
     files: dict[FileCategory, list[FileIdAndNameAndReadUrl]] | None
     # Derived metadata produced by Nextclade

--- a/preprocessing/nextclade/src/loculus_preprocessing/nextclade.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/nextclade.py
@@ -359,7 +359,7 @@ def write_nextclade_input_fasta(
     with open(input_file, "w", encoding="utf-8") as f:
         for entry in unprocessed:
             accession_version = entry.accessionVersion
-            for fasta_id, seq in entry.data.unalignedNucleotideSequences.items():
+            for fasta_id, seq in entry.unalignedNucleotideSequences.items():
                 id = f"{accession_version}__{fasta_id}"
                 id_map[accession_version, fasta_id] = id
                 f.write(f">{id}\n")
@@ -396,7 +396,7 @@ def assign_segment(
     sort_results_map: dict[SegmentName, list[AssignedSequence]] = defaultdict(list)
     sequence_assignment = SequenceAssignment()
 
-    for fasta_id in entry.data.unalignedNucleotideSequences:
+    for fasta_id in entry.unalignedNucleotideSequences:
         seq_id = id_map[entry.accessionVersion, fasta_id]
         if seq_id not in best_hits[SequenceIdentifier].unique():
             method = config.segment_classification_method.display_name
@@ -443,7 +443,7 @@ def assign_segment(
 
         sequence_assignment.sequenceNameToFastaId[ids[0].name] = ids[0].fasta_id
         sequence_assignment.unalignedNucleotideSequences[ids[0].name] = (
-            entry.data.unalignedNucleotideSequences[ids[0].fasta_id]
+            entry.unalignedNucleotideSequences[ids[0].fasta_id]
         )
 
     return sequence_assignment
@@ -625,7 +625,7 @@ def assign_all_single_segments(
     for entry in unprocessed:
         accession_version = entry.accessionVersion
         sequence_assignment = assign_single_segment(
-            entry.data.unalignedNucleotideSequences,
+            entry.unalignedNucleotideSequences,
             config=config,
         )
         batch.sequenceNameToFastaId[accession_version] = sequence_assignment.sequenceNameToFastaId
@@ -748,7 +748,7 @@ def assign_segment_for_alignment(
     errors = {}
     for entry in unprocessed:
         errors[entry.accessionVersion] = error_on_excess_sequences(
-            len(entry.data.unalignedNucleotideSequences),
+            len(entry.unalignedNucleotideSequences),
             config,
         )
     if not config.multi_datasets:
@@ -795,14 +795,14 @@ def enrich_with_nextclade(  # noqa: PLR0914
     )` object.
     """
     submission_context: dict[AccessionVersion, SubmissionContext] = {
-        entry.accessionVersion: entry.data.submissionContext for entry in unprocessed
+        entry.accessionVersion: entry.submissionContext for entry in unprocessed
     }
     input_metadata: dict[AccessionVersion, dict[str, Any]] = {
-        entry.accessionVersion: entry.data.metadata for entry in unprocessed
+        entry.accessionVersion: entry.metadata for entry in unprocessed
     }
     input_files: dict[
         AccessionVersion, dict[FileCategory, list[FileIdAndNameAndReadUrl]] | None
-    ] = {entry.accessionVersion: entry.data.files for entry in unprocessed}
+    ] = {entry.accessionVersion: entry.files for entry in unprocessed}
 
     batch = assign_segment_for_alignment(unprocessed, config=config, dataset_dir=dataset_dir)
     unaligned_nucleotide_sequences = batch.unalignedNucleotideSequences

--- a/preprocessing/nextclade/src/loculus_preprocessing/nextclade.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/nextclade.py
@@ -38,7 +38,7 @@ from .datatypes import (
     SegmentName,
     SequenceAssignment,
     SequenceAssignmentBatch,
-    SubmissionDetails,
+    SubmissionContext,
     UnprocessedAfterNextclade,
     UnprocessedEntry,
 )
@@ -794,8 +794,8 @@ def enrich_with_nextclade(  # noqa: PLR0914
             sequenceNameToFastaId: dict[SegmentName, str]
     )` object.
     """
-    submission_details: dict[AccessionVersion, SubmissionDetails] = {
-        entry.accessionVersion: entry.data.submissionDetails for entry in unprocessed
+    submission_context: dict[AccessionVersion, SubmissionContext] = {
+        entry.accessionVersion: entry.data.submissionContext for entry in unprocessed
     }
     input_metadata: dict[AccessionVersion, dict[str, Any]] = {
         entry.accessionVersion: entry.data.metadata for entry in unprocessed
@@ -894,7 +894,7 @@ def enrich_with_nextclade(  # noqa: PLR0914
 
     return {
         id: UnprocessedAfterNextclade(
-            submissionDetails=submission_details[id],
+            submissionContext=submission_context[id],
             inputMetadata=input_metadata[id],
             files=input_files[id],
             nextcladeMetadata=nextclade_metadata[id],

--- a/preprocessing/nextclade/src/loculus_preprocessing/nextclade.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/nextclade.py
@@ -38,6 +38,7 @@ from .datatypes import (
     SegmentName,
     SequenceAssignment,
     SequenceAssignmentBatch,
+    SubmissionDetails,
     UnprocessedAfterNextclade,
     UnprocessedEntry,
 )
@@ -793,15 +794,11 @@ def enrich_with_nextclade(  # noqa: PLR0914
             sequenceNameToFastaId: dict[SegmentName, str]
     )` object.
     """
+    submission_details: dict[AccessionVersion, SubmissionDetails] = {
+        entry.accessionVersion: entry.data.submissionDetails for entry in unprocessed
+    }
     input_metadata: dict[AccessionVersion, dict[str, Any]] = {
-        entry.accessionVersion: {
-            **entry.data.metadata,
-            "submitter": entry.data.submitter,
-            "submittedAt": entry.data.submittedAt,
-            "submissionId": entry.data.submissionId,
-            "group_id": entry.data.group_id,
-        }
-        for entry in unprocessed
+        entry.accessionVersion: entry.data.metadata for entry in unprocessed
     }
     input_files: dict[
         AccessionVersion, dict[FileCategory, list[FileIdAndNameAndReadUrl]] | None
@@ -897,6 +894,7 @@ def enrich_with_nextclade(  # noqa: PLR0914
 
     return {
         id: UnprocessedAfterNextclade(
+            submissionDetails=submission_details[id],
             inputMetadata=input_metadata[id],
             files=input_files[id],
             nextcladeMetadata=nextclade_metadata[id],

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -308,6 +308,7 @@ def processed_entry_no_alignment(
             errors=errors,
             warnings=warnings,
         ),
+        group_id=unprocessed.submissionContext.group_id,
         submitter=unprocessed.submissionContext.submitter,
     )
 
@@ -650,11 +651,12 @@ def process_single_unaligned(
     )
 
 
-def processed_entry_with_errors(id) -> SubmissionData:
+def processed_entry_with_errors(submission_context: SubmissionContext) -> SubmissionData:
+    accession_version = submission_context.accessionVersion
     return SubmissionData(
         processed_entry=ProcessedEntry(
-            accession=accession_from_str(id),
-            version=version_from_str(id),
+            accession=accession_from_str(accession_version),
+            version=version_from_str(accession_version),
             data=ProcessedData(
                 metadata=dict[str, ProcessedMetadataValue](),
                 files=None,
@@ -670,14 +672,16 @@ def processed_entry_with_errors(id) -> SubmissionData:
                     "unknown",
                     AnnotationSourceType.METADATA,
                     message=(
-                        f"Failed to process submission with id: {id} - please review your "
-                        "submission or reach out to an administrator if this error persists."
+                        f"Failed to process submission with id: {accession_version} - please "
+                        "review your submission or reach out to an administrator if this error "
+                        "persists."
                     ),
                 ),
             ],
             warnings=[],
         ),
-        submitter=None,
+        group_id=submission_context.group_id,
+        submitter=submission_context.submitter,
     )
 
 
@@ -693,7 +697,7 @@ def process_all(
                 processed_single = process_single(result, config)
             except Exception as e:
                 logger.error(f"Processing failed for {id} with error: {e}")
-                processed_single = processed_entry_with_errors(id)
+                processed_single = processed_entry_with_errors(result.submissionContext)
             processed_results.append(processed_single)
     else:
         for entry in unprocessed:
@@ -701,7 +705,7 @@ def process_all(
                 processed_single = process_single_unaligned(entry.data, config)
             except Exception as e:
                 logger.error(f"Processing failed for {entry.accessionVersion} with error: {e}")
-                processed_single = processed_entry_with_errors(entry.accessionVersion)
+                processed_single = processed_entry_with_errors(entry.data.submissionContext)
             processed_results.append(processed_single)
 
     return processed_results
@@ -711,10 +715,14 @@ def upload_flatfiles(processed: Sequence[SubmissionData], config: Config) -> Non
     for submission_data in processed:
         accession = submission_data.processed_entry.accession
         version = submission_data.processed_entry.version
+        if submission_data.processed_entry.errors:
+            # The entry won't be released, so don't build a flatfile for it - and don't stack
+            # an "EMBL upload failed" error on top of the errors the submitter has to fix.
+            logger.debug(
+                "Skipping EMBL file for %s.%s: entry already has errors", accession, version
+            )
+            continue
         try:
-            if submission_data.group_id is None:
-                msg = "Group ID is required for EMBL file upload"
-                raise ValueError(msg)
             file_content = create_flatfile(config, submission_data)
             file_name = f"{accession}.{version}.embl"
             upload_info = request_upload(submission_data.group_id, 1, config)[0]

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -48,7 +48,6 @@ from .datatypes import (
     SubmissionContext,
     SubmissionData,
     UnprocessedAfterNextclade,
-    UnprocessedData,
     UnprocessedEntry,
 )
 from .embl import create_flatfile
@@ -277,7 +276,7 @@ def _call_processing_function(  # noqa: PLR0913, PLR0917
 
 
 def processed_entry_no_alignment(
-    unprocessed: UnprocessedData,
+    unprocessed: UnprocessedEntry,
     output_metadata: ProcessedMetadata,
     errors: list[ProcessingAnnotation],
     warnings: list[ProcessingAnnotation],
@@ -324,7 +323,7 @@ def get_sequence_length(
 
 
 def get_output_metadata(  # noqa: C901, PLR0912, PLR0915
-    unprocessed: UnprocessedData | UnprocessedAfterNextclade,
+    unprocessed: UnprocessedEntry | UnprocessedAfterNextclade,
     config: Config,
 ) -> tuple[ProcessedMetadata, list[ProcessingAnnotation], list[ProcessingAnnotation]]:
     errors: list[ProcessingAnnotation] = []
@@ -456,7 +455,7 @@ def build_missing_required_msg(output_field: str, input_fields: list[str], confi
 def check_required_when_condition(
     condition: str,
     output_field: str,
-    unprocessed: UnprocessedData | UnprocessedAfterNextclade,
+    unprocessed: UnprocessedEntry | UnprocessedAfterNextclade,
     output_metadata: ProcessedMetadata,
 ) -> str | None:
     input_metadata = (
@@ -620,7 +619,7 @@ def process_single(
 
 
 def process_single_unaligned(
-    unprocessed: UnprocessedData,
+    unprocessed: UnprocessedEntry,
     config: Config,
 ) -> SubmissionData:
     """Process a single sequence per config"""
@@ -702,10 +701,10 @@ def process_all(
     else:
         for entry in unprocessed:
             try:
-                processed_single = process_single_unaligned(entry.data, config)
+                processed_single = process_single_unaligned(entry, config)
             except Exception as e:
                 logger.error(f"Processing failed for {entry.accessionVersion} with error: {e}")
-                processed_single = processed_entry_with_errors(entry.data.submissionContext)
+                processed_single = processed_entry_with_errors(entry.submissionContext)
             processed_results.append(processed_single)
 
     return processed_results

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -45,8 +45,8 @@ from .datatypes import (
     ProcessingResult,
     SegmentClassificationMethod,
     SegmentName,
+    SubmissionContext,
     SubmissionData,
-    SubmissionDetails,
     UnprocessedAfterNextclade,
     UnprocessedData,
     UnprocessedEntry,
@@ -250,16 +250,14 @@ def add_input_metadata(
 
 
 def _call_processing_function(  # noqa: PLR0913, PLR0917
-    accession_version: AccessionVersion,
     spec: ProcessingSpec,
     output_field: str,
-    submission_details: SubmissionDetails,
+    submission_context: SubmissionContext,
     input_data: InputMetadata,
     input_fields: list[str],
     config: Config,
 ) -> ProcessingResult:
     args = dict(spec.args) if spec.args else {}
-    args["ACCESSION_VERSION"] = accession_version
     args["taxonomy_service"] = config._taxonomy_service  # type: ignore
 
     try:
@@ -269,7 +267,7 @@ def _call_processing_function(  # noqa: PLR0913, PLR0917
             input_data,
             output_field,
             input_fields,
-            submission_details,
+            submission_context,
         )
     except Exception as e:
         msg = f"Processing for spec: {spec} with input data: {input_data} failed with {e}"
@@ -278,8 +276,7 @@ def _call_processing_function(  # noqa: PLR0913, PLR0917
     return processing_result
 
 
-def processed_entry_no_alignment(  # noqa: PLR0913, PLR0917
-    accession_version: AccessionVersion,
+def processed_entry_no_alignment(
     unprocessed: UnprocessedData,
     output_metadata: ProcessedMetadata,
     errors: list[ProcessingAnnotation],
@@ -292,6 +289,7 @@ def processed_entry_no_alignment(  # noqa: PLR0913, PLR0917
     aligned_aminoacid_sequences: dict[GeneName, AminoAcidSequence | None] = {}
     nucleotide_insertions: dict[SequenceName, list[NucleotideInsertion]] = {}
     amino_acid_insertions: dict[GeneName, list[AminoAcidInsertion]] = {}
+    accession_version = unprocessed.submissionContext.accessionVersion
 
     return SubmissionData(
         processed_entry=ProcessedEntry(
@@ -310,7 +308,7 @@ def processed_entry_no_alignment(  # noqa: PLR0913, PLR0917
             errors=errors,
             warnings=warnings,
         ),
-        submitter=unprocessed.submissionDetails.submitter,
+        submitter=unprocessed.submissionContext.submitter,
     )
 
 
@@ -325,7 +323,6 @@ def get_sequence_length(
 
 
 def get_output_metadata(  # noqa: C901, PLR0912, PLR0915
-    accession_version: AccessionVersion,
     unprocessed: UnprocessedData | UnprocessedAfterNextclade,
     config: Config,
 ) -> tuple[ProcessedMetadata, list[ProcessingAnnotation], list[ProcessingAnnotation]]:
@@ -397,10 +394,9 @@ def get_output_metadata(  # noqa: C901, PLR0912, PLR0915
                 input_fields.append(resolved_path)
 
         processing_result = _call_processing_function(
-            accession_version=accession_version,
             spec=spec,
             output_field=output_field,
-            submission_details=unprocessed.submissionDetails,
+            submission_context=unprocessed.submissionContext,
             input_data=input_data,
             input_fields=input_fields,
             config=config,
@@ -412,7 +408,7 @@ def get_output_metadata(  # noqa: C901, PLR0912, PLR0915
 
         if (
             not null_per_backend(processing_result.datum)
-            or unprocessed.submissionDetails.is_insdc_ingest_group
+            or unprocessed.submissionContext.is_insdc_ingest_group
         ):
             # skip requirement checks when the field has a value, or for INSDC ingested data.
             continue
@@ -441,7 +437,7 @@ def get_output_metadata(  # noqa: C901, PLR0912, PLR0915
             for msg in requirement_errors
         )
 
-    logger.debug(f"Processed {accession_version}: {output_metadata}")
+    logger.debug(f"Processed {unprocessed.submissionContext.accessionVersion}: {output_metadata}")
     return output_metadata, errors, warnings
 
 
@@ -562,16 +558,16 @@ def unpack_annotations(config, nextclade_metadata: dict[str, Any] | None) -> dic
 
 
 def process_single(
-    accession_version: AccessionVersion,
     unprocessed: UnprocessedAfterNextclade,
     config: Config,
 ) -> SubmissionData:
     """Process a single sequence per config"""
+    accession_version = unprocessed.submissionContext.accessionVersion
     # process files first as S3 read URLs have a limited lifetime
     file_errors = []
     if unprocessed.files and any(unprocessed.files.values()):
         file_errors = config._file_processing_service.process_files(
-            unprocessed.files, accession_version=accession_version
+            unprocessed.files, accession_version
         )
 
     iupac_errors = errors_if_non_iupac(unprocessed.unalignedNucleotideSequences)
@@ -586,9 +582,7 @@ def process_single(
         config,
     )
 
-    output_metadata, metadata_errors, metadata_warnings = get_output_metadata(
-        accession_version, unprocessed, config
-    )
+    output_metadata, metadata_errors, metadata_warnings = get_output_metadata(unprocessed, config)
 
     processed_entry = ProcessedEntry(
         accession=accession_from_str(accession_version),
@@ -619,13 +613,12 @@ def process_single(
     return SubmissionData(
         processed_entry=processed_entry,
         annotations=unpack_annotations(config, unprocessed.nextcladeMetadata),
-        group_id=unprocessed.submissionDetails.group_id,
-        submitter=unprocessed.submissionDetails.submitter,
+        group_id=unprocessed.submissionContext.group_id,
+        submitter=unprocessed.submissionContext.submitter,
     )
 
 
 def process_single_unaligned(
-    accession_version: AccessionVersion,
     unprocessed: UnprocessedData,
     config: Config,
 ) -> SubmissionData:
@@ -634,7 +627,7 @@ def process_single_unaligned(
     file_errors = []
     if unprocessed.files and any(unprocessed.files.values()):
         file_errors = config._file_processing_service.process_files(
-            unprocessed.files, accession_version=accession_version
+            unprocessed.files, unprocessed.submissionContext.accessionVersion
         )
 
     segment_assignment = assign_segment_using_header(
@@ -644,12 +637,9 @@ def process_single_unaligned(
     unprocessed.unalignedNucleotideSequences = segment_assignment.unalignedNucleotideSequences
     iupac_errors = errors_if_non_iupac(unprocessed.unalignedNucleotideSequences)
 
-    output_metadata, metadata_errors, metadata_warnings = get_output_metadata(
-        accession_version, unprocessed, config
-    )
+    output_metadata, metadata_errors, metadata_warnings = get_output_metadata(unprocessed, config)
 
     return processed_entry_no_alignment(
-        accession_version=accession_version,
         unprocessed=unprocessed,
         output_metadata=output_metadata,
         errors=list(
@@ -700,7 +690,7 @@ def process_all(
         nextclade_results = enrich_with_nextclade(unprocessed, dataset_dir, config)
         for id, result in nextclade_results.items():
             try:
-                processed_single = process_single(id, result, config)
+                processed_single = process_single(result, config)
             except Exception as e:
                 logger.error(f"Processing failed for {id} with error: {e}")
                 processed_single = processed_entry_with_errors(id)
@@ -708,9 +698,7 @@ def process_all(
     else:
         for entry in unprocessed:
             try:
-                processed_single = process_single_unaligned(
-                    entry.accessionVersion, entry.data, config
-                )
+                processed_single = process_single_unaligned(entry.data, config)
             except Exception as e:
                 logger.error(f"Processing failed for {entry.accessionVersion} with error: {e}")
                 processed_single = processed_entry_with_errors(entry.accessionVersion)

--- a/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/prepro.py
@@ -46,6 +46,7 @@ from .datatypes import (
     SegmentClassificationMethod,
     SegmentName,
     SubmissionData,
+    SubmissionDetails,
     UnprocessedAfterNextclade,
     UnprocessedData,
     UnprocessedEntry,
@@ -147,7 +148,7 @@ def get_nested_metadata(metadata: dict[str, Any], path: str, separator: str = ".
     return value
 
 
-def add_nextclade_metadata(
+def add_nextclade_metadata(  # noqa: C901, PLR0911
     spec: ProcessingSpec,
     unprocessed: UnprocessedAfterNextclade,
     nextclade_path: str,
@@ -252,15 +253,12 @@ def _call_processing_function(  # noqa: PLR0913, PLR0917
     accession_version: AccessionVersion,
     spec: ProcessingSpec,
     output_field: str,
-    group_id: int | None,
-    submitted_at: str | None,
+    submission_details: SubmissionDetails,
     input_data: InputMetadata,
     input_fields: list[str],
     config: Config,
 ) -> ProcessingResult:
     args = dict(spec.args) if spec.args else {}
-    args["is_insdc_ingest_group"] = config.insdc_ingest_group_id == group_id
-    args["submittedAt"] = submitted_at
     args["ACCESSION_VERSION"] = accession_version
     args["taxonomy_service"] = config._taxonomy_service  # type: ignore
 
@@ -271,6 +269,7 @@ def _call_processing_function(  # noqa: PLR0913, PLR0917
             input_data,
             output_field,
             input_fields,
+            submission_details,
         )
     except Exception as e:
         msg = f"Processing for spec: {spec} with input data: {input_data} failed with {e}"
@@ -311,7 +310,7 @@ def processed_entry_no_alignment(  # noqa: PLR0913, PLR0917
             errors=errors,
             warnings=warnings,
         ),
-        submitter=unprocessed.submitter,
+        submitter=unprocessed.submissionDetails.submitter,
     )
 
 
@@ -325,7 +324,7 @@ def get_sequence_length(
     return len(sequence) if sequence else 0
 
 
-def get_output_metadata(  # noqa: C901, PLR0912, PLR0914, PLR0915
+def get_output_metadata(  # noqa: C901, PLR0912, PLR0915
     accession_version: AccessionVersion,
     unprocessed: UnprocessedData | UnprocessedAfterNextclade,
     config: Config,
@@ -389,12 +388,6 @@ def get_output_metadata(  # noqa: C901, PLR0912, PLR0914, PLR0915
                     warnings.extend(input_metadata.warnings)
 
                 input_fields.append(resolved_path)
-                group_id = (
-                    int(unprocessed.inputMetadata["group_id"])
-                    if unprocessed.inputMetadata["group_id"]
-                    else None
-                )
-                submitted_at = unprocessed.inputMetadata["submittedAt"]
             else:
                 input_data[arg_name] = (  # type: ignore
                     output_metadata.get(resolved_path)  # type: ignore
@@ -402,15 +395,12 @@ def get_output_metadata(  # noqa: C901, PLR0912, PLR0914, PLR0915
                     else unprocessed.metadata.get(resolved_path)
                 )
                 input_fields.append(resolved_path)
-                group_id = unprocessed.group_id
-                submitted_at = unprocessed.submittedAt
 
         processing_result = _call_processing_function(
             accession_version=accession_version,
             spec=spec,
             output_field=output_field,
-            group_id=group_id,
-            submitted_at=submitted_at,
+            submission_details=unprocessed.submissionDetails,
             input_data=input_data,
             input_fields=input_fields,
             config=config,
@@ -422,7 +412,7 @@ def get_output_metadata(  # noqa: C901, PLR0912, PLR0914, PLR0915
 
         if (
             not null_per_backend(processing_result.datum)
-            or group_id == config.insdc_ingest_group_id
+            or unprocessed.submissionDetails.is_insdc_ingest_group
         ):
             # skip requirement checks when the field has a value, or for INSDC ingested data.
             continue
@@ -629,8 +619,8 @@ def process_single(
     return SubmissionData(
         processed_entry=processed_entry,
         annotations=unpack_annotations(config, unprocessed.nextcladeMetadata),
-        group_id=int(str(unprocessed.inputMetadata["group_id"])),
-        submitter=str(unprocessed.inputMetadata["submitter"]),
+        group_id=unprocessed.submissionDetails.group_id,
+        submitter=unprocessed.submissionDetails.submitter,
     )
 
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -28,7 +28,7 @@ from .datatypes import (
     ProcessingAnnotation,
     ProcessingResult,
     RawProcessingResult,
-    SubmissionDetails,
+    SubmissionContext,
     _internal_error_message,
     processing_error,
     raw_internal_error,
@@ -256,7 +256,7 @@ class ProcessingFunctions:
         input_data: InputMetadata,
         output_field: str,
         input_fields: list[str],
-        submission_details: SubmissionDetails,
+        submission_context: SubmissionContext,
     ) -> ProcessingResult:
         if not hasattr(cls, function_name):
             msg = (
@@ -271,7 +271,7 @@ class ProcessingFunctions:
                 output_field,
                 input_fields=input_fields,
                 args=args,
-                submission_details=submission_details,
+                submission_context=submission_context,
             )
         except Exception as e:
             result = raw_internal_error(
@@ -322,7 +322,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,  # args is essential - even if Pylance says it's not used
-        submission_details: SubmissionDetails,
+        submission_context: SubmissionContext,
     ) -> RawProcessingResult:
         """Check that date is complete YYYY-MM-DD
         If not according to format return error
@@ -351,7 +351,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,  # args is essential - even if Pylance says it's not used
-        submission_details: SubmissionDetails,
+        submission_context: SubmissionContext,
     ) -> RawProcessingResult:
         """
         Parse date string (`input.date`) with input formats:
@@ -379,11 +379,11 @@ class ProcessingFunctions:
 
         try:
             submitted_at = datetime.fromtimestamp(
-                float(submission_details.submittedAt), tz=pytz.utc
+                float(submission_context.submittedAt), tz=pytz.utc
             )
         except Exception:
             return raw_internal_error(
-                f"parse_into_ranges did not receive a valid submittedAt date, with input {input_data} and submittedAt {submission_details.submittedAt!r}."
+                f"parse_into_ranges did not receive a valid submittedAt date, with input {input_data} and submittedAt {submission_context.submittedAt!r}."
             )
 
         max_upper_limit = min(submitted_at, release_date) if release_date else submitted_at
@@ -509,7 +509,7 @@ class ProcessingFunctions:
         output_field,
         input_fields: list[str],
         args: FunctionArgs,  # args is essential - even if Pylance says it's not used
-        submission_details: SubmissionDetails,
+        submission_context: SubmissionContext,
     ) -> RawProcessingResult:
         """Parse date string. If it's incomplete, add 01-01, if no year, return null and error
         input_data:
@@ -574,7 +574,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,  # args is essential - even if Pylance says it's not used
-        submission_details: SubmissionDetails,
+        submission_context: SubmissionContext,
     ) -> RawProcessingResult:
         """Parse a timestamp string, e.g. 2022-11-01T00:00:00Z and return a YYYY-MM-DD string"""
         timestamp = input_data["timestamp"]
@@ -596,7 +596,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
-        submission_details: SubmissionDetails,
+        submission_context: SubmissionContext,
     ) -> RawProcessingResult:
         """Concatenates input fields using the "/" separator in the order
         specified by the order argument. Optionally, a 'fallback_value' argument can be provided.
@@ -606,12 +606,7 @@ class ProcessingFunctions:
         warnings: list[str] = []
         errors: list[str] = []
 
-        if not isinstance(args["ACCESSION_VERSION"], str):
-            return raw_internal_error(
-                f"concatenate did not receive a valid ACCESSION_VERSION (got: {args['ACCESSION_VERSION']!r})."
-            )
-
-        accession_version: str = args["ACCESSION_VERSION"]
+        accession_version = submission_context.accessionVersion
         order = args["order"]
         field_types = args["type"]
         fallback_value = (
@@ -646,7 +641,7 @@ class ProcessingFunctions:
                         output_field,
                         input_fields,
                         args,
-                        submission_details,
+                        submission_context,
                     )
                     formatted_input_data.append(
                         fallback_value
@@ -678,7 +673,7 @@ class ProcessingFunctions:
                         output_field,
                         input_fields,
                         args,
-                        submission_details,
+                        submission_context,
                     )
                     formatted_input_data.append(
                         fallback_value
@@ -727,7 +722,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
-        submission_details: SubmissionDetails,
+        submission_context: SubmissionContext,
     ) -> RawProcessingResult:
         authors = input_data["authors"]
 
@@ -778,7 +773,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
-        submission_details: SubmissionDetails,
+        submission_context: SubmissionContext,
     ) -> RawProcessingResult:
         """
         Extracts a substring from the `regex_field` using the provided regex `pattern`
@@ -823,7 +818,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
-        submission_details: SubmissionDetails,
+        submission_context: SubmissionContext,
     ) -> RawProcessingResult:
         """
         Validates that the field regex_field matches the regex expression.
@@ -850,7 +845,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
-        submission_details: SubmissionDetails,
+        submission_context: SubmissionContext,
     ) -> RawProcessingResult:
         """Identity function, takes input_data["input"] and returns it as output"""
         if "input" not in input_data:
@@ -906,7 +901,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
-        submission_details: SubmissionDetails,
+        submission_context: SubmissionContext,
     ) -> RawProcessingResult:
         """Checks that option is in options"""
         if "options" not in args or not isinstance(args["options"], list):
@@ -930,7 +925,7 @@ class ProcessingFunctions:
         if standardized_input_datum in options:
             output_datum = options[standardized_input_datum]
         # Allow ingested data to include fields not in options
-        elif submission_details.is_insdc_ingest_group:
+        elif submission_context.is_insdc_ingest_group:
             return RawProcessingResult(datum=input_datum, warnings=[error_msg])
         else:
             return processing_error(error_msg)
@@ -942,7 +937,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
-        submission_details: SubmissionDetails,
+        submission_context: SubmissionContext,
     ) -> RawProcessingResult:
         """Flag if input value is above a threshold specified in args"""
         if "threshold" not in args:
@@ -968,7 +963,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
-        submission_details: SubmissionDetails,
+        submission_context: SubmissionContext,
     ) -> RawProcessingResult:
         """Flag if number of mutations is above mutation rate (specified in args) times length"""
         if "mu" not in args:
@@ -989,7 +984,7 @@ class ProcessingFunctions:
                 output_field=output_field,
                 input_fields=input_fields,
                 args={"threshold": threshold},
-                submission_details=submission_details,
+                submission_context=submission_context,
             )
         except (ValueError, TypeError):
             return processing_error(
@@ -1007,7 +1002,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
-        submission_details: SubmissionDetails,
+        submission_context: SubmissionContext,
     ) -> RawProcessingResult:
         """
         Assign flu lineage based on seg4 and seg6.
@@ -1092,7 +1087,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
-        submission_details: SubmissionDetails,
+        submission_context: SubmissionContext,
     ) -> RawProcessingResult:
         """Builds a displayName from input_fields. The identifier field in the displayName is based
         on specimenCollectorSampleId or - if it is not set - submissionId (direct submissions only).
@@ -1102,7 +1097,7 @@ class ProcessingFunctions:
             - specimenCollectorSampleId must be in the input_data
             - IDENTIFIER keyword must be in args['order'] and args['type']
             - the IDENTIFIER is resolved by trying specimenCollectorSampleId first, then the
-              submissionId from submission_details; if neither yields a usable value it is
+              submissionId from submission_context; if neither yields a usable value it is
               replaced with ACCESSION_VERSION
             - if fallback_value is not in args, { 'fallback_value': 'unknown' } is added to the args
               before passing them on to concatenate()
@@ -1147,18 +1142,18 @@ class ProcessingFunctions:
         concatenate_order = order.copy()
         concatenate_field_types = field_types.copy()
 
-        insdc_ingested = bool(submission_details.is_insdc_ingest_group)
+        insdc_ingested = bool(submission_context.is_insdc_ingest_group)
 
         # Try to parse the specimenCollectorSampleId first
         identifier = parse_identifier_string(
-            collector_id, insdc_ingested, submission_details, regex_pattern
+            collector_id, insdc_ingested, submission_context, regex_pattern
         )
         if identifier is None and not insdc_ingested:
             # For direct submissions only: try to parse the submissionId
             # Don't do this for ingested since there the submissionId is just the
             # (concatenation of) nuccore accession(s) of the sequence(s)
             identifier = parse_identifier_string(
-                submission_details.submissionId, insdc_ingested, submission_details, regex_pattern
+                submission_context.submissionId, insdc_ingested, submission_context, regex_pattern
             )
 
         def replace_identifier(values, replacement):
@@ -1185,7 +1180,6 @@ class ProcessingFunctions:
                 "order": concatenate_order,
                 "type": concatenate_field_types,
                 "fallback_value": args.get("fallback_value", "unknown"),
-                "ACCESSION_VERSION": args["ACCESSION_VERSION"],
             }
         )
 
@@ -1194,7 +1188,7 @@ class ProcessingFunctions:
             output_field,
             input_fields,
             new_args,
-            submission_details,
+            submission_context,
         )
 
         return RawProcessingResult(
@@ -1209,7 +1203,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
-        submission_details: SubmissionDetails,
+        submission_context: SubmissionContext,
     ) -> RawProcessingResult:
         """Validates that the host exists
         in NCBI's taxonomy. Checks either the hostTaxonId or the
@@ -1227,7 +1221,7 @@ class ProcessingFunctions:
 
         taxonomy_service: TaxonomyService = args["taxonomy_service"]  # type: ignore
         return taxonomy_service.get_tax_id(
-            unvalidated_host, not bool(submission_details.is_insdc_ingest_group)
+            unvalidated_host, not bool(submission_context.is_insdc_ingest_group)
         )
 
     @staticmethod
@@ -1236,7 +1230,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
-        submission_details: SubmissionDetails,
+        submission_context: SubmissionContext,
     ) -> RawProcessingResult:
         tax_id: str | None = input_data.get("hostTaxonId")
         if not tax_id:
@@ -1244,7 +1238,7 @@ class ProcessingFunctions:
 
         taxonomy_service: TaxonomyService = args["taxonomy_service"]  # type: ignore
         return taxonomy_service.get_scientific_name(
-            tax_id, not bool(submission_details.is_insdc_ingest_group)
+            tax_id, not bool(submission_context.is_insdc_ingest_group)
         )
 
     @staticmethod
@@ -1253,7 +1247,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
-        submission_details: SubmissionDetails,
+        submission_context: SubmissionContext,
     ) -> RawProcessingResult:
         tax_id: str | None = input_data.get("hostTaxonId")
         if not tax_id:
@@ -1481,7 +1475,7 @@ def process_phenotype_values(input: str | None, args: FunctionArgs | None) -> In
 def parse_identifier_string(
     input: ProcessedMetadataValue,
     insdc_ingested: bool,
-    submission_details: SubmissionDetails,
+    submission_context: SubmissionContext,
     regex_pattern: str | None = None,
 ) -> str | None:
     """Return an IDENTIFIER string to use in the displayName or None if `input` cannot be used
@@ -1508,7 +1502,7 @@ def parse_identifier_string(
         output_field="IDENTIFIER",
         input_fields=[],
         args={"pattern": regex_pattern, "capture_group": "identifier"},
-        submission_details=submission_details,
+        submission_context=submission_context,
     )
     return None if extract_result.datum is None else str(extract_result.datum)
 

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -1052,6 +1052,7 @@ class ProcessingFunctions:
                     {"regex_field": references.get(segment, "")},
                     "output_field",
                     ["segment_name"],
+                    submission_context,
                 ).datum
             logger.debug(f"Extracted lineages: {extracted_lineages} from references: {references}")
             if not ha_subtype or not na_subtype:

--- a/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
+++ b/preprocessing/nextclade/src/loculus_preprocessing/processing_functions.py
@@ -28,6 +28,7 @@ from .datatypes import (
     ProcessingAnnotation,
     ProcessingResult,
     RawProcessingResult,
+    SubmissionDetails,
     _internal_error_message,
     processing_error,
     raw_internal_error,
@@ -248,13 +249,14 @@ def derive_date_range_string(lower: datetime, upper: datetime) -> str:
 
 class ProcessingFunctions:
     @classmethod
-    def call_function(
+    def call_function(  # noqa: PLR0913, PLR0917
         cls,
         function_name: str,
         args: FunctionArgs,
         input_data: InputMetadata,
         output_field: str,
         input_fields: list[str],
+        submission_details: SubmissionDetails,
     ) -> ProcessingResult:
         if not hasattr(cls, function_name):
             msg = (
@@ -264,7 +266,13 @@ class ProcessingFunctions:
             raise ValueError(msg)
         func = getattr(cls, function_name)
         try:
-            result = func(input_data, output_field, input_fields=input_fields, args=args)
+            result = func(
+                input_data,
+                output_field,
+                input_fields=input_fields,
+                args=args,
+                submission_details=submission_details,
+            )
         except Exception as e:
             result = raw_internal_error(
                 f"{function_name} raised an unexpected exception for output field '{output_field}': {e}. "
@@ -314,6 +322,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,  # args is essential - even if Pylance says it's not used
+        submission_details: SubmissionDetails,
     ) -> RawProcessingResult:
         """Check that date is complete YYYY-MM-DD
         If not according to format return error
@@ -342,6 +351,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,  # args is essential - even if Pylance says it's not used
+        submission_details: SubmissionDetails,
     ) -> RawProcessingResult:
         """
         Parse date string (`input.date`) with input formats:
@@ -368,10 +378,12 @@ class ProcessingFunctions:
             release_date = None
 
         try:
-            submitted_at = datetime.fromtimestamp(float(str(args["submittedAt"])), tz=pytz.utc)
+            submitted_at = datetime.fromtimestamp(
+                float(submission_details.submittedAt), tz=pytz.utc
+            )
         except Exception:
             return raw_internal_error(
-                f"parse_into_ranges did not receive a valid submittedAt date, with input {input_data} and args {args}."
+                f"parse_into_ranges did not receive a valid submittedAt date, with input {input_data} and submittedAt {submission_details.submittedAt!r}."
             )
 
         max_upper_limit = min(submitted_at, release_date) if release_date else submitted_at
@@ -497,6 +509,7 @@ class ProcessingFunctions:
         output_field,
         input_fields: list[str],
         args: FunctionArgs,  # args is essential - even if Pylance says it's not used
+        submission_details: SubmissionDetails,
     ) -> RawProcessingResult:
         """Parse date string. If it's incomplete, add 01-01, if no year, return null and error
         input_data:
@@ -561,6 +574,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,  # args is essential - even if Pylance says it's not used
+        submission_details: SubmissionDetails,
     ) -> RawProcessingResult:
         """Parse a timestamp string, e.g. 2022-11-01T00:00:00Z and return a YYYY-MM-DD string"""
         timestamp = input_data["timestamp"]
@@ -577,11 +591,12 @@ class ProcessingFunctions:
             )
 
     @staticmethod
-    def concatenate(
+    def concatenate(  # noqa: C901, PLR0911, PLR0912
         input_data: InputMetadata,
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
+        submission_details: SubmissionDetails,
     ) -> RawProcessingResult:
         """Concatenates input fields using the "/" separator in the order
         specified by the order argument. Optionally, a 'fallback_value' argument can be provided.
@@ -627,7 +642,11 @@ class ProcessingFunctions:
             for i in range(len(order)):
                 if field_types[i] == "date":
                     processed = ProcessingFunctions.parse_and_assert_past_date(
-                        {"date": input_data[order[i]]}, output_field, input_fields, args
+                        {"date": input_data[order[i]]},
+                        output_field,
+                        input_fields,
+                        args,
+                        submission_details,
                     )
                     formatted_input_data.append(
                         fallback_value
@@ -655,7 +674,11 @@ class ProcessingFunctions:
                     )
                 elif field_types[i] == "timestamp":
                     processed = ProcessingFunctions.parse_timestamp(
-                        {"timestamp": input_data[order[i]]}, output_field, input_fields, args
+                        {"timestamp": input_data[order[i]]},
+                        output_field,
+                        input_fields,
+                        args,
+                        submission_details,
                     )
                     formatted_input_data.append(
                         fallback_value
@@ -704,6 +727,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
+        submission_details: SubmissionDetails,
     ) -> RawProcessingResult:
         authors = input_data["authors"]
 
@@ -754,6 +778,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
+        submission_details: SubmissionDetails,
     ) -> RawProcessingResult:
         """
         Extracts a substring from the `regex_field` using the provided regex `pattern`
@@ -798,6 +823,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
+        submission_details: SubmissionDetails,
     ) -> RawProcessingResult:
         """
         Validates that the field regex_field matches the regex expression.
@@ -820,7 +846,11 @@ class ProcessingFunctions:
 
     @staticmethod
     def identity(  # noqa: C901, PLR0912
-        input_data: InputMetadata, output_field: str, input_fields: list[str], args: FunctionArgs
+        input_data: InputMetadata,
+        output_field: str,
+        input_fields: list[str],
+        args: FunctionArgs,
+        submission_details: SubmissionDetails,
     ) -> RawProcessingResult:
         """Identity function, takes input_data["input"] and returns it as output"""
         if "input" not in input_data:
@@ -872,7 +902,11 @@ class ProcessingFunctions:
 
     @staticmethod
     def process_options(
-        input_data: InputMetadata, output_field: str, input_fields: list[str], args: FunctionArgs
+        input_data: InputMetadata,
+        output_field: str,
+        input_fields: list[str],
+        args: FunctionArgs,
+        submission_details: SubmissionDetails,
     ) -> RawProcessingResult:
         """Checks that option is in options"""
         if "options" not in args or not isinstance(args["options"], list):
@@ -896,7 +930,7 @@ class ProcessingFunctions:
         if standardized_input_datum in options:
             output_datum = options[standardized_input_datum]
         # Allow ingested data to include fields not in options
-        elif args["is_insdc_ingest_group"]:
+        elif submission_details.is_insdc_ingest_group:
             return RawProcessingResult(datum=input_datum, warnings=[error_msg])
         else:
             return processing_error(error_msg)
@@ -904,7 +938,11 @@ class ProcessingFunctions:
 
     @staticmethod
     def is_above_threshold(
-        input_data: InputMetadata, output_field: str, input_fields: list[str], args: FunctionArgs
+        input_data: InputMetadata,
+        output_field: str,
+        input_fields: list[str],
+        args: FunctionArgs,
+        submission_details: SubmissionDetails,
     ) -> RawProcessingResult:
         """Flag if input value is above a threshold specified in args"""
         if "threshold" not in args:
@@ -926,7 +964,11 @@ class ProcessingFunctions:
 
     @staticmethod
     def is_variant(
-        input_data: InputMetadata, output_field: str, input_fields: list[str], args: FunctionArgs
+        input_data: InputMetadata,
+        output_field: str,
+        input_fields: list[str],
+        args: FunctionArgs,
+        submission_details: SubmissionDetails,
     ) -> RawProcessingResult:
         """Flag if number of mutations is above mutation rate (specified in args) times length"""
         if "mu" not in args:
@@ -947,6 +989,7 @@ class ProcessingFunctions:
                 output_field=output_field,
                 input_fields=input_fields,
                 args={"threshold": threshold},
+                submission_details=submission_details,
             )
         except (ValueError, TypeError):
             return processing_error(
@@ -960,7 +1003,11 @@ class ProcessingFunctions:
 
     @staticmethod
     def assign_custom_lineage(  # noqa: C901
-        input_data: InputMetadata, output_field: str, input_fields: list[str], args: FunctionArgs
+        input_data: InputMetadata,
+        output_field: str,
+        input_fields: list[str],
+        args: FunctionArgs,
+        submission_details: SubmissionDetails,
     ) -> RawProcessingResult:
         """
         Assign flu lineage based on seg4 and seg6.
@@ -1045,16 +1092,18 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
+        submission_details: SubmissionDetails,
     ) -> RawProcessingResult:
         """Builds a displayName from input_fields. The identifier field in the displayName is based
         on specimenCollectorSampleId or - if it is not set - submissionId (direct submissions only).
 
         This method wraps ProcessingFunctions.concatenate(). Thus, it has the same required input
         args, as well as adding some additional checks and requirements:
-            - submissionId and specimenCollectorSampleId must be in the input_data
+            - specimenCollectorSampleId must be in the input_data
             - IDENTIFIER keyword must be in args['order'] and args['type']
-            - the IDENTIFIER is resolved by trying specimenCollectorSampleId first, then
-              submissionId; if neither yields a usable value it is replaced with ACCESSION_VERSION
+            - the IDENTIFIER is resolved by trying specimenCollectorSampleId first, then the
+              submissionId from submission_details; if neither yields a usable value it is
+              replaced with ACCESSION_VERSION
             - if fallback_value is not in args, { 'fallback_value': 'unknown' } is added to the args
               before passing them on to concatenate()
             - for sequences ingested from INSDC, we do not try to parse the IDENTIFIER field using
@@ -1065,7 +1114,6 @@ class ProcessingFunctions:
               (e.g. '<any>/<any>/<identifier>/<date>')
         """
         collector_id = input_data.get("specimenCollectorSampleId", None)
-        submission_id = input_data.get("submissionId", None)
         warnings: list[str] = []
 
         order = args.get("order")
@@ -1099,15 +1147,19 @@ class ProcessingFunctions:
         concatenate_order = order.copy()
         concatenate_field_types = field_types.copy()
 
-        insdc_ingested = bool(args["is_insdc_ingest_group"])
+        insdc_ingested = bool(submission_details.is_insdc_ingest_group)
 
         # Try to parse the specimenCollectorSampleId first
-        identifier = parse_identifier_string(collector_id, insdc_ingested, regex_pattern)
+        identifier = parse_identifier_string(
+            collector_id, insdc_ingested, submission_details, regex_pattern
+        )
         if identifier is None and not insdc_ingested:
             # For direct submissions only: try to parse the submissionId
             # Don't do this for ingested since there the submissionId is just the
             # (concatenation of) nuccore accession(s) of the sequence(s)
-            identifier = parse_identifier_string(submission_id, insdc_ingested, regex_pattern)
+            identifier = parse_identifier_string(
+                submission_details.submissionId, insdc_ingested, submission_details, regex_pattern
+            )
 
         def replace_identifier(values, replacement):
             return [replacement if v == "IDENTIFIER" else v for v in values]
@@ -1142,6 +1194,7 @@ class ProcessingFunctions:
             output_field,
             input_fields,
             new_args,
+            submission_details,
         )
 
         return RawProcessingResult(
@@ -1156,6 +1209,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
+        submission_details: SubmissionDetails,
     ) -> RawProcessingResult:
         """Validates that the host exists
         in NCBI's taxonomy. Checks either the hostTaxonId or the
@@ -1173,7 +1227,7 @@ class ProcessingFunctions:
 
         taxonomy_service: TaxonomyService = args["taxonomy_service"]  # type: ignore
         return taxonomy_service.get_tax_id(
-            unvalidated_host, not bool(args["is_insdc_ingest_group"])
+            unvalidated_host, not bool(submission_details.is_insdc_ingest_group)
         )
 
     @staticmethod
@@ -1182,13 +1236,16 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
+        submission_details: SubmissionDetails,
     ) -> RawProcessingResult:
         tax_id: str | None = input_data.get("hostTaxonId")
         if not tax_id:
             return RawProcessingResult()
 
         taxonomy_service: TaxonomyService = args["taxonomy_service"]  # type: ignore
-        return taxonomy_service.get_scientific_name(tax_id, not bool(args["is_insdc_ingest_group"]))
+        return taxonomy_service.get_scientific_name(
+            tax_id, not bool(submission_details.is_insdc_ingest_group)
+        )
 
     @staticmethod
     def common_name_from_id(
@@ -1196,6 +1253,7 @@ class ProcessingFunctions:
         output_field: str,
         input_fields: list[str],
         args: FunctionArgs,
+        submission_details: SubmissionDetails,
     ) -> RawProcessingResult:
         tax_id: str | None = input_data.get("hostTaxonId")
         if not tax_id:
@@ -1421,7 +1479,10 @@ def process_phenotype_values(input: str | None, args: FunctionArgs | None) -> In
 
 
 def parse_identifier_string(
-    input: ProcessedMetadataValue, insdc_ingested: bool, regex_pattern: str | None = None
+    input: ProcessedMetadataValue,
+    insdc_ingested: bool,
+    submission_details: SubmissionDetails,
+    regex_pattern: str | None = None,
 ) -> str | None:
     """Return an IDENTIFIER string to use in the displayName or None if `input` cannot be used
     as an identifier.
@@ -1447,6 +1508,7 @@ def parse_identifier_string(
         output_field="IDENTIFIER",
         input_fields=[],
         args={"pattern": regex_pattern, "capture_group": "identifier"},
+        submission_details=submission_details,
     )
     return None if extract_result.datum is None else str(extract_result.datum)
 

--- a/preprocessing/nextclade/tests/factory_methods.py
+++ b/preprocessing/nextclade/tests/factory_methods.py
@@ -18,15 +18,37 @@ from loculus_preprocessing.datatypes import (
     ProcessingAnnotation,
     ProcessingAnnotationAlignment,
     SegmentName,
+    SubmissionContext,
     UnprocessedData,
     UnprocessedEntry,
 )
+
+# Mirrors the default of Config.insdc_ingest_group_id
+DEFAULT_INSDC_INGEST_GROUP_ID = 1
 
 
 def ts_from_ymd(year: int, month: int, day: int) -> str:
     """Convert a year, month, and day into a UTC timestamp string."""
     dt = datetime(year, month, day, tzinfo=pytz.UTC)
     return str(dt.timestamp())
+
+
+def make_submission_context(
+    accession_version: str = "accession.1",
+    group_id: int = 2,
+    submitted_at: str | None = None,
+    submission_id: str = "test_submission_id",
+    is_insdc_ingest_group: bool = False,
+) -> SubmissionContext:
+    """A SubmissionContext for tests that call ProcessingFunctions directly."""
+    return SubmissionContext(
+        accessionVersion=accession_version,
+        submitter="test_submitter",
+        group_id=group_id,
+        submittedAt=submitted_at if submitted_at is not None else ts_from_ymd(2021, 12, 15),
+        submissionId=submission_id,
+        is_insdc_ingest_group=is_insdc_ingest_group,
+    )
 
 
 @dataclass
@@ -74,22 +96,30 @@ class ProcessedAlignment:
 @dataclass
 class UnprocessedEntryFactory:
     @staticmethod
-    def create_unprocessed_entry(
+    def create_unprocessed_entry(  # noqa: PLR0913, PLR0917
         metadata_dict: dict[str, str | None],
         accession_id: str,
         sequences: dict[SegmentName, NucleotideSequence | None],
         group_id: int = 2,
         files: dict[FileCategory, list[FileIdAndNameAndReadUrl]] | None = None,
+        insdc_ingest_group_id: int = DEFAULT_INSDC_INGEST_GROUP_ID,
     ) -> UnprocessedEntry:
+        accession_version = f"LOC_{accession_id}.1"
         return UnprocessedEntry(
-            accessionVersion=f"LOC_{accession_id}.1",
+            accessionVersion=accession_version,
             data=UnprocessedData(
-                submitter="test_submitter",
-                submittedAt=str(
-                    datetime.strptime("2021-12-15", "%Y-%m-%d").replace(tzinfo=pytz.utc).timestamp()
+                submissionContext=SubmissionContext(
+                    accessionVersion=accession_version,
+                    submitter="test_submitter",
+                    submittedAt=str(
+                        datetime.strptime("2021-12-15", "%Y-%m-%d")
+                        .replace(tzinfo=pytz.utc)
+                        .timestamp()
+                    ),
+                    submissionId=metadata_dict.get("submissionId") or "test_submission_id",
+                    group_id=group_id,
+                    is_insdc_ingest_group=group_id == insdc_ingest_group_id,
                 ),
-                submissionId=metadata_dict.get("submissionId") or "test_submission_id",
-                group_id=group_id,
                 metadata=metadata_dict,
                 unalignedNucleotideSequences=sequences,
                 files=files,

--- a/preprocessing/nextclade/tests/factory_methods.py
+++ b/preprocessing/nextclade/tests/factory_methods.py
@@ -6,7 +6,6 @@ from datetime import datetime
 
 import pytz
 
-from loculus_preprocessing.config import Config
 from loculus_preprocessing.datatypes import (
     AnnotationSource,
     AnnotationSourceType,

--- a/preprocessing/nextclade/tests/factory_methods.py
+++ b/preprocessing/nextclade/tests/factory_methods.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 import pytz
 
+from loculus_preprocessing.config import Config
 from loculus_preprocessing.datatypes import (
     AnnotationSource,
     AnnotationSourceType,
@@ -23,9 +24,6 @@ from loculus_preprocessing.datatypes import (
     UnprocessedEntry,
 )
 
-# Mirrors the default of Config.insdc_ingest_group_id
-DEFAULT_INSDC_INGEST_GROUP_ID = 1
-
 
 def ts_from_ymd(year: int, month: int, day: int) -> str:
     """Convert a year, month, and day into a UTC timestamp string."""
@@ -35,19 +33,23 @@ def ts_from_ymd(year: int, month: int, day: int) -> str:
 
 def make_submission_context(
     accession_version: str = "accession.1",
-    group_id: int = 2,
     submitted_at: str | None = None,
     submission_id: str = "test_submission_id",
     is_insdc_ingest_group: bool = False,
+    insdc_ingest_group_id: int = 1,
 ) -> SubmissionContext:
-    """A SubmissionContext for tests that call ProcessingFunctions directly."""
+    """A SubmissionContext for tests that call ProcessingFunctions directly.
+
+    `group_id` is picked to match the requested `is_insdc_ingest_group`, so tests can't
+    construct the contradictory pairing that can never arise in production.
+    """
     return SubmissionContext(
         accessionVersion=accession_version,
         submitter="test_submitter",
-        group_id=group_id,
+        group_id=insdc_ingest_group_id if is_insdc_ingest_group else insdc_ingest_group_id + 1,
         submittedAt=submitted_at if submitted_at is not None else ts_from_ymd(2021, 12, 15),
         submissionId=submission_id,
-        is_insdc_ingest_group=is_insdc_ingest_group,
+        insdc_ingest_group_id=insdc_ingest_group_id,
     )
 
 
@@ -96,29 +98,19 @@ class ProcessedAlignment:
 @dataclass
 class UnprocessedEntryFactory:
     @staticmethod
-    def create_unprocessed_entry(  # noqa: PLR0913, PLR0917
+    def create_unprocessed_entry(
         metadata_dict: dict[str, str | None],
         accession_id: str,
         sequences: dict[SegmentName, NucleotideSequence | None],
-        group_id: int = 2,
+        is_insdc_ingest_group: bool = False,
         files: dict[FileCategory, list[FileIdAndNameAndReadUrl]] | None = None,
-        insdc_ingest_group_id: int = DEFAULT_INSDC_INGEST_GROUP_ID,
     ) -> UnprocessedEntry:
-        accession_version = f"LOC_{accession_id}.1"
         return UnprocessedEntry(
-            accessionVersion=accession_version,
             data=UnprocessedData(
-                submissionContext=SubmissionContext(
-                    accessionVersion=accession_version,
-                    submitter="test_submitter",
-                    submittedAt=str(
-                        datetime.strptime("2021-12-15", "%Y-%m-%d")
-                        .replace(tzinfo=pytz.utc)
-                        .timestamp()
-                    ),
-                    submissionId=metadata_dict.get("submissionId") or "test_submission_id",
-                    group_id=group_id,
-                    is_insdc_ingest_group=group_id == insdc_ingest_group_id,
+                submissionContext=make_submission_context(
+                    accession_version=f"LOC_{accession_id}.1",
+                    submission_id=metadata_dict.get("submissionId") or "test_submission_id",
+                    is_insdc_ingest_group=is_insdc_ingest_group,
                 ),
                 metadata=metadata_dict,
                 unalignedNucleotideSequences=sequences,
@@ -207,7 +199,7 @@ class Case:
     expected_errors: list[ProcessingAnnotation] | None = None
     expected_warnings: list[ProcessingAnnotation] | None = None
     expected_processed_alignment: ProcessedAlignment | None = None
-    group_id: int = 2
+    is_insdc_ingest_group: bool = False
 
     def create_test_case(self, factory_custom: ProcessedEntryFactory) -> ProcessingTestCase:
         if not self.expected_processed_alignment:
@@ -216,7 +208,7 @@ class Case:
             metadata_dict=self.input_metadata,
             accession_id=self.accession_id,
             sequences=self.input_sequence,
-            group_id=self.group_id,
+            is_insdc_ingest_group=self.is_insdc_ingest_group,
             files=self.input_files,
         )
         expected_output = factory_custom.create_processed_entry(

--- a/preprocessing/nextclade/tests/factory_methods.py
+++ b/preprocessing/nextclade/tests/factory_methods.py
@@ -20,7 +20,6 @@ from loculus_preprocessing.datatypes import (
     ProcessingAnnotationAlignment,
     SegmentName,
     SubmissionContext,
-    UnprocessedData,
     UnprocessedEntry,
 )
 
@@ -106,16 +105,14 @@ class UnprocessedEntryFactory:
         files: dict[FileCategory, list[FileIdAndNameAndReadUrl]] | None = None,
     ) -> UnprocessedEntry:
         return UnprocessedEntry(
-            data=UnprocessedData(
-                submissionContext=make_submission_context(
-                    accession_version=f"LOC_{accession_id}.1",
-                    submission_id=metadata_dict.get("submissionId") or "test_submission_id",
-                    is_insdc_ingest_group=is_insdc_ingest_group,
-                ),
-                metadata=metadata_dict,
-                unalignedNucleotideSequences=sequences,
-                files=files,
+            submissionContext=make_submission_context(
+                accession_version=f"LOC_{accession_id}.1",
+                submission_id=metadata_dict.get("submissionId") or "test_submission_id",
+                is_insdc_ingest_group=is_insdc_ingest_group,
             ),
+            metadata=metadata_dict,
+            unalignedNucleotideSequences=sequences,
+            files=files,
         )
 
 

--- a/preprocessing/nextclade/tests/test_assign_custom_lineage.py
+++ b/preprocessing/nextclade/tests/test_assign_custom_lineage.py
@@ -1,6 +1,8 @@
 # ruff: noqa: S101
 """Tests for ProcessingFunctions.assign_custom_lineage and is_variant."""
 
+from factory_methods import make_submission_context
+
 from loculus_preprocessing.processing_functions import ProcessingFunctions
 
 ARGS: dict[str, list[str] | str | bool | int | float | None] = {
@@ -37,6 +39,7 @@ def assign_custom_lineage(input_data: dict) -> str | int | float | bool | None:
         output_field="lineage",
         input_fields=list(input_data.keys()),
         args=ARGS,
+        submission_context=make_submission_context(),
     ).datum
 
 
@@ -188,6 +191,7 @@ def assign_custom_lineage_is_variant(length, num_mutations, mu="0.01"):
         output_field="variant",
         input_fields=["length", "numMutations"],
         args={"mu": mu},
+        submission_context=make_submission_context(),
     )
 
 
@@ -231,6 +235,7 @@ class TestIsVariant:
             output_field="variant",
             input_fields=["length", "numMutations"],
             args={},
+            submission_context=make_submission_context(),
         )
         assert result.datum is None
         assert len(result.errors) == 1

--- a/preprocessing/nextclade/tests/test_host_name_validation.py
+++ b/preprocessing/nextclade/tests/test_host_name_validation.py
@@ -8,7 +8,6 @@ from loculus_preprocessing import external_services
 from loculus_preprocessing.config import Config, get_config
 from loculus_preprocessing.datatypes import (
     SubmissionContext,
-    UnprocessedData,
     UnprocessedEntry,
 )
 from loculus_preprocessing.prepro import process_all
@@ -30,19 +29,17 @@ def make_response(status_code, json_data):
 
 def make_entry(metadata: dict, group_id: int, config: Config) -> UnprocessedEntry:
     return UnprocessedEntry(
-        data=UnprocessedData(
-            submissionContext=SubmissionContext(
-                accessionVersion="LOC_01.1",
-                submitter="test_submitter",
-                submissionId="test_submission_id",
-                submittedAt="2026-01-01",
-                group_id=group_id,
-                insdc_ingest_group_id=config.insdc_ingest_group_id,
-            ),
-            metadata=metadata,
-            unalignedNucleotideSequences={},
-            files=None,
+        submissionContext=SubmissionContext(
+            accessionVersion="LOC_01.1",
+            submitter="test_submitter",
+            submissionId="test_submission_id",
+            submittedAt="2026-01-01",
+            group_id=group_id,
+            insdc_ingest_group_id=config.insdc_ingest_group_id,
         ),
+        metadata=metadata,
+        unalignedNucleotideSequences={},
+        files=None,
     )
 
 

--- a/preprocessing/nextclade/tests/test_host_name_validation.py
+++ b/preprocessing/nextclade/tests/test_host_name_validation.py
@@ -7,6 +7,7 @@ import pytest
 from loculus_preprocessing import external_services
 from loculus_preprocessing.config import get_config
 from loculus_preprocessing.datatypes import (
+    SubmissionContext,
     UnprocessedData,
     UnprocessedEntry,
 )
@@ -27,14 +28,18 @@ def make_response(status_code, json_data):
     return mock
 
 
-def make_entry(metadata: dict, group_id: int) -> UnprocessedEntry:
+def make_entry(metadata: dict, group_id: int, insdc_ingest_group_id: int) -> UnprocessedEntry:
     return UnprocessedEntry(
         accessionVersion="LOC_01.1",
         data=UnprocessedData(
-            submitter="test_submitter",
-            submissionId="test_submission_id",
-            submittedAt="2026-01-01",
-            group_id=group_id,
+            submissionContext=SubmissionContext(
+                accessionVersion="LOC_01.1",
+                submitter="test_submitter",
+                submissionId="test_submission_id",
+                submittedAt="2026-01-01",
+                group_id=group_id,
+                is_insdc_ingest_group=group_id == insdc_ingest_group_id,
+            ),
             metadata=metadata,
             unalignedNucleotideSequences={},
             files=None,
@@ -65,6 +70,7 @@ def test_host_processing_tax_id(mock_session: MagicMock) -> None:
     entry = make_entry(
         metadata={"host": "7159"},
         group_id=config.insdc_ingest_group_id + 1,
+        insdc_ingest_group_id=config.insdc_ingest_group_id,
     )
 
     result = process_all([entry], "temp", config)
@@ -91,6 +97,7 @@ def test_host_processing_sci_name(mock_session: MagicMock) -> None:
     entry = make_entry(
         metadata={"host": "Aedes aegypti"},
         group_id=config.insdc_ingest_group_id,
+        insdc_ingest_group_id=config.insdc_ingest_group_id,
     )
 
     result = process_all([entry], "temp", config)
@@ -125,6 +132,7 @@ def test_host_processing_legacy(mock_session: MagicMock) -> None:
             "hostTaxonId": "7159",
         },
         group_id=config.insdc_ingest_group_id,
+        insdc_ingest_group_id=config.insdc_ingest_group_id,
     )
 
     result = process_all([entry], "temp", config)
@@ -151,6 +159,7 @@ def test_host_processing_invalid_host_insdc(mock_session: MagicMock) -> None:
     entry = make_entry(
         metadata={"host": "not a real species"},
         group_id=config.insdc_ingest_group_id,
+        insdc_ingest_group_id=config.insdc_ingest_group_id,
     )
 
     result = process_all([entry], "temp", config)
@@ -179,6 +188,7 @@ def test_host_processing_invalid_host_direct(mock_session: MagicMock) -> None:
     entry = make_entry(
         metadata={"host": "not a real species"},
         group_id=config.insdc_ingest_group_id + 1,
+        insdc_ingest_group_id=config.insdc_ingest_group_id,
     )
 
     result = process_all([entry], "temp", config)

--- a/preprocessing/nextclade/tests/test_host_name_validation.py
+++ b/preprocessing/nextclade/tests/test_host_name_validation.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from loculus_preprocessing import external_services
-from loculus_preprocessing.config import get_config
+from loculus_preprocessing.config import Config, get_config
 from loculus_preprocessing.datatypes import (
     SubmissionContext,
     UnprocessedData,
@@ -28,9 +28,8 @@ def make_response(status_code, json_data):
     return mock
 
 
-def make_entry(metadata: dict, group_id: int, insdc_ingest_group_id: int) -> UnprocessedEntry:
+def make_entry(metadata: dict, group_id: int, config: Config) -> UnprocessedEntry:
     return UnprocessedEntry(
-        accessionVersion="LOC_01.1",
         data=UnprocessedData(
             submissionContext=SubmissionContext(
                 accessionVersion="LOC_01.1",
@@ -38,7 +37,7 @@ def make_entry(metadata: dict, group_id: int, insdc_ingest_group_id: int) -> Unp
                 submissionId="test_submission_id",
                 submittedAt="2026-01-01",
                 group_id=group_id,
-                is_insdc_ingest_group=group_id == insdc_ingest_group_id,
+                insdc_ingest_group_id=config.insdc_ingest_group_id,
             ),
             metadata=metadata,
             unalignedNucleotideSequences={},
@@ -70,7 +69,7 @@ def test_host_processing_tax_id(mock_session: MagicMock) -> None:
     entry = make_entry(
         metadata={"host": "7159"},
         group_id=config.insdc_ingest_group_id + 1,
-        insdc_ingest_group_id=config.insdc_ingest_group_id,
+        config=config,
     )
 
     result = process_all([entry], "temp", config)
@@ -97,7 +96,7 @@ def test_host_processing_sci_name(mock_session: MagicMock) -> None:
     entry = make_entry(
         metadata={"host": "Aedes aegypti"},
         group_id=config.insdc_ingest_group_id,
-        insdc_ingest_group_id=config.insdc_ingest_group_id,
+        config=config,
     )
 
     result = process_all([entry], "temp", config)
@@ -132,7 +131,7 @@ def test_host_processing_legacy(mock_session: MagicMock) -> None:
             "hostTaxonId": "7159",
         },
         group_id=config.insdc_ingest_group_id,
-        insdc_ingest_group_id=config.insdc_ingest_group_id,
+        config=config,
     )
 
     result = process_all([entry], "temp", config)
@@ -159,7 +158,7 @@ def test_host_processing_invalid_host_insdc(mock_session: MagicMock) -> None:
     entry = make_entry(
         metadata={"host": "not a real species"},
         group_id=config.insdc_ingest_group_id,
-        insdc_ingest_group_id=config.insdc_ingest_group_id,
+        config=config,
     )
 
     result = process_all([entry], "temp", config)
@@ -188,7 +187,7 @@ def test_host_processing_invalid_host_direct(mock_session: MagicMock) -> None:
     entry = make_entry(
         metadata={"host": "not a real species"},
         group_id=config.insdc_ingest_group_id + 1,
-        insdc_ingest_group_id=config.insdc_ingest_group_id,
+        config=config,
     )
 
     result = process_all([entry], "temp", config)

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -10,6 +10,7 @@ from factory_methods import (
     ProcessingTestCase,
     UnprocessedEntryFactory,
     build_processing_annotations,
+    make_submission_context,
     ts_from_ymd,
     verify_processed_entry,
 )
@@ -1129,10 +1130,7 @@ def test_preprocessing_without_consensus_sequences(config: Config) -> None:
     sequence_entry_data = UnprocessedEntry(
         accessionVersion="LOC_01.1",
         data=UnprocessedData(
-            submitter="test_submitter",
-            submissionId="test_submission_id",
-            group_id=2,
-            submittedAt=ts_from_ymd(2021, 12, 15),
+            submissionContext=make_submission_context(accession_version="LOC_01.1"),
             metadata={
                 "ncbi_required_collection_date": "2024-01-01",
                 "name_required": sequence_name,
@@ -1185,8 +1183,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": ts_from_ymd(2022, 12, 15),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2022, 12, 15)),
         ).datum
         == "2021-12"
     ), "dateRangeString: 2021-12 should be returned as is."
@@ -1197,8 +1195,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeLower",
-                "submittedAt": ts_from_ymd(2021, 12, 15),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2021, 12, 15)),
         ).datum
         == "2021-12-01"
     ), "dateRangeLower: 2021-12 should be returned as 2021-12-01."
@@ -1209,8 +1207,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": ts_from_ymd(2022, 12, 15),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2022, 12, 15)),
         ).datum
         == "2021-12-31"
     ), "dateRangeUpper: 2021-12 should be returned as 2021-12-31."
@@ -1221,8 +1219,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": ts_from_ymd(2021, 12, 15),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2021, 12, 15)),
         ).datum
         == "2021-12-15"
     ), "dateRangeUpper: 2021-12 should be returned as submittedAt time: 2021-12-15."
@@ -1233,8 +1231,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": ts_from_ymd(2021, 3, 15),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2021, 3, 15)),
         ).datum
         == "2021-02-28"
     ), "dateRangeUpper: 2021-02 should be returned as 2021-02-28."
@@ -1245,8 +1243,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": ts_from_ymd(2021, 12, 15),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2021, 12, 15)),
         ).datum
         == "2021-12-15"
     ), "dateRangeUpper: 2021 should be returned as 2021-12-15."
@@ -1257,8 +1255,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": ts_from_ymd(2022, 1, 15),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2022, 1, 15)),
         ).datum
         == "2021-12-31"
     ), "dateRangeUpper: 2021 should be returned as 2021-12-31."
@@ -1269,8 +1267,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": ts_from_ymd(2021, 12, 16),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2021, 12, 16)),
         ).datum
         == "2021-12-15"
     ), "dateRangeUpper: 2021-12 with releaseDate 2021-12-15 should be returned as 2021-12-15."
@@ -1281,8 +1279,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": ts_from_ymd(2021, 12, 16),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2021, 12, 16)),
         ).datum
         == "2021-12-15"
     ), "dateRangeUpper: empty date with releaseDate 2021-12-15 should be returned as 2021-12-15."
@@ -1293,8 +1291,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": ts_from_ymd(2021, 12, 16),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2021, 12, 16)),
         ).datum
         is None
     ), "dateRangeString: empty date should be returned as None."
@@ -1305,8 +1303,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": ts_from_ymd(2021, 12, 16),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2021, 12, 16)),
         ).datum
         is None
     ), "dateRangeString: invalid date should be returned as None."
@@ -1317,8 +1315,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeLower",
-                "submittedAt": ts_from_ymd(2021, 12, 16),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2021, 12, 16)),
         ).datum
         is None
     ), "dateRangeLower: empty date should be returned as None."
@@ -1329,8 +1327,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeLower",
-                "submittedAt": ts_from_ymd(2022, 1, 1),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2022, 1, 1)),
         ).datum
         == "2021-01-02"
     ), "dateRangeLower: lucene range should return lower bound."
@@ -1341,8 +1339,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeLower",
-                "submittedAt": ts_from_ymd(2022, 1, 1),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2022, 1, 1)),
         ).datum
         == "2021-01-01"
     ), "dateRangeLower: lucene range should return lower bound of leading year."
@@ -1353,8 +1351,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": ts_from_ymd(2022, 1, 1),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2022, 1, 1)),
         ).datum
         == "2021-06-30"
     ), "dateRangeUpper: lucene range should return upper bound."
@@ -1365,8 +1363,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": ts_from_ymd(2022, 1, 1),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2022, 1, 1)),
         ).datum
         == "2021-12-31"
     ), "dateRangeUpper: lucene range should return upper bound of final date."
@@ -1377,8 +1375,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": ts_from_ymd(2022, 1, 1),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2022, 1, 1)),
         ).datum
         == "2021-05/2021-06"
     ), "dateRangeString: lucene range should be returned in ISO format (compressed to month range)."
@@ -1389,8 +1387,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": ts_from_ymd(2022, 1, 1),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2022, 1, 1)),
         ).datum
         == "2021-01/2021-06"
     ), "dateRangeString: lucene range should be returned in ISO format (compressed to month range)."
@@ -1401,8 +1399,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeLower",
-                "submittedAt": ts_from_ymd(2022, 1, 1),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2022, 1, 1)),
         ).datum
         == "2021-03-05"
     ), "dateRangeLower: ISO range should return lower bound."
@@ -1413,8 +1411,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeLower",
-                "submittedAt": ts_from_ymd(2022, 1, 1),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2022, 1, 1)),
         ).datum
         == "2021-01-01"
     ), "dateRangeLower: ISO range should return lower bound of leading date."
@@ -1425,8 +1423,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": ts_from_ymd(2022, 1, 1),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2022, 1, 1)),
         ).datum
         == "2021-06-12"
     ), "dateRangeUpper: ISO range should return upper bound."
@@ -1437,8 +1435,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": ts_from_ymd(2022, 1, 1),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2022, 1, 1)),
         ).datum
         == "2021-06-30"
     ), "dateRangeUpper: ISO range should return upper bound of trailing date."
@@ -1449,8 +1447,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": ts_from_ymd(2022, 1, 1),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2022, 1, 1)),
         ).datum
         == "2020-01/2021-06"
     ), "dateRangeString: ISO range should be returned compressed to month range."
@@ -1461,8 +1459,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": ts_from_ymd(2022, 1, 1),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2022, 1, 1)),
         ).errors[0]
         == "Metadata field field_name: Detected date range but could not parse date: 20-01-2020/2021-06-30."
     ), "Invalid date range format errors."
@@ -1473,8 +1471,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": ts_from_ymd(2022, 1, 1),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2022, 1, 1)),
         ).errors[0]
         == "Metadata field field_name:'2022-01-01/2021-06-30' is an invalid date range. Lower bound: 2022-01-01 00:00:00+00:00 is after upper bound: 2021-06-30 00:00:00+00:00."
     ), "Invalid date range format errors."
@@ -1485,8 +1483,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": ts_from_ymd(2022, 6, 15),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2022, 6, 15)),
         ).datum
         == "2021"
     ), "Years are compressed in dateRangeString."
@@ -1497,8 +1495,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": ts_from_ymd(2024, 6, 15),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2024, 6, 15)),
         ).datum
         == "2021/2022"
     ), "Multiple years are compressed in dateRangeString."
@@ -1509,8 +1507,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeString",
-                "submittedAt": ts_from_ymd(2024, 6, 15),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2024, 6, 15)),
         ).datum
         == "2024-02"
     ), "Months are compressed in dateRangeString (also for leap years)."
@@ -1521,8 +1519,8 @@ def test_parse_date_into_range() -> None:
             ["field_name"],
             {
                 "fieldType": "dateRangeUpper",
-                "submittedAt": ts_from_ymd(2021, 6, 15),
             },
+            make_submission_context(submitted_at=ts_from_ymd(2021, 6, 15)),
         ).datum
         == "2021-06-15"
     ), "dateRangeUpper: lucene range upper bound should be tightened by submittedAt."
@@ -1543,7 +1541,6 @@ concatenate_cases = [
         input_data={"date": "2021-01-01/2021-12-31", "country": "USA"},
         input_fields=["date", "country"],
         concatenate_args={
-            "ACCESSION_VERSION": "accession.1",
             "order": ["date", "country"],
             "type": ["dateRangeString", "string"],
         },
@@ -1554,7 +1551,6 @@ concatenate_cases = [
         input_data={"someInt": "", "geoLocCountry": "", "sampleCollectionDate": "2025"},
         input_fields=["geoLocCountry", "sampleCollectionDate"],
         concatenate_args={
-            "ACCESSION_VERSION": "accession.1",
             "order": ["someInt", "geoLocCountry", "ACCESSION_VERSION", "sampleCollectionDate"],
             "type": ["integer", "string", "ACCESSION_VERSION", "date"],
         },
@@ -1565,7 +1561,6 @@ concatenate_cases = [
         input_data={"someInt": "0", "geoLocCountry": "", "sampleCollectionDate": "2025"},
         input_fields=["geoLocCountry", "sampleCollectionDate"],
         concatenate_args={
-            "ACCESSION_VERSION": "accession.1",
             "order": ["someInt", "geoLocCountry", "ACCESSION_VERSION", "sampleCollectionDate"],
             "type": ["integer", "string", "ACCESSION_VERSION", "date"],
         },
@@ -1576,7 +1571,6 @@ concatenate_cases = [
         input_data={"someInt": "", "geoLocCountry": "", "sampleCollectionDate": ""},
         input_fields=["geoLocCountry", "sampleCollectionDate"],
         concatenate_args={
-            "ACCESSION_VERSION": "accession.1",
             "order": ["someInt", "geoLocCountry", "ACCESSION_VERSION", "sampleCollectionDate"],
             "type": ["integer", "string", "ACCESSION_VERSION", "date"],
             "fallback_value": "unknown",
@@ -1588,7 +1582,6 @@ concatenate_cases = [
         input_data={"someInt": "0", "geoLocCountry": "", "sampleCollectionDate": "2025"},
         input_fields=["geoLocCountry", "sampleCollectionDate"],
         concatenate_args={
-            "ACCESSION_VERSION": "accession.1",
             "order": ["someInt", "geoLocCountry", "sampleCollectionDate"],
             "type": ["integer", "string", "date"],
             "fallback_value": "unknown",
@@ -1605,6 +1598,7 @@ def test_concatenate(case: ConcatenateCase) -> None:
         output_field="displayName",
         input_fields=case.input_fields,
         args=case.concatenate_args,
+        submission_context=make_submission_context(),
     )
     assert result.datum == case.expected
 
@@ -1727,8 +1721,6 @@ input_fields = [
     "sampleCollectionDate",
 ]
 base_args: FunctionArgs = {
-    "ACCESSION_VERSION": "accession.1",
-    "is_insdc_ingest_group": False,
     "order": ["nextclade.clade", "geoLocCountry", "IDENTIFIER", "sampleCollectionDate"],
     "type": ["string", "string", "IDENTIFIER", "string"],
     # regex pattern constraints:
@@ -1739,7 +1731,6 @@ base_args: FunctionArgs = {
     "regex_pattern": r"^(?:[^/]+/)?[^/]+/(?P<identifier>[^/]+)/\d{4}(?:-\d{2}){0,2}$",
     "human_readable_pattern": "<any>/<any>/<identifier>/<date>",
 }
-insdc_args: FunctionArgs = {**base_args, "is_insdc_ingest_group": True}
 prefix_args: FunctionArgs = {
     **base_args,
     "order": ["ARG:prefix", "geoLocCountry", "IDENTIFIER", "sampleCollectionDate"],
@@ -1760,23 +1751,32 @@ def test_display_name_construction(case: DisplayNameCase) -> None:
             "specimenCollectorSampleId": case.specimen_collector_id,
         }
 
+    # submissionId is read off the SubmissionContext, not the input metadata
+    direct_context = make_submission_context(submission_id=case.submission_id)
+    insdc_context = make_submission_context(
+        submission_id=case.submission_id, is_insdc_ingest_group=True
+    )
+
     res = ProcessingFunctions.build_display_name(
         input_data(),
         "displayName",
         input_fields,
         base_args | case.extra_args,
+        direct_context,
     )
     res_insdc = ProcessingFunctions.build_display_name(
         input_data(),
         "displayName",
         input_fields,
-        insdc_args | case.extra_args,
+        base_args | case.extra_args,
+        insdc_context,
     )
     res_prefix = ProcessingFunctions.build_display_name(
         input_data(),
         "displayName",
         input_fields,
         prefix_args | case.extra_args,
+        direct_context,
     )
 
     assert res.datum == case.expected_regular
@@ -1795,7 +1795,6 @@ def test_call_function_converts_raw_errors_to_annotations() -> None:
     output_field = "myField"
     args: FunctionArgs = {
         "options": ["OptionA", "OptionB"],
-        "is_insdc_ingest_group": False,
     }
 
     result = ProcessingFunctions.call_function(
@@ -1804,6 +1803,7 @@ def test_call_function_converts_raw_errors_to_annotations() -> None:
         input_data={"input": "NotAnOption"},
         output_field=output_field,
         input_fields=input_fields,
+        submission_context=make_submission_context(),
     )
 
     assert result.datum is None

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -24,7 +24,6 @@ from loculus_preprocessing.datatypes import (
     FunctionArgs,
     InputMetadata,
     ProcessedEntry,
-    UnprocessedData,
     UnprocessedEntry,
 )
 from loculus_preprocessing.prepro import process_all
@@ -1128,15 +1127,13 @@ def test_required_field_message_lists_only_user_input_fields() -> None:
 def test_preprocessing_without_consensus_sequences(config: Config) -> None:
     sequence_name = "entry without sequences"
     sequence_entry_data = UnprocessedEntry(
-        data=UnprocessedData(
-            submissionContext=make_submission_context(accession_version="LOC_01.1"),
-            metadata={
-                "ncbi_required_collection_date": "2024-01-01",
-                "name_required": sequence_name,
-            },
-            unalignedNucleotideSequences={},
-            files=None,
-        ),
+        submissionContext=make_submission_context(accession_version="LOC_01.1"),
+        metadata={
+            "ncbi_required_collection_date": "2024-01-01",
+            "name_required": sequence_name,
+        },
+        unalignedNucleotideSequences={},
+        files=None,
     )
 
     result = process_all([sequence_entry_data], "temp_dataset_dir", config)

--- a/preprocessing/nextclade/tests/test_metadata_processing_functions.py
+++ b/preprocessing/nextclade/tests/test_metadata_processing_functions.py
@@ -87,7 +87,7 @@ test_case_definitions = [
             "concatenated_string": "LOC_21.1",
             "required_collection_date": None,
         },
-        group_id=1,
+        is_insdc_ingest_group=True,
     ),
     Case(
         name="invalid_option",
@@ -1128,7 +1128,6 @@ def test_required_field_message_lists_only_user_input_fields() -> None:
 def test_preprocessing_without_consensus_sequences(config: Config) -> None:
     sequence_name = "entry without sequences"
     sequence_entry_data = UnprocessedEntry(
-        accessionVersion="LOC_01.1",
         data=UnprocessedData(
             submissionContext=make_submission_context(accession_version="LOC_01.1"),
             metadata={
@@ -1713,11 +1712,12 @@ def _assert_display_name_warnings(warnings: list, expected_message: str | None) 
         assert warnings[0] == expected_message
 
 
+# Mirrors the build_display_name inputs in values.yaml: submissionId is not among them,
+# it reaches the function via the SubmissionContext.
 input_fields = [
     "nextclade.clade",
     "geoLocCountry",
     "specimenCollectorSampleId",
-    "submissionId",
     "sampleCollectionDate",
 ]
 base_args: FunctionArgs = {
@@ -1747,11 +1747,12 @@ def test_display_name_construction(case: DisplayNameCase) -> None:
             "nextclade.clade": "DENV-1",
             "geoLocCountry": case.geo_loc_country,
             "sampleCollectionDate": case.sample_collection_date,
-            "submissionId": case.submission_id,
             "specimenCollectorSampleId": case.specimen_collector_id,
         }
 
-    # submissionId is read off the SubmissionContext, not the input metadata
+    # submissionId is read off the SubmissionContext, and reaches the function nowhere else:
+    # it is absent from input_data above, so a regression to reading it from the input
+    # metadata falls through to the ACCESSION_VERSION identifier and fails these cases.
     direct_context = make_submission_context(submission_id=case.submission_id)
     insdc_context = make_submission_context(
         submission_id=case.submission_id, is_insdc_ingest_group=True

--- a/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
+++ b/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
@@ -14,7 +14,7 @@ from factory_methods import (
     ProcessingAnnotationHelper,
     ProcessingTestCase,
     build_processing_annotations,
-    ts_from_ymd,
+    make_submission_context,
     verify_processed_entry,
 )
 
@@ -1276,10 +1276,7 @@ def test_max_sequences_per_entry_batch_isolation() -> None:
     bad_entry = UnprocessedEntry(
         accessionVersion="LOC_01.1",
         data=UnprocessedData(
-            group_id=2,
-            submitter="test_submitter",
-            submissionId="test_submission_id",
-            submittedAt=ts_from_ymd(2021, 12, 15),
+            submissionContext=make_submission_context(accession_version="LOC_01.1"),
             metadata={},
             unalignedNucleotideSequences={
                 "ebola-sudan": sequence_with_mutation("ebola-sudan"),
@@ -1292,10 +1289,7 @@ def test_max_sequences_per_entry_batch_isolation() -> None:
     good_entry = UnprocessedEntry(
         accessionVersion="LOC_02.1",
         data=UnprocessedData(
-            group_id=2,
-            submitter="test_submitter",
-            submissionId="test_submission_id",
-            submittedAt=ts_from_ymd(2021, 12, 15),
+            submissionContext=make_submission_context(accession_version="LOC_02.1"),
             metadata={},
             unalignedNucleotideSequences={
                 "ebola-sudan": sequence_with_mutation("ebola-sudan"),
@@ -1325,10 +1319,7 @@ def test_preprocessing_without_metadata() -> None:
     sequence_entry_data = UnprocessedEntry(
         accessionVersion="LOC_01.1",
         data=UnprocessedData(
-            group_id=2,
-            submitter="test_submitter",
-            submissionId="test_submission_id",
-            submittedAt=ts_from_ymd(2021, 12, 15),
+            submissionContext=make_submission_context(accession_version="LOC_01.1"),
             metadata={},
             unalignedNucleotideSequences={
                 "ebola-sudan": sequence_with_mutation("ebola-sudan"),
@@ -1449,10 +1440,7 @@ def test_create_flatfile():
     sequence_entry_data = UnprocessedEntry(
         accessionVersion="LOC_01.1",
         data=UnprocessedData(
-            submitter="test_submitter",
-            group_id=2,
-            submittedAt=ts_from_ymd(2021, 12, 15),
-            submissionId="test_submission_id",
+            submissionContext=make_submission_context(accession_version="LOC_01.1"),
             metadata={
                 "sampleCollectionDate": "2024-01-01",
                 "geoLocCountry": "Netherlands",

--- a/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
+++ b/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
@@ -1274,7 +1274,6 @@ def test_max_sequences_per_entry_batch_isolation() -> None:
     config.max_sequences_per_entry = 1
 
     bad_entry = UnprocessedEntry(
-        accessionVersion="LOC_01.1",
         data=UnprocessedData(
             submissionContext=make_submission_context(accession_version="LOC_01.1"),
             metadata={},
@@ -1287,7 +1286,6 @@ def test_max_sequences_per_entry_batch_isolation() -> None:
     )
 
     good_entry = UnprocessedEntry(
-        accessionVersion="LOC_02.1",
         data=UnprocessedData(
             submissionContext=make_submission_context(accession_version="LOC_02.1"),
             metadata={},
@@ -1317,7 +1315,6 @@ def test_max_sequences_per_entry_batch_isolation() -> None:
 def test_preprocessing_without_metadata() -> None:
     config = get_config(MULTI_SEGMENT_CONFIG, ignore_args=True)
     sequence_entry_data = UnprocessedEntry(
-        accessionVersion="LOC_01.1",
         data=UnprocessedData(
             submissionContext=make_submission_context(accession_version="LOC_01.1"),
             metadata={},
@@ -1438,7 +1435,6 @@ def test_create_flatfile():
     config.processing_order = get_processing_order(config)
     config.create_embl_file = True
     sequence_entry_data = UnprocessedEntry(
-        accessionVersion="LOC_01.1",
         data=UnprocessedData(
             submissionContext=make_submission_context(accession_version="LOC_01.1"),
             metadata={

--- a/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
+++ b/preprocessing/nextclade/tests/test_nextclade_preprocessing.py
@@ -28,7 +28,6 @@ from loculus_preprocessing.datatypes import (
     AnnotationSourceType,
     SegmentClassificationMethod,
     SubmissionData,
-    UnprocessedData,
     UnprocessedEntry,
 )
 from loculus_preprocessing.embl import create_flatfile, reformat_authors_from_loculus_to_embl_style
@@ -1274,26 +1273,22 @@ def test_max_sequences_per_entry_batch_isolation() -> None:
     config.max_sequences_per_entry = 1
 
     bad_entry = UnprocessedEntry(
-        data=UnprocessedData(
-            submissionContext=make_submission_context(accession_version="LOC_01.1"),
-            metadata={},
-            unalignedNucleotideSequences={
-                "ebola-sudan": sequence_with_mutation("ebola-sudan"),
-                "ebola-zaire": sequence_with_mutation("ebola-zaire"),
-            },
-            files=None,
-        ),
+        submissionContext=make_submission_context(accession_version="LOC_01.1"),
+        metadata={},
+        unalignedNucleotideSequences={
+            "ebola-sudan": sequence_with_mutation("ebola-sudan"),
+            "ebola-zaire": sequence_with_mutation("ebola-zaire"),
+        },
+        files=None,
     )
 
     good_entry = UnprocessedEntry(
-        data=UnprocessedData(
-            submissionContext=make_submission_context(accession_version="LOC_02.1"),
-            metadata={},
-            unalignedNucleotideSequences={
-                "ebola-sudan": sequence_with_mutation("ebola-sudan"),
-            },
-            files=None,
-        ),
+        submissionContext=make_submission_context(accession_version="LOC_02.1"),
+        metadata={},
+        unalignedNucleotideSequences={
+            "ebola-sudan": sequence_with_mutation("ebola-sudan"),
+        },
+        files=None,
     )
 
     result = process_all([bad_entry, good_entry], MULTI_EBOLA_DATASET, config)
@@ -1315,15 +1310,13 @@ def test_max_sequences_per_entry_batch_isolation() -> None:
 def test_preprocessing_without_metadata() -> None:
     config = get_config(MULTI_SEGMENT_CONFIG, ignore_args=True)
     sequence_entry_data = UnprocessedEntry(
-        data=UnprocessedData(
-            submissionContext=make_submission_context(accession_version="LOC_01.1"),
-            metadata={},
-            unalignedNucleotideSequences={
-                "ebola-sudan": sequence_with_mutation("ebola-sudan"),
-                "ebola-zaire": sequence_with_mutation("ebola-zaire"),
-            },
-            files=None,
-        ),
+        submissionContext=make_submission_context(accession_version="LOC_01.1"),
+        metadata={},
+        unalignedNucleotideSequences={
+            "ebola-sudan": sequence_with_mutation("ebola-sudan"),
+            "ebola-zaire": sequence_with_mutation("ebola-zaire"),
+        },
+        files=None,
     )
 
     config.processing_spec = {}
@@ -1435,18 +1428,16 @@ def test_create_flatfile():
     config.processing_order = get_processing_order(config)
     config.create_embl_file = True
     sequence_entry_data = UnprocessedEntry(
-        data=UnprocessedData(
-            submissionContext=make_submission_context(accession_version="LOC_01.1"),
-            metadata={
-                "sampleCollectionDate": "2024-01-01",
-                "geoLocCountry": "Netherlands",
-                "geoLocAdmin1": "North Holland",
-                "geoLocCity": "Amsterdam",
-                "authors": "Smith, Doe A;",
-            },
-            unalignedNucleotideSequences={"main": sequence_with_mutation("single")},
-            files=None,
-        ),
+        submissionContext=make_submission_context(accession_version="LOC_01.1"),
+        metadata={
+            "sampleCollectionDate": "2024-01-01",
+            "geoLocCountry": "Netherlands",
+            "geoLocAdmin1": "North Holland",
+            "geoLocCity": "Amsterdam",
+            "authors": "Smith, Doe A;",
+        },
+        unalignedNucleotideSequences={"main": sequence_with_mutation("single")},
+        files=None,
     )
 
     result = process_all([sequence_entry_data], EBOLA_SUDAN_DATASET, config)


### PR DESCRIPTION
**Not fully polished**

I was preparing to work on https://github.com/loculus-project/loculus/issues/7247 and thought the way we get the `group_id` from UnprocessedData and UnprocessedAfterNextclade in get_output_metadata currently is quite messy. 

I somehow completely blanked that I'd reviewed this PR https://github.com/loculus-project/loculus/pull/6980 and ended up with a similar concept (probably unconsciously plagiarising that PR!), with some differences:

- https://github.com/loculus-project/loculus/pull/6980 defines a ProcessingContext, which is very similar to the SubmissionContext I added here.
- Main difference is that I create SubmissionContext during parse_ndjson and add it to both UnprocessedEntry and UnprocessedAfterNextclade (so they have the same interface for getting group_id, submitter, accessionVersion etc.). The existing PR computes it per-call in _call_processing_function
- Existing PR also moves taxonomy_service into the context, out of the args, which is much better!

I'd argue we should merge https://github.com/loculus-project/loculus/pull/6980 rather than this PR: it's a smaller diff with less churn. But I wanted to post this as a draft since there are some different ideas on the data model that we could discuss or come back to in the future.

IMO UnprocessedEntry and UnprocessedAfterNextclade are quite natural places for the Context to move in the long run: it's context that remains the same from the time the entry is parsed until it is submitted back to the backend, and things like the accessionVersion and group_id are accessed in different places along the way (currently via dict["key"]). It would also get rid of the inconsistency where for UnprocessedAfterNextclade we need to do this dance to get the group_id and submitted_at:

https://github.com/loculus-project/loculus/blob/44f78e752e35f0f5aa7d56a037695f600eca86b6/preprocessing/nextclade/src/loculus_preprocessing/prepro.py#L392-L397

but not for UnprocessedData:

https://github.com/loculus-project/loculus/blob/44f78e752e35f0f5aa7d56a037695f600eca86b6/preprocessing/nextclade/src/loculus_preprocessing/prepro.py#L405-L406

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable