### PR TITLE
fix(backend): improve duplicate ID error messages, exclude include postgres internals

### DIFF
--- a/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/model/SubmitModel.kt
@@ -30,6 +30,7 @@ import org.loculus.backend.service.submission.SubmissionIdFilesMappingPreconditi
 import org.loculus.backend.service.submission.UploadDatabaseService
 import org.loculus.backend.utils.DateProvider
 import org.loculus.backend.utils.FastaReader
+import org.loculus.backend.utils.extractDuplicateRecordId
 import org.loculus.backend.utils.metadataEntryStreamAsSequence
 import org.loculus.backend.utils.revisionEntryStreamAsSequence
 import org.springframework.stereotype.Service
@@ -336,8 +337,10 @@ class SubmitModel(
             }
         } catch (e: ExposedSQLException) {
             if (e.sqlState == UNIQUE_CONSTRAINT_VIOLATION_SQL_STATE) {
+                val duplicateId = e.extractDuplicateRecordId(uploadId)?.value
                 throw DuplicateKeyException(
-                    "Metadata file contains at least one duplicate submissionId: ${e.cause?.cause}",
+                    "Metadata file contains at least one duplicate submissionId" +
+                        (duplicateId?.let { ": $it" } ?: ""),
                 )
             }
             throw e
@@ -357,8 +360,10 @@ class SubmitModel(
                 )
             } catch (e: ExposedSQLException) {
                 if (e.sqlState == UNIQUE_CONSTRAINT_VIOLATION_SQL_STATE) {
+                    val duplicateId = e.extractDuplicateRecordId(uploadId)?.value
                     throw DuplicateKeyException(
-                        "Sequence file contains at least one duplicate submissionId: ${e.cause?.cause}",
+                        "Sequence file contains at least one duplicate FASTA ID" +
+                            (duplicateId?.let { ": $it" } ?: ""),
                     )
                 }
                 throw e

--- a/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/service/submission/UploadDatabaseService.kt
@@ -23,6 +23,7 @@ import org.loculus.backend.log.AuditLogger
 import org.loculus.backend.model.FastaId
 import org.loculus.backend.model.SubmissionId
 import org.loculus.backend.model.SubmissionParams
+import org.loculus.backend.model.UNIQUE_CONSTRAINT_VIOLATION_SQL_STATE
 import org.loculus.backend.service.GenerateAccessionFromNumberService
 import org.loculus.backend.service.datauseterms.DataUseTermsDatabaseService
 import org.loculus.backend.service.groupmanagement.GroupManagementPreconditionValidator
@@ -44,6 +45,7 @@ import org.loculus.backend.utils.FastaEntry
 import org.loculus.backend.utils.MetadataEntry
 import org.loculus.backend.utils.RevisionEntry
 import org.loculus.backend.utils.chunkedForDatabase
+import org.loculus.backend.utils.extractDuplicateRecordId
 import org.loculus.backend.utils.getNextSequenceNumbers
 import org.loculus.backend.utils.processInDatabaseSafeChunks
 import org.springframework.stereotype.Service
@@ -90,21 +92,6 @@ class UploadDatabaseService(
         }
     }
 
