### PR TITLE
feat(docs): update the loculus docs with AWS specific configuration information

### DIFF
--- a/docs/src/content/docs/for-administrators/configuring-extra-files.md
+++ b/docs/src/content/docs/for-administrators/configuring-extra-files.md
@@ -24,6 +24,10 @@ When configuring this feature for an organism, you can configure file categories
 
 You need admin access to an S3 bucket, and have the [credentials](../../reference/glossary#s3-credentials) at hand.
 
+The credentials consist of an `accessKey` and a `secretKey` (an Access Key ID/Secret Access Key pair) that together authenticate as a single S3 identity - much like a username and password. This identity must be able to read, write, tag, and delete objects in the bucket (see [IAM permissions](#iam-permissions) below).
+
+For AWS S3, you get such a pair by creating an [IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users.html) and then generating an [access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for that user.
+
 Enable S3 and configure the location of the bucket:
 
 ```yaml
@@ -66,6 +70,8 @@ secrets:
       secretKey: AgAS8a/ldl....
 ```
 
+To create the `encryptedData` above, seal your `accessKey`/`secretKey` with `kubeseal` - see [Adding a sealed secret](https://github.com/loculus-project/loculus/blob/main/kubernetes/README.md#adding-a-sealed-secret).
+
 :::note
 Alternatively, you can also use the `raw` secret type. If you do, ensure the configuration file is properly access-protected, since it will contain credentials in plain text.
 
@@ -80,6 +86,25 @@ secrets:
 ```
 
 :::
+
+#### IAM permissions
+
+The `accessKey`/`secretKey` only need enough permissions for the backend to read, write, tag, and delete objects under the bucket.
+
+For AWS, attach a policy like this to the IAM user (replace `my-loculus-bucket` with your bucket name):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject", "s3:PutObjectTagging", "s3:DeleteObject"],
+      "Resource": "arn:aws:s3:::my-loculus-bucket/*"
+    }
+  ]
+}
+```
 
 ### Configuring file submission
 

--- a/docs/src/content/docs/for-administrators/configuring-extra-files.md
+++ b/docs/src/content/docs/for-administrators/configuring-extra-files.md
@@ -170,7 +170,6 @@ You can set a permissive CORS policy on your bucket with `s3cmd setcors cors.xml
     <AllowedMethod>HEAD</AllowedMethod>
     <AllowedMethod>POST</AllowedMethod>
     <AllowedMethod>PUT</AllowedMethod>
-    <AllowedMethod>DELETE</AllowedMethod>
     <AllowedOrigin>*</AllowedOrigin>
   </CORSRule>
 </CORSConfiguration>

--- a/docs/src/content/docs/for-administrators/configuring-extra-files.md
+++ b/docs/src/content/docs/for-administrators/configuring-extra-files.md
@@ -35,6 +35,21 @@ s3:
     bucket: loculus-data
 ```
 
+For AWS S3 specifically:
+
+```yaml
+s3:
+  enabled: true
+  bucket:
+    region: eu-central-1
+    endpoint: https://s3.eu-central-1.amazonaws.com
+    bucket: my-loculus-bucket
+```
+
+:::note
+`endpoint` must include the `https://` protocol and be the _regional_ S3 endpoint, not a bucket-specific virtual-hosted one (e.g. not `https://my-loculus-bucket.s3.eu-central-1.amazonaws.com`) - the backend addresses objects path-style (`endpoint/bucket/key`) and supplies the bucket name separately via `bucket`. `bucket` is the bare bucket name, not the ARN (`arn:aws:s3:::my-loculus-bucket`).
+:::
+
 :::note
 Have a look at the [Helm Chart S3 reference](../../reference/helm-chart-config/#s3-deployments) for more information on these configuration settings.
 :::

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -152,6 +152,10 @@ This will create a `my-secret.yaml` file. Now, ensure that you have correctly co
 
 You now have a file `my-sealed-secret.yaml` with `spec.encryptedData` in it. You can now add this `encryptedData` to the `values.yaml` under `secrets.<yoursecretname>`. See `values_preview_server.yaml` for examples.
 
+## Configuring an S3 bucket (e.g. AWS)
+
+See [Configuring extra file submission](/docs/src/content/docs/for-administrators/configuring-extra-files.md) for the full walkthrough (bucket config, credentials via sealed secrets, CORS, bucket policy).
+
 ## Setting up kubeconfig locally to access the remote cluster
 
 To access the remote cluster without `ssh`ing to the containing machine, you need to set up your `kubeconfig` file.

--- a/kubernetes/loculus/values.schema.json
+++ b/kubernetes/loculus/values.schema.json
@@ -1901,18 +1901,18 @@
             "endpoint": {
               "groups": ["s3"],
               "type": "string",
-              "default": "s3-<host value>",
-              "description": "The endpoint where S3 is running. Do not include a protocol prefix."
+              "default": "https://s3-<host value>",
+              "description": "The base URL of the S3-compatible service, including the protocol (e.g. https://). This is passed directly to the AWS SDK's endpoint override, which requires a scheme; a value without one will fail with 'The scheme of the endpoint override must not be null.' The backend addresses objects path-style (endpoint/bucket/key), so for AWS S3 use the regional endpoint rather than a bucket-specific virtual-hosted one, e.g. https://s3.eu-central-1.amazonaws.com for a bucket in eu-central-1. Ignored when runDevelopmentS3 is true: the dev S3 (MinIO) URL is generated automatically, scheme included."
             },
             "region": {
               "groups": ["s3"],
               "type": "string",
-              "description": "The region where the bucket is located."
+              "description": "The region where the bucket is located, e.g. eu-central-1 for AWS S3."
             },
             "bucket": {
               "groups": ["s3"],
               "type": "string",
-              "description": "The name of the bucket."
+              "description": "The name of the bucket, e.g. my-loculus-bucket for AWS S3. Do not include the arn:aws:s3::: prefix or any path - just the bucket name."
             }
           },
           "required": ["bucket"],


### PR DESCRIPTION
resolves https://github.com/loculus-project/loculus/issues/4926

Additionally fixes the values.schema.json: Protocol prefix is actually required and backend will not be able to talk to S3 without it.

### Screenshot

### PR Checklist
- [x] All necessary documentation has been adapted.
- [ ] ~The implemented feature is covered by appropriate, automated tests.~
- [ ] ~Any manual testing that has been done is documented (i.e. what exactly was tested?)~

🚀 Preview: Add `preview` label to enable