### PR TITLE
fix(ci): build docs image on native runners to avoid qemu hangs

### DIFF
--- a/.github/workflows/docs-image.yml
+++ b/.github/workflows/docs-image.yml
@@ -5,56 +5,34 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      build_arm:
-        type: boolean
-        description: "Build for ARM as well"
-        default: false
-        required: false
   workflow_call:
-    inputs:
-      build_arm:
-        type: boolean
-        description: "Build for ARM as well"
-        default: false
-        required: false
 env:
   DOCKER_IMAGE_NAME: ghcr.io/loculus-project/docs
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-  BUILD_ARM: ${{ github.event.inputs.build_arm || inputs.build_arm || github.ref == 'refs/heads/main' }}
   sha: ${{ github.event.pull_request.head.sha || github.sha }}
 concurrency:
-  group: ci-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}-docs-${{github.event.inputs.build_arm}}
+  group: ci-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}-docs
   cancel-in-progress: true
 jobs:
-  docs-docker:
-    name: Build Docs Docker Image
+  check-cache:
+    name: Check Cache
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 5
     permissions:
       contents: read
       packages: write
-      checks: read
+    outputs:
+      cache-hit: ${{ steps.check-image.outputs.cache-hit }}
+      dir-hash: ${{ steps.prepare.outputs.dir-hash }}
+      sha-short: ${{ steps.prepare.outputs.sha-short }}
     steps:
-      - name: Shorten sha
-        run: echo "sha=${sha::7}" >> $GITHUB_ENV
       - uses: actions/checkout@v7
       - name: Generate files hash
-        id: files-hash
+        id: prepare
         run: |
           DIR_HASH=$(echo -n ${{ hashFiles('docs/**', '.github/workflows/docs-image.yml', 'kubernetes/loculus/values.schema.json') }})
-          echo "DIR_HASH=$DIR_HASH${{ env.BUILD_ARM == 'true' && '-arm' || '' }}" >> $GITHUB_ENV
-      - name: Setup Docker metadata
-        id: dockerMetadata
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.DOCKER_IMAGE_NAME }}
-          tags: |
-            type=raw,value=${{ env.DIR_HASH }}
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=raw,value=${{ env.BRANCH_NAME }}
-            type=raw,value=commit-${{ env.sha }}
-            type=raw,value=${{ env.BRANCH_NAME }}-arm,enable=${{ env.BUILD_ARM }}
+          echo "dir-hash=$DIR_HASH" >> $GITHUB_OUTPUT
+          echo "sha-short=${sha::7}" >> $GITHUB_OUTPUT
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -64,33 +42,126 @@ jobs:
       - name: Check if image exists
         id: check-image
         run: |
-          EXISTS=$(docker manifest inspect ${{ env.DOCKER_IMAGE_NAME }}:${{ env.DIR_HASH }} > /dev/null 2>&1 && echo "true" || echo "false")
-          echo "CACHE_HIT=$EXISTS" >> $GITHUB_ENV
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Get node version build arg
-        if: env.CACHE_HIT == 'false'
+          EXISTS=$(docker manifest inspect ${{ env.DOCKER_IMAGE_NAME }}:${{ steps.prepare.outputs.dir-hash }} > /dev/null 2>&1 && echo "true" || echo "false")
+          echo "cache-hit=$EXISTS" >> $GITHUB_OUTPUT
+
+  build:
+    name: Build ${{ matrix.platform }}
+    needs: check-cache
+    if: needs.check-cache.outputs.cache-hit == 'false'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v7
+      - name: Prepare build variables
+        id: prepare
         run: |
-          NODE_VERSION=$(cat docs/.nvmrc | tr -cd [:digit:].)
-          echo "NODE_VERSION=$NODE_VERSION" >> $GITHUB_ENV
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          NODE_VERSION=$(grep -v "^[[:space:]]*#" docs/.nvmrc | tr -d 'v')
+          echo "NODE_VERSION=$NODE_VERSION" >> $GITHUB_OUTPUT
       - name: Copy Kubernetes schema to docs
         run: npm run copy-schema
         working-directory: ./docs