-    private val keyDetail =
-        Regex("""Key \((?<cols>[^)]+)\)=\((?<vals>[^)]+)\) already exists""")
-
-    private fun ExposedSQLException.extractDuplicateColumns(): Map<String, String>? {
-        val text = this.cause?.message ?: this.message ?: return null
-        val match = keyDetail.find(text) ?: return null
-
-        val cols = match.groups["cols"]?.value?.split(",")?.map { it.trim() } ?: return null
-        val vals = match.groups["vals"]?.value?.split(",")?.map { it.trim() } ?: return null
-
-        return cols.zip(vals)
-            .filter { (col, _) -> col in listOf("accession", "submission_id") }
-            .toMap()
-    }
-
     fun batchInsertRevisedMetadataInAuxTable(
         uploadId: String,
         authenticatedUser: AuthenticatedUser,
@@ -127,14 +114,17 @@ class UploadDatabaseService(
                 }
             }
         } catch (e: ExposedSQLException) {
-            log.error { "Error inserting revised metadata in aux table: ${e.message}" }
-            val duplicates = e.extractDuplicateColumns() ?: throw UnprocessableEntityException(
-                "Error inserting revised metadata in aux table - please contact an administrator.",
-            )
-            val details = duplicates.entries.joinToString(" ") { (col, value) ->
-                "Duplicate $col found in metadata file: $value"
+            val duplicateId = e.extractDuplicateRecordId(uploadId) ?: run {
+                log.error(e.takeUnless { it.sqlState == UNIQUE_CONSTRAINT_VIOLATION_SQL_STATE }) {
+                    "Error inserting revised metadata for upload $uploadId with SQL state ${e.sqlState}"
+                }
+                throw UnprocessableEntityException(
+                    "Error inserting revised metadata in aux table - please contact an administrator.",
+                )
             }
-            throw UnprocessableEntityException(details)
+            throw UnprocessableEntityException(
+                "Metadata file contains at least one duplicate ${duplicateId.field}: ${duplicateId.value}",
+            )
         }
     }
 

--- a/backend/src/main/kotlin/org/loculus/backend/utils/DuplicateRecordId.kt
+++ b/backend/src/main/kotlin/org/loculus/backend/utils/DuplicateRecordId.kt
@@ -1,0 +1,33 @@
+package org.loculus.backend.utils
+
+import org.postgresql.util.PSQLException
+import org.postgresql.util.PSQLState
+import java.sql.SQLException
+
+data class DuplicateRecordId(val field: String, val value: String)
+
+// Record IDs can contain commas and parentheses.
+private val duplicateRecordKey = Regex(
+    """Key \(upload_id, (\w+)\)=\(([^,]+), (.+)\) already exists\.""",
+    RegexOption.DOT_MATCHES_ALL,
+)
+
+/** Returns null if the duplicate ID cannot be read from the error. */
+fun SQLException.extractDuplicateRecordId(uploadId: String): DuplicateRecordId? =
+    generateSequence<Throwable>(this) { it.cause }
+        .filterIsInstance<SQLException>()
+        .flatMap { it.asSequence() }
+        .filterIsInstance<PSQLException>()
+        .filter { it.sqlState == PSQLState.UNIQUE_VIOLATION.state }
+        .firstNotNullOfOrNull { exception ->
+            val detail: String = exception.serverErrorMessage?.detail ?: return@firstNotNullOfOrNull null
+            val match = duplicateRecordKey.matchEntire(detail) ?: return@firstNotNullOfOrNull null
+            val (column, errorUploadId, id) = match.destructured
+            val field = when (column) {
+                "submission_id" -> "submissionId"
+                "fasta_id" -> "FASTA ID"
+                "accession" -> "accession"
+                else -> return@firstNotNullOfOrNull null
+            }
+            if (errorUploadId == uploadId) DuplicateRecordId(field, id) else null
+        }

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/ReviseEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/ReviseEndpointTest.kt
@@ -210,7 +210,7 @@ class ReviseEndpointTest(
             .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
             .andExpect(
                 jsonPath("\$.detail").value(
-                    "Duplicate accession found in metadata file: ${accessions.first()}",
+                    "Metadata file contains at least one duplicate accession: ${accessions.first()}",
                 ),
             )
     }
