### PR TITLE
feat(config): actually validate the organism name

### DIFF
--- a/kubernetes/loculus/templates/_enabledOrganisms.tpl
+++ b/kubernetes/loculus/templates/_enabledOrganisms.tpl
@@ -4,6 +4,14 @@
 {{- range $key := (keys $allOrganisms | sortAlpha) -}}
   {{- $organism := get $allOrganisms $key -}}
   {{- if ne $organism.enabled false -}}
+{{- /*
+    Organism keys are substituted verbatim into `metadata.name` of many per-organism
+    resources (ConfigMaps, Deployments, Services, CronJobs, ingress middleware), so each
+    key must be a valid RFC 1123 DNS label.
+*/ -}}
+    {{- if not (regexMatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" $key) -}}
+      {{- fail (printf "Invalid organism key %q: organism keys must be a lower-case RFC 1123 DNS label (lower-case alphanumeric characters or '-', starting and ending with an alphanumeric character, e.g. 'chikungunya'). Rename this key in your organism config." $key) -}}
+    {{- end -}}
 {{- $enabledList = append $enabledList (dict "key" $key "contents" $organism) -}}
   {{- end -}}
 {{- end -}}

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1750,10 +1750,10 @@
     "organisms": {
       "groups": ["organism-conf"],
       "type": "object",
-      "description": "An object where the keys are the organism IDs and values are an [Organism (type)](#organism-type). Keys are used verbatim as `metadata.name` of per-organism Kubernetes resources, so they must be valid RFC 1123 DNS labels: lower-case alphanumeric characters or '-'.",
+      "description": "An object where the keys are the organism IDs and values are an [Organism (type)](#organism-type). Keys are used verbatim as `metadata.name` of per-organism Kubernetes resources (Services included), so each key must be a valid RFC 1123 DNS label: lower-case alphanumeric characters or '-', starting and ending with an alphanumeric character.",
       "additionalProperties": false,
       "patternProperties": {
-        "^[a-z0-9-]+$": { "$ref": "#/definitions/organism" }
+        "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$": { "$ref": "#/definitions/organism" }
       }
     },
     "defaultOrganismConfig": {
@@ -1763,7 +1763,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^[a-z0-9-]+$": { "$ref": "#/definitions/organism" }
+        "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$": { "$ref": "#/definitions/organism" }
       }
     },
     "lineageSystemDefinitions": {

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1750,7 +1750,7 @@
     "organisms": {
       "groups": ["organism-conf"],
       "type": "object",
-      "description": "An object where the keys are the organism IDs and values are an [Organism (type)](#organism-type). Keys are used verbatim as `metadata.name` of per-organism Kubernetes resources (Services included), so each key must be a valid RFC 1123 DNS label: lower-case alphanumeric characters or '-', starting and ending with an alphanumeric character.",
+      "description": "An object where the keys are the organism IDs and values are an [Organism (type)](#organism-type). Keys are used verbatim in per-organism Kubernetes resource names (Services included), so each key must be a valid RFC 1123 DNS label: lower-case alphanumeric characters or '-', starting and ending with an alphanumeric character.",
       "additionalProperties": false,
       "patternProperties": {
         "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$": { "$ref": "#/definitions/organism" }

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1750,7 +1750,8 @@
     "organisms": {
       "groups": ["organism-conf"],
       "type": "object",
-      "description": "An object where the keys are the organism IDs and values are an [Organism (type)](#organism-type)",
+      "description": "An object where the keys are the organism IDs and values are an [Organism (type)](#organism-type). Keys are used verbatim as `metadata.name` of per-organism Kubernetes resources, so they must be valid RFC 1123 DNS labels: lower-case alphanumeric characters or '-'.",
+      "additionalProperties": false,
       "patternProperties": {
         "^[a-z0-9-]+$": { "$ref": "#/definitions/organism" }
       }
@@ -1760,6 +1761,7 @@
     },
     "defaultOrganisms": {
       "type": "object",
+      "additionalProperties": false,
       "patternProperties": {
         "^[a-z0-9-]+$": { "$ref": "#/definitions/organism" }
       }


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/7303

The schema looked like it restricted keys:

  "organisms": {
    "type": "object",
    "patternProperties": { "^[a-z0-9-]+$": { "$ref": "#/definitions/organism" } }
  }

  But patternProperties is not a whitelist — it only applies its subschema to keys that match. A key like Chikungunya
  simply doesn't match, so no subschema applied and, with no additionalProperties: false, it passed straight through
  (and was never validated against the organism definition at all).

### Screenshot

### PR Checklist
- [x] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by appropriate, automated tests.
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
I confirmed the values.schema.json will now throw an error if the organism name is capitalized

```
(loculus-ena-submission) aparker-adm@eve-501 loculus % helm lint kubernetes/loculus -f kubernetes/loculus/values.yaml
==> Linting kubernetes/loculus
[ERROR] values.yaml: - at '/defaultOrganisms': additional properties 'Ebola-sudan' not allowed

[ERROR] templates/: values don't meet the specifications of the schema(s) in the following chart(s):
loculus:
- at '/defaultOrganisms': additional properties 'Ebola-sudan' not allowed


Error: 1 chart(s) linted, 1 chart(s) failed
```

Without running the schema the helm chart now also throws an error (which will be caught on PPX):
```
  File "/Users/aparker-adm/Documents/Github/loculus/./deploy.py", line 157, in run_command
    raise subprocess.SubprocessError(output.stderr)
subprocess.SubprocessError: Error: execution error at (loculus/templates/silo-service.yaml:1:24): Invalid organism key "Ebola-sudan": organism keys must be a lower-case RFC 1123 DNS label (lower-case alphanumeric characters or '-', starting and ending with an alphanumeric character, e.g. 'chikungunya'). Rename this key in your organism config.

Use --debug flag to render out invalid YAML
```

🚀 Preview: Add `preview` label to enable