### PR TITLE
fix(website): Add `Access control allow origin` header for website file requests

### DIFF
--- a/website/src/pages/seq/[accessionVersion]/[fileCategory]/[fileName].spec.ts
+++ b/website/src/pages/seq/[accessionVersion]/[fileCategory]/[fileName].spec.ts
@@ -48,4 +48,9 @@ describe('file download proxy route', () => {
         // Without 'manual' the file would be streamed through the website instead of from S3
         expect(backendRequest().redirect).toBe('manual');
     });
+
+    test('allows any origin on the S3 redirect', async () => {
+        const response = await callRoute({ isLoggedIn: false });
+        expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    });
 });

--- a/website/src/pages/seq/[accessionVersion]/[fileCategory]/[fileName].ts
+++ b/website/src/pages/seq/[accessionVersion]/[fileCategory]/[fileName].ts
@@ -5,6 +5,13 @@ import { createAuthorizationHeader } from '../../../../utils/createAuthorization
 import { parseAccessionVersionFromString } from '../../../../utils/extractAccessionVersion';
 import { getAccessToken } from '../../../../utils/getAccessToken';
 
+// Allow requests from any origin
+// Same as the backend allows on /files/get, which this route proxies
+function withCorsHeader(headers: Headers): Headers {
+    headers.set('Access-Control-Allow-Origin', '*');
+    return headers;
+}
+
 async function proxyToBackend({ params, locals }: Parameters<APIRoute>[0], method: 'GET' | 'HEAD'): Promise<Response> {
     const runtimeConfig = getRuntimeConfig();
     const { accessionVersion, fileCategory, fileName } = params;
@@ -23,16 +30,22 @@ async function proxyToBackend({ params, locals }: Parameters<APIRoute>[0], metho
     if (response.status === 307 || response.status === 302) {
         const s3Url = response.headers.get('Location');
         if (!s3Url) {
-            return new Response('Backend redirect missing Location header', { status: 500 });
+            return new Response('Backend redirect missing Location header', {
+                status: 500,
+                headers: withCorsHeader(new Headers()),
+            });
         }
         return new Response(null, {
             status: response.status,
             // eslint-disable-next-line @typescript-eslint/naming-convention
-            headers: { Location: s3Url },
+            headers: withCorsHeader(new Headers({ Location: s3Url })),
         });
     }
 
-    return new Response(response.body, { status: response.status, headers: new Headers(response.headers) });
+    return new Response(response.body, {
+        status: response.status,
+        headers: withCorsHeader(new Headers(response.headers)),
+    });
 }
 
 export const GET: APIRoute = (ctx) => proxyToBackend(ctx, 'GET');


### PR DESCRIPTION
### Summary

Switching to `outputFileUrlType: website` in #7301 showed these errors in the CI:

```
Error: Unexpected console error: Access to fetch at 'http://10.1.0.60:3000/seq/LOC_000001Y.1/annotations/LOC_000001Y.1.embl' from origin 'http://localhost:3000' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

this only appears for `chromium` because of logic in `console-warnings.fixture.ts`:

```
                if (!isHarmless && browserName === 'chromium') {
                    expect(false, `Unexpected console ${msg.type()}: ${messageText}`).toBe(true);
                }
            } 
```

CORS always hurts my head but through some discussions with Claude the issue is essentially:

- To get the file size, the website uses `fetch` to do a `HEAD` request to whatever the absolute file URL is.
- Before, with URL type `backend`, this was fine because the backend has `allowedOrigins('*')` in `WebConfig.kt`.
- However with URL type `website`, this hits `[fileName].ts` which never returned an `Allow origins: *` header to the browser. Therefore, any cross origin request here gets blocked by the browser.
- This only appears as an issue in CI because the playwright browser is at `localhost` but the fetch request goes to `10.1.0.60` which is the GitHub Actions runner's own private network address (therefore a cross origin request).

The fix is then to do what the backend does and `Allow origins: *` for this website endpoint. As far as I understand, this is not an issue security wise as with the current setup, `Allow origins: *` means a cross-origin request with user cookies would get a response but the browser will refuse to read it. If we also enabled `Access-Control-Allow-Credentials: true` that could cause problems with a malicious site making authenticated requests.

### Notes

I would think a more straightforward thing in future is to have the file size not need to be requested separately, and remove the separate `HEAD` request entirely, I think this is a bigger change though.

### Screenshot

### PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [ ] Any manual testing that has been done is documented (i.e. what exactly was tested?)

🚀 Preview: Add `preview` label to enable