@@ -589,14 +589,14 @@ class ReviseEndpointTest(
                 SubmitFiles.revisedMetadataFileWith(
                     content = """
                             accession	submissionId	firstColumn
-                            1	sameHeader	someValue
-                            2	sameHeader	someValue2
+                            1	same,Header(1)	someValue
+                            2	same,Header(1)	someValue2
                     """.trimIndent(),
                 ),
                 SubmitFiles.sequenceFileWith(),
                 status().isUnprocessableContent,
                 "Unprocessable Content",
-                "Duplicate submission_id found in metadata file: sameHeader",
+                "Metadata file contains at least one duplicate submissionId: same,Header(1)",
             ),
             Arguments.of(
                 "duplicate headers in sequence file",
@@ -611,7 +611,7 @@ class ReviseEndpointTest(
                 ),
                 status().isUnprocessableContent,
                 "Unprocessable Content",
-                "Sequence file contains at least one duplicate submissionId",
+                "Sequence file contains at least one duplicate FASTA ID: sameHeader_main",
             ),
             Arguments.of(
                 "metadata file misses headers",

--- a/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
+++ b/backend/src/test/kotlin/org/loculus/backend/controller/submission/SubmitEndpointTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
 import org.loculus.backend.api.DataUseTerms
 import org.loculus.backend.api.FileIdAndName
 import org.loculus.backend.api.Organism
@@ -213,6 +214,32 @@ class SubmitEndpointTest(
             .andExpect(jsonPath("\$.detail", containsString(expectedMessage)))
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = ["SAMPLE_C", "SAMPLE,C(1)"])
+    fun `GIVEN duplicate metadata IDs THEN reports the ID without database details`(id: String) {
+        submissionControllerClient.submit(
+            metadataFile = SubmitFiles.metadataFileWith(
+                content = "submissionId\tfirstColumn\n$id\tvalue\n$id\totherValue",
+            ),
+            sequencesFile = DefaultFiles.sequencesFile,
+            groupId = groupId,
+        )
+            .andExpect(status().isUnprocessableContent)
+            .andExpect(jsonPath("\$.detail").value("Metadata file contains at least one duplicate submissionId: $id"))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["SAMPLE_C", "SAMPLE,C(1)"])
+    fun `GIVEN duplicate FASTA IDs THEN reports the ID without database details`(id: String) {
+        submissionControllerClient.submit(
+            metadataFile = DefaultFiles.metadataFile,
+            sequencesFile = SubmitFiles.sequenceFileWith(content = ">$id\nAC\n>$id\nAC"),
+            groupId = groupId,
+        )
+            .andExpect(status().isUnprocessableContent)
+            .andExpect(jsonPath("\$.detail").value("Sequence file contains at least one duplicate FASTA ID: $id"))
+    }
+
     @Test
     fun `GIVEN no sequence file for organism that requires one THEN returns bad request`() {
         submissionControllerClient.submit(
@@ -384,39 +411,6 @@ class SubmitEndpointTest(
                     status().isUnprocessableContent,
                     "Unprocessable Content",
                     "The metadata file does not contain either header 'id' or 'submissionId'",
-                    DEFAULT_ORGANISM,
-                    DataUseTerms.Open,
-                ),
-                Arguments.of(
-                    "duplicate headers in metadata file",
-                    SubmitFiles.metadataFileWith(
-                        content = """
-                            id	firstColumn
-                            sameHeader	someValue
-                            sameHeader	someValue2
-                        """.trimIndent(),
-                    ),
-                    DefaultFiles.sequencesFile,
-                    status().isUnprocessableContent,
-                    "Unprocessable Content",
-                    "Metadata file contains at least one duplicate submissionId",
-                    DEFAULT_ORGANISM,
-                    DataUseTerms.Open,
-                ),
-                Arguments.of(
-                    "duplicate headers in sequence file",
-                    DefaultFiles.metadataFile,
-                    SubmitFiles.sequenceFileWith(
-                        content = """
-                            >sameHeader_main
-                            AC
-                            >sameHeader_main
-                            AC
-                        """.trimIndent(),
-                    ),
-                    status().isUnprocessableContent,
-                    "Unprocessable Content",
-                    "Sequence file contains at least one duplicate submissionId",
                     DEFAULT_ORGANISM,
                     DataUseTerms.Open,
                 ),


### PR DESCRIPTION
Shows duplicate IDs instead of raw Postgres errors, using one helper for submission and revision.

Closes #7106

### PR Checklist

- ~~All necessary documentation has been adapted.~~
  - no docs changes needed
- [x] The implemented feature is covered by appropriate, automated tests.
  - submission and revision endpoint tests
- [x] Any manual testing that has been done is documented (i.e. what exactly was tested?)
  - ran `./gradlew test ktlintCheck` locally, 638 tests passed and 1 skipped

🚀 Preview: Add `preview` label to enable