-      - name: Build and push image
-        if: env.CACHE_HIT == 'false'
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.DOCKER_IMAGE_NAME }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: ./docs
-          push: true
-          tags: ${{ steps.dockerMetadata.outputs.tags }}
-          cache-from: type=gha,scope=docs-${{ github.ref }}
-          cache-to: type=gha,mode=max,scope=docs-${{ github.ref }}
-          platforms: ${{ env.BUILD_ARM == 'true' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          build-args: NODE_VERSION=${{ env.NODE_VERSION }}
-      - name: Retag and push existing image if cache hit
-        if: env.CACHE_HIT == 'true'
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=docs-${{ github.ref }}-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=docs-${{ github.ref }}-${{ env.PLATFORM_PAIR }}
+          outputs: type=image,name=${{ env.DOCKER_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          build-args: NODE_VERSION=${{ steps.prepare.outputs.NODE_VERSION }}
+      - name: Export digest
         run: |
-          TAGS=(${{ steps.dockerMetadata.outputs.tags }})
-          for TAG in "${TAGS[@]}"; do
-            docker buildx imagetools create --tag $TAG ${{ env.DOCKER_IMAGE_NAME }}:${{ env.DIR_HASH }}
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-or-retag:
+    name: Build Docs Docker Image
+    needs: [check-cache, build]
+    if: always() && needs.check-cache.result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Setup Docker metadata
+        id: dockerMetadata
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.DOCKER_IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ needs.check-cache.outputs.dir-hash }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=${{ env.BRANCH_NAME }}
+            type=raw,value=commit-${{ needs.check-cache.outputs.sha-short }}
+      - name: Download digests
+        if: needs.check-cache.outputs.cache-hit == 'false'
+        uses: actions/download-artifact@v8
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Create manifest list and push
+        if: needs.check-cache.outputs.cache-hit == 'false'
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          METADATA='${{ steps.dockerMetadata.outputs.json }}'
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$METADATA") \
+            $(printf '${{ env.DOCKER_IMAGE_NAME }}@sha256:%s ' *)
+      - name: Inspect image
+        if: needs.check-cache.outputs.cache-hit == 'false'
+        run: |
+          docker buildx imagetools inspect ${{ env.DOCKER_IMAGE_NAME }}:${{ needs.check-cache.outputs.dir-hash }}
+      - name: Retag and push existing image
+        if: needs.check-cache.outputs.cache-hit == 'true'
+        run: |
+          METADATA='${{ steps.dockerMetadata.outputs.json }}'
+          TAGS=$(jq -r '.tags[]' <<< "$METADATA")
+          for TAG in $TAGS; do
+            docker buildx imagetools create --tag $TAG ${{ env.DOCKER_IMAGE_NAME }}:${{ needs.check-cache.outputs.dir-hash }}
           done

--- a/.github/workflows/docs-image.yml
+++ b/.github/workflows/docs-image.yml
@@ -59,7 +59,7 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
     steps:


### PR DESCRIPTION
Resolves https://github.com/loculus-project/loculus/issues/5642

QEMU often hangs in docker builds, switch also docs image build to native dual build and merge - we did this for website image a while back in #5514 due to same failure mode. We're just copying the pattern from website image to docs - so low risk.

Docs images are used only by previews so we can see docs changes on previews. In prod docs are running via github pages.

More reliable and big speed up with arm native runner rather than QEMU: 10s of seconds rather than 5min (when it worked - when it doesn't it's 15min).

Still works:
<img width="978" height="570" alt="image" src="https://github.com/user-attachments/assets/b3789b5d-294b-469d-a916-0c1878934683" />


<details>

The docs image has been failing on `main` roughly every other time it actually rebuilds. The arm64 half of the build dies inside `npm ci` under emulation and then sits there doing nothing until the job's 15 minute limit kills it:

```
#15 [linux/arm64 4/7] RUN npm ci
#15 23.90 qemu: uncaught target signal 4 (Illegal instruction) - core dumped
##[error]The operation was canceled.        <- 14 minutes later, nothing in between
```

This is the same failure [#5514](https://github.com/loculus-project/loculus/pull/5514) fixed for the website image in November ("Website ARM image builds hang about 1 in 10 times during `npm ci`"), so this is that fix applied to docs: build each architecture on a native runner, then merge the two manifests. Docs was the only npm-based image still building arm64 through emulation. That's the ecosystem that has this QEMU hang.

It is a hang and not a slow build, so raising the timeout would not have helped: green builds finish in 216-419 s and every failure sits at 883-888 s, which is the limit. Instances, all with the identical log line above: [33863848031](https://github.com/loculus-project/loculus/actions/runs/33863848031), [33867555784](https://github.com/loculus-project/loculus/actions/runs/33867555784), [34374633309](https://github.com/loculus-project/loculus/actions/runs/34374633309), [34589119390](https://github.com/loculus-project/loculus/actions/runs/34589119390) and [32502545323](https://github.com/loculus-project/loculus/actions/runs/32502545323) back in August. That is 4 of the last 18 builds that were not cache hits. Two were re-run and went green on the identical commit, so it is not triggered by any particular change.

</details>

🚀 Preview of docs using image built from this refactored workflow: https://docs-ci-docs-image-native-arm.loculus.org/

🚀 Preview: https://ci-docs-image-native-arm.loculus